### PR TITLE
Implement Casting Call

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -7,7 +7,7 @@
                            (str "install " c " ICE and trash " (- 3 c) " cards")))
                :effect (req (doseq [c (take 3 (:deck corp))]
                               (if (= (:type c) "ICE")
-                                (corp-install state side c nil {:no-install-cost true :rezzed true})
+                                (corp-install state side c nil {:no-install-cost true :install-state :rezzed})
                                 (trash state side c))))}}
 
    "Ancestral Imager"
@@ -200,7 +200,7 @@
                       {:prompt "Choose a card to install" :msg (msg "install and rez " (:title target))
                        :choices (req (filter #(#{"Asset" "Upgrade"} (:type %))
                                              ((if (= target "HQ") :hand :discard) corp)))
-                       :effect (effect (corp-install target nil {:rezzed true}))} card targets))}
+                       :effect (effect (corp-install target nil {:install-state :rezzed}))} card targets))}
 
    "Mandatory Upgrades"
    {:effect (effect (gain :click 1 :click-per-turn 1))}
@@ -208,13 +208,11 @@
    "Market Research"
    {:req (req tagged) :effect (effect (set-prop card :counter 1 :agendapoints 3))}
 
-
    "Medical Breakthrough"
    {:effect (effect (update-all-advancement-costs))
     :stolen (effect (update-all-advancement-costs))
     :advancement-cost-bonus (req (- (count (filter #(= (:title %) "Medical Breakthrough")
                                                    (concat (:scored corp) (:scored runner))))))}
-
 
    "NAPD Contract"
    {:steal-cost-bonus (req [:credit 4])

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -40,6 +40,26 @@
    "Blue Level Clearance"
    {:effect (effect (gain :credit 5) (draw 2))}
 
+   "Casting Call"
+   {:choices {:req #(and (:type % "Agenda") (= (:zone %) [:hand]))}
+    :effect (req (let [agenda target]
+                   (resolve-ability
+                     state side {:prompt (str "Choose a server to install " (:title agenda))
+                                 :choices (server-list state agenda)
+                                 :effect (req (corp-install state side agenda target {:install-state :face-up})
+                                              ; find where the agenda ended up and host on it
+                                              (let [agenda (some #(when (= (:cid %) (:cid agenda)) %)
+                                                                 (all-installed state :corp))]
+                                                ; the operation ends up in :discard when it is played; to host it,
+                                                ; we need (host) to look for it in discard.
+                                                (host state side agenda (assoc card :zone [:discard]
+                                                                                    :seen true :installed true))
+                                                (system-msg state side
+                                                            (str "hosts Casting Call on " (:title agenda)))))}
+                     card nil)))
+    :events {:access {:req (req (= (:cid target) (:cid (:host card))))
+                      :effect (effect (gain :runner :tag 2)) :msg "give the Runner 2 tags"}}}
+
    "Celebrity Gift"
    {:choices {:max 5 :req #(and (:side % "Corp") (= (:zone %) [:hand]))}
     :msg (msg "reveal " (join ", " (map :title targets)) " and gain " (* 2 (count targets)) " [Credits]")


### PR DESCRIPTION
Implements Casting Call from Old Hollywood.

Had to do some surgery on the core routines for this to work.

1. `corp-install`: instead of a parameter `:rezzed`, take the more general `:install-state` which can be either `:rezzed` or `:face-up`. Migrated License Acquisition and Accelerated Beta Test to this system.
2. `card-init`: take a parameter `resolve`, which is true by default, and only resolves the card's ability if `resolve` is true. This allows us to not resolve cards that are being installed `:face-up`, yet still take advantage of the rest of `card-init` (which is useful otherwise). Without this, using Casting Call on an agenda with a "when scored" ability would trigger that ability on install. Super OP.
3. `move`: when a server is collapsed, all the cards in subsequent servers have their zones updated with their new server numbers. This was not applying to cards HOSTED in those servers. Likewise, hosted cards were not having their events re-registered (necessary because the zones have now changed). This has been fixed.
4. I moved the trigger for the `:access` event to before the access happens rather than after... otherwise accessing the agenda hosting Casting Call will cause a steal, trashing Casting Call, preventing it from handling events.

I have tested this with a variety of agendas, also in Haarpsichord and Argus.