### PR TITLE
WitRD now correctly addresses the Corporation.

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -8,7 +8,7 @@
                                          " [Credits], gain " (* 2 (min 5 (:credit corp)))
                                          " [Credits] and take 2 tags")
                                :effect (effect (tag-runner 2)
-                                               (gain :ru:credit (* 2 (min 5 (:credit corp))))
+                                               (gain :runner :credit (* 2 (min 5 (:credit corp))))
                                                (lose :corp :credit (min 5 (:credit corp))))}} card))}
 
    "Amped Up"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -618,9 +618,10 @@
    "Woman in the Red Dress"
    {:events {:runner-turn-begins
              {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")
-              :optional {:prompt (msg "Draw " (:title (first (:deck corp))) "?")
+              :optional {:player :corp
+                         :prompt (msg "Draw " (:title (first (:deck corp))) "?")
                          :msg (msg "draw " (:title (first (:deck corp))))
-                         :yes-ability {:effect :player :corp (effect (draw))}
+                         :yes-ability {:effect (effect (draw))}
                          :no-ability {:effect (effect (system-msg "doesn't draw with Woman in the Red Dress"))}}}}}
 
    "Wyldside"


### PR DESCRIPTION
The :player :corp key was in the wrong position.

Fixes issue #634 