### PR TITLE
Implemented Wasteland

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -205,8 +205,8 @@
                  :cost [:click 1] :advance-counter-cost 1 :effect (effect (gain :click 2))}]}
 
    "Hostile Infrastructure"
-   {:events {:trash {:req (req (and (= (:side target) "Corp") (= side :runner)))
-                     :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}
+   {:events {:runner-trash {:req (req (= (:side target) "Corp"))
+                            :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}
     :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
 
    "Isabel McGuire"
@@ -334,8 +334,8 @@
                                                               (gain state side :credit 5)))}
                                               card targets)))}}}
    "Ronald Five"
-   {:events {:trash {:req (req (and (= (:side target) "Corp") (= side :runner) (> (:click runner) 0)))
-                     :msg "force the runner to lose 1 [Click]" :effect (effect (lose :runner :click 1))}}}
+   {:events {:runner-trash {:req (req (and (= (:side target) "Corp") (> (:click runner) 0)))
+                            :msg "force the runner to lose 1 [Click]" :effect (effect (lose :runner :click 1))}}}
 
    "Ronin"
    {:advanceable :always

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -246,8 +246,9 @@
 
    "Q-Coherence Chip"
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
-    :events {:trash {:msg "trash itself" :req (req (= (last (:zone target)) :program))
-                     :effect (effect (trash card))}}}
+    :events (let [e {:msg "trash itself" :req (req (= (last (:zone target)) :program))
+                     :effect (effect (trash card))}] 
+              {:runner-trash e :corp-trash e})}
 
    "R&D Interface"
    {:effect (effect (gain :rd-access 1)) :leave-play (effect (lose :rd-access 1))}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -16,8 +16,8 @@
 
    "Armand \"Geist\" Walker"
    {:effect (effect (gain :link 1))
-    :events {:trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
-                                :prompt "Draw a card?" :msg (msg "draw a card") :effect (effect (draw 1))}}}}
+    :events {:runner-trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
+                                       :prompt "Draw a card?" :msg (msg "draw a card") :effect (effect (draw 1))}}}}
 
    "Blue Sun: Powering the Future"
    {:abilities [{:msg (msg "add " (:title target) " to HQ and gain " (:cost target) " [Credits]")

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -132,8 +132,9 @@
    {:abilities [{:msg "break all but 1 subroutine" :effect (effect (trash card {:cause :ability-cost}))}]}
 
    "Gravedigger"
-   {:events {:trash {:req (req (and (= (first (:zone target)) :servers) (= (:side target) "Corp")))
-                     :effect (effect (add-prop :runner card :counter 1))}}
+   {:events (let [e {:req (req (and (= (first (:zone target)) :servers) (= (:side target) "Corp")))
+                               :effect (effect (add-prop :runner card :counter 1))}]
+              {:runner-trash e :corp-trash e})
     :abilities [{:counter-cost 1 :cost [:click 1] :msg "force the Corp to trash the top card of R&D"
                  :effect (effect (mill :corp))}]}
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -521,6 +521,11 @@
                  :choices {:req #(and (has? % :subtype "Virus") (>= (:counter %) 1))}
                  :effect (effect (add-prop target :counter 1))}]}
 
+   "Wasteland"
+   {:events {:runner-trash {:req (req (and (first-event state :runner :runner-trash) (:installed target)))
+                     :effect (effect (gain :credit 1))
+                     :msg "to gain 1[Credit]"}}}
+                 
    "Woman in the Red Dress"
    {:events {:runner-turn-begins
              {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -654,7 +654,7 @@
         (when (and (not unpreventable) (not= cause :ability-cost))
           (swap! state update-in [:trash :trash-prevent] dissoc ktype))
         (when (not= (last zone) :current)
-          (apply trigger-event state side :trash card cause targets))
+          (apply trigger-event state side (keyword (str (name side) "-trash")) card cause targets))
         (let [prevent (get-in @state [:prevent :trash ktype])]
           (if (and (not unpreventable) (not= cause :ability-cost) (> (count prevent) 0))
             (do


### PR DESCRIPTION
Splitted the `:trash` event up into `:runner-trash` and `:corp-trash`, so it's
like `:runner-install` and `:corp-install`.

Some cards are now simpler, like *Geist* and *Hostile Infrastructure*, since they can listen for the new `:runner-trash` event.

Other cards have now to listen for both events (e.g. *Gravedigger*), but that's just an additional `let` binding.