### PR TITLE
When triggering SMC show only programs the runner can install

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -380,7 +380,9 @@
    "Self-modifying Code"
    {:abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
                  :priority true
-                 :choices (req (filter #(has? % :type "Program") (:deck runner)))
+                 :choices (req (filter #(and (has? % :type "Program") 
+                                             (<= (:cost %) (- (:credit runner) 2)))
+                                       (:deck runner)))
                  :cost [:credit 2]
                  :effect (effect (trash card {:cause :ability-cost}) (runner-install target) (shuffle! :deck))}]}
 


### PR DESCRIPTION
Implementing feature #416. Not sure if this is entirely desirable as it could potentially confuse the user as to why certain programs do not appear as options. Then again, it might be better than having them select a program they do not have the credits to install and have SMC trash and nothing happen.