### PR TITLE
Make Kate's ability apply only if the install succeeded.

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -123,10 +123,13 @@
 
    "Kate \"Mac\" McCaffrey: Digital Tinker"
    {:effect (effect (gain :link 1))
-    :events {:pre-install {:once :per-turn
-                           :req (req (some #(= % (:type target)) '("Hardware" "Program")))
-                           :msg (msg "reduce the install cost of " (:title target) " by 1 [Credits]")
-                           :effect (effect (install-cost-bonus -1))}}}
+    :events {:pre-install {:req (req (and (#{"Hardware" "Program"} (:type target))
+                                          (not (get-in @state [:per-turn (:cid card)]))))
+                           :effect (effect (install-cost-bonus -1))}  
+             :runner-install {:req (req (and (#{"Hardware" "Program"} (:type target))
+                                             (not (get-in @state [:per-turn (:cid card)]))))
+                              :msg (msg "reduce the install cost of " (:title target) " by 1 [Credits]")
+                              :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
 
    "Ken \"Express\" Tenma: Disappeared Clone"
    {:events {:play-event {:req (req (has? target :subtype "Run")) :once :per-turn


### PR DESCRIPTION
Fix for #389 so that Kate's ability is not disabled when attempting to install something you can't actually afford. Move the "once per turn" logic to runner-install so her ability only gets disabled once an install succeeds. Works with installs off SMC, Clone Chip, and Modded.