### PR TITLE
add reveals to Grail ice

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2590,7 +2590,12 @@
                  :effect (effect (damage :meat 2) (end-run))}]}
 
    "Galahad"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:label "Reveal up to 2 Grail ice from HQ"
+                 :choices {:max 2 :req #(and (:side % "Corp") 
+                                             (= (:zone %) [:hand])
+                                             (has? % :subtype "Grail"))}
+                 :msg (msg "reveal " (join ", " (map :title targets)))}
+                {:msg "end the run" :effect (effect (end-run))}]}
 
    "Gemini"
    {:abilities [{:label "Trace 2"
@@ -2690,7 +2695,12 @@
                  :effect (effect (trash target) (trash card))}]}
 
    "Lancelot"
-   {:abilities [{:prompt "Choose a program to trash" :msg (msg "trash " (:title target))
+   {:abilities [{:label "Reveal up to 2 Grail ice from HQ"
+                 :choices {:max 2 :req #(and (:side % "Corp") 
+                                             (= (:zone %) [:hand])
+                                             (has? % :subtype "Grail"))}
+                 :msg (msg "reveal " (join ", " (map :title targets)))}
+                {:prompt "Choose a program to trash" :msg (msg "trash " (:title target))
                  :label "Trash a program" :choices (req (get-in runner [:rig :program]))
                  :effect (effect (trash target))}]}
 
@@ -2728,7 +2738,12 @@
                  :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
 
    "Merlin"
-   {:abilities [{:msg "do 2 net damage" :effect (effect (damage :net 2))}]}
+   {:abilities [{:label "Reveal up to 2 Grail ice from HQ"
+                 :choices {:max 2 :req #(and (:side % "Corp") 
+                                             (= (:zone %) [:hand])
+                                             (has? % :subtype "Grail"))}
+                 :msg (msg "reveal " (join ", " (map :title targets)))}
+                {:msg "do 2 net damage" :effect (effect (damage :net 2))}]}
 
    "Meru Mati"
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2590,7 +2590,7 @@
                  :effect (effect (damage :meat 2) (end-run))}]}
 
    "Galahad"
-   {:abilities [{:label "Reveal up to 2 Grail ice from HQ"
+   {:abilities [{:label "Reveal up to 2 Grail ICE from HQ"
                  :choices {:max 2 :req #(and (:side % "Corp") 
                                              (= (:zone %) [:hand])
                                              (has? % :subtype "Grail"))}
@@ -2695,7 +2695,7 @@
                  :effect (effect (trash target) (trash card))}]}
 
    "Lancelot"
-   {:abilities [{:label "Reveal up to 2 Grail ice from HQ"
+   {:abilities [{:label "Reveal up to 2 Grail ICE from HQ"
                  :choices {:max 2 :req #(and (:side % "Corp") 
                                              (= (:zone %) [:hand])
                                              (has? % :subtype "Grail"))}
@@ -2738,7 +2738,7 @@
                  :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
 
    "Merlin"
-   {:abilities [{:label "Reveal up to 2 Grail ice from HQ"
+   {:abilities [{:label "Reveal up to 2 Grail ICE from HQ"
                  :choices {:max 2 :req #(and (:side % "Corp") 
                                              (= (:zone %) [:hand])
                                              (has? % :subtype "Grail"))}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2743,7 +2743,7 @@
                                              (= (:zone %) [:hand])
                                              (has? % :subtype "Grail"))}
                  :msg (msg "reveal " (join ", " (map :title targets)))}
-                {:msg "do 2 net damage" :effect (effect (damage :net 2))}]}
+                {:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}]}
 
    "Meru Mati"
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}


### PR DESCRIPTION
Add ability to reveal other Grails to Galahad, Lancelot, and Merlin based on functionality of Celebrity Gift. Maybe it's not quite right but hopefully pretty close. I wasn't sure if I needed nested `#(and (and` but it doesn't look like it, having peeked at Notoriety.