### PR TITLE
Don't show trash prevention prompts when inappropriate

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -46,7 +46,7 @@
                             :effect (effect (rez-cost-bonus (- (:counter (get-card state card)))))}}}
 
    "Breaking News"
-   {:effect (effect (gain :runner :tag 2)) :msg "give the Runner 2 tags"
+   {:effect (effect (tag-runner :runner 2)) :msg "give the Runner 2 tags"
     :end-turn {:effect (effect (lose :runner :tag 2)) :msg "make the Runner lose 2 tags"}}
 
    "Character Assassination"
@@ -252,7 +252,7 @@
    "Posted Bounty"
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
                :msg "give the Runner 1 tag and take 1 bad publicity"
-               :yes-ability {:effect (effect (gain :bad-publicity 1) (gain :runner :tag 1) (forfeit card))}}}
+               :yes-ability {:effect (effect (gain :bad-publicity 1) (tag-runner :runner 1) (forfeit card))}}}
 
    "Priority Requisition"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))}
@@ -305,7 +305,7 @@
 
    "Restructured Datapool"
    {:abilities [{:cost [:click 1]
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
 
    "Self-Destruct Chips"
    {:effect (effect (lose :runner :max-hand-size 1))}
@@ -330,7 +330,7 @@
                                 :effect (effect (ice-strength-bonus 1))}}}
 
    "TGTBT"
-   {:access {:msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+   {:access {:msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
 
    "The Cleaners"
    {:events {:pre-damage {:req (req (= target :meat)) :msg "do 1 additional meat damage"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -61,7 +61,7 @@
              {:prompt "Pay 1 [Credits] or take 1 tag" :choices ["Pay 1 [Credits]" "Take 1 tag"]
               :player :runner :msg "make the Runner pay 1 [Credits] or take 1 tag"
               :effect (req (if-not (and (= target "Pay 1 [Credits]") (pay state side card :credit 1))
-                             (do (gain state side :tag 1) (system-msg state side "takes 1 tag"))
+                             (do (tag-runner state side 1) (system-msg state side "takes 1 tag"))
                              (system-msg state side "pays 1 [Credits]")))}}}
 
    "Constellation Protocol"
@@ -206,7 +206,7 @@
     :access {:optional {:req (req installed) :prompt "Use Ghost Branch ability?"
                         :msg (msg "give the Runner " (:advance-counter card) " tag"
                                   (when (> (:advance-counter card) 1) "s"))
-                        :yes-ability {:effect (effect (gain :runner :tag (:advance-counter card)))}}}}
+                        :yes-ability {:effect (effect (tag-runner :runner (:advance-counter card)))}}}}
 
    "GRNDL Refinery"
    {:advanceable :always
@@ -350,7 +350,7 @@
                                 :effect (req (if (= target "add News Team to score area")
                                                  (do (gain state :runner :agenda-point -1)
                                                      (move state :runner card :scored nil))
-                                                 (gain :runner :tag 2)))}
+                                                 (tag-runner :runner 2)))}
                                card targets))}}
 
    "PAD Campaign"
@@ -501,7 +501,7 @@
    {:access {:optional {:req (req (not= (first (:zone card)) :discard))
                         :prompt "Pay 4 [Credits] to use Snare! ability?" :cost [:credit 4]
                         :msg "do 3 net damage and give the Runner 1 tag"
-                        :yes-ability {:effect (effect (damage :net 3 {:card card}) (gain :runner :tag 1))}}}}
+                        :yes-ability {:effect (effect (damage :net 3 {:card card}) (tag-runner :runner 1))}}}}
 
    "Space Camp"
    {:access {:msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -7,7 +7,8 @@
                               {:msg (msg "force the Corp to lose " (min 5 (:credit corp))
                                          " [Credits], gain " (* 2 (min 5 (:credit corp)))
                                          " [Credits] and take 2 tags")
-                               :effect (effect (gain :tag 2 :credit (* 2 (min 5 (:credit corp))))
+                               :effect (effect (tag-runner 2)
+                                               (gain :ru:credit (* 2 (min 5 (:credit corp))))
                                                (lose :corp :credit (min 5 (:credit corp))))}} card))}
 
    "Amped Up"
