### PR TITLE
Expand install-cost-bonus framework; implement Utopia, Eden, Hades Shard installs

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -138,7 +138,7 @@
    {:abilities [{:cost [:click 2] :msg "add 1 power counter" :effect (effect (add-prop card :counter 1))}]
     :events {:pre-install {:req (req (and (not (zero? (:counter card)))
                                           (not (get-in @state [:per-turn (:cid card)]))))
-                           :effect (effect (install-cost-bonus (:counter card)))}
+                           :effect (effect (install-cost-bonus [:credit (:counter card)]))}
              :runner-install {:req (req (and (not (zero? (:counter card)))
                                              (not (get-in @state [:per-turn (:cid card)]))))
                               :msg (msg "increase the install cost of " (:title target) " by " (:counter card) " [Credits]")

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -44,7 +44,7 @@
    "Career Fair"
    {:prompt "Choose a Resource to install"
     :choices (req (filter #(#{"Resource"} (:type %)) (:hand runner)))
-    :effect  (effect (install-cost-bonus -3) (runner-install target))}
+    :effect  (effect (install-cost-bonus [:credit -3]) (runner-install target))}
 
    "Code Siphon"
    {:effect (effect (run :rd
@@ -52,7 +52,7 @@
                           {:prompt "Choose a program to install"
                            :msg (msg "install " (:title target) " and take 1 tag")
                            :choices (req (filter #(has? % :type "Program") (:deck runner)))
-                           :effect (effect (install-cost-bonus (* -3 (count (get-in corp [:servers :rd :ices]))))
+                           :effect (effect (install-cost-bonus [:credit (* -3 (count (get-in corp [:servers :rd :ices])))])
                                            (runner-install target) (gain :tag 1) (shuffle! :deck))}} card))}
 
    "Day Job"
@@ -279,7 +279,7 @@
    "Modded"
    {:prompt "Choose a card to install"
     :choices (req (filter #(#{"Hardware" "Program"} (:type %)) (:hand runner)))
-    :effect (effect (install-cost-bonus -3) (runner-install target))}
+    :effect (effect (install-cost-bonus [:credit -3]) (runner-install target))}
 
    "Net Celebrity"
    {:recurring 1}
@@ -397,7 +397,7 @@
                                         :choices (req (filter #(and (= (:type %) "Program")
                                                                     (<= (:cost %) (+ (:credit runner) (:cost trashed))))
                                                               ((if (= fr "Grip") :hand :discard) runner)))
-                                        :effect (effect (install-cost-bonus (- (:cost trashed)))
+                                        :effect (effect (install-cost-bonus [:credit (- (:cost trashed))])
                                                         (runner-install target))} card nil)))} card nil)))}
 
 

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -139,7 +139,7 @@
    {:effect (effect (gain :link 1))
     :events {:pre-install {:req (req (and (#{"Hardware" "Program"} (:type target))
                                           (not (get-in @state [:per-turn (:cid card)]))))
-                           :effect (effect (install-cost-bonus -1))}
+                           :effect (effect (install-cost-bonus [:credit -1]))}
              :runner-install {:req (req (and (#{"Hardware" "Program"} (:type target))
                                              (not (get-in @state [:per-turn (:cid card)]))))
                               :msg (msg "reduce the install cost of " (:title target) " by 1 [Credits]")

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -110,7 +110,12 @@
 
    "Eden Shard"
    {:abilities [{:effect (effect (trash card {:cause :ability-cost}) (draw :corp 2))
-                 :msg "force the Corp to draw 2 cards"}]}
+                 :msg "force the Corp to draw 2 cards"}]
+    :install-cost-bonus (req (if (and run (= (:server run) [:rd]) (= 0 (:position run)))
+                               [:credit -7 :click -1] nil))
+    :effect (req (when (and run (= (:server run) [:rd]) (= 0 (:position run)))
+                   (swap! state update-in [:runner :prompt] rest)
+                   (handle-end-run state side)))}
 
    "Enhanced Vision"
    {:events {:successful-run {:msg (msg "force the Corp to reveal " (:title (first (shuffle (:hand corp)))))
@@ -169,7 +174,12 @@
 
    "Hades Shard"
    {:abilities [{:msg "access all cards in Archives"
-                 :effect (effect (trash card {:cause :ability-cost}) (handle-access (access state side [:archives])))}]}
+                 :effect (effect (trash card {:cause :ability-cost}) (handle-access (access state side [:archives])))}]
+    :install-cost-bonus (req (if (and run (= (:server run) [:archives]) (= 0 (:position run)))
+                               [:credit -7 :click -1] nil))
+    :effect (req (when (and run (= (:server run) [:archives]) (= 0 (:position run)))
+                   (swap! state update-in [:runner :prompt] rest)
+                   (handle-end-run state side)))}
 
    "Hard at Work"
    {:events {:runner-turn-begins {:msg "gain 2 [Credits] and lose [Click]"
@@ -476,7 +486,7 @@
                                        (:hosted card)))
                  :msg (msg "install " (:title target) " lowering its install cost by 1 [Credits]")
                  :effect (effect
-                           (install-cost-bonus -1) (runner-install (dissoc target :facedown))
+                           (install-cost-bonus [:credit -1]) (runner-install (dissoc target :facedown))
                            (trash (update-in card [:hosted]
                                              (fn [coll]
                                                (remove-once #(not= (:cid %) (:cid target)) coll)))
@@ -572,7 +582,12 @@
    "Utopia Shard"
    {:abilities [{:effect (effect (trash-cards :corp (take 2 (shuffle (:hand corp))))
                                  (trash card {:cause :ability-cost}))
-                 :msg "force the Corp to discard 2 cards from HQ at random"}]}
+                 :msg "force the Corp to discard 2 cards from HQ at random"}]
+    :install-cost-bonus (req (if (and run (= (:server run) [:hq]) (= 0 (:position run)))
+                               [:credit -7 :click -1] nil))
+    :effect (req (when (and run (= (:server run) [:hq]) (= 0 (:position run)))
+                   (swap! state update-in [:runner :prompt] rest)
+                   (handle-end-run state side)))}
 
    "Virus Breeding Ground"
    {:data {:counter-type "Virus"}


### PR DESCRIPTION
As shown here: https://www.livecoding.tv/video/jintekinet-events-utopia-shard-12/

Expand the `install-cost-bonus` framework with two additions:

1. A card can modify its own install cost by implementing `:install-cost-bonus` in the card-def, similar to corp cards that modify their own rez cost.
2. All modifications to install cost (whether through `:install-cost-bonus` or the `(install-cost-bonus)` function) are now of the form `[type amount]`. Rather than assuming (and restricting) bonuses to be regarding the credit cost, we now let the modifications be to any cost that can be paid through `pay`. This turns Modded into `(install-cost-bonus [:credit -3])`, for example, and allows full implementation of installing the Shards by clicking on them during a run.

I implemented the Shards by incorporating a `:install-cost-bonus` of `[:credit -7 :click -1]` when you install them during a run on the appropriate server after passing all ice (at `:position 0`). The new framework allows us to modify not only the credit cost of the Shard, but also cancel out the `:click 1` that comes from trying to install the card from hand. 

Any cost that can be paid through `deduce` can be modified by this bonus framework. That includes `:memory`... which would allow the Cloud breakers to cancel their memory cost on install if the runner has >= 2 link. I'll leave that to someone else.