### PR TITLE
Add recursion sanity check for nested hosting

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -113,7 +113,8 @@
   (if-let [h (get-card state (:host card))]
     (recur state side (let [[head tail] (split-with #(not= (:cid %) cid) (:hosted h))]
                         (assoc h :hosted (vec (concat head [card] (rest tail))))))
-    (update! state side card)))
+    (when-not (:host card)
+      (update! state side card))))
 
 (defn remove-from-host [state side {:keys [cid] :as card}]
   (let [host-card (get-card state (:host card))]


### PR DESCRIPTION
If you have a host and that host can be found with `get-card`, update that card recursively.

If you do not have a host, use `update!`. Since you don't have a host, `update!` won't recurse back to `update-hosted!`.