### PR TITLE
remove prompt when triggering Geist ability as draw is not optional

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -33,10 +33,9 @@
 
    "Armand \"Geist\" Walker: Tech Lord"
    {:effect (effect (gain :link 1))
-    :events {:runner-trash {:optional {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
-                                       :prompt "Draw a card?"
-                                       :yes-ability {:msg "draw a card"
-                                                     :effect (effect (draw 1))}}}}}
+    :events {:runner-trash {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
+                            :msg "draw a card"
+                            :effect (effect (draw 1))}}}
 
    "Blue Sun: Powering the Future"
    {:abilities [{:choices {:req #(:rezzed %)}


### PR DESCRIPTION
The original Geist implementation offered the runner the choice of drawing a card or not when triggering his ability. The wording on the card implies that the draw is not optional, so I removed the prompt.

Does this seem ok to you?