### PR TITLE
Temporary Run Credits

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -2606,6 +2606,7 @@
    "Stimhack"
    {:prompt "Choose a server" :choices (req servers)
     :effect (effect (gain :credit 9)
+                    (gain :run-credit 9)
                     (run target {:end-run
                                  {:msg " take 1 brain damage"
                                   :effect (effect (damage :brain 1 {:unpreventable true :card card}))}}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -738,6 +738,10 @@
       "New remote" [:servers :remote (count (get-in @state [:corp :servers :remote]))]
       [:servers :remote (-> (split server #" ") last Integer/parseInt)])))
 
+(defn add-bad-publicity-credit [state]
+  (swap! state update-in [:runner :run-credit] + (get-in @state [:corp :bad-publicity]))
+  (swap! state update-in [:runner :credit] + (get-in @state [:corp :bad-publicity])))
+
 (defn run
   ([state side server] (run state side server nil nil))
   ([state side server run-effect card]
@@ -752,6 +756,7 @@
          (swap! state assoc :per-run nil
                 :run {:server s :position (count ices) :ices ices :access-bonus 0
                       :run-effect (assoc run-effect :card card)})
+         (add-bad-publicity-credit state)
          (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
          (trigger-event state :runner :run s)))))
 

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -378,7 +378,7 @@
 
 (defmulti stats-view #(get-in % [:identity :side]))
 
-(defmethod stats-view "Runner" [{:keys [user click credit memory link tag brain-damage agenda-point
+(defmethod stats-view "Runner" [{:keys [user click credit run-credit memory link tag brain-damage agenda-point
                                         max-hand-size]} owner]
   (om/component
    (sab/html
@@ -386,7 +386,7 @@
       [:div.stats.panel.blue-shade {}
        [:h4.ellipsis (om/build avatar user {:opts {:size 22}}) (:username user)]
        [:div (str click " Click" (if (> click 1) "s" "")) (when me? (controls :click))]
-       [:div (str credit " Credit" (if (> credit 1) "s" "")) (when me? (controls :credit))]
+       [:div (str credit " Credit" (if (> credit 1) "s" "") (when (> run-credit 0) (str " (" run-credit " for run)"))) (when me? (controls :credit))]
        [:div (str memory " Memory Unit" (if (> memory 1) "s" "")) (when me? (controls :memory))]
        [:div (str link " Link" (if (> link 1) "s" "")) (when me? (controls :link))]
        [:div (str agenda-point " Agenda Point" (when (> agenda-point 1) "s"))


### PR DESCRIPTION
I added tracking of temporary credits that are given at the beginning of the run and are returned at the end of the run. The amount of credits available on just the run (and will be returned at the end) is displayed on the credit count if applicable. I've implemented stimhack and bad publicity credits here.