### PR TITLE
Choose order of accessing cards

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -124,9 +124,8 @@
 
    "Gang Sign"
    {:events {:agenda-scored {:msg "access 1 card from HQ"
-                             :effect (req (doseq [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
-                                            (system-msg state :runner (str "accesses " (:title c)))
-                                            (handle-access state :runner [c])))}}}
+                             :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
+                                            (choose-access c '(:hq))))}}}
 
    "Ghost Runner"
    {:data {:counter 3}
@@ -316,9 +315,8 @@
                                 (resolve-ability
                                  ref side
                                  {:msg "access 1 card from HQ"
-                                  :effect (req (doseq [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
-                                                 (system-msg state side (str "accesses " (:title c)))
-                                                 (handle-access state side [c])))} card nil)))))
+                                  :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
+                                                 (choose-access c '(:hq))))} card nil)))))
     :leave-play (req (remove-watch state :raymond-flint))
     :abilities [{:label "Expose 1 card"
                  :effect (effect (resolve-ability

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -792,7 +792,6 @@
         (when (= (:type c) "Agenda")
           (trigger-event state side :pre-steal-cost c)
           (let [cost (steal-cost state side c)]
-            (prn (pr-str cost))
             (if (pos? (count cost))
               (optional-ability state :runner c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
                                 {:cost cost
@@ -813,6 +812,161 @@
       (min max-access accesses) accesses)))
 
 (defmulti access (fn [state side server] (first server)))
+(defmulti choose-access (fn [cards server] (first server)))
+
+(defn access-helper-remote [cards]
+  {:prompt "Click a card to access it. You must access all cards in this server."
+   :choices {:req #(some (fn [c] (= (:cid %) (:cid c))) cards)}
+   :effect (req (handle-access state side [target])
+                (when (< 1 (count cards))
+                  (resolve-ability state side (access-helper-remote (filter #(not= (:cid %) (:cid target)) cards))
+                                   card nil)))})
+
+(defmethod choose-access :remote [cards server]
+  {:effect (req (if (>= 1 (count cards))
+                  (handle-access state side cards)
+                  (resolve-ability state side (access-helper-remote cards) card nil)))})
+
+(defn access-helper-hq [cards]
+  {:prompt "Select a card to access."
+   :choices (concat (when (some #(= (first (:zone %)) :hand) cards) ["Card from hand"])
+                    (map #(if (:rezzed %) (:title %) "Upgrade in HQ") (filter #(= (last (:zone %)) :content) cards)))
+   :effect (req (case target
+                  "Upgrade in HQ"
+                  ; accessing an unrezzed upgrade
+                  (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) cards)]
+                    (if (= 1 (count unrezzed))
+                      ; only one unrezzed upgrade; access it and continue
+                      (do (system-msg state side (str "accesses " (:title (first unrezzed))))
+                          (handle-access state side unrezzed)
+                          (when (< 1 (count cards))
+                            (resolve-ability
+                              state side (access-helper-hq (filter #(not= (:cid %) (:cid (first unrezzed))) cards))
+                              card nil)))
+                    ; more than one unrezzed upgrade. allow user to select with mouse.
+                    (resolve-ability state side
+                                     {:prompt "Choose an upgrade in HQ to access."
+                                      :choices {:req #(= (second (:zone %)) :hq)}
+                                      :effect (effect (system-msg (str "accesses " (:title target)))
+                                                      (handle-access [target])
+                                                      (resolve-ability (access-helper-hq
+                                                                         (remove-once #(not= (:cid %) (:cid target))
+                                                                                      cards)) card nil))} card nil)))
+                  ; accessing a card in hand or a rezzed upgade
+                  "Card from hand"
+                  (do (system-msg state side (str "accesses " (:title (first cards))))
+                      (handle-access state side [(first cards)])
+                      (when (< 1 (count cards))
+                        (resolve-ability state side (access-helper-hq (rest cards)) card nil)))
+                  ; accessing a rezzed upgrade
+                  (do (system-msg state side (str "accesses " target))
+                      (handle-access state side [(some #(when (= (:title %) target) %) cards)])
+                      (when (< 1 (count cards))
+                        (resolve-ability state side (access-helper-hq
+                                                      (remove-once #(not= (:title %) target) cards)) card nil)))))})
+
+(defmethod choose-access :hq [cards server]
+  {:effect (req (if (pos? (count cards))
+                  (if (= 1 (count cards))
+                    (do (when (pos? (count cards)) (system-msg state side (str "accesses " (:title (first cards)))))
+                      (handle-access state side cards))
+                    (resolve-ability state side (access-helper-hq cards) card nil))))})
+
+(defn access-helper-rd [cards]
+  {:prompt "Select a card to access."
+   :choices (concat (when (some #(= (first (:zone %)) :deck) cards) ["Card from deck"])
+                    (map #(if (:rezzed %) (:title %) "Upgrade in R&D") (filter #(= (last (:zone %)) :content) cards)))
+   :effect (req (case target
+                  "Upgrade in R&D"
+                  ; accessing an unrezzed upgrade
+                  (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) cards)]
+                    (if (= 1 (count unrezzed))
+                      ; only one unrezzed upgrade; access it and continue
+                      (do (system-msg state side (str "accesses " (:title (first unrezzed))))
+                          (handle-access state side unrezzed)
+                          (when (< 1 (count cards))
+                            (resolve-ability
+                              state side (access-helper-rd (filter #(not= (:cid %) (:cid (first unrezzed))) cards))
+                              card nil)))
+                      ; more than one unrezzed upgrade. allow user to select with mouse.
+                      (resolve-ability state side
+                                       {:prompt "Choose an upgrade in R&D to access."
+                                        :choices {:req #(= (second (:zone %)) :rd)}
+                                        :effect (effect (system-msg (str "accesses " (:title target)))
+                                                        (handle-access [target])
+                                                        (resolve-ability (access-helper-rd
+                                                                           (remove-once #(not= (:cid %) (:cid target))
+                                                                                        cards)) card nil))} card nil)))
+                  ; accessing a card in deck or a rezzed upgade
+                  "Card from deck"
+                  (do (system-msg state side (str "accesses " (:title (first cards))))
+                      (handle-access state side [(first cards)])
+                      (when (< 1 (count cards))
+                        (resolve-ability state side (access-helper-rd (rest cards)) card nil)))
+                  ; accessing a rezzed upgrade
+                  (do (system-msg state side (str "accesses " target))
+                      (handle-access state side [(some #(when (= (:title %) target) %) cards)])
+                      (when (< 1 (count cards))
+                        (resolve-ability state side (access-helper-rd
+                                                      (remove-once #(not= (:title %) target) cards)) card nil)))))})
+
+(defmethod choose-access :rd [cards server]
+  {:effect (req (if (pos? (count cards))
+                  (if (= 1 (count cards))
+                    (do (when (pos? (count cards)) (system-msg state side (str "accesses " (:title (first cards)))))
+                        (handle-access state side cards))
+                    (resolve-ability state side (access-helper-rd cards) card nil))))})
+
+(defn access-helper-archives [cards]
+  {:prompt "Select a card to access. You must access all cards."
+   :choices (map #(if (= (last (:zone %)) :content)
+                   (if (:rezzed %) (:title %) "Upgrade in Archives")
+                   (:title %)) cards)
+   :effect (req (case target
+                  "Upgrade in Archives"
+                  ; accessing an unrezzed upgrade
+                  (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) cards)]
+                    (if (= 1 (count unrezzed))
+                      ; only one unrezzed upgrade; access it and continue
+                      (do (system-msg state side (str "accesses " (:title (first unrezzed))))
+                          (handle-access state side unrezzed)
+                          (when (< 1 (count cards))
+                            (resolve-ability
+                              state side (access-helper-archives (filter #(not= (:cid %) (:cid (first unrezzed))) cards))
+                              card nil)))
+                    ; more than one unrezzed upgrade. allow user to select with mouse.
+                      (resolve-ability state side
+                                       {:prompt "Choose an upgrade in Archives to access."
+                                        :choices {:req #(= (second (:zone %)) :archives)}
+                                        :effect (effect (system-msg (str "accesses " (:title target)))
+                                                        (handle-access [target])
+                                                        (resolve-ability (access-helper-archives
+                                                                           (remove-once #(not= (:cid %) (:cid target))
+                                                                                        cards)) card nil))} card nil)))
+                  ; accessing a rezzed upgrade, or a card in archives
+                  (do (system-msg state side (str "accesses " target))
+                      (handle-access state side [(some #(when (= (:title %) target) %) cards)])
+                      (when (< 1 (count cards))
+                        (resolve-ability state side (access-helper-archives
+                                                      (remove-once #(not= (:title %) target) cards)) card nil)))))})
+
+(defmethod choose-access :archives [cards server]
+  {:effect (req (let [; only include agendas and cards with an :access ability whose :req is true
+                      ; (or don't have a :req, or have an :optional with no :req, or :optional with a true :req.)
+                      cards (filter #(let [cdef (card-def %)]
+                                      (or (= (:type %) "Agenda") (= (last (:zone %)) :content)
+                                          (and (:access cdef) (not (get-in cdef [:access :optional]))
+                                               (or (not (get-in cdef [:access :req]))
+                                                   ((get-in cdef [:access :req]) state side % nil)))
+                                          (and (get-in cdef [:access :optional])
+                                               (or (not (get-in cdef [:access :optional :req]))
+                                                   ((get-in cdef [:access :optional :req]) state side % nil)))))
+                                    cards)]
+                  (if (pos? (count cards))
+                    (if (= 1 (count cards))
+                      (do (when (pos? (count cards)) (system-msg state side (str "accesses " (:title (first cards)))))
+                          (handle-access state side cards))
+                      (resolve-ability state side (access-helper-archives cards) card nil)))))})
 
 (defmethod access :hq [state side server]
   (concat (take (access-count state side :hq-access) (shuffle (get-in @state [:corp :hand])))
@@ -837,9 +991,13 @@
     (when-not (or (= (get-in @state [:run :max-access]) 0) (empty? cards))
       (if (= (first server) :rd)
         (let [n (count cards)]
-          (system-msg state side (str "accesses " n " card" (when (> n 1) "s"))))
-        (system-msg state side (str "accesses " (join ", "(map :title cards)))))
-      (handle-access state side cards)))
+          (system-msg state side (str "accesses " n " card" (when (> n 1) "s")))))
+      (resolve-ability state side (choose-access cards server) nil nil)))
+      ;(case (first server)
+      ;  :remote (resolve-ability state side (choose-access-remote cards) nil nil)
+      ;  :hq (resolve-ability state side (choose-access-hq) nil nil)
+      ;  :archives (resolve-ability state side (choose-access-archives) nil nil)
+      ;  :rd (resolve-ability state side (choose-access-rd) nil nil))))
   (handle-end-run state side))
 
 (defn replace-access [state side ability card]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -832,9 +832,10 @@
 (defn access-helper-hq [cards]
   {:prompt "Select a card to access."
    :choices (concat (when (some #(= (first (:zone %)) :hand) cards) ["Card from hand"])
-                    (map #(if (:rezzed %) (:title %) "Upgrade in HQ") (filter #(= (last (:zone %)) :content) cards)))
+                    (map #(if (:rezzed %) (:title %) "Unrezzed upgrade in HQ")
+                         (filter #(= (last (:zone %)) :content) cards)))
    :effect (req (case target
-                  "Upgrade in HQ"
+                "Unrezzed upgrade in HQ"
                   ; accessing an unrezzed upgrade
                   (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) cards)]
                     (if (= 1 (count unrezzed))
@@ -877,9 +878,10 @@
 (defn access-helper-rd [cards]
   {:prompt "Select a card to access."
    :choices (concat (when (some #(= (first (:zone %)) :deck) cards) ["Card from deck"])
-                    (map #(if (:rezzed %) (:title %) "Upgrade in R&D") (filter #(= (last (:zone %)) :content) cards)))
+                    (map #(if (:rezzed %) (:title %) "Unrezzed upgrade in R&D")
+                         (filter #(= (last (:zone %)) :content) cards)))
    :effect (req (case target
-                  "Upgrade in R&D"
+                  "Unrezzed upgrade in R&D"
                   ; accessing an unrezzed upgrade
                   (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) cards)]
                     (if (= 1 (count unrezzed))
@@ -922,10 +924,10 @@
 (defn access-helper-archives [cards]
   {:prompt "Select a card to access. You must access all cards."
    :choices (map #(if (= (last (:zone %)) :content)
-                   (if (:rezzed %) (:title %) "Upgrade in Archives")
+                   (if (:rezzed %) (:title %) "Unrezzed upgrade in Archives")
                    (:title %)) cards)
    :effect (req (case target
-                  "Upgrade in Archives"
+                  "Unrezzed upgrade in Archives"
                   ; accessing an unrezzed upgrade
                   (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) cards)]
                     (if (= 1 (count unrezzed))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -993,11 +993,6 @@
         (let [n (count cards)]
           (system-msg state side (str "accesses " n " card" (when (> n 1) "s")))))
       (resolve-ability state side (choose-access cards server) nil nil)))
-      ;(case (first server)
-      ;  :remote (resolve-ability state side (choose-access-remote cards) nil nil)
-      ;  :hq (resolve-ability state side (choose-access-hq) nil nil)
-      ;  :archives (resolve-ability state side (choose-access-archives) nil nil)
-      ;  :rd (resolve-ability state side (choose-access-rd) nil nil))))
   (handle-end-run state side))
 
 (defn replace-access [state side ability card]


### PR DESCRIPTION
My system for letting the runner choose order of access when it is appropriate and unobtrusive. See #470 for pictures and a brief description. In general, we use both click-on-card and click-on-prompt to allow the runner to choose in what order they will access cards in a server. Intelligently (mostly) auto-selects cards when the context is clear. For example, if HQ has two rezzed upgrades and one unrezzed, and the runner selects to access "Upgrade in HQ" (as opposed to the names of the other two upgrades), they will not have to further specify; but if there are two unrezzed upgrades, they will then have to click on the one they want.

Addresses a number of issues with the simpler access system:

1. Oaktown Grid and Snare! in a server. Oaktown Grid rezzed prior to access. Live behavior: runner accesses in "random" order (based on install order), possibly having to pay 3cr to trash Snare and 4cr to trash Oaktown. Fixed behavior: runner can choose to access Oaktown and trash for 4cr first, then access Snare and trash for 0cr.
2. Accessing multiple unrezzed upgrades in a server. Live behavior: all cards accessed are printed to chat log, and then accessed in "random" order; runner can peek at what will be accessed later and decide to not trash the first thing they access to save money for the next. Fixed behavior: no reveal of what will be accessed until it is clicked.
3. Likewise, accessing multiple cards from HQ. Live behavior: runner sees he accesses NAPD and The Future Perfect; having only 4 cr, he chooses not to steal NAPD so he can play Psi game. Fixed behavior: must resolve the first access with no idea what's coming.
4. For Haarpsichord Studios, choosing order of access from Archives will be very important. Live behavior will theoretically give you the first agenda to enter Archives.

Known issues:

1. Ironically, Red Herrings and Strongbox like the old system and will no longer enforce their "including during the run in which Red Herrings is trashed" effect. Easy fix.
2. This prevents Edward Kim from accessing operations in Archives, which is supposed to disable his ability for the rest of the turn. Medium fix.