### PR TITLE
Trash code minor refactor to indicate cause of trashing; Armand "Geist" Walker implementation

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2786,7 +2786,7 @@
    "Gordian Blade"
    {:abilities [{:cost [:credit 1] :msg "break 1 code gate subroutine"}
                 {:cost [:credit 1] :msg "add 1 strength for the remainder of this run"
-                 :effect (effect (pump card 1 {:pump-duration :per-run}))}]}
+                 :effect (effect (pump card 1 true))}]}
 
    "Gingerbread"
    {:abilities [{:cost [:credit 1] :msg "break 1 tracer subroutine"}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -618,8 +618,8 @@
                     (swap! state update-in [:trash :trash-prevent] dissoc ktype))
                   (do
                     (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
-                    (resolve-trash state side card args targets))))))
-          (resolve-trash state side card args targets))))))
+                    (apply resolve-trash state side card args targets))))))
+          (apply resolve-trash state side card args targets))))))
 
 (defn trash-cards [state side cards]
   (doseq [c cards] (trash state side c)))


### PR DESCRIPTION
Small refactoring to trash code to support an optional argument to `trash` with key `:cause`, indicating the "reason" why the card was trashed. So far this is used in three ways:

1. `:cause :ability-cost` -- any ability that has a cost of trashing the card should pass this key. Trash prevention effects will not fire when this key is present, because you cannot prevent the cost of using an ability. (I did not know this when implementing trash prevention.) 

    I updated all the cards in this list with `:cause ability-cost`: http://netrunnerdb.com/find/?q=x%3A%22%5BTrash%5D%22+d%3Ar&sort=name&view=list&_locale=en; except for Raymond Flint, Disrupter, and Street Peddler, all of which are unimplemented. 

2. `:cause :meat/:net/:brain` -- if the trash was caused by taking damage, that type of damage will be set as the cause.
3. `:cause :subroutine` -- ice that have Trash a Program / Trash a Hardware routines will pass this as the cause, although that knowledge is currently unused by any cards. Who knows, maybe we'll get a cardware that says "prevent a program from being trashed by a subroutine".

The `:cause` of trashing is sent as the first argument in `targets` to a card-def's `:trash-effect`; and as the SECOND argument to the `:trash` event (the first being the actual card that was trashed). It can be used like this:

````clojure
"Ive Had Worse"
   {:effect (effect (draw 3))
    :trash-effect {:req (req (#{:meat :net} target))
                   :effect (effect (draw :runner 3)) :msg "draw 3 cards"}}
````

To check to see if the cause was meat or net damage. 

### Armand "Geist" Walker

Spoilers on Reddit reveal this Criminal ID's ability as "you may draw a card whenever you use the [Trash] ability of a card." These changes help implement Geist by examining the cause of a card's trashing:

````clojure
"Armand \"Geist\" Walker"
   {:effect (effect (gain :link 1))
    :events {:trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
                                :prompt "Draw a card?" :msg (msg "draw a card" targets) :effect (effect (draw 1))}}}}
````

Geist's full English title has not been revealed yet, so we will probably have to fix his name here once that is known.

### Cortez Chip

I also implemented Cortez Chip. Yay.