### PR TITLE
Add/improve cards that temporarily assign subtypes to ice

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -246,6 +246,22 @@
              :rez {:req (req (and (= (:type target) "ICE") (not (get-in @state [:per-turn (:cid card)]))))
                               :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
 
+   "Rielle \"Kit\" Peddler: Transhuman"
+   {:abilities [{:req (req (and (:run @state)
+                                (:rezzed (get-card state current-ice))))
+                 :once :per-turn :msg (msg "make " (:title current-ice) " gain code gate until the end of the run")
+                 :effect (req (let [ice current-ice
+                                    stypes (:subtype ice)]
+                                (update! state side (assoc ice :subtype
+                                                               (->> (vec (.split (:subtype ice) " - "))
+                                                                    (cons "Code Gate")
+                                                                    distinct
+                                                                    (join " - "))))
+                                (register-events state side {:run-ends
+                                                             {:effect (effect (update! (assoc ice :subtype stypes))
+                                                                              (unregister-events card))}} card)))}]
+    :events {:run-ends nil}}
+
    "Silhouette: Stealth Operative"
    {:events {:successful-run
              {:req (req (= target :hq)) :once :per-turn

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -379,7 +379,12 @@
 
    "Sub Boost"
    {:choices {:req #(and (= (:type %) "ICE") (:rezzed %))}
-    :effect (effect (host target (assoc card :zone [:discard] :seen true)))}
+    :effect (effect (update! (assoc target :subtype
+                                           (->> (vec (.split (:subtype target) " - "))
+                                                (concat ["Barrier"])
+                                                distinct
+                                                (join " - "))))
+                    (host (get-card state target) (assoc card :zone [:discard] :seen true)))}
 
    "Subliminal Messaging"
    {:effect (effect (gain :credit 1)

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -434,25 +434,26 @@
                                                               :yes-ability {:msg "jack out"
                                                                             :effect (effect (jack-out nil))}}}
                                                   card nil))}]}
+
    "Surfer"
    {:abilities [{:cost [:credit 2]
-                 :req (req (and (:run @state) (:rezzed current-ice)))
-                 :label "Swap a piece of barrier ice currently being encountered with a piece of ice directly before or after it"
+                 :req (req (and (:run @state) (:rezzed current-ice) (has? current-ice :subtype "Barrier")))
+                 :label "Swap the barrier ICE currently being encountered with a piece of ICE directly before or after it"
                  :effect (req (let [cice current-ice]
                                 (resolve-ability
                                   state side
-                                  {:prompt (msg "Choose an ice before or after " (:title cice))
-                                   :choices {:req #(and (= (:type %) "ICE") 
+                                  {:prompt (msg "Choose an ICE before or after " (:title cice))
+                                   :choices {:req #(and (= (:type %) "ICE")
                                                         (= (:zone %) (:zone cice))
                                                         (= 1 (abs (- (ice-index state %) (ice-index state cice)))))}
-                                   :msg "swap a piece of barrier ice"
+                                   :msg "swap a piece of barrier ICE"
                                    :effect (req (let [tgtndx (ice-index state target)
                                                       oldndx (ice-index state cice)]
                                                   (swap! state update-in (cons :corp (:zone cice))
                                                       #(assoc % tgtndx cice))
                                                   (swap! state update-in (cons :corp (:zone cice))
                                                       #(assoc % oldndx target))
-                                                  (swap! state update-in [:run] 
+                                                  (swap! state update-in [:run]
                                                       #(assoc % :position (inc tgtndx)))
                                                   (update-ice-strength state side (cons :corp (:zone cice)))
                                                   (update-run-ice state side)))}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -295,13 +295,23 @@
    "Paintbrush"
    {:abilities [{:cost [:click 1]
                  :choices {:req #(and (= (first (:zone %)) :servers) (has? % :type "ICE") (:rezzed %))}
-                 :effect (req (let [ice target]
+                 :effect (req (let [ice target
+                                    stypes (:subtype ice)]
                            (resolve-ability
                               state :runner
-                              {:prompt (msg "Choose a type")
-                               :choices ["sentry" "code gate" "barrier"]
-                               :msg (msg "give " (:title ice) " " target " until the end of next run this turn")}
-                              card nil)))}]}
+                              {:prompt (msg "Choose a subtype")
+                               :choices ["Sentry" "Code Gate" "Barrier"]
+                               :msg (msg "give " (:title ice) " " (.toLowerCase target) " until the end of the next run this turn")
+                               :effect (effect (update! (assoc ice :subtype
+                                                                   (->> (vec (.split (:subtype ice) " - "))
+                                                                        (cons target)
+                                                                        distinct
+                                                                        (join " - "))))
+                                               (register-events {:run-ends
+                                                                 {:effect (effect (update! (assoc ice :subtype stypes))
+                                                                                  (unregister-events card))}} card))}
+                              card nil)))}]
+    :events {:run-ends nil}}
 
    "Parasite"
    {:hosting {:req #(and (= (:type %) "ICE") (:rezzed %))}


### PR DESCRIPTION
Full implementations of Tinkering and Paintbrush, plus the addition of a barrier targeting requirement to Surfer. For Tinkering, we log the position of the ice and the server it's protecting to avoid confusion when targeting a piece of unrezzed ice. Sub Boost applies the barrier subtype to the ice it's hosted on (but doesn't remove it if that ice leaves play--I'll tackle that later in the unlikely event it gets to be an issue). 

Adds a new implementation of Rielle "Kit" Peddler, which the Runner can click during the encounter of the first rezzed ice of a turn to add *Code Gate* to its subtypes. It's of limited usefulness right now (will turn on auto-pumping ability for decoders), but who knows what might come in the future where it could come in handy. 