### PR TITLE
Reina's ability is only consumed if the ICE was rezzed successfully.

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -173,9 +173,10 @@
 
    "Reina Roja: Freedom Fighter"
    {:effect (effect (gain :link 1))
-    :events {:pre-rez
-             {:req (req (= (:type target) "ICE")) :once :per-turn
-              :effect (effect (rez-cost-bonus 1))}}}
+    :events {:pre-rez {:req (req (and (= (:type target) "ICE") (not (get-in @state [:per-turn (:cid card)]))))
+                       :effect (effect (rez-cost-bonus 1))}
+             :rez {:req (req (and (= (:type target) "ICE") (not (get-in @state [:per-turn (:cid card)]))))
+                              :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
 
    "Silhouette: Stealth Operative"
    {:events {:successful-run


### PR DESCRIPTION
Addresses https://github.com/mtgred/netrunner/issues/428