@@ -53,7 +54,7 @@
                            :msg (msg "install " (:title target) " and take 1 tag")
                            :choices (req (filter #(has? % :type "Program") (:deck runner)))
                            :effect (effect (install-cost-bonus [:credit (* -3 (count (get-in corp [:servers :rd :ices])))])
-                                           (runner-install target) (gain :tag 1) (shuffle! :deck))}} card))}
+                                           (runner-install target) (tag-runner 1) (shuffle! :deck))}} card))}
 
    "Day Job"
    {:additional-cost [:click 3] :effect (effect (gain :credit 10))}

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -138,9 +138,15 @@
    "Dorm Computer"
    {:data {:counter 4}
     :abilities [{:counter-cost 1 :cost [:click 1]
+                 :req (req (not run))
                  :prompt "Choose a server" :choices (req servers)
                  :msg "make a run and avoid all tags for the remainder of the run"
-                 :effect (effect (run target))}]}
+                 :effect (effect (update! (assoc card :dorm-active true))
+                                 (run target))}]
+    :events {:pre-tag {:req (req (:dorm-active card))
+                       :effect (effect (tag-prevent Integer/MAX_VALUE))
+                       :msg "avoid all tags during the run"}
+             :run-ends {:effect (effect (update! (dissoc card :dorm-active)))}}}
 
    "Dyson Fractal Generator"
    {:recurring 1}
@@ -166,8 +172,11 @@
                                                                (damage-prevent :brain 2)) }]}
 
    "Forger"
-   {:effect (effect (gain :link 1)) :leave-play (effect (lose :link 1))
-    :abilities [{:msg "remove 1 tag"
+   {:prevent {:tag [:all]}
+    :effect (effect (gain :link 1)) :leave-play (effect (lose :link 1))
+    :abilities [{:msg "avoid 1 tag" :label "[Trash]: Avoid 1 tag"
+                 :effect (effect (tag-prevent 1) (trash card {:cause :ability-cost}))}
+                {:msg "remove 1 tag" :label "[Trash]: Remove 1 tag"
                  :effect (effect (trash card {:cause :ability-cost}) (lose :tag 1))}]}
 
    "Grimoire"
@@ -278,6 +287,17 @@
                      :effect (effect (trash card))}]
               {:runner-trash e :corp-trash e})}
 
+   "Qianju PT"
+   {:events {:runner-turn-begins
+             {:optional {:prompt "Lose [Click] to avoid the first tag until next turn?"
+                         :yes-ability {:effect (effect (lose :click 1)
+                                                       (update! (assoc card :qianju-active true)))
+                                       :msg "avoid the first tag received until his/her next turn"}
+                         :no-ability {:effect (effect (update! (dissoc card :qianju-active)))}}}
+             :pre-tag {:req (req (:qianju-active card))
+                       :msg "to avoid the first tag received"
+                       :effect (effect (tag-prevent 1) (update! (dissoc card :qianju-active)))}}}
+
    "R&D Interface"
    {:effect (effect (gain :rd-access 1)) :leave-play (effect (lose :rd-access 1))}
 
@@ -309,7 +329,7 @@
                  :msg "force the Corp to initiate a trace"
                  :label "Trace 5 - Give the Runner 1 tag and end the run"
                  :trace {:once :per-turn :base 5 :msg "give the Runner 1 tag and end the run"
-                         :effect (effect (gain :runner :tag 1) (end-run))
+                         :effect (effect (tag-runner :runner 1) (end-run))
                          :unsuccessful {:msg "bypass the current ICE"}}}]}
 
    "Silencer"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -264,7 +264,7 @@
     :prevent {:damage [:meat]}
     :abilities [{:counter-cost 1 :msg "prevent 1 meat damage"
                  :effect (req (damage-prevent state side :meat 1)
-                              (when (= (:counter card) 0) (trash state side card)))}]}
+                              (when (= (:counter card) 0) (trash state side card {:unpreventable true})))}]}
 
    "Prepaid VoicePAD"
    {:recurring 1}

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -46,7 +46,7 @@
     :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
 
    "Bandwidth"
