### PR TITLE
Added commands to manually change the game state

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1630,9 +1630,9 @@
         "/bp"         #(swap! %1 assoc-in [%2 :bad-publicity] (max 0 value))
         "/link"       #(swap! %1 assoc-in [%2 :link] (max 0 value))
         "/handsize"   #(swap! %1 assoc-in [%2 :max-hand-size] (max 0 value))
-        "/take-meat"  #(when (= %2 runner) (damage %1 %2 :meat  (max 0 value)))
-        "/take-net"   #(when (= %2 runner) (damage %1 %2 :net   (max 0 value)))
-        "/take-brain" #(when (= %2 runner) (damage %1 %2 :brain (max 0 value)))
+        "/take-meat"  #(when (= %2 :runner) (damage %1 %2 :meat  (max 0 value)))
+        "/take-net"   #(when (= %2 :runner) (damage %1 %2 :net   (max 0 value)))
+        "/take-brain" #(when (= %2 :runner) (damage %1 %2 :brain (max 0 value)))
         "/discard"    #(move %1 %2 (nth (get-in @%1 [%2 :hand]) num nil) :discard)
         "/deck"       #(move %1 %2 (nth (get-in @%1 [%2 :hand]) num nil) :deck {:front true})
         nil

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -48,3 +48,10 @@
                             (step more seen)
                             (cons x (step more (conj seen k))))))))]
     (step coll #{})))
+
+(defn String->Num [s]
+  (try
+    (bigdec s)
+  (catch Exception e nil)))
+
+(def safe-split (fnil clojure.string/split ""))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -154,11 +154,13 @@
 (defn create-span-impl [item]
   (if (= "[hr]" item)
     [:hr ]
+  (if (= "[!]" item)
+    [:div.smallwarning "!"]
   (if-let [class (anr-icons item)]
     [:span {:class (str "anr-icon " class)}]
   (if-let [[title code] (extract-card-info item)]
     [:span {:class "fake-link" :id code} title]
-    [:span item]))))
+    [:span item])))))
 
 (defn get-alt-art [[title cards]]
   (let [s (sort-by #(not= (:setname %) "Alternates") cards)]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -157,6 +157,17 @@ button.small
   color: orangered
   margin-left: 5px
 
+.smallwarning
+    position: relative
+    background: transparent-orange
+    border: 1px solid orange
+    color: white
+    margin-left: 2px
+    margin-right: 2px
+    width: 12px
+    display: inline-block
+    text-align: center
+
 .warning
     position: relative
     background: #34849F


### PR DESCRIPTION
A bunch of commands you can enter in the chat box to change the game state.

- `/draw n` -> Draw `n` cards
- `/credit n` -> Set your credits to `n`
- `/click n` -> Set your clicks to `n`
- `/memory n` -> Set your memory to `n`
- `/tag n` -> Set your tags to `n`
- `/bp n` -> Set your bad publicity to `n`
- `/link n` -> Set your link to `n`
- `/handsize n` -> Set your handsize to `n`
- `/take-meat n` -> Take `n` meat damage (Runner only)
- `/take-net n` -> Take `n` meat damage (Runner only) 
- `/take-brain n` -> Take `n` meat damage (Runner only)
- `/discard #n` -> Discard card number `n` from your hand  
- `/deck #n` -> Put card number `n` from your hand on top of your deck

Spectators can't use commands. When a player uses such a command, it is displayed in the log with a warning icon:

![bild 3](https://cloud.githubusercontent.com/assets/3126597/9814746/be64c844-5890-11e5-9088-ab3c6fb4082f.png)

This makes it easier/possible to

- take things back (like a accidentally rezzed, expensive ice/asset)
- manually resolve unimplemented cards
- debug things (e.g. just set clicks/credits to 1000)
- discard cards where dragging is broken (e.g. IE)

without to clutter up the UI.