### PR TITLE
Prevent cards from queueing the same prompt multiple times

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -242,7 +242,11 @@
   ([state side card msg choices f] (show-prompt state side card msg choices f nil))
   ([state side card msg choices f {:keys [priority prompt-type show-discard] :as args}]
    (let [prompt (if (string? msg) msg (msg state side card nil))]
-     (when (or (:number choices) (#{:credit :counter} choices) (> (count choices) 0))
+     (when (and (or (:number choices) (#{:credit :counter} choices) (> (count choices) 0))
+                (or (nil? card)
+                    (empty? (->> (get-in @state [side :prompt])
+                                 (map #(vec [(get-in % [:card :cid]) (:msg %)]))
+                                 (filter #(= % (vec [(:cid card) msg])))))))
        (swap! state update-in [side :prompt]
               (if priority
                 #(cons {:msg prompt :choices choices :effect f :card card


### PR DESCRIPTION
related to #85

This prevents a card to create the same prompt multiple times (filtered by `:cid` and `msg`), so you can no longer use e.g. Self-modifying Code to search multiple programs or Executive Boot Camp to search for multiple assets.