### PR TITLE
Fix for Security Testing and Comet.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -317,7 +317,7 @@
                    :effect (effect (draw :runner))}}}
 
    "Comet"
-   (:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
+   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
     :events {:play-event
              {:optional {:prompt "Play another event?" :once :per-turn
                          :effect (effect (resolve-ability
@@ -1609,7 +1609,7 @@
                                     {:mandatory true
                                      :effect (effect (resolve-ability
                                                       {:msg "gain 2 [Credits] instead of accessing"
-                                                       :effect (gain :credit 2)} st nil))})))}}}
+                                                       :effect (effect (gain :credit 2))} st nil))})))}}}
 
    "Self-modifying Code"
    {:abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))


### PR DESCRIPTION
This fixes the syntax error in Comet and the code cleanup of Security Testing.

Users on the live site reported that S.T. wasn't working. Quote:

>On an unrelated note, Security Testing has been implemented, but incorrectly. It is giving the runner the option whether or not to use it when they complete the run. Security Testing is a REQUIRED conditional ability, unlike, say, Account Siphon, which uses the phrase "the runner MAY..."
>It also is not working with desperado. Only crediting the runner 2 credits instead of 3. Actually it is only giving 1 credit, not 3."

I can't reproduce the first issue, but I have confirmed the second, and more generally that the `:effect` of S.T.'s `:successful-run` wasn't triggering. I reinstated the `(effect ..)` around the `(gain :credit 2)` that had been removed, and that has resolved the issue. I don't know enough about the system to surmise WHY this is the fix, but it works :).