### PR TITLE
Agenda advancement cost effects: SanSan City Grid, et. al.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -298,6 +298,15 @@
     :trash-effect {:req (req (:access @state))
                    :effect (effect (move :runner card :scored) (gain :runner :agenda-point 2))}}
 
+   "Chakana"
+   {:leave-play (effect (update-all-advancement-costs))
+    :events {:successful-run {:effect (effect (add-prop card :counter 1)) :req (req (= target :rd))}
+             :pre-advancement-cost {:req (req (>= (get-virus-counters state side card) 3))
+                               :effect (effect (advancement-cost-bonus 1))}
+             :counter-added
+             {:req (req (or (= (:title target) "Hivemind") (= (:cid target) (:cid card))))
+              :effect (effect (update-all-advancement-costs))}}}
+
    "Chaos Theory: Wünderkind"
    {:effect (effect (gain :memory 1))}
 
@@ -1313,6 +1322,12 @@
    {:events {:runner-turn-begins {:msg "trash the top 2 cards from Stack and draw 1 card"
                                   :effect (effect (mill 2) (draw))}}}
 
+   "Medical Breakthrough"
+   {:effect (effect (update-all-advancement-costs))
+    :stolen (effect (update-all-advancement-costs))
+    :advancement-cost-bonus (req (- (count (filter #(= (:title %) "Medical Breakthrough")
+                                                (concat (:scored corp) (:scored runner))))))}
+
    "Medical Research Fundraiser"
    {:effect (effect (gain :credit 8) (gain :runner :credit 3))}
 
@@ -1385,7 +1400,8 @@
     :effect (effect (corp-install (assoc target :advance-counter 3) "New remote"))}
 
    "NAPD Contract"
-   {:steal-cost [:credit 4]}
+   {:steal-cost [:credit 4]
+    :advancement-cost-bonus (req (:bad-publicity corp))}
 
    "NBN: Making News"
    {:recurring 2}
@@ -1897,6 +1913,14 @@
                                              (<= (:cost %) (:credit runner))) (:discard runner)))
                  :effect (effect (trash card) (play-instant target))}]}
 
