### PR TITLE
Give :cid to ID cards

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -613,8 +613,8 @@
         runner (some #(when (= (:side %) "Runner") %) players)
         corp-deck (create-deck (:deck corp))
         runner-deck (create-deck (:deck runner))
-        corp-identity (or (get-in corp [:deck :identity]) {:side "Corp" :type "Identity"})
-        runner-identity (or (get-in runner [:deck :identity]) {:side "Runner" :type "Identity"})
+        corp-identity (assoc (or (get-in corp [:deck :identity]) {:side "Corp" :type "Identity"}) :cid (make-cid))
+        runner-identity (assoc (or (get-in runner [:deck :identity]) {:side "Runner" :type "Identity"}) :cid (make-cid))
         state (atom
                {:gameid gameid :log [] :active-player :runner :end-turn true
                 :corp {:user (:user corp) :identity corp-identity


### PR DESCRIPTION
Fixes #640. IDs weren't being given `:cid` tags, so `:once` was using `nil` in the `:per-turn` map. That worked fine as long as there was only one ID with a `:once` key, but fails if both sides have a "once per turn" ability on the ID.