### PR TITLE
Install cost bonuses; Chrome Parlor; card implementations

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1785,7 +1785,7 @@
                                       :run-ends
                                       {:effect (effect (unregister-events card))}}
                                      (assoc card :zone '(:discard))))
-    :events {:pre-rez nil}}
+    :events {:pre-rez nil :run-ends nil}}
 
    "Ryon Knight"
    {:abilities [{:msg "do 1 brain damage" :req (req (and this-server (zero? (:click runner))))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1839,11 +1839,14 @@
                              {:prompt "Choose a program to install"
                               :choices (req (filter #(and (= (:type %) "Program")
                                                           (<= (:cost %) (+ (:credit runner) (:cost trashed))))
-                                                    ((if (= fr "Grip") :hand :discard ) runner)))
-                              :effect (effect (gain :credit (min (:cost target) (:cost trashed)))
-                                              (runner-install target))}
-                             card nil)))}
-            card nil)))}
+                                                    ((if (= fr "Grip") :hand :discard) runner)))
+                              :effect (effect (register-events {:pre-install
+                                                                {:effect
+                                                                 (effect (install-cost-bonus (- (:cost trashed)))
+                                                                         (unregister-events card))}}
+                                                               (assoc card :zone '(:discard)))
+                                              (runner-install target))} card nil)))} card nil)))
+    :events {:pre-install nil}}
 
    "Scorched Earth"
    {:req (req tagged) :effect (effect (damage :meat 4))}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -338,8 +338,7 @@
    "Clone Chip"
    {:abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
                  :priority true
-                 :choices (req (filter #(and (has? % :type "Program")
-                                             (<= (:cost %) (:credit runner))) (:discard runner)))
+                 :choices (req (filter #(and (has? % :type "Program")) (:discard runner)))
                  :effect (effect (trash card) (runner-install target))}]}
 
    "Clone Retirement"

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1185,10 +1185,6 @@
    "Lucky Find"
    {:effect (effect (gain :credit 9))}
 
-   "MaxX: Maximum Punk Rock"
-   {:events {:runner-turn-begins {:msg "trash the top 2 cards from Stack and draw 1 card"
-                                  :effect (effect (mill 2) (draw))}}}
-
    "Magnum Opus"
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 
@@ -1198,6 +1194,24 @@
    "Manhunt"
    {:events {:successful-run {:once :per-turn :trace {:base 2 :msg "give the Runner 1 tag"
                                                       :effect (effect (gain :runner :tag 1))}}}}
