### PR TITLE
Fix for Autoscripter

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -176,11 +176,13 @@
    {:events {:jack-out {:effect (effect (gain :credit 1)) :msg "gain 1 [Credits]"}}}
 
    "Autoscripter"
-   {:events {:runner-install {:req (req (and (= (:active-player @state) :runner)
-                                             (has? target :type "Program")))
-                              :once :per-turn :msg "gain [Click]" :effect (effect (gain :click 1))}
+   {:events {:runner-install {:req (req (and (has? target :type "Program")
+                                             (= (:active-player @state) :runner)
+                                             (empty? (filter #(has? % :type "Program")
+                                                             (map first (turn-events state side :runner-install))))))
+                              :msg "gain [Click]" :effect (effect (gain :click 1))}
              :unsuccessful-run {:effect (effect (trash card)
-                                                (system-msg "Autoscripter is trashed"))}}}
+                                                (system-msg "trashes Autoscripter"))}}}
 
    "Bank Job"
    {:data {:counter 8}


### PR DESCRIPTION
Thought I was cool and really understood what `mapcat` does, but failed. Should be `map`, plus the additional requirement of the new install being a program. Whoops.