### PR TITLE
Fixed nested prompts in an :optional ability not firing

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -5,10 +5,10 @@
    {:optional {:prompt "Look at the top 3 cards of R&D?"
                :msg (msg (let [c (count (filter #(= (:type %) "ICE") (take 3 (:deck corp))))]
                            (str "install " c " ICE and trash " (- 3 c) " cards")))
-               :effect (req (doseq [c (take 3 (:deck corp))]
-                              (if (= (:type c) "ICE")
-                                (corp-install state side c nil {:no-install-cost true :install-state :rezzed})
-                                (trash state side c))))}}
+               :yes-ability {:effect (req (doseq [c (take 3 (:deck corp))]
+                                           (if (= (:type c) "ICE")
+                                             (corp-install state side c nil {:no-install-cost true :install-state :rezzed})
+                                             (trash state side c))))}}}
 
    "Ancestral Imager"
    {:events {:jack-out {:msg "do 1 net damage" :effect (effect (damage :net 1))}}}
@@ -98,7 +98,8 @@
 
    "Explode-a-palooza"
    {:access {:optional {:prompt "Gain 5 [Credits] with Explode-a-Palooza ability?"
-                        :msg "gain 5 [Credits]" :effect (effect (gain :corp :credit 5))}}}
+                        :msg "gain 5 [Credits]" 
+                        :yes-ability {:effect (effect (gain :corp :credit 5))}}}}
 
    "False Lead"
    {:abilities [{:req (req (>= (:click runner) 2)) :msg "force the Runner to lose [Click][Click]"
@@ -145,11 +146,12 @@
    {:events {:corp-turn-begins
              {:optional
               {:prompt "Add 1 card from Archives to bottom of R&D?"
-               :effect (effect (resolve-ability
-                                 {:prompt "Choose a card" :choices (:discard corp)
-                                  :effect (effect (move target :deck))
-                                  :msg (msg "add " (if (:seen target) (:title target) "a card")
-                                            " to the bottom of R&D")} card target))}}}}
+               :yes-ability {:effect (effect (resolve-ability
+                                              {:prompt "Choose a card"
+                                               :choices (:discard corp)
+                                               :effect (effect (move target :deck))
+                                               :msg (msg "add " (if (:seen target) (:title target) "a card")
+                                                         " to the bottom of R&D")} card target))}}}}}
 
    "Helium-3 Deposit"
    {:choices ["0", "1", "2"] :prompt "How many power counters?"
@@ -239,7 +241,7 @@
    "Posted Bounty"
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
                :msg "give the Runner 1 tag and take 1 bad publicity"
-               :effect (effect (gain :bad-publicity 1) (gain :runner :tag 1) (forfeit card))}}
+               :yes-ability {:effect (effect (gain :bad-publicity 1) (gain :runner :tag 1) (forfeit card))}}}
 
    "Priority Requisition"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))}

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -12,10 +12,10 @@
     :access {:optional
              {:req (req installed) :prompt "Pay 2 [Credits] to use Aggressive Secretary ability?"
               :cost [:credit 2]
-              :effect (req (let [agg card]
-                             (resolve-ability
-                               state side (assoc (assoc-in trash-program [:choices :max] (req (:advance-counter agg)))
-                                            :effect (effect (trash-cards targets))) agg nil)))}}}
+              :yes-effect {:effect (req (let [agg card]
+                                          (resolve-ability
+                                           state side (assoc (assoc-in trash-program [:choices :max] (req (:advance-counter agg)))
+                                                        :effect (effect (trash-cards targets))) agg nil)))}}}}
 
    "Alix T4LB07"
    {:events {:corp-install {:effect (effect (add-prop card :counter 1))}}
@@ -47,7 +47,7 @@
     :access {:optional {:req (req installed)
                         :prompt "Pay 3 [Credits] to use Cerebral Overwriter ability?"
                         :cost [:credit 3] :msg (msg "do " (:advance-counter card) " brain damage")
-                        :effect (effect (damage :brain (:advance-counter card) {:card card}))}}}
+                        :yes-ability {:effect (effect (damage :brain (:advance-counter card) {:card card}))}}}}
 
    "Chairman Hiro"
    {:effect (effect (lose :runner :max-hand-size 2))
@@ -67,25 +67,22 @@
    {:events {:corp-turn-begins
              {:optional
               {:prompt "Move one advancement token between ICE?"
-               :effect (effect
-                         (resolve-ability
-                           {:choices {:req #(and (= (:type %) "ICE") (:advance-counter %))}
+               :yes-ability {:choices {:req #(and (= (:type %) "ICE") (:advance-counter %))}
                             :priority true
                             :effect (req
-                                      (let [fr target]
-                                        (resolve-ability
-                                          state side
-                                          {:priority true
-                                           :prompt "Move to where?"
-                                           :choices {:req #(and (= (:type %) "ICE")
-                                                                (not= (:cid fr) (:cid %))
-                                                                (or (= (:advanceable %) "always")
-                                                                    (and (= (:advanceable %) "while-rezzed")
-                                                                         (:rezzed %))))}
-                                           :effect (effect (add-prop :corp target :advance-counter 1)
-                                                           (add-prop :corp fr :advance-counter -1))} card nil)
-                                        card nil))}
-                           card nil))}}}}
+                                     (let [fr target]
+                                       (resolve-ability
+                                        state side
+                                        {:priority true
+                                         :prompt "Move to where?"
+                                         :choices {:req #(and (= (:type %) "ICE")
+                                                              (not= (:cid fr) (:cid %))
+                                                              (or (= (:advanceable %) "always")
+                                                                  (and (= (:advanceable %) "while-rezzed")
+                                                                       (:rezzed %))))}
+                                         :effect (effect (add-prop :corp target :advance-counter 1)
+                                                         (add-prop :corp fr :advance-counter -1))} card nil)
+                                       card nil))}}}}}
 
    "Contract Killer"
    {:advanceable :always
@@ -158,8 +155,8 @@
               :prompt "Pay 3 [Credits] to use Edge of World ability?"
               :msg (msg "do " (count (get-in corp [:servers :remote (last (:server run)) :ices]))
                         " brain damage")
-              :effect (req (damage state side :brain
-                                   (count (get-in corp [:servers :remote (last (:server run)) :ices])) {:card card}))}}}
+              :yes-ability {:effect (req (damage state side :brain
+                                        (count (get-in corp [:servers :remote (last (:server run)) :ices])) {:card card}))}}}}
 
    "Elizabeth Mills"
    {:effect (effect (lose :bad-publicity 1)) :msg "remove 1 bad publicity"
@@ -209,7 +206,7 @@
     :access {:optional {:req (req installed) :prompt "Use Ghost Branch ability?"
                         :msg (msg "give the Runner " (:advance-counter card) " tag"
                                   (when (> (:advance-counter card) 1) "s"))
-                        :effect (effect (gain :runner :tag (:advance-counter card)))}}}
+                        :yes-ability {:effect (effect (gain :runner :tag (:advance-counter card)))}}}}
 
    "GRNDL Refinery"
    {:advanceable :always
@@ -334,16 +331,14 @@
    "Plan B"
    {:advanceable :always
     :access {:optional
-             {:prompt "Score an Agenda from HQ?" :req (req installed)
-              :effect (effect
-                        (resolve-ability
-                          {:prompt "Choose an Agenda to score"
+             {:prompt "Score an Agenda from HQ?" 
+              :req (req installed)
+              :yes-ability {:prompt "Choose an Agenda to score"
                            :choices (req (filter #(and (has? % :type "Agenda")
                                                        (<= (:advancementcost %) (:advance-counter card)))
                                                  (:hand corp)))
                            :msg (msg "score " (:title target))
-                           :effect (effect (score (assoc target :advance-counter (:advancementcost target))))}
-                          card targets))}}}
+                           :effect (effect (score (assoc target :advance-counter (:advancementcost target))))}}}}
 
    "Primary Transmission Dish"
    {:recurring 3}
