### PR TITLE
Implement rez- and trash-cost increase/reduce effects

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -192,6 +192,10 @@
    {:effect (effect (damage :brain 1) (gain :max-hand-size 3))
     :leave-play (effect (lose :max-hand-size 3))}
 
+   "Breaker Bay Grid"
+   {:events {:pre-rez {:req (req (= (:zone card) (:zone target)))
+                       :effect (effect (rez-cost-bonus 5))}}}
+
    "Breaking News"
    {:effect (effect (gain :runner :tag 2)) :msg "give the Runner 2 tags"
     :end-turn {:effect (effect (lose :runner :tag 2)) :msg "make the Runner lose 2 tags"}}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -54,6 +54,12 @@
    "Akamatsu Mem Chip"
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))}
 
+
+   "Akitaro Watanabe"
+   {:events {:pre-rez {:req (req (and (= (:type target) "ICE")
+                                        (= (card->server state card) (card->server state target))))
+                       :effect (effect (rez-cost-bonus 2))}}}
+
    "Alix T4LB07"
    {:events {:corp-install {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:cost [:click 1] :label "Gain 2 [Credits] for each counter on Alix T4LB07"
@@ -191,6 +197,12 @@
    "Brain Cage"
    {:effect (effect (damage :brain 1) (gain :max-hand-size 3))
     :leave-play (effect (lose :max-hand-size 3))}
+
+   "Braintrust"
+   {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)))
+    :events {:pre-rez
+             {:req (req (= (:type target) "ICE"))
+              :effect (effect (rez-cost-bonus (:counter (get-card state card))))}}}
 
    "Breaker Bay Grid"
    {:events {:pre-rez {:req (req (= (:zone card) (:zone target)))
@@ -3100,9 +3112,6 @@
    ;; partial implementation
    "Bad Times"
    {:req (req tagged)}
-
-   "Braintrust"
-   {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)))}
 
    "Chakana"
    {:events {:successful-run {:effect (effect (add-prop card :counter 1)) :req (req (= target :rd))}}}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -58,7 +58,7 @@
    "Akitaro Watanabe"
    {:events {:pre-rez {:req (req (and (= (:type target) "ICE")
                                         (= (card->server state card) (card->server state target))))
-                       :effect (effect (rez-cost-bonus 2))}}}
+                       :effect (effect (rez-cost-bonus -2))}}}
 
    "Alix T4LB07"
    {:events {:corp-install {:effect (effect (add-prop card :counter 1))}}
@@ -201,17 +201,17 @@
    "Brain-Taping Warehouse"
    {:events {:pre-rez
              {:req (req (and (= (:type target) "ICE") (has? target :subtype "Bioroid")))
-              :effect (effect (rez-cost-bonus (:click runner)))}}}
+              :effect (effect (rez-cost-bonus (- (:click runner))))}}}
 
    "Braintrust"
    {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)))
     :events {:pre-rez
              {:req (req (= (:type target) "ICE"))
-              :effect (effect (rez-cost-bonus (:counter (get-card state card))))}}}
+              :effect (effect (rez-cost-bonus (- (:counter (get-card state card)))))}}}
 
    "Breaker Bay Grid"
    {:events {:pre-rez {:req (req (= (:zone card) (:zone target)))
-                       :effect (effect (rez-cost-bonus 5))}}}
+                       :effect (effect (rez-cost-bonus -5))}}}
 
    "Breaking News"
    {:effect (effect (gain :runner :tag 2)) :msg "give the Runner 2 tags"
@@ -1617,7 +1617,7 @@
    {:effect (effect (gain :link 1))
     :events {:pre-rez
              {:req (req (= (:type target) "ICE")) :once :per-turn
-              :effect (effect (rez-cost-bonus -1))}}}
+              :effect (effect (rez-cost-bonus 1))}}}
 
    "Replicator"
    {:events {:runner-install
@@ -2309,7 +2309,7 @@
 
    "Xanadu"
    {:events {:pre-rez {:req (req (= (:type target) "ICE"))
-                       :effect (effect (rez-cost-bonus -1))}}}
+                       :effect (effect (rez-cost-bonus 1))}}}
    ;; Icebreakers
 
    "Alpha"

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1304,6 +1304,10 @@
                    (some #{:archives} (:successful-run runner-reg))))
     :effect (effect (gain-agenda-point 1) (move (first (:play-area runner)) :scored))}
 
