### PR TITLE
Removed gender-specific language

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -46,12 +46,12 @@
 
    "Déjà Vu"
    {:prompt "Choose a card to add to Grip" :choices (req (:discard runner))
-    :msg (msg "add " (:title target) " to his Grip")
+    :msg (msg "add " (:title target) " to their Grip")
     :effect (req (move state side target :hand)
                  (when (has? target :subtype "Virus")
                    (resolve-ability state side
                                     {:prompt "Choose a virus to add to Grip"
-                                     :msg (msg "add " (:title target) " to his Grip")
+                                     :msg (msg "add " (:title target) " to their Grip")
                                      :choices (req (filter #(has? % :subtype "Virus") (:discard runner)))
                                      :effect (effect (move target :hand))} card nil)))}
 
@@ -169,7 +169,7 @@
    "Hostage"
    {:prompt "Choose a Connection"
     :choices (req (filter #(has? % :subtype "Connection") (:deck runner)))
-    :msg (msg "adds " (:title target) " to his Grip and shuffles his Stack") 
+    :msg (msg "adds " (:title target) " to their Grip and shuffles their Stack") 
     :effect (req (let [connection target]
                    (resolve-ability 
                      state side 
@@ -273,7 +273,7 @@
    "Networking"
    {:effect (effect (lose :tag 1))
     :optional {:cost [:credit 1] :prompt "Pay 1 [Credits] to add Networking to Grip?"
-               :msg "add it to his Grip" :effect (effect (move (last (:discard runner)) :hand))}}
+               :msg "add it to their Grip" :effect (effect (move (last (:discard runner)) :hand))}}
 
    "Notoriety"
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
@@ -392,7 +392,7 @@
 
    "Special Order"
    {:prompt "Choose an Icebreaker"
-    :effect (effect (system-msg (str "adds " (:title target) " to his Grip and shuffles his Stack"))
+    :effect (effect (system-msg (str "adds " (:title target) " to their Grip and shuffles their Stack"))
                     (move target :hand) (shuffle! :deck))
     :choices (req (filter #(has? % :subtype "Icebreaker") (:deck runner)))}
 
@@ -458,7 +458,7 @@
     :effect (effect (trash target) (gain [:credit (quot (:cost target) 2)])
                     (resolve-ability {:prompt "Choose a Hardware to add to Grip from Stack"
                                       :choices (req (filter #(= (:type %) "Hardware") (:deck runner)))
-                                      :msg (msg "adds " (:title target) " to his Grip")
+                                      :msg (msg "adds " (:title target) " to their Grip")
                                       :effect (effect (move target :hand))} card nil))}
 
    "Traffic Jam"
@@ -470,7 +470,7 @@
 
    "Uninstall"
    {:choices {:req #(and (:installed %) (#{"Program" "Hardware"} (:type %)))}
-    :msg (msg "move " (:title target) " to his or her grip")
+    :msg (msg "move " (:title target) " to their Grip")
     :effect (effect (move target :hand))}
 
    "Vamp"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -268,7 +268,7 @@
    {:events {:runner-install
              {:optional {:req (req (= (:type target) "Hardware"))
                          :prompt "Use Replicator to add a copy?"
-                         :msg (msg "add a copy of " (:title target) " to his Grip")
+                         :msg (msg "add a copy of " (:title target) " to their Grip")
                          :effect (effect (move (some #(when (= (:title %) (:title target)) %)
                                                      (:deck runner)) :hand)
                                          (shuffle! :deck))}}}}
@@ -316,5 +316,5 @@
                                   :msg "draw 1 card" :effect (effect (draw 1))}}}
 
    "Window"
-   {:abilities [{:cost [:click 1] :msg "draw 1 card from the bottom of his Stack"
+   {:abilities [{:cost [:click 1] :msg "draw 1 card from the bottom of their Stack"
                  :effect (effect (move (last (:deck runner)) :hand))}]}})

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -93,7 +93,7 @@
 
    "Djinn"
    {:abilities [{:label "Add a virus program to your Grip from your Stack"
-                 :prompt "Choose a Virus" :msg (msg "adds " (:title target) " to his Grip")
+                 :prompt "Choose a Virus" :msg (msg "adds " (:title target) " to their Grip")
                  :choices (req (filter #(and (= (:type %) "Program")
                                              (has? % :subtype "Virus"))
                                        (:deck runner)))
@@ -386,6 +386,6 @@
    {:events {:runner-turn-begins {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:label "Remove Trope from the game to reshuffle cards from Heap back into Stack"
                  :cost [:click 1] :msg (msg "reshuffle " (:counter card) " card" (when (> (:counter card) 1) "s")
-                                            " in the Heap back into his Stack")
+                                            " in the Heap back into their Stack")
                  :effect (effect (move card :rfg))}]}
 })

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -219,7 +219,7 @@
                  :msg (msg "host " (:title target))
                  :effect (effect (runner-install target {:host-card card :no-cost true}))}
                 {:label "Add a program hosted on London Library to your Grip" :cost [:click 1]
-                 :choices {:req #(:host %)} :msg (msg "add " (:title target) "to his or her Grip")
+                 :choices {:req #(:host %)} :msg (msg "add " (:title target) "to their Grip")
                  :effect (effect (move target :hand))}]
     :events {:runner-turn-ends {:effect (req (doseq [c (:hosted card)]
                                                (trash state side c)))}}}
@@ -227,7 +227,7 @@
    "Motivation"
    {:events
     {:runner-turn-begins
-     {:msg "look at the top card of his Stack"
+     {:msg "look at the top card of their Stack"
       :effect (effect (prompt! card (str "The top card of your Stack is "
                                          (:title (first (:deck runner)))) ["OK"] {}))}}}
    "Mr. Li"
@@ -501,7 +501,7 @@
     :leave-play (effect (damage :meat 3 {:unboostable true :card card}))}
 
    "Tyson Observatory"
-   {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "adds " (:title target) " to his Grip")
+   {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "adds " (:title target) " to their Grip")
                  :choices (req (filter #(has? % :type "Hardware") (:deck runner)))
                  :cost [:click 2] :effect (effect (move target :hand) (shuffle! :deck))}]}
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -620,7 +620,7 @@
 
 (defn keep-hand [state side args]
   (swap! state assoc-in [side :keep] true)
-  (system-msg state side "keeps his or her hand")
+  (system-msg state side "keeps their hand")
   (trigger-event state side :pre-first-turn))
 
 (defn gain-agenda-point [state side n]
@@ -1084,7 +1084,7 @@
         (resolve-ability state side ab card targets))))
 
 (defn start-turn [state side args]
-  (system-msg state side (str "started his or her turn"))
+  (system-msg state side (str "started their turn"))
   (swap! state assoc :active-player side :per-turn nil :end-turn false)
   (swap! state assoc-in [side :register] nil)
   (swap! state assoc-in [side :click] (get-in @state [side :click-per-turn]))
@@ -1094,7 +1094,7 @@
 (defn end-turn [state side args]
   (let [max-hand-size (get-in @state [side :max-hand-size])]
     (when (<= (count (get-in @state [side :hand])) max-hand-size)
-      (system-msg state side (str "is ending his or her turn"))
+      (system-msg state side (str "is ending their turn"))
       (if (= side :runner)
         (do (when (< (get-in @state [:runner :max-hand-size]) 0)
               (flatline state))
@@ -1376,8 +1376,8 @@
 (defn shuffle-deck [state side {:keys [close] :as args}]
   (swap! state update-in [side :deck] shuffle)
   (if close
-    (system-msg state side "stops looking at his deck and shuffles it")
-    (system-msg state side "shuffles his deck")))
+    (system-msg state side "stops looking at their deck and shuffles it")
+    (system-msg state side "shuffles their deck")))
 
 (defn auto-pump [state side args]
   (let [run (:run @state) card (get-card state (:card args))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -350,13 +350,13 @@
 (defn show-deck [event owner ref]
   (-> (om/get-node owner (str ref "-content")) js/$ .fadeIn)
   (-> (om/get-node owner (str ref "-menu")) js/$ .fadeOut)
-  (send-command "system-msg" {:msg "looks at his deck"}))
+  (send-command "system-msg" {:msg "looks at their deck"}))
 
 (defn close-popup [event owner ref shuffle?]
   (-> (om/get-node owner ref) js/$ .fadeOut)
   (if shuffle?
     (send-command "shuffle" {:close "true"})
-    (send-command "system-msg" {:msg "stops looking at his deck"}))
+    (send-command "system-msg" {:msg "stops looking at their deck"}))
   (.stopPropagation event))
 
 (defmulti deck-view #(get-in % [:identity :side]))


### PR DESCRIPTION
I aimed to change all instances of "his" with "his or her" like the program tends to have, but went one step further and changed both "his" and "his or her" to "their". Hopefully this makes the platform more
friendly to use for people who aren't male!

Note that this is for all instances of "his" or "his or her" unless my grep-fu has failed me.