### PR TITLE
Implement Security Testing; implement Mother Goddess dynamic subtyping

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2547,7 +2547,55 @@
                  :effect (req (corp-install state side target (:server run)))}]}
 
    "Mother Goddess"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :events {
+      :rez {
+         :req (req (= (:type target) "ICE")) 
+         :effect (req (let [allice (->> (flatten (seq (:servers corp))) (map #(:ices %)) (filter #(not (nil? %))) flatten
+                              (filter #(and (:rezzed %) (not= (:cid card) (:cid %)))))
+                            allsubtypes (->> allice 
+                              (map #(vec (.split (:subtype %) " - "))) flatten)
+                            newtypes (clojure.string/join " - " (distinct (cons "Mythic" allsubtypes)))]
+            (resolve-ability state side {
+               :msg (msg "gain subtypes " newtypes)
+               :effect (req(let [c (assoc card :subtype newtypes)]
+                  (update! state side c)
+               ))
+            } card nil)
+         ))
+      }
+      :trash {
+         :req (req (= (:type target) "ICE")) 
+         :effect (req (let [allice (->> (flatten (seq (:servers corp))) (map #(:ices %)) (filter #(not (nil? %))) flatten
+                              ; the trash event triggers while the ice is still installed, so the filter must rule out the target
+                              (filter #(and (:rezzed %) (not= (:cid card) (:cid %)) (not= (:cid target) (:cid %)))))
+                            allsubtypes (->> allice 
+                              (map #(vec (.split (:subtype %) " - "))) flatten)
+                            newtypes (clojure.string/join " - " (distinct (cons "Mythic" allsubtypes)))]
+            (resolve-ability state side {
+               :msg (msg "gain subtypes " newtypes)
+               :effect (req(let [c (assoc card :subtype newtypes)]
+                  (update! state side c)
+               ))
+            } card nil)
+         ))
+      }
+      :derez {
+         :req (req (= (:type target) "ICE")) 
+         :effect (req (let [allice (->> (flatten (seq (:servers corp))) (map #(:ices %)) (filter #(not (nil? %))) flatten
+                              (filter #(and (:rezzed %) (not= (:cid card) (:cid %)))))
+                            allsubtypes (->> allice 
+                              (map #(vec (.split (:subtype %) " - "))) flatten)
+                            newtypes (clojure.string/join " - " (distinct (cons "Mythic" allsubtypes)))]
+            (resolve-ability state side {
+               :msg (msg "gain subtypes " newtypes)
+               :effect (req(let [c (assoc card :subtype newtypes)]
+                  (update! state side c)
+               ))
+            } card nil)
+         ))
+      }
+      }}
 
    "Muckraker"
    {:effect (effect (gain :bad-publicity 1))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -530,7 +530,7 @@
 
    "Edward Kim: Humanitys Hammer"
    {:events {:access {:req (req (= (:type target) "Operation")) :once :per-turn
-                      :msg (msg "trash " (:title target)) :effect (effect (trash-no-cost))}}}
+                      :msg (msg "trash " (:title target)) :effect (effect (trash target))}}}
 
    "Efficiency Committee"
    {:data {:counter 3}
@@ -758,7 +758,7 @@
 
    "Hades Shard"
    {:abilities [{:msg "access all cards in Archives"
-                 :effect (effect (handle-access (:discard corp)) (trash card))}]}
+                 :effect (effect (trash card) (access [:archives]))}]}
 
    "Hard at Work"
    {:events {:runner-turn-begins {:msg "gain 2 [Credits] and lose [Click]"
@@ -835,7 +835,7 @@
 
    "Ice Analyzer"
    {:events {:rez {:req (req (= (:type target) "ICE")) :msg "place 1 [Credits] on Ice Analyzer"
-                   :effect (effect (add-prop card :counter 1))}}
+                   :effect (effect (add-prop :runner card :counter 1))}}
     :abilities [{:counter-cost 1 :effect (effect (gain :credit 1))
                  :msg "take 1 [Credits] to install programs"}]}
 
@@ -1883,6 +1883,13 @@
    "Turtlebacks"
    {:events {:server-created {:msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
+   "Tyrs Hand"
+   {:abilities [{:label "Prevent a subroutine on a Bioroid from being broken"
+                 :req (req (prn "tyr" (:zone current-ice) (:zone card))
+                       (and (= (butlast (:zone current-ice)) (butlast (:zone card)))
+                                (has? current-ice :subtype "Bioroid"))) :effect (effect (trash card))
+                 :msg (msg "prevent a subroutine on " (:title current-ice) " from being broken")}]}
+
    "Tyson Observatory"
    {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "adds " (:title target) " to his Grip")
                  :choices (req (filter #(has? % :type "Hardware") (:deck runner)))
@@ -2263,7 +2270,7 @@
                  :effect #(do (swap! %1 assoc-in [:run :position] 0) (derez %1 %2 %3))}]}
 
    "Changeling"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:advanceable true :abilities [{:msg "end the run" :effect (effect (end-run))}]}
 
    "Checkpoint"
    {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -762,7 +762,8 @@
 
 (defn derez [state side card]
   (system-msg state side (str "derez " (:title card)))
-  (update! state :corp (desactivate state :corp card true)))
+  (update! state :corp (desactivate state :corp card true))
+  (trigger-event state side :derez card))
 
 (defn advance [state side {:keys [card]}]
   (when (pay state side card :click 1 :credit 1)


### PR DESCRIPTION
This adds automated support for Security Testing. I have not worked with Clojure before, so comments on style are welcome.

When turn begins, S.T. prompts to choose a server. After the prompt, the card's state is updated with key :security-testing-target associated with a vector holding the target server. 

On successful run, :once :per-turn, S.T. checks its state to see if the :run's :server is the same as its :security-testing-target value. If so, we change the game state to override the run's :replace-access with a new function that gains 2 credits with no access. 

I have tested the following scenarios, beyond the simple run-on-S.T.-server:

1. Any event that triggers a run on a S.T. server (Indexing, Legwork, Account Siphon, etc.): card's instead-of-access is ignored, gain 2 credits, no option on whether to access (Siphon, Indexing).
2. Multiple S.T. on the same server: the first run on the server gains 2 credits with no access. Subsequent runs gain access.
3. Multiple S.T. on different servers: the first run on each server gains 2 credits with no access.
4. Bonus effects from other cards on successful run (Dirty Laundry, Desperado, John Masanori) still trigger.

I have not tested:

1. S.T. on HQ, Sneakdoor Beta. Expected: S.T. triggers after Sneakdoor, gain 2 credits no access. Actual: ???
2. S.T. on Archives, Sneakdoor Beta: Expected: Sneakdoor switches to H.Q., S.T. does not trigger. Actual: ???

(My instinct is that the Sneakdoor Beta interaction will depend on what order the successful-run events are called on the two cards.)

Known issues:

1. S.T. on Jackson Howard, J.H. removed from game before run is complete. No credits gained (EXPECTED). However, the game then "shifts" remove servers down to fill the hole left by Jackson. If you run the "new" server with the same number that Jackson had, S.T. will trigger. I don't know how to resolve, as I don't see a way of handling a "run is over because server disappeared" event. Same thing would happen with Self Destruct.