### PR TITLE
Implement Oaktown Renovation.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1279,6 +1279,12 @@
                    (some #{:archives} (:successful-run runner-reg))))
     :effect (effect (gain-agenda-point 1) (move (first (:play-area runner)) :scored))}
 
+   "Oaktown Renovation"
+   {:install-rezzed true
+    :events {:advance {:req (req (= (:cid card) (:cid target)))
+                       :effect (req (gain state side :credit
+                                          (if (>= (:advance-counter (get-card state card)) 5) 3 2)))}}}
+
    "Off-Campus Apartment"
    {:abilities [{:effect (effect (draw))
                  :msg "host a Connection and draw 1 card"}]}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -817,7 +817,7 @@
 (defn rez
   ([state side card] (rez state side card nil))
   ([state side card {:keys [no-cost] :as args}]
-     (when (#{"Asset" "ICE" "Upgrade"} (:type card))
+     (when (or (#{"Asset" "ICE" "Upgrade"} (:type card)) (:install-rezzed (card-def card)))
        (let [cdef (card-def card)]
          (when (or no-cost (pay state side card :credit (:cost card) (:additional-cost cdef)))
            (card-init state side (assoc card :rezzed true))
@@ -836,7 +836,8 @@
                  slot (conj (server->zone state server) (if (= (:type c) "ICE") :ices :content))
                  dest-zone (get-in @state (cons :corp slot))
                  install-cost (if (and (= (:type c) "ICE") (not no-install-cost))
-                                (count dest-zone) 0)]
+                                (count dest-zone) 0)
+                 rezzed (or rezzed (:install-rezzed (card-def card)))]
              (when (and (not (and (has? c :subtype "Region")
                                   (some #(has? % :subtype "Region") dest-zone)))
                         (pay state side card extra-cost :credit install-cost))
@@ -845,7 +846,7 @@
                    (system-msg state side (str "trashes " (if (:rezzed prev-card)
                                                             (:title prev-card) "a card") " in " server))
                    (trash state side prev-card)))
-               (let [card-name (if rezzed (:title card) "a card")]
+               (let [card-name (if (or rezzed (:rezzed c)) (:title card) "a card")]
                  (if (> install-cost 0)
                    (system-msg state side (str "pays " install-cost " [Credits] to install "
                                                card-name " in " server))


### PR DESCRIPTION
Implements Oaktown Renovation from Chrome City.

Adds a new tag `:install-rezzed true` which installs a corp card rezzed. I thought about doing this automatically for the "Public" sybtype, but I don't think we have confirmation on this being a consistent game mechanic, so I went with the tag instead. After advancing the card, the corp gains 2 or 3 credits depending on the number of counters now on the card.

I tested this by putting its code in The Cleaners, since the public card set doesn't include Chrome City yet.