### PR TITLE
Targeted trashing and trash prevention

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -457,7 +457,7 @@
                    (gain state :corp :credit 7) (lose state :corp :credit :all)))}
 
    "Crash Space"
-   {:prevent [:meat]
+   {:prevent {:damage [:meat]}
     :recurring 2
     :abilities [{:label "Trash to prevent up to 3 meat damage"
                  :msg "prevent up to 3 meat damage"
@@ -770,7 +770,7 @@
                     (move target :hand) (shuffle! :deck))}
 
    "Feedback Filter"
-   {:prevent [:net :brain]
+   {:prevent {:damage [:net :brain]}
     :abilities [{:cost [:credit 3] :msg "prevent 1 net damage" :effect (effect (damage-prevent :net 1))}
                 {:msg "prevent 2 brain damage" :effect (effect (trash card) (damage-prevent :brain 2)) }]}
 
@@ -1365,7 +1365,7 @@
     :events {:pre-install nil}}
 
    "Monolith"
-   {:prevent [:net :brain]
+   {:prevent {:damage [:net :brain]}
     :effect (effect (gain :memory 3)) :leave-play (effect (lose :memory 3))
     :abilities [{:msg (msg "prevent 1 brain or net damage by trashing " (:title target))
                  :priority true
@@ -1427,7 +1427,7 @@
    {:recurring 1}
 
    "Net Shield"
-   {:prevent [:net]
+   {:prevent {:damage [:net]}
     :abilities [{:cost [:credit 1] :once :per-turn :msg "prevent the first net damage this turn"
                  :effect (effect (damage-prevent :net 1))}]}
 
@@ -1621,7 +1621,7 @@
 
    "Plascrete Carapace"
    {:data [:counter 4]
-    :prevent [:meat]
+    :prevent {:damage [:meat]}
     :abilities [{:counter-cost 1 :msg "prevent 1 meat damage"
                  :effect (req (damage-prevent state side :meat 1)
                               (when (= (:counter card) 0) (trash state side card)))}]}
@@ -1888,7 +1888,7 @@
                  :effect (effect (trash card) (damage :brain 1 {:card card}))}]}
 
    "Sacrificial Clone"
-   {:prevent [:meat :net :brain]
+   {:prevent {:damage [:meat :net :brain]}
     :abilities [{:effect (req (doseq [c (concat (get-in runner [:rig :hardware])
                                                 (filter #(not (has? % :subtype "Virtual"))
                                                         (get-in runner [:rig :resource]))
@@ -2614,7 +2614,7 @@
     :abilities [{:cost [:credit 2] :msg "break ICE subroutine"}]}
 
    "Deus X"
-   {:prevent [:net]
+   {:prevent {:damage [:net]}
     :abilities [{:msg "break any number of AP subroutines" :effect (effect (trash card))}
                 {:msg "prevent any amount of net damage"
                  :effect (effect (trash card) (damage-prevent :net Integer/MAX_VALUE))}]}

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -36,7 +36,8 @@
    "choice" core/resolve-prompt
    "select" core/select
    "shuffle" core/shuffle-deck
-   "ability" core/play-ability})
+   "ability" core/play-ability
+   "trash-resource" core/trash-resource})
 
 (defn convert [args]
   (try
@@ -63,7 +64,8 @@
           (.send socket (generate-string (assoc (dissoc @(@game-states gameid) :events) :action action)))
           (.send socket (generate-string "ok")))
         (catch Exception e
-          (println "Error " action command (get-in args [:card :title]) e)
+          (println "Error " action command (get-in args [:card :title]) e "\nStack trace:"
+                   (java.util.Arrays/toString (.getStackTrace e)))
           (if (and state (#{"do" "start"} action))
             (.send socket (generate-string state))
             (.send socket (generate-string "error"))))))))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -587,7 +587,7 @@
                                       label])
                                    servers)])]])
                        (when (= side :corp)
-                          (cond-button "Purge" (>= (:click me) 3) #(send-command "purge")))
+                         (cond-button "Purge" (>= (:click me) 3) #(send-command "purge")))
                        (when (= side :corp)
                          (cond-button "Trash Resource" (and (>= (:click me) 1) (>= (:credit me) 2)
                                                             (>= (:tag opponent) 1)) #(send-command "trash-resource")))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -587,7 +587,10 @@
                                       label])
                                    servers)])]])
                        (when (= side :corp)
-                         (cond-button "Purge" (>= (:click me) 3) #(send-command "purge")))
+                          (cond-button "Purge" (>= (:click me) 3) #(send-command "purge")))
+                       (when (= side :corp)
+                         (cond-button "Trash Resource" (and (>= (:click me) 1) (>= (:credit me) 2)
+                                                            (>= (:tag opponent) 1)) #(send-command "trash-resource")))
                        (cond-button "Draw" (>= (:click me) 1) #(send-command "draw"))
                        (cond-button "Gain Credit" (>= (:click me) 1) #(send-command "credit"))])))]]
 


### PR DESCRIPTION
Implements a Trash Resource button for Corp, refactors most "trash a ____" abilities for Corp, and adds trash prevention cards (Sacrificial Construct etc.).

### Core changes

1. Refactors the damage prevention code to unify all prevention effects under `@state`'s `:prevent` field. We now have `:prevent :damage` and `:prevent :trash`, and in the future can implement `:prevent :tag`. Feedback Filter now registers its prevention effect as `:prevent {:damage [:net :brain]}`, and Sacrifical Construct as `:prevent {:trash [:program :hardware]}`.
2. Adds code for trash prevention, giving the Runner time to activate any prevention cards when appropriate. Very similar to damage prevention code.
3. Adds a conditional "Trash Resource" button to the Corp's action area.

### Card implementations

Refactorings:

1. Refactors all Destroyer-type effects on ice to use a single shared ability defined at the top of `cards.clj`. I found several different implementations of "trash a program" abilities and decided to unify them all under one ability map. I am not 100% convinced that my submission is the BEST way of doing trash-a-program, but now we can change one set of code to affect all ice with this ability. For reference, the new ability is:

    ````clojure
 {:prompt "Choose a program to trash" :label "Trash a program"
                    :msg (msg "trash " (:title target))
                    :choices {:req #(= (:type %) "Program")}
                    :effect (effect (trash target))}
    ````

    which is an improvement (IMHO) in that the Corp clicks on the ice to trash instead of selecting its name from a list, which has the problem of not distinguishing between multiple ice with the same name (relevant for Datasucker and Parasite in particular). I do see a potential issue outlined below.
2. Similarly refactors "trash a hardware" routines, which are far fewer.

New card implementations:

1. Aggressive Secretary: allow the Corp to select the programs to trash, instead of just printing a message.
2. Shattered Remains: likewise.
3. Fall Guy: `:prevent {:trash [:resource]}`. Fall Guy itself is trashed as `:unpreventable` just to make the code work... otherwise Fall Guy's self-trash triggers his own "Prevent trash?" routine which is just messy.
4. Sacrificial Construct: `:prevent {:trash [:program :hardware]}`.
5. LLDS Energy Regulator: `:prevent {:trash [:hardware]}`.

### Misc

1. Added a stack trace to exceptions caught by the server. Should help with debugging. If you want to send me a server log every few days, I can look into some of the error messages that crop up.
2. I really messed up my Git repository while trying to learn to `git rebase`. I am 95% sure I got everything restored for this submit, and have done my due diligence testing this latest submission, but I may have missed something.

### Known issues:

1. If a runner discards a card from hand, trash-prevention effects will trigger. Probably easy to fix but haven't looked into it. (Note to self: try `:unpreventable true` when calling `trash` in `move-card`.)
2. BIGGER ISSUE: when taking damage of any kind, if you have a prevention card installed, you will get a prevention prompt if the damage makes you trash a preventable card.
2. The refactored Trash a Program routine filters to cards with `:type "Program"`. This is IMO better than filtering to cards in the `:rig :program` zone, since Parasite and other hosted cards are not in this zone. However it does allow someone to trash a program on Personal Workshop, which to the best of my knowledge is not allowed...?