### PR TITLE
add :previous-zone when hosting cards...

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1167,7 +1167,8 @@
    (swap! state update-in (cons side (vec zone)) (fn [coll] (remove-once #(not= (:cid %) cid) coll)))
    (let [c (assoc target :host (update-in card [:zone] #(map to-keyword %))
                          :facedown facedown
-                         :zone '(:onhost))] ;; hosted cards should not be in :discard or :hand etc
+                         :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
+                         :previous-zone (:zone target))]
      (update! state side (update-in card [:hosted] #(conj % c)))
      (when-let [events (:events (card-def target))]
        (when installed


### PR DESCRIPTION
...so it behaves like the move function.

This enables Autoscripter to work correctly when the card is not directly
installed but due to a host'n'install ability like Scheherazade.