### PR TITLE
Implement damage prevention and boosting cards

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -294,6 +294,7 @@
    "Clone Chip"
    {:prevent [:net]
     :abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
+                 :priority true
                  :choices (req (filter #(and (has? % :type "Program")
                                              (<= (:cost %) (:credit runner))) (:discard runner)))
                  :effect (effect (trash card) (runner-install target))}]}
@@ -1381,7 +1382,7 @@
    "Plascrete Carapace"
    {:data [:counter 4]
     :prevent [:meat]
-    :abilities [{:counter-cost 1 :effect (effect (damage-prevent :meat 1))}]}
+    :abilities [{:counter-cost 1 :msg "prevent 1 meat damage" :effect (effect (damage-prevent :meat 1))}]}
 
    "Priority Requisition"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))}
@@ -1747,6 +1748,7 @@
    "Self-modifying Code"
    {:prevent [:net]
     :abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
+                 :priority true
                  :choices (req (filter #(has? % :type "Program") (:deck runner)))
                  :cost [:credit 2]
                  :effect (effect (trash card) (runner-install target) (shuffle! :deck))}]}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1340,7 +1340,29 @@
 
    "Plascrete Carapace"
    {:data [:counter 4]
-    :abilities [{:counter-cost 1 :msg "prevent 1 meat damage"}]}
+    :events
+          {:pre-damage
+           {:req (req (and (= target :meat) (> (:counter card) 0)))
+            :effect (req (let [plasc card]
+                              (prompt! state :runner card "Use Plascrete Carapace tokens to prevent meat damage?"
+                                  (take (inc (:counter plasc)) ["0" "1" "2" "3" "4"])
+                                  {:effect (req (let [c (Integer/parseInt target)]
+                                                     (damage-bonus state side :meat (- c))
+                                                     (add-prop state :runner plasc :counter (- c))))
+                                   :msg (msg "prevent " target " meat damage")
+                                   })))
+            }}}
+                 ;(req (let [plasc card]
+                 ;             (resolve-ability
+                 ;               state :runner
+                 ;               {:prompt "Use Plascrete Carapace tokens to prevent meat damage?"
+                 ;                :choices (take (inc (:counter plasc)) ["0" "1" "2" "3" "4"])
+                 ;                :effect (req (let [c (Integer/parseInt target)]
+                 ;                                  (damage-bonus state side :meat (- c))
+                 ;                                  (add-prop state :runner plasc :counter (- c))))
+                 ;                :msg (msg "prevent " target " meat damage")
+                 ;                } card nil)))}}}
+    ;:abilities [{:counter-cost 1 :msg "prevent 1 meat damage"}]}
 
    "Priority Requisition"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))}
@@ -1936,6 +1958,13 @@
                    :effect (effect (move :runner card :scored) (gain :runner :agenda-point 2))}
     :events {:agenda-stolen {:req (req (> (:agendapoints target) 0))
                              :effect (effect (lose :runner :agenda-point 1))}}}
