### PR TITLE
Fixed networking. Fixes mtgred/netrunner#141

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1699,7 +1699,7 @@
    "Networking"
    {:effect (effect (lose :tag 1))
     :optional {:cost [:credit 1] :prompt "Pay 1 [Credits] to add Networking to Grip?"
-               :msg "add it to his Grip" :effect (effect (move (first (:discard runner)) :hand))}}
+               :msg "add it to his Grip" :effect (effect (move (last (:discard runner)) :hand))}}
 
    "Neural EMP"
    {:req (req (:made-run runner-reg)) :effect (effect (damage :net 1 {:card card}))}


### PR DESCRIPTION
If a card is played and is added to the :discard zone, it is added at the
end of the collection (since the front parameter is not set).

So, to take the "top" card of archive, you have to take the last card of
the :discard collection.