### PR TITLE
Implement Nasir; fix obscure hosting issue

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -161,7 +161,17 @@
                                   :effect (effect (mill 2) (draw))}}}
 
    "Nasir Meidan: Cyber Explorer"
-   {:effect (effect (gain :link 1))}
+   {:effect (effect (gain :link 1))
+    :abilities [{:req (req (and (:run @state)
+                                (:rezzed (get-card state current-ice))))
+                 :effect (req (let [current-ice (get-card state current-ice)]
+                           (trigger-event state side :pre-rez-cost current-ice)
+                           (let [cost (rez-cost state side current-ice)]
+                             (lose state side :credit (:credit runner))
+                             (gain state side :credit cost)
+                             (system-msg state side (str "loses all credits and gains " cost
+                                                         " [Credits] from the rez of " (:title current-ice)))
+                             (swap! state update-in [:bonus] dissoc :cost))))}]}
 
    "NBN: Making News"
    {:recurring 2}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1234,6 +1234,10 @@
        (let [cdef (card-def card) cost (rez-cost state side card)]
          (when (or no-cost (pay state side card :credit cost (:additional-cost cdef)))
            (card-init state side (assoc card :rezzed true))
+           (doseq [h (:hosted card)]
+             (update! state side (-> h
+                                     (update-in [:zone] #(map to-keyword %))
+                                     (update-in [:host :zone] #(map to-keyword %)))))
            (system-msg state side (str "rez " (:title card) (when no-cost " at no cost")))
            (when (#{"ICE"} (:type card)) (update-ice-strength state side card))
            (trigger-event state side :rez card))))


### PR DESCRIPTION
This is @JoelCFC25's code for Nasir. While helping him debug its interaction with Rook I came across an obscure issue with the hosting code. That fix is bundled with this submission.

This is a partial implementation of Nasir: click the ID when in a run and the corp has just rezzed an ice to lose all your credits and gain back credits for the modified rez cost of the ice. There are too many edge cases to make this completely automated, and I agree with Joel that this is the best implementation for our system.

The hosting issue is thus: when rezzing a card, the zones of any hosted cards were retaining the ClojureScript version of the `:zone` field, which uses strings instead of keywords. Thus the `:zone` of the `:host` of a card (say, Rook) is a vector of strings, whereas the `:zone` of the host card itself is a seq of keywords. Complicated, but fixed with the same code we apply to fix the `:zone` of the host card itself.