### PR TITLE
fix Tri-maf Contact

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -612,7 +612,7 @@
    "Tri-maf Contact"
    {:abilities [{:cost [:click 1] :msg "gain 2 [Credits]" :once :per-turn
                  :effect (effect (gain :credit 2))}]
-    :trash-effect {:effect (effect (damage :meat 3 {:unboostable true :card card}))}}
+    :leave-play (effect (damage :meat 3 {:unboostable true :card card}))}
 
    "Tyson Observatory"
    {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "adds " (:title target) " to their Grip")


### PR DESCRIPTION
Fix for #724. Only deal the 3 damage if Tri-maf Contact is trashed while in play. 