### PR TITLE
Fix Parasite infinite recursion with Grimoire out.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1865,9 +1865,10 @@
               :effect (effect (ice-strength-bonus (- (get-virus-counters state side card))))}
              :ice-strength-changed
              {:req (req (and (= (:cid target) (:cid (:host card))) (<= (:current-strength target) 0)))
-              :effect (req (when (get-in card [:special :installing])
-                             (trigger-event state side :runner-install card)
-                             (update! state side (update-in card [:special] dissoc :installing)))
+              :effect (req (unregister-events state side card)
+                           (when (get-in card [:special :installing])
+                             (update! state side (update-in card [:special] dissoc :installing))
+                             (trigger-event state side :runner-install card))
                            (trash state side target))
               :msg (msg "trash " (:title target))}}}
 


### PR DESCRIPTION
Introduced by #372, installing Parasite onto a strength 0 ice with Grimoire installed causes an infinite recursion loop, whereby Parasite wants to trigger its Noise ability fix, which triggers `:runner-install`, which Grimoire handles to add a counter to the virus, which triggers Parasite to re-check the ice strength, which triggers the Noise ability fix, which triggers `:runner-install` etc.

Fix: unregister all events from Parasite the moment it notices that its host strength is 0 or less. It will then not listen to any more events causing these types of situations. Incidentally, this would have fixed the crashes from NEXT Bronze and Wraparound a long time ago.