### PR TITLE
move-card no longer shows name from :play-area

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1377,10 +1377,12 @@
 
 (defn move-card [state side {:keys [card server]}]
   (let [c (update-in card [:zone] #(map to-keyword %))
-        label (if (or (and (= (:side c) "Runner") (not (:facedown c)))
-                      (:rezzed c) 
-                      (:seen c)
-                      (= (last (:zone c)) :deck))
+        last-zone (last (:zone c))
+        label (if (and (not (= last-zone :play-area)) 
+                       (or (and (= (:side c)  "Runner") (not (:facedown c)))
+                           (:rezzed c) 
+                           (:seen c)
+                           (= last-zone :deck)))
                 (:title c) "a card")
         s (if (#{"HQ" "R&D" "Archives"} server) :corp :runner)]
     (case server


### PR DESCRIPTION
The problem with Rolodex displaying the moved cards to the Corp wasn't with the card itself. It was the fact that runner cards moved onto the Stack were not being hid by move-card. This is why Indexing didn't have this problem. It moved Corp cards to R&D.

So, this prevents cards in the :play-area region from being displayed when moved. This should prevent future problems with cards moving from the :play-area from being displayed too.

Fixes Issue #536 