### PR TITLE
Fixes for nested hosting situations

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -150,9 +150,12 @@
    "Darwin"
    {:events {:runner-turn-begins
              {:optional {:cost [:credit 1] :prompt "Place 1 virus counter on Darwin?"
-                         :msg "place 1 virus counter" 
-                         :yes-ability {:effect (effect (add-prop card :counter 1))}}}}
-    :abilities [{:cost [:credit 2] :msg "break ICE subroutine"}]}
+                         :msg "place 1 virus counter"
+                         :yes-ability {:effect (effect (add-prop card :counter 1)
+                                                       (update-breaker-strength card))}}}
+             :purge {:effect (effect (update-breaker-strength card))}}
+    :abilities [{:cost [:credit 2] :msg "break ICE subroutine"}]
+    :strength-bonus (req (or (get-virus-counters state side card) 0))}
 
    "Deus X"
    {:prevent {:damage [:net]}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1283,6 +1283,13 @@
                (get-in @state [:runner :rig (to-keyword (:type card))]))]
     (some #(= (:title %) (:title card)) dest)))
 
+(defn assoc-host-zones [card]
+  (let [card (update-in card [:zone] #(map to-keyword %))]
+    (if (:host card)
+      (assoc card :host (assoc-host-zones (:host card)))
+      card)))
+
+
 (defn host
   ([state side card target] (host state side card target nil))
   ([state side card {:keys [zone cid host installed] :as target} {:keys [facedown] :as options}]
@@ -1297,9 +1304,8 @@
        (swap! state update-in (cons s (vec zone))
               (fn [coll] (remove-once #(not= (:cid %) cid) coll)))))
    (swap! state update-in (cons side (vec zone)) (fn [coll] (remove-once #(not= (:cid %) cid) coll)))
-   (let [c (assoc target :host (-> card
-                                   (update-in [:zone] #(map to-keyword %))
-                                   (dissoc :hosted))
+   (let [card (assoc-host-zones card)
+         c (assoc target :host (dissoc card :hosted)
                          :facedown facedown
                          :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
                          :previous-zone (:zone target))]


### PR DESCRIPTION
Fixes #573 and #449 and several other potential issues with nested hosting. Also adds dynamic breaker strength code to Darwin in terms of its virus counters.

Let's take Off-Campus Apartment hosting The Supplier hosting Daily Casts as an example. At start of turn, runner is asked to install Daily Casts off the Supplier, and does so. Daily Casts is run through `runner-install` which checks to see if it is hosted; it is, so `runner-install` attempts to remove Casts from its host card. This fails however because it is assumed that the host card is in a "direct zone", that is, directly installed in the state at a zone like `:rig :resource`... but The Supplier is NOT in a direct zone, but is instead inside the `:hosted` vector of Apartment, which itself is in a direct zone. So the attempt to remove Casts from its host fails, meaning The Supplier's vector of hosted cards retains its current copy of Casts, and a second copy then ends up in the runner's rig. The issue can be generalized as such: any time a HOSTED card is updated, the update only works if the host of the card is directly installed (not itself on a host).

I fixed this by reworking `get-card` and `update!` to use recursive search. In short, we make stronger attempts at keeping the `:host` of each card as accurate as possible, including accurate `:zone`s for the host and whatever its host might be (recursively to any depth). When that data is accurate, we can then recursively dig through `:host` fields to find the host that is actually installed directly in a zone, and then update THAT card with updated versions of all its hosted cards N levels deep. It's complicated.

For `get-card`: if the card has a host, find its most-nested host (the one installed in `:runner :rig`). Do a depth-first recursive search of the `:hosted` vector of that card until you find a card with the `:cid` of the original target. That is the "canonical" version of the card in question.  If the card has no host, find it from its `:zone` in the state.

For `update!`: if the card has no host, directly update the state in the card's zone. Otherwise, update the `:hosted` vector of the canonical version of the card's host; then update the `:hosted` vector of THAT card's host; recursively, until finally updating the nested host that is in the rig, at which point the state is actually updated.