### PR TITLE
User-selected indicators for skill level and seriousness when creating games

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -88,7 +88,7 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
   socket.on 'netrunner', (msg) ->
     switch msg.action
       when "create"
-        game = {date: new Date(), gameid: ++gameid, title: msg.title,\
+        game = {date: new Date(), gameid: ++gameid, title: msg.title, skill: msg.skill, type:msg.type,\
                 players: [{user: socket.request.user, id: socket.id, side: "Corp"}]}
         games[gameid] = game
         socket.join(gameid)

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -922,6 +922,57 @@ nav ul
 
   .game-title
     width: 250px
+    margin-bottom: 5px
+
+  .game-skill
+    width: 150px
+
+  .game-type
+    width: 150px
+
+  .game-icons
+    position: absolute
+    right: 70px
+    top: 16px
+
+  .game-icon-type
+    float: right
+    color: black
+    float: right
+    text-align: center
+    vertical-align: middle
+    height: 20px
+    width: 20px
+    border-radius: 50%
+    border: 1px solid black
+    margin-right: 2px
+
+  .game-icon-skill
+    float: right
+    color: black
+    text-align: center
+    vertical-align: middle
+    height: 19px
+    width: 19px
+    border: 1px solid black
+
+  .private
+    color: white
+    background-color: black
+  .beginner
+    background-color: green
+  .intermediate
+    background-color: yellow
+
+  .expert
+    background-color: red
+  .friendly
+    background-color: green
+  .serious
+    background-color: yellow
+  .tournament
+    background-color: red
+
 
   .deck-collection
     width: 496px


### PR DESCRIPTION
Add options for "Skill Level" and "Game Type" ("seriousness") when creating a game. This information is displayed in the game list with colored icons that can be hovered over.  Addresses #179, #345, and #355, giving a simple visual cue as to what type of game a player is looking for. Attempts to be nonintrusive by setting default options to "Intermediate/Serious", which is probably what most site users look for.

![skill-create](https://cloud.githubusercontent.com/assets/10083341/9017866/6fd9e3bc-378e-11e5-9d4b-8013bc7f625c.PNG)

Skill options:
* Beginner (green)
* Intermediate (yellow) DEFAULT
* Expert (red)

Game Type options:
* Private (black)
* Friendly (green)
* Serious (yellow) DEFAULT
* Tournament (red)

Game lobby list:
![skill-list](https://cloud.githubusercontent.com/assets/10083341/9017893/a6f0c230-378e-11e5-8f45-f79dceda1a93.PNG)


Hovering the icons shows a descriptive popup message, along the lines of "Looking for Expert opponent" and "This is a Friendly match".

I used built-in CSS color names "red", "green", and "yellow", which obviously can be tweaked.