### PR TITLE
Fix for Autoscripter

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -179,8 +179,12 @@
    "Autoscripter"
    {:events {:runner-install {:req (req (and (has? target :type "Program")
                                              (= (:active-player @state) :runner)
-                                             (empty? (filter #(has? % :type "Program")
-                                                             (map first (turn-events state side :runner-install))))))
+                                             ;; only trigger when played a programm from grip
+                                             (some #{:hand} (:previous-zone target))
+                                             ;; check if didn't played a program from the grip this turn
+                                             (empty? (let [cards (map first (turn-events state side :runner-install))
+                                                           progs (filter #(has? % :type "Program") cards)]
+                                                          (filter #(some #{:hand} (:previous-zone %)) progs)))))
                               :msg "gain [Click]" :effect (effect (gain :click 1))}
              :unsuccessful-run {:effect (effect (trash card)
                                                 (system-msg "trashes Autoscripter"))}}}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -3875,7 +3875,12 @@
    {:req (req tagged)}
 
    "Exile: Streethawk"
-   {:effect (effect (gain :link 1))}
+   {:effect (effect (gain :link 1))
+    :events {:runner-install {:req (req (and (has? target :type "Program")
+                                              (= (:active-player @state) :runner)
+                                              ;; only trigger when played a programm from heap
+                                              (some #{:discard} (:previous-zone target))))
+                               :msg (msg "draw a card") :effect (effect (draw 1))}}}
 
    "Deep Red"
    {:effect (effect (gain :memory 3)) :leave-play (effect (lose :memory 3))}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -128,7 +128,7 @@
              c (if (and (or installed (#{:servers :scored :current} (first zone)))
                         (#{:hand :deck :discard} (first dest)))
                  (desactivate state side c) c)
-             moved-card (assoc c :zone dest :host nil :hosted nil)]
+             moved-card (assoc c :zone dest :host nil :hosted nil :previous-zone (:zone c))]
          (if front
            (swap! state update-in (cons side dest) #(cons moved-card (vec %)))
            (swap! state update-in (cons side dest) #(conj (vec %) moved-card)))
@@ -960,7 +960,9 @@
        (swap! state update-in (cons s (vec zone))
               (fn [coll] (remove-once #(not= (:cid %) cid) coll)))))
    (swap! state update-in (cons side (vec zone)) (fn [coll] (remove-once #(not= (:cid %) cid) coll)))
-   (let [c (assoc target :host (update-in card [:zone] #(map to-keyword %)) :facedown facedown)]
+   (let [c (assoc target :host (update-in card [:zone] #(map to-keyword %))
+                         :facedown facedown
+                         :zone '(:onhost))] ;; hosted cards should not be in :discard or :hand etc
      (update! state side (update-in card [:hosted] #(conj % c)))
      c)))
 


### PR DESCRIPTION
Hosted cards no longer stay in thier original zone, but gets moved to a zone called `:onhost`.

When a card gets moved, the previous zone is now saved in `:previous-zone`