### PR TITLE
Little fix for the card preview

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -162,14 +162,16 @@
 (defn prepare-cards []
  (->> (:cards @app-state)
       (group-by :title)
-      (map get-alt-art)))
-
+      (map get-alt-art)
+      (sort-by #(count (:title %1)))
+      (reverse)))
+  
 (def prepared-cards (memoize prepare-cards))
 
 (def create-span (memoize create-span-impl))
 
 (defn add-image-codes-impl [text]
-  (reduce #(.replace %1 (js/RegExp. (str "\\b" (:title %2) "\\b") "g") (str "[" (:title %2) "~"(:code %2) "]")) text (prepared-cards)))
+  (reduce #(.replace %1 (js/RegExp. (str "\\b" (:title %2) "\\b" "(?!~)") "g") (str "[" (:title %2) "~"(:code %2) "]")) text (prepared-cards)))
 
 (def add-image-codes (memoize add-image-codes-impl))  
   


### PR DESCRIPTION
Sort the cards by title length before applying the regex

Otherwise, it can happen that "Pop-up Window" is recognized as <Pop-up
><"Window">, highlighting "Window" instead of "Pop-up Window".