### PR TITLE
Checkpoint fix; update older card routines

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -70,7 +70,7 @@
 
    "Cell Portal"
    {:abilities [{:msg "make the Runner approach the outermost ICE"
-                 :effect #(do (swap! %1 assoc-in [:run :position] 0) (derez %1 %2 %3))}]}
+                 :effect (req (swap! state assoc-in [:run :position] 0) (derez state side card))}]}
 
    "Changeling"
    {:advanceable :always :abilities [end-the-run]}
@@ -79,10 +79,10 @@
    {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
     :abilities [{:label "Trace 5 - Do 3 meat damage when this run is successful"
                  :trace {:base 5
-                         :effect #(do (swap! %1 assoc-in [:run :run-effect :end-run]
+                         :effect (req (swap! state assoc-in [:run :run-effect :end-run]
                                              {:req (req (:successful run)) :msg "do 3 meat damage"
                                               :effect (effect (damage :meat 3 {:card card}))})
-                                      (swap! %1 assoc-in [:run :run-effect :card] %3))}}]}
+                                      (swap! state assoc-in [:run :run-effect :card] card))}}]}
 
    "Chimera"
    {:prompt "Choose one subtype" :choices ["Barrier" "Code Gate" "Sentry"]

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -143,10 +143,10 @@
 
    "Grifter"
    {:events {:runner-turn-ends
-             {:effect #(let [ab (if (get-in @%1 [:runner :register :successful-run])
-                                  {:effect (effect (gain :credit 1)) :msg "gain 1 [Credits]"}
-                                  {:effect (effect (trash %3)) :msg "trash Grifter"})]
-                        (resolve-ability %1 %2 ab %3 %4))}}}
+             {:effect (req (let [ab (if (get-in @state [:runner :register :successful-run])
+                                      {:effect (effect (gain :credit 1)) :msg "gain 1 [Credits]"}
+                                      {:effect (effect (trash card)) :msg "trash Grifter"})]
+                             (resolve-ability state side ab card targets)))}}}
 
    "Hades Shard"
    {:abilities [{:msg "access all cards in Archives"
@@ -277,13 +277,13 @@
    "Oracle May"
    {:abilities [{:cost [:click 1] :once :per-turn :prompt "Choose card type"
                  :choices ["Event" "Hardware" "Program" "Resource"]
-                 :effect #(let [c (first (get-in @%1 [:runner :deck]))]
-                           (system-msg %1 %2 (str "uses Oracle May, names " (first %4)
-                                                  " and reveals " (:title c)))
-                           (if (= (:type c) (first %4))
-                             (do (system-msg %1 %2 (str "gains 2 [Credits] and draws " (:title c)))
-                                 (gain %1 %2 :credit 2) (draw %1 %2))
-                             (do (system-msg %1 %2 (str "trashes " (:title c))) (mill %1 %2))))}]}
+                 :effect (req (let [c (first (get-in @state [:runner :deck]))]
+                                (system-msg state side (str "uses Oracle May, names " target
+                                                            " and reveals " (:title c)))
+                                (if (= (:type c) target)
+                                  (do (system-msg state side (str "gains 2 [Credits] and draws " (:title c)))
+                                      (gain state side :credit 2) (draw state side))
+                                  (do (system-msg state side (str "trashes " (:title c))) (mill state side)))))}]}
 
    "Order of Sol"
    {:effect (req (add-watch state :order-of-sol


### PR DESCRIPTION
Checkpoint was using an older style of code for its trace effect, via an anonymous function instead of `req` or `effect` macros. Simple fix. I also fixed three other cards with the same code style: Cell Portal, Oracle May, and Grifter.

Fixes #373.