### PR TITLE
Better support for some "the first time _____" events

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -38,7 +38,9 @@
                           :effect (effect (gain :corp :bad-publicity 1))}}}
 
    "Adjusted Chronotype"
-   {:events {:runner-loss {:req (req (some #{:click} target)) :once :per-turn
+   {:events {:runner-loss {:req (req (and (some #{:click} target)
+                                          (empty? (filter #(= :click %)
+                                                          (mapcat first (turn-events state side :runner-loss))))))
                            :msg "gain [Click]" :effect (effect (gain :runner :click 1))}}}
 
    "Adonis Campaign"
@@ -177,8 +179,9 @@
 
    "Autoscripter"
    {:events {:runner-install {:req (req (and (= (:active-player @state) :runner)
-                                             (has? target :type "Program")))
-                              :once :per-turn :msg "gain [Click]" :effect (effect (gain :click 1))}
+                                             (empty? (filter #(has? % :type "Program")
+                                                             (mapcat first (turn-events state side :runner-install))))))
+                              :msg "gain [Click]" :effect (effect (gain :click 1))}
              :unsuccessful-run {:effect (effect (trash card)
                                                 (system-msg "Autoscripter is trashed"))}}}
 
@@ -562,6 +565,7 @@
    "Daily Business Show"
    {:events {:corp-draw
              {:msg "draw additional cards" :once :per-turn :once-key :daily-business-show
+              :req (req (first-event state side :corp-draw))
               :effect (req
                         (let [dbs (->> (:corp @state) :servers seq flatten (mapcat :content)
                                        (filter #(and (:rezzed %) (= (:title %) "Daily Business Show")))  count)
@@ -817,7 +821,7 @@
 
    "Enhanced Vision"
    {:events {:successful-run {:msg (msg "force the Corp to reveal " (:title (first (shuffle (:hand corp)))))
-                              :once :per-turn}}}
+                              :req (req (first-event state side :successful-run))}}}
 
    "Eureka!"
    {:effect
@@ -1310,9 +1314,11 @@
                                          :effect (effect (add-prop target :advance-counter 4))} card nil)))))}]}
 
    "John Masanori"
