### PR TITLE
Cortez Chip target ID, Quicksand manual effect, discounted Monolith program installs, fix DaVinci

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -508,9 +508,11 @@
    {:abilities [end-the-run]}
 
    "Quicksand"
-   {:events {:encounter-ice {:req (req (= (:cid target) (:cid card)))
-                             :effect (effect (add-prop card :counter 1))}}
-    :strength-bonus (req (or (:counter card) 0)) :abilities [end-the-run]}
+   {:abilities [{:req (req (and this-server (= (dec (:position run)) (ice-index state card))))
+                 :label "Add 1 power counter"
+                 :effect (effect (add-prop card :counter 1))}
+                 end-the-run]
+    :strength-bonus (req (or (:counter card) 0))}
 
    "Rainbow"
    {:abilities [end-the-run]}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -86,7 +86,7 @@
    "DaVinci"
    {:events {:successful-run {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:prompt "Choose a card to install"
-                 :choices (req (filter #(and (<= (:cost %) (:counter card))
+                 :choices (req (filter #(and (<= (:cost %) (or (:counter card) 0))
                                              (#{"Hardware" "Program" "Resource"} (:type %)))
                                        (:hand runner)))
                  :msg (msg "install " (:title target) " at no cost")


### PR DESCRIPTION
The addition to Cortez Chip solves #638 in the same manner as Tinkering does now with unrezzed ice--just identify the server and the position (0 = innermost). 

Adding a power counter to Quicksand is now done manually by the Corp, which should hopefully alleviate some or all of the issues in #714, #699, and #311. 

The discounted program installs granted when installing Monolith are restored (got reverted some time ago erroneously), and work better now--the recursive function in Shipment from MirrorMorph is ported over so you can order the installs (e.g., maximizing Overmind counters by installing it first). Note: this function won't work until the reversion in #730 is merged. 

Added a nil check to DaVinci so it can install 0-cost programs when it has no counters. Fixes #735.