### PR TITLE
Fixes for Quicksand and Oaktown Renovation

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -3258,9 +3258,10 @@
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
 
    "Quicksand"
-   {:abilities [{:msg "add 1 power counter"
-                 :effect (effect (add-prop card :counter 1) (add-prop card :strength 1))}
-                {:msg "end the run" :effect (effect (end-run))}]}
+   {:events {:encounter-ice {:req (req (= (:cid target) (:cid card)))
+                             :effect (effect (add-prop card :counter 1))}}
+    :strength-bonus (req (or (:counter card) 0))
+    :abilities [{:msg "end the run" :effect (effect (end-run))}]}
 
    "Rainbow"
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1511,7 +1511,7 @@
                          :effect (effect (trash-cost-bonus 3))}}}
 
    "Oaktown Renovation"
-   {:install-rezzed true
+   {:install-state :face-up
     :events {:advance {:req (req (= (:cid card) (:cid target)))
                        :effect (req (gain state side :credit
                                           (if (>= (:advance-counter (get-card state card)) 5) 3 2)))}}}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -966,12 +966,12 @@
                 (server-list state card) {:effect (effect (corp-install card target args))})
        (do (when (= server "New remote")
              (trigger-event state side :server-created card))
-           (let [c (assoc card :advanceable (:advanceable (card-def card)))
+           (let [cdef (card-def card)
+                 c (assoc card :advanceable (:advanceable cdef))
                  slot (conj (server->zone state server) (if (= (:type c) "ICE") :ices :content))
                  dest-zone (get-in @state (cons :corp slot))
                  install-cost (if (and (= (:type c) "ICE") (not no-install-cost))
-                                (count dest-zone) 0)
-                 rezzed (or rezzed (:install-rezzed (card-def card)))]
+                                (count dest-zone) 0)]
              (when (and (not (and (has? c :subtype "Region")
                                   (some #(has? % :subtype "Region") dest-zone)))
                         (pay state side card extra-cost :credit install-cost))
@@ -980,7 +980,7 @@
                    (system-msg state side (str "trashes " (if (:rezzed prev-card)
                                                             (:title prev-card) "a card") " in " server))
                    (trash state side prev-card)))
-               (let [card-name (if (or rezzed (:rezzed c)) (:title card) "a card")]
+               (let [card-name (if (or rezzed (:rezzed c) (= (:install-state cdef) :face-up)) (:title card) "a card")]
                  (if (> install-cost 0)
                    (system-msg state side (str "pays " install-cost " [Credits] to install "
                                                card-name " in " server))
@@ -989,7 +989,11 @@
                  (trigger-event state side :corp-install moved-card)
                  (when (= (:type c) "Agenda")
                    (update-advancement-cost state side moved-card))
-                 (when rezzed (rez state side moved-card {:no-cost true})))))))))
+                 (when (or rezzed (= (:install-state cdef) :rezzed))
+                   (rez state side moved-card {:no-cost true}))
+                 (when (= (:install-state cdef) :face-up)
+                   (do (card-init state side (assoc (get-card state moved-card) :rezzed true))
+                       (resolve-ability state side cdef (get-card state moved-card) nil))))))))))
 
 (defn play [state side {:keys [card server]}]
   (case (:type card)


### PR DESCRIPTION
Fix for Quicksand to fit the new ice-strength system. Counter is gained during `:encounter-ice`, which is when the Corp clicks "No more action".

Fix for #270 by refactoring the "install rezzed" code. Changed `:install-rezzed true` to a more general `:install-state` key. Oaktown Renovation uses `:install-state :face-up`; if this feature is used on new cards in the future, we can easily expand to `:install-state :rezzed` or any other state. In `corp-install`, if a card is flagged `:install-state :face-up`, it is "pseudo-rezzed": we set `:rezzed` to true for display purposes and initialize the card, but notably do NOT trigger event `:rezzed`, so Hacktivist Meeting does not respond. If more cards make use of the distinction between rezzed and face-up, we can expand the UI code to visibly show "face-up" cards without setting the `:rezzed` key to true.