### PR TITLE
Fix trash and steal cost not being correctly applied.

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -851,8 +851,8 @@
                 (let [cost (steal-cost state side c)]
                   (if (pos? (count cost))
                     (optional-ability state :runner c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
-                                      {:cost cost
-                                       :yes-ability {:effect (effect (system-msg (str "pays " (costs-to-symbol cost)
+                                      {:yes-ability {:cost cost
+                                                     :effect (effect (system-msg (str "pays " (costs-to-symbol cost)
                                                                                       " to steal " (:title c)))
                                                                      (resolve-steal c))}
                                        :no-ability {:effect (effect (resolve-steal-events c))}} nil)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -851,11 +851,7 @@
                 (let [cost (steal-cost state side c)]
                   (if (pos? (count cost))
                     (optional-ability state :runner c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
-<<<<<<< HEAD
                                       {:yes-ability {:cost cost
-=======
-                                      {:yes-ability {:cost
->>>>>>> 8db3e973dc5876dbdad2587afb20b1bdc239a6e5
                                                      :effect (effect (system-msg (str "pays " (costs-to-symbol cost)
                                                                                       " to steal " (:title c)))
                                                                      (resolve-steal c))}


### PR DESCRIPTION
I missed these flags in the agenda scoring/stealing process because of the lack of an `:optional` key. Trashing and steal costs should work now.