### PR TITLE
Let upgrades overlap in remote servers

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -532,7 +532,7 @@
             (om/build card-view ice {:opts {:flipped (not (:rezzed ice))}}))])
        (when content
          [:div.content {:class (str (when (= (count content) 1) "center") " " (when central "shift"))}
-          (for [card (reverse content)]
+          (for [card content]
             (om/build card-view card {:opts {:flipped (not (:rezzed card))}}))
           (om/build label content {:opts opts})])]))))
 
@@ -633,7 +633,7 @@
                 (om/build rfg-view {:cards (:current me) :name "Current"})]
                (when-not (= side :spectator)
                  [:div.button-pane { :on-mouse-over card-preview-mouse-over
-                                    :on-mouse-out  card-preview-mouse-out  }
+                                     :on-mouse-out  card-preview-mouse-out  }
                   (when-not (:keep me)
                     [:div.panel.blue-shade
                      [:h4 "Keep hand?"]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1303,11 +1303,11 @@ nav ul
 
       .runner-board
         padding: 10px
-
+          
       .content.shift > .card-frame
         margin-left: 8px
         margin-top: -8px
-
+        
       .corp-board
         display-flex()
 
@@ -1391,6 +1391,7 @@ nav ul
             height: 86px
 
             .card
+              margin: 0 -40px 0 0
               .abilities
                 left: -145px
                 bottom: 85px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1306,7 +1306,7 @@ nav ul
           
       .content.shift > .card-frame
         margin-left: 8px
-        margin-top: -8px
+        margin-top: -16px
         
       .corp-board
         display-flex()


### PR DESCRIPTION
this enables multiple cards in a remote server to overlap:

![bild 13](https://cloud.githubusercontent.com/assets/3126597/10014032/c3d48510-6116-11e5-8f38-21df4d19f734.png)

so you can actually play with 3 (or 4) cards in a single remote.
In a perfect world the (CSS-)size of a remote would increase with more cards, but I think it's not worth implementing.

Also, the order of cards in a server is no longer reversed, so installing a new card in a server does not move the old cards to the side (so you can better keep track of the order in which the cards were installed).

Relates to #552, #551, #512, #427 and probably others, too.