### PR TITLE
add missing Muertos Gang Member effects, partially implement Off the Grid

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -243,7 +243,7 @@
                         :choices {:req #(not (:rezzed %))}
                         :effect (req (gain state :corp :credit (rez-cost state side target))
                                      (rez state side target) 
-                                     (system-msg state side (str "rezzes " (:title target) " at no cast")))}
+                                     (system-msg state side (str "rezzes " (:title target) " at no cost")))}
                       card nil))
     :abilities [{:msg "draw 1 card"
                  :effect (effect (trash card {:cause :ability-cost}) (draw))}]}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -231,8 +231,22 @@
                                 (move state side (first (:deck runner)) :deck)))}]}
 
    "Muertos Gang Member"
-   {:abilities [{:msg "draw 1 card"
-                 :effect (effect (trash card {:cause :ability-cost}) (draw))}] }
+   {:effect (req (resolve-ability
+                   state :corp
+                   {:prompt "Choose a card to derez"
+                    :choices {:req #(and (= (:side %) "Corp") (:rezzed %))}
+                    :effect (req (derez state side target))}
+                  card nil))
+    :leave-play (req (resolve-ability
+                       state :corp
+                       {:prompt "Choose a card to rez, ignoring the rez cost"
+                        :choices {:req #(not (:rezzed %))}
+                        :effect (req (gain state :corp :credit (rez-cost state side target))
+                                     (rez state side target) 
+                                     (system-msg state side (str "rezzes " (:title target) " at no cast")))}
+                      card nil))
+    :abilities [{:msg "draw 1 card"
+                 :effect (effect (trash card {:cause :ability-cost}) (draw))}]}
 
    "New Angeles City Hall"
    {:events {:agenda-stolen {:msg "trash itself" :effect (effect (trash card))}}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -109,6 +109,11 @@
    {:events {:pre-trash {:req (req (= (:zone card) (:zone target)))
                          :effect (effect (trash-cost-bonus 3))}}}
 
+   "Off the Grid"
+   {:events {:successful-run {:req (req (= target :hq))
+                              :effect (req (trash state :corp card)
+                                           (system-msg state :corp (str "trashes Off the Grid")))}}}
+
    "Panic Button"
    {:init {:root "HQ"} :abilities [{:cost [:credit 1] :effect (effect (draw))
                                     :req (req (and run (= (first (:server run)) :hq)))}]}


### PR DESCRIPTION
Completes Muertos Gang Member with the missing Corp derez and discounted rez effects when MGM is installed and leaves play. 

Added a partial Off the Grid--it trashes itself whenever a run on HQ is successful. 