### PR TITLE
Fixed Crash Space (and other cards using recurring credits) menu item text

### DIFF
--- a/src/node/game/core.cljs
+++ b/src/node/game/core.cljs
@@ -297,7 +297,7 @@
                     (conj (:abilities cdef) "Use [Recurring Credits]")
                     (:abilities cdef))
         abilities (for [ab abilities]
-                    (or (:label ab) (and (string? (:msg ab)) (capitalize (:msg ab))) ""))
+                    (or (:label ab) (and (string? (:msg ab)) (capitalize (:msg ab))) "Use [Recurring Credits]"))
         data (if-let [recurring (:recurring cdef)]
                (assoc (:data cdef) :counter recurring)
                (:data cdef))


### PR DESCRIPTION
This fixes #125 where Crash Space has a blank menu option for using the recurring credit on it. I've added the text to show the appropriate text to use the recurring credit. This fix will extend to all cards using recurring credits.