### PR TITLE
Network improvements, fix for Personal Workshop and Off-Campus Apartment

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -578,7 +578,9 @@
 
 (defn create-deck [deck]
   (shuffle (mapcat #(map (fn [card]
-                           (let [c (assoc card :cid (make-cid))]
+                           (let [c (assoc card :cid (make-cid))
+                                 c (dissoc c :setname :text :_id :influence :number :uniqueness :influencelimit
+                                           :faction :factioncost)]
                              (if-let [init (:init (card-def c))] (merge c init) c)))
                          (repeat (:qty %) (:card %)))
                    (:cards deck))))
@@ -1180,7 +1182,9 @@
        (swap! state update-in (cons s (vec zone))
               (fn [coll] (remove-once #(not= (:cid %) cid) coll)))))
    (swap! state update-in (cons side (vec zone)) (fn [coll] (remove-once #(not= (:cid %) cid) coll)))
-   (let [c (assoc target :host (update-in card [:zone] #(map to-keyword %))
+   (let [c (assoc target :host (-> card
+                                   (update-in [:zone] #(map to-keyword %))
+                                   (dissoc :hosted))
                          :facedown facedown
                          :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
                          :previous-zone (:zone target))]

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -63,7 +63,7 @@
                            (swap! state update-in [:log] #(conj % {:user "__system__" :text text})))
           "quit" (system-msg state (keyword side) "left the game"))
         (if-let [state (@game-states gameid)]
-          (.send socket (generate-string (assoc (dissoc @state :events) :action action)))
+          (.send socket (generate-string (assoc (dissoc @state :events :turn-events) :action action)))
           (.send socket (generate-string "ok")))
         (catch Exception e
           (println "Error " action command (get-in args [:card :title]) e "\nStack trace:"


### PR DESCRIPTION
As discussed on Slack. Fixes #354.

Remove unnecessary card data from game state: `:setname :text :_id :influence :number :uniqueness :influencelimit :faction :factioncost`.

Remove the `:hosted` array when associating a card like Personal Workshop as the `:host` of another card that it is hosting. Dramatic reduction in state size when many cards are hosted.

I'd estimate a 30-40% reduction in state size for most games, and significantly greater reduction for decks running PW/Off-Campus Apartment.