@@ -358,7 +353,7 @@
    {:advanceable :always
     :access {:optional {:prompt "Pay 1 [Credits] to use Project Junebug ability?" :cost [:credit 1]
                         :req (req installed) :msg (msg "do " (* 2 (:advance-counter card)) " net damage")
-                        :effect (effect (damage :net (* 2 (:advance-counter card)) {:card card}))}}}
+                        :yes-ability {:effect (effect (damage :net (* 2 (:advance-counter card)) {:card card}))}}}}
 
    "Psychic Field"
    (let [ab {:psi {:req (req installed)
@@ -452,10 +447,10 @@
     :access {:optional
              {:req (req installed) :prompt "Pay 1 [Credits] to use Shattered Remains ability?"
               :cost [:credit 1]
-              :effect (req (let [shat card]
-                             (resolve-ability
-                               state side (assoc (assoc-in trash-hardware [:choices :max] (req (:advance-counter shat)))
-                                            :effect (effect (trash-cards targets))) shat nil)))}}}
+              :yes-ability {:effect (req (let [shat card]
+                                          (resolve-ability
+                                           state side (assoc (assoc-in trash-hardware [:choices :max] (req (:advance-counter shat)))
+                                                        :effect (effect (trash-cards targets))) shat nil)))}}}}
 
    "Shi.Kyū"
    {:access {:req (req (not= (first (:zone card)) :deck))
@@ -479,7 +474,7 @@
    {:access {:optional {:req (req (not= (first (:zone card)) :discard))
                         :prompt "Pay 4 [Credits] to use Snare! ability?" :cost [:credit 4]
                         :msg "do 3 net damage and give the Runner 1 tag"
-                        :effect (effect (damage :net 3 {:card card}) (gain :runner :tag 1))}}}
+                        :yes-ability {:effect (effect (damage :net 3 {:card card}) (gain :runner :tag 1))}}}}
 
    "Space Camp"
    {:access {:msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -12,7 +12,7 @@
     :access {:optional
              {:req (req installed) :prompt "Pay 2 [Credits] to use Aggressive Secretary ability?"
               :cost [:credit 2]
-              :yes-effect {:effect (req (let [agg card]
+              :yes-ability {:effect (req (let [agg card]
                                           (resolve-ability
                                            state side (assoc (assoc-in trash-program [:choices :max] (req (:advance-counter agg)))
                                                         :effect (effect (trash-cards targets))) agg nil)))}}}}

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -286,8 +286,10 @@
 
    "Networking"
    {:effect (effect (lose :tag 1))
-    :optional {:cost [:credit 1] :prompt "Pay 1 [Credits] to add Networking to Grip?"
-               :msg "add it to their Grip" :effect (effect (move (last (:discard runner)) :hand))}}
+    :optional {:cost [:credit 1] 
+               :prompt "Pay 1 [Credits] to add Networking to Grip?"
+               :msg "add it to their Grip" 
+               :yes-ability {:effect  (effect (move (last (:discard runner)) :hand))}}}
 
    "Notoriety"
    {:req (req (and (some #{:hq} (:successful-run runner-reg))

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -71,11 +71,10 @@
              {:optional {:prompt "Play another event?"
                          :req (req (and (first-event state side :play-event)
                                         (not (empty? (filter #(has? % :type "Event") (:hand runner))))))
-                         :effect (effect (resolve-ability
-                                           {:prompt "Choose an Event to play"
-                                            :choices (req (filter #(has? % :type "Event") (:hand runner)))
-                                            :msg (msg "play " (:title target))
-                                            :effect (effect (play-instant target))} card nil))}}}}
+                         :yes-ability {:prompt "Choose an Event to play"
+                                      :choices (req (filter #(has? % :type "Event") (:hand runner)))
+                                      :msg (msg "play " (:title target))
+                                      :effect (effect (play-instant target))}}}}}
 
    "Cortez Chip"
    {:abilities [{:label "increase cost to rez a piece of ice by 2 [Credits]"
@@ -131,9 +130,10 @@
     :events {:successful-run-ends
              {:optional
               {:once :per-turn :prompt "Use Doppelgänger to run again?" :player :runner
-               :effect (effect (resolve-ability {:prompt "Choose a server" :choices (req servers)
-                                                 :msg (msg "to make a run on " target)
-                                                 :effect (effect (run target))} card targets))}}}}
+               :yes-ability {:prompt "Choose a server" 
+                            :choices (req servers)
+                            :msg (msg "to make a run on " target)
+                            :effect (effect (run target))}}}}}
 
    "Dorm Computer"
    {:data {:counter 4}
@@ -283,14 +283,14 @@
 
    "Rabbit Hole"
    {:effect
-                (effect (gain :link 1)
-                        (resolve-ability
-                          {:optional {:req (req (some #(when (= (:title %) "Rabbit Hole") %) (:deck runner)))
-                                      :prompt "Install another Rabbit Hole?" :msg "install another Rabbit Hole"
-                                      :effect (req (when-let [c (some #(when (= (:title %) "Rabbit Hole") %)
+    (effect (gain :link 1)
+            (resolve-ability
+             {:optional {:req (req (some #(when (= (:title %) "Rabbit Hole") %) (:deck runner)))
+                         :prompt "Install another Rabbit Hole?" :msg "install another Rabbit Hole"
+                         :yes-ability {:effect (req (when-let [c (some #(when (= (:title %) "Rabbit Hole") %)
                                                                       (:deck runner))]
                                                      (runner-install state side c)
-                                                     (shuffle! state :runner :deck)))}} card nil))
+                                                     (shuffle! state :runner :deck)))}}} card nil))
     :leave-play (effect (lose :link 1))}
 
    "Replicator"
@@ -298,9 +298,9 @@
              {:optional {:req (req (= (:type target) "Hardware"))
                          :prompt "Use Replicator to add a copy?"
                          :msg (msg "add a copy of " (:title target) " to their Grip")
-                         :effect (effect (move (some #(when (= (:title %) (:title target)) %)
-                                                     (:deck runner)) :hand)
-                                         (shuffle! :deck))}}}}
+                         :yes-ability {:effect (effect (move (some #(when (= (:title %) (:title target)) %)
+                                                                  (:deck runner)) :hand)
+                                                      (shuffle! :deck))}}}}}
 
    "Security Nexus"
    {:effect (effect (gain :link 1) (gain :memory 1))

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -7,8 +7,9 @@
 (def cards-ice
   {"Archangel"
    {:access {:optional
-             {:prompt "Pay 3 [Credits] to force Runner to encounter Archangel?" :cost [:credit 3]
-              :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}}
+             {:prompt "Pay 3 [Credits] to force Runner to encounter Archangel?" 
+              :yes-ability {:cost [:credit 3]
+                           :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}}}
     :abilities [{:label "Trace 6 - Add 1 installed card to the Runner's Grip"
                  :trace {:base 6 :choices {:req #(:installed %)}
                          :msg (msg "add " (:title target) " to the Runner's Grip")
@@ -688,7 +689,7 @@
                 {:msg "look at the top card of R&D"
                  :optional {:prompt (msg "Add " (:title (first (:deck corp))) " to bottom of R&D?")
                             :msg "add the top card of R&D to the bottom"
-                            :effect (effect (move (first (:deck corp)) :deck))}}]}
+                            :yes-ability {:effect (effect (move (first (:deck corp)) :deck))}}}]}
 
    "Zed 1.0"
    {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))}]}})

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -135,7 +135,8 @@
    "Darwin"
    {:events {:runner-turn-begins
              {:optional {:cost [:credit 1] :prompt "Place 1 virus counter on Darwin?"
-                         :msg "place 1 virus counter" :effect (effect (add-prop card :counter 1))}}}
+                         :msg "place 1 virus counter" 
+                         :yes-ability {:effect (effect (add-prop card :counter 1))}}}}
     :abilities [{:cost [:credit 2] :msg "break ICE subroutine"}]}
 
    "Deus X"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -24,7 +24,9 @@
    "Armand \"Geist\" Walker: Tech Lord"
    {:effect (effect (gain :link 1))
     :events {:runner-trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
-                                       :prompt "Draw a card?" :msg (msg "draw a card") :effect (effect (draw 1))}}}}
+                                       :prompt "Draw a card?" 
+                                       :msg (msg "drew a card") 
+                                       :yes-ability {:effect (effect (draw 1))}}}}}
 
    "Blue Sun: Powering the Future"
    {:abilities [{:choices {:req #(:rezzed %)}
@@ -88,13 +90,13 @@
              {:optional {:prompt (msg "Install another " (:type target) " from Grip?")
                          :req (req (and (first-event state side :runner-install) ;; If this is the first installation of the turn
                                         (some #(= (:type  %) (:type target)) (:hand runner)))) ;; and there are additional cards of that type in hand
-                         :effect (req (let [type (:type target)]
-                                        (resolve-ability
-                                          state side
-                                          {:prompt (msg "Choose a " type " to install")
-                                           :choices (req (filter #(has? % :type type) (:hand runner)))
-                                           :msg (msg "install " (:title target))
-                                           :effect (effect (runner-install target))} card nil)))}}}}
+                         :yes-ability {:effect (req (let [type (:type target)]
+                                              (resolve-ability
+                                               state side
+                                               {:prompt (msg "Choose a " type " to install")
+                                                :choices (req (filter #(has? % :type type) (:hand runner)))
+                                                :msg (msg "install " (:title target))
+                                                :effect (effect (runner-install target))} card nil)))}}}}}
 
    "Iain Stirling: Retired Spook"
    {:effect (effect (gain :link 1))
@@ -159,7 +161,7 @@
                                                          (filter #(not (= % :remote)) successes))))))
                               :optional {:prompt "Force the Corp to draw 1 card?"
                                          :msg "force the Corp to draw 1 card"
-                                         :effect (effect (draw :corp))}}}}
+                                         :yes-ability {:effect (effect (draw :corp))}}}}}
 
    "Leela Patel: Trained Pragmatist"
    {:events {:agenda-scored {:choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :msg "add 1 unrezzed card to HQ"
@@ -242,8 +244,9 @@
                                     (filter #(has? % :type "ICE") rezzed-this-turn))))) ;; Is this the first ice you've rezzed this turn
            :optional
                 {:prompt "Add another copy to HQ?"
-                 :effect (effect (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand)
-                                 (shuffle! :deck))
+                 :yes-ability {:effect
+                              (effect (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand)
+                                      (shuffle! :deck))}
                  :msg (msg "add a copy of " (:title target) " from R&D to HQ")}}}}
 
    "Titan Transnational: Investing In Your Future"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -402,7 +402,7 @@
    {:abilities [{:once :per-run :req (req current-ice) :msg (msg "expose " (:title current-ice))
                  :effect (effect (expose current-ice)
                                  (resolve-ability {:optional {:prompt "Jack out?" :msg "jack out"
-                                                              :effect (effect (jack-out nil))}}
+                                                              :yes-ability {:effect (effect (jack-out nil))}}}
                                                   card nil))}]}
    "Trope"
    {:events {:runner-turn-begins {:effect (effect (add-prop card :counter 1))}}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -621,7 +621,7 @@
               :optional {:prompt (msg "Draw " (:title (first (:deck corp))) "?")
                          :msg (msg "draw " (:title (first (:deck corp))))
                          :yes-ability {:effect :player :corp (effect (draw))}
-                         :no-effect {:effect (effect (system-msg "doesn't draw with Woman in the Red Dress"))}}}}}
+                         :no-ability {:effect (effect (system-msg "doesn't draw with Woman in the Red Dress"))}}}}}
 
    "Wyldside"
    {:events {:runner-turn-begins {:msg "draw 2 cards and lose [Click]"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -32,7 +32,7 @@
                  :effect (req (when (zero? (:counter card)) (trash state :runner card)))
                  :optional {:prompt (msg "Add " (:title (first (:deck runner))) " to bottom of Stack?")
                             :msg "add the top card of Stack to the bottom"
-                            :effect (req (move state side (first (:deck runner)) :deck))}}]}
+                            :yes-ability {:effect (req (move state side (first (:deck runner)) :deck))}}}]}
 
    "Armitage Codebusting"
    {:data {:counter 12}
@@ -169,9 +169,9 @@
    {:req (req (> (:link runner) 1))
     :events {:runner-turn-begins
              {:optional {:prompt "Use Globalsec Security Clearance to lose [Click]?" :msg "lose [Click]"
-                         :effect (effect (lose :click 1)
-                                         (prompt! card (str "The top card of R&D is "
-                                         (:title (first (:deck corp)))) ["OK"] {}))}}}}
+                         :yes-ability {:effect (effect (lose :click 1)
+                                                      (prompt! card (str "The top card of R&D is "
+                                                                         (:title (first (:deck corp)))) ["OK"] {}))}}}}}
 
    "Grifter"
    {:events {:runner-turn-ends
@@ -237,7 +237,7 @@
    "Joshua B."
    {:events {:runner-turn-begins
              {:optional {:prompt "Use Joshua B. to gain [Click]?" :msg "gain [Click]"
-                         :effect (effect (gain :click 1))
+                         :yes-ability {:effect (effect (gain :click 1))}
                          :end-turn {:effect (effect (gain :tag 1)) :msg "gain 1 tag"}}}}}
 
    "Kati Jones"
@@ -349,22 +349,22 @@
    (let [pphelper (fn [card cards]
                     (let [num (count cards)]
                       {:optional {:req (req (> num 0))
-                       :prompt (str "Use Paige Piper to trash copies of " (:title card) "?")
-                       :choices {:number (req num)}
-                       :msg "to shuffle their Stack"
-                       :effect (req (doseq [c (take (int target) cards)]
-                                      (trash state side c))
-                                    (shuffle! state :runner :deck)
-                                    (when (> (int target) 0)
-                                      (system-msg state side (str "trashes " (int target)
-                                                                  " cop" (if (> (int target) 1) "ies" "y")
-                                                                  " of " (:title card)))))}}))]
-    {:events {:runner-install {:req (req (first-event state side :runner-install))
-                               :effect (effect (resolve-ability
-                                                (pphelper target (->> (:deck runner)
-                                                                      (filter #(has? % :title (:title target)))
-                                                                      (vec)))
-                                                card nil))}}})
+                                  :prompt (str "Use Paige Piper to trash copies of " (:title card) "?")
+                                  :choices {:number (req num)}
+                                  :msg "to shuffle their Stack"
+                                  :yes-ability {:effect (req (doseq [c (take (int target) cards)]
+                                                              (trash state side c))
+                                                            (shuffle! state :runner :deck)
+                                                            (when (> (int target) 0)
+                                                              (system-msg state side (str "trashes " (int target)
+                                                                                          " cop" (if (> (int target) 1) "ies" "y")
+                                                                                          " of " (:title card)))))}}}))]
+     {:events {:runner-install {:req (req (first-event state side :runner-install))
+                                :effect (effect (resolve-ability
+                                                 (pphelper target (->> (:deck runner)
+                                                                       (filter #(has? % :title (:title target)))
+                                                                       (vec)))
+                                                 card nil))}}})
 
    "Paparazzi"
    {:effect (req (swap! state update-in [:runner :tagged] inc))
@@ -620,8 +620,8 @@
              {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")
               :optional {:prompt (msg "Draw " (:title (first (:deck corp))) "?")
                          :msg (msg "draw " (:title (first (:deck corp))))
-                         :no-effect {:effect (effect (system-msg "doesn't draw with Woman in the Red Dress"))}
-                         :player :corp :effect (effect (draw))}}}}
+                         :yes-ability {:effect :player :corp (effect (draw))}
+                         :no-effect {:effect (effect (system-msg "doesn't draw with Woman in the Red Dress"))}}}}}
 
    "Wyldside"
    {:events {:runner-turn-begins {:msg "draw 2 cards and lose [Click]"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -11,7 +11,7 @@
      {:corp-install  {:optional {:req (req (and (= (:type target) "ICE")
                                                 (= (card->server state card) (card->server state target))))
                                  :prompt "Rez ICE with rez cost lowered by 3?"
-                                 :effect (effect (rez-cost-bonus -3) (rez target))}}}}
+                                 :yes-ability {:effect (effect (rez-cost-bonus -3) (rez target))}}}}}
 
    "Ash 2X3ZB9CY"
    {:abilities [{:label "Trace 4 - Prevent the Runner from accessing cards other than Ash 2X3ZB9CY"
@@ -74,7 +74,8 @@
 
    "Cyberdex Virus Suite"
    {:access {:optional {:prompt "Purge viruses with Cyberdex Virus Suite?"
-                        :msg (msg "purge viruses") :effect (effect (purge))}}
+                        :msg (msg "purge viruses") 
+                        :yes-ability {:effect (effect (purge))}}}
     :abilities [{:msg "purge viruses" :effect (effect (purge) (trash card))}]}
 
    "Dedicated Technician Team"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -252,7 +252,8 @@
 
 (defn optional-ability [state side card msg ability targets]
   (show-prompt state side card msg ["Yes" "No"] #(if (= % "Yes")
-                                                   (resolve-ability state side ability card targets)
+                                                   (when-let [yes-ability (:yes-ability ability)]
+                                                     (resolve-ability state side yes-ability card targets))
                                                    (when-let [no-ability (:no-effect ability)]
                                                      (resolve-ability state side no-ability card targets)))))
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -258,7 +258,7 @@
   (show-prompt state side card msg ["Yes" "No"] #(if (= % "Yes")
                                                    (when-let [yes-ability (:yes-ability ability)]
                                                      (resolve-ability state side yes-ability card targets))
-                                                   (when-let [no-ability (:no-effect ability)]
+                                                   (when-let [no-ability (:no-ability ability)]
                                                      (resolve-ability state side no-ability card targets)))))
 
 (defn resolve-trace [state side boost]
@@ -852,10 +852,10 @@
                   (if (pos? (count cost))
                     (optional-ability state :runner c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
                                       {:cost cost
-                                       :effect (effect (system-msg (str "pays " (costs-to-symbol cost)
-                                                                        " to steal " (:title c)))
-                                                       (resolve-steal c))
-                                       :no-effect {:effect (effect (resolve-steal-events c))}} nil)
+                                       :yes-ability {:effect (effect (system-msg (str "pays " (costs-to-symbol cost)
+                                                                                      " to steal " (:title c)))
+                                                                     (resolve-steal c))}
+                                       :no-ability {:effect (effect (resolve-steal-events c))}} nil)
                     (resolve-ability state :runner
                                      {:prompt (str "You access " (:title c)) :choices ["Steal"]
                                       :effect (req (resolve-steal state :runner c))} c nil)))


### PR DESCRIPTION
As in the titile, I fixed nested prompts not firing after the Yes/No prompt from an `:optional` ability.

This creates a new structure for the `:optional` maps that should be:

```
"Card Name"
{:events {:runner-install {:optional
    :prompt "Yes or no?"
    :yes-ability {:effect (req ...)}
    :no-ability {:effect (req ...)
}}}
```

I also went through and changed this for all cards that use optionals.

Cards affected:
Agendas:
Accelerated Beta Test
Hades Fragment
Explode-a-palooza
Posted Bounty

Assets:
Aggressive Secretary
Cerebral Overwriter
Constellation Protocol
Edge of World
Ghost Branch
Plan B
Project Junebug
Shattered Remains
Snare!

Events:
Networking

Hardware:
Comet
Doppleganger
Rabbit Hole
Replicator

ICE:
Archangel
Yagura

Icebreakers
Darwin

Identities:
Geist
Hayley Kaplan
Fisk
Titan Transitional

Programs:
Snitch

Resources:
Angel Arena
Globalsec Security Clearance
Joshua B.
Paige Piper
Woman in the Red Dress

Upgrades:
Amazon Industrial Zone
Cyberdex Virus Suite

Fixes #610 and hopefully a lot of other ones as well.