### PR TITLE
Ice strength modifications; card fixes.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -426,7 +426,22 @@
                                  state side
                                  {:choices {:req #(and (has? % :type "ICE") (:rezzed %))}
                                   :msg (msg "add " boost " strength to " (:title target))
-                                  :effect (effect (trash card))} card nil)))}]}
+                                  :effect (req
+                                            (update! state side (assoc card :troubleshooter-target target
+                                                                       :troubleshooter-amount boost))
+                                            (trash state side (get-card state card))
+                                            (update-ice-strength state side target))} card nil)))}]
+    :events {:pre-ice-strength nil :end-turn nil}
+    :trash-effect
+      {:effect (req (register-events
+                      state side
+                      (let [ct {:effect (req (unregister-events state side card)
+                                             (update! state side (dissoc card :troubleshooter-target))
+                                             (update-ice-strength state side (:troubleshooter-target card)))}]
+                        {:pre-ice-strength
+                          {:req (req (= (:cid target) (:cid (:troubleshooter-target card))))
+                           :effect (effect (ice-strength-bonus (:troubleshooter-amount card)))}
+                         :runner-turn-ends ct :corp-turn-ends ct}) card))}}
 
    "Corporate War"
    {:msg (msg (if (> (:credit corp) 6) "gain 7 [Credits]" "lose all credits"))
@@ -504,9 +519,18 @@
                  :msg "force the Corp to trash the top card of R&D"}]}
 
    "Datasucker"