-   {:abilities [{:msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}]}
+   {:abilities [{:msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}]}
 
    "Bastion"
    {:abilities [end-the-run]}
@@ -151,9 +151,9 @@
                 end-the-run]}
 
    "Data Raven"
-   {:abilities [{:msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}
+   {:abilities [{:msg "give the Runner 1 tag" :effect (effect (tag-runner 1))}
                 {:msg "give the Runner 1 tag using 1 power counter"
-                 :counter-cost 1 :effect (effect (gain :runner :tag 1))}
+                 :counter-cost 1 :effect (effect (tag-runner 1))}
                 {:label "Trace 3 - Add 1 power counter"
                  :trace {:base 3 :msg "add 1 power counter" :effect (effect (add-prop card :counter 1))}}]}
 
@@ -163,7 +163,7 @@
     :strength-bonus (req (or (:counter card) 0))
     :abilities [{:label "Trace 2"
                  :trace {:base 2 :msg "give the Runner 1 tag and end the run"
-                         :effect (effect (gain :runner :tag 1) (end-run))}}]}
+                         :effect (effect (tag-runner :runner 1) (end-run))}}]}
 
    "Eli 1.0"
    {:abilities [end-the-run]}
@@ -238,7 +238,7 @@
 
    "Gutenberg"
    {:abilities [{:label "Trace 7 - Give the Runner 1 tag"
-                 :trace {:base 7 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]
+                 :trace {:base 7 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]
     :strength-bonus (req (if (= (second (:zone card)) :rd) 3 0))}
 
    "Hadrians Wall"
@@ -296,7 +296,7 @@
 
    "Hunter"
    {:abilities [{:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
 
    "Ice Wall"
    {:advanceable :always :abilities [end-the-run]
@@ -306,13 +306,13 @@
    {:abilities [trash-program
                 {:label "Trace 1 - Give the Runner 1 tag and do 1 brain damage"
                  :trace {:base 1 :msg "give the Runner 1 tag and do 1 brain damage"
-                         :effect (effect (damage :brain 1 {:card card}) (gain :runner :tag 1))}}]}
+                         :effect (effect (damage :brain 1 {:card card}) (tag-runner :runner 1))}}]}
 
    "Ichi 2.0"
    {:abilities [trash-program
                 {:label "Trace 3 - Give the Runner 1 tag and do 1 brain damage"
                  :trace {:base 3 :msg "give the Runner 1 tag and do 1 brain damage"
-                         :effect (effect (damage :brain 1 {:card card}) (gain :runner :tag 1))}}]}
+                         :effect (effect (damage :brain 1 {:card card}) (tag-runner :runner 1))}}]}
 
    "IQ"
    {:abilities [end-the-run]
@@ -321,7 +321,7 @@
 
    "Information Overload"
    {:abilities [{:label "Trace 1 - Give the Runner 1 tag"
-                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
                 trash-installed]}
 
    "Ireress"
@@ -393,7 +393,7 @@
                  :choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
                  :cost [:credit 1] :effect (effect (add-prop target :advance-counter 1))}
                 {:label "Trace 2 - Give the Runner 1 tag"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
 
    "Merlin"
    {:abilities [{:label "Do 2 net damage" :msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}
@@ -432,11 +432,11 @@
    "Muckraker"
    {:effect (effect (gain :bad-publicity 1))
     :abilities [{:label "Trace 1 - Give the Runner 1 tag"
-                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
                 {:label "Trace 2 - Give the Runner 1 tag"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
                 {:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
                 {:msg "end the run if the Runner is tagged" :req (req tagged)
                  :effect (effect (end-run))}]}
 
@@ -453,7 +453,7 @@
 
    "News Hound"
    {:abilities [{:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
                 {:label "End the run if a Current is active"
                  :req (req (or (not (empty? (runner :current)))
                                (not (empty? (corp :current))))) 
@@ -531,19 +531,19 @@
    "Salvage"
    {:advanceable :while-rezzed
     :abilities [{:label "Trace 2 - Give the Runner 1 tag"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
 
    "Searchlight"
    {:advanceable :always
     :abilities [{:label "Trace X - Give the runner 1 tag"
-                 :trace {:base (req (or (:advance-counter card) 0)) :effect (effect (gain :runner :tag 1))
+                 :trace {:base (req (or (:advance-counter card) 0)) :effect (effect (tag-runner :runner 1))
                          :msg "give the Runner 1 tag"}}]}
 
    "Shadow"
    {:advanceable :always
     :abilities [{:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))}
                 {:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]
+                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]
     :strength-bonus (req (or (:advance-counter card) 0))}
 
    "Sherlock 1.0"
@@ -644,7 +644,7 @@
    {:abilities [{:msg "force the Runner to lose 1 [Credits]"
                  :effect (effect (lose :runner :credit 1))}
                 {:label "Trace 5 - Give the Runner 1 tag"
-                 :trace {:base 5 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}]}
+                 :trace {:base 5 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
 
    "Tyrant"
    {:advanceable :while-rezzed :abilities [end-the-run]}
@@ -681,9 +681,9 @@
 
    "Virgo"
    {:abilities [{:label "Trace 2"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))
+                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))
                          :kicker {:min 5 :msg "give the Runner 1 tag"
-                                  :effect (effect (gain :runner :tag 1))}}}]}
+                                  :effect (effect (tag-runner :runner 1))}}}]}
 
    "Wall of Static"
    {:abilities [end-the-run]}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -26,7 +26,7 @@
               :choices ["1 tag" "2 meat damage"] :player :runner
               :msg "make the Runner take 1 tag or suffer 2 meat damage"
               :effect (req (if (= target "1 tag")
-                             (do (gain state :runner :tag 1) (system-msg state side "takes 1 tag"))
+                             (do (tag-runner state :runner 1) (system-msg state side "takes 1 tag"))
                              (do (damage state :runner :meat 2 {:unboostable true :card card})
                                  (system-msg state side "suffers 2 meat damage"))))}}}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -39,7 +39,7 @@
    {:effect (effect (gain :credit 3))}
 
    "Big Brother"
-   {:req (req tagged) :effect (effect (gain :runner :tag 2))}
+   {:req (req tagged) :effect (effect (tag-runner :runner 2))}
 
    "Bioroid Efficiency Research"
    {:choices {:req #(and (= (:type %) "ICE") (has? % :subtype "Bioroid") (not (:rezzed %)))}
@@ -71,7 +71,7 @@
                                                             (str "hosts Casting Call on " (:title agenda)))))}
                      card nil)))
     :events {:access {:req (req (= (:cid target) (:cid (:host card))))
-                      :effect (effect (gain :runner :tag 2)) :msg "give the Runner 2 tags"}}}
+                      :effect (effect (tag-runner :runner 2)) :msg "give the Runner 2 tags"}}}
 
    "Celebrity Gift"
    {:choices {:max 5 :req #(and (:side % "Corp") (= (:zone %) [:hand]))}
@@ -82,7 +82,7 @@
    {:psi {:not-equal {:player :runner :prompt "Take 1 tag or 1 brain damage?"
                       :choices ["1 tag" "1 brain damage"] :msg (msg "The Runner takes " target)
                       :effect (req (if (= target "1 tag")
-                                     (gain state side :tag 1)
+                                     (tag-runner state side 1)
                                      (damage state side :brain 1 {:card card})))}}}
 
    "Cerebral Static"
@@ -170,7 +170,7 @@
    "Manhunt"
    {:events {:successful-run {:req (req (first-event state side :successful-run))
                               :trace {:base 2 :msg "give the Runner 1 tag"
-                                      :effect (effect (gain :runner :tag 1))}}}}
+                                      :effect (effect (tag-runner :runner 1))}}}}
 
    "Medical Research Fundraiser"
    {:effect (effect (gain :credit 8) (gain :runner :credit 3))}
