### PR TITLE
fix Net-Ready Eyes strength boost

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1484,7 +1484,7 @@
     :events {:run {:choices {:req #(and (= (:zone %) [:rig :program])
                                         (has? % :subtype "Icebreaker"))}
                    :msg (msg "give " (:title target) " +1 strength")
-                   :effect (effect (pump target 1))}}}
+                   :effect (effect (pump target 1 true))}}}
 
    "New Angeles City Hall"
    {:events {:agenda-stolen {:msg "trash itself" :effect (effect (trash card))}}


### PR DESCRIPTION
The boost given to the targeted icebreaker should last for the rest of the run like Gordian Blade, Pipeline, et al.

Fix for #264. 