### PR TITLE
miscellaneous fixes

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -64,8 +64,8 @@
   ([state side card] (desactivate state side card nil))
   ([state side card keep-counter]
    (let [c (dissoc card :current-strength :abilities :rezzed :special)
-         c (if (= (:side c) "Runner") (dissoc c :installed :counter) c)
-         c (if keep-counter c (dissoc c :counter :advance-counter))]
+         c (if (= (:side c) "Runner") (dissoc c :installed :counter :rec-counter) c)
+         c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
      (when-let [leave-effect (:leave-play (card-def card))]
        (when (or (= (:side card) "Runner") (:rezzed card))
          (leave-effect state side card nil)))


### PR DESCRIPTION
Removes the new lime-green recurring credits from cards that get trashed or uninstalled by adding `rec-counter` to the list of things that get dissociated.

Fixes: 

* Typo in Dinosaurus hosting message
* Add click cost to the "Install and host" option of Off-Campus Apartment
* Add HQ run requirement to Leverage
* Add partial stub for Bug

Cosmetic changes: 
* Move Zona Sul Shipping out of ice section and Deep Thought up into the section of working cards