### PR TITLE
enable chatbox with [hotkey] + [l]

### DIFF
--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -39,7 +39,7 @@
   (om/component
    (sab/html
     [:form.msg-box {:on-submit #(send-msg % channel owner)}
-     [:input {:type "text" :ref "msg-input" :placeholder "Say something..."}]
+     [:input {:type "text" :ref "msg-input" :placeholder "Say something..." :accessKey "l"}]
      [:button "Send"]])))
 
 (defn channel-view [{:keys [channel active-channel]} owner]

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -204,7 +204,7 @@
                [:div.username (get-in msg [:user :username])]
                [:div (for [item (get-message-parts (:text msg))] (create-span item))]]]))]
         [:form {:on-submit #(send-msg % owner)}
-         [:input {:ref "msg-input" :placeholder "Say something"}]]]))))
+         [:input {:ref "msg-input" :placeholder "Say something" :accessKey "l"}]]]))))
 
 (defn remote-list [remotes]
   (map #(str "Server " %) (-> remotes count range reverse)))

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -136,7 +136,7 @@
                [:div (:text msg)]]]))]
         [:div
          [:form.msg-box {:on-submit #(send-msg % owner)}
-          [:input {:ref "msg-input" :placeholder "Say something"}]
+          [:input {:ref "msg-input" :placeholder "Say something" :accessKey "l"}]
           [:button "Send"]]]]))))
 
 (defn game-lobby [{:keys [games gameid messages user] :as cursor} owner]


### PR DESCRIPTION
Fixes mtgred/netrunner#213

You can now focus the chat inputbox with the access key `l`.

On Chrome, you can use [ALT] + [l]
On Safari, it's [ALT] + [l] on Windows and [ALT] + [CTRL] + [l] on Mac

The exact key combination is dependant on your [browser](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey).