### PR TITLE
don't trash  cards already in :discard

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -39,8 +39,10 @@
 
    "Edward Kim: Humanitys Hammer"
    {:effect (effect (gain :link 1))
-    :events {:access {:req (req (= (:type target) "Operation")) :once :per-turn
-                      :msg (msg "trash " (:title target)) :effect (effect (trash target))}}}
+    :events {:access {:once :per-turn
+                      :req (req (= (:type target) "Operation"))
+                      :effect (effect (trash target))
+                      :msg (msg "trash " (:title target) (if (some #{:discard} (:zone target)) ", but it is already trashed."))}}}
 
    "Exile: Streethawk"
    {:effect (effect (gain :link 1))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -24,3 +24,4 @@
 
 (def cards (merge cards-agendas cards-assets cards-events cards-hardware cards-ice cards-icebreakers cards-identities
                   cards-operations cards-programs cards-resources cards-upgrades))
+                  

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -640,26 +640,27 @@
 (defn trash
   ([state side {:keys [zone type] :as card}] (trash state side card nil))
   ([state side {:keys [zone type] :as card} {:keys [unpreventable cause] :as args} & targets]
-    (let [ktype (keyword (clojure.string/lower-case type))]
-      (when (and (not unpreventable) (not= cause :ability-cost))
-        (swap! state update-in [:trash :trash-prevent] dissoc ktype))
-      (when (not= (last zone) :current)
-        (apply trigger-event state side :trash card cause targets))
-      (let [prevent (get-in @state [:prevent :trash ktype])]
-        (if (and (not unpreventable) (not= cause :ability-cost) (> (count prevent) 0))
-          (do
-            (system-msg state :runner "has the option to prevent trash effects")
-            (show-prompt
-              state :runner nil (str "Prevent the trashing of " (:title card) "?") ["Done"]
-              (fn [choice]
-                (if-let [prevent (get-in @state [:trash :trash-prevent ktype])]
-                  (do
-                    (system-msg state :runner (str "prevents the trashing of " (:title card)))
-                    (swap! state update-in [:trash :trash-prevent] dissoc ktype))
-                  (do
-                    (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
-                    (apply resolve-trash state side card args targets))))))
-          (apply resolve-trash state side card args targets))))))
+   (when (not (some #{:discard} zone))
+     (let [ktype (keyword (clojure.string/lower-case type))]
+        (when (and (not unpreventable) (not= cause :ability-cost))
+          (swap! state update-in [:trash :trash-prevent] dissoc ktype))
+        (when (not= (last zone) :current)
+          (apply trigger-event state side :trash card cause targets))
+        (let [prevent (get-in @state [:prevent :trash ktype])]
+          (if (and (not unpreventable) (not= cause :ability-cost) (> (count prevent) 0))
+            (do
+              (system-msg state :runner "has the option to prevent trash effects")
+              (show-prompt
+                state :runner nil (str "Prevent the trashing of " (:title card) "?") ["Done"]
+                (fn [choice]
+                  (if-let [prevent (get-in @state [:trash :trash-prevent ktype])]
+                    (do
+                      (system-msg state :runner (str "prevents the trashing of " (:title card)))
+                      (swap! state update-in [:trash :trash-prevent] dissoc ktype))
+                    (do
+                      (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
+                      (apply resolve-trash state side card args targets))))))
+            (apply resolve-trash state side card args targets)))))))
 
 (defn trash-cards [state side cards]
   (doseq [c cards] (trash state side c)))


### PR DESCRIPTION
fixes mtgred/netrunner#379

Show different message if a card can't be trashed by Edwards ability
because it is already trashed