### PR TITLE
Enable websocket compression over socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "passport": "~0.2.0",
     "passport-local": "~1.0.0",
     "request": "~2.34.0",
-    "socket.io": "~1.0.6",
+    "socket.io": "~1.3.6",
     "stylus": "~0.44.0",
     "zmq": "^2.11.0"
   }

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -17,7 +17,7 @@ html
 
     if env === "dev"
       script(type="text/javascript").
-        var iourl = location.hostname;
+        var iourl = window.location.origin;
     else
       script(type="text/javascript").
         var tokens = location.hostname.split(".");


### PR DESCRIPTION
This upgrades socket.io to version 1.3.6. Version 1.3 implemented the `permessage-deflate` WebSocket standard for compressing socket communication. This is enabled by default, so all we have to do is upgrade to immediately receive the benefits.

I have verified that this works on my dev machine: the Request headers include `Sec-WebSockets-Extensions: permessage-deflate` (from compatible browsers), and the Response headers likewise show the extension. (Without socket 1.3, the Response does not include the deflate header.)

socket 1.3 changes the handling of sockets on namespaces with non-default ports, which is why I had to change the client code for the dev environment to use the current port for the socket request. @mtgred , I don't know if the Production code will likewise have to change, you will need to make sure that the port of the websocket is included in the connection code [here](https://github.com/nealterrell/netrunner/blob/42ef3c314c551539481c32a69670ef0bc76165ac/views/layout.jade#L26).

@queueseven's experiments suggest this may reduce the size of websocket transmissions to 1/7 their original size, for browsers that support deflate.