### PR TITLE
Implement Cerebral Static

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -46,6 +46,12 @@
                                      (gain state side :tag 1)
                                      (damage state side :brain 1 {:card card})))}}}
 
+   "Cerebral Static"
+   {:msg "disable the Runner's identity"
+    :effect (req (unregister-events state side (:identity runner)))
+    :leave-play (req (when-let [events (:events (card-def (:identity runner)))]
+                       (register-events state side events (:identity runner))))}
+
    "Closed Accounts"
    {:req (req tagged) :effect (effect (lose :runner :credit :all))}
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -80,7 +80,7 @@
          c (if (= (:side c) "Runner") (dissoc c :installed :counter :rec-counter :pump) c)
          c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
      (when-let [leave-effect (:leave-play (card-def card))]
-       (when (or (= (:side card) "Runner") (:rezzed card))
+       (when (or (= (:side card) "Runner") (:rezzed card) (= (first (:zone card)) :current))
          (leave-effect state side card nil)))
      (when-let [prevent (:prevent (card-def card))]
        (doseq [[ptype pvec] prevent]
@@ -971,7 +971,6 @@
          (let [c (move state side (assoc card :seen true) :play-area)]
            (system-msg state side (str "plays " title))
            (trigger-event state side (if (= side :corp) :play-operation :play-event) c)
-           (resolve-ability state side cdef card nil)
            (if (has? c :subtype "Current")
              (do (doseq [s [:corp :runner]]
                    (when-let [current (first (get-in @state [s :current]))]
@@ -979,7 +978,9 @@
                      (trash state side current)))
                  (let [moved-card (move state side (first (get-in @state [side :play-area])) :current)]
                    (card-init state side moved-card)))
-             (move state side (first (get-in @state [side :play-area])) :discard)))))))
+             (do
+               (resolve-ability state side cdef card nil)
+               (move state side (first (get-in @state [side :play-area])) :discard))))))))
 
 (defn in-play? [state card]
   (let [dest (when (= (:side card) "Runner")


### PR DESCRIPTION
A simple implementation of Cerebral Static. Not 100% perfect, but good enough for now.

Unregisters the runner identity's events, so it won't receive notifications about board state changes. The overwhelming majority of runner identities simply do things in response to game events, so unregistering these events makes the identity effectively blank. Example: Kate will not receive `:pre-install-cost` and won't apply her discount; Noise won't receive `:runner-install` and can't mill when viruses are installed; Gabe won't receive `:successful-run` for his credits, etc.

A few identities don't handle events and are not correctly handled. All these can be manually accounted for with minimal effort:

1. Whizzard - keeps his recurring credits. Just don't click them!
2. Chaos Theory - keeps her +1 MU. Adjust MU in interface.
3. Quetzal - can still click her identity to "break 1 barrier subroutine"... but all it really does is print to the log.

I had to hook up a few things in core to make this work, but it's simple: currents can now receive `:leave-play` when they are trashed, and currents won't have their events hooked twice (an old bug that isn't noticeable, because most currents are "the first time" events.)