### PR TITLE
Implement Self-destruct, Searchlight

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1687,7 +1687,8 @@
                                                        :effect (effect (gain :credit 2))} st nil))})))}}}
 
    "Self-destruct"
-   {:abilities [{:label "Trace X - Do 3 net damage"
+   {:abilities [{:req (req this-server)
+                 :label "Trace X - Do 3 net damage"
                  :effect (req (let [serv (card->server state card)
                                     cards (concat (:ices serv) (:content serv))]
                                    (trash state side card)

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2774,7 +2774,7 @@
    "Searchlight"
    {:advanceable :always
     :abilities [{:label "Trace X - Give the runner 1 tag"
-                 :trace {:base (req (:advance-counter card)) :effect (effect (gain :runner :tag 1))
+                 :trace {:base (req (or (:advance-counter card) 0)) :effect (effect (gain :runner :tag 1))
                          :msg "give the Runner 1 tag"}}]}
    "Shadow"
    {:advanceable :always

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1686,6 +1686,18 @@
                                                       {:msg "gain 2 [Credits] instead of accessing"
                                                        :effect (effect (gain :credit 2))} st nil))})))}}}
 
+   "Self-destruct"
+   {:abilities [{:label "Trace X - Do 3 net damage"
+                 :effect (req (let [serv (card->server state card)
+                                    cards (concat (:ices serv) (:content serv))]
+                                   (trash state side card)
+                                   (doseq [c cards] (trash state side c))
+                                   (resolve-ability
+                                     state side
+                                     {:trace {:base (req (dec (count cards)))
+                                              :effect (effect (damage :net 3))
+                                              :msg "do 3 net damage"}} card nil)))}]}
+
    "Self-Destruct Chips"
    {:effect (effect (lose :runner :max-hand-size 1))}
 
@@ -2767,8 +2779,9 @@
 
    "Searchlight"
    {:advanceable :always
-    :abilities [{:msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}]}
-
+    :abilities [{:label "Trace X - Give the runner 1 tag"
+                 :trace {:base (req (:advance-counter card)) :effect (effect (gain :runner :tag 1))
+                         :msg "give the Runner 1 tag"}}]}
    "Shadow"
    {:advanceable :always
     :abilities [{:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -205,7 +205,7 @@
         (resolve-ability state :corp kicker card [strength (+ (:link runner) boost)])))))
 
 (defn init-trace [state side card {:keys [base] :as ability} boost]
-  (let [s (+ base boost)]
+  (let [base (if (fn? base) (base state side card nil) base) s (+ base boost)]
     (system-msg state :corp (str "uses " (:title card) " to initiate a trace with strength "
                                  s " (" base " + " boost " [Credits])"))
     (show-prompt state :runner card (str "Boost link strength?") :credit #(resolve-trace state side %))
@@ -501,6 +501,12 @@
       (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
       (trash state side current))
     (trigger-event state :runner :agenda-stolen c)))
+
+(defn card->server [state card]
+  (let [z (:zone card)]
+       (if (= (second z) :remote)
+         (nth (get-in @state [:corp :servers :remote]) (nth z 2))
+         (get-in @state [:corp :servers (second z)]))))
 
 (defn server->zone [state server]
   (if (sequential? server)


### PR DESCRIPTION
Implement dynamic trace strength for Self-destruct and Searchlight. `:trace :base` can now be a function instead of only a constant.

I also added a core function `card->server` to take a card and give back a server for the card's `:zone`. The server is returned as a map with `:content` and `:ices` keys. Self-destruct uses the code to get all cards "in or protecting this server". There may be a better way of implementing this, but I couldn't find any... the closest I saw was Singularity, but that uses a prompt to select the server, instead of the choice being implicit based on the card being used.