-   {:events {:successful-run {:msg "draw 1 card" :once :per-turn :once-key :john-masanori-draw
+   {:events {:successful-run {:req (req (first-event state side :successful-run))
+                              :msg "draw 1 card" :once-key :john-masanori-draw
                               :effect (effect (draw))}
-             :unsuccessful-run {:msg "take 1 tag" :once :per-turn :once-key :john-masanori-tag
+             :unsuccessful-run {:req (req (first-event state side :unsuccessful-run))
+                                :msg "take 1 tag" :once-key :john-masanori-tag
                                 :effect (effect (gain :runner :tag 1))}}}
 
    "Joshua B."
@@ -1498,8 +1504,9 @@
    {:effect (effect (gain :click 1 :click-per-turn 1))}
 
    "Manhunt"
-   {:events {:successful-run {:once :per-turn :trace {:base 2 :msg "give the Runner 1 tag"
-                                                      :effect (effect (gain :runner :tag 1))}}}}
+   {:events {:successful-run {:req (req (first-event state side :successful-run))
+                              :trace {:base 2 :msg "give the Runner 1 tag"
+                                      :effect (effect (gain :runner :tag 1))}}}}
 
    "Marcus Batty"
    {:abilities [{:msg "start a Psi game"
@@ -2546,11 +2553,13 @@
    {:effect (effect (gain :credit (count (:hand runner))))}
 
    "Symmetrical Visage"
-   {:events {:runner-click-draw {:once :per-turn :msg "gain 1 [Credits]"
+   {:events {:runner-click-draw {:req (req (first-event state side :runner-click-draw))
+                                 :msg "gain 1 [Credits]"
                                  :effect (effect (gain :credit 1))}}}
 
    "Synthetic Blood"
-   {:events {:damage {:once :per-turn :msg "draw 1 card" :effect (effect (draw :runner))}}}
+   {:events {:damage {:req (req (first-event state side :damage)) :msg "draw 1 card"
+                      :effect (effect (draw :runner))}}}
 
    "Tech Startup"
    {:abilities [{:label "Install an asset from R&D"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -383,9 +383,7 @@
     (when-let [card (get-card state (:card e))]
       (when (or (not (:req ability)) ((:req ability) state side card targets))
         (resolve-ability state side ability card targets))))
-  (swap! state update-in [:turn-events] #(cons [event targets] %))
-  ;(system-msg state side (pr-str "EVENTS " (:turn-events @state)))
-  )
+  (swap! state update-in [:turn-events] #(cons [event targets] %)))
 
 (defn card-init [state side card]
   (let [cdef (card-def card)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -382,7 +382,10 @@
   (doseq [{:keys [ability] :as e} (get-in @state [:events event])]
     (when-let [card (get-card state (:card e))]
       (when (or (not (:req ability)) ((:req ability) state side card targets))
-        (resolve-ability state side ability card targets)))))
+        (resolve-ability state side ability card targets))))
+  (swap! state update-in [:turn-events] #(cons [event targets] %))
+  ;(system-msg state side (pr-str "EVENTS " (:turn-events @state)))
+  )
 
 (defn card-init [state side card]
   (let [cdef (card-def card)
@@ -884,7 +887,8 @@
         (trigger-event state side :corp-turn-ends))
       (doseq [a (get-in @state [side :register :end-turn])]
         (resolve-ability state side (:ability a) (:card a) (:targets a)))
-      (swap! state assoc :end-turn true))))
+      (swap! state assoc :end-turn true)
+      (swap! state dissoc :turn-events))))
 
 (defn purge [state side]
   (let [rig-cards (apply concat (vals (get-in @state [:runner :rig])))
@@ -1139,5 +1143,11 @@
   (if close
     (system-msg state side "stops looking at his deck and shuffles it")
     (system-msg state side "shuffles his deck")))
+
+(defn turn-events [state side ev]
+  (mapcat #(rest %) (filter #(= ev (first %)) (:turn-events @state))))
+
+(defn first-event [state side ev]
+  (empty? (turn-events state side ev)))
 
 (load "cards")


### PR DESCRIPTION
Our use of `:once :per-turn` works well for most cards, but there are a few cards where this system doesn't work well. The crux of the issue is that the `:once` system only checks to see if the event in question has happened _since the card was installed/rezzed_. Thus, if the Runner spends a click to Draw, then installs Symmetrical Visage, then Draws again, Visage will grant a credit when it's not supposed to because it sees the second draw as the "first" time a draw occurred. This system works for cards that can reasonably expect to be installed/rezzed before the events they listen to could possibly occur (like all identities), or for cards with their own abilities that can only be used once... but not for cards that could be activated after their event has already happened once in the turn.

This is a small framework extension to support true "first time this turn" effects by saving every event that gets triggered in a vector in the state. Every time `trigger-event` is called, we push a pair into `@state :turn-events` consisting of the event's key and the targets/arguments passed to handlers of the event. From there, we just need a few utility functions to see if a specific event key has happened this turn or not.

I have applied this framework to some, but not all, of the cards that need it:

* Daily Business Show: to fix #281.
* Symmetrical Visage
* Adjusted Chronotype
* Autoscripter
* Enhanced Vision
* John Masanori
* Manhunt
* Synthetic Blood

These cards still need implementing. I passed on them because they were either difficult, weren't urgent, or are under bug review:

* Sundew (pending #301)
* Housekeeping (difficult. fortunately there is currently no way for Housekeeping to come into play during the Runner's turn, but that will change with a leaked NBN ID)
* Comet (difficult because of asynchronous prompt issues)
* NeoTokyo Grid
* Order of Sol (needs better event support)