### PR TITLE
Add several Data & Destiny cards

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -188,6 +188,10 @@
     :abilities [{:counter-cost 1 :msg "do 1 net damage" :req (req (:run @state)) :once :per-run
                  :effect (effect (damage :net 1 {:card card}))}]}
 
+   "Improved Tracers"
+   {:events {:pre-ice-strength {:req (req (has? target :subtype "Tracer"))
+                                :effect (effect (ice-strength-bonus 1))}}}
+
    "Labyrinthine Servers"
    {:data {:counter 2}
     :abilities [{:counter-cost 1 :effect (effect (prevent-jack-out))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -352,6 +352,12 @@
                              (move state :corp (dissoc card :counter) :scored)
                              (gain state :corp :agenda-point 1)))} }}
 
+   "Reality Threedee"
+   {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
+    :events {:corp-turn-begins
+             {:effect (req (gain state side :credit (if '(tagged) 2 1)))
+              :msg (msg (if '(tagged) "gain 2 [Credits]" "gain 1 [Credits]"))}}}
+
    "Reversed Accounts"
    {:advanceable :always
     :abilities [{:cost [:click 1]

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -258,6 +258,12 @@
                                          (shuffle! state side :deck))}
                            card nil))}]}
 
+   "Launch Campaign"
+   {:effect (effect (add-prop card :counter 6))
+    :events {:corp-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
+                                :effect (req (gain state :corp :credit 2)
+                                             (when (zero? (:counter card)) (trash state :corp card)))}}}
+
    "Levy University"
    {:abilities [{:prompt "Choose an ICE" :msg (msg "adds " (:title target) " to HQ")
                  :choices (req (filter #(has? % :type "ICE") (:deck corp)))
@@ -398,6 +404,19 @@
              :corp-install {:req (req (has? target :type "ICE"))
                             :effect (effect (trash card)
                                             (system-msg "trashes Server Diagnostics"))}}}
+
+   "Shannon Claire"
+   {:abilities [{:cost [:click 1] :msg "draw 1 card from the bottom of R&D"
+                 :effect (effect (move (last (:deck corp)) :hand))}
+                {:label "[Trash]: Search R&D for an agenda" :prompt "Choose an agenda to add to the bottom of R&D"
+                 :msg (msg "reveal " (:title target) " from R&D and add it to the bottom of R&D")
+                 :choices (req (filter #(has? % :type "Agenda") (:deck corp)))
+                 :effect (effect (shuffle! :deck) (move target :deck)
+                                 (trash card {:cause :ability-cost}))}
+                {:label "[Trash]: Search Archives for an agenda" :prompt "Choose an agenda to add to the bottom of R&D"
+                 :msg (msg "reveal " (:title target) " from Archives and add it to the bottom of R&D")
+                 :choices (req (filter #(has? % :type "Agenda") (:discard corp)))
+                 :effect (effect (move target :deck) (trash card {:cause :ability-cost}))}]}
 
    "Shattered Remains"
    {:advanceable :always

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -502,12 +502,12 @@
    "Windfall"
    {:effect (req (shuffle! state :runner :deck)
                  (let [topcard (first (:deck runner))
-				               cost (:cost topcard)]
-				           (if (= (:type topcard) "Event")
-				             (do (trash state side topcard) 
-					               (system-msg state side (str "shuffles their Stack and trashes " 
+                       cost (:cost topcard)]
+                   (if (= (:type topcard) "Event")
+                     (do (trash state side topcard) 
+                         (system-msg state side (str "shuffles their Stack and trashes " 
                           (:title topcard) " to gain 0 [Credits]")))
                      (do (gain state side :credit cost)
-					               (trash state side topcard) 
-					               (system-msg state side (str "shuffles their Stack and trashes " 
+                         (trash state side topcard) 
+                         (system-msg state side (str "shuffles their Stack and trashes " 
                           (:title topcard) " to gain " cost " [Credits]"))))))}})

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -497,4 +497,17 @@
                         :choices (req (map str (range 1 (inc (:click runner)))))
                         :effect (req (let [n (Integer/parseInt target)]
                                        (when (pay state :runner card :click n)
-                                         (trash-cards state :corp (take n (shuffle (:hand corp)))))))}} card))}})
+                                         (trash-cards state :corp (take n (shuffle (:hand corp)))))))}} card))}
+                                       
+   "Windfall"
+   {:effect (req (shuffle! state :runner :deck)
+                 (let [topcard (first (:deck runner))
+				               cost (:cost topcard)]
+				           (if (= (:type topcard) "Event")
+				             (do (trash state side topcard) 
+					               (system-msg state side (str "shuffles their Stack and trashes " 
+                          (:title topcard) " to gain 0 [Credits]")))
+                     (do (gain state side :credit cost)
+					               (trash state side topcard) 
+					               (system-msg state side (str "shuffles their Stack and trashes " 
+                          (:title topcard) " to gain " cost " [Credits]"))))))}})

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -34,6 +34,12 @@
    "Ashigaru"
    {:abilities [end-the-run]}
 
