### PR TITLE
improvement to Bad Times, Improved Tracers

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -191,7 +191,9 @@
    "Improved Tracers"
    {:effect (req (update-all-ice state side))
     :events {:pre-ice-strength {:req (req (has? target :subtype "Tracer"))
-                                :effect (effect (ice-strength-bonus 1))}}}
+                                :effect (effect (ice-strength-bonus 1))}
+             :pre-init-trace {:req (req (has? target :type "ICE"))
+                              :effect (effect (init-trace-bonus 1))}}}
 
    "Labyrinthine Servers"
    {:data {:counter 2}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -27,7 +27,16 @@
               (* 3 (:advance-counter target)) " [Credits]")}
 
    "Bad Times"
-   {:req (req tagged)}
+   {:effect (req (lose state :runner :memory 2)
+                 (system-msg state :runner "loses 2[mu] until the end of the turn")
+                 (when (< (:memory runner) 0)
+                  (system-msg state :runner "must trash programs to free up [mu]"))
+                 (register-events state side (:events (card-def card))
+                                             (assoc card :zone '(:discard))))
+    :events {:corp-turn-ends
+             {:effect (req (gain state :runner :memory 2)
+                           (system-msg state :runner "regains 2[mu]")
+                           (unregister-events state side card))}}}
 
    "Beanstalk Royalties"
    {:effect (effect (gain :credit 3))}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -28,16 +28,12 @@
 
    "Bad Times"
    {:req (req tagged)
+    :msg "force the Runner to lose 2[mu] until the end of the turn"
     :effect (req (lose state :runner :memory 2)
-                 (system-msg state :runner "loses 2[mu] until the end of the turn")
                  (when (< (:memory runner) 0)
-                  (system-msg state :runner "must trash programs to free up [mu]"))
-                 (register-events state side (:events (card-def card))
-                                             (assoc card :zone '(:discard))))
-    :events {:corp-turn-ends
-             {:effect (req (gain state :runner :memory 2)
-                           (system-msg state :runner "regains 2[mu]")
-                           (unregister-events state side card))}}}
+                  (system-msg state :runner "must trash programs to free up [mu]")))
+    :end-turn {:effect (req (gain state :runner :memory 2)
+                            (system-msg state :runner "regains 2[mu]"))}}
 
    "Beanstalk Royalties"
    {:effect (effect (gain :credit 3))}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -27,7 +27,8 @@
               (* 3 (:advance-counter target)) " [Credits]")}
 
    "Bad Times"
-   {:effect (req (lose state :runner :memory 2)
+   {:req (req tagged)
+    :effect (req (lose state :runner :memory 2)
                  (system-msg state :runner "loses 2[mu] until the end of the turn")
                  (when (< (:memory runner) 0)
                   (system-msg state :runner "must trash programs to free up [mu]"))


### PR DESCRIPTION
Now that MU can go negative with the new cloud breaker subsystem, Bad Times can reduce the Runner's MU by 2 until the end of the Corp turn and then restore it. If MU dips below 0, in addition to the new visual indicator, a message is put into the log reminder the Runner to trash programs. 