### PR TITLE
Implement Hivemind

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -704,8 +704,8 @@
    {:abilities [{:cost [:click 2] :effect (effect (gain :credit 3)) :msg "gain 3 [Credits]"}]}
 
    "Gorman Drip v1"
-   {:abilities [{:cost [:click 1] :effect (effect (gain :credit (:counter card)) (trash card))
-                 :msg (msg "gain " (:counter card) " [Credits]")}]
+   {:abilities [{:cost [:click 1] :effect (effect (gain :credit (get-virus-counters state side card)) (trash card))
+                 :msg (msg "gain " (get-virus-counters state side card) " [Credits]")}]
     :events {:corp-click-credit {:effect (effect (add-prop :runner card :counter 1))}
              :corp-click-draw {:effect (effect (add-prop :runner card :counter 1))}}}
 
@@ -805,6 +805,33 @@
    {:data {:counter 1}
     :abilities [{:cost [:click 1] :counter-cost 1 :msg (msg "gain" (:credit runner) " [Credits]")
                  :effect (effect (gain :credit (:credit runner)))}]}
+
+
+   "Hivemind"
+   {:data {:counter 1 :counter-type "Virus"}
+    :abilities [{:req (req (> (:counter card) 0))
+                 :prompt "Move a virus counter to which card?"
+                 :priority true
+                 :choices {:req #(has? % :subtype "Virus")}
+                 :effect (req (let [abilities (:abilities (card-def target)) virus target]
+                              (add-prop state :runner virus :counter 1)
+                              (add-prop state :runner card :counter -1)
+                              (if (= (count abilities) 1)
+                                ((swap! state update-in [side :prompt] rest) ; remove the Hivemind prompt so Imp works
+                                  (resolve-ability state side (first abilities) (get-card state virus) nil))
+                                (resolve-ability
+                                  state side {
+                                              :prompt "Choose an ability to trigger"
+                                              :choices (vec (map :msg abilities))
+                                              :effect (req
+                                                        (swap! state update-in [side :prompt] rest)
+                                                        (resolve-ability
+                                                             state side (first (filter #(= (:msg %) target) abilities))
+                                                             card nil))
+                                              } (get-card state virus) nil))
+                              ))
+                 :msg (msg "to trigger an ability on " (:title target))}]}
+
 
    "Hokusai Grid"
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"
@@ -1077,9 +1104,11 @@
    {:effect (effect (gain :credit 8) (gain :runner :credit 3))}
 
    "Medium"
-   {:events {:successful-run {:req (req (= target :rd))
-                              :effect (effect (access-bonus (:counter card))
-                                              (add-prop card :counter 1))}}}
+   {:events
+    {:successful-run
+     {:req (req (= target :rd))
+      :effect (effect (add-prop card :counter 1)
+                      (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}}
 
    "Melange Mining Corp."
    {:abilities [{:cost [:click 3] :effect (effect (gain :credit 7)) :msg "gain 7 [Credits]"}]}
@@ -1144,9 +1173,12 @@
                        :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Nerve Agent"
-   {:events {:successful-run {:req (req (= target :hq))
-                              :effect (effect (access-bonus (:counter card))
-                                              (add-prop card :counter 1))}}}
+   {:events
+    {:successful-run
+     {:req (req (= target :hq))
+      :effect (effect (add-prop card :counter 1)
+                      (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}}
+
    "Net Celebrity"
    {:recurring 1}
 
@@ -2874,7 +2906,7 @@
    "Deep Thought"
    {:events {:successful-run {:effect (effect (add-prop card :counter 1)) :req (req (= target :rd))}
              :runner-turn-begins
-             {:req (req (>= (:counter card) 3)) :msg "look at the top card of R&D"
+             {:req (req (>= (get-virus-counters state side card) 3)) :msg "look at the top card of R&D"
               :effect (effect (prompt! card (str "The top card of your R&D is "
                                                  (:title (first (:deck corp)))) ["OK"] {}))}}}
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -151,11 +151,15 @@
 
 (declare resolve-ability)
 
-(defn show-prompt [state side card msg choices f]
-  (let [prompt (if (string? msg) msg (msg state side card nil))]
+(defn show-prompt
+  ([state side card msg choices f] (show-prompt state side card msg choices f nil))
+  ([state side card msg choices f priority]
+    (let [prompt (if (string? msg) msg (msg state side card nil))]
     (when (or (#{:credit :counter} choices) (> (count choices) 0))
       (swap! state update-in [side :prompt]
-             #(conj (vec %) {:msg prompt :choices choices :effect f :card card})))))
+             (if priority
+               #(cons {:msg prompt :choices choices :effect f :card card} (vec %))
+               #(conj (vec %) {:msg prompt :choices choices :effect f :card card})))))))
 
 (defn resolve-psi [state side card psi bet]
   (swap! state assoc-in [:psi side] bet)
@@ -176,8 +180,10 @@
                  (map #(str % " [Credits]") (range (min 3 (inc (get-in @state [s :credit])))))
                  #(resolve-psi state s card psi (Integer/parseInt (first (split % #" ")))))))
 
-(defn prompt! [state side card msg choices ability]
-  (show-prompt state side card msg choices #(resolve-ability state side ability card [%])))
+(defn prompt!
+  ([state side card msg choices ability] (prompt! state side card msg choices ability nil))
+  ([state side card msg choices ability priority]
+    (show-prompt state side card msg choices #(resolve-ability state side ability card [%]) priority)))
 
 (defn optional-ability [state side card msg ability targets]
   (show-prompt state side card msg ["Yes" "No"] #(if (= % "Yes")
@@ -215,19 +221,21 @@
   (swap! state assoc-in [side :selected] nil)
   (swap! state update-in [side :prompt] rest))
 
-(defn show-select [state side card ability]
-  (swap! state assoc-in [side :selected]
-         {:ability (dissoc ability :choices) :req (get-in ability [:choices :req])
-          :max (get-in ability [:choices :max])})
-  (show-prompt state side card
-               (if-let [m (get-in ability [:choices :max])]
-                 (str "Select up to " m " targets for " (:title card))
-                 (str "Select a target for " (:title card)))
-               ["Done"] (fn [choice] (resolve-select state side))))
+(defn show-select
+  ([state side card ability] (show-select state side card ability nil))
+  ([state side card ability priority]
+    (swap! state assoc-in [side :selected]
+           {:ability (dissoc ability :choices) :req (get-in ability [:choices :req])
+            :max (get-in ability [:choices :max])})
+    (show-prompt state side card
+                 (if-let [m (get-in ability [:choices :max])]
+                         (str "Select up to " m " targets for " (:title card))
+                         (str "Select a target for " (:title card)))
+                 ["Done"] (fn [choice] (resolve-select state side)) priority)))
 
 (defn resolve-ability [state side {:keys [counter-cost advance-counter-cost cost effect msg req once
                                           once-key optional prompt choices end-turn player psi trace
-                                          not-distinct] :as ability}
+                                          not-distinct priority] :as ability}
                        {:keys [title cid counter advance-counter] :as card} targets]
   (when ability
     (when (and optional
@@ -243,13 +251,13 @@
                (or (not req) (req state side card targets)))
       (if choices
         (if (map? choices)
-          (show-select state (or player side) card ability)
+          (show-select state (or player side) card ability priority)
           (let [cs (if-not (fn? choices)
                      choices
                      (let [cards (choices state side card targets)]
                              (if not-distinct
                                cards (distinct-by :title cards))))]
-            (prompt! state (or player side) card prompt cs (dissoc ability :choices))))
+            (prompt! state (or player side) card prompt cs (dissoc ability :choices) priority)))
         (when (and (or (not counter-cost) (<= counter-cost counter))
                    (or (not advance-counter-cost) (<= advance-counter-cost advance-counter))
                    (apply pay (concat [state side card] cost)))
@@ -628,7 +636,9 @@
                p (assoc p :current-strength nil))))
     (system-msg state side "continues the run")))
 
+
 (defn play-ability [state side {:keys [card ability targets] :as args}]
+      (system-msg state side (str "play ability"))
   (let [cdef (card-def card)
         abilities (:abilities cdef)
         ab (if (= ability (count abilities))
@@ -664,6 +674,10 @@
     (when (or (has? card :subtype "Virus") (= (:counter-type card) "Virus"))
       (set-prop state :runner card :counter 0)))
   (trigger-event state side :purge))
+
+(defn get-virus-counters [state side card]
+   (let [hiveminds (filter #(= (:title %) "Hivemind") (get-in @state [:runner :rig :program]))]
+        (reduce + (map :counter (cons card hiveminds)))))
 
 (defn play-instant
   ([state side card] (play-instant state side card nil))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -641,7 +641,6 @@
                p (assoc p :current-strength nil))))
     (system-msg state side "continues the run")))
 
-
 (defn play-ability [state side {:keys [card ability targets] :as args}]
   (let [cdef (card-def card)
         abilities (:abilities cdef)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -643,7 +643,6 @@
 
 
 (defn play-ability [state side {:keys [card ability targets] :as args}]
-      (system-msg state side (str "play ability"))
   (let [cdef (card-def card)
         abilities (:abilities cdef)
         ab (if (= ability (count abilities))


### PR DESCRIPTION
This submission implements Hivemind and its interactions with existing virus programs.

### Core changes

1. Added a function get-virus-counters which returns the number of virus counters on target card, PLUS the number of counters on an installed Hivemind, if any. In effect, the function counts how many virus counters a card should "see".
2. Added support for a `:priority true` key for prompts in effects. If an effect has `:priority true` along with `:prompt`, the prompt shown will be placed at the beginning of the prompt queue instead of the end, forcing the player to resolve it immediately. Needed for Imp support.

### Hivemind implementation
1. Starts with 1 virus counter.
2. Its mere presence will cause some virus cards to "see" that they have extra counters for their effects (see below).
3. Has a single ability to transfer a virus token and immediately trigger an ability on another virus card.
  1. With `:priority`, a token is transferred from Hivemind to a target virus.
  2. If that target has only a single ability, its ability is immediately triggered. 
  3. If that target has multiple abilities, a prompt allows the user to select which to trigger. This functionality is currently unused, since all viruses have only a single ability.
  4. The target ability is run through resolve-ability, meaning any costs or requirements attached to the ability will be enforced. 

### Card updates
1. Medium: grants a token immediately upon successful run, before access. Grants an access-bonus equal to 1 less than its get-virus-count.
2. Nerve Agent: likewise.
3. Gorman Drip: gives 1 credit per get-virus-count.
4. Deep Thought: grants the reveal if get-virus-count is at least 3.

### Other viruses
Going through [this list](http://netrunnerdb.com/find/?q=s%3Avirus&sort=name&view=list&_locale=en)...

1. Cache: Hivemind can trigger.
2. Chakana: not implemented.
3. Clot: N/A.
4. Crypsis: did not fully test. Triggering with Hivemind will probably give it a token, but then trigger the Break 1 Subroutine ability, costing the runner 1cr. Credits can be adjusted manually by runner, and the transferred token can then be sacrificed to keep Crypsis alive.
5. Datasucker: untested, should consume counter and print message.
6. Gravedigger: untested, should consume and mill.
7. Imp: Hivemind can trigger.
8. Incubator: broken; if targeted by Hivemind, will transfer a token to Incubator and then do nothing. In reality, Hivemind should not be able to target Incubator. Will fix.
9. Ixodidae: N/A.
10. Lamprey: N/A.
11. Parasite: has to be manually tracked.
12. Pheromones: not implemented.