### PR TITLE
Support for psi games and the future perfect.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,8 @@
 
   :source-paths ["src/node" "src/cljs"]
 
+  :java-cmd "/Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home/bin/java"
+
   :cljsbuild {
     :builds [
       {:id "node"

--- a/src/node/game/cards.cljs
+++ b/src/node/game/cards.cljs
@@ -1183,15 +1183,15 @@
              (psi-game
               {:ability-corp-win
                {:msg "The Future Perfect's ability prevents it from being stolen."
-                :effect (effect
-                 (deregister-pending-input card nil)
-                 (access-queue (:pending-accesses @state)))}
+                :effect (effect                 
+                         (access-queue (:pending-accesses @state)
+                                       (+ 1 (:cards-accessed @state))))}
                :ability-runner-win
                {:msg "The Future Perfect's ability does not prevent it from being stolen."
                 :effect (effect
-                 (deregister-pending-input card nil)
                  (maybe-steal-agenda card)
-                 (access-queue (:pending-accesses @state)))}})}}
+                 (access-queue (:pending-accesses @state)
+                               (+ 1 (:cards-accessed @state))))}})}}
 
    "The Makers Eye"
    {:effect (effect (run :rd) (access-bonus 2))}

--- a/src/node/game/cards.cljs
+++ b/src/node/game/cards.cljs
@@ -1,9 +1,13 @@
 (ns game.cards
-  (:require-macros [game.macros :refer [effect req msg]])
-  (:require [game.core :refer [pay gain lose draw move damage shuffle-into-deck trash purge add-prop
-                               set-prop resolve-ability system-msg end-run unregister-event mill run
-                               gain-agenda-point pump access-bonus shuffle! runner-install prompt!
-                               play-instant corp-install forfeit prevent-run prevent-jack-out] :as core]
+  (:require-macros [game.macros :refer [effect req msg effect-with-pending-input]])
+  (:require [game.core :refer
+             [pay gain lose draw move damage shuffle-into-deck trash purge add-prop
+              set-prop resolve-ability system-msg end-run unregister-event mill run
+              gain-agenda-point pump access-bonus shuffle! runner-install prompt!
+              play-instant corp-install forfeit prevent-run prevent-jack-out
+              psi-game register-pending-input deregister-pending-input maybe-steal-agenda
+              access-queue]
+             :as core]
             [clojure.string :refer [join]]
             [game.utils :refer [has?]]))
 
@@ -1172,6 +1176,22 @@
             :effect (effect (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand)
                             (shuffle! :deck))
             :msg (msg "add a copy of " (:title target) " from R&D to HQ")}}}}
+
+   "The Future Perfect"
+   {:access {:req (req (some #(= (first (:zone card)) %) [:deck :hand :discard]))
+             :effect
+             (psi-game
+              {:ability-corp-win
+               {:msg "The Future Perfect's ability prevents it from being stolen."
+                :effect (effect
+                 (deregister-pending-input card nil)
+                 (access-queue (:pending-accesses @state)))}
+               :ability-runner-win
+               {:msg "The Future Perfect's ability does not prevent it from being stolen."
+                :effect (effect
+                 (deregister-pending-input card nil)
+                 (maybe-steal-agenda card)
+                 (access-queue (:pending-accesses @state)))}})}}
 
    "The Makers Eye"
    {:effect (effect (run :rd) (access-bonus 2))}

--- a/src/node/game/cards.cljs
+++ b/src/node/game/cards.cljs
@@ -132,7 +132,7 @@
    {:effect (effect (gain :link 1 :max-hand-size 1))
     :leave-play (effect (lose :link 1 :max-hand-size 1))}
 
-   "BOX-E"
+   "Box-E"
    {:effect (effect (gain :memory 2 :max-hand-size 2))
     :leave-play (effect (lose :memory 2 :max-hand-size 2))}
 
@@ -378,6 +378,12 @@
                                 :effect #(do (gain %1 :corp :credit 2)
                                              (when (zero? (:counter %3)) (trash %1 :corp %3)))}}}
 
