### PR TITLE
Steal cost bonuses: Red Herrings, etc.

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -90,7 +90,7 @@
    "Fetal AI"
    {:access {:req (req (not= (first (:zone card)) :discard)) :msg "do 2 net damage"
              :effect (effect (damage :net 2 {:card card}))}
-    :steal-cost [:credit 2]}
+    :steal-cost-bonus (req [:credit 2])}
 
    "Firmware Updates"
    {:data [:counter 3]
@@ -185,7 +185,7 @@
 
 
    "NAPD Contract"
-   {:steal-cost [:credit 4]
+   {:steal-cost-bonus (req [:credit 4])
     :advancement-cost-bonus (req (:bad-publicity corp))}
 
    "Nisei MK II"
@@ -288,6 +288,11 @@
    "Unorthodox Predictions"
    {:prompt "Choose an ICE type for Unorthodox Predictions" :choices ["Sentry", "Code Gate", "Barrier"]
     :msg (msg "prevent subroutines on " target " ICE from being broken until next turn.")}
+
+   "Utopia Fragment"
+   {:events {:pre-steal-cost {:req (req (pos? (or (:advance-counter target) 0)))
+                              :effect (req (let [counter (:advance-counter target)]
+                                             (steal-cost-bonus state side [:credit (* 2 counter)])))}}}
 
    "Veterans Program"
    {:effect (effect (lose :bad-publicity 2))}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -184,6 +184,9 @@
                                      :msg (msg "trash " (:title target)) :effect (effect (trash target))}
                                     card nil)))}
 
+   "Predictive Algorithm"
+   {:events {:pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 2]))}}}
+
    "Psychographics"
    {:req (req tagged) :choices :credit :prompt "How many credits?"
     :effect (req (let [c (min target (:tag runner))]

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -436,7 +436,8 @@
     :leave-play (effect (update-all-advancement-costs))
     :events {:agenda-scored {:effect (effect (trash card))}
              :agenda-stolen {:effect (effect (trash card))}
-             :pre-advancement-cost {:effect (effect (advancement-cost-bonus 1))}}}
+             :pre-advancement-cost {:effect (effect (advancement-cost-bonus 1))}
+             :pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 3]))}}}
 
    "Theophilius Bagbiter"
    {:effect (req (lose state :runner :credit :all)

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -92,6 +92,10 @@
    {:init {:root "HQ"} :abilities [{:cost [:credit 1] :effect (effect (draw))
                                     :req (req (and run (= (first (:server run)) :hq)))}]}
 
+   "Red Herrings"
+   {:events {:pre-steal-cost {:req (req (= (:zone card) (:zone target)))
+                              :effect (effect (steal-cost-bonus [:credit 5]))}}}
+
    "Research Station"
    {:init {:root "HQ"}
     :effect (effect (gain :max-hand-size 2)) :leave-play (effect (lose :max-hand-size 2))}
@@ -131,6 +135,10 @@
 
    "Simone Diego"
    {:recurring 2}
+
+   "Strongbox"
+   {:events {:pre-steal-cost {:req (req (= (:zone card) (:zone target)))
+                              :effect (effect (steal-cost-bonus [:click 1]))}}}
 
    "Tyrs Hand"
    {:abilities [{:label "Prevent a subroutine on a Bioroid from being broken"

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -31,11 +31,11 @@
   (str (Character/toUpperCase (first string)) (subs string 1)))
 
 (defn costs-to-symbol [costs]
-  (reduce #(let [key (first %2) value (last %2)]
-             (case key
-               :credit (str %1 value " [Credits]")
-               :click (reduce str %1 (for [i (range value)] "[Click]"))
-               (str %1 value " " (str key)))) "" (partition 2 (flatten costs))))
+  (clojure.string/join ", " (map #(let [key (first %) value (last %)]
+                                   (case key
+                                     :credit (str value "[Credits]")
+                                     :click (reduce str (for [i (range value)] "[Click]"))
+                                     (str value (str key)))) (partition 2 (flatten costs)))))
 
 (defn vdissoc [v n]
   (vec (concat (subvec v 0 n) (subvec v (inc n)))))


### PR DESCRIPTION
Implementation of the framework discussed in #260, #441, etc. Extends the current support for NAPD Contract and Fetal AI to third-party cards that can also impose costs on stealing agendas.

### Core changes

1. Added event `:pre-steal-cost` for third parties to handle to increase agenda steal costs. Triggered during `handle-access` once we know the card is an agenda.
2. Added function `(steal-cost-bonus)` taking a vector of costs to apply to the current steal attempt. (Example: Red Herrings applies `(steal-cost-bonus [:credit 5])` to agendas in the same server.)
2. Tweaked the `:steal-cost` tag of card definitions to rename as `:steal-cost-bonus` (matching other "bonus" frameworks) and be a `req`. Updated definitions of NAPD Contract and Fetal AI to match. (This change is future-proofing, as the `req` allows the card to define a steal cost in terms of the game state. This would allow easy implementation of a theoretical "Pay X credits to steal this card if it is not installed"-type agendas.)
3. In `handle-access`, merge the steal costs from `(steal-cost-bonus)` and from a card's `:steal-cost-bonus` function into one cost vector, and apply the existing `optional` prompt to resolve the additional costs.

### Card implementations

1. The Source: `(steal-cost-bonus [:credit 3])`.
2. Red Herrings: see above.
3. Strongbox: `(steal-cost-bonus [:click 1])` for agendas in the same server.
4. Predictive Algorithm: 2 credits for all agendas.
5. Utopia Fragment: 2 credits for each `:advance-counter` on the target agenda.

### All together now
![steal-costs](https://cloud.githubusercontent.com/assets/10083341/8890876/0c2fc678-32c6-11e5-82f9-c6abfeb265ba.PNG)

NAPD with 3 tokens, Red Herrings, Strongbox, Predictive Algorithm, The Source, and scored Utopia Fragment

4cr (NAPD) + 5cr (Herrings) + 1click (Strongbox) + 2cr (Predictive) + 3cr (The Source) + 6cr (Utopia) = 20cr, 1click :dancers: 