### PR TITLE
Fixing "First time X you may Y" abilities

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -68,7 +68,9 @@
    "Comet"
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
     :events {:play-event
-             {:optional {:prompt "Play another event?" :once :per-turn
+             {:optional {:prompt "Play another event?"
+                         :req (req (and (first-event state side :play-event)
+                                        (not (empty? (filter #(has? % :type "Event") (:hand runner))))))
                          :effect (effect (resolve-ability
                                            {:prompt "Choose an Event to play"
                                             :choices (req (filter #(has? % :type "Event") (:hand runner)))

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -85,7 +85,7 @@
 
    "Hayley Kaplan: Universal Scholar"
    {:events {:runner-install
-             {:optional {:prompt (msg "Install another " (:type target) " from Grip?") :once :per-turn
+             {:optional {:prompt (msg "Install another " (:type target) " from Grip?")
                          :req (req (and (first-event state side :runner-install) ;; If this is the first installation of the turn
                                         (some #(= (:type  %) (:type target)) (:hand runner)))) ;; and there are additional cards of that type in hand
                          :effect (req (let [type (:type target)]

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -89,7 +89,7 @@
                          :effect (req (let [type (:type target)]
                                         (resolve-ability
                                           state side
-                                          {:prompt (msg "Choose a " type "to install")
+                                          {:prompt (msg "Choose a " type " to install")
                                            :choices (req (filter #(has? % :type type) (:hand runner)))
                                            :msg (msg "install " (:title target))
                                            :effect (effect (runner-install target))} card nil)))}}}}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -229,9 +229,12 @@
 
    "The Foundry: Refining the Process"
    {:events
-    {:rez {:req (req (and (= (:type target) "ICE") (some #(= (:title %) (:title target)) (:deck corp))))
+    {:rez {:req (req (and (= (:type target) "ICE") ;; Did you rez and ice just now
+                          (some #(= (:title %) (:title target)) (:deck corp)) ;; Are there more copies in the dec
+                          (empty? (let [rezzed-this-turn (map first (turn-events state side :rez))]
+                                    (filter #(has? % :type "ICE") rezzed-this-turn))))) ;; Is this the first ice you've rezzed this turn
            :optional
-                {:prompt "Add another copy to HQ?" :once :per-turn
+                {:prompt "Add another copy to HQ?"
                  :effect (effect (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand)
                                  (shuffle! :deck))
                  :msg (msg "add a copy of " (:title target) " from R&D to HQ")}}}}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -86,6 +86,8 @@
    "Hayley Kaplan: Universal Scholar"
    {:events {:runner-install
              {:optional {:prompt (msg "Install another " (:type target) " from Grip?") :once :per-turn
+                         :req (req (and (first-event state side :runner-install) ;; If this is the first installation of the turn
+                                        (some #(= (:type  %) (:type target)) (:hand runner)))) ;; and there are additional cards of that type in hand
                          :effect (req (let [type (:type target)]
                                         (resolve-ability
                                           state side

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -152,9 +152,13 @@
                           :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Laramy Fisk: Savvy Investor"
-   {:events {:successful-run {:req (req (and (#{:hq :rd :archives} target)))
+   {:events {:successful-run {:req (req (and (#{:hq :rd :archives} target)
+                                             (empty? (let [successes (map first (turn-events state side :successful-run))]
+                                                       (do
+                                                         (prn successes)
+                                                         (filter #(not (= % :remote)) successes))))))
                               :optional {:prompt "Force the Corp to draw 1 card?"
-                                         :msg "force the Corp to draw 1 card" :once :per-turn
+                                         :msg "force the Corp to draw 1 card"
                                          :effect (effect (draw :corp))}}}}
 
    "Leela Patel: Trained Pragmatist"


### PR DESCRIPTION
I've just finished updating the cards with rules text that says, "the first time X happens, you may Y." I believe I've fixed them all. The only one that remains unimplemented is Tori Hanzo because it is a good bit more difficult.

The problem was with the `:once :per-turn` tags not working properly with the `:optional` abilities. I've added `:req` calls that make use of the very handy `(turn-events)` function to make sure the game state is proper for the call.

This pull request addresses issues with:
Laramy Fisk
Hayley
Comet
The Foundry

It also fixes issues #596 and #63.