### PR TITLE
Fix for Rachel Beckman, prevention of trashes from taking damage

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -480,7 +480,7 @@
              (swap! state update-in [:runner :brain-damage] #(+ % n))
              (swap! state update-in [:runner :max-hand-size] #(- % n)))
        (doseq [c (take n (shuffle hand))]
-              (trash state side c nil type))
+              (trash state side c {:unpreventable true} type))
        (trigger-event state side :damage type card)))
 
 (defn damage


### PR DESCRIPTION
Fix for Rachel Beckman's infinite recursion when trashed, by removing her watch effect before trashing her, so the trash effect does not trigger her watch effect in an infinite recursion loop.

Fix to disallow using trash-prevention effects when trashing cards from grip because of damage.