### PR TITLE
Dockerize

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,10 @@ mongo:
     image: mongo:3.1.5
     volumes:
         - /tmp/netrunner/mongo-data:/data/db
-node:
+nodeBase:
     image: node:0.12.7
     volumes:
         - .:/workdir
-    links:
-        - mongo:mongo
-        - clojure:clojure
     ports:
         - 1042:1042
     command: |
@@ -22,14 +19,43 @@ node:
                MONGO_URL=mongodb://mongo/netrunner \
                CLOJURE_HOST=clojure \
                  ./node_modules/.bin/coffee server.coffee"
-clojure:
+clojureBase:
     image: clojure:lein-2.5.1
     volumes:
         - .:/workdir
         - /tmp/netrunner/maven_repo:/root/.m2/repository
+prod:
+    extends:
+        service: nodeBase
+        file: docker-compose.yml
+    links:
+        - mongo:mongo
+        - clojureProd:clojure
+dev:
+    extends:
+        service: nodeBase
+        file: docker-compose.yml
+    links:
+        - mongo:mongo
+        - clojureDev:clojure
+clojureProd:
+    extends:
+        service: clojureBase
+        file: docker-compose.yml
     links:
         - mongo:mongo
     command: |
         sh -c "cd /workdir
                lein uberjar
                java -jar target/netrunner-0.1.0-SNAPSHOT-standalone.jar"
+clojureDev:
+    extends:
+        service: clojureBase
+        file: docker-compose.yml
+    links:
+        - mongo:mongo
+    ports:
+        - 7001:7001
+    command: |
+        sh -c "cd /workdir
+               lein repl :headless :host '*' :port 7001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+mongo:
+    image: mongo:3.1.5
+    volumes:
+        - /tmp/netrunner/mongo-data:/data/db
+node:
+    image: node:0.12.7
+    volumes:
+        - .:/workdir
+    links:
+        - mongo:mongo
+        - clojure:clojure
+    ports:
+        - 1042:1042
+    command: |
+        sh -c "apt-get update && apt-get install -y libzmq-dev
+               cd /workdir
+               npm install
+               ./node_modules/.bin/bower --allow-root install
+               cd data && OPENSHIFT_MONGODB_DB_HOST=mongo \
+                            ../node_modules/.bin/coffee fetch.coffee \
+                       && cd ..
+               MONGO_URL=mongodb://mongo/netrunner \
+               CLOJURE_HOST=clojure \
+                 ./node_modules/.bin/coffee server.coffee"
+clojure:
+    image: clojure:lein-2.5.1
+    volumes:
+        - .:/workdir
+        - /tmp/netrunner/maven_repo:/root/.m2/repository
+    links:
+        - mongo:mongo
+    command: |
+        sh -c "cd /workdir
+               lein uberjar
+               java -jar target/netrunner-0.1.0-SNAPSHOT-standalone.jar"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ clojureProd:
     command: |
         sh -c "cd /workdir
                lein uberjar
-               java -jar target/netrunner-0.1.0-SNAPSHOT-standalone.jar"
+               ZMQ_HOST='*' \
+                 java -jar target/netrunner-0.1.0-SNAPSHOT-standalone.jar"
 clojureDev:
     extends:
         service: clojureBase
@@ -58,4 +59,5 @@ clojureDev:
         - 7001:7001
     command: |
         sh -c "cd /workdir
-               lein repl :headless :host '*' :port 7001"
+               ZMQ_HOST='*' \
+                 lein repl :headless :host '*' :port 7001"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "type": "git",
     "url": "https://github.com/mtgred/netrunner.git"
   },
-  "scripts": {
-    "start": "coffee server.coffee"
+  "devDependencies": {
+    "bower": "1.4.1",
+    "coffee-script": "1.9.3"
   },
-  "main": "server.coffee",
   "dependencies": {
     "async": "~0.9.0",
     "bcrypt": "~0.8.1",

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
                  [org.zeromq/jeromq "0.3.4"]
                  [cheshire "5.4.0"]
                  [org.omcljs/om "0.8.8"]
-                 [sablono "0.3.4"]]
+                 [sablono "0.3.4"]
+                 [environ "1.0.0"]]
 
   :profiles {:dev {:dependencies [[figwheel "0.2.5"]]}}
 

