### PR TITLE
implement Cyber Threat, Social Engineering, Shipment from MirrorMorph

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -340,6 +340,14 @@
     :msg (msg "1 advancement tokens on " (count targets) " cards")
     :effect (req (doseq [t targets] (add-prop state :corp t :advance-counter 1)))}
 
+   "Shipment from MirrorMorph"
+   (let [shelper (fn sh [n] {:prompt "Select a card to install"
+                             :choices {:req #(and (:side % "Corp") (not= (:type %) "Operation") (= (:zone %) [:hand]))}
+                             :effect (req (corp-install state side target nil)
+                                          (when (< n 3)
+                                            (resolve-ability state side (sh (inc n)) card nil)))})]
+     {:effect (effect (resolve-ability (shelper 1) card nil))})
+
    "Shipment from SanSan"
    {:choices ["0", "1", "2"] :prompt "How many advancement tokens?"
     :effect (req (let [c (Integer/parseInt target)]


### PR DESCRIPTION
I feel like I hammered away on Cyber Threat for a month before finally getting it. Lessons learned from An Offer You Can't Refuse...had to manually create the run with a `swap! state` in the `:no-ability` to get it to work. 

Social Engineering steals from Tinkering to notify the Corp which ice was selected (ice position 0 = innermost). An event is registered to give the Runner the credits if that ice is rezzed anytime during the rest of the turn, then unregister when the turn ends. 

Credit to @queueseven for the recursive install function in Shipment from MirrorMorph. Without it you can't get a new remote you create with the first install to show up in the list for the rest of the installs. 