+   "Assassin"
+   {:abilities [{:label "Trace 5 - Do 3 net damage"
+                 :trace {:base 5 :msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}}
+                {:label "Trace 4 - Trash a program"
+                 :trace (assoc trash-program :base 4)}]}
+
    "Asteroid Belt"
    {:advanceable :always :abilities [end-the-run]
     :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -5,7 +5,16 @@
 (def end-the-run {:msg "end the run" :effect (effect (end-run))})
 
 (def cards-ice
-  {"Archer"
+  {"Archangel"
+   {:access {:optional 
+             {:prompt "Pay 3 [Credits] to force Runner to encounter Archangel?" :cost [:credit 3]
+              :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}}
+    :abilities [{:label "Trace 6 - Add 1 installed card to the Runner's Grip"
+                 :trace {:base 6 :choices {:req #(:installed %)}
+                         :msg (msg "add " (:title target) " to the Runner's Grip")
+                         :effect (effect (move :runner target :hand true))}}]}
+   
+   "Archer"
    {:additional-cost [:forfeit]
     :abilities [{:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))}
                 trash-program end-the-run]}
@@ -527,6 +536,11 @@
    "Snowflake"
    {:abilities [{:msg "start a Psi game"
                  :psi {:not-equal end-the-run}}]}
+
+   "Special Offer"
+   {:abilities [{:label "Gain 5 [Credits] and trash Special Offer"
+                 :effect (effect (gain :corp :credit 5) (trash card)
+                                 (system-msg (str "gains 5 [Credits] and trashes Special Offer")))}]}
 
    "Spiderweb"
    {:abilities [end-the-run]}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -216,9 +216,9 @@
    "Spark Agency: Worldswide Reach"
    {:events
     {:rez {:req (req (has? target :subtype "Advertisement"))
-           {:once :per-turn
-            :effect (effect (lose :runner :credit 1))
-            :msg (msg "make the Runner lose 1 [Credits] by rezzing an advertisement")}}}}
+           :once :per-turn
+           :effect (effect (lose :runner :credit 1))
+           :msg (msg "make the Runner lose 1 [Credits] by rezzing an advertisement")}}}
 
    "Tennin Institute: The Secrets Within"
    {:abilities [{:msg "add 1 advancement counter on a card" :choices {:req #(= (first (:zone %)) :servers)}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -213,6 +213,13 @@
                                                 :effect (effect (expose target)) :msg "expose 1 card"}
                                                card nil))}}}
 
+   "Spark Agency: Worldswide Reach"
+   {:events
+    {:rez {:req (req (has? target :subtype "Advertisement"))
+           {:once :per-turn
+            :effect (effect (lose :runner :credit 1))
+            :msg (msg "make the Runner lose 1 [Credits] by rezzing an advertisement")}}}}
+
    "Tennin Institute: The Secrets Within"
    {:abilities [{:msg "add 1 advancement counter on a card" :choices {:req #(= (first (:zone %)) :servers)}
                  :req (req (not (:successful-run runner-reg))) :once :per-turn

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -499,6 +499,14 @@
                               :effect (effect (gain :bad-publicity 1) (gain :runner :tag 1))
                               :req (req (or (has? target :subtype "Black Ops")
                                             (has? target :subtype "Gray Ops")))}}}
+                                          
+   "Technical Writer"
+   {:events {:runner-install {:req (req (some #(= % (:type target)) '("Hardware" "Program")))
+                              :effect (effect (add-prop :runner card :counter 1)
+                                              (system-msg (str "places 1 [Credits] on Technical Writer")))}}
+    :abilities [{:cost [:click 1] :msg (msg "gain " (:counter card) " [Credits]")
+                 :effect (effect (gain :credit (:counter card)) (trash card {:cause :ability-cost}))}]}                                          
+                                          
    "The Helpful AI"
    {:effect (effect (gain :link 1)) :leave-play (effect (lose :link 1))
     :abilities [{:msg (msg "give +2 strength to " (:title target))


### PR DESCRIPTION
All are fully working except Archangel and Improved Tracers. For Archangel, the Corp is prompted to choose whether to pay 3 credits when Archangel is accessed, but actually executing the subroutine would require it to be manually installed and rezzed--unless we want to try passing a prompt over to the Runner asking if they plan to break it, then doing the trace if they don't/can't. 

Improved Tracers only adds strength to Tracer ice currently--increasing base trace strength can be done by taking an extra credit and boosting by 1 in addition to what would be spent. 