### PR TITLE
fix Order of Sol turn start issue

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -321,7 +321,10 @@
                                                            :effect (effect (gain :credit 1))} card nil)))))
     :events {:runner-turn-begins {:req (req (= (:credit runner) 0)) :msg "gain 1 [Credits]"
                                   :effect (req (gain state :runner :credit 1)
-                                               (swap! state assoc-in [:per-turn (:cid card)] true))}}
+                                               (swap! state assoc-in [:per-turn (:cid card)] true))}
+             :corp-turn-begins {:req (req (= (:credit runner) 0)) :msg "gain 1 [Credits]"
+                                :effect (req (gain state :runner :credit 1)
+                                             (swap! state assoc-in [:per-turn (:cid card)] true))}}
     :leave-play (req (remove-watch state :order-of-sol))}
 
    "Paige Piper"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -319,6 +319,9 @@
                                          (zero? (get-in new [:runner :credit])))
                                 (resolve-ability ref side {:msg "gain 1 [Credits]" :once :per-turn
                                                            :effect (effect (gain :credit 1))} card nil)))))
+    :events {:runner-turn-begins {:req (req (= (:credit runner) 0)) :msg "gain 1 [Credits]"
+                                  :effect (req (gain state :runner :credit 1)
+                                               (swap! state assoc-in [:per-turn (:cid card)] true))}}
     :leave-play (req (remove-watch state :order-of-sol))}
 
    "Paige Piper"


### PR DESCRIPTION
Fixes #344. Add a `runner-turn-begins` to get Order of Sol to add a credit when starting the Runner turn on 0 credits, then update `:per-turn` to make sure it doesn't fire again if you drop to 0 during that same turn. 

EDIT: Forgot it needed a `corp-turn-begins` for the same reasons. 