### PR TITLE
Fix for infinite recursion Parasite on NEXT Bronze.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -3075,7 +3075,7 @@
                                          (+ c (count (filter (fn [ice] (and (:rezzed ice) (has? ice :subtype "NEXT")))
                                                              (:ices server)))))
                                      0 (flatten (seq (:servers corp)))))
-    :events (let [nb {:req (req (has? target :subtype "NEXT"))
+    :events (let [nb {:req (req (and (not= (:cid target) (:cid card)) (has? target :subtype "NEXT")))
                    :effect (effect (update-ice-strength card))}]
                  {:rez nb :derez nb :trash nb :card-moved nb})}
 


### PR DESCRIPTION
Don't update ice strength if it's NEXT Bronze itself that is being trashed.