### PR TITLE
Fix IQ to update strength dynamically, update all ice after a purge

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -119,7 +119,7 @@
                                    :prompt "Choose a target for Clairvoyant Monitor"
                                    :msg (msg "place 1 advancement token on "
                                              (if (:rezzed target) (:title target) "a card") " and end the run")
-                                   :choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
+                                   :choices {:req #(= (first (:zone %)) :servers)}
                                    :effect (effect (add-prop target :advance-counter 1) (end-run))}}}]}
 
    "Chum"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -322,9 +322,16 @@
                          :effect (effect (damage :brain 1 {:card card}) (tag-runner :runner 1))}}]}
 
    "IQ"
-   {:abilities [end-the-run]
+   {:effect (req (add-watch state (keyword (str "iq" (:cid card)))
+                   (fn [k ref old new]
+                     (let [handsize (count (get-in new [:corp :hand]))]
+                       (when (not= (count (get-in old [:corp :hand])) handsize)
+                         (update! ref side (assoc (get-card ref card) :strength-bonus handsize))
+                         (update-ice-strength ref side (get-card ref card)))))))
+    :abilities [end-the-run]
     :strength-bonus (req (count (:hand corp)))
-    :rez-cost-bonus (req (count (:hand corp)))}
+    :rez-cost-bonus (req (count (:hand corp)))
+    :leave-play (req (remove-watch state (keyword (str "iq" (:cid card)))))}
 
    "Information Overload"
    {:abilities [{:label "Trace 1 - Give the Runner 1 tag"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1301,7 +1301,8 @@
         hosted-on-ice (->> (get-in @state [:corp :servers]) seq flatten (mapcat :ices) (mapcat :hosted))]
     (doseq [card (concat rig-cards hosted-cards hosted-on-ice)]
       (when (or (has? card :subtype "Virus") (= (:counter-type card) "Virus"))
-        (set-prop state :runner card :counter 0))))
+        (set-prop state :runner card :counter 0)))
+    (update-all-ice state side))
   (trigger-event state side :purge))
 
 (defn get-virus-counters [state side card]
@@ -1480,7 +1481,7 @@
   (trigger-event state side :play card))
 
 (defn derez [state side card]
-  (system-msg state side (str "derez " (:title card)))
+  (system-msg state side (str "derezzes " (:title card)))
   (update! state :corp (desactivate state :corp card true))
   (when-let [derez-effect (:derez-effect (card-def card))]
     (resolve-ability state side derez-effect (get-card state card) nil))
@@ -1515,7 +1516,7 @@
     (add-prop state side (get-card state card) :advance-counter 1)))
 
 (defn forfeit [state side card]
-  (system-msg state side (str "forfeit " (:title card)))
+  (system-msg state side (str "forfeits " (:title card)))
   (gain state side :agenda-point (- (:agendapoints card)))
   (move state :corp card :rfg))
 


### PR DESCRIPTION
Fixes for #723 and #733.   EDIT: Added a fix for #749.

Add a watch state to IQ so its strength updates in real-time as the Corp's hand size changes. Purging viruses is now followed up by a call to `update-all-ice` so strengths get shown correctly right away instead of waiting until the next encounter. Messages for derezzing a card and forfeiting an agenda are also tweaked to match the present tense of other game action messages. 