### PR TITLE
implement Director Haas' Pet Project and The Twins

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -77,6 +77,28 @@
      :events {:runner-turn-begins e
               :corp-turn-begins   e}})
 
+   "Director Haas Pet Project"
+   (let [dhelper (fn dpp [n] {:prompt "Select a card to install"
+                              :show-discard true
+                              :choices {:req #(and (:side % "Corp")
+                                                   (not= (:type %) "Operation")
+                                                   (or (= (:zone %) [:hand])
+                                                       (= (:zone %) [:discard])))}
+                              :effect (req (corp-install state side target
+                                            (str "Server " (dec (count (get-in @state [:corp :servers :remote])))) {:no-install-cost true})
+                                           (when (< n 2)
+                                             (resolve-ability state side (dpp (inc n)) card nil)))})]
+     {:optional {:prompt "Create a new remote server?"
+                 :yes-ability {:prompt "Select a card to install"
+                               :show-discard true
+                               :choices {:req #(and (:side % "Corp")
+                                                    (not= (:type %) "Operation")
+                                                    (or (= (:zone %) [:hand])
+                                                        (= (:zone %) [:discard])))}
+                               :effect (req (corp-install state side target "New remote" {:no-install-cost true})
+                                            (resolve-ability state side (dhelper 1) card nil))
+                               :msg "create a new remote server, installing cards at no cost"}}})
+
    "Domestic Sleepers"
    {:abilities [{:cost [:click 3] :msg "place 1 agenda counter on Domestic Sleepers"
                  :effect (req (when (zero? (:counter card))

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -177,6 +177,24 @@
    {:events {:pre-steal-cost {:req (req (= (:zone card) (:zone target)))
                               :effect (effect (steal-cost-bonus [:click 1]))}}}
 
+   "The Twins"
+   {:abilities [{:label "Reveal and trash a copy of the ICE just passed from HQ"
+                 :req (req (and this-server
+                                (> (count (:ices run)) (:position run))
+                                (:rezzed (get-in (:ices (card->server state card)) [(:position run)]))))
+                 :effect (req (let [icename (:title (get-in (:ices (card->server state card)) [(:position run)]))]
+                                (resolve-ability
+                                  state side
+                                  {:prompt "Choose a copy of the ICE just passed"
+                                   :choices {:req #(and (= (:zone %) [:hand])
+                                                        (= (:type %) "ICE")
+                                                        (= (:title %) icename))}
+                                   :effect (req (trash state side (assoc target :seen true))
+                                                (swap! state update-in [:run]
+                                                       #(assoc % :position (inc (:position run)))))
+                                   :msg (msg "trash a copy of " (:title target) " from HQ and force the Runner to encounter it again")}
+                                 card nil)))}]}
+
    "Tyrs Hand"
    {:abilities [{:label "Prevent a subroutine on a Bioroid from being broken"
                  :req (req (and (= (butlast (:zone current-ice)) (butlast (:zone card)))


### PR DESCRIPTION
Pet Project: Very similar to Shipment from MirrorMorph, except that we skip past the server selection prompt--on the first install, automatically make a new remote, then in the helper function we identify the outermost remote that was just created and keep installing there. 

The Twins: Enforces that the run is on this server, that the Runner has passed at least 1 piece of ice and that the most-recently-passed ice is rezzed, and that the ice you choose from HQ matches its title. 