### PR TITLE
Implement Film Critic

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -62,7 +62,7 @@
    {:effect (effect (gain :credit 5 :bad-publicity 1))}
 
    "Haarpsichord Studios"
-   {:events {:pre-steal-cost {:req (req (pos? (or (:stole-agenda runner-reg) 0)))
+   {:events {:pre-steal-cost {:req (req (:stole-agenda runner-reg))
                               :effect (effect (prevent-steal))}}}
 
    "Haas-Bioroid: Engineering the Future"


### PR DESCRIPTION
Implements Film Critic by a slight tweak to the "steal agenda" flow of logic. Also a fix for Haarpsichord interaction with Domestic Sleepers.

It adds an extra click, but the best benefit/effort ratio solution I can think of for Film Critic is to expand the Access Agenda UI to _always_ show a prompt to the user. Upon accessing an agenda, we show one of three different prompts:

0. If the agenda cannot be stolen (currently only for Haarpsichord), show the existing "You accessed but cannot steal ____" prompt.
1. If the agenda has a steal cost (via Red Herrings, Fetal AI, NAPD, etc.), show the existing "Pay ___ to steal?" prompt.
2. Otherwise the agenda has no steal cost; show a simple "You accessed ___" prompt with a single "Steal" button. (Previously, this class of agenda would be automatically stolen.)

By always showing a prompt, we delay the completion of the Access/Steal logic because it is now tied to the user's response. This allows the user to interact with the accessed agenda with other cards, namely hosting on Film Critic or trashing with Imp. The rest is easy.

There is a slight complication to this solution: because Film Critic's interaction needs to prevent the firing of `:access` events _after they've already happened_, I delayed the triggering of these events until after the "Steal" button is pressed. This is a technical violation of the game rules: "when you access" events are supposed to be resolved before deciding to steal, which for example allows you to decide whether to pay 2cr to steal Fetal AI after seeing which cards are lost to the net damage. I decided to sacrifice this extreme border case in order to make the entire system much easier to code and manage. It also allows Imp and Film Critic to share the same opportunity window for use.

Speaking of Imp, this solution now lets you Imp any agenda you access, as intended. Due to the change in event timings, I had to update `trash-no-cost` to trigger agenda `:access` events when Imping an agenda. 

I also fixed Haarpsichord/Domestic Sleepers interaction. Haarps now prevents stealing when the `:agenda-stolen` value is non-nil, instead of when it is positive.