### PR TITLE
hotfix for register redirect if there is no demo user

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -249,9 +249,12 @@ app.post '/register', (req, res) ->
             for deck in demoDecks
               delete deck._id
               deck.username = req.body.username
-            db.collection('decks').insert demoDecks, (err, newDecks) ->
-              throw err if err
-              res.json(200, {user: req.user, decks: newDecks})
+            if demoDecks.length > 0
+              db.collection('decks').insert demoDecks, (err, newDecks) ->
+                throw err if err
+                res.json(200, {user: req.user, decks: newDecks})
+            else
+              res.json(200, {user: req.user, decks: []})
 
 app.get '/check/:username', (req, res) ->
   db.collection('users').findOne username: req.params.username, (err, user) ->


### PR DESCRIPTION
Basically, the issue is that there's never a redirect when you register a user (developing locally here).

The issue is because a Response (code: 200) is never sent back. This is because when a new user registers, the system checks for new decks under "__demo__" user and then copies // inserts those into the newly registered user's "decks". However, there is no "__demo__" user in a local database (hint: feature to pre-seed this data, along with their decks).

I've just added some minor business logic to account for this and allow a redirect.  
