### PR TITLE
fix Gemini, make Bifrost Array optional

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -35,10 +35,11 @@
 
    "Bifrost Array"
    {:req (req (not (empty? (filter #(not= (:title %) "Bifrost Array") (:scored corp)))))
-    :msg (msg "trigger the score ability on " (:title target))
-    :prompt "Choose an agenda to trigger"
-    :choices (req (filter #(not= (:title %) "Bifrost Array") (:scored corp)))
-    :effect (effect (card-init target))}
+    :optional {:prompt "Trigger the ability of a scored agenda?"
+               :yes-ability {:prompt "Choose an agenda to trigger its \"when scored\" ability"
+                             :choices (req (filter #(not= (:title %) "Bifrost Array") (:scored corp)))
+                             :msg (msg "trigger the \"when scored\" ability of " (:title target))
+                             :effect (effect (card-init target))}}}
 
    "Braintrust"
    {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)))

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -225,8 +225,8 @@
                                 (resolve-ability state side (first (:abilities (card-def ice))) card nil)))}]}
 
    "Gemini"
-   {:abilities [{:label "Trace 2"
-                 :trace {:base 2 :msg "do 1 net damage" :effect (effect (damage :net 1) {:card card})
+   {:abilities [{:label "Trace 2 - Do 1 net damage"
+                 :trace {:base 2 :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))
                          :kicker {:min 5 :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}}]}
 
    "Grim"
@@ -535,7 +535,7 @@
 
    "Searchlight"
    {:advanceable :always
-    :abilities [{:label "Trace X - Give the runner 1 tag"
+    :abilities [{:label "Trace X - Give the Runner 1 tag"
                  :trace {:base (req (or (:advance-counter card) 0)) :effect (effect (tag-runner :runner 1))
                          :msg "give the Runner 1 tag"}}]}
 
@@ -575,7 +575,7 @@
    "Snoop"
    {:abilities [{:msg "place 1 power counter on Snoop" :effect (effect (add-prop card :counter 1))}
                 {:counter-cost 1 :label "Look at all cards in Grip and trash 1 card"
-                 :msg (msg "Look at all cards in Grip and trashes " (:title target))
+                 :msg (msg "look at all cards in Grip and trash " (:title target))
                  :choices (req (:hand runner)) :prompt "Choose a card to trash"
                  :effect (effect (trash target))}]}
 
@@ -626,7 +626,7 @@
    {:abilities [end-the-run]}
 
    "Troll"
-   {:abilities [{:label "Trace 2 - Force the runner to lose [Click] or end the run"
+   {:abilities [{:label "Trace 2 - Force the Runner to lose [Click] or end the run"
                  :trace {:base 2 :player :runner
                          :prompt "Choose one" :choices ["Lose [Click]" "End the run"]
                          :effect (req (if-not (and (= target "Lose [Click]") (pay state side card :click 1))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -414,6 +414,13 @@
    "Trope"
    {:events {:runner-turn-begins {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:label "Remove Trope from the game to reshuffle cards from Heap back into Stack"
-                 :cost [:click 1] :msg (msg "reshuffle " (:counter card) " card" (when (> (:counter card) 1) "s")
-                                            " in the Heap back into their Stack")
-                 :effect (effect (move card :rfg))}]}})
+                 :effect (effect
+                          (move card :rfg)
+                          (resolve-ability
+                           {:show-discard true
+                            :choices {:max (:counter card) :req #(and (:side % "Runner") (= (:zone %) [:discard]))}
+                            :msg (msg "shuffle " (join ", " (map :title targets))
+                                      " into their Stack")
+                            :effect (req (doseq [c targets] (move state side c :deck))
+                                         (shuffle! state side :deck))}
+                           card nil))}]}})


### PR DESCRIPTION
Fixes for #689 and #693, plus minor corrections for a few ability labels. Also added the new Jackson Howard method of multi-selecting from Archives/Heap to Trope so it can automate the return of cards to the Runner's Stack. 