+   "Executive Boot Camp"
+   {:abilities [{:prompt "Choose an asset to add to HQ" :msg (msg "add " (:title target) " to HQ")
+                 :choices (req (filter #(has? % :type "Asset") (:deck corp)))
+                 :cost [:credit 1] :label "Search R&D for an asset"
+                 :effect (effect (trash card) (move target :hand) (shuffle! :deck))}]}
+
    "Executive Retreat"
    {:data {:counter 1} :effect (effect (shuffle-into-deck :hand))
     :abilities [{:cost [:click 1] :counter-cost 1 :msg "draw 5 cards" :effect (effect (draw 5))}]}
@@ -522,6 +528,17 @@
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"
                               :effect (req (damage state side :net 1))}}}
 
+   "Hostage"
+   {:prompt "Choose a Connection to install"
+    :choices (req (filter #(and (has? % :subtype "Connection")
+                                (<= (:cost %) (:credit runner))) (:deck runner)))
+    :effect (effect (runner-install target) (shuffle! :deck))}
+
+   "Hostile Infrastructure"
+   {:events {:trash {:req (req (and (= (:side target) "Corp") (= side :runner)))
+                     :msg "do 1 net damage" :effect (effect (damage :net 1))}}
+    :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1))}]}
+
    "Hostile Takeover"
    {:effect (effect (gain :credit 7 :bad-publicity 1))}
 
@@ -535,16 +552,6 @@
                              :effect (effect (gain :runner :credit (:agendapoints target)))}
              :agenda-stolen {:msg (msg "gain " (:agendapoints target) " [Credits]")
                              :effect (effect (gain :credit (:agendapoints target)))}}}
-
-   "Hostage"
-   {:prompt "Choose a Connection to install"
-    :choices (req (filter #(and (has? % :subtype "Connection")
-                                (<= (:cost %) (:credit runner))) (:deck runner)))
-    :effect (effect (runner-install target) (shuffle! :deck))}
-
-   "Hostile Infrastructure"
-   {:events {:trash {:req (req (and (= (:side target) :corp) (= side :runner)))
-                     :effect (effect (damage :net 1))}}}
 
    "HQ Interface"
    {:effect (effect (gain :hq-access 1)) :leave-play (effect (lose :hq-access 1))}
@@ -588,6 +595,11 @@
                                             ((if (= target "HQ") :hand :discard) corp)))
                       :effect (effect (corp-install target nil {:no-install-cost true}))}
                      card targets))}
+
+   "IT Department"
+   {:abilities [{:counter-cost 1 :label "Add strength to a rezzed ICE"
+                 :msg (msg "add " (:counter card) " strength to a rezzed ICE")}
+                {:cost [:click 1] :msg "add 1 counter" :effect (effect (add-prop card :counter 1))}]}
 
    "Jinteki: Personal Evolution"
    {:events {:agenda-scored {:msg "do 1 net damage" :effect (effect (damage :net 1))}
@@ -1247,6 +1259,16 @@
    {:events {:runner-turn-begins {:msg "gain 1 [Credits]" :req (req (>= (:link runner) 2))
                                   :effect (effect (gain :credit 1))}}}
 
+   "Unregistered S&W 35"
+   {:abilities
+    [{:cost [:click 2] :req (req (some #{:hq} (:successful-run runner-reg)))
+      :label "trash a Bioroid, Clone, Executive or Sysop" :prompt "Choose a card to trash"
+      :choices (req (filter #(and (:rezzed %)
+                                  (or (has? % :subtype "Bioroid") (has? % :subtype "Clone")
+                                      (has? % :subtype "Executive") (has? % :subtype "Sysop")))
+                            (mapcat :content (flatten (seq (:servers corp))))))
+      :msg (msg "trash " (:title target)) :effect (effect (trash target))}]}
+
    "Valencia Estevez: The Angel of Cayambe"
    {:effect (effect (gain :corp :bad-publicity 1))}
 
@@ -1569,6 +1591,9 @@
 
    "Galahad"
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+
+   "Gemini"
+   {:abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1))}]}
 
    "Grim"
    {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))

--- a/src/node/game/core.cljs
+++ b/src/node/game/core.cljs
@@ -122,16 +122,12 @@
                                once-key optional prompt choices end-turn player] :as ability}
                        {:keys [title cid counter advance-counter] :as card}
                        targets]
