### PR TITLE
Grail ice with reveal and resolve

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2902,8 +2902,8 @@
                  :msg (msg "reveal "
                            (join ", " (map #(str (:title %) " ("
                                                  (:label (first (:abilities (card-def %)))) ")") targets)))}
-                {:label "Resolve up to 2 Grail ICE subroutines from HQ"
-                 :choices {:max 2 :req #(and (:side % "Corp") (= (:zone %) [:hand]) (has? % :subtype "Grail"))}
+                {:label "Resolve a Grail ICE subroutine from HQ"
+                 :choices {:req #(and (:side % "Corp") (= (:zone %) [:hand]) (has? % :subtype "Grail"))}
                  :effect (req (doseq [ice targets]
                                 (resolve-ability state side (first (:abilities (card-def ice))) card nil)))}]}
 
@@ -3017,8 +3017,8 @@
                  :msg (msg "reveal "
                            (join ", " (map #(str (:title %) " ("
                                                  (:label (first (:abilities (card-def %)))) ")") targets)))}
-                {:label "Resolve up to 2 Grail ICE subroutines from HQ"
-                 :choices {:max 2 :req #(and (:side % "Corp") (= (:zone %) [:hand]) (has? % :subtype "Grail"))}
+                {:label "Resolve a Grail ICE subroutine from HQ"
+                 :choices {:req #(and (:side % "Corp") (= (:zone %) [:hand]) (has? % :subtype "Grail"))}
                  :effect (req (doseq [ice targets]
                                 (resolve-ability state side (first (:abilities (card-def ice))) card nil)))}]}
 
@@ -3062,8 +3062,8 @@
                  :msg (msg "reveal "
                            (join ", " (map #(str (:title %) " ("
                                                  (:label (first (:abilities (card-def %)))) ")") targets)))}
-                {:label "Resolve up to 2 Grail ICE subroutines from HQ"
-                 :choices {:max 2 :req #(and (:side % "Corp") (= (:zone %) [:hand]) (has? % :subtype "Grail"))}
+                {:label "Resolve a Grail ICE subroutine from HQ"
+                 :choices {:req #(and (:side % "Corp") (= (:zone %) [:hand]) (has? % :subtype "Grail"))}
                  :effect (req (doseq [ice targets]
                                 (resolve-ability state side (first (:abilities (card-def ice))) card nil)))}]}
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -417,8 +417,7 @@
       (swap! state update-in [:bonus] dissoc :ice-strength)
       (trigger-event state side :pre-ice-strength ice)
       (update! state side (assoc ice :current-strength (ice-strength state side ice)))
-      (when (not= oldstren (:current-strength (get-card state ice)))
-        (trigger-event state side :ice-strength-changed (get-card state ice) oldstren)))))
+      (trigger-event state side :ice-strength-changed (get-card state ice) oldstren))))
 
 (defn update-ice-in-server [state side server]
   (doseq [ice (:ices server)] (update-ice-strength state side ice) ))


### PR DESCRIPTION
Building off of @JoelCFC25's initial Grail code, here is an implementation of Grail ice that can:

1. Reveal up to 2 `:subtype "Grail"` ice from HQ; and then
2. Resolve one ability from a Grail ice in HQ at a time.

So on encounter, Corp clicks his rezzed Grail to reveal 2 Grail from hand. If the subs are not broken, Corp can choose which subs to fire in which order, by either trigger the rezzed ice's subroutine or by triggering the rezzed ice's ability to resolve another Grail's subroutine. It's a little click intensive, but gives the most control and accuracy over execution, and is important for making sure that Lancelot's Trash routine fully resolves before Merlin's net damage (in case Deus Ex is installed).

This code assumes that the ice's actual subroutine is first among its abilities, so the abilities should not be rearranged.