### PR TITLE
netrunnerdb specifies cards restricted to 1 copy

### DIFF
--- a/data/fetch.coffee
+++ b/data/fetch.coffee
@@ -43,10 +43,8 @@ cardFields = [
 
 baseurl = "http://netrunnerdb.com/api/"
 
-restricted = ["Director Haas' Pet Project", "Philotic Entanglement", "Eden Shard", "Eden Fragment", "Hades Shard", "Hades Fragment", "Utopia Shard", "Uptopia Fragment", "Government Takeover"]
-
 selectFields = (fields, objectList) ->
-  ((fields.reduce ((newObj, key) -> newObj[key] = obj[key]; newObj["limit"] = 1 if obj.title in restricted; newObj), {}) for obj in objectList)
+  ((fields.reduce ((newObj, key) -> newObj[key] = obj[key]; newObj["limit"] = 1 if obj["limited"]; newObj), {}) for obj in objectList)
 
 # request.get baseurl + "sets", (error, response, body) ->
 #   if !error and response.statusCode is 200


### PR DESCRIPTION
Take advantage of the fact that netrunnerdb (now) specifies a `limited` field, to avoid hard-coding the list of cards restricted to one copy per deck.