### PR TITLE
Implement Gagarin Deep Space

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -77,6 +77,10 @@
    {:events {:successful-run {:msg "gain 2 [Credits]" :once :per-turn
                               :effect (effect (gain :credit 2)) :req (req (= target :hq))}}}
 
+   "Gagarin Deep Space: Expanding the Horizon"
+   {:events {:pre-access-card {:req (req (= (second (:zone target)) :remote))
+                               :effect (effect (access-cost-bonus [:credit 1]))}}}
+
    "GRNDL: Power Unleashed"
    {:effect (effect (gain :credit 5 :bad-publicity 1))}
 


### PR DESCRIPTION
Implement Gagarin Deep Space by adding `access-cost` framework triggering off the `:pre-access-card` event trigger.

Although the core game rules state that additional costs can always be declined, and so should be tied in our system to an `:optional` prompt, I automatically deduct costs in this implementation. Because Gagarin only applies to remote servers, and because our "Choose a card to access" system involves opting-in to the access, I thought it was safe to automatically charge the credit when the runner clicks a card in a remote server to access it. If the runner does not want to pay the 1cr, they can just not click the card, selecting "Done" to finish the access step instead. This may require a minor learning curve, but I think it's better than adding "Pay 1cr to access?" prompts to every single remote access click.