### PR TITLE
fix Gang Sign to work with HQ Interface

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -992,7 +992,7 @@
 
    "Gang Sign"
    {:events {:agenda-scored {:msg "access 1 card from HQ"
-                             :effect (req (let [c (first (shuffle (:hand corp)))]
+                             :effect (req (doseq [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
                                             (system-msg state side (str "accesses " (:title c)))
                                             (handle-access state side [c])))}}}
 

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -3870,5 +3870,6 @@
    "The Source"
    {:effect (effect (update-all-advancement-costs))
     :leave-play (effect (update-all-advancement-costs))
-    :events {:agenda-scored (effect (trash card)) :agenda-stolen (effect (trash card))
+    :events {:agenda-scored {:effect (effect (trash card))}
+             :agenda-stolen {:effect (effect (trash card))}
              :pre-advancement-cost {:effect (effect (advancement-cost-bonus 1))}}}})


### PR DESCRIPTION
Partially fixes #308. 

Still left with the issue of how to handle multiple Gang Signs, but at least for now this will grant an additional access for every HQ Interface installed. 