### PR TITLE
Fisk bug workaround

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -170,14 +170,15 @@
                           :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Laramy Fisk: Savvy Investor"
-   {:events {:successful-run {:req (req (and (#{:hq :rd :archives} target)
-                                             (empty? (let [successes (map first (turn-events state side :successful-run))]
-                                                       (do
-                                                         (prn successes)
-                                                         (filter #(not (= % :remote)) successes))))))
-                              :optional {:prompt "Force the Corp to draw 1 card?"
-                                         :yes-ability {:msg "force the Corp to draw 1 card"
-                                                       :effect (effect (draw :corp))}}}}}
+   {:abilities [{:msg "force the Corp to draw 1 card"
+                 :req (req (and run
+                                (some #{:hq :rd :archives} (:server run))
+                                (:no-action run)
+                                (not current-ice)
+                                (not (get-in @state [:per-turn (:cid card)]))
+                                (empty? (let [successes (map first (turn-events state side :successful-run))]
+                                          (filter #(not (= % :remote)) successes)))))
+                 :effect (req (effect (draw :corp)) (swap! state assoc-in [:per-turn (:cid card)] true))}]}
 
    "Leela Patel: Trained Pragmatist"
    {:events {:agenda-scored {:choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :msg "add 1 unrezzed card to HQ"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -170,7 +170,14 @@
                           :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Laramy Fisk: Savvy Investor"
-   {:abilities [{:msg "force the Corp to draw 1 card"
+   {:events {:no-action {:effect (effect (system-msg "can be forced to draw by clicking on Laramy Fisk"))
+                         :req (req (and run
+                                        (some #{:hq :rd :archives} (:server run))
+                                        (not current-ice)
+                                        (not (get-in @state [:per-turn (:cid card)]))
+                                        (empty? (let [successes (map first (turn-events state side :successful-run))]
+                                                  (filter #(not (= % :remote)) successes)))))}}
+    :abilities [{:msg "force the Corp to draw 1 card"
                  :req (req (and run
                                 (some #{:hq :rd :archives} (:server run))
                                 (:no-action run)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -893,7 +893,7 @@
     (let [s (get-in @state [:run :server])
           ices (get-in @state (concat [:corp :servers] s [:ices]))]
       (swap! state assoc-in [:run :ices] ices))))
-  
+
 (defn run
   ([state side server] (run state side server nil nil))
   ([state side server run-effect card]
@@ -1222,6 +1222,7 @@
 (defn no-action [state side args]
   (swap! state assoc-in [:run :no-action] true)
   (system-msg state side "has no further action")
+  (trigger-event state side :no-action)
   (when-let [pos (get-in @state [:run :position])]
     (when-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
       (when (:rezzed ice)
@@ -1427,7 +1428,7 @@
                                      (update-in [:host :zone] #(map to-keyword %)))))
            (system-msg state side (str (build-spend-msg cost-str "rez" "rezzes")
                                        (:title card) (when no-cost " at no cost")))
-           (when (#{"ICE"} (:type card)) 
+           (when (#{"ICE"} (:type card))
              (update-ice-strength state side card)
              (update-run-ice state side))
            (trigger-event state side :rez card))))
@@ -1624,5 +1625,5 @@
 
 (defn ice-index [state ice]
   (first (keep-indexed #(when (= (:cid %2) (:cid ice)) %1) (get-in @state (cons :corp (:zone ice))))))
-  
+
 (load "cards")


### PR DESCRIPTION
Implementation of workaround suggested by @nealterrell to deal with #515.
- Clicking Fisk just before a successful-run event trigger forces the draw.
- Displays system message when Laramy Fisk can be used and describing how to the ability.

Drawback is that the player can jack out after using Fisk's ability, aborting the successful run. 