### PR TITLE
Foxfire can trash hosted but not installed cards

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -961,7 +961,7 @@
 
    "Foxfire"
    {:trace {:base 7 :prompt "Choose 1 card to trash" :not-distinct true
-            :choices {:req #(and (:installed %)
+            :choices {:req #(and (not (some #{:discard} (:zone %)))
                                  (or (has? % :subtype "Virtual") (has? % :subtype "Link")))}
             :msg (msg "trash " (:title target)) :effect (effect (trash target))}}
 


### PR DESCRIPTION
since there's not limitation that the target card has to be installed

fixes mtgred/netrunner#396