### PR TITLE
re-enable Geist

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -14,7 +14,7 @@
                              (do (damage state :runner :meat 2 {:unboostable true :card card})
                                  (system-msg state side "suffers 2 meat damage"))))}}}
 
-   "Armand \"Geist\" Walker"
+   "Armand \"Geist\" Walker: Tech Lord"
    {:effect (effect (gain :link 1))
     :events {:trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
                                 :prompt "Draw a card?" :msg (msg "draw a card") :effect (effect (draw 1))}}}}


### PR DESCRIPTION
Armand "Geist" Walker has stopped working altogether--then I suddenly noticed that his subtitle is missing, so the card definition isn't matching the correct card title as pulled from NetrunnerDB! 