### PR TITLE
Implement Apex

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -158,6 +158,18 @@
    {:effect (effect (gain :memory 2)) :leave-play (effect (lose :memory 2))
     :events {:runner-install {:req (req (has? target :subtype "Virus"))
                               :effect (effect (add-prop target :counter 1))}}}
+
+   "Heartbeat"
+   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
+    :prevent {:damage [:meat :net :brain]}
+    :abilities [{:msg "prevent 1 damage"
+                 :choices {:req #(and (= (:side %) "Runner") (:installed %))}
+                 :priority true
+                 :effect (effect (trash target {:cause :ability-cost})
+                                 (damage-prevent :brain 1)
+                                 (damage-prevent :meat 1)
+                                 (damage-prevent :net 1))}]}
+
    "HQ Interface"
    {:effect (effect (gain :hq-access 1)) :leave-play (effect (lose :hq-access 1))}
 

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -4,6 +4,13 @@
   {"Andromeda: Dispossessed Ristie"
    {:effect (effect (gain :link 1) (draw 4)) :mulligan (effect (draw 4))}
 
+   "Apex: Invasive Predator"
+   {:events {:runner-turn-begins 
+              {:prompt "Select a card to install facedown"
+               :choices {:max 1 :req #(and (:side % "Runner") (= (:zone %) [:hand]))}
+               :req (req (> (count (:hand runner)) 0))
+               :effect (req (runner-install state side target {:facedown true}))}}}
+   
    "Argus Security: Protection Guaranteed"
    {:events {:agenda-stolen
              {:prompt "Take 1 tag or suffer 2 meat damage?"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -146,6 +146,11 @@
     :abilities [{:counter-cost 1 :cost [:click 1] :msg "force the Corp to trash the top card of R&D"
                  :effect (effect (mill :corp))}]}
 
+    "Harbinger"
+    {:trash-effect 
+      {:req (req (not (some #{:facedown} (:previous-zone card))))
+       :effect (effect (runner-install card {:facedown true}))}}
+
    "Hemorrhage"
    {:events {:successful-run {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:counter-cost 2 :cost [:click 1] :msg "force the Corp to trash 1 card from HQ"}]}
@@ -268,7 +273,7 @@
                  :effect (req (let [ice target]
                            (resolve-ability
                               state :runner
-                              {:prompt (msg "Choose a type") 
+                              {:prompt (msg "Choose a type")
                                :choices ["sentry" "code gate" "barrier"]
                                :msg (msg "give " (:title ice) " " target " until the end of next run this turn")}
                               card nil)))}]}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -161,7 +161,15 @@
                              :effect (effect (gain :runner :credit (:agendapoints target)))}
              :agenda-stolen {:msg (msg "gain " (:agendapoints target) " [Credits]")
                              :effect (effect (gain :credit (:agendapoints target)))}}}
-
+   "Hunting Grounds"
+   {:abilities [{:label "Prevent a \"when encountered\" ability on a piece of ice"
+                 :msg "prevent a \"when encountered\" ability on a piece of ice"
+                 :once :per-turn}
+                 {:label "Install the top 3 cards of your stack facedown" 
+                  :effect (req (trash state side card {:cause :ability-cost}) 
+                               (doseq [c (take 3 (:deck runner))]
+                                  (runner-install state side c {:facedown true})))}]}
+   
    "Ice Analyzer"
    {:events {:rez {:req (req (= (:type target) "ICE")) :msg "place 1 [Credits] on Ice Analyzer"
                    :effect (effect (add-prop :runner card :counter 1))}}

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -91,13 +91,14 @@
           (if (not rezzed) (cons "rez" %) (cons "derez" %))
           %))))
 
-(defn handle-abilities [{:keys [abilities] :as card} owner]
+(defn handle-abilities [{:keys [abilities facedown side] :as card} owner]
   (let [actions (action-list card)
         c (+ (count actions) (count abilities))]
-    (cond (> c 1) (-> (om/get-node owner "abilities") js/$ .toggle)
-          (= c 1) (if (= (count abilities) 1)
-                        (send-command "ability" {:card card :ability 0})
-                        (send-command (first actions) {:card card})))))
+    (when (not (and (= side "Runner") facedown))
+      (cond (> c 1) (-> (om/get-node owner "abilities") js/$ .toggle)
+            (= c 1) (if (= (count abilities) 1)
+                          (send-command "ability" {:card card :ability 0})
+                          (send-command (first actions) {:card card}))))))
 
 (defn handle-card-click [{:keys [type zone counter advance-counter advancementcost advanceable
                                  root] :as card} owner]
@@ -558,7 +559,7 @@
   (om/component
    (sab/html
     [:div.runner-board
-     (for [zone [:program :resource :hardware]]
+     (for [zone [:program :hardware :resource :facedown]]
        [:div (for [c (zone (:rig player))]
                [:div.card-wrapper {:class (when (playable? c) "playable")}
                 (om/build card-view c)])])])))


### PR DESCRIPTION
Added a new zone [:runner :rig :facedown] for facedown cards.
When adding a card to that zone, it will be deactivated.
Facedown runner cards can't use abilities.
Installing a runner card facedown never has any costs.
Installing a runner card facedown does ignores unique cards.

The 'You cannot install non-virtual resources.'-part is not enforced.