### PR TITLE
Fixed path change on netrunnerdb for image files.

### DIFF
--- a/data/fetch.coffee
+++ b/data/fetch.coffee
@@ -61,7 +61,7 @@ fetchSets = (callback) ->
 fetchImg = (code, imgPath, t) ->
   setTimeout ->
     console.log code
-    url = "http://netrunnerdb.com/web/bundles/netrunnerdbcards/images/cards/en/#{code}.png"
+    url = "http://netrunnerdb.com/bundles/netrunnerdbcards/images/cards/en/#{code}.png"
     request(url).pipe(fs.createWriteStream(imgPath))
   , t
 


### PR DESCRIPTION
NetrunnerDB seems to have changed the path where it stores its images. Changed fetch.coffee to reflect that so actual images are being properly retrieved again.