### PR TITLE
Implement Analog Dreamers, Constellation Protocol, Mark Yale

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -75,14 +75,17 @@
 
    "Analog Dreamers"
    {:abilities [{:cost [:click 1] :msg "make a run on R&D"
-                 :effect (effect (run :rd
-                                      {:replace-access
-                                       {:prompt "Choose a card to shuffle into R&D"
-                                        :choices {:req #(and (not (= (:type %) "ICE"))
-                                                             (not (:rezzed %))
-                                                             (not (:advance-counter %)))}
-                                        :effect (req (move state :corp target :deck) (shuffle! state :corp :deck))
-                                        :msg "shuffle a card into R&D"}}))}]}
+                 :effect (effect (run :rd {:replace-access
+                                           {:prompt "Choose a card to shuffle into R&D"
+                                            :choices {:req #(and (not (= (:type %) "ICE"))
+                                                                 (not (:rezzed %))
+                                                                 (not (:advance-counter %)))}
+                                            :effect (req (move state :corp target :deck)
+                                                         (shuffle! state :corp :deck)
+                                                         (swap! state update-in [:runner :prompt] rest)
+                                                         (handle-end-run state side)) ; remove the replace-access prompt
+                                            :msg "shuffle a card into R&D"}} card))}]}
+
 
    "Andromeda: Dispossessed Ristie"
    {:effect (effect (gain :link 1) (draw 4)) :mulligan (effect (draw 4))}
@@ -1956,20 +1959,11 @@
                             card nil)))}}
 
    "Sneakdoor Beta"
-   {:abilities [{:cost [:click 1] :msg "make a run on R&D"
-                 :effect (effect (run :rd
-                                      {:replace-access
-                                       {:prompt "Choose a card to shuffle into R&D"
-                                        :choices {:req #(and (not (= (:type %) "ICE"))
-                                                             (not (:rezzed %))
-                                                             (not (:advance-counter %)))}
-                                        :effect (req (move state :corp target :deck) (shuffle! state :corp :deck))
-                                        :msg "shuffle a card into R&D"}} card))}]}
-   ;{:abilities [{:cost [:click 1] :msg "make a run on Archives"
-   ;              :effect (effect (run :archives
-   ;                                {:successful-run
-   ;                                 {:msg "make a successful run on HQ"
-   ;                                  :effect (req (swap! state assoc-in [:run :server] [:hq]))}} card))}]}
+   {:abilities [{:cost [:click 1] :msg "make a run on Archives"
+                 :effect (effect (run :archives
+                                   {:successful-run
+                                    {:msg "make a successful run on HQ"
+                                     :effect (req (swap! state assoc-in [:run :server] [:hq]))}} card))}]}
 
    "Snare!"
    {:access {:optional {:req (req (not= (first (:zone card)) :discard))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1185,10 +1185,6 @@
    "Lucky Find"
    {:effect (effect (gain :credit 9))}
 
-   "MaxX: Maximum Punk Rock"
-   {:events {:runner-turn-begins {:msg "trash the top 2 cards from Stack and draw 1 card"
-                                  :effect (effect (mill 2) (draw))}}}
-
    "Magnum Opus"
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 
@@ -1198,6 +1194,24 @@
    "Manhunt"
    {:events {:successful-run {:once :per-turn :trace {:base 2 :msg "give the Runner 1 tag"
                                                       :effect (effect (gain :runner :tag 1))}}}}
+
+   "Mark Yale"
+   {:events {:agenda-counter-spent {:effect (effect (gain :credit 1))
+                                    :msg "gain 1 [Credits]"}}
+    :abilities [{:label "Trash to gain 2 [Credits]"
+                 :msg "gain 2 [Credits]"
+                 :effect (effect (gain :credit 2) (trash card))}
+                {:label "Spend an agenda counter to gain 2 [Credits]"
+                 :effect (req (resolve-ability
+                                state side
+                                {:prompt "Select an agenda with a counter"
+                                 :choices {:req #(and (= (:type %) "Agenda")
+                                                      (:counter %))}
+                                 :effect (req (add-prop state side target :counter -1)
+                                              (gain state :corp :credit 2)
+                                              (trigger-event state side :agenda-counter-spent card))
+                                 :msg (msg "spend an agenda token on " (:title target) " and gain 2 [Credits]")}
+                                card nil))}]}
 
    "Marked Accounts"
    {:abilities [{:cost [:click 1] :msg "store 3 [Credits]"
@@ -1212,6 +1226,10 @@
    {:choices {:max 3 :req #(and (has? % :type "Program") (= (:zone %) [:hand]))}
     :msg (msg "install " (join ", " (map :title targets)))
     :effect (req (doseq [c targets] (runner-install state side c)))}
+
+   "MaxX: Maximum Punk Rock"
+   {:events {:runner-turn-begins {:msg "trash the top 2 cards from Stack and draw 1 card"
+                                  :effect (effect (mill 2) (draw))}}}
 
    "Medical Research Fundraiser"
    {:effect (effect (gain :credit 8) (gain :runner :credit 3))}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -86,7 +86,6 @@
                                                          (handle-end-run state side)) ; remove the replace-access prompt
                                             :msg "shuffle a card into R&D"}} card))}]}
 
-
    "Andromeda: Dispossessed Ristie"
    {:effect (effect (gain :link 1) (draw 4)) :mulligan (effect (draw 4))}
 
