### PR TITLE
Implement Scavenge; fix placing tokens on :advanceable :while-rezzed

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -156,7 +156,7 @@
    "Blue Sun: Powering the Future"
    {:abilities [{:msg (msg "add " (:title target) " to HQ and gain " (:cost target) " [Credits]")
                  :choices {:req #(:rezzed %)}
-                 :effect (effect (gain :credit (:cost target)) (move (assoc target :rezzed false) :hand))}]}
+                 :effect (effect (gain :credit (:cost target)) (move target :hand))}]}
 
    "Big Brother"
    {:req (req tagged) :effect (effect (gain :runner :tag 2))}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -491,7 +491,7 @@
    "Dorm Computer"
    {:data {:counter 4}
     :abilities [{:counter-cost 1 :cost [:click 1]
-                 :prompt "Choose a server" :choices (req servers) 
+                 :prompt "Choose a server" :choices (req servers)
                  :msg "make a run and avoid all tags for the remainder of the run"
                  :effect (effect (run target))}]}
 
@@ -1908,6 +1908,27 @@
    {:abilities [{:cost [:click 1] :msg "gain 2 [Credits]" :once :per-turn
                  :effect (effect (gain :credit 2))}]
     :leave-play (effect (damage :meat 3))}
+
+   "Trick of Light"
+   {:choices {:req #(and (contains? % :advance-counter) (> (:advance-counter %) 0))}
+    :effect  (req (let [fr target tol card]
+                       (resolve-ability state side
+                         {:prompt  "Move how many advancement tokens?"
+                          :choices (take (+ (:advance-counter fr) 1) ["0" "1" "2"])
+                          :effect  (req (let [c (Integer/parseInt target)]
+                                             (resolve-ability state side
+                                               {:prompt  "Move to where?"
+                                                ; valid targets: not the "from" card; advanceable always, or advanceable and rezzed, or agenda
+                                                :choices {:req #(and (not= (:cid fr) (:cid %))
+                                                                     (or (and (:advanceable %) (or (= (:advanceable %) "always") (:rezzed %)))
+                                                                         (= (:type %) "Agenda")))}
+                                                :effect  (effect (add-prop :corp target :advance-counter c)
+                                                                 (set-prop :corp fr :advance-counter (- (:advance-counter fr) c))
+                                                                 (system-msg (str "moves " c " advancement tokens from "
+                                                                                  (if (:rezzed fr) (:title fr) "a card") " to "
+                                                                                  (if (:rezzed target) (:title target) "a card"))))
+                                                } tol nil)))
+                          } card nil)))}
 
    "Turtlebacks"
    {:events {:server-created {:msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1569,19 +1569,21 @@
 
    "Scavenge"
    {:choices {:req #(= (:type %) "Program")}
-    :effect  (req (let [pr target]
-                       (trash state side pr)
+    :effect  (req (let [trashed target]
+                       (trash state side trashed)
                        (resolve-ability state side
                                         {:prompt  "Install a card from Grip or Heap?" :choices ["Grip" "Heap"]
-                                         :msg (msg "install a card from " target)
-
                                          :effect  (req (let [fr target]
+                                                            (system-msg state side (str "trashes " (:title trashed)
+                                                                                        " to install a card from " fr))
                                                             (resolve-ability state side
                                                               {:prompt "Choose a program to install"
-                                                               :choices (req (filter #(= (:type %) "Program")
+                                                               :choices (req (filter #(and (= (:type %) "Program")
+                                                                                           (<= (:cost %) (+ (:credit runner) (:cost trashed))))
                                                                                      ((if (= fr "Grip") :hand :discard ) runner)))
-                                                               :effect (effect (gain :credit (min (:cost target) (:cost pr)))
+                                                               :effect (effect (gain :credit (min (:cost target) (:cost trashed)))
                                                                                (runner-install target))
+
                                                                } card nil)))
                                          } card nil)))}
 

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -97,7 +97,9 @@
    {:data {:counter 1}
     :abilities [{:counter-cost 1 :msg (msg "place 1 advancement token on "
                                            (if (:rezzed target) (:title target) "a card"))
-                 :choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
+                 :choices {:req #(or (= (:advanceable %) "always")
+                                     (and (= (:advanceable %) "while-rezzed") (:rezzed %))
+                                     (= (:type %) "Agenda"))}
                  :effect (effect (add-prop target :advance-counter 1))}]}
 
    "Argus Security: Protection Guaranteed"
@@ -1677,7 +1679,9 @@
                               card targets))}}
 
    "Shipment from Kaguya"
-   {:choices {:max 2 :req #(or (= (:type %) "Agenda") (:advanceable %))}
+   {:choices {:max 2 :req #(or (= (:advanceable %) "always")
+                               (and (= (:advanceable %) "while-rezzed") (:rezzed %))
+                               (= (:type %) "Agenda"))}
     :msg (msg "1 advancement tokens on " (count targets) " cards")
     :effect (req (doseq [t targets] (add-prop state :corp t :advance-counter 1)))}
 
@@ -1685,7 +1689,9 @@
    {:choices ["0", "1", "2"] :prompt "How many advancement tokens?"
     :effect (req (let [c (Integer/parseInt target)]
                    (resolve-ability state side
-                    {:choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
+                    {:choices {:req #(or (= (:advanceable %) "always")
+                                         (and (= (:advanceable %) "while-rezzed") (:rezzed %))
+                                         (= (:type %) "Agenda"))}
                      :msg (msg "add " c " advancement tokens on a card")
                      :effect (effect (add-prop :corp target :advance-counter c))} card nil)))}
 

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -154,7 +154,7 @@
    "Blue Sun: Powering the Future"
    {:abilities [{:msg (msg "add " (:title target) " to HQ and gain " (:cost target) " [Credits]")
                  :choices {:req #(:rezzed %)}
-                 :effect (effect (gain :credit (:cost target)) (move target :hand))}]}
+                 :effect (effect (gain :credit (:cost target)) (move (assoc target :rezzed false) :hand))}]}
 
    "Big Brother"
    {:req (req tagged) :effect (effect (gain :runner :tag 2))}
@@ -1566,6 +1566,24 @@
                  :prompt "Choose a program to install"
                  :choices (req (filter #(= (:type %) "Program") (:hand runner)))
                  :effect (effect (runner-install target))}]}
+
+   "Scavenge"
+   {:choices {:req #(= (:type %) "Program")}
+    :effect  (req (let [pr target]
+                       (trash state side pr)
+                       (resolve-ability state side
+                                        {:prompt  "Install a card from Grip or Heap?" :choices ["Grip" "Heap"]
+                                         :msg (msg "install a card from " target)
+
+                                         :effect  (req (let [fr target]
+                                                            (resolve-ability state side
+                                                              {:prompt "Choose a program to install"
+                                                               :choices (req (filter #(= (:type %) "Program")
+                                                                                     ((if (= fr "Grip") :hand :discard ) runner)))
+                                                               :effect (effect (gain :credit (min (:cost target) (:cost pr)))
+                                                                               (runner-install target))
+                                                               } card nil)))
+                                         } card nil)))}
 
    "Scorched Earth"
    {:req (req tagged) :effect (effect (damage :meat 4))}


### PR DESCRIPTION
My implementation for Scavenge, based on code for Test Run (select Heap or Grip to install from) and Modded (reduce cost of install by gaining credits first). Also fixes issue #191 by applying filter from Trick of Light to Shipment from Kaguya/SanSan and AstroScript Pilot Program.

Reasonably straightforward implementation. Feel free to tweak the messaging; right now, the players see:

> nealterrell plays Scavenge.
> nealterrell trashes Femme Fatale to install a card from Heap.
> nealterrell installs Femme Fatale

when using Scavenge to trash and reinstall Femme.

Also, the filter for choosing which card to install from Grip/Heap will only show programs that the Runner can afford to install with the Scavenge discount. Other cards like SMC don't add this filter, so feel free to remove it. If the filter is not there, the Runner can choose a program they cannot afford, but the install fails and nothing happens (as expected).

I have tested the expected interactions: Scavenge a Lady to refresh tokens; Scavenge a program played via Test Run to prevent it from going back on the Stack; Scavenge a Cache to refresh tokens.