### PR TITLE
Implement Crisium Grid

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -190,7 +190,10 @@
    {:effect (effect (draw 3) (lose :tag 2))}
 
    "Legwork"
-   {:effect (effect (run :hq) (access-bonus 2))}
+   {:effect (effect (run :hq) (register-events (:events (card-def card))
+                                               (assoc card :zone '(:discard))))
+    :events {:successful-run {:effect (effect (access-bonus 2))}
+             :run-ends {:effect (effect (unregister-events card))}}}
 
    "Leverage"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
@@ -392,7 +395,10 @@
              card targets))}
 
    "The Makers Eye"
-   {:effect (effect (run :rd) (access-bonus 2))}
+   {:effect (effect (run :rd) (register-events (:events (card-def card))
+                                               (assoc card :zone '(:discard))))
+    :events {:successful-run {:effect (effect (access-bonus 2))}
+             :run-ends {:effect (effect (unregister-events card))}}}
 
    "Three Steps Ahead"
    {:end-turn {:effect (effect (gain :credit (* 2 (count (:successful-run runner-reg)))))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -228,17 +228,17 @@
 
    "Medium"
    {:events
-    {:successful-run
-     {:req (req (= target :rd))
-      :effect (effect (add-prop card :counter 1)
-                      (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}}
+    {:successful-run {:req (req (= target :rd))
+                      :effect (effect (add-prop card :counter 1))}
+     :pre-access {:req (req (= target :rd))
+                  :effect (effect (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}}
 
    "Nerve Agent"
    {:events
-    {:successful-run
-     {:req (req (= target :hq))
-      :effect (effect (add-prop card :counter 1)
-                      (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}}
+    {:successful-run {:req (req (= target :hq))
+                      :effect (effect (add-prop card :counter 1))}
+     :pre-access {:req (req (= target :hq))
+                  :effect (effect (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}}
 
    "Net Shield"
    {:prevent {:damage [:net]}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -55,8 +55,7 @@
                                   :runner-turn-ends ct :corp-turn-ends ct}) card))}}
 
    "Crisium Grid"
-   {:suppress {:successful-run {:req (req (and this-server (not= (:cid target) (:cid card))))}
-               :unsuccessful-run {:req (req (and this-server (not= (:cid target) (:cid card))))}}
+   {:suppress {:successful-run {:req (req (and this-server (not= (:cid target) (:cid card))))}}
     :events {:successful-run {:req (req this-server)
                               :effect (req (swap! state update-in [:run :run-effect] dissoc :replace-access)
                                            (swap! state update-in [:run] dissoc :successful)

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -54,6 +54,14 @@
                                                      :effect (effect (ice-strength-bonus (:troubleshooter-amount card)))}
                                   :runner-turn-ends ct :corp-turn-ends ct}) card))}}
 
+   "Crisium Grid"
+   {:suppress {:successful-run {:req (req (and this-server (not= (:cid target) (:cid card))))}
+               :unsuccessful-run {:req (req (and this-server (not= (:cid target) (:cid card))))}}
+    :events {:successful-run {:req (req this-server)
+                              :effect (req (swap! state update-in [:run :run-effect] dissoc :replace-access)
+                                           (swap! state update-in [:run] dissoc :successful)
+                                           (swap! state update-in [:runner :register :successful-run] #(butlast %)))}}}
+
    "Cyberdex Virus Suite"
    {:access {:optional {:prompt "Purge viruses with Cyberdex Virus Suite?"
                         :msg (msg "purge viruses") :effect (effect (purge))}}


### PR DESCRIPTION
This was a fun card. In terms of our game engine, Crisium Grid needs to interact with four categories of cards:

1. Cards that initiate runs with a `:replace-access` to forgo the normal access routine in favor of a custom outcome. (Account Siphon, Indexing.)
2. Cards that handle the `:successful-run` event to perform some action when a run is declared successful. (Data Sucker/Medium/Nerve Agent add token, Desperado, Security Testing.)
3. Cards that handle `:successful-run-ends` to perform an action when a successful run finishes. (Dirty Laundry, Doppelganger.)
4. Cards that have a requirement of a successful or unsuccessful run in the current or previous turn. (SEA Source, Unregistered S&W, Emergency Shutdown, Notoriety.)

For number 2, I added an event suppression mechanism that is currently only used by Crisium Grid. When `trigger-event` is called, before dispatching an event to a handler it checks for a registered suppression handler and invokes any that it finds. If any suppression handler returns `true`, the event is not dispatched. The suppression mechanism is flexible: a suppression handler knows who is supposed to receive the event and what the event's arguments are, and can make decisions based on that. Crisium Grid uses this to suppress `:successful-run` to all cards except itself, for any run on its server. Datasucker etc. never see the `:successful-run` event and the Grid is happy.

For number 1, Crisium Grid itself handles `:successful-run` to dissoc the `:replace-access` effect of these cards, so the normal access procedure is followed.

For number 4, Crisium Grid also dissocs `[:run :successful]` and removes the server from `[:runner :register :successful-run]`. Any card that requires a successful run on a particular server in order to play will not see that server in the register and you won't be able to play it. 

Number 3 is a natural consequence of number 4. Because `[:run :successful]` is not true, `handle-end-run` will not trigger the `successful-run-ends` event. 

Simple :).

Using the list in the first review on [this page](http://netrunnerdb.com/en/card/06048) as a checklist, I have tested all major categories of interactions. The only issue is with Will-o'-the-Wisp, since we do not have a window for the Corp to rez cards between Successful Run triggering and Access occurring. Will-o' doesn't enforce the timing window at all, so it will require manual user interaction to recognize that Will-o' can't be used on a run on a Crisium server. (Likewise for Ash 2X3Z.)

I had to rework Legwork and Maker's Eye so they only grant the access bonus once the run is declared successful, instead of at the beginning of the run. Medium and Nerve Agent also had to be tweaked to separate the gaining of tokens from the access bonus. (Correct interaction: if Crisium is on R&D, Medium gains no tokens, but still grants bonus access for whatever tokens it already has.)