### PR TITLE
implement Shiro and Hellion Alpha Test

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -492,6 +492,16 @@
                 {:label "Trace 3 - Do 3 net damage"
                  :trace {:base 3 :msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}}]}
 
+   "Shiro"
+   {:abilities [{:label "Rearrange the top 3 cards of R&D"
+                 :msg "rearrange the top 3 cards of R&D"
+                 :effect (req (doseq [c (take 3 (:deck corp))]
+                                (move state side c :play-area)))}
+                {:label "Force the Runner to access the top card of R&D"
+                 :effect (req (doseq [c (take (get-in @state [:runner :rd-access]) (:deck corp))]
+                                (system-msg state :runner (str "accesses " (:title c)))
+                                (handle-access state side [c])))}]}
+
    "Snoop"
    {:abilities [{:msg "place 1 power counter on Snoop" :effect (effect (add-prop card :counter 1))}
                 {:counter-cost 1 :label "Look at all cards in Grip and trash 1 card"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -89,6 +89,13 @@
    "Hedge Fund"
    {:effect (effect (gain :credit 9))}
 
+   "Hellion Alpha Test"
+   {:req (req (:installed-resource runner-reg))
+    :trace {:base 2 :choices {:req #(and (:installed %) (= (:type %) "Resource"))}
+            :msg (msg "add " (:title target) " to the top of the Stack")
+            :effect (effect (move :runner target :deck true))
+            :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain :corp :bad-publicity 1))}}}
+
    "Housekeeping"
    {:events {:runner-install {:req (req (= side :runner)) :choices (req (:hand runner))
                               :prompt "Choose a card to trash for Housekeeping" :once :per-turn

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -106,7 +106,7 @@
                       card targets))}
 
    "Invasion of Privacy"
-   {:trace {:base 2 :msg (msg "reveal the Runner's Grip")
+   {:trace {:base 2 :msg (msg "reveal the Runner's Grip and trash up to " (- target (second targets)) " resources or events")
             :effect (req (doseq [c (:hand runner)]
                            (move state side c :play-area)))
             :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain :corp :bad-publicity 1))}}}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1019,6 +1019,7 @@
                                          (when no-cost " at no cost")))
              (trigger-event state side :runner-install installed-card)
              (when (has? c :subtype "Icebreaker") (update-breaker-strength state side c)))))))
+   (when (has? card :type "Resource") (swap! state assoc-in [:runner :register :installed-resource] true))
    (swap! state update-in [:bonus] dissoc :install-cost)))
 
 (defn server-list [state card]


### PR DESCRIPTION
Shiro is tested and works with R&D Interface(s), stealing the same method as used with Raymond Flint/Gang Sign and HQ Interface. 

Added a line to `runner-install` to note in the Runner's `:register` when a Resource has been installed--this provides the support for Hellion Alpha Test. 

Made a very small tweak to the Invasion of Privacy message to make clear how many cards the Corp is eligible to trash. 