### PR TITLE
Make get-virus-counter handle nil :counter without crashing

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1247,8 +1247,8 @@
   (trigger-event state side :purge))
 
 (defn get-virus-counters [state side card]
-   (let [hiveminds (filter #(= (:title %) "Hivemind") (all-installed state :runner))]
-        (reduce + (map :counter (cons card hiveminds)))))
+  (let [hiveminds (filter #(= (:title %) "Hivemind") (all-installed state :runner))]
+    (reduce + (map #(get % :counter 0) (cons card hiveminds)))))
 
 (defn play-instant
   ([state side card] (play-instant state side card nil))


### PR DESCRIPTION
`get-virus-counters` was barfing when a virus never had any counters installed on it, giving a `:counter` of `nil`. This caused #407 and most likely #670.