### PR TITLE
Make run-credit a separate UI-changeable property

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -361,8 +361,7 @@
 
    "Stimhack"
    {:prompt "Choose a server" :choices (req servers)
-    :effect (effect (gain :credit 9)
-                    (gain :run-credit 9)
+    :effect (effect (gain :run-credit 9)
                     (run target {:end-run
                                  {:msg " take 1 brain damage"
                                   :effect (effect (damage :brain 1 {:unpreventable true :card card}))}}

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -400,7 +400,9 @@
       [:div.stats.panel.blue-shade {}
        [:h4.ellipsis (om/build avatar user {:opts {:size 22}}) (:username user)]
        [:div (str click " Click" (if (> click 1) "s" "")) (when me? (controls :click))]
-       [:div (str credit " Credit" (if (> credit 1) "s" "") (when (> run-credit 0) (str " (" run-credit " for run)"))) (when me? (controls :credit))]
+       [:div (str credit " Credit" (if (> credit 1) "s" "")) (when me? (controls :credit))]
+       (when (> run-credit 0)
+        [:div (str run-credit " Run Credit" (if (> credit 1) "s" "")) (when me? (controls :run-credit))])
        [:div (str memory " Memory Unit" (if (> memory 1) "s" "")) (when me? (controls :memory))]
        [:div (str link " Link" (if (> link 1) "s" "")) (when me? (controls :link))]
        [:div (str agenda-point " Agenda Point" (when (> agenda-point 1) "s"))


### PR DESCRIPTION
See discussion in my previous pull request (https://github.com/mtgred/netrunner/pull/400). I think that that run credits should be manually adjustable because any time you would want to manually spend credits, you would probably want to manually spend run credits if available. This change separates credits and run credits as different resources, where credit costs will use run credits if available. 

Currently, run credits show up in the UI if available. I can foresee some need for it to show regardless at 0 (if a run credit was mistakenly used, and the player wants it back), but I don't know if that clutters the UI more than necessary.