-   {:events {:successful-run {:effect (effect (add-prop card :counter 1))
-                              :req (req (#{:hq :rd :archives} target))}}
-    :abilities [{:counter-cost 1 :msg (msg "give -1 strength to " (:title current-ice))}]}
+   {:events (let [ds {:effect (req (update! state side (dissoc card :datasucker-count)))}]
+                 {:successful-run {:effect (effect (add-prop card :counter 1))
+                                   :req (req (#{:hq :rd :archives} target))}
+                  :pre-ice-strength {:req (req (and (= (:cid target) (:cid current-ice))
+                                                    (:datasucker-count card)))
+                                     :effect (req (let [c (:datasucker-count (get-card state card))]
+                                                       (ice-strength-bonus state side (- c))))}
+                  :pass-ice ds :run-ends ds})
+    :abilities [{:counter-cost 1 :msg (msg "give -1 strength to " (:title current-ice))
+                 :req (req current-ice)
+                 :effect (req (update! state side (update-in card [:datasucker-count] (fnil #(+ % 1) 0)))
+                              (update-ice-strength state side current-ice))}]}
 
    "Day Job"
    {:additional-cost [:click 3] :effect (effect (gain :credit 10))}
@@ -666,7 +690,10 @@
                           (reduce (fn [c server]
                                     (+ c (count (filter (fn [ice] (and (has? ice :subtype "Code Gate")
                                                                        (:rezzed ice))) (:ices server)))))
-                                  0 (flatten (seq (:servers corp))))))}
+                                  0 (flatten (seq (:servers corp))))))
+
+    :events {:pre-ice-strength {:req (req (has? target :subtype "Code Gate"))
+                                :effect (effect (ice-strength-bonus 1))}}}
 
    "Encryption Protocol"
    {:events {:pre-trash {:req (req (= (first (:zone target)) :servers))
@@ -707,6 +734,13 @@
 
    "Executive Wiretaps"
    {:msg (msg "reveal cards in HQ: " (map :title (:hand corp)))}
+
+   "Experiential Data"
+   {:effect (req (update-ice-in-server state side (card->server state card)))
+    :events {:pre-ice-strength {:req (req (= (card->server state card) (card->server state target)))
+                                :effect (effect (ice-strength-bonus 1))}}
+    :derez-effect {:effect (req (update-ice-in-server state side (card->server state card)))}
+    :trash-effect {:effect (req (update-all-ice state side))}}
 
    "Expert Schedule Analyzer"
    {:abilities
@@ -868,6 +902,10 @@
    {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"
                             :effect (effect (gain :credit 1))}}}
 
+   "Haas-Bioroid: Stronger Together"
+   {:events {:pre-ice-strength {:req (req (and (= (:type target) "ICE") (has? target :subtype "Bioroid")))
+                                :effect (effect (ice-strength-bonus 1))}}}
+
    "Hacktivist Meeting"
    {:events {:rez {:req (req (not= (:type target) "ICE"))
                    :msg "force the Corp to trash 1 card from HQ at random"
@@ -989,6 +1027,11 @@
                    :effect (effect (add-prop :runner card :counter 1))}}
     :abilities [{:counter-cost 1 :effect (effect (gain :credit 1))
                  :msg "take 1 [Credits] to install programs"}]}
+
+   "Ice Carver"
+   {:events {:pre-ice-strength
+             {:req (req (and (= (:cid target) (:cid current-ice)) (:rezzed target)))
+              :effect (effect (ice-strength-bonus -1))}}}
 
    "Imp"
    {:data {:counter 2}
@@ -1129,6 +1172,9 @@
    {:data {:counter 2}
     :abilities [{:counter-cost 1 :effect (effect (prevent-jack-out))
                  :msg "prevent the Runner from jacking out"}]}
+
+   "Lag Time"
+   {:events {:pre-ice-strength {:effect (effect (ice-strength-bonus 1))}}}
 
    "Lamprey"
    {:events {:successful-run {:req (req (= target :hq)) :msg "to force the Corp to lose 1 [Credits]"
@@ -1430,6 +1476,12 @@
    "PAD Campaign"
    {:events {:corp-turn-begins {:msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
+   "Patch"
+   {:hosting {:req #(and (= (:type %) "ICE") (:rezzed %))}
+    :effect (effect (update-ice-strength (:host card)))
+    :events {:pre-ice-strength {:req (req (= (:cid target) (:cid (:host card))))
+                                :effect (effect (ice-strength-bonus 2))}}}
+
    "Posted Bounty"
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
                :msg "give the Runner 1 tag and take 1 bad publicity"
@@ -1470,14 +1522,15 @@
 
    "Parasite"
    {:hosting {:req #(and (= (:type %) "ICE") (:rezzed %))}
-    :effect (req (when-let [h (:host card)]
-                   (when (<= (:strength h) (:counter card))
-                     (trash state side h))))
+    :effect (req (when-let [h (:host card)] (update-ice-strength state side h)))
     :events {:runner-turn-begins
-             {:effect (req (add-prop state side card :counter 1)
-                           (when-let [h (get-card state (:host card))]
-                             (when (>= (inc (:counter card)) (:strength h))
-                               (trash state side h))))}}}
+             {:effect (req (add-prop state side card :counter 1) (update-ice-strength state side (:host card)))}
+             :pre-ice-strength
+             {:req (req (= (:cid target) (:cid (:host card))))
+              :effect (effect (ice-strength-bonus (- (get-virus-counters state side card))))}
+             :ice-strength-changed
+             {:req (req (and (= (:cid target) (:cid (:host card))) (<= (:current-strength target) 0)))
+              :effect (effect (trash target))}}}
 
    "Paricia"
    {:recurring 2}
@@ -1861,6 +1914,14 @@
    "Scorched Earth"
    {:req (req tagged) :effect (effect (damage :meat 4 {:card card}))}
 
+   "Scrubbed"
+   {:events (let [sc {:effect (req (update! state side (dissoc card :scrubbed-target)))}]
+                 {:encounter-ice {:once :per-turn
+                                  :effect (effect (update! (assoc card :scrubbed-target target)))}
+                  :pre-ice-strength {:req (req (= (:cid target) (:cid (:scrubbed-target card))))
+                                     :effect (effect (ice-strength-bonus -2))}
+                  :pass-ice sc :run-ends sc})}
+
    "Scrubber"
    {:recurring 2}
 
@@ -2113,11 +2174,14 @@
                                                                    (:rezzed ice))) (:ices server)))))
                               0 (flatten (seq (:servers corp))))
               " [Credits]")
-    :effect (effect (gain :credit
+    :effect (req (do (gain state :corp :credit
                           (reduce (fn [c server]
                                     (+ c (count (filter (fn [ice] (and (has? ice :subtype "Barrier")
                                                                        (:rezzed ice))) (:ices server)))))
-                                  0 (flatten (seq (:servers corp))))))}
+                                  0 (flatten (seq (:servers corp)))))
+                     (update-all-ice state side)))
+    :events {:pre-ice-strength {:req (req (has? target :subtype "Barrier"))
+                                :effect (effect (ice-strength-bonus 1))}}}
 
    "Sure Gamble"
    {:effect (effect (gain :credit 9))}
@@ -2728,10 +2792,15 @@
 
    "Crick"
    {:abilities [{:msg "install a card from Archives" :choices (req (:discard corp))
-                 :prompt "Choose a card to install" :effect (effect (corp-install target nil))}]}
+                 :prompt "Choose a card to install" :effect (effect (corp-install target nil))}]
+    :strength-bonus (req (if (= (second (:zone card)) :archives) 3 0))}
 
    "Curtain Wall"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (let [ices (:ices (card->server state card))]
+                              (if (= (:cid card) (:cid (last ices))) 4 0)))
+    :events {:rez {:req (req (= (card->server state card) (card->server state target)))
+                   :effect (effect (update-ice-strength card))}}}
 
    "Data Hound"
    {:abilities [{:label "Trace 2 - Look at the top of Stack"
@@ -2757,6 +2826,7 @@
    "Dracō"
    {:prompt "How many power counters?" :choices :credit :msg (msg "add " target " power counters")
     :effect (effect (set-prop card :counter target))
+    :strength-bonus (req (or (:counter card) 0))
     :abilities [{:label "Trace 2"
                  :trace {:base 2 :msg "give the Runner 1 tag and end the run"
                          :effect (effect (gain :runner :tag 1) (end-run))}}]}
@@ -2782,7 +2852,8 @@
                 {:msg "end the run" :effect (effect (end-run))}]}
 
    "Fire Wall"
-   {:advanceable :always :abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:advanceable :always :abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (or (:advance-counter card) 0))}
 
    "Flare"
    {:abilities [{:prompt "Choose a piece of hardware to trash"
@@ -2810,11 +2881,13 @@
 
    "Gutenberg"
    {:abilities [{:label "Trace 7 - Give the Runner 1 tag"
-                 :trace {:base 7 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 7 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]
+    :strength-bonus (req (if (= (second (:zone card)) :rd) 3 0))}
 
    "Hadrians Wall"
    {:advanceable :always
-    :abilities [{:msg "end the run" :effect (effect (end-run))}]}
+    :abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (or (:advance-counter card) 0))}
 
    "Himitsu-Bako"
    {:abilities [{:msg "end the run" :effect (effect (end-run))}
@@ -2845,7 +2918,8 @@
                  :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
 
    "Ice Wall"
-   {:advanceable :always :abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:advanceable :always :abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (or (:advance-counter card) 0))}
 
    "Ichi 1.0"
    {:abilities [{:prompt "Choose a program to trash" :msg (msg "trash " (:title target))
@@ -2864,7 +2938,8 @@
                          :effect (effect (damage :brain 1 {:card card}) (gain :runner :tag 1))}}]}
 
    "IQ"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (count (:hand corp)))}
 
    "Information Overload"
    {:abilities [{:label "Trace 1 - Give the Runner 1 tag"
@@ -2933,7 +3008,8 @@
    {:abilities [{:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}]}
 
    "Meru Mati"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (if (= (second (:zone card)) :hq) 3 0))}
 
    "Minelayer"
    {:abilities [{:msg "install an ICE from HQ"
@@ -2980,7 +3056,14 @@
    {:abilities [{:msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}]}
 
    "NEXT Bronze"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (reduce (fn [c server]
+                                         (+ c (count (filter (fn [ice] (and (:rezzed ice) (has? ice :subtype "NEXT")))
+                                                             (:ices server)))))
+                                     0 (flatten (seq (:servers corp)))))
+    :events (let [nb {:req (req (has? target :subtype "NEXT"))
+                   :effect (effect (update-ice-strength card))}]
+                 {:rez nb :derez nb :trash nb :card-moved nb})}
 
    "NEXT Gold"
    {:abilities [{:label "Do 1 net damage for each rezzed NEXT ice"
@@ -3056,11 +3139,13 @@
     :abilities [{:label "Trace X - Give the runner 1 tag"
                  :trace {:base (req (or (:advance-counter card) 0)) :effect (effect (gain :runner :tag 1))
                          :msg "give the Runner 1 tag"}}]}
+
    "Shadow"
    {:advanceable :always
     :abilities [{:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))}
                 {:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]
+    :strength-bonus (req (or (:advance-counter card) 0))}
 
    "Sherlock 1.0"
    {:abilities [{:label "Trace 4 - Add an installed program to the top of Stack"
@@ -3138,7 +3223,8 @@
                 {:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
 
    "Turing"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (if (= (second (:zone card)) :remote) 3 0))}
 
    "Tyrant"
    {:advanceable :while-rezzed
@@ -3207,7 +3293,12 @@
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
 
    "Wraparound"
-   {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :strength-bonus (req (if (some #(has? % :subtype "Fracter") (get-in runner [:rig :program]))
+                           0 7))
+    :events (let [wr {:req (req (has? target :subtype "Fracter"))
+                      :effect (effect (update-ice-strength card))}]
+                 {:runner-install wr :trash wr :card-moved wr})}
 
    "Yagura"
    {:abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -416,7 +416,6 @@
       (swap! state update-in [:bonus] dissoc :ice-strength)
       (trigger-event state side :pre-ice-strength ice)
       (update! state side (assoc ice :current-strength (ice-strength state side ice)))
-      ;(when (not= (:current-strength (get-card state ice)) oldstren)
       (trigger-event state side :ice-strength-changed (get-card state ice) oldstren))))
 
 (defn update-ice-in-server [state side server]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -432,9 +432,11 @@
   (swap! state update-in [:bonus :cost] (fnil #(+ % n) 0)))
 
 (defn rez-cost [state side {:keys [cost] :as card}]
-  (-> cost
-      (+ (or (get-in @state [:bonus :cost]) 0))
-      (max 0)))
+  (if (nil? cost)
+    nil
+    (-> cost
+        (+ (or (get-in @state [:bonus :cost]) 0))
+        (max 0))))
 
 (defn trash-cost-bonus [state side n]
   (swap! state update-in [:bonus :trash] (fnil #(+ % n) 0)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -154,6 +154,7 @@
                  (when-let [events (:events (card-def c))]
                    (unregister-events state side c)
                    (register-events state side events c))))))
+         (trigger-event state side :card-moved moved-card)
          moved-card)))))
 
 (defn draw
@@ -321,10 +322,13 @@
               (resolve-ability state side end-run-effect (:card run-effect) [(first server)]))))
         (swap! state assoc :run nil))))
 
