### PR TITLE
Fixes for Project Atlas and Geist.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -8,7 +8,7 @@
 (def trash-hardware {:prompt "Choose a piece of hardware to trash" :label "Trash a piece of hardware"
                      :msg (msg "trash " (:title target))
                      :choices {:req #(= (:type %) "Hardware")}
-                     :effect (effect (trash target {:cause :subroutine}))})
+                     :effect (effect (trash target {:cause :subrprojectoutine}))})
 
 (def cards
   {"Accelerated Beta Test"
@@ -125,7 +125,7 @@
    "Armand \"Geist\" Walker"
    {:effect (effect (gain :link 1))
     :events {:trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
-                                :prompt "Draw a card?" :msg (msg "draw a card" targets) :effect (effect (draw 1))}}}}
+                                :prompt "Draw a card?" :msg (msg "draw a card") :effect (effect (draw 1))}}}}
 
    "Armitage Codebusting"
    {:data {:counter 12}
@@ -1766,7 +1766,7 @@
                  :msg "do 1 meat damage"}]}
 
    "Project Atlas"
-   {:effect (effect (set-prop card :counter (- (:advance-counter card) 3)))
+   {:effect (effect (set-prop card :counter (max 0 (- (:advance-counter card) 3))))
     :abilities [{:counter-cost 1 :prompt "Choose a card" :label "Search R&D and add 1 card to HQ"
                  :msg (msg "add " (:title target) " to HQ from R&D")
                  :choices (req (:deck corp)) :effect (effect (move target :hand) (shuffle! :deck))}]}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -8,7 +8,7 @@
 (def trash-hardware {:prompt "Choose a piece of hardware to trash" :label "Trash a piece of hardware"
                      :msg (msg "trash " (:title target))
                      :choices {:req #(= (:type %) "Hardware")}
-                     :effect (effect (trash target {:cause :subrprojectoutine}))})
+                     :effect (effect (trash target {:cause :subroutine}))})
 
 (def cards
   {"Accelerated Beta Test"


### PR DESCRIPTION
Remove debug message from Geist's ability. Fix Project Atlas receiving -1 counters when scored under SanSan City Grid.