### PR TITLE
Fix get-virus-counters to see Hiveminds that are hosted.

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -903,7 +903,7 @@
   (trigger-event state side :purge))
 
 (defn get-virus-counters [state side card]
-   (let [hiveminds (filter #(= (:title %) "Hivemind") (get-in @state [:runner :rig :program]))]
+   (let [hiveminds (filter #(= (:title %) "Hivemind") (all-installed state :runner))]
         (reduce + (map :counter (cons card hiveminds)))))
 
 (defn play-instant


### PR DESCRIPTION
Simple fix to find Hiveminds that are hosted and count their tokens. Fixes the un-reported issues with Medium etc. not getting Hivemind bonuses when Hivemind is on Progenitor.