### PR TITLE
Improved card list scrolling performance

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -595,6 +595,7 @@ nav ul
   overflow: auto
   -webkit-overflow-scrolling: touch
   padding-top: 40px
+  transform: translateZ(0)
   flex(1)
 
 


### PR DESCRIPTION
A lot of elements are being repainted when scrolling the card list.
This is taking a lot of time and the frame rate is restricted to around 20fps.
By moving the cards to a seperate layer, no more painting is needed when scrolling.
We are left with compositing only, and this is hardware accelerated on the gpu.
This boosts the performance to around 60fps.