### PR TITLE
Fix for hosted icebreakers.

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -90,7 +90,7 @@
                      (when (:installed card)
                        (handle-abilities card owner))
                      (send-command "play" {:card card}))
-            ("rig" "current") (handle-abilities card owner)
+            ("rig" "current" "onhost") (handle-abilities card owner)
             nil)
           (case (first zone)
             "hand" (case type


### PR DESCRIPTION
UI only builds a card-view for cards that are in runner's `:rig`, which #391 changed. Adds `:onhost` to the list of zones for which card-views should be built. Fixes #408.