### PR TITLE
Fix for Progenitor granting tokens on purge.

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -316,7 +316,10 @@
                                       (has? % :subtype "Virus")
                                       (:installed %))}
                  :msg (msg "host " (:title target)) :effect (effect (host card target))}]
-    :events {:purge {:effect (req (when-let [c (first (:hosted card))]
+    :events {:pre-purge {:effect (req (when-let [c (first (:hosted card))]
+                                        (update! state side (assoc-in card [:special :numpurged] (:counter c)))))}
+             :purge {:req (req (pos? (or (get-in card [:special :numpurged]) 0)))
+                     :effect (req (when-let [c (first (:hosted card))]
                                     (add-prop state side c :counter 1)))}}}
 
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -931,6 +931,7 @@
       (swap! state dissoc :turn-events))))
 
 (defn purge [state side]
+  (trigger-event state side :pre-purge)
   (let [rig-cards (apply concat (vals (get-in @state [:runner :rig])))
         hosted-cards (filter :installed (mapcat :hosted rig-cards))
         hosted-on-ice (->> (get-in @state [:corp :servers]) seq flatten (mapcat :ices) (mapcat :hosted))]


### PR DESCRIPTION
New event :pre-purge that happens before tokens are purged, so Progenitor can ensure the hosted card had at least one token before the purge happened. Fixes #388.