+
+   "The Cleaners"
+   {:events
+    {:pre-damage
+     {:req (req (= target :meat))
+      :msg "to do 1 additional meat damage"
+      :effect (effect (damage-bonus :meat 1))}}}
 
    "The Foundry: Refining the Process"
    {:events

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -67,6 +67,10 @@
      (when-let [leave-effect (:leave-play (card-def card))]
        (when (or (= (:side card) "Runner") (:rezzed card))
          (leave-effect state side card nil)))
+     (when-let [prevent (:prevent (card-def card))]
+               (doseq [dtype prevent]
+                      (swap! state update-in [:damage :prevent dtype]
+                             (fn [pv] (remove #(= (:cid %) (:cid card)) pv)))))
      (unregister-events state side card)
      (when-let [mu (:memoryunits card)]
        (gain state :runner :memory mu))
@@ -360,34 +364,59 @@
       (register-events state side
                        {(if (= side :corp) :corp-turn-begins :runner-turn-begins)
                         {:effect (effect (set-prop card :counter recurring))}} c))
+    (when-let [prevent (:prevent cdef)]
+       (doseq [dtype prevent]
+              (swap! state update-in [:damage :prevent dtype] #(conj % card))))
     (update! state side c)
     (resolve-ability state side cdef c nil)
     (when-let [events (:events cdef)] (register-events state side events c))
     (get-card state c)))
 
 (defn damage-count [state side dtype n]
-  (max 0 (if-let [bonus (get-in @state [:special :damage-bonus dtype])]
-                 (+ n bonus) n)))
+  (-> n
+      (+ (or (get-in @state [:damage :damage-bonus dtype]) 0))
+      (- (or (get-in @state [:damage :damage-prevent dtype]) 0))
+      (max 0)))
 
 (defn damage-bonus [state side dtype n]
-      ;(system-msg state side (str (+ n (get-in state [:special :damage-bonus dtype]))))
-  (swap! state update-in [:special :damage-bonus dtype] (fnil #(+ % n) 0)))
+  (swap! state update-in [:damage :damage-bonus dtype] (fnil #(+ % n) 0)))
+
+(defn damage-prevent [state side dtype n]
+  (swap! state update-in [:damage :damage-prevent dtype] (fnil #(+ % n) 0)))
+
 (defn flatline [state]
   (system-msg state :runner "is flatlined"))
 
-(defn damage [state side type n]
-  (trigger-event state side :pre-damage type)
-  (let [n (damage-count state side type n) hand (get-in @state [:runner :hand])]
-       (system-msg state side (str n " " type))
-    (when (< (count hand) n)
-      (flatline state))
-    (when (= type :brain)
-      (swap! state update-in [:runner :brain-damage] #(+ % n))
-      (swap! state update-in [:runner :max-hand-size] #(- % n)))
-    (doseq [c (take n (shuffle hand))]
-      (trash state side c type))
-    (trigger-event state side :damage type))
-  (swap! state update-in [:special :damage-bonus] dissoc type))
+(defn resolve-damage [state side type n]
+  (let [hand (get-in @state [:runner :hand])]
+       (when (< (count hand) n)
+             (flatline state))
+       (when (= type :brain)
+             (swap! state update-in [:runner :brain-damage] #(+ % n))
+             (swap! state update-in [:runner :max-hand-size] #(- % n)))
+       (doseq [c (take n (shuffle hand))]
+              (trash state side c type))
+       (trigger-event state side :damage type)))
+
+(defn damage
+  ([state side type n] (damage state side type n false))
+  ([state side type n unpreventable]
+    (swap! state update-in [:damage :damage-bonus] dissoc type)
+    (swap! state update-in [:damage :damage-prevent] dissoc type)
+    (trigger-event state side :pre-damage type)
+    (let [n (damage-count state side type n)]
+         (let [prevent (get-in @state [:damage :prevent type])]
+              (if (and (not unpreventable) prevent (> (count prevent) 0))
+                (do (system-msg state :runner "has the option to prevent damage")
+                    (show-prompt
+                      state :runner nil (str "Prevent any of the " n " " (name type) " damage?") ["Done"]
+                      (fn [choice]
+                          (let [prevent (get-in @state [:damage :damage-prevent type])]
+                               (system-msg state :runner
+                                           (if prevent (str "prevents " prevent " " (name type) " damage")
+                                                       "will not prevent damage"))
+                               (resolve-damage state side type (max 0 (- n (or prevent 0))))))))
+                (resolve-damage state side type n))))))
 
 (defn shuffle! [state side kw]
   (swap! state update-in [side kw] shuffle))
@@ -725,7 +754,7 @@
 
 (defn runner-install
   ([state side card] (runner-install state side card nil))
-  ([state side {:keys [title type cost memoryunits uniqueness] :as card} {:keys [extra-cost no-cost]}]
+  ([state side {:keys [title type cost memoryunits uniqueness prevent] :as card} {:keys [extra-cost no-cost]}]
      (let [dest [:rig (to-keyword type)]
            cost (if no-cost 0 cost)]
        (when (and (or (not uniqueness) (not (in-play? state card)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -280,7 +280,7 @@
                      (let [cards (choices state side card targets)]
                              (if not-distinct
                                cards (distinct-by :title cards))))]
-            (prompt! state (or player side) card prompt cs (dissoc ability :choices))))
+            (prompt! state (or player side) card prompt cs (dissoc ability :choices) priority)))
         (when (and (or (not counter-cost) (<= counter-cost (or counter 0)))
                    (or (not advance-counter-cost) (<= advance-counter-cost (or advance-counter 0)))
                    (apply pay (concat [state side card] cost)))
@@ -432,9 +432,7 @@
                       state :runner nil (str "Prevent any of the " n " " (name type) " damage?") ["Done"]
                       (fn [choice]
                           (let [prevent (get-in @state [:damage :damage-prevent type])]
-                               (system-msg state :runner
-                                           (if prevent (str "prevents " prevent " " (name type) " damage")
-                                                       "will not prevent damage"))
+                               (when-not prevent (system-msg state :runner "will not prevent damage"))
                                (resolve-damage state side type (max 0 (- n (or prevent 0))))))))
                 (resolve-damage state side type n))))))
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -641,7 +641,6 @@
                p (assoc p :current-strength nil))))
     (system-msg state side "continues the run")))
 
-
 (defn play-ability [state side {:keys [card ability targets] :as args}]
   (let [cdef (card-def card)
         abilities (:abilities cdef)


### PR DESCRIPTION
This adds a framework for preventing and boosting damage effects, and implements the most common related cards.

In summary, if a card that can prevent damage is installed when the runner suffers some sort of damage, a prompt will show to give the runner opportunity to prevent the damage. After spending tokens/credits/whatever, any unprevented damage is then applied.

### Core changes

0. Added state values (`:damage :prevent`) to store references to cards that can prevent damage. In a card's definition, the `:prevent` field can be used to signify that the card can potentially prevent some types of damage, specified by a vector, as in `:prevent [:net :brain]` or `:prevent [:meat]`.
1. Added functions `(damage-bonus)` and `(damage-prevent)` to core. Given a type and an amount, these functions will boost or prevent the next source of damage of that type, by updating state values `:damage :damage-bonus` and `:damage :damage-prevent` respectively.
2. Added an event `:pre-damage`, which fires in the `(damage)` function before the damage is applied. Cards can handle the event to automatically boost or prevent damage without user interaction (see below).
3. Added a function `(damage-count)` which calculates total damage to be applied after bonus and prevent effects.
4. Split `(damage)` into two functions. 
  1. `(damage)` itself fires the `:pre-damage` event, and then checks `:damage :prevent` for any cards that can prevent the damage. If there are cards, a prompt is shown to the runner to activate any cards he/she wishes, and then finish by clicking the "Done" button. After Done is clicked, or if there are no cards that can prevent, `(resolve-damage)` is called.
  2. `(resolve-damage)` applies the damage appropriately. By separating this into another function, we can tie its execution to the completion of the runner's damage prevention prompt.
5. Damage can be "unpreventable" by passing `:unpreventable` to `(damage)`.

### Card updates
Going through [this list](http://netrunnerdb.com/find/?q=x%3A%22prevent%22+x%3Adamage&sort=name&view=list&_locale=en)...

0. The Cleaners: boosts all sources of meat damage by 1. See Known Issues below.
1. Amped Up: damage is `:unpreventable`.
2. Chrome Parlor: not implemented. Not sure if it will work until `:pre-damage` also passes a card that is the source of the damage.
3. Crash Space: `:prevent [:meat]`
4. Deus Ex: `:prevent [:net]` (see Self-modifying Code below)
5. Feedback Filter: `:prevent [:net :brain]`
6. Flare: damage is `:unpreventable`
7. Leverage: not implemented, but should be doable.
8. Monolith: not implemented, should be doable.
9. Muresh Bodysuit: automatically (no user interaction) prevents only the first net damage.
10. Net Shield: can `:prevent [:net]` once per turn with user interaction. Technically can prevent ANY single net damage in the turn, not just the first overall, so this is a minor issue.
11. Plascrete Carapace: `:prevent [:meat]`
12. Sacrificial Clone: not implemented, should be doable.
13. Stim Dealer: damage is `:unpreventable`
14. Stimhack: damage is `:unpreventable`

### Miscellaneous

1. Self-modifying Code and Clone Chip have `:prevent [:net]` because the user can potentially use them to bring out Deus Ex. There are no programs to prevent meat or brain damage. If SMC or Clone Chip are installed, the runner will get the prompt to prevent any net damage (regardless if Deus Ex is in their deck or not).
2. I made the `:prompt`s for SMC and Clone Chip `:priority true`, so they will jump to the front of the prompt queue when used in the middle of a damage prevention prompt. Works great!

### Tests completed

1. Simple prevention: 
  1. Plascrete Carapace
  2. Feedback Filter (both net and brain damage)
  3. Crash Space (trash to prevent)
2. More complicated:
  1. Net Shield: works only once per turn.
  2. Muresh Bodysuit: works automatically on first net damage. Multiple copies still only prevent one damage (using `:once-key :muresh-bodysuit`)
  3. Deus Ex: can use Clone Chip or SMC to install Deus Ex and then use its ability to prevent all net damage. Very satisfying! :)

### Known issues

1. The Cleaners boosts the damage of Argus Security's meat damage effect, even though the cards are specifically worded to avoid this. (Argus says "suffer 2 meat damage", whereas Cleaners specifies "when you do meat damage".) To fix, need to add another parameter `:unboostable` to `(damage)` (maybe wrapping it into a map along with `:unpreventable`).