### PR TITLE
Implement Eureka!

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -599,6 +599,19 @@
    {:events {:successful-run {:msg (msg "force the Corp to reveal " (:title (first (shuffle (:hand corp)))))
                               :once :per-turn}}}
 
+   "Eureka!"
+   {:effect
+    (req (let [topcard (first (:deck runner))
+               caninst (some #(= % (:type topcard)) '("Hardware" "Resource" "Program"))
+               cost (min 10 (:cost topcard))]
+              (when caninst
+                    (do (gain state side :credit cost)
+                        (runner-install state side topcard)))
+              (when (get-card state topcard) ; only true if card was not installed
+                    (do (system-msg state side (str "reveals and trashes " (:title topcard)))
+                        (trash state side topcard)
+                        (when caninst (lose state side :credit cost))))))}
+
    "Eve Campaign"
    {:data {:counter 16}
     :events {:corp-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -292,8 +292,7 @@
    {:recurring 1}
 
    "Clone Chip"
-   {:prevent [:net]
-    :abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
+   {:abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
                  :priority true
                  :choices (req (filter #(and (has? % :type "Program")
                                              (<= (:cost %) (:credit runner))) (:discard runner)))
@@ -1770,8 +1769,7 @@
    {:effect (effect (lose :runner :max-hand-size 1))}
 
    "Self-modifying Code"
-   {:prevent [:net]
-    :abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
+   {:abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
                  :priority true
                  :choices (req (filter #(has? % :type "Program") (:deck runner)))
                  :cost [:credit 2]


### PR DESCRIPTION
Implementation of Eureka!, and a fix for Clone Chip and SMC to remove their :prevent ability.

Eureka pulls the top card of the Stack and:

1. If it is a Program, Hardware, or Resource, gives the Runner credits to cover the discounted cost of the card and calls `(runner-install)`. 
2. If the card is still on the Stack (this happens if the card was an Event, OR if it could not be installed for various reasons -- Console already installed, Unique card, ...), the card is revealed and trashed. If the Runner had received credits to cover the discounted cost, those are revoked.