### PR TITLE
Adam and his directives

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -1,7 +1,16 @@
 (in-ns 'game.core)
 
 (def cards-identities
-  {"Andromeda: Dispossessed Ristie"
+  {"Adam: Compulsive Hacker"
+   {:effect (req (let [titles ["Safety First" "Always Be Running" "Neutralize All Threats"]
+                       indeck (filter #(some #{(:title %)} titles) (:deck runner))
+                       inhand (filter #(some #{(:title %)} titles) (:hand runner))]
+                   (doseq [c (concat indeck inhand)]
+                     (runner-install state side c {:no-cost true 
+                                                   :custom-message (str "starts with " (:title c) " in play")}))
+                   (draw state :runner (count inhand))))}
+  
+   "Andromeda: Dispossessed Ristie"
    {:effect (effect (gain :link 1) (draw 4)) :mulligan (effect (draw 4))}
 
    "Apex: Invasive Predator"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -301,6 +301,14 @@
     :abilities [{:msg "draw 1 card"
                  :effect (effect (trash card {:cause :ability-cost}) (draw))}]}
 
+   "Neutralize All Threats"
+   {:effect (effect (gain :hq-access 1))
+    :leave-play (effect (lose :hq-access 1))
+    :events {:access {:effect (req (swap! state assoc-in [:runner :register :force-trash] false))}
+             :pre-trash {:req (req (let [cards (map first (turn-events state side :pre-trash))]
+                                     (empty? (filter #(not (nil? (:trash %))) cards))))
+                         :effect (req (swap! state assoc-in [:runner :register :force-trash] true))}}}
+
    "New Angeles City Hall"
    {:events {:agenda-stolen {:msg "trash itself" :effect (effect (trash card))}}
     :abilities [{:cost [:credit 2] :msg "avoid 1 tag" :effect (effect (lose :tag 1))}]}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -458,6 +458,12 @@
     :abilities [{:effect (effect (trash-prevent :program 1) (trash-prevent :hardware 1)
                                  (trash card {:cause :ability-cost}))}]}
 
+   "Safety First"
+   {:effect (effect (lose :runner :max-hand-size 2))
+    :leave-play (effect (gain :runner :max-hand-size 2))
+    :events {:runner-turn-ends {:req (req (< (count (:hand runner)) (:max-hand-size runner)))
+                                :effect (effect (draw 1))}}}
+
    "Same Old Thing"
    {:abilities [{:cost [:click 2]
                  :prompt "Choose an event to play" :msg (msg "play " (:title target))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -470,6 +470,7 @@
    {:effect (effect (lose :runner :max-hand-size 2))
     :leave-play (effect (gain :runner :max-hand-size 2))
     :events {:runner-turn-ends {:req (req (< (count (:hand runner)) (:max-hand-size runner)))
+                                :msg (msg "draw a card")
                                 :effect (effect (draw 1))}}}
 
    "Same Old Thing"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -6,20 +6,28 @@
 
    "Activist Support"
    {:events
-    {:corp-turn-begins {:req (req (not tagged)) :msg "take 1 tag" :effect (effect (gain :runner :tag 1))}
-     :runner-turn-begins {:req (req (zero? (:bad-publicity corp))) :msg "give the Corp 1 bad publicity"
-                           :effect (effect (gain :corp :bad-publicity 1))}}}
+    {:corp-turn-begins {:req (req (not tagged)) 
+                        :msg "take 1 tag" 
+                        :effect (effect (gain :runner :tag 1))}
+     :runner-turn-begins {:req (req (zero? (:bad-publicity corp))) 
+                          :msg "give the Corp 1 bad publicity"
+                          :effect (effect (gain :corp :bad-publicity 1))}}}
 
    "Adjusted Chronotype"
    {:events {:runner-loss {:req (req (and (some #{:click} target)
                                            (empty? (filter #(= :click %)
                                                            (mapcat first (turn-events state side :runner-loss))))))
-                            :msg "gain [Click]" :effect (effect (gain :runner :click 1))}}}
+                           :msg "gain [Click]" :effect (effect (gain :runner :click 1))}}}
 
    "Aesops Pawnshop"
    {:abilities [{:msg (msg "trash " (:title target) " and gain 3 [Credits]")
-                  :choices {:req #(and (= (:side %) "Runner") (:installed %))}
-                  :effect (effect (gain :credit 3) (trash target))}]}
+                 :choices {:req #(and (= (:side %) "Runner") (:installed %))}
+                 :effect (effect (gain :credit 3) (trash target))}]}
+
+   "Always Be Running"
+   {:abilities [{:once :per-turn
+                 :cost [:click 2]
+                 :msg (msg "break 1 subroutine")}]}
 
    "All-nighter"
    {:abilities [{:cost [:click 1] :effect (effect (trash card {:cause :ability-cost}) (gain :click 2))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -849,11 +849,17 @@
             (when (not= (:zone c) [:discard])
               (if-let [trash-cost (trash-cost state side c)]
                 (let [card (assoc c :seen true)]
-                  (optional-ability state :runner card (str "Pay " trash-cost "[Credits] to trash " name "?")
-                                    {:cost [:credit trash-cost]
-                                     :effect (effect (trash card)
-                                                     (system-msg (str "pays " trash-cost " [Credits] to trash "
-                                                                      (:title card))))} nil))
+                  (if (and (get-in @state [:runner :register :force-trash])
+                           (can-pay? state :runner :credit trash-cost))
+                    (resolve-ability state :runner {:cost [:credit trash-cost]
+                                                    :effect (effect (trash card)
+                                                            (system-msg (str "is forced to pay " trash-cost
+                                                                             " [Credits] to trash " (:title card))))} card nil)
+                    (optional-ability state :runner card (str "Pay " trash-cost "[Credits] to trash " name "?")
+                                      {:cost [:credit trash-cost]
+                                       :effect (effect (trash card)
+                                                       (system-msg (str "pays " trash-cost " [Credits] to trash "
+                                                                        (:title card))))} nil)))
                 (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {})))))))))
 
 (defn max-access [state side n]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1220,8 +1220,8 @@
 
 (defn runner-install
   ([state side card] (runner-install state side card nil))
-  ([state side {:keys [title type cost memoryunits uniqueness] :as card}
-    {:keys [extra-cost no-cost host-card facedown] :as params}]
+  ([state side {:keys [title type cost memoryunits uniqueness ] :as card}
+    {:keys [extra-cost no-cost host-card facedown custom-message] :as params}]
 
    (if-let [hosting (and (not host-card) (:hosting (card-def card)))]
      (resolve-ability state side
@@ -1243,9 +1243,11 @@
                  installed-card (card-init state side (assoc c :installed true) (not facedown))]
              (if facedown
                (system-msg state side "installs a card facedown" )
+             (if custom-message
+               (system-msg state side custom-message)
                (system-msg state side (str "installs " title
                                            (when host-card (str " on " (:title host-card)))
-                                           (when no-cost " at no cost"))))
+                                           (when no-cost " at no cost")))))
              (trigger-event state side :runner-install installed-card)
              (when (has? c :subtype "Icebreaker") (update-breaker-strength state side c)))))))
    (when (has? card :type "Resource") (swap! state assoc-in [:runner :register :installed-resource] true))


### PR DESCRIPTION
Adam: you have to have the 3 directives in your deck. They will be installed automatically when the game begins.

Neutralize All Threats: If you can't pay the trash cost, the regular prompt is shown, so you can use e.g. Ghost Runner or recurring credits. If you can pay, the card is automatically trashed.

Safety First: Nothing special, fully automated

Always Be Running: The 'Your first Click...' condition is not enforced; and I think it's not a big deal. There was a discussion on Slack on adding a `:runner :restrictions` map to the state. I think we could fully implement *Always Be Running* once we have *Replicating Perfection* fully implemented.