### PR TITLE
Fix for IHW: passing variadic arguments to resolve-trash.

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -618,8 +618,8 @@
                     (swap! state update-in [:trash :trash-prevent] dissoc ktype))
                   (do
                     (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
-                    (resolve-trash state side card args targets))))))
-          (resolve-trash state side card args targets))))))
+                    (apply resolve-trash state side card args targets))))))
+          (apply resolve-trash state side card args targets))))))
 
 (defn trash-cards [state side cards]
   (doseq [c cards] (trash state side c)))


### PR DESCRIPTION
Apparently passing a variadic argument sequence to another function taking a variadic argument sequence passes the original sequence as the first argument in the second function's sequence, so the second receives a sequence containing a sequence rather than a sequence containing the elements of the other sequence.

SEQUENCE.

This fixes I've Had Worse, which was receiving a `target` of `(:net)` instead of `:net` (likewise `:meat`).