@@ -178,7 +178,7 @@
    "Midseason Replacements"
    {:req (req (:stole-agenda runner-reg))
     :trace {:base 6 :msg (msg "give the Runner " (- target (second targets)) " tags")
-            :effect (effect (gain :runner :tag (- target (second targets))))}}
+            :effect (effect (tag-runner :runner (- target (second targets))))}}
 
    "Mushin No Shin"
    {:prompt "Choose a card to install"
@@ -302,7 +302,7 @@
 
    "SEA Source"
    {:req (req (:successful-run runner-reg))
-    :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (gain :runner :tag 1))}}
+    :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
 
    "Shipment from Kaguya"
    {:choices {:max 2 :req #(or (= (:advanceable %) "always")
@@ -343,7 +343,7 @@
                                                 (if (= target "Yes")
                                                   {:msg (msg "take 1 tag to prevent " (:title c)
                                                              " from being trashed")
-                                                   :effect (effect (gain :runner :tag 1))}
+                                                   :effect (effect (tag-runner :runner 1))}
                                                   {:effect (trash state side c) :msg (msg "trash " (:title c))})
                                                 card nil))}
                              card nil)))}}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -37,7 +37,7 @@
    {:prompt "How many power counters?" :choices :credit :msg (msg "add " target " power counters")
     :effect (effect (set-prop card :counter target))
     :abilities [{:counter-cost 1 :msg "look at the top card of Stack"
-                 :effect (req (when (zero? (:counter card)) (trash state :runner card {:unpreventable true}))
+                 :effect (req (when (zero? (:counter card)) (trash state :runner card {:unpreventable true})))
                  :optional {:prompt (msg "Add " (:title (first (:deck runner))) " to bottom of Stack?")
                             :msg "add the top card of Stack to the bottom"
                             :yes-ability {:effect (req (move state side (first (:deck runner)) :deck))}}}]}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -37,7 +37,7 @@
    {:prompt "How many power counters?" :choices :credit :msg (msg "add " target " power counters")
     :effect (effect (set-prop card :counter target))
     :abilities [{:counter-cost 1 :msg "look at the top card of Stack"
-                 :effect (req (when (zero? (:counter card)) (trash state :runner card)))
+                 :effect (req (when (zero? (:counter card)) (trash state :runner card {:unpreventable true}))
                  :optional {:prompt (msg "Add " (:title (first (:deck runner))) " to bottom of Stack?")
                             :msg "add the top card of Stack to the bottom"
                             :yes-ability {:effect (req (move state side (first (:deck runner)) :deck))}}}]}
@@ -46,14 +46,14 @@
    {:data {:counter 12}
     :abilities [{:cost [:click 1] :counter-cost 2 :msg "gain 2 [Credits]"
                  :effect (req (gain state :runner :credit 2)
-                              (when (zero? (:counter card)) (trash state :runner card)))}]}
+                              (when (zero? (:counter card)) (trash state :runner card {:unpreventable true})))}]}
 
    "Bank Job"
    {:data {:counter 8}
     :abilities [{:label "Take any number of [Credits] on Bank Job"
                  :prompt "How many [Credits]?" :choices :counter :msg (msg "gain " target " [Credits]")
                  :effect (req (gain state side :credit target)
-                              (when (= target (:counter card)) (trash state :runner card)))}]}
+                              (when (= target (:counter card)) (trash state :runner card {:unpreventable true})))}]}
 
    "Beach Party"
    {:effect (effect (gain :max-hand-size 5)) :leave-play (effect (lose :max-hand-size 5))
@@ -84,7 +84,8 @@
    {:data {:counter 8}
     :events {:runner-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
                                   :effect (req (gain state :runner :credit 2)
-                                               (when (zero? (:counter card)) (trash state :runner card)))}}}
+                                               (when (zero? (:counter card)) (trash state :runner card
+                                                                                    {:unpreventable true})))}}}
 
    "Data Dealer"
    {:abilities [{:cost [:click 1 :forfeit] :effect (effect (gain :credit 9))
@@ -114,7 +115,7 @@
     :events {:runner-turn-begins {:msg "draw 2 cards" :counter-cost 1
                                   :effect (req (draw state :runner 2)
                                                (when (zero? (:counter card))
-                                                 (trash state :runner card)))}}}
+                                                 (trash state :runner card {:unpreventable true})))}}}
 
    "Eden Shard"
    {:abilities [{:effect (effect (trash card {:cause :ability-cost}) (draw :corp 2))
@@ -171,7 +172,7 @@
    {:data {:counter 3}
     :abilities [{:counter-cost 1 :msg "gain 1 [Credits]" :req (req (:run @state))
                  :effect (req (gain state side :credit 1)
-                              (when (zero? (:counter card)) (trash state :runner card)))}]}
+                              (when (zero? (:counter card)) (trash state :runner card {:unpreventable true})))}]}
 
    "Globalsec Security Clearance"
    {:req (req (> (:link runner) 1))
@@ -260,7 +261,7 @@
    {:data {:counter 16}
     :abilities [{:cost [:click 1] :counter-cost 4 :msg "gain 4 [Credits]"
                  :effect (req (gain state :runner :credit 4)
-                              (when (= (:counter card) 0) (trash state :runner card)))}]}
+                              (when (= (:counter card) 0) (trash state :runner card {:unpreventable true})))}]}
 
    "London Library"
    {:abilities [{:label "Install a non-virus program on London Library" :cost [:click 1]

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -8,7 +8,7 @@
    {:events
     {:corp-turn-begins {:req (req (not tagged)) 
                         :msg "take 1 tag" 
-                        :effect (effect (gain :runner :tag 1))}
+                        :effect (effect (tag-runner :runner 1))}
      :runner-turn-begins {:req (req (zero? (:bad-publicity corp))) 
                           :msg "give the Corp 1 bad publicity"
                           :effect (effect (gain :corp :bad-publicity 1))}}}
@@ -101,7 +101,8 @@
                  :msg "force the Corp to trash the top card of R&D"}]}
 
    "Decoy"