+
+   "Mark Yale"
+   {:events {:agenda-counter-spent {:effect (effect (gain :credit 1))
+                                    :msg "gain 1 [Credits]"}}
+    :abilities [{:label "Trash to gain 2 [Credits]"
+                 :msg "gain 2 [Credits]"
+                 :effect (effect (gain :credit 2) (trash card))}
+                {:label "Spend an agenda counter to gain 2 [Credits]"
+                 :effect (req (resolve-ability
+                                state side
+                                {:prompt "Select an agenda with a counter"
+                                 :choices {:req #(and (= (:type %) "Agenda")
+                                                      (:counter %))}
+                                 :effect (req (add-prop state side target :counter -1)
+                                              (gain state :corp :credit 2)
+                                              (trigger-event state side :agenda-counter-spent card))
+                                 :msg (msg "spend an agenda token on " (:title target) " and gain 2 [Credits]")}
+                                card nil))}]}
 
    "Marked Accounts"
    {:abilities [{:cost [:click 1] :msg "store 3 [Credits]"
@@ -1212,6 +1226,10 @@
    {:choices {:max 3 :req #(and (has? % :type "Program") (= (:zone %) [:hand]))}
     :msg (msg "install " (join ", " (map :title targets)))
     :effect (req (doseq [c targets] (runner-install state side c)))}
+
+   "MaxX: Maximum Punk Rock"
+   {:events {:runner-turn-begins {:msg "trash the top 2 cards from Stack and draw 1 card"
+                                  :effect (effect (mill 2) (draw))}}}
 
    "Medical Research Fundraiser"
    {:effect (effect (gain :credit 8) (gain :runner :credit 3))}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -292,7 +292,8 @@
                       (update-in [:advance-counter] #(- (or % 0) (or advance-counter-cost 0)))
                       (update-in [:counter] #(- (or % 0) (or counter-cost 0))))]
             (when (or counter-cost advance-counter-cost)
-              (update! state side c))
+              (update! state side c)
+              (when (= (:type card) "Agenda") (trigger-event state side :agenda-counter-spent card)))
             (when msg
               (let [desc (if (string? msg) msg (msg state side card targets))]
                 (system-msg state (to-keyword (:side card))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -413,6 +413,14 @@
       (+ (or (get-in @state [:bonus :trash]) 0))
       (max 0)))
 
+(defn install-cost-bonus [state side n]
+  (swap! state update-in [:bonus :install-cost] (fnil #(+ % n) 0)))
+
+(defn install-cost [state side {:keys [cost] :as card}]
+  (-> cost
+      (+ (or (get-in @state [:bonus :install-cost]) 0))
+      (max 0)))
+
 (defn damage-count [state side dtype n {:keys [unpreventable unboostable] :as args}]
   (-> n
       (+ (or (when (not unboostable) (get-in @state [:damage :damage-bonus dtype])) 0))
@@ -814,23 +822,25 @@
   ([state side card] (runner-install state side card nil))
   ([state side {:keys [title type cost memoryunits uniqueness] :as card}
     {:keys [extra-cost no-cost host-card] :as params}]
-   (if-let [hosting (and (not host-card) (:hosting (card-def card)))]
-     (resolve-ability state side
-                      {:choices hosting
-                       :effect (effect (runner-install card (assoc params :host-card target)))} card nil)
-     (let [cost (if no-cost 0 cost)]
-       (when (and (or (not uniqueness) (not (in-play? state card)))
-                  (if-let [req (:req (card-def card))]
-                    (req state side card nil) true)
-                  (pay state side card :credit cost (when memoryunits [:memory memoryunits]) extra-cost))
-         (let [c (if host-card
-                   (host state side host-card card)
-                   (move state side card [:rig (to-keyword type)]))
-               installed-card (card-init state side c)]
-           (system-msg state side (str "installs " title
-                                       (when host-card (str " on " (:title host-card)))
-                                       (when no-cost " at no cost")))
-           (trigger-event state side :runner-install installed-card)))))))
+    (swap! state update-in [:bonus] dissoc :install-cost)
+    (trigger-event state side :pre-install card)
+    (if-let [hosting (and (not host-card) (:hosting (card-def card)))]
+      (resolve-ability state side
+                       {:choices hosting
+                        :effect (effect (runner-install card (assoc params :host-card target)))} card nil)
+      (let [cost (if no-cost 0 (install-cost state side card))]
+        (when (and (or (not uniqueness) (not (in-play? state card)))
+                   (if-let [req (:req (card-def card))]
+                     (req state side card nil) true)
+                   (pay state side card :credit cost (when memoryunits [:memory memoryunits]) extra-cost))
+          (let [c (if host-card
+                    (host state side host-card card)
+                    (move state side card [:rig (to-keyword type)]))
+                installed-card (card-init state side c)]
+            (system-msg state side (str "installs " title
+                                        (when host-card (str " on " (:title host-card)))
+                                        (when no-cost " at no cost")))
+            (trigger-event state side :runner-install installed-card)))))))
 
 (defn server-list [state card]
   (let [remotes (cons "New remote" (for [i (range (count (get-in @state [:corp :servers :remote])))]


### PR DESCRIPTION
A mishmash of implementations.

### Install cost bonuses

Extended the "bonus" framework to Runner installs via `:pre-install` and `(install-cost-bonus)`. Implemented these cards:

1. Kate "Mac" McCaffrey: bonus of -1 `:once :per-turn` for installing Hardware or Programs. Works in all expected cases: installing from SMC, Scavenge, Test Run (consumes the effect for no gain), Clone Chip, in conjunction with Modded, etc.
2. Modded: uses the tech from Leverage to register a temp event to handle the -3 install cost bonus. 
3. Career Fair: likewise for resources.
4. Scavenge: reworked to use install cost bonus.
5. Clone Chip: I couldn't figure out a way for the `req` filter to work nicely with Kate's ability. It currently only shows programs that the Runner can afford, so it won't show a program that could be afforded via Kate's ability. I removed the filter completely a la SMC, so the user can select a program they can't afford, and runner-install will handle the rest.

### Chrome Parlor

Extended `(damage)` and `:pre-damage` to pass the card dealing the damage as a parameter. `:pre-event` now receives a `target` of the damage type, and a `(second targets)` of the card. This allows Chrome Parlor to prevent damage from Cybernetics. Works perfectly.

### Running Interference
A fun card. Implemented with a temporary event that handles `:pre-rez` to increase all ICE rezzing on the run by the ICE's cost.