### PR TITLE
implement Exploratory Romp and Raymond Flint

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -890,17 +890,19 @@
    "Exploratory Romp"
    {:prompt "Choose a server" :choices (req servers)
     :effect (effect (run target
-	                   {:replace-access
-		                  {:prompt "Remove how many advancements from a card in or protecting this server?"
-		                   :choices ["0", "1", "2", "3"]
-		                   :effect (req (let [c (Integer/parseInt target)]
-				                          (resolve-ability state side
-                                           {:choices {:req #(and (contains? % :advance-counter)
-							                                    (or (= (last (:zone %)) :ices)
-                                                      (= (last (:zone %)) :content)))}
-				                            :msg (msg "remove " c " advancements from " (if (:seen target) (:title target) "a card"))
-				                            :effect (effect (add-prop :corp target :advance-counter (- c)))}
-				                           card nil)))}}) card)}
+	              {:replace-access
+		       {:prompt "Remove how many advancements from a card in or protecting this server?"
+		        :choices ["0", "1", "2", "3"]
+		        :effect (req (let [c (Integer/parseInt target)]
+				       (resolve-ability state side
+                                        {:choices {:req #(and (contains? % :advance-counter)
+							      (or (= (last (:zone %)) :ices)
+                                                                  (= (last (:zone %)) :content)))}
+				                   :msg (msg "remove " c " advancements from " (if (:seen target) (:title target) "a card"))
+				                   :effect (req (add-prop state :corp target :advance-counter (- c))
+				                                (swap! state update-in [:runner :prompt] rest)
+				                                (handle-run-end state side))}
+				        card nil)))}}) card)}
 
    "Exposé"
    {:advanceable :always

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -887,6 +887,21 @@
       :effect (effect (run :hq {:replace-access
                                 {:msg (msg "reveal cards in HQ: " (map :title (:hand corp)))}} card))}]}
 
+   "Exploratory Romp"
+   {:prompt "Choose a server" :choices (req servers)
+    :effect (effect (run target
+	                   {:replace-access
+		                  {:prompt "Remove how many advancements from a card in or protecting this server?"
+		                   :choices ["0", "1", "2", "3"]
+		                   :effect (req (let [c (Integer/parseInt target)]
+				                          (resolve-ability state side
+                                           {:choices {:req #(and (contains? % :advance-counter)
+							                                    (or (= (last (:zone %)) :ices)
+                                                      (= (last (:zone %)) :content)))}
+				                            :msg (msg "remove " c " advancements from " (if (:seen target) (:title target) "a card"))
+				                            :effect (effect (add-prop :corp target :advance-counter (- c)))}
+				                           card nil)))}}) card)}
+
    "Exposé"
    {:advanceable :always
     :abilities [{:label "Remove 1 bad publicity for each advancement token on Exposé"

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2143,6 +2143,24 @@
                                 (system-msg ref side "trashes Rachel Beckman for being tagged")))))
     :leave-play (effect (lose :click 1 :click-per-turn 1))}
 
+   "Raymond Flint"
+   {:effect (req (add-watch state :raymond-flint
+                            (fn [k ref old new]
+                              (when (< (get-in old [:corp :bad-publicity]) (get-in new [:corp :bad-publicity]))
+                                (resolve-ability
+                                  ref side
+                                  {:msg "access 1 card from HQ"
+                                   :effect (req (let [c (first (shuffle (:hand corp)))]
+                                                  (system-msg state side (str "accesses " (:title c)))
+                                                  (handle-access state side [c])))} card nil)))))
+    :leave-play (req (remove-watch state :raymond-flint))
+    :abilities [{:label "Expose 1 card"
+                 :effect (effect (resolve-ability
+                                   {:choices {:req #(= (first (:zone %)) :servers)}
+                                    :effect (effect (expose target) (trash card {:cause :ability-cost}))
+                                    :msg (msg "expose " (:title target))}
+                                   card nil))}]}
+
    "Recon"
    {:prompt "Choose a server" :choices (req servers) :effect (effect (run target))}
 

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2148,9 +2148,9 @@
                             (fn [k ref old new]
                               (when (< (get-in old [:corp :bad-publicity]) (get-in new [:corp :bad-publicity]))
                                 (resolve-ability
-                                  ref side
+                                 ref side
                                   {:msg "access 1 card from HQ"
-                                   :effect (req (let [c (first (shuffle (:hand corp)))]
+                                   :effect (req (doseq [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
                                                   (system-msg state side (str "accesses " (:title c)))
                                                   (handle-access state side [c])))} card nil)))))
     :leave-play (req (remove-watch state :raymond-flint))


### PR DESCRIPTION
@mtgred @nealterrell 

This is the first thing I successfully got working with repeated tweaking/reloading using the REPL in the test environment (yay!). I can verify this works except for *one* part--even after choosing to use the Run ability instead of accessing and then removing advancements from a card, you get the "Successful run / Jack out" prompt like we used to see after Leela's ability sometimes. 

I tried adding `(handle-run-end state side)` in a couple different places but couldn't get it to take--it would then stop removing advancements and hang. In the REPL it complained about the wrong number of arguments being passed. Was that because I wasn't preceding it with `(swap! state update-in [:runner :prompt] rest)`? 

So I'm wondering if adding these two lines immediately after the `(add-prop :corp target :advance-counter (- c))` will tidy it up: 

`(swap! state update-in [:runner :prompt] rest)`
`(handle-run-end state side)`