### PR TITLE
update Character Assassination to use targeting system

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -50,7 +50,8 @@
     :end-turn {:effect (effect (lose :runner :tag 2)) :msg "make the Runner lose 2 tags"}}
 
    "Character Assassination"
-   {:prompt "Choose a resource to trash" :choices (req (get-in runner [:rig :resource]))
+   {:prompt "Choose a resource to trash"
+    :choices {:req #(and (:installed %) (= (:type %) "Resource"))}
     :msg (msg "trash " (:title target)) :effect (effect (trash target))}
 
    "Chronos Project"


### PR DESCRIPTION
Addresses #679 by making Character Assassination use the targeting system. This way the Corp can distinguish between specific copies of Liberated Account, Armitage Codebusting, etc. and trash the one that makes the most sense. 