### PR TITLE
improve Bad Times, fully implement Improved Tracers

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -191,7 +191,9 @@
    "Improved Tracers"
    {:effect (req (update-all-ice state side))
     :events {:pre-ice-strength {:req (req (has? target :subtype "Tracer"))
-                                :effect (effect (ice-strength-bonus 1))}}}
+                                :effect (effect (ice-strength-bonus 1))}
+             :pre-init-trace {:req (req (has? target :type "ICE"))
+                              :effect (effect (init-trace-bonus 1))}}}
 
    "Labyrinthine Servers"
    {:data {:counter 2}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -27,7 +27,13 @@
               (* 3 (:advance-counter target)) " [Credits]")}
 
    "Bad Times"
-   {:req (req tagged)}
+   {:req (req tagged)
+    :msg "force the Runner to lose 2[mu] until the end of the turn"
+    :effect (req (lose state :runner :memory 2)
+                 (when (< (:memory runner) 0)
+                  (system-msg state :runner "must trash programs to free up [mu]")))
+    :end-turn {:effect (req (gain state :runner :memory 2)
+                            (system-msg state :runner "regains 2[mu]"))}}
 
    "Beanstalk Royalties"
    {:effect (effect (gain :credit 3))}


### PR DESCRIPTION
Bad Times does the temporary MU loss to the Runner and uses a message to remind them to trash programs if they dip below 0 MU. 

Improved Tracers is now 100% complete thanks to the `init-trace-bonus` feature done by @queueseven! 