### PR TITLE
Added option to display a msg when an ability gets activated

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -863,6 +863,7 @@
 
    "Executive Boot Camp"
    {:abilities [{:prompt "Choose an asset to add to HQ" :msg (msg "add " (:title target) " to HQ")
+                 :activatemsg "searches HQ for an asset"
                  :choices (req (filter #(has? % :type "Asset") (:deck corp)))
                  :cost [:credit 1] :label "Search R&D for an asset"
                  :effect (effect (trash card) (move target :hand) (shuffle! :deck))}]}
@@ -3218,7 +3219,9 @@
                 {:msg "end the run" :effect (effect (end-run))}]}
 
    "Architect"
-   {:abilities [{:msg "look at the top 5 cards of R&D" :prompt "Choose a card to install"
+   {:abilities [{:msg "look at the top 5 cards of R&D"
+                 :prompt "Choose a card to install"
+                 :activatemsg "uses Architect to look at the top 5 cards of R&D"
                  :req (req (not (string? target))) :not-distinct true
                  :choices (req (conj (take 5 (:deck corp)) "No install"))
                  :effect (effect (corp-install target nil {:no-install-cost true}))}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -875,9 +875,12 @@
         ab (if (= ability (count abilities))
              {:msg "take 1 [Recurring Credits]" :req (req (> (:rec-counter card) 0))
               :effect (effect (add-prop card :rec-counter -1) (gain :credit 1))}
-             (get-in cdef [:abilities ability]))]
-    (when-let [activatemsg (:activatemsg ab)] (system-msg state side activatemsg))
-    (resolve-ability state side ab card targets)))
+             (get-in cdef [:abilities ability]))
+        cost (:cost ab)]
+    (when (or (nil? cost)
+              (apply can-pay? state side cost))
+        (when-let [activatemsg (:activatemsg ab)] (system-msg state side activatemsg))
+        (resolve-ability state side ab card targets))))
 
 (defn start-turn [state side args]
   (system-msg state side (str "started his or her turn"))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -869,6 +869,7 @@
              {:msg "take 1 [Recurring Credits]" :req (req (> (:rec-counter card) 0))
               :effect (effect (add-prop card :rec-counter -1) (gain :credit 1))}
              (get-in cdef [:abilities ability]))]
+    (when-let [activatemsg (:activatemsg ab)] (system-msg state side activatemsg))
     (resolve-ability state side ab card targets)))
 
 (defn start-turn [state side args]


### PR DESCRIPTION
Fixes mtgred/netrunner#358.

Also added it to Executive Boot Camp; it's probably usefull to a lot of
other cards where the standard :msg is not sufficient.

It enables your opponent to see what you're doing and helps prevent
cheating.

Let me know what you think.