### PR TITLE
Revert the prompt preventing stuff

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -262,12 +262,8 @@
 (defn show-prompt
   ([state side card msg choices f] (show-prompt state side card msg choices f nil))
   ([state side card msg choices f {:keys [priority prompt-type show-discard] :as args}]
-   (let [prompt (if (string? msg) msg (msg state side card nil))]
-     (when (and (or (:number choices) (#{:credit :counter} choices) (> (count choices) 0))
-                (or (nil? card)
-                    (empty? (->> (get-in @state [side :prompt])
-                                 (map #(vec [(get-in % [:card :cid]) (:msg %)]))
-                                 (filter #(and (not (nil? (:cid card))) (= % (vec [(:cid card) msg]))))))))
+  (let [prompt (if (string? msg) msg (msg state side card nil))]
+     (when (or (:number choices) (#{:credit :counter} choices) (> (count choices) 0))
        (swap! state update-in [side :prompt]
               (if priority
                 #(cons {:msg prompt :choices choices :effect f :card card


### PR DESCRIPTION
There was another issue and I think it's better to revert this entirely and come up with another approach to solve the underlying issue. 

The root cause is that when an effect shows a prompt, the cost is paid when the choice is done by the user, not directly after activating the effect/ability.