-   {:abilities [{:msg "avoid 1 tag" :effect (effect (trash card {:cause :ability-cost}))}]}
+   {:prevent {:tag [:all]}
+    :abilities [{:msg "avoid 1 tag" :effect (effect (tag-prevent 1) (trash card {:cause :ability-cost}))}]}
 
    "Drug Dealer"
    {:events {:corp-turn-begins {:msg "draw 1 card" :effect (effect (draw :runner 1))}
@@ -241,13 +242,13 @@
                               :effect (effect (draw))}
              :unsuccessful-run {:req (req (first-event state side :unsuccessful-run))
                                 :msg "take 1 tag" :once-key :john-masanori-tag
-                                :effect (effect (gain :runner :tag 1))}}}
+                                :effect (effect (tag-runner :runner 1))}}}
 
    "Joshua B."
    {:events {:runner-turn-begins
              {:optional {:prompt "Use Joshua B. to gain [Click]?" :msg "gain [Click]"
                          :yes-ability {:effect (effect (gain :click 1))}
-                         :end-turn {:effect (effect (gain :tag 1)) :msg "gain 1 tag"}}}}}
+                         :end-turn {:effect (effect (tag-runner 1)) :msg "gain 1 tag"}}}}}
 
    "Kati Jones"
    {:abilities
@@ -319,8 +320,9 @@
                          :effect (req (swap! state assoc-in [:runner :register :force-trash] true))}}}
 
    "New Angeles City Hall"
