### PR TITLE
implement Project Ares, fix Exile, partial Immolation Script

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -239,6 +239,19 @@
     :effect (effect (gain :credit (* 5 (Integer/parseInt target))
                           :bad-publicity (Integer/parseInt target)))}
 
+   "Project Ares"
+   {:req (req #(and (> (:advance-counter card) 4) (> (count (all-installed state :runner)) 0)))
+    :msg (msg "force the Runner to trash " (- (:advance-counter card) 4) " installed cards and take 1 bad publicity")
+	  :effect (req (let [ares card]
+	                 (resolve-ability
+	                   state :runner
+	                   {:prompt (msg "Choose " (- (:advance-counter ares) 4) " installed cards to trash")
+                      :choices {:max (- (:advance-counter ares) 4) :req #(and (:installed %) (= (:side %) "Runner"))}
+                      :effect (effect (trash-cards targets)
+                                      (system-msg (str "trashes " (join ", " (map :title targets)))))}
+                    card nil))
+	               (gain state :corp :bad-publicity 1))}
+
    "Project Atlas"
    {:effect (effect (set-prop card :counter (max 0 (- (:advance-counter card) 3))))
     :abilities [{:counter-cost 1 :prompt "Choose a card" :label "Search R&D and add 1 card to HQ"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -177,6 +177,9 @@
     :trash-effect {:req (req (#{:meat :net} target))
                    :effect (effect (draw :runner 3)) :msg "draw 3 cards"}}
 
+   "Immolation Script"
+   {:effect (effect (run :archives))}
+
    "Indexing"
    {:effect (effect (run :rd {:replace-access
                               {:msg "rearrange the top 5 cards of R&D"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -47,11 +47,8 @@
    "Exile: Streethawk"
    {:effect (effect (gain :link 1))
     :events {:runner-install {:req (req (and (has? target :type "Program")
-                                             (= (:active-player @state) :runner)
-                                             ;; only trigger when played a programm from heap
                                              (some #{:discard} (:previous-zone target))))
                               :msg (msg "draw a card") :effect (effect (draw 1))}}}
-
 
    "Gabriel Santiago: Consummate Professional"
    {:events {:successful-run {:msg "gain 2 [Credits]" :once :per-turn


### PR DESCRIPTION
Exile was wrongly generating the card draw only during the Runner's turn--it should happen every time regardless of whose turn it is. Added in a stub for Immolation Script to at least have it initiate an Archives run. 

Project Ares checks to see if it's over-advanced and that the Runner's rig isn't empty, whereupon it passes a multi-select prompt to the Runner to trash the requisite number of cards and then gives the Corp a bad publicity. 