### PR TITLE
Enable card preview in log window and prompts

### DIFF
--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -21,7 +21,7 @@
   (str "/img/cards/" (:code card) ".png"))
 
 (defn add-symbols [card-text]
-  (-> card-text
+  (-> (if (nil? card-text) "" card-text)
       (make-span "\\[Credits\\]" "credit")
       (make-span "\\[Credit\\]" "credit")
       (make-span "\\[Click\\]" "click")


### PR DESCRIPTION
Fixes #4
Fixes #216
Fixes #319

Also, it enables you to type some special words that gets translated to the netrunner icons, like `[Credit]` or `[c]`/`[$]` for the credit symbol, `[Trash]` or `[t]` for the trash symbol, etc.
