### PR TITLE
Fix for trash costs on multi-access.

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -660,8 +660,8 @@
 
 (defn handle-access [state side cards]
   (swap! state assoc :access true)
-  (swap! state update-in [:bonus] dissoc :trash)
   (doseq [c cards]
+    (swap! state update-in [:bonus] dissoc :trash)
     (let [cdef (card-def c)
           c (assoc c :seen true)]
       (when-let [name (:title c)]


### PR DESCRIPTION
Reset trash cost for each card in the doseq instead of at the start of the function.