### PR TITLE
Fix "add as an agenda" cards to be forfeitable

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -484,13 +484,13 @@
              :prompt "How many [Credits] for Shi.Kyū?" :choices :credit
              :msg (msg "attempt to do " target " net damage")
              :effect (effect (resolve-ability
-                               {:player :runner :msg (msg target)
-                                :prompt (str "Take " target " net damage or take Shi.Kyū as -1 agenda points?")
-                                :choices [(str "take " target " net damage") "add Shi.Kyū to score area"]
+                               {:player :runner
+                                :prompt (str "Take " target " net damage or take Shi.Kyū as -1 agenda point?")
+                                :choices [(str "Take " target " net damage") "Add Shi.Kyū to score area"]
                                 :effect (let [dmg target]
-                                          (req (if (= target "add Shi.Kyū to score area")
-                                                 (do (gain state :runner :agenda-point -1)
-                                                     (move state :runner card :scored nil))
+                                          (req (if (= target "Add Shi.Kyū to score area")
+                                                 (do (as-agenda state :runner card -1)
+                                                     (system-msg state :runner (str "adds Shi.Kyū to their score area as -1 agenda point")))
                                                  (damage state :corp :net dmg {:card card}))))}
                                card targets))}}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -197,9 +197,8 @@
                  :effect (effect (trash card) (lose :bad-publicity (:advance-counter card)))}]}
 
    "Franchise City"
-   {:events {:access {:req (req (= (:type target) "Agenda"))
-                      :msg "add it to his score area and gain 1 agenda point"
-                      :effect (effect (move :corp card :scored) (gain :agenda-point 1))}}}
+   {:events {:pre-steal-cost {:msg "add it to their score area and gain 1 agenda point"
+                              :effect (effect (as-agenda :corp card 1))}}}
 
    "Ghost Branch"
    {:advanceable :always

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -340,15 +340,15 @@
     :effect (effect (set-prop card :rec-counter (:link runner)))}
 
    "News Team"
-   {:access {:req (req (not= (first (:zone card)) :deck))
-             :msg (msg "give the Runner 2 tags or -1 agenda points")
+   {:access {:msg (msg "give the Runner 2 tags or -1 agenda point")
              :effect (effect (resolve-ability
                                {:player :runner
-                                :prompt "Take 2 tags or take News Team as -1 agenda points?"
-                                :choices ["take 2 tags" "add News Team to score area"]
-                                :effect (req (if (= target "add News Team to score area")
-                                                 (do (gain state :runner :agenda-point -1)
-                                                     (move state :runner card :scored nil))
+                                :prompt "Take 2 tags or take News Team as -1 agenda point?"
+                                :choices ["Take 2 tags" "Add News Team to score area"]
+                                :effect (req (if (= target "Add News Team to score area")
+                                                 (do (as-agenda state :runner card -1)
+                                                     (system-msg state :runner
+                                                       (str "adds News Team to their score area as -1 agenda point")))
                                                  (tag-runner :runner 2)))}
                                card targets))}}
 

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -334,7 +334,8 @@
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
                    (some #{:rd} (:successful-run runner-reg))
                    (some #{:archives} (:successful-run runner-reg))))
-    :effect (effect (gain-agenda-point 1) (move (first (:play-area runner)) :scored))}
+    :effect (effect (as-agenda :runner (first (:play-area runner)) 1))
+    :msg "add it to their score area as an agenda worth 1 agenda point"}
 
    "Paper Tripping"
    {:effect (effect (lose :tag :all))}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -138,8 +138,8 @@
                 {:effect (effect (trash card {:cause :ability-cost}) (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 
    "Fan Site"
-   {:events {:agenda-scored {:msg "add it to the Runner's score area"
-                             :effect (effect (move :runner card :scored))}}}
+   {:events {:agenda-scored {:msg "add it to their score area as an agenda worth 0 agenda points"
+                             :effect (effect (as-agenda :runner card 0))}}}
 
    "Fester"
    {:events {:purge {:msg "force the Corp to lose 2 [Credits] if able"


### PR DESCRIPTION
This fixes #655, so Franchise City will no longer break games. 

The new `as-agenda` function is applied to Franchise City, Notoriety, Fan Site, News Team, and Shi.Kyu to make them forfeitable (e.g. to Data Dealer, or to rez an Archer in the case of Franchise City). Messaging is also beefed up to be clearer in the log what has happened. 

This also fixes a bug that was reported in chat--News Team was not firing from R&D as it should have been. 