### PR TITLE
Retain counters on derezzed Corp assets

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -42,7 +42,7 @@
                            :msg "gain [Click]" :effect (effect (gain :runner :click 1))}}}
 
    "Adonis Campaign"
-   {:data {:counter 12}
+   {:effect (effect (add-prop card :counter 12))
     :events {:corp-turn-begins {:msg "gain 3 [Credits]" :counter-cost 3
                                 :effect (req (gain state :corp :credit 3)
                                              (when (zero? (:counter card)) (trash state :corp card)))}}}
@@ -833,7 +833,7 @@
                         (when caninst (lose state side :credit cost))))))}
 
    "Eve Campaign"
-   {:data {:counter 16}
+   {:effect (effect (add-prop card :counter 16))
     :events {:corp-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
                                 :effect (req (gain state :corp :credit 2)
                                              (when (zero? (:counter card)) (trash state :corp card)))}}}
@@ -1907,7 +1907,7 @@
     :effect (effect (rez target {:no-cost true}))}
 
    "Private Contracts"
-   {:data {:counter 14}
+   {:effect (effect (add-prop card :counter 14))
     :abilities [{:cost [:click 1] :counter-cost 2 :msg "gain 2 [Credits]"
                  :effect (req (gain state :corp :credit 2)
                               (when (= (:counter card) 0) (trash state :corp card)))}]}
@@ -2130,7 +2130,7 @@
     :effect (effect (move target :deck) (shuffle! :deck))}
 
    "Rex Campaign"
-   {:data [:counter 3]
+   {:effect (effect (add-prop card :counter 3))
     :events {:corp-turn-begins
              {:effect (req (add-prop state side card :counter -1)
                            (when (= (:counter card) 1)

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1857,6 +1857,10 @@
                          :label "Remove 1 counter from a hosted card" :cost [:credit 1])]
       :events {:runner-turn-begins remove-counter}})
 
+   "Pheromones"
+   {:events
+    {:successful-run {:req (req (= target :hq)) :effect (effect (add-prop card :counter 1))}}}
+
    "Philotic Entanglement"
    {:msg (msg "do " (count (:scored runner)) " net damage")
     :effect (effect (damage :net (count (:scored runner)) {:card card}))}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -679,8 +679,8 @@
                                              (has? % :subtype "Virus"))
                                        (:deck runner)))
                  :cost [:click 1 :credit 1] :effect (effect (move target :hand) (shuffle! :deck))}
-                {:label "Install a non Icebreaker program on Djin" :cost [:click 1]
-                 :prompt "Choose a non Icebreaker program to install on Djin"
+                {:label "Install a non-Icebreaker program on Djinn" :cost [:click 1]
+                 :prompt "Choose a non-Icebreaker program to install on Djinn"
                  :choices (req (filter #(and (= (:type %) "Program")
                                              (not (has? % :subtype "Icebreaker"))
                                              (<= (:cost %) (:credit runner)))
@@ -1964,7 +1964,7 @@
                                                       (:discard runner))))))}
 
    "Power Grid Overload"
-   {:trace {:base 2 :msg (msg "trash 1 piece of hardware with install cost lower or equal to "
+   {:trace {:base 2 :msg (msg "trash 1 piece of hardware with install cost less than or equal to "
                               (- target (second targets)))
             :effect (req (let [max-cost (- target (second targets))]
                            (resolve-ability state side
@@ -2249,7 +2249,7 @@
     :events {:pre-install nil}}
 
    "Scheherazade"
-   {:abilities [{:cost [:click 1] :prompt "Choose a program to install on Scherazade"
+   {:abilities [{:cost [:click 1] :prompt "Choose a program to install on Scheherazade"
                  :choices (req (filter #(and (has? % :type "Program")
                                              (<= (:cost %) (:credit runner))
                                              (<= (:memoryunits %) (:memory runner)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -63,9 +63,9 @@
 (defn desactivate
   ([state side card] (desactivate state side card nil))
   ([state side card keep-counter]
-   (let [c (dissoc card :counter :current-strength :abilities :rezzed :special)
-         c (if (= (:side c) "Runner") (dissoc c :installed) c)
-         c (if keep-counter c (dissoc c :advance-counter))]
+   (let [c (dissoc card :current-strength :abilities :rezzed :special)
+         c (if (= (:side c) "Runner") (dissoc c :installed :counter) c)
+         c (if keep-counter c (dissoc c :counter :advance-counter))]
      (when-let [leave-effect (:leave-play (card-def card))]
        (when (or (= (:side card) "Runner") (:rezzed card))
          (leave-effect state side card nil)))


### PR DESCRIPTION
Per the Official FAQ (page 4), a derezzed Corp card needs to *retain* all hosted credits, cards, and counters. 

This is relevant now with the introduction of Test Ground, which is useful for reloading an Adonis or Eve Campaign with credits prior to them running out and self-trashing (and if you're really on the ball you'll re-rez for free with Breaker Bay Grid). 

Currently we're only preserving `:advance-counter` on advanceable Weyland ice and advanceable assets when they derez. What this should do is stop dissociating `:counter` no matter what, then only proceed to dissociate them if it's a Runner card (Imps, Gravediggers, et al) or if `keep-counter true` has been passed via the `derez` function.

Adonis/Eve/Rex Campaigns and Private Contracts also get a minor modification so that if credits remain when derezzing, a later re-rez will **add** the placed counters instead of wiping out the remaining ones--i.e. an Eve with 2 left when derezzed by Test Ground will have 18 when later re-rezzed.

Also added a partial for Pheromones to address some of #299. It's not the whole thing, maybe later an `add-watch` can get slapped on and/or the CSS will allow showing both recurring credits and counters on a single card. 