-  (.log js/console "in resolve-ability")
-  (.log js/console (str "check it " (pr-str choices)))
-  (.log js/console (str "corp got " (pr-str (-> @state side :credit))))
   (when (and optional
              (not (get-in @state [once (or once-key cid)]))
              (or (not (:req optional)) ((:req optional) state side card targets)))
     (optional-ability state side card (:prompt optional) optional targets))
   (if choices
     (let [cs (if (sequential? choices) choices (choices state side card targets))]
-      (.log js/console (str "resolve-ability called for " (:title card)))
       (prompt! state (or player side) card prompt cs (dissoc ability :choices)))
     (when (and (not (get-in @state [once (or once-key cid)]))
                (or (not req) (req state side card targets))
@@ -146,8 +142,7 @@
         (when msg
           (let [desc (if (string? msg) msg (msg state side card targets))]
             (system-msg state side (str "uses " title (when desc (str " to " desc))))))        
-        (when effect (.log js/console "'bout to call effect") (effect state side c targets)
-              (.log js/console "called effect"))
+        (when effect (effect state side c targets))
         (when end-turn
           (swap! state update-in [side :register :end-turn]
                  #(conj % {:ability end-turn :card card :targets targets}))))
@@ -268,6 +263,7 @@
         state (atom
                {:gameid gameid :log [] :active-player :runner :end-turn true
                 :access-queue []
+                :cards-accessed 0
                 :corp {:user (:user corp) :identity corp-identity
                        :deck (zone :deck (drop 5 corp-deck))
                        :hand (zone :hand (take 5 corp-deck))
@@ -358,25 +354,20 @@
     (trigger-event state :runner :agenda-stolen c)))
 
 (declare register-pending-input)
+(declare deregister-pending-input)
 (defn psi-game [{:keys [ability-corp-win ability-runner-win]}]
   (effect-with-pending-input
    (resolve-ability
-    {:prompt (do (.log js/console "NI")
-                 #(str "Secretly spend how many credits for " (:title %3) "?"))
-     :choices (req (do (.log js/console (pr-str (str "heerrrrp "
-                                                     (->
-                                                      @state
-                                                      side :credit))))
-                       (map str
-                            (filter #(>= (-> @state side :credit) %)
-                                    [0 1 2]))))
+    {:prompt #(str "Secretly spend how many credits for " (:title %3) "?")
+     :choices (req (map str
+                        (filter #(>= (-> @state side :credit) %)
+                                [0 1 2])))
      :effect
      (effect-with-pending-input    
       (resolve-ability
        :runner
        {:prompt
-        (do ; (.log js/console "HAO")
-            #(str "Secretly spend how many credits for " (:title %3) "?"))
+        #(str "Secretly spend how many credits for " (:title %3) "?")
         :choices
         (req (map str
                   (filter #(>= (-> @state :runner :credit) %)
@@ -386,6 +377,8 @@
           (effect-with-pending-input
            (system-msg :runner (str "paid " target))
            (system-msg :corp (str "paid " corp-paid))
+           (pay :runner card :credit (let [runner-paid (int target)] runner-paid))
+           (pay :corp card :credit corp-paid)
            ; NB: here target is bound to result of runner prompt
            (resolve-ability (let [runner-paid (int target)]
                               (if (not= runner-paid corp-paid)
@@ -423,8 +416,6 @@
   (swap! state assoc :access true)
   (let [c card]    
     (when-let [access-effect (:access (card-def c))]
-      (.log js/console "in handle-access")
-      (.log js/console (str "before entering " (pr-str (keys access-effect))))
       (resolve-ability state (to-keyword (:side c)) access-effect c nil))
     (when (not (:pending-input @state))
       (normal-access state side c))))
@@ -477,24 +468,25 @@
       (resolve-ability state side end-run-effect nil [(first server)])))
   (swap! state assoc :run nil))
 
-(defn access-queue [state side cards]
+(defn access-queue [state side cards first-card-num]
   (let [f (fn [n cards]
             (let [c (first cards)]
-              (system-msg state side (str "Accessing card #: " n))
-              (.log js/console "calling access-queue for " (:title c))
-              (handle-access state side c)
-              (if-not (or (:pending-input state)
-                          (empty? (rest cards)))
-                (recur (inc n) (rest cards))                 
-                (rest cards))))
-        cards-pending (f 1 cards)]
+              (if-not (or (:pending-input @state)
+                          (empty? cards))
+                (do (system-msg state side (str "Accessing card #: " n))
+                    (handle-access state side c)
+                    (recur (inc n) (rest cards)))                 
+                cards)))
+        number-to-access (count cards)
+        cards-pending (f first-card-num cards)]
     (swap! state assoc-in [:pending-accesses] cards-pending)
+    (swap! state assoc-in [:cards-accessed] (- number-to-access (count cards-pending)))
     (if (empty? cards-pending) ; FIXME: Add logic here for Raymond Flint, Shiro, et al
       (handle-end-run state side))))
 
 (defn do-access [state side server]
-  (let [cards (access state side server)]    
-    (access-queue state side cards)))
+  (let [cards (access state side server)]
+    (access-queue state side cards 1)))
 
 (defn successful-run [state side]
   (when-let [successful-run-effect (get-in @state [:run :run-effect :successful-run])]
@@ -678,11 +670,16 @@
   (swap! state assoc-in [:runner :register :prevent-steal] true))
 
 (defn register-pending-input [state side card targets]
-  (.log js/console "registering pending input")
-  (swap! state assoc-in [:pending-input] true))
+  (swap! state assoc-in [:pending-input] true)
+  (let [other-side (if (= side :corp) :runner :corp)]
+    (prompt! state other-side card
+             (str "Waiting for other player's input on card: " (:title card))
+             ["OK"] {})))
 
 (defn deregister-pending-input [state side card targets]
-  (swap! state assoc-in [:pending-input] false))
+  (swap! state assoc-in [:pending-input] false)
+  (let [other-side (if (= side :corp) :runner :corp)]
+    (swap! state update-in [other-side :prompt] rest)))
 
 (defn prevent-jack-out [state side]
   (swap! state assoc-in [:run :cannot-jack-out] true))

--- a/src/node/game/macros.clj
+++ b/src/node/game/macros.clj
@@ -52,6 +52,9 @@
                 'corp-reg '(get-in @state [:corp :register])
                 'runner-reg '(get-in @state [:runner :register])
                 'target '(first targets)]
+           (when ~'target
+             (~'deregister-pending-input ~'state ~'side ~'card nil))
            (do ~@actions)
-           (~'register-pending-input ~'state ~'side ~'card nil)
+           (when-not ~'target
+             (~'register-pending-input ~'state ~'side ~'card nil))
              ))))

--- a/src/node/game/macros.clj
+++ b/src/node/game/macros.clj
@@ -40,3 +40,18 @@
             'runner-reg '(get-in @state [:runner :register])
             'target '(first targets)]
        (str ~@expr))))
+
+(defmacro effect-with-pending-input [& expr]
+  `(fn ~['state 'side 'card 'targets]
+     ~(let [actions (map #(if (#{:runner :corp} (second %))
+                            (concat [(first %) 'state (second %)] (drop 2 %))
+                            (concat [(first %) 'state 'side] (rest %)))
+                         expr)]
+        `(let ~['runner '(:runner @state)
+                'corp '(:corp @state)
+                'corp-reg '(get-in @state [:corp :register])
+                'runner-reg '(get-in @state [:runner :register])
+                'target '(first targets)]
+           (do ~@actions)
+           (~'register-pending-input ~'state ~'side ~'card nil)
+             ))))


### PR DESCRIPTION
Important additions:

Accessing has been reworked so that access effects (like psi games) that require input from one or both players will cause the cards remaining to be accessed to be pushed into a queue until all of the necessary input has been secured.  To facilitate this, two new keys have been added to the game state, `:pending-accesses` and `cards-accessed`.  The former holds a list of cards that will be accessed after the current access is resolved, the latter is used to correctly print a message stating which card (#1, #2, etc) the runner is currently accessing when processing of the queue begins again.

These kinds of effects are created with the macro `effect-with-pending-input`, which works the same way as `effect`, except that it causes `(:pending-input @state)` (which the new access system checks in order to ensure that it's OK to proceed with accessing) to return true when the ability resolves without a target (setting the relevant user's prompt and setting the other user's prompt to indicate waiting for input) and causing it to return nil when the ability resolves with a target (which happens when the relevant user clicks an option in his/her prompt).

Note that access abilities are responsible for restarting the access queue, so any access ability created with `effect-with-pending-input` must end with a call to

`(access-queue (:pending-accesses @state)
                               (+ 1 (:cards-accessed @state)))`

to ensure that accessing cards resumes after the input-dependent access effect is resolved.

Psi games have been implemented using the new `effect-with-pending-input` infrastructure.