-   {:events {:agenda-stolen {:msg "trash itself" :effect (effect (trash card))}}
-    :abilities [{:cost [:credit 2] :msg "avoid 1 tag" :effect (effect (lose :tag 1))}]}
+   {:prevent {:tag [:all]}
+    :events {:agenda-stolen {:msg "trash itself" :effect (effect (trash card))}}
+    :abilities [{:cost [:credit 2] :msg "avoid 1 tag" :effect (effect (tag-prevent 1))}]}
 
    "Off-Campus Apartment"
    {:abilities [{:label "Install and host a connection on Off-Campus Apartment"
@@ -544,7 +546,7 @@
                  :effect (effect (trash card {:cause :ability-cost}) (draw (:bad-publicity corp)))
                  :msg (msg "draw " (:bad-publicity corp) " cards")}]
     :events {:play-operation {:msg "give the Corp 1 bad publicity and take 1 tag"
-                              :effect (effect (gain :bad-publicity 1) (gain :runner :tag 1))
+                              :effect (effect (gain :bad-publicity 1) (tag-runner :runner 1))
                               :req (req (or (has? target :subtype "Black Ops")
                                             (has? target :subtype "Gray Ops")))}}}
 

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -26,7 +26,7 @@
    "Bernice Mai"
    {:events {:successful-run {:req (req this-server)
                               :trace {:base 5 :msg "give the Runner 1 tag"
-                                      :effect (effect (gain :runner :tag 1))}}}}
+                                      :effect (effect (tag-runner :runner 1))}}}}
 
    "Breaker Bay Grid"
    {:events {:pre-rez-cost {:req (req (= (:zone card) (:zone target)))
@@ -38,7 +38,7 @@
 
    "ChiLo City Grid"
    {:events {:successful-trace {:req (req this-server)
-                                :effect (effect (gain :runner :tag 1))
+                                :effect (effect (tag-runner :runner 1))
                                 :msg "give the Runner 1 tag"}}}
 
    "Corporate Troubleshooter"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1432,7 +1432,7 @@
         s (if (#{"HQ" "R&D" "Archives"} server) :corp :runner)]
     (case server
       ("Heap" "Archives")
-      (do (trash state s c)
+      (do (trash state s c {:unpreventable true})
           (system-msg state side (str "trashes " label)))
       ("HQ" "Grip")
       (do (move state s (dissoc c :seen :rezzed) :hand)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -668,6 +668,43 @@
   (when (>= (get-in @state [side :agenda-point]) (get-in @state [side :agenda-point-req]))
     (system-msg state side "wins the game")))
 
+
+(defn tag-prevent [state side n]
+  (swap! state update-in [:tag :tag-prevent] (fnil #(+ % n) 0)))
+
+(defn tag-count [state side n {:keys [unpreventable unboostable] :as args}]
+  (-> n
+      (+ (or (when (not unboostable) (get-in @state [:tag :tag-bonus])) 0))
+      (- (or (when (not unpreventable) (get-in @state [:tag :tag-prevent])) 0))
+      (max 0)))
+
+(defn resolve-tag [state side n args]
+  (when (pos? n)
+    (gain state :runner :tag n)
+    (trigger-event state side :runner-gain-tag n)))
+
+(defn tag-runner
+  ([state side n] (tag-runner state side n nil))
+  ([state side n {:keys [unpreventable unboostable card] :as args}]
+    (swap! state update-in [:tag] dissoc :tag-bonus :tag-prevent)
+    (trigger-event state side :pre-tag card)
+    (let [n (tag-count state side n args)]
+      (let [prevent (get-in @state [:prevent :tag :all])]
+        (if (and (pos? n) (not unpreventable) (pos? (count prevent)))
+          (do (system-msg state :runner "has the option to avoid tags")
+              (show-prompt
+                state :runner nil (str "Avoid any of the " n " tags?") ["Done"]
+                (fn [choice]
+                  (let [prevent (get-in @state [:tag :tag-prevent])]
+                    (system-msg state :runner
+                                (if prevent
+                                  (str "avoids " (if (= prevent Integer/MAX_VALUE) "all" prevent)
+                                       (if (< 1 prevent) " tags" " tag"))
+                                  "will not avoid tags"))
+                    (resolve-tag state side (max 0 (- n (or prevent 0))) args)))))
+          (resolve-tag state side n args))))))
+
+
 (defn resolve-trash [state side {:keys [zone type] :as card} {:keys [unpreventable cause keep-server-alive] :as args} & targets]
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]


### PR DESCRIPTION
Don't show trash prevention prompts for:

1. Discarding from hand. 
2. Self-trashing a card from a lack of counters.