### PR TITLE
Implement cloud icebreaker

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -30,6 +30,20 @@
                               :run-ends breaker-auto-pump :ice-strength-changed breaker-auto-pump
                               :breaker-strength-changed breaker-auto-pump :approach-ice breaker-auto-pump })))
 
+(defn cloud-icebreaker [cdef]
+  (assoc cdef :effect (req (add-watch state (keyword (str "cloud" (:cid card)))
+                        (fn [k ref old new]
+                          (when (and (< (get-in old [:runner :link]) 2)
+                                     (> (get-in new [:runner :link]) 1))
+                            (gain state :runner :memory (:memoryunits card)))
+                          (when (and (> (get-in old [:runner :link]) 1)
+                                     (< (get-in new [:runner :link]) 2))
+                            (gain state :runner :memory (* -1 (:memoryunits card)))))))
+              :leave-play (req (remove-watch state (keyword (str "cloud" (:cid card))))
+                               (when (> (get-in @state [:runner :link]) 1)
+                                 (lose state :runner :memory (:memoryunits card))))
+              :install-cost-bonus (req (if (> (get-in @state [:runner :link]) 1) [:memory (* -1 (:memoryunits card))]))))
+
 (def cards-icebreakers
   {"Alpha"
    (auto-icebreaker ["All"]
@@ -103,16 +117,17 @@
                                  {:cost [:credit 1] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]})
 
    "Creeper"
-   (auto-icebreaker ["Sentry"]
-                    {:abilities [{:cost [:credit 2] :msg "break 1 sentry subroutine"}
-                                 {:cost [:credit 1] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]})
+   (cloud-icebreaker
+     (auto-icebreaker ["Sentry"]
+                      {:abilities [{:cost [:credit 2] :msg "break 1 sentry subroutine"}
+                                   {:cost [:credit 1] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]}))
 
    "Crowbar"
-   {:abilities [{:msg "break up to 3 code gate subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
-    :events (let [cloud {:req (req (has? target :subtype "Icebreaker"))
-                         :effect (effect (update-breaker-strength card))}]
-              {:runner-install cloud :trash cloud :card-moved cloud})
-    :strength-bonus (req (count (filter #(has? % :subtype "Icebreaker") (all-installed state :runner))))}
+   (cloud-icebreaker {:abilities [{:msg "break up to 3 code gate subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
+                      :events (let [cloud {:req (req (has? target :subtype "Icebreaker"))
+                                           :effect (effect (update-breaker-strength card))}]
+                                {:runner-install cloud :trash cloud :card-moved cloud})
+                      :strength-bonus (req (count (filter #(has? % :subtype "Icebreaker") (all-installed state :runner))))})
 
    "Crypsis"
    (auto-icebreaker ["All"]
@@ -198,19 +213,22 @@
                                  {:cost [:credit 2] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]})
 
    "GS Sherman M3"
-   (auto-icebreaker ["Barrier"]
-                    {:abilities [{:cost [:credit 2] :msg "break any number of barrier subroutines"}
-                                 {:cost [:credit 2] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]})
+   (cloud-icebreaker
+     (auto-icebreaker ["Barrier"]
+                      {:abilities [{:cost [:credit 2] :msg "break any number of barrier subroutines"}
+                                   {:cost [:credit 2] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]}))
 
    "GS Shrike M2"
-   (auto-icebreaker ["Sentry"]
-                    {:abilities [{:cost [:credit 2] :msg "break any number of sentry subroutines"}
-                                 {:cost [:credit 2] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]})
+   (cloud-icebreaker
+     (auto-icebreaker ["Sentry"]
+                      {:abilities [{:cost [:credit 2] :msg "break any number of sentry subroutines"}
+                                   {:cost [:credit 2] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]}))
 
    "GS Striker M1"
-   (auto-icebreaker ["Code Gate"]
-                    {:abilities [{:cost [:credit 2] :msg "break any number of code gate subroutines"}
-                                 {:cost [:credit 2] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]})
+   (cloud-icebreaker
+     (auto-icebreaker ["Code Gate"]
+                      {:abilities [{:cost [:credit 2] :msg "break any number of code gate subroutines"}
+                                   {:cost [:credit 2] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]}))
 
    "Inti"
    (auto-icebreaker ["Barrier"]
@@ -299,18 +317,18 @@
                                  {:cost [:credit 1] :msg "add 2 strength" :effect (effect (pump card 2)) :pump 2}]})
 
    "Shiv"
-   {:abilities [{:msg "break up to 3 sentry subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
-    :events (let [cloud {:req (req (has? target :subtype "Icebreaker"))
-                         :effect (effect (update-breaker-strength card))}]
-              {:runner-install cloud :trash cloud :card-moved cloud})
-    :strength-bonus (req (count (filter #(has? % :subtype "Icebreaker") (all-installed state :runner))))}
+   (cloud-icebreaker {:abilities [{:msg "break up to 3 sentry subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
+                      :events (let [cloud {:req (req (has? target :subtype "Icebreaker"))
+                                           :effect (effect (update-breaker-strength card))}]
+                                {:runner-install cloud :trash cloud :card-moved cloud})
+                      :strength-bonus (req (count (filter #(has? % :subtype "Icebreaker") (all-installed state :runner))))})
 
    "Spike"
-   {:abilities [{:msg "break up to 3 barrier subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
-    :events (let [cloud {:req (req (has? target :subtype "Icebreaker"))
-                         :effect (effect (update-breaker-strength card))}]
-              {:runner-install cloud :trash cloud :card-moved cloud})
-    :strength-bonus (req (count (filter #(has? % :subtype "Icebreaker") (all-installed state :runner))))}
+   (cloud-icebreaker {:abilities [{:msg "break up to 3 barrier subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
+                      :events (let [cloud {:req (req (has? target :subtype "Icebreaker"))
+                                           :effect (effect (update-breaker-strength card))}]
+                                {:runner-install cloud :trash cloud :card-moved cloud})
+                      :strength-bonus (req (count (filter #(has? % :subtype "Icebreaker") (all-installed state :runner))))})
 
    "Study Guide"
    {:abilities [{:cost [:credit 1] :msg "break 1 code gate subroutine"}
@@ -346,6 +364,7 @@
    {:abilities [{:msg "break 1 code gate subroutine"}]}
 
    "ZU.13 Key Master"
-   (auto-icebreaker ["Code Gate"]
-                    {:abilities [{:cost [:credit 1] :msg "break 1 code gate subroutine"}
-                                 {:cost [:credit 1] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]})})
+   (cloud-icebreaker
+     (auto-icebreaker ["Code Gate"]
+                      {:abilities [{:cost [:credit 1] :msg "break 1 code gate subroutine"}
+                                   {:cost [:credit 1] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]}))})

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -492,11 +492,11 @@
                   (when (> run-credit 0)
                     (str " (" run-credit " for run)")))
         (when me? (controls :credit))]
-       [:div (str memory " Memory Unit" (if (> memory 1) "s" "")) (when me? (controls :memory))]
+       [:div (str memory " Memory Unit" (if (not= memory 0) "s" "")) (when (< memory 0) [:div.warning "!"]) (when me? (controls :memory))]
        [:div (str link " Link" (if (> link 1) "s" "")) (when me? (controls :link))]
        [:div (str agenda-point " Agenda Point" (when (> agenda-point 1) "s"))
         (when me? (controls :agenda-point))]
-       [:div (str tag " Tag" (if (> tag 1) "s" "")) (when me? (controls :tag))]
+       [:div (str tag " Tag" (if (> tag 1) "s" "")) (when (> tag 0) [:div.warning "!"]) (when me? (controls :tag))]
        [:div (str brain-damage " Brain Damage" (if (> brain-damage 1) "s" ""))
         (when me? (controls :brain-damage))]
        [:div (str max-hand-size " Max hand size") (when me? (controls :max-hand-size))]]))))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -133,14 +133,13 @@
                (get-in @game-state [:runner :rig (keyword (.toLowerCase (:type card)))]))]
     (some #(= (:title %) (:title card)) dest)))
 
-(defn playable? [{:keys [title side zone cost type uniqueness abilities memoryunits] :as card}]
+(defn playable? [{:keys [title side zone cost type uniqueness abilities] :as card}]
   (let [my-side (:side @game-state)
         me (my-side @game-state)]
     (and (= (keyword (.toLowerCase side)) my-side)
          (and (= zone ["hand"])
               (or (not uniqueness) (not (in-play? card)))
               (or (#{"Agenda" "Asset" "Upgrade" "ICE"} type) (>= (:credit me) cost))
-              (or (not memoryunits) (<= memoryunits (:memory me)))
               (> (:click me) 0)))))
 
 (defn is-card-item [item]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -157,6 +157,37 @@ button.small
   color: orangered
   margin-left: 5px
 
+.warning
+    position: relative
+    background: #34849F
+    border: 1px solid #9AC2CF
+    margin-left: 12px
+    width: 12px
+    display: inline-block
+    text-align: center
+
+.warning:after, .warning:before
+    right: 100%
+    top: 50%
+    border: solid transparent
+    content: " "
+    height: 0
+    width: 0
+    position: absolute
+    pointer-events: none
+
+.warning:after
+    border-color: rgba(52, 132, 159, 0)
+    border-right-color: #34849F
+    border-width: 8px
+    margin-top: -8px
+
+.warning:before
+    border-color: rgba(154, 194, 207, 0)
+    border-right-color: #9AC2CF
+    border-width: 10px
+    margin-top: -10px
+
 .fake-link
   color: orange
   cursor: pointer


### PR DESCRIPTION
The first step was to enable MU to be negative. Image you have a bunch of cloud breaker and other programs installed, and then you somehow lose your 2nd link. Suddenly you have to trash a bunch of programs, because your MU is "negative" until you trashed enough programs.

This also fixes the annoyance when you e.g. clone chip or SMC a program with not enough memory left: the clone chip or SMC would get trashed, but the program would not get installed.

Implementing the cloud breaker was straight forward thanks to @nealterrell's `:install-cost-bonus` and @mtgred's tip with simply using `add-watch`. First I wanted to implement them directly in `core.clj`, but I couldn't get it to work because the `:install-cost-bonus` has to be part of the card definition before the card is in play. I created a function `cloud-icebreaker` that simply wraps a card definition (like `auto-icebreaker`), so there's no code duplication.

I added a little visual clue to show when the runner's MU is negative, and, while at it, I also show it when the runner is tagged, since that's also an important information and unfortunately easy to miss:

![bild 27](https://cloud.githubusercontent.com/assets/3126597/9467297/ee9075a8-4b3a-11e5-8288-3c5ea4c5abe6.png)