@@ -376,6 +375,30 @@
    "Commercialization"
    {:msg (msg "gain " (:advance-counter target) " [Credits]")
     :choices {:req #(has? % :type "ICE")} :effect (effect (gain :credit (:advance-counter target)))}
+
+   "Constellation Protocol"
+   {:events {:corp-turn-begins
+             {:optional
+              {:prompt "Move one advancement token between ICE?"
+               :effect (effect
+                         (resolve-ability
+                           {:choices {:req #(and (= (:type %) "ICE") (:advance-counter %))}
+                            :priority true
+                            :effect (req
+                                      (let [fr target]
+                                           (resolve-ability
+                                             state side
+                                             {:priority true
+                                              :prompt "Move to where?"
+                                              :choices {:req #(and (= (:type %) "ICE")
+                                                                   (not= (:cid fr) (:cid %))
+                                                                   (or (= (:advanceable %) "always")
+                                                                       (and (= (:advanceable %) "while-rezzed")
+                                                                            (:rezzed %))))}
+                                              :effect (effect (add-prop :corp target :advance-counter 1)
+                                                              (add-prop :corp fr :advance-counter -1))} card nil)
+                                           card nil))}
+                           card nil))}}}}
 
    "Corporate Shuffle"
    {:effect (effect (shuffle-into-deck :hand) (draw 5))}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -73,6 +73,17 @@
    "Amped Up"
    {:effect (effect (gain :click 3) (damage :brain 1 {:unpreventable true}))}
 
+   "Analog Dreamers"
+   {:abilities [{:cost [:click 1] :msg "make a run on R&D"
+                 :effect (effect (run :rd
+                                      {:replace-access
+                                       {:prompt "Choose a card to shuffle into R&D"
+                                        :choices {:req #(and (not (= (:type %) "ICE"))
+                                                             (not (:rezzed %))
+                                                             (not (:advance-counter %)))}
+                                        :effect (req (move state :corp target :deck) (shuffle! state :corp :deck))
+                                        :msg "shuffle a card into R&D"}}))}]}
+
    "Andromeda: Dispossessed Ristie"
    {:effect (effect (gain :link 1) (draw 4)) :mulligan (effect (draw 4))}
 
@@ -1945,11 +1956,20 @@
                             card nil)))}}
 
    "Sneakdoor Beta"
-   {:abilities [{:cost [:click 1] :msg "make a run on Archives"
-                 :effect (effect (run :archives
-                                   {:successful-run
-                                    {:msg "make a successful run on HQ"
-                                     :effect (req (swap! state assoc-in [:run :server] [:hq]))}} card))}]}
+   {:abilities [{:cost [:click 1] :msg "make a run on R&D"
+                 :effect (effect (run :rd
+                                      {:replace-access
+                                       {:prompt "Choose a card to shuffle into R&D"
+                                        :choices {:req #(and (not (= (:type %) "ICE"))
+                                                             (not (:rezzed %))
+                                                             (not (:advance-counter %)))}
+                                        :effect (req (move state :corp target :deck) (shuffle! state :corp :deck))
+                                        :msg "shuffle a card into R&D"}} card))}]}
+   ;{:abilities [{:cost [:click 1] :msg "make a run on Archives"
+   ;              :effect (effect (run :archives
+   ;                                {:successful-run
+   ;                                 {:msg "make a successful run on HQ"
+   ;                                  :effect (req (swap! state assoc-in [:run :server] [:hq]))}} card))}]}
 
    "Snare!"
    {:access {:optional {:req (req (not= (first (:zone card)) :discard))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -292,7 +292,8 @@
                       (update-in [:advance-counter] #(- (or % 0) (or advance-counter-cost 0)))
                       (update-in [:counter] #(- (or % 0) (or counter-cost 0))))]
             (when (or counter-cost advance-counter-cost)
-              (update! state side c))
+              (update! state side c)
+              (when (= (:type card) "Agenda") (trigger-event state side :agenda-counter-spent card)))
             (when msg
               (let [desc (if (string? msg) msg (msg state side card targets))]
                 (system-msg state (to-keyword (:side card))


### PR DESCRIPTION
Implementations for three new cards.

1. Analog Dreamers: I tested this by replacing Sneakdoor Beta's code (temporarily). While testing, I came across an interesting bug. If a `:replace-access` effect shows a prompt that is a map, thus triggering a `(show-select)` instead of a `(show-prompt)`, after the select resolves the run prompt is returned to the "Successful Run/Jack Out" options, and the runner can once again select Successful Run -> Use Card Ability to trigger the selection prompt again. I don't know the root cause of this, but it's something about how `(resolve-prompt)` vs `(resolve-select)` works with respect to ending runs. To hack around this, I added 

    `(swap! state update-in [:runner :prompt] rest)
(handle-end-run state side)`

    manually to the end of Analog Dreamers, which has the effect of fixing this issue.
2. Constellation Protocol: I tweaked selection prompts to use the `:prompt` string of an ability if it is present, instead of always automatically showing "Select a target for X". This is nice in Constellation Protocol, because otherwise you get two prompts in a row saying "Select a target for Constellation Protocol" and you aren't sure if your first click (select which ICE to move a token from) went through or not. Now the second prompt says "Move to where?" to be clear.

    I also had to tweak the code that removes prompts from the prompt queue when resolving them. Due to timing issues, any prompt that pushed a `:priority` prompt during its resolution would inadvertently pop the new prompt from the queue at the end of the original prompt's resolution. Now, the specific prompt that is being resolved will be filtered out of the queue, regardless of whether it's still first in the line. This is necessary for multiple copies of Constellation Protocol to work together: if the first prompt isn't priority, then you will start your turn with two "Use Constellation Protocol?" messages, then receive two "Select a target for Constellation Protocol" prompts, then two "Move to where?" prompts. With priority fixed, you fully resolve on CP before triggering the next.

3. Mark Yale: added an event `:agenda-counter-spent` any time an Agenda uses an ability with a `:counter-cost`. Otherwise straightforward. And yes, using Mark's ability to consume another Agenda's token does trigger his own 1-cr bonus for a total of 3 cr :).