--- a/server.coffee
+++ b/server.coffee
@@ -16,7 +16,7 @@ cors = require('cors')
 
 # MongoDB connection
 appName = 'netrunner'
-mongoUrl = "mongodb://127.0.0.1:27017/netrunner"
+mongoUrl = process.env['MONGO_URL'] || "mongodb://127.0.0.1:27017/netrunner"
 db = mongoskin.db(mongoUrl)
 
 # Game lobby
@@ -52,8 +52,9 @@ joinGame = (socket, gameid) ->
     lobby.emit('netrunner', {type: "games", games: games})
 
 # ZeroMQ
+clojure_hostname = process.env['CLOJURE_HOST'] || "127.0.0.1"
 requester = zmq.socket('req')
-requester.connect('tcp://127.0.0.1:1043')
+requester.connect("tcp://#{clojure_hostname}:1043")
 requester.on 'message', (data) ->
   response = JSON.parse(data)
   unless response is "ok"

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -73,13 +73,13 @@
 (defn dev []
   (println "[Dev] Listening on port 1043 for incoming commands...")
   (let [socket (.socket ctx ZMQ/REP)]
-    (.bind socket "tcp://127.0.0.1:1043")
+    (.bind socket "tcp://*:1043")
     (run socket)))
 
 (defn -main []
   (println "[Prod] Listening on port 1043 for incoming commands...")
   (let [worker-url "inproc://responders"
-        router (doto (.socket ctx ZMQ/ROUTER) (.bind "tcp://127.0.0.1:1043"))
+        router (doto (.socket ctx ZMQ/ROUTER) (.bind "tcp://*:1043"))
         dealer (doto (.socket ctx ZMQ/DEALER) (.bind worker-url))]
     (dotimes [n 2]
       (.start

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -3,7 +3,8 @@
   (:require [cheshire.core :refer [parse-string generate-string]]
             [cheshire.generate :refer [add-encoder encode-str]]
             [game.macros :refer [effect]]
-            [game.core :refer [game-states system-msg pay gain draw end-run] :as core])
+            [game.core :refer [game-states system-msg pay gain draw end-run] :as core]
+            [environ.core :refer [env]])
   (:gen-class :main true))
 
 (add-encoder java.lang.Object encode-str)
@@ -70,16 +71,20 @@
             (.send socket (generate-string state))
             (.send socket (generate-string "error"))))))))
 
+(defn zmq-url
+  []
+  (str "tcp://" (or (env :zmq-host) "127.0.0.1") ":1043"))
+
 (defn dev []
   (println "[Dev] Listening on port 1043 for incoming commands...")
   (let [socket (.socket ctx ZMQ/REP)]
-    (.bind socket "tcp://*:1043")
+    (.bind socket (zmq-url))
     (run socket)))
 
 (defn -main []
   (println "[Prod] Listening on port 1043 for incoming commands...")
   (let [worker-url "inproc://responders"
-        router (doto (.socket ctx ZMQ/ROUTER) (.bind "tcp://*:1043"))
+        router (doto (.socket ctx ZMQ/ROUTER) (.bind (zmq-url)))
         dealer (doto (.socket ctx ZMQ/DEALER) (.bind worker-url))]
     (dotimes [n 2]
       (.start

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -90,3 +90,8 @@
             (run socket))))))
 
     (.start (Thread. #(.run (ZMQQueue. ctx router dealer))))))
+
+(comment
+  "Start development server"
+  (future-call dev)
+  )


### PR DESCRIPTION
With these changes, the application runs completely inside of Docker containers. This has two advantages:

* All dependencies are made explicit in the `docker-compose.yml`.
* For people who have `docker-compose` installed, running the project is simply `docker-compose up {dev|prod}`.

For people who do not want to use `docker`, the `docker-compose.yml` file is still valuable, up-to-date documentation that describes how to start the complete system.

`docker-compose up prod` will start the Clojure server in "production" settings, which means it will compile the uberjar and run the server from there.
`docker-compose up dev` will start a Clojure REPL server on `localhost:7001` for development. The server itself is not started and must be run manually by evaluating `(future-call dev)` in the `game.main` namespace as before.

To connect to the REPL server, one can run `lein repl :connect localhost:7001` from the host machine. A similar command should allow any Clojure development tool to connect to the running REPL server.