### PR TITLE
Cards that modify their own rez cost while unrezzed: IQ, space ice

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -3138,7 +3138,8 @@
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}
 
    "Asteroid Belt"
-   {:advanceable :always :abilities [{:msg "end the run" :effect (effect (end-run))}]}
+   {:advanceable :always :abilities [{:msg "end the run" :effect (effect (end-run))}]
+    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
 
    "Bandwidth"
    {:abilities [{:msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}]}
@@ -3487,7 +3488,8 @@
 
    "Nebula"
    {:advanceable :always
-    :abilities [trash-program]}
+    :abilities [trash-program]
+    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
 
    "Negotiator"
    {:abilities [{:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))}
@@ -3527,7 +3529,8 @@
    "Orion"
    {:advanceable :always
     :abilities [trash-program
-                {:msg "end the run" :effect (effect (end-run))}]}
+                {:msg "end the run" :effect (effect (end-run))}]
+    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
 
    "Pachinko"
    {:abilities [{:label "End the run if the Runner is tagged"
@@ -3718,7 +3721,8 @@
     :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
 
    "Wormhole"
-   {:advanceable :always}
+   {:advanceable :always
+    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
 
    "Wotan"
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -3369,7 +3369,8 @@
 
    "IQ"
    {:abilities [{:msg "end the run" :effect (effect (end-run))}]
-    :strength-bonus (req (count (:hand corp)))}
+    :strength-bonus (req (count (:hand corp)))
+    :rez-cost-bonus (req (count (:hand corp)))}
 
    "Information Overload"
    {:abilities [{:label "Trace 1 - Give the Runner 1 tag"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -441,7 +441,9 @@
 (defn rez-cost [state side {:keys [cost] :as card}]
   (if (nil? cost)
     nil
-    (-> cost
+    (-> (if-let [rezfun (:rez-cost-bonus (card-def card))]
+          (+ cost (rezfun state side card nil))
+          cost)
         (+ (or (get-in @state [:bonus :cost]) 0))
         (max 0))))
 


### PR DESCRIPTION
Simple addition to allow a card to modify its own rez cost while it is unrezzed, as cards cannot participate in the event-based rez cost discount system while unrezzed. Implement IQ and the "space ice" Asteroid Belt, Nebula, Orion, Wormhole.