### PR TITLE
fuller implementations: Pawn, Bishop, Bandwidth, Sage

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -46,7 +46,14 @@
     :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
 
    "Bandwidth"
-   {:abilities [{:msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}]}
+   {:abilities [{:msg "give the Runner 1 tag"
+                 :effect (effect (tag-runner :runner 1)
+                                 (register-events
+                                   {:successful-run {:effect (effect (lose :runner :tag 1))
+                                                     :msg "make the Runner lose 1 tag"}
+                                    :run-ends {:effect (effect (unregister-events card))}}
+                                  card))}]
+    :events {:successful-run nil :run-ends nil}}
 
    "Bastion"
    {:abilities [end-the-run]}

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -301,7 +301,9 @@
                                  {:cost [:credit 1] :msg "add 3 strength" :effect (effect (pump card 3)) :pump 3}]})
 
    "Sage"
-   {:abilities [{:cost [:credit 2] :msg "break 1 code gate or barrier subroutine"}]
+   {:abilities [{:cost [:credit 2] :req (req (or (has? current-ice :subtype "Barrier")
+                                                 (has? current-ice :subtype "Code Gate")))
+                 :msg "break 1 code gate or barrier subroutine"}]
     :effect (req (add-watch state (keyword (str "sage" (:cid card)))
                             (fn [k ref old new]
                               (when (not= (get-in old [:runner :memory]) (get-in new [:runner :memory]))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -15,24 +15,32 @@
                                                          (handle-end-run state side)) ; remove the replace-access prompt
                                             :msg "shuffle a card into R&D"}} card))}]}
 
-
-
    "Au Revoir"
    {:events {:jack-out {:effect (effect (gain :credit 1)) :msg "gain 1 [Credits]"}}}
 
-
    "Bishop"
-   {:abilities [{:label "Host Bishop on a piece of ICE" :cost [:click 1]
-                 :choices {:req #(and (= (:type %) "ICE")
-                                      (= (last (:zone %)) :ices)
-                                      (not (some (fn [c] (has? c :subtype "Caïssa")) (:hosted %))))}
-                 :msg (msg "host it on " (if (:rezzed target) (:title target) "a piece of ICE"))
-                 :effect (effect (host target card))}]
+   {:abilities [{:cost [:click 1]
+                 :effect (req (let [b (get-card state card)
+                                    hosted? (:host b)
+                                    remote? (some #{:remote} (rest (butlast (:zone (:host b)))))]
+                                (resolve-ability state side
+                                 {:prompt (msg "Host Bishop on a piece of ICE protecting "
+                                            (if hosted? (if remote? "a central" "a remote") "any") " server")
+                                  :choices {:req #(if hosted?
+                                                    (and (if (some #{:remote} (rest (butlast (:zone (:host b)))))
+                                                           (some #{:hq :rd :archives} (rest (butlast (:zone %))))
+                                                           (some #{:remote} (rest (butlast (:zone %)))))
+                                                         (= (:type %) "ICE")
+                                                         (= (last (:zone %)) :ices)
+                                                         (not (some (fn [c] (has? c :subtype "Caïssa")) (:hosted %))))
+                                                    (and (= (:type %) "ICE")
+                                                         (= (last (:zone %)) :ices)
+                                                         (not (some (fn [c] (has? c :subtype "Caïssa")) (:hosted %)))))}
+                                  :msg (msg "host it on " (if (:rezzed target) (:title target) "a piece of ICE"))
+                                  :effect (effect (host target card))} card nil)))}]
     :events {:pre-ice-strength
              {:req (req (and (= (:cid target) (:cid (:host card))) (:rezzed target)))
               :effect (effect (ice-strength-bonus -2))}}}
-
-
 
    "Bug"
    {:req (req (some #{:hq} (:successful-run runner-reg)))}


### PR DESCRIPTION
Bandwidth now takes away a tag when the run is successful. 

Once hosted, Bishop will now require bouncing back and forth between central servers and remotes as required, and will prompt the Runner accordingly. 

Pawn automatically advances to the next-innermost ice when it sees a successful run, and then trashes itself and kicks off the free Caissa install from Grip or Heap once it advances past the last ice. 

Sage checks for the correct ice subtypes now. 