### PR TITLE
New trash-installed function, add to ice that use it

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -56,7 +56,10 @@
                                      (move state side card (conj (server->zone state target) :ices)))}}}]}
 
    "Burke Bugs"
-   {:abilities [trash-program]}
+   {:abilities [{:label "Trace 0 - Force the Runner to trash a program"
+                 :trace (assoc trash-program :base 0 :not-distinct true
+                                             :player :runner
+                                             :msg (msg "force the Runner to trash " (:title target)))}]}
 
    "Caduceus"
    {:abilities [{:label "Trace 3 - Gain 3 [Credits]"
@@ -267,7 +270,11 @@
 
    "Information Overload"
    {:abilities [{:label "Trace 1 - Give the Runner 1 tag"
-                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+                (assoc trash-installed :label "Force the Runner to trash an installed card"
+                                       :player :runner
+                                       :msg (msg "force the Runner to trash " (:title target))
+                                       :effect (effect (trash target)))]}
 
    "Ireress"
    {:abilities [{:msg "make the Runner lose 1 [Credits]" :effect (effect (lose :runner :credit 1))}]}
@@ -326,7 +333,10 @@
                                    :effect (effect (add-prop :runner card :counter 1))}}}]}
 
    "Markus 1.0"
-   {:abilities [{:msg "force the Runner to trash a card"}
+   {:abilities [(assoc trash-installed :label "Force the Runner to trash an installed card"
+                                       :player :runner
+                                       :msg (msg "force the Runner to trash " (:title target))
+                                       :effect (effect (trash target)))
                 {:msg "end the run" :effect (effect (end-run))}]}
 
    "Matrix Analyzer"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare trash-program trash-hardware)
+(declare trash-program trash-hardware trash-installed)
 
 (def cards-ice
   {"Archer"

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -10,6 +10,11 @@
                      :choices {:req #(and (:installed %) (= (:type %) "Hardware"))}
                      :effect (effect (trash target {:cause :subroutine}))})
 
+(def trash-installed {:prompt "Choose an installed card to trash" :label "Trash an installed card"
+                      :msg (msg "trash " (:title target))
+                      :choices {:req #(and (:installed %) (= (:side %) "Runner"))}
+                      :effect (effect (trash target {:cause :subroutine}))})
+
 (load "cards-agendas")
 (load "cards-assets")
 (load "cards-events")


### PR DESCRIPTION
This adds a more generalized version of the `trash-program` and `trash-hardware` functions in `cards.clj`. Instead of relying on the Runner to trash something manually, we handle it with a prompt. Markus 1.0 and Information Overload now use it. 

Burke Bugs is fixed up to add the trace and have the Runner choose the program to trash--it was erroneously having the Corp choose. 