### PR TITLE
Fix grifter fixes mtgred/netrunner#370

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1046,9 +1046,9 @@
    "Grifter"
    {:events {:runner-turn-ends
              {:effect #(let [ab (if (get-in @%1 [:runner :register :successful-run])
-                                  {:effect (effect (gain [:credit 1])) :msg "gain 1 [Credits]"}
+                                  {:effect (effect (gain :credit 1)) :msg "gain 1 [Credits]"}
                                   {:effect (effect (trash %3)) :msg "trash Grifter"})]
-                         (resolve-ability %1 %2 ab %3 nil))}}}
+                         (resolve-ability %1 %2 ab %3 %4))}}}
 
    "Grimoire"
    {:effect (effect (gain :memory 2)) :leave-play (effect (lose :memory 2))


### PR DESCRIPTION
The gain function does not take a vector or similiar, since it uses & args.
Maybe the gain function should check for an even amount of args.

The function in :effect is called with 4 arguments, so the anynomous function has to use %4 instead of nil.