### PR TITLE
Fix messages and costs for optional abilities

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -3,9 +3,9 @@
 (def cards-agendas
   {"Accelerated Beta Test"
    {:optional {:prompt "Look at the top 3 cards of R&D?"
-               :msg (msg (let [c (count (filter #(= (:type %) "ICE") (take 3 (:deck corp))))]
-                           (str "install " c " ICE and trash " (- 3 c) " cards")))
-               :yes-ability {:effect (req (doseq [c (take 3 (:deck corp))]
+               :yes-ability {:msg (msg (let [c (count (filter #(= (:type %) "ICE") (take 3 (:deck corp))))]
+                                         (str "install " c " ICE and trash " (- 3 c) " cards")))
+                             :effect (req (doseq [c (take 3 (:deck corp))]
                                            (if (= (:type c) "ICE")
                                              (corp-install state side c nil {:no-install-cost true :install-state :rezzed})
                                              (trash state side c))))}}}
@@ -107,8 +107,8 @@
 
    "Explode-a-palooza"
    {:access {:optional {:prompt "Gain 5 [Credits] with Explode-a-Palooza ability?"
-                        :msg "gain 5 [Credits]" 
-                        :yes-ability {:effect (effect (gain :corp :credit 5))}}}}
+                       :yes-ability {:msg "gain 5 [Credits]"
+                                     :effect (effect (gain :corp :credit 5))}}}}
 
    "False Lead"
    {:abilities [{:req (req (>= (:click runner) 2)) :msg "force the Runner to lose [Click][Click]"
@@ -251,8 +251,8 @@
 
    "Posted Bounty"
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
-               :msg "give the Runner 1 tag and take 1 bad publicity"
-               :yes-ability {:effect (effect (gain :bad-publicity 1) (tag-runner :runner 1) (forfeit card))}}}
+               :yes-ability {:msg "give the Runner 1 tag and take 1 bad publicity"
+                             :effect (effect (gain :bad-publicity 1) (tag-runner :runner 1) (forfeit card))}}}
 
    "Priority Requisition"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))}

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -13,8 +13,8 @@
    {:advanceable :always
     :access {:optional
              {:req (req installed) :prompt "Pay 2 [Credits] to use Aggressive Secretary ability?"
-              :cost [:credit 2]
-              :yes-ability {:effect (req (let [agg card]
+              :yes-ability {:cost [:credit 2]
+                            :effect (req (let [agg card]
                                           (resolve-ability
                                            state side (assoc (assoc-in trash-program [:choices :max] (req (:advance-counter agg)))
                                                         :effect (effect (trash-cards targets))) agg nil)))}}}}
@@ -48,8 +48,8 @@
    {:advanceable :always
     :access {:optional {:req (req installed)
                         :prompt "Pay 3 [Credits] to use Cerebral Overwriter ability?"
-                        :cost [:credit 3] :msg (msg "do " (:advance-counter card) " brain damage")
-                        :yes-ability {:effect (effect (damage :brain (:advance-counter card) {:card card}))}}}}
+                        :yes-ability {:cost [:credit 3] :msg (msg "do " (:advance-counter card) " brain damage")
+                                      :effect (effect (damage :brain (:advance-counter card) {:card card}))}}}}
 
    "Chairman Hiro"
    {:effect (effect (lose :runner :max-hand-size 2))
@@ -69,21 +69,20 @@
              {:optional
               {:prompt "Move one advancement token between ICE?"
                :yes-ability {:choices {:req #(and (= (:type %) "ICE") (:advance-counter %))}
-                            :priority true
-                            :effect (req
-                                     (let [fr target]
-                                       (resolve-ability
-                                        state side
-                                        {:priority true
-                                         :prompt "Move to where?"
-                                         :choices {:req #(and (= (:type %) "ICE")
-                                                              (not= (:cid fr) (:cid %))
-                                                              (or (= (:advanceable %) "always")
-                                                                  (and (= (:advanceable %) "while-rezzed")
-                                                                       (:rezzed %))))}
-                                         :effect (effect (add-prop :corp target :advance-counter 1)
-                                                         (add-prop :corp fr :advance-counter -1))} card nil)
-                                       card nil))}}}}}
+                             :priority true
+                             :effect (req (let [fr target]
+                                            (resolve-ability
+                                              state side
+                                              {:priority true
+                                               :prompt "Move to where?"
+                                               :choices {:req #(and (= (:type %) "ICE")
+                                                                    (not= (:cid fr) (:cid %))
+                                                                    (or (= (:advanceable %) "always")
+                                                                        (and (= (:advanceable %) "while-rezzed")
+                                                                             (:rezzed %))))}
+                                               :effect (effect (add-prop :corp target :advance-counter 1)
+                                                               (add-prop :corp fr :advance-counter -1))} card nil)
+                                            card nil))}}}}}
 
    "Contract Killer"
    {:advanceable :always
@@ -151,11 +150,12 @@
 
    "Edge of World"
    {:access {:optional
-             {:req (req installed) :cost [:credit 3]
+             {:req (req installed)
               :prompt "Pay 3 [Credits] to use Edge of World ability?"
-              :msg (msg "do " (count (get-in corp [:servers :remote (last (:server run)) :ices]))
-                        " brain damage")
-              :yes-ability {:effect (req (damage state side :brain
+              :yes-ability {:cost [:credit 3]
+                            :msg (msg "do " (count (get-in corp [:servers :remote (last (:server run)) :ices]))
+                                      " brain damage")
+                            :effect (req (damage state side :brain
                                         (count (get-in corp [:servers :remote (last (:server run)) :ices])) {:card card}))}}}}
 
    "Elizabeth Mills"
@@ -204,9 +204,9 @@
    "Ghost Branch"
    {:advanceable :always
     :access {:optional {:req (req installed) :prompt "Use Ghost Branch ability?"
-                        :msg (msg "give the Runner " (:advance-counter card) " tag"
-                                  (when (> (:advance-counter card) 1) "s"))
-                        :yes-ability {:effect (effect (tag-runner :runner (:advance-counter card)))}}}}
+                        :yes-ability {:msg (msg "give the Runner " (:advance-counter card) " tag"
+                                                (when (> (:advance-counter card) 1) "s"))
+                                      :effect (effect (tag-runner :runner (:advance-counter card)))}}}}
 
    "GRNDL Refinery"
    {:advanceable :always
@@ -380,8 +380,9 @@
    "Project Junebug"
    {:advanceable :always
     :access {:optional {:prompt "Pay 1 [Credits] to use Project Junebug ability?" :cost [:credit 1]
-                        :req (req installed) :msg (msg "do " (* 2 (:advance-counter card)) " net damage")
-                        :yes-ability {:effect (effect (damage :net (* 2 (:advance-counter card)) {:card card}))}}}}
+                        :req (req installed)
+                        :yes-ability {:msg (msg "do " (* 2 (:advance-counter card)) " net damage")
+                                      :effect (effect (damage :net (* 2 (:advance-counter card)) {:card card}))}}}}
 
    "Psychic Field"
    (let [ab {:psi {:req (req installed)
@@ -473,8 +474,8 @@
    {:advanceable :always
     :access {:optional
              {:req (req installed) :prompt "Pay 1 [Credits] to use Shattered Remains ability?"
-              :cost [:credit 1]
-              :yes-ability {:effect (req (let [shat card]
+              :yes-ability {:cost [:credit 1]
+                            :effect (req (let [shat card]
                                           (resolve-ability
                                            state side (assoc (assoc-in trash-hardware [:choices :max] (req (:advance-counter shat)))
                                                         :effect (effect (trash-cards targets))) shat nil)))}}}}
@@ -499,9 +500,10 @@
 
    "Snare!"
    {:access {:optional {:req (req (not= (first (:zone card)) :discard))
-                        :prompt "Pay 4 [Credits] to use Snare! ability?" :cost [:credit 4]
-                        :msg "do 3 net damage and give the Runner 1 tag"
-                        :yes-ability {:effect (effect (damage :net 3 {:card card}) (tag-runner :runner 1))}}}}
+                        :prompt "Pay 4 [Credits] to use Snare! ability?"
+                        :yes-ability {:cost [:credit 4]
+                                      :msg "do 3 net damage and give the Runner 1 tag"
+                                      :effect (effect (damage :net 3 {:card card}) (tag-runner :runner 1))}}}}
 
    "Space Camp"
    {:access {:msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -311,10 +311,10 @@
 
    "Networking"
    {:effect (effect (lose :tag 1))
-    :optional {:cost [:credit 1] 
-               :prompt "Pay 1 [Credits] to add Networking to Grip?"
-               :msg "add it to their Grip" 
-               :yes-ability {:effect  (effect (move (last (:discard runner)) :hand))}}}
+    :optional {:prompt "Pay 1 [Credits] to add Networking to Grip?"
+               :yes-ability {:cost [:credit 1]
+                             :msg "add it to their Grip"
+                             :effect (effect (move (last (:discard runner)) :hand))}}}
 
    "Notoriety"
    {:req (req (and (some #{:hq} (:successful-run runner-reg))

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -72,9 +72,9 @@
                          :req (req (and (first-event state side :play-event)
                                         (not (empty? (filter #(has? % :type "Event") (:hand runner))))))
                          :yes-ability {:prompt "Choose an Event to play"
-                                      :choices (req (filter #(has? % :type "Event") (:hand runner)))
-                                      :msg (msg "play " (:title target))
-                                      :effect (effect (play-instant target))}}}}}
+                                       :choices (req (filter #(has? % :type "Event") (:hand runner)))
+                                       :msg (msg "play " (:title target))
+                                       :effect (effect (play-instant target))}}}}}
 
    "Cortez Chip"
    {:abilities [{:label "increase cost to rez a piece of ice by 2 [Credits]"
@@ -129,11 +129,12 @@
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
     :events {:successful-run-ends
              {:optional
-              {:once :per-turn :prompt "Use Doppelgänger to run again?" :player :runner
+              {:req (req (first-event state side :run))
+               :prompt "Use Doppelgänger to run again?" :player :runner
                :yes-ability {:prompt "Choose a server" 
-                            :choices (req servers)
-                            :msg (msg "to make a run on " target)
-                            :effect (effect (run target))}}}}}
+                             :choices (req servers)
+                             :msg (msg "to make a run on " target)
+                             :effect (effect (run target))}}}}}
 
    "Dorm Computer"
    {:data {:counter 4}
@@ -317,8 +318,8 @@
    {:events {:runner-install
              {:optional {:req (req (= (:type target) "Hardware"))
                          :prompt "Use Replicator to add a copy?"
-                         :msg (msg "add a copy of " (:title target) " to their Grip")
-                         :yes-ability {:effect (effect (move (some #(when (= (:title %) (:title target)) %)
+                         :yes-ability {:msg (msg "add a copy of " (:title target) " to their Grip")
+                                       :effect (effect (move (some #(when (= (:title %) (:title target)) %)
                                                                   (:deck runner)) :hand)
                                                       (shuffle! :deck))}}}}}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -9,7 +9,7 @@
    {:access {:optional
              {:prompt "Pay 3 [Credits] to force Runner to encounter Archangel?" 
               :yes-ability {:cost [:credit 3]
-                           :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}}}
+                            :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}}}
     :abilities [{:label "Trace 6 - Add 1 installed card to the Runner's Grip"
                  :trace {:base 6 :choices {:req #(:installed %)}
                          :msg (msg "add " (:title target) " to the Runner's Grip")

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -34,8 +34,8 @@
    {:effect (effect (gain :link 1))
     :events {:runner-trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
                                        :prompt "Draw a card?" 
-                                       :msg (msg "drew a card") 
-                                       :yes-ability {:effect (effect (draw 1))}}}}}
+                                       :yes-ability {:msg "draw a card"
+                                                     :effect (effect (draw 1))}}}}}
 
    "Blue Sun: Powering the Future"
    {:abilities [{:choices {:req #(:rezzed %)}
@@ -169,8 +169,8 @@
                                                          (prn successes)
                                                          (filter #(not (= % :remote)) successes))))))
                               :optional {:prompt "Force the Corp to draw 1 card?"
-                                         :msg "force the Corp to draw 1 card"
-                                         :yes-ability {:effect (effect (draw :corp))}}}}}
+                                         :yes-ability {:msg "force the Corp to draw 1 card"
+                                                       :effect (effect (draw :corp))}}}}}
 
    "Leela Patel: Trained Pragmatist"
    {:events {:agenda-scored {:choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :msg "add 1 unrezzed card to HQ"
@@ -252,11 +252,10 @@
                           (empty? (let [rezzed-this-turn (map first (turn-events state side :rez))]
                                     (filter #(has? % :type "ICE") rezzed-this-turn))))) ;; Is this the first ice you've rezzed this turn
            :optional
-                {:prompt "Add another copy to HQ?"
-                 :yes-ability {:effect
-                              (effect (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand)
-                                      (shuffle! :deck))}
-                 :msg (msg "add a copy of " (:title target) " from R&D to HQ")}}}}
+           {:prompt "Add another copy to HQ?"
+            :yes-ability {:msg (msg "add a copy of " (:title target) " from R&D to HQ")
+                          :effect (effect (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand)
+                                          (shuffle! :deck))}}}}}
 
    "Titan Transnational: Investing In Your Future"
    {:events {:agenda-scored {:msg (msg "add 1 agenda counter to " (:title target))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -401,13 +401,13 @@
    "Snitch"
    {:abilities [{:once :per-run :req (req current-ice) :msg (msg "expose " (:title current-ice))
                  :effect (effect (expose current-ice)
-                                 (resolve-ability {:optional {:prompt "Jack out?" :msg "jack out"
-                                                              :yes-ability {:effect (effect (jack-out nil))}}}
+                                 (resolve-ability {:optional {:prompt "Jack out?"
+                                                              :yes-ability {:msg "jack out"
+                                                                            :effect (effect (jack-out nil))}}}
                                                   card nil))}]}
    "Trope"
    {:events {:runner-turn-begins {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:label "Remove Trope from the game to reshuffle cards from Heap back into Stack"
                  :cost [:click 1] :msg (msg "reshuffle " (:counter card) " card" (when (> (:counter card) 1) "s")
                                             " in the Heap back into their Stack")
-                 :effect (effect (move card :rfg))}]}
-})
+                 :effect (effect (move card :rfg))}]}})

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -39,8 +39,8 @@
     :abilities [{:counter-cost 1 :msg "look at the top card of Stack"
                  :effect (req (when (zero? (:counter card)) (trash state :runner card {:unpreventable true})))
                  :optional {:prompt (msg "Add " (:title (first (:deck runner))) " to bottom of Stack?")
-                            :msg "add the top card of Stack to the bottom"
-                            :yes-ability {:effect (req (move state side (first (:deck runner)) :deck))}}}]}
+                            :yes-ability {:msg "add the top card of Stack to the bottom"
+                                          :effect (req (move state side (first (:deck runner)) :deck))}}}]}
 
    "Armitage Codebusting"
    {:data {:counter 12}
@@ -180,8 +180,8 @@
     :events {:runner-turn-begins
              {:optional {:prompt "Use Globalsec Security Clearance to lose [Click]?" :msg "lose [Click]"
                          :yes-ability {:effect (effect (lose :click 1)
-                                                      (prompt! card (str "The top card of R&D is "
-                                                                         (:title (first (:deck corp)))) ["OK"] {}))}}}}}
+                                                       (prompt! card (str "The top card of R&D is "
+                                                                          (:title (first (:deck corp)))) ["OK"] {}))}}}}}
 
    "Grifter"
    {:events {:runner-turn-ends
@@ -246,8 +246,8 @@
 
    "Joshua B."
    {:events {:runner-turn-begins
-             {:optional {:prompt "Use Joshua B. to gain [Click]?" :msg "gain [Click]"
-                         :yes-ability {:effect (effect (gain :click 1))}
+             {:optional {:prompt "Use Joshua B. to gain [Click]?"
+                         :yes-ability { :msg "gain [Click]" :effect (effect (gain :click 1))}
                          :end-turn {:effect (effect (tag-runner 1)) :msg "gain 1 tag"}}}}}
 
    "Kati Jones"
@@ -367,17 +367,18 @@
    "Paige Piper"
    (let [pphelper (fn [card cards]
                     (let [num (count cards)]
-                      {:optional {:req (req (> num 0))
-                                  :prompt (str "Use Paige Piper to trash copies of " (:title card) "?")
-                                  :choices {:number (req num)}
-                                  :msg "to shuffle their Stack"
-                                  :yes-ability {:effect (req (doseq [c (take (int target) cards)]
-                                                              (trash state side c))
-                                                            (shuffle! state :runner :deck)
-                                                            (when (> (int target) 0)
-                                                              (system-msg state side (str "trashes " (int target)
-                                                                                          " cop" (if (> (int target) 1) "ies" "y")
-                                                                                          " of " (:title card)))))}}}))]
+                      {:optional
+                       {:req (req (> num 0))
+                        :prompt (str "Use Paige Piper to trash copies of " (:title card) "?")
+                        :choices {:number (req num)}
+                        :msg "to shuffle their Stack"
+                        :yes-ability {:effect (req (doseq [c (take (int target) cards)]
+                                                               (trash state side c))
+                                                   (shuffle! state :runner :deck)
+                                                   (when (> (int target) 0)
+                                                     (system-msg state side (str "trashes " (int target)
+                                                                                 " cop" (if (> (int target) 1) "ies" "y")
+                                                                                 " of " (:title card)))))}}}))]
      {:events {:runner-install {:req (req (first-event state side :runner-install))
                                 :effect (effect (resolve-ability
                                                  (pphelper target (->> (:deck runner)

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -74,8 +74,8 @@
 
    "Cyberdex Virus Suite"
    {:access {:optional {:prompt "Purge viruses with Cyberdex Virus Suite?"
-                        :msg (msg "purge viruses") 
-                        :yes-ability {:effect (effect (purge))}}}
+                        :yes-ability {:msg (msg "purge viruses")
+                                      :effect (effect (purge))}}}
     :abilities [{:msg "purge viruses" :effect (effect (purge) (trash card))}]}
 
    "Dedicated Technician Team"


### PR DESCRIPTION
Fixes a few issues related to the recent `:optional` refactoring. `:msg` and `:cost` belong inside the `:yes-ability` of the optionals, rather than outside. Fixes issues with traps not charging the corp money, and with messages not printing when the optional is used.