### PR TITLE
Blue Sun accounts for modifications to rez cost

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -42,9 +42,8 @@
 
    "Braintrust"
    {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)))
-    :events {:pre-rez
-             {:req (req (= (:type target) "ICE"))
-              :effect (effect (rez-cost-bonus (- (:counter (get-card state card)))))}}}
+    :events {:pre-rez-cost {:req (req (= (:type target) "ICE"))
+                            :effect (effect (rez-cost-bonus (- (:counter (get-card state card)))))}}}
 
    "Breaking News"
    {:effect (effect (gain :runner :tag 2)) :msg "give the Runner 2 tags"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -20,9 +20,13 @@
                                 :prompt "Draw a card?" :msg (msg "draw a card") :effect (effect (draw 1))}}}}
 
    "Blue Sun: Powering the Future"
-   {:abilities [{:msg (msg "add " (:title target) " to HQ and gain " (:cost target) " [Credits]")
-                 :choices {:req #(:rezzed %)}
-                 :effect (effect (gain :credit (:cost target)) (move target :hand))}]}
+   {:abilities [{:choices {:req #(:rezzed %)}
+                 :effect (req (trigger-event state side :pre-rez-cost target)
+                              (let [cost (rez-cost state side target)]
+                                (gain state side :credit cost)
+                                (move state side target :hand)
+                                (system-msg state side (str "add " (:title target) " to HQ and gain " cost " [Credits]"))
+                                (swap! state update-in [:bonus] dissoc :cost)))}]}
 
    "Cerebral Imaging: Infinite Frontiers"
    {:effect (req (add-watch state :cerebral-imaging

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -335,8 +335,8 @@
                                       (not (some (fn [c] (has? c :subtype "Caïssa")) (:hosted %))))}
                  :msg (msg "host it on " (if (:rezzed target) (:title target) "a piece of ICE"))
                  :effect (effect (host target card))}]
-    :events {:pre-rez {:req (req (= (:zone (:host card)) (:zone target)))
-                       :effect (effect (rez-cost-bonus 2))}}}
+    :events {:pre-rez-cost {:req (req (= (:zone (:host card)) (:zone target)))
+                            :effect (effect (rez-cost-bonus 2))}}}
 
    "Sahasrara"
    {:recurring 2}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -534,8 +534,8 @@
                                   :effect (effect (lose :click 1) (draw 2))}}}
 
    "Xanadu"
-   {:events {:pre-rez {:req (req (= (:type target) "ICE"))
-                       :effect (effect (rez-cost-bonus 1))}}}
+   {:events {:pre-rez-cost {:req (req (= (:type target) "ICE"))
+                            :effect (effect (rez-cost-bonus 1))}}}
 
    "Zona Sul Shipping"
    {:events {:runner-turn-begins {:effect (effect (add-prop card :counter 1))}}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -3,9 +3,9 @@
 (def cards-upgrades
   {
    "Akitaro Watanabe"
-   {:events {:pre-rez {:req (req (and (= (:type target) "ICE")
-                                      (= (card->server state card) (card->server state target))))
-                       :effect (effect (rez-cost-bonus -2))}}}
+   {:events {:pre-rez-cost {:req (req (and (= (:type target) "ICE")
+                                           (= (card->server state card) (card->server state target))))
+                            :effect (effect (rez-cost-bonus -2))}}}
 
    "Amazon Industrial Zone"
    {:events 
@@ -32,8 +32,8 @@
                                       :effect (effect (gain :runner :tag 1))}}}}
 
    "Breaker Bay Grid"
-   {:events {:pre-rez {:req (req (= (:zone card) (:zone target)))
-                       :effect (effect (rez-cost-bonus -5))}}}
+   {:events {:pre-rez-cost {:req (req (= (:zone card) (:zone target)))
+                            :effect (effect (rez-cost-bonus -5))}}}
 
    "Caprice Nisei"
    {:abilities [{:msg "start a Psi game"


### PR DESCRIPTION
This turned out to be harder than anticipated because of the red queen Reina Roja. Reina's ability notably does NOT grant Blue Sun an extra credit, whereas every other source of rez cost modification does. This is justified on ANCUR by Lukas due to Reina's ability only being active while the rez action is taking place, while the others are constant effects. 

So we separate `:pre-rez` into a second event, `:pre-rez-cost`, which we can trigger to only alert cards that have constant effects on rez cost. Reina remains as the only card handling `:pre-rez` for the moment, as she should only be affecting rez cost as the card is being rezzed.

Fixes #517.