### PR TITLE
Fix for Fetal AI

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -583,7 +583,7 @@
              {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")
               :optional {:prompt (msg "Draw " (:title (first (:deck corp))) "?")
                          :msg (msg "draw " (:title (first (:deck corp))))
-                         :no-msg "doesn't draw with Woman in the Red Dress"
+                         :no-effect {:effect (effect (system-msg "doesn't draw with Woman in the Red Dress"))}
                          :player :corp :effect (effect (draw))}}}}
 
    "Wyldside"


### PR DESCRIPTION
When declining additional costs on an agenda, we still need to fire the `:access` events. Also applies to Red Herrings and Strongbox.

I upgrade `:no-msg` in optional prompts to be a full-fledged ability called `:no-effect`, so that the agenda access code could run functions when the optional prompt is declined instead of just printing a message. I updated Woman in the Red Dress (the only use of `:no-msg`!) to reflect this change.