### PR TITLE
Haarpsichord Studios and prevent-steal framework.

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -60,6 +60,10 @@
    "GRNDL: Power Unleashed"
    {:effect (effect (gain :credit 5 :bad-publicity 1))}
 
+   "Haarpsichord Studios"
+   {:events {:pre-steal-cost {:req (req (pos? (or (:stole-agenda runner-reg) 0)))
+                              :effect (effect (prevent-steal))}}}
+
    "Haas-Bioroid: Engineering the Future"
    {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"
                             :effect (effect (gain :credit 1))}}}


### PR DESCRIPTION
The real reason I was working on choosing access order. Uses a new register `[:runner :register :cannot-steal]` to prevent stealing agendas when the number of points stolen this turn is non-zero. Doesn't stop the `:access` events, so Explode-a-palooza, TGTBT, etc. still trigger their on-access effects :D.