### PR TITLE
Fix for Curtain Wall, Wraparound, Parasite

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2829,7 +2829,8 @@
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]
     :strength-bonus (req (let [ices (:ices (card->server state card))]
                               (if (= (:cid card) (:cid (last ices))) 4 0)))
-    :events (let [cw {:req (req (= (card->server state card) (card->server state target)))
+    :events (let [cw {:req (req (and (not= (:cid card) (:cid target))
+                                     (= (card->server state card) (card->server state target))))
                       :effect (effect (update-ice-strength card))}]
                  {:corp-install cw :trash cw :card-moved cw})}
 
@@ -3327,7 +3328,7 @@
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]
     :strength-bonus (req (if (some #(has? % :subtype "Fracter") (get-in runner [:rig :program]))
                            0 7))
-    :events (let [wr {:req (req (has? target :subtype "Fracter"))
+    :events (let [wr {:req (req (and (not= (:cid target) (:cid card)) (has? target :subtype "Fracter")))
                       :effect (effect (update-ice-strength card))}]
                  {:runner-install wr :trash wr :card-moved wr})}
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -417,7 +417,8 @@
       (swap! state update-in [:bonus] dissoc :ice-strength)
       (trigger-event state side :pre-ice-strength ice)
       (update! state side (assoc ice :current-strength (ice-strength state side ice)))
-      (trigger-event state side :ice-strength-changed (get-card state ice) oldstren))))
+      (when (not= oldstren (:current-strength (get-card state ice)))
+        (trigger-event state side :ice-strength-changed (get-card state ice) oldstren)))))
 
 (defn update-ice-in-server [state side server]
   (doseq [ice (:ices server)] (update-ice-strength state side ice) ))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -417,8 +417,7 @@
       (swap! state update-in [:bonus] dissoc :ice-strength)
       (trigger-event state side :pre-ice-strength ice)
       (update! state side (assoc ice :current-strength (ice-strength state side ice)))
-      (when (not= oldstren (:current-strength (get-card state ice)))
-        (trigger-event state side :ice-strength-changed (get-card state ice) oldstren)))))
+      (trigger-event state side :ice-strength-changed (get-card state ice) oldstren))))
 
 (defn update-ice-in-server [state side server]
   (doseq [ice (:ices server)] (update-ice-strength state side ice) ))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -775,9 +775,9 @@
 (defn continue [state side args]
   (when (get-in @state [:run :no-action])
     (when-let [pos (get-in @state [:run :position])]
-      (when-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
+      (let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
         (trigger-event state side :pass-ice ice)
-        (update-ice-in-server state side (card->server state ice))))
+        (when ice (update-ice-in-server state side (card->server state ice)))))
     (swap! state update-in [:run :position] dec)
     (swap! state assoc-in [:run :no-action] false)
     (swap! state assoc-in [:runner :rig :program]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -776,9 +776,9 @@
 (defn continue [state side args]
   (when (get-in @state [:run :no-action])
     (when-let [pos (get-in @state [:run :position])]
-      (let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
+      (when-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
         (trigger-event state side :pass-ice ice)
-        (when ice (update-ice-in-server state side (card->server state ice)))))
+        (update-ice-in-server state side (card->server state ice))))
     (swap! state update-in [:run :position] dec)
     (swap! state assoc-in [:run :no-action] false)
     (swap! state assoc-in [:runner :rig :program]


### PR DESCRIPTION
Fix infinite recursion when Parasite trashes Curtain Wall or Wraparound. Don't listen to `:trash` events if you are the card being trashed. Same fix as for NEXT Bronze.

I am still a noob at GitHub so there are a few commits here that I had to revert because they weren't ready. Commit 93cb7c2a8ed761f2bff749a54fcd4fbc662d4f3a is the money commit.