### PR TITLE
up bcrypt to 0.8.1 for node 0.12.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "server.coffee",
   "dependencies": {
     "async": "*",
-    "bcrypt": "~0.7.8",
+    "bcrypt": "~0.8.1",
     "connect-mongo": "~0.4.1",
     "express": "~3.4.7",
     "jade": "*",


### PR DESCRIPTION
bcrypt doesn't build with node 0.10 which makes this app fail at the `npm install` step. I upgraded to latest (0.8.1) and the install completed successfully. I didn't see any API changes in the bcrypt release notes and initial tests didn't yield any errors. This upgrade also makes the app run on latest stable iojs.