+   "Oaktown Grid"
+   {:events {:pre-trash {:req (req (= (:zone card) (:zone target)))
+                         :effect (effect (trash-cost-bonus 3))}}}
+
    "Oaktown Renovation"
    {:install-rezzed true
     :events {:advance {:req (req (= (:cid card) (:cid target)))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -198,6 +198,11 @@
    {:effect (effect (damage :brain 1) (gain :max-hand-size 3))
     :leave-play (effect (lose :max-hand-size 3))}
 
+   "Brain-Taping Warehouse"
+   {:events {:pre-rez
+             {:req (req (and (= (:type target) "ICE") (has? target :subtype "Bioroid")))
+              :effect (effect (rez-cost-bonus (:click runner)))}}}
+
    "Braintrust"
    {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)))
     :events {:pre-rez

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1608,6 +1608,12 @@
     :effect (req (doseq [c (filter #(= (:title target) (:title %)) (:discard corp))]
                    (move state side c :hand)))}
 
+   "Reina Roja: Freedom Fighter"
+   {:effect (effect (gain :link 1))
+    :events {:pre-rez
+             {:req (req (= (:type target) "ICE")) :once :per-turn
+              :effect (effect (rez-cost-bonus -1))}}}
+
    "Replicator"
    {:events {:runner-install
              {:optional {:req (req (= (:type target) "Hardware"))
@@ -2296,6 +2302,9 @@
    {:events {:runner-turn-begins {:msg "draw 2 cards and lose [Click]"
                                   :effect (effect (lose :click 1) (draw 2))}}}
 
+   "Xanadu"
+   {:events {:pre-rez {:req (req (= (:type target) "ICE"))
+                       :effect (effect (rez-cost-bonus -1))}}}
    ;; Icebreakers
 
    "Alpha"
@@ -3156,9 +3165,6 @@
 
    "Power Shutdown"
    {:req (req (:made-run runner-reg))}
-
-   "Reina Roja: Freedom Fighter"
-   {:effect (effect (gain :link 1))}
 
    "Tallie Perrault"
    {:abilities [{:cost [:click 1] :effect (effect (trash card) (draw (:bad-publicity corp)))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -956,6 +956,10 @@
                                :effect (req (doseq [c (take 5 (:deck corp))]
                                               (move state side c :play-area)))}} card))}
 
+   "Industrial Genomics: Growing Solutions"
+   {:events {:pre-trash {:effect (effect (trash-cost-bonus
+                                           (count (filter #(not (:seen %)) (:discard corp)))))}}}
+
    "Infiltration"
    {:prompt "Gain 2 [Credits] or expose a card?" :choices ["Gain 2 [Credits]" "Expose a card"]
     :effect (effect (resolve-ability (if (= target "Expose a card")
@@ -1920,7 +1924,8 @@
                                        (trash state side c)))}} card))}
 
    "Skulljack"
-   {:effect (effect (damage :brain 1))}
+   {:effect (effect (damage :brain 1))
+    :events {:pre-trash {:effect (effect (trash-cost-bonus -1))}}}
 
    "Snatch and Grab"
    {:trace {:base 3 :choices {:req #(has? % :subtype "Connection")}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -616,6 +616,10 @@
                                                                        (:rezzed ice))) (:ices server)))))
                                   0 (flatten (seq (:servers corp))))))}
 
+   "Encryption Protocol"
+   {:events {:pre-trash {:req (req (= (first (:zone target)) :servers))
+                         :effect (effect (trash-cost-bonus 1))}}}
+
    "Enhanced Vision"
    {:events {:successful-run {:msg (msg "force the Corp to reveal " (:title (first (shuffle (:hand corp)))))
                               :once :per-turn}}}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -400,6 +400,14 @@
       (+ (or (get-in @state [:bonus :cost]) 0))
       (max 0)))
 
+(defn trash-cost-bonus [state side n]
+  (swap! state update-in [:bonus :trash] (fnil #(+ % n) 0)))
+
+(defn trash-cost [state side {:keys [cost] :as card}]
+  (-> cost
+      (+ (or (get-in @state [:bonus :trash]) 0))
+      (max 0)))
+
 (defn damage-count [state side dtype n {:keys [unpreventable unboostable] :as args}]
   (-> n
       (+ (or (when (not unboostable) (get-in @state [:damage :damage-bonus dtype])) 0))
@@ -612,7 +620,7 @@
         (when-let [access-effect (:access cdef)]
           (resolve-ability state (to-keyword (:side c)) access-effect c nil))
         (when (not= (:zone c) [:discard])
-          (if-let [trash-cost (:trash c)]
+          (if-let [trash-cost (trash-cost state side (:trash c))]
             (let [card (assoc c :seen true)]
               (optional-ability state :runner card (str "Pay " trash-cost "[Credits] to trash " name "?")
                                 {:cost [:credit trash-cost]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -397,7 +397,7 @@
 
 (defn rez-cost [state side {:keys [cost] :as card}]
   (-> cost
-      (- (or (get-in @state [:bonus :cost]) 0))
+      (+ (or (get-in @state [:bonus :cost]) 0))
       (max 0)))
 
 (defn damage-count [state side dtype n {:keys [unpreventable unboostable] :as args}]


### PR DESCRIPTION
I took the framework for damage bonus/prevention and applied it to Corp rez and trash costs.

### Core changes

1. Added functions `(trash-cost-bonus)` and `(rez-cost-bonus)` to increase the trash or rez cost of a corp card that is currently being accessed or rezzed, respectively. To decrease costs, a negative argument is used.
2. Added events `:pre-trash` and `:pre-rez`.
2. Modified `(rez)` and `(handle-access)` to use costs modified by the bonus functions. These functions fire the `:pre-X` events before calculating rez/trash costs, allowing cards to modify costs appropriately.

### Card updates
Rez costs:

1. Akitaro Watanabe: -2 rez cost for ice protecting his server.
2. Braintrust: -1 rez cost for all ice for each token on the scored agenda.
3. Xanadu: +1 rez cost for all ice.
4. Reina Roja: +1 rez cost for ice, `:once :per-turn`.
5. Brain-Taping Warehouse: -1 rez cost for `:subtype "Bioroid" ice for each `(:click runner)`.
6. Breaker Bay Grid: -5 rez cost for cards in the same server's `:content`.

Trash costs:

1. Encryption Protocol: +1 trash cost for installed cards.
2. Industrial Genomics: +1 trash cost for all cards in archives that are `(not (:seen))`.
3. Skulljack: -1 trash cost for all cards.
4. Oaktown Grid: +3 trash cost for all cards in the same server's `:content`.

### To-do

1. Rook: I don't know enough about hosting to get this guy working yet, but once it is hosted, it can listen to `:pre-rez`, check the target's server to see if it is the same as Rook's host's server, and if so, call `(rez-cost-bonus 2)`.
2. Running Interference: can use the framework from Leverage to register a `:pre-rez` event that only triggers until the end of the run. In `:pre-rez`, call `(rez-cost-bonus (:cost target))`.
3. IQ: I don't know if this one can be done, since I BELIEVE (?) installed cards won't receive events until they are rezzed