+   "SanSan City Grid"
+   {:effect (req (when-let [agenda (some #(when (= (:type %) "Agenda") %) (:content (card->server state card)))]
+                   (update-advancement-cost state side agenda)))
+    :events {:corp-install {:req (req (and (= (:type target) "Agenda") (= (:zone card) (:zone target))))
+                            :effect (effect (update-advancement-cost target))}
+             :pre-advancement-cost {:req (req (= (:zone card) (:zone target)))
+                               :effect (effect (advancement-cost-bonus -1))}}}
+
    "Satellite Uplink"
    {:req (req tagged) :msg (msg "expose " (join ", " (map :title targets)))
     :choices {:max 2 :req #(= (first (:zone %)) :servers)}
@@ -2348,6 +2372,13 @@
 
    "Traffic Accident"
    {:req (req (>= (:tag runner) 2)) :effect (effect (damage :meat 2 {:card card}))}
+
+   "Traffic Jam"
+   {:effect (effect (update-all-advancement-costs))
+    :leave-play (effect (update-all-advancement-costs))
+    :events {:pre-advancement-cost
+             {:effect (req (advancement-cost-bonus
+                             state side (count (filter #(= (:title %) (:title target)) (:scored corp)))))}}}
 
    "Tri-maf Contact"
    {:abilities [{:cost [:click 1] :msg "gain 2 [Credits]" :once :per-turn
@@ -3383,9 +3414,6 @@
    "Bad Times"
    {:req (req tagged)}
 
-   "Chakana"
-   {:events {:successful-run {:effect (effect (add-prop card :counter 1)) :req (req (= target :rd))}}}
-
    "Exile: Streethawk"
    {:effect (effect (gain :link 1))}
 
@@ -3433,4 +3461,7 @@
                                             (has? target :subtype "Gray Ops")))}}}
 
    "The Source"
-   {:events {:agenda-scored (effect (trash card)) :agenda-stolen (effect (trash card))}}})
+   {:effect (effect (update-all-advancement-costs))
+    :leave-play (effect (update-all-advancement-costs))
+    :events {:agenda-scored (effect (trash card)) :agenda-stolen (effect (trash card))
+             :pre-advancement-cost {:effect (effect (advancement-cost-bonus 1))}}}})

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -989,7 +989,6 @@
     (update-advancement-cost state side ag)))
 
 (defn update-advancement-cost [state side agenda]
-  (system-msg state side (str "update agenda " (:title agenda)))
   (swap! state update-in [:bonus] dissoc :advancement-cost)
   (trigger-event state side :pre-advancement-cost agenda)
   (update! state side (assoc agenda :current-cost (advancement-cost state side agenda))))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -998,7 +998,7 @@
   (when (pay state side card :click 1 :credit 1)
     (system-msg state side "advances a card")
     (update-advancement-cost state side card)
-    (add-prop state side card :advance-counter 1)))
+    (add-prop state side (get-card state card) :advance-counter 1)))
 
 (defn forfeit [state side card]
   (system-msg state side (str "forfeit " (:title card)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -20,7 +20,7 @@
   (let [username (get-in @state [side :user :username])]
     (say state side {:user "__system__" :text (str username " " text ".")})))
 
-(declare prompt! forfeit trigger-event handle-end-run trash update-advancement-cost)
+(declare prompt! forfeit trigger-event handle-end-run trash update-advancement-cost update-all-advancement-costs)
 
 (defn pay [state side card & args]
   (let [costs (merge-costs (remove #(or (nil? %) (= % [:forfeit])) args))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -56,9 +56,9 @@
       (aset input "value" "")
       (.focus input))))
 
-(defn action-list [{:keys [type zone rezzed advanceable advance-counter advancementcost] :as card}]
+(defn action-list [{:keys [type zone rezzed advanceable advance-counter advancementcost current-cost] :as card}]
   (-> []
-      (#(if (and (= type "Agenda") (>= advance-counter advancementcost))
+      (#(if (and (= type "Agenda") (>= advance-counter current-cost))
           (cons "score" %) %))
       (#(if (or (and (= type "Agenda") (= (first zone) "servers"))
                 (= advanceable "always")
@@ -153,7 +153,7 @@
         side (if (#{"HQ" "R&D" "Archives"} server) "Corp" "Runner")]
     (send-command "move" {:card card :server server})))
 
-(defn card-view [{:keys [zone code type abilities counter advance-counter advancementcost subtype
+(defn card-view [{:keys [zone code type abilities counter advance-counter advancementcost current-cost subtype
                          advanceable rezzed strength current-strength title remotes selected hosted]
                   :as cursor}
                  owner {:keys [flipped] :as opts}]
@@ -205,7 +205,7 @@
               abilities)]))
         (when (= (first zone) "servers")
           (cond
-            (and (= type "Agenda") (>= advance-counter advancementcost))
+            (and (= type "Agenda") (>= advance-counter (or current-cost advancementcost)))
             [:div.blue-shade.panel.menu.abilities {:ref "agenda"}
              [:div {:on-click #(send-command "advance" {:card @cursor})} "Advance"]
              [:div {:on-click #(send-command "score" {:card @cursor})} "Score"]]


### PR DESCRIPTION
Extension of the cost-bonus framework to agenda advancement requirements.

### Core changes

1. Added event `:pre-advancement-cost` that triggers when an agenda's advancement requirement is being calculated. Advancement requirements are calculated when:
    1. An agenda is installed.
    2. An agenda is advanced.
    2. Corp's turn begins.
    3. Requested by third parties.
2. Function `(update-advancement-cost)` updates an individual agenda's advancement requirement; utility `(update-all-advancement-costs)` does so for all installed agendas.
3. Cards can implement the key `:advancement-cost-bonus` as an `effect` to change their advancement requirement based on the state of the game. NAPD Contract uses this to give +1 advancement cost for each bad pub; Medical Breakthrough uses it to count the number of scored Medical Breakthroughs.
3. Function `(advancement-cost-bonus)` can be used by third parties to apply a bonus to the advancement requirement of an agenda that is currently being updated in `update-advancement-cost`, typically by handling the `:pre-advancement-cost` event. The Source uses this to always give a cost bonus of 1; Chakana uses it to give a cost bonus of 1 if there are at least 3 virus counters on it. 

### Card implementations

1. Chakana: bonus of 1 if there are at least 3 virus counters (including Hivemind).
2. Medical Breakthrough: bonus of -1 for each scored Medical Breakthrough.
3. NAPD Contract: self-inflicted +1 bonus for each bad publicity.
4. SanSan City Grid: triggers a cost update for any agenda already installed in the server, or installed later into the server. -1 bonus for any agenda in the same server.
5. The Source: +1 bonus for all agendas.
6. Traffic Jam: +1 bonus for each corp-scored agenda with the same title as the scorable agenda.

### Known issues

1. If a corp somehow gains a bad publicity AFTER installing NAPD Contract, AFTER the start of turn on the turn in which they attempt to score it, the bad publicity will not affect the contract's advancement requirement. Example: NAPD installed with 4 counters; Start of Turn; Draw; (SOMEHOW gain 1 bad publicity); score NAPD with only 4 counters.