### PR TITLE
fully implement Kraken and Hemorrhage

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -264,7 +264,18 @@
 
    "Kraken"
    {:req (req (:stole-agenda runner-reg)) :prompt "Choose a server" :choices (req servers)
-    :msg (msg "force the Corp to trash an ICE protecting " target)}
+    :msg (msg "force the Corp to trash an ICE protecting " target)
+    :effect (req (let [serv (next (server->zone state target))
+                       servname target]
+                   (resolve-ability
+                     state :corp
+                     {:prompt (msg "Choose a piece of ICE in " target " to trash")
+                      :choices {:req #(and (= (last (:zone %)) :ices)
+                                           (= serv (rest (butlast (:zone %)))))}
+                      :effect (req (trash state :corp target)
+                                   (system-msg state side (str "trashes "
+                                    (if (:rezzed target) (:title target) "an ICE") " protecting " servname)))}
+                    card nil)))}
 
    "Lawyer Up"
    {:effect (effect (draw 3) (lose :tag 2))}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -156,7 +156,13 @@
 
    "Hemorrhage"
    {:events {:successful-run {:effect (effect (add-prop card :counter 1))}}
-    :abilities [{:counter-cost 2 :cost [:click 1] :msg "force the Corp to trash 1 card from HQ"}]}
+    :abilities [{:counter-cost 2 :cost [:click 1] :msg "force the Corp to trash 1 card from HQ"
+                 :effect (req (resolve-ability
+                                state :corp
+                                {:prompt "Choose a card to trash"
+                                 :choices (req (filter #(:hand corp)))
+                                 :effect (effect (trash target))}
+                               card nil))}]}
 
    "Hivemind"
    {:data {:counter 1 :counter-type "Virus"}


### PR DESCRIPTION
This just automates Kraken all the way, giving the Corp a prompt to trash a piece ice from the Runner's chosen server (and ensuring that the trash happens from that exact server). 

Same goes for Hemorrhage (just eliminates having to drag the card to Archives). 