### PR TITLE
implement Nasir Meidan, add rest of Muertos Gang Member

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -157,7 +157,11 @@
                                   :effect (effect (mill 2) (draw))}}}
 
    "Nasir Meidan: Cyber Explorer"
-   {:effect (effect (gain :link 1))}
+   {:effect (effect (gain :link 1))
+    :abilities [{:req (req (:run @state))
+                 :effect (req (lose state side :credit (:credit runner))
+                              (gain state side :credit (rez-cost state side current-ice)))
+                 :msg (msg "lose all credits and gain " (rez-cost state side current-ice) " [Credits] from the rez of " (:title current-ice))}]}
 
    "NBN: Making News"
    {:recurring 2}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -231,8 +231,22 @@
                                 (move state side (first (:deck runner)) :deck)))}]}
 
    "Muertos Gang Member"
-   {:abilities [{:msg "draw 1 card"
-                 :effect (effect (trash card {:cause :ability-cost}) (draw))}] }
+   {:effect (req (resolve-ability
+                   state :corp
+                   {:prompt "Choose a card to derez"
+                    :choices {:req #(and (= (:side %) "Corp") (:rezzed %))}
+                    :effect (req (derez state side target))}
+                  card nil))
+    :leave-play (req (resolve-ability
+                       state :corp
+                       {:prompt "Choose a card to rez, ignoring the rez cost"
+                        :choices {:req #(not (:rezzed %))}
+                        :effect (req (gain state :corp :credit (rez-cost state side target))
+                                     (rez state side target)
+                                     (system-msg state side (str "rezzes " (:title target) " at no cast")))}
+                      card nil))
+    :abilities [{:msg "draw 1 card"
+                 :effect (effect (trash card {:cause :ability-cost}) (draw))}]}
 
    "New Angeles City Hall"
    {:events {:agenda-stolen {:msg "trash itself" :effect (effect (trash card))}}


### PR DESCRIPTION
This gives Nasir a "click ID to use him" ability a la Blue Sun. Nasir likes to spend down his credits with all kinds of shenanigans in step 2.3 of the timing chart, so the Runner needs to pop Clone Chips, SMCs, and do whatever else before clicking him. I've confirmed that this will add back credits equal to modified rez cost--so e.g. hitting a twice-advanced Weyland space ice will leave Nasir sitting at 3 credits.  

Muertos Gang Member will now prompt the Corp on install to derez something, and give a free rez prompt when it leaves play. 