### PR TITLE
Fix for Imp in multi-card servers

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -204,13 +204,13 @@
 
 (defn show-prompt
   ([state side card msg choices f] (show-prompt state side card msg choices f nil))
-  ([state side card msg choices f priority]
+  ([state side card msg choices f {:keys [priority prompt-type] :as args}]
    (let [prompt (if (string? msg) msg (msg state side card nil))]
      (when (or (:number choices) (#{:credit :counter} choices) (> (count choices) 0))
        (swap! state update-in [side :prompt]
               (if priority
-                #(cons {:msg prompt :choices choices :effect f :card card} (vec %))
-                #(conj (vec %) {:msg prompt :choices choices :effect f :card card})))))))
+                #(cons {:msg prompt :choices choices :effect f :card card :prompt-type prompt-type} (vec %))
+                #(conj (vec %) {:msg prompt :choices choices :effect f :card card :prompt-type prompt-type})))))))
 
 (defn resolve-psi [state side card psi bet]
   (swap! state assoc-in [:psi side] bet)
@@ -233,8 +233,8 @@
 
 (defn prompt!
   ([state side card msg choices ability] (prompt! state side card msg choices ability nil))
-  ([state side card msg choices ability priority]
-    (show-prompt state side card msg choices #(resolve-ability state side ability card [%]) priority)))
+  ([state side card msg choices ability {:keys [priority prompt-type] :as args}]
+    (show-prompt state side card msg choices #(resolve-ability state side ability card [%]) args)))
 
 (defn optional-ability [state side card msg ability targets]
   (show-prompt state side card msg ["Yes" "No"] #(if (= % "Yes")
@@ -276,7 +276,7 @@
 
 (defn show-select
   ([state side card ability] (show-select state side card ability nil))
-  ([state side card ability priority]
+  ([state side card ability {:keys [priority] :as args}]
    (let [ability (update-in ability [:choices :max] #(if (fn? %) (% state side card nil) %))]
      (swap! state update-in [side :selected]
             #(conj (vec %) {:ability (dissoc ability :choices) :req (get-in ability [:choices :req])
@@ -287,7 +287,8 @@
                     (if-let [m (get-in ability [:choices :max])]
                       (str "Select up to " m " targets for " (:title card))
                       (str "Select a target for " (:title card))))
-                  ["Done"] (fn [choice] (resolve-select state side)) priority))))
+                  ["Done"] (fn [choice] (resolve-select state side))
+                  (assoc args :prompt-type :select)))))
 
 (defn resolve-ability [state side {:keys [counter-cost advance-counter-cost cost effect msg req once
                                           once-key optional prompt choices end-turn player psi trace
@@ -308,7 +309,7 @@
       (if choices
         (if (map? choices)
           (if (:req choices)
-            (show-select state (or player side) card ability priority)
+            (show-select state (or player side) card ability {:priority priority})
             (let [n ((:number choices) state side card targets)]
               (prompt! state (or player side) card prompt {:number n} (dissoc ability :choices))))
           (let [cs (if-not (fn? choices)
@@ -316,7 +317,7 @@
                      (let [cards (choices state side card targets)]
                              (if not-distinct
                                cards (distinct-by :title cards))))]
-            (prompt! state (or player side) card prompt cs (dissoc ability :choices) priority)))
+            (prompt! state (or player side) card prompt cs (dissoc ability :choices) {:priority priority})))
         (when (and (or (not counter-cost) (<= counter-cost (or counter 0)))
                    (or (not advance-counter-cost) (<= advance-counter-cost (or advance-counter 0)))
                    (apply pay (concat [state side card] cost)))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -102,7 +102,7 @@
 (defn handle-card-click [{:keys [type zone counter advance-counter advancementcost advanceable
                                  root] :as card} owner]
   (let [side (:side @game-state)]
-    (if-not (empty? (get-in @game-state [side :selected]))
+    (if (= (get-in @game-state [side :prompt 0 :prompt-type]) "select")
       (send-command "select" {:card card})
       (if (and (= (:type card) "Identity") (= side (keyword (.toLowerCase (:side card)))))
         (handle-abilities card owner)


### PR DESCRIPTION
Another interesting issue.

The UI will ignore card clicks (for the purpose of activating an ability) if there is a Selection prompt active, because the user is supposed to be clicking cards to resolve some ability on. However the UI wasn't doing a bright job of this -- it was looking to see if there were ANY Selection prompts queued up, not if the currently active prompt was a Selection. This has never been an issue until the multi-access revamp, which puts Selection prompts in the prompt queue behind the Handle Access prompt when accessing from a multi-card server. The UI was therefore trying to Select Imp as the target card to access in the server, even though the "select a card to access" prompt wasn't the active prompt.

The fix involves communicating to the UI what a prompt's "type" is. Only Selection prompts use this for now. The UI then will then only ignore card clicks if the active prompt is a "select" prompt, otherwise it will let the click go through.

Fixes #533.