### PR TITLE
Fix for Architect installing top card of R&D in NEH.

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -15,7 +15,7 @@
                  :activatemsg "uses Architect to look at the top 5 cards of R&D"
                  :req (req (not (string? target))) :not-distinct true
                  :choices (req (conj (take 5 (:deck corp)) "No install"))
-                 :effect (effect (corp-install target nil {:no-install-cost true}))}
+                 :effect (effect (corp-install (move state side target :play-area) nil {:no-install-cost true}))}
                 {:msg "install a card from Archives" :choices (req (:discard corp))
                  :prompt "Choose a card to install" :effect (effect (corp-install target nil))}
                 {:msg "install a card from HQ" :choices (req (:hand corp))


### PR DESCRIPTION
Fixes #278 by moving the card selected by Architect to `:play-area`, so that when `corp-install` triggers the `:server-created` event, the card is no longer on top of R&D and drawn by NEH's ability. The selected card stays in play area until the corp selects a server for it.