### PR TITLE
Implement Shoot the Moon

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1758,6 +1758,21 @@
    "Shock!"
    {:access {:msg "do 1 net damage" :effect (effect (damage :net 1))}}
 
+   "Shoot the Moon"
+   {:effect
+    (req (if (< (:tag runner)
+                (reduce (fn [c server]
+                            (+ c (count (filter (fn [ice] (not (:rezzed ice))) (:ices server)))))
+                        0 (flatten (seq (:servers corp)))))
+           (resolve-ability
+             state side
+             {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))
+                        :max (req (:tag runner))}
+              :effect (req (doseq [t targets] (rez state side t {:no-cost true})))} card nil)
+           (doseq [ice (->> (mapcat :ices (flatten (seq (:servers corp))))
+                  (filter #(not (:rezzed %))))]
+                  (rez state side ice {:no-cost true}))))}
+
    "Silencer"
    {:recurring 1}
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -224,14 +224,15 @@
 (defn show-select
   ([state side card ability] (show-select state side card ability nil))
   ([state side card ability priority]
-    (swap! state assoc-in [side :selected]
-           {:ability (dissoc ability :choices) :req (get-in ability [:choices :req])
-            :max (get-in ability [:choices :max])})
-    (show-prompt state side card
-                 (if-let [m (get-in ability [:choices :max])]
-                         (str "Select up to " m " targets for " (:title card))
-                         (str "Select a target for " (:title card)))
-                 ["Done"] (fn [choice] (resolve-select state side)) priority)))
+    (let [ability (update-in ability [:choices :max] #(if (fn? %) (% state side card nil) %))]
+         (swap! state assoc-in [side :selected]
+                {:ability (dissoc ability :choices) :req (get-in ability [:choices :req])
+                 :max (get-in ability [:choices :max])})
+         (show-prompt state side card
+                      (if-let [m (get-in ability [:choices :max])]
+                              (str "Select up to " m " targets for " (:title card))
+                              (str "Select a target for " (:title card)))
+                      ["Done"] (fn [choice] (resolve-select state side)) priority))))
 
 (defn resolve-ability [state side {:keys [counter-cost advance-counter-cost cost effect msg req once
                                           once-key optional prompt choices end-turn player psi trace

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -641,7 +641,6 @@
                p (assoc p :current-strength nil))))
     (system-msg state side "continues the run")))
 
-
 (defn play-ability [state side {:keys [card ability targets] :as args}]
   (let [cdef (card-def card)
         abilities (:abilities cdef)


### PR DESCRIPTION
Not the most pressing card to implement, but it was an easy job while waiting to hear about Plascrete Carapace in #197.

To support Shoot the Moon, I expanded the capabilities of `:choices` prompts so that the `:max` field can be a function instead of only a constant. The function will be evaluated in `(show-select)` and the result used as the constant for the maximum number of cards that can be selected. This allows Shoot the Moon to use `(:tag runner)` as the max number of ICE to be selected.

The only other detail of interest is that Shoot the Moon will automatically rez all ICE if the number of unrezzed ICE is <= the number of tags. Otherwise the Corp is given the prompt to choose the ICE to rez.