### PR TITLE
Fixes #668 - Doppelganger doesn't prompt to run again

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -141,7 +141,7 @@
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
     :events {:successful-run-ends
              {:optional
-              {:req (req (first-event state side :run))
+              {:req (req (has-one-event state side :run))
                :prompt "Use Doppelgänger to run again?" :player :runner
                :yes-ability {:prompt "Choose a server" 
                              :choices (req servers)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1618,6 +1618,9 @@
 (defn first-event [state side ev]
   (empty? (turn-events state side ev)))
 
+(defn has-one-event [state side ev]
+  (= (turn-events state side ev) 1))
+
 (defn ice-index [state ice]
   (first (keep-indexed #(when (= (:cid %2) (:cid ice)) %1) (get-in @state (cons :corp (:zone ice))))))
   


### PR DESCRIPTION
Hi,

I'm still getting used to the language and dev environment, so don't hesitate to crack down on me if this fix is totally bogus :)

Doppelganger was checking if turn-events (:run) was empty (via first-event :run) but it already contained one for the current active run. I saw that quite a few cards were using (first-event :run) so I didnt want to modify that function in case of side effects. So I added a new function (has-one-event) and made Doppelganger use that instead. It seems a bit crappy though, so if there is a better way to fix this I'd be happy to re-do it.

As an aside, I saw you guys have some dev comms going on via slack. Would it be ok to get an invite for that please? It'd probably be better to ask questions on there instead of via pull requests.

Thanks