+(declare update-ice-strength)
+
 (defn add-prop [state side card key n]
   (update! state side (update-in card [key] #(+ (or % 0) n)))
   (when (= key :advance-counter)
-    (trigger-event state side :advance card)))
+    (trigger-event state side :advance card)
+    (when (and (#{"ICE"} (:type card)) (:rezzed card)) (update-ice-strength state side card))))
 
 (defn set-prop [state side card & args]
   (update! state side (apply assoc (cons card args))))
@@ -392,10 +396,37 @@
        (doseq [dtype prevent]
               (swap! state update-in [:damage :prevent dtype] #(conj % card))))
     (update! state side c)
-    (resolve-ability state side cdef c nil)
     (when-let [events (:events cdef)]
       (register-events state side events c))
+    (resolve-ability state side cdef c nil)
     (get-card state c)))
+
+(defn ice-strength-bonus [state side n]
+  (swap! state update-in [:bonus :ice-strength] (fnil #(+ % n) 0)))
+
+(defn ice-strength [state side {:keys [strength] :as card}]
+  (-> (if-let [strfun (:strength-bonus (card-def card))]
+              (+ strength (strfun state side card nil))
+              strength)
+      (+ (or (get-in @state [:bonus :ice-strength]) 0))))
+
+(defn update-ice-strength [state side ice]
+  (let [ice (get-card state ice) oldstren (or (:current-strength ice) (:strength ice))]
+    (when (:rezzed ice)
+      (swap! state update-in [:bonus] dissoc :ice-strength)
+      (trigger-event state side :pre-ice-strength ice)
+      (update! state side (assoc ice :current-strength (ice-strength state side ice)))
+      ;(when (not= (:current-strength (get-card state ice)) oldstren)
+      (trigger-event state side :ice-strength-changed (get-card state ice) oldstren))))
+
+(defn update-ice-in-server [state side server]
+  (doseq [ice (:ices server)] (update-ice-strength state side ice) ))
+
+(defn update-all-ice [state side]
+  (doseq [central `(:archives :rd :hq)]
+    (update-ice-in-server state side (get-in @state [:corp :servers central])))
+  (doseq [remote (get-in @state [:corp :servers :remote])]
+    (update-ice-in-server state side remote)))
 
 (defn rez-cost-bonus [state side n]
   (swap! state update-in [:bonus :cost] (fnil #(+ % n) 0)))
@@ -724,22 +755,40 @@
   (let [server (first (get-in @state [:run :server]))]
     (swap! state update-in [:runner :register :unsuccessful-run] #(conj % server))
     (swap! state assoc-in [:run :unsuccessful] true)
+    (update-all-ice state side)
     (trigger-event state side :unsuccessful-run)
     (handle-end-run state side)))
 
 (defn no-action [state side args]
   (swap! state assoc-in [:run :no-action] true)
-  (system-msg state side "has no further action"))
+  (system-msg state side "has no further action")
+  (when-let [pos (get-in @state [:run :position])]
+    (when-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
+      (when (:rezzed ice)
+        (trigger-event state side :encounter-ice ice)
+        (update-ice-strength state side ice)
+        (let [stren (:current-strength (get-card state ice))]
+          (system-msg state :runner (str "encounters " (:title ice) " at strength " stren)))))))
 
 (defn continue [state side args]
   (when (get-in @state [:run :no-action])
+    (when-let [pos (get-in @state [:run :position])]
+      (when-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
+        (trigger-event state side :pass-ice ice)
+        (update-ice-in-server state side (card->server state ice))))
     (swap! state update-in [:run :position] dec)
     (swap! state assoc-in [:run :no-action] false)
     (swap! state assoc-in [:runner :rig :program]
            (for [p (get-in @state [:runner :rig :program])]
              (if (or (not (:current-strength p)) (:all-run p))
                p (assoc p :current-strength nil))))
-    (system-msg state side "continues the run")))
+    (system-msg state side "continues the run")
+    (let [pos (get-in @state [:run :position])]
+      (when (> (count (get-in @state [:run :ices])) 0)
+        (update-ice-strength state side (nth (get-in @state [:run :ices]) pos)))
+      (when (> pos 0)
+        (let [ice (get-card state (nth (get-in @state [:run :ices]) (dec pos)))]
+          (trigger-event state side :approach-ice ice))))))
 
 (defn play-ability [state side {:keys [card ability targets] :as args}]
   (let [cdef (card-def card)
@@ -861,6 +910,8 @@
          (when (or no-cost (pay state side card :credit cost (:additional-cost cdef)))
            (card-init state side (assoc card :rezzed true))
            (system-msg state side (str "rez " (:title card) (when no-cost " at no cost")))
+           (resolve-ability state side cdef card nil)
+           (when (#{"ICE"} (:type card)) (update-ice-strength state side card))
            (trigger-event state side :rez card))))))
 
 (defn corp-install
@@ -904,6 +955,8 @@
 (defn derez [state side card]
   (system-msg state side (str "derez " (:title card)))
   (update! state :corp (desactivate state :corp card true))
+  (when-let [derez-effect (:derez-effect (card-def card))]
+    (resolve-ability state side derez-effect (get-card state card) nil))
   (trigger-event state side :derez card))
 
 (defn advance [state side {:keys [card]}]

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -176,7 +176,8 @@
         [:div.counters
          (when (> counter 0) [:div.darkbg.counter counter])
          (when (> advance-counter 0) [:div.darkbg.advance.counter advance-counter])]
-        (when current-strength [:div.darkbg.strength current-strength])
+        (when (and current-strength (not= strength current-strength))
+              current-strength [:div.darkbg.strength current-strength])
         (when (and (= zone ["hand"]) (#{"Agenda" "Asset" "ICE" "Upgrade"} type))
           (let [centrals ["HQ" "R&D" "Archives"]
                 remotes (conj (remote-list remotes) "New remote")


### PR DESCRIPTION
This is an implementation of dynamic strengths for ice, including most cards that affect an ice's strength after it is rezzed. Although ultimately only Parasite really NEEDS this system, I believe it is a good step towards greater automation of ice interactions and breaking. I have done due diligence in testing this system, but I would recommend thorough testing by others before deploying it live, because the changes are fairly extensive.

Because I am a noob at GitHub, this PR also has a few miscellaneous fixes for #230 and #231.

### Core changes

Functions for handling dynamic ice strengths.

0. Ice cards now have a key `:current-strength` that gets updated at certain key moments or when requested, representing the ice's strength after modifying effects. `:strength` remains the ice's printed strength.
1. Ice card definitions can define key `:strength-bonus`, a function that returns an integer amount to modify the ice's `:strength` by. This is the starting point for dynamic ice strengths, and is used by any ice that has a simple "gain +X under this condition" bonuses. For example, Wraparound has `(req (if (some #(has? % :subtype "Fracter") (get-in runner [:rig :program])) 0 7))` as its `:strength-bonus` to grant 7 strength if there is no Fracter installed.
2. Similar to the systems for rez/install/trash cost bonuses, function `(ice-strength-bonus)` allows a third party to apply a bonus to a particular ice's strength. A paired function `(ice-strength)` accumulates all the bonuses and gives a particular ice's final `:current-strength`.
3. `(update-ice-strength)` can be called any time someone wants an ice's current strength to update. This function triggers event `:pre-ice-strength`, which a card definition can handle to set a `(ice-strength-bonus)` as applicable. `(update-ice-strength)` is called at several points in the game cycle:
    1. On ice rez
    2. On ice encounter (added a new event `:ice-encounter` for cards that trigger "on encounter")
    3. On ice install (for Curtain Wall)
    4. On adding a counter to an ice
4. Cards can call `(update-ice-strength)` if they have taken or responded to some action that modifies a target ice's strength (Datasucker, Parasite; see below).
5. Utility functions to update all ice in a server `(update-ice-in-server)` or all ice on the board `(update-all-ice)`. 
6. An event `:ice-strength-changed` which fires any time an ice's strength is recalculated. Needed for Parasite.

This may sound confusing, but these card implementation details may help...

### Card implementations

Self-boosting ice:

1. Location-based boosts (Gutenberg, Crick, Turing, Meru Mati, Curtain Wall): use `:strength-boost` to increase the ice's strength based on its server / position.
2. Counter-based boosts (Ice Wall, Fire Wall, Draco, Hadrian's Wall, Shadow): use `:strength-boost` based on `:counter` or `:advance-counter`.
3. Other conditions (Wraparound, IQ, NEXT Bronze): various techniques to count the required information for the boost.

Third-party boosts:

1. Permanent boosts (Superior Cyberwalls, Encrypted Portals, HB: Stronger Together, Lag Time, Experiential Data): handle `:pre-ice-strength` with appropriate `:req` to give bonuses to only certain types of ice. Example (Encypted Portals): 

  `:events {:pre-ice-strength {:req (req (has? target :subtype "Code Gate"))
                                :effect (effect (ice-strength-bonus 1))}`
2. Encounter-based boosts (Scrubbed, Ice Carver): handles the `:pre-ice-strength` triggered by the "on-encounter" core code; calls `(ice-strength-bonus)` when the target ice is the run's `current-ice`.
3. Boosts until end of turn (Corporate Troubleshooter, IT Department): after triggering the card's effect, "save" the target of the effect and call `(update-ice-strength)` to trigger a strength recalculation. Do fancy magic to apply a strength bonus.
4. Datasucker: if the runner is encountering an ice, keep track of how many tokens the runner has spent from the Datasucker, and call `(update-ice-strength)` each time a token is spent to update with the new (negative) strength bonus.
5. Parasite: on install, call `(update-ice-strength)`. Likewise on runner start of turn. Handle event `:ice-strength-changed` to check the ice for strength <= 0 to trash it. 
6. Patch: corp cards cannot currently be hosted; but once hosting is enabled, this card should work.

### UI

The current build shows an ice's current strength in orange, similar to a boosted icebreaker, if the current strength is not equal to the base strength. Picture:
![image](https://cloud.githubusercontent.com/assets/10083341/8028452/18726be4-0d63-11e5-939a-63ea4b4b8968.png)

This can be removed if it is distracting or unneeded.

### Tested scenarios

1. Parasite is the only card that REALLY needs this system (for now), and should work very well, including a fix for #214. Accounts for all boosting effects by requiring `:current-strength` to be <= 0, rather than base `:strength`. I have tested:
    1. Parasite on strength 0, immediate trash.
    2. Parasite on other strength, lowers current-strength by 1 each start of runner's turn.
    3. Parasite on ice, use Datasucker to drop strength to 0, immediate trash.
    4. Approach ice, Clone Chip a Parasite, use Datasucker to trash.
    5. Approach ice, corp uses IT Department to boost, Runner uses Datasucker to lower to a point that WOULD have trashed the ice... after passing ice, it resets to Parasited value.

### To-do

1. Bishop: still don't have a handle on hosting code, but should be simple to implement.
2. Quicksand: should be easy by handling the new event `:encounter-ice`.

Feedback welcome :).
