### PR TITLE
Testing framework iteration. Tests for Djinn, Virus Breeding Ground.

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -636,9 +636,13 @@
    "Virus Breeding Ground"
    {:data {:counter-type "Virus"}
     :events {:runner-turn-begins {:effect (effect (add-prop card :counter 1))}}
-    :abilities [{:cost [:click 1] :counter-cost 1 :msg (msg "move 1 virus counter to " (:title target))
-                 :choices {:req #(and (has? % :subtype "Virus") (>= (:counter %) 1))}
-                 :effect (effect (add-prop target :counter 1))}]}
+    :abilities [{:cost [:click 1]
+                 :msg (msg "move 1 virus counter to " (:title target))
+                 :req (req (pos? (get card :counter 0)))
+                 :choices {:req #(and (has? % :subtype "Virus") (>= (get % :counter 0) 1))}
+                 :effect (req (when (pos? (get-virus-counters state side target))
+                                (add-prop state side card :counter -1)
+                                (add-prop state side target :counter 1)))}]}
 
    "Wasteland"
    {:events {:runner-trash {:req (req (and (first-event state :runner :runner-trash) (:installed target)))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -526,7 +526,7 @@
                    (host state side (get-card state card) c {:facedown true})))
     :abilities [{:prompt "Choose a card on Street Peddler to install"
                  :choices (req (filter #(and (not= (:type %) "Event")
-                                             (<= (:cost %) (inc (:credit runner))))
+                                             (can-pay? state side (modified-install-cost state side % [:credit -1])))
                                        (:hosted card)))
                  :msg (msg "install " (:title target) " lowering its install cost by 1 [Credits]")
                  :effect (effect

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -11,6 +11,6 @@
       (core/rez state :corp jhow)
       (is (= 5 (count (:hand (get-corp)))))
       (is (= 2 (:click (get-corp))))
-      (card-ability state :corp (core/get-card state jhow) 0)
+      (card-ability state :corp jhow 0)
       (is (= 7 (count (:hand (get-corp)))) "Drew 2 cards")
       (is (= 1 (:click (get-corp)))))))

--- a/src/clj/test/cards-ice.clj
+++ b/src/clj/test/cards-ice.clj
@@ -11,6 +11,6 @@
     (is (= [:hq] (get-in @state [:run :server])))
     (let [iwall (get-in @state [:corp :servers :hq :ices 0])]
       (core/rez state :corp iwall)
-      (card-ability state :corp (core/get-card state iwall) 0)
+      (card-ability state :corp iwall 0)
       (is (not (:run @state)) "Run is ended")
       (is (get-in @state [:runner :register :unsuccessful-run]) "Run was unsuccessful"))))

--- a/src/clj/test/cards-identities.clj
+++ b/src/clj/test/cards-identities.clj
@@ -9,11 +9,22 @@
     (is (= 1 (:credit (get-runner))))))
 
 (deftest kate-mac-mccaffrey-no-discount
-  "Kate 'Mac' McCaffrey - Install discount"
+  "Kate 'Mac' McCaffrey - No discount for 0 cost"
   (do-game
     (new-game (default-corp) (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" [(qty "Magnum Opus" 1)
                                                                                   (qty "Self-modifying Code" 1)]))
     (take-credits state :corp)
     (play-from-hand state :runner "Self-modifying Code")
     (play-from-hand state :runner "Magnum Opus")
+    (is (= 0 (:credit (get-runner))))))
+
+(deftest kate-mac-mccaffrey-discount-cant-afford
+  "Kate 'Mac' McCaffrey - Can Only Afford With the Discount"
+  (do-game
+    (new-game (default-corp) (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" [(qty "Magnum Opus" 1)]))
+    (take-credits state :corp)
+    (core/lose state :runner :credit 1)
+    (is (= 4 (:credit (get-runner))))
+    (play-from-hand state :runner "Magnum Opus")
+    (is (= 1 (count (get-in @state [:runner :rig :program]))))
     (is (= 0 (:credit (get-runner))))))

--- a/src/clj/test/cards-programs.clj
+++ b/src/clj/test/cards-programs.clj
@@ -1,5 +1,56 @@
 (in-ns 'test.core)
 
+(deftest djinn-host-chakana
+  "Djinn - Hosted Chakana does not disable advancing agendas. Issue #750"
+  (do-game
+    (new-game (default-corp [(qty "Priority Requisition" 1)])
+              (default-runner [(qty "Djinn" 1) (qty "Chakana" 1)]))
+    (play-from-hand state :corp "Priority Requisition" "New remote")
+    (take-credits state :corp 2)
+    (play-from-hand state :runner "Djinn")
+    (let [djinn (get-in @state [:runner :rig :program 0])
+          agenda (get-in @state [:corp :servers :remote 0 :content 0])]
+      (is agenda "Agenda was installed")
+      (card-ability state :runner djinn 1)
+      (core/resolve-prompt state :runner {:card (find-card "Chakana" (:hand (get-runner)))})
+      (let [chak (first (:hosted (refresh djinn)))]
+        (is (= "Chakana" (:title chak)) "Djinn has a hosted Chakana")
+        (core/add-prop state :runner (first (:hosted (refresh djinn))) :counter 3) ; manually add 3 counters
+        (take-credits state :runner 2)
+        (core/advance state :corp {:card agenda})
+        (is (= 1 (:advance-counter (refresh agenda))) "Agenda was advanced")))))
+
+(deftest djinn-host-program
+  "Djinn - Host a non-icebreaker program"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Djinn" 1) (qty "Chakana" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Djinn")
+    (is (= 3 (:memory (get-runner))))
+    (let [djinn (get-in @state [:runner :rig :program 0])]
+      (card-ability state :runner djinn 1)
+      (core/resolve-prompt state :runner {:card (find-card "Chakana" (:hand (get-runner)))})
+      (is (= 3 (:memory (get-runner))) "No memory used to host on Djinn")
+      (is (= "Chakana" (:title (first (:hosted (refresh djinn))))) "Djinn has a hosted Chakana")
+      (is (= 1 (:credit (get-runner))) "Full cost to host on Djinn"))))
+
+(deftest djinn-tutor-virus
+  "Djinn - Tutor a virus program"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Djinn" 1) (qty "Parasite" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Djinn")
+    (core/move state :runner (find-card "Parasite" (:hand (get-runner))) :deck)
+    (is (zero? (count (:hand (get-runner)))) "No cards in hand after moving Parasite to deck")
+    (let [djinn (get-in @state [:runner :rig :program 0])]
+      (card-ability state :runner djinn 0)
+      (core/resolve-prompt state :runner {:card (find-card "Parasite" (:deck (get-runner)))})
+      (is (= "Parasite" (:title (first (:hand (get-runner))))) "Djinn moved Parasite to hand")
+      (is (= 2 (:credit (get-runner))) "1cr to use Djinn ability")
+      (is (= 2 (:click (get-runner))) "1click to use Djinn ability"))))
+
 (deftest magnum-opus-click
   "Magnum Opus - Gain 2 cr"
   (do-game

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -10,18 +10,53 @@
     (let [kati (get-in @state [:runner :rig :resource 0])]
       (card-ability state :runner kati 0)
       (is (= 2 (:click (get-runner))))
-      (is (= 3 (:counter (core/get-card state kati))) "Store 3cr on Kati")
-      (card-ability state :runner (core/get-card state kati) 0)
+      (is (= 3 (:counter (refresh kati))) "Store 3cr on Kati")
+      (card-ability state :runner kati 0)
       (is (= 2 (:click (get-runner))) "Second use of Kati should not be allowed")
-      (is (= 3 (:counter (core/get-card state kati))) "Second use of Kati should not be allowed")
+      (is (= 3 (:counter (refresh kati))) "Second use of Kati should not be allowed")
       (take-credits state :runner 2)
       (is (= 5 (:credit (get-runner))) "Pass turn, take 2cr")
       (take-credits state :corp)
-      (card-ability state :runner (core/get-card state kati) 0)
-      (is (= 6 (:counter (core/get-card state kati))) "Store 3cr more on Kati")
+      (card-ability state :runner kati 0)
+      (is (= 6 (:counter (refresh kati))) "Store 3cr more on Kati")
       (take-credits state :runner 3)
       (is (= 8 (:credit (get-runner))) "Pass turn, take 3cr")
       (take-credits state :corp)
-      (card-ability state :runner (core/get-card state kati) 1)
+      (card-ability state :runner (refresh kati) 1)
       (is (= 14 (:credit (get-runner))) "Take 6cr from Kati")
-      (is (zero? (:counter (core/get-card state kati))) "No counters left on Kati"))))
+      (is (zero? (:counter (refresh kati))) "No counters left on Kati"))))
+
+(deftest virus-breeding-ground-gain
+  "Virus Breeding Ground - Gain counters"
+  (do-game
+    (new-game (default-corp) (default-runner [(qty "Virus Breeding Ground" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Virus Breeding Ground")
+    (let [vbg (get-in @state [:runner :rig :resource 0])]
+      (is (zero? (get vbg :counter 0)) "Virus Breeding Ground starts with 0 counters")
+      (take-credits state :runner 3)
+      (take-credits state :corp)
+      (is (= 1 (get (refresh vbg) :counter 0)) "Virus Breeding Ground gains 1 counter per turn")
+      (take-credits state :runner 3)
+      (take-credits state :corp)
+      (is (= 2 (get (refresh vbg) :counter 0)) "Virus Breeding Ground gains 1 counter per turn"))))
+
+(deftest virus-breeding-ground-gain
+  "Virus Breeding Ground - Move counters"
+  (do-game
+    (new-game (default-corp) (default-runner [(qty "Virus Breeding Ground" 1) (qty "Hivemind" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Virus Breeding Ground")
+    (play-from-hand state :runner "Hivemind")
+    (let [hive (get-in @state [:runner :rig :program 0])
+          vbg (get-in @state [:runner :rig :resource 0])]
+      (is (= 1 (get hive :counter 0)) "Hivemind starts with 1 counter")
+      (is (zero? (get vbg :counter 0)) "Virus Breeding Ground starts with 0 counters")
+      (take-credits state :runner 3)
+      (take-credits state :corp)
+      (is (= 1 (get (refresh vbg) :counter 0)) "Virus Breeding Ground gains 1 counter per turn")
+      (card-ability state :runner vbg 0)
+      (core/select state :runner {:card (refresh hive)})
+      (is (= 2 (get (refresh hive) :counter 0)) "Hivemind gained 1 counter")
+      (is (= 0 (get (refresh vbg) :counter 0)) "Virus Breeding Ground lost 1 counter"))))
+

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -15,7 +15,7 @@
     (take-credits state :runner 2)
     (let [cvs (first (get-in @state [:corp :servers :hq :content]))]
       (core/rez state :corp cvs)
-      (card-ability state :corp (core/get-card state cvs) 0)
+      (card-ability state :corp cvs 0)
       ; nothing in hq content
       (is (empty? (get-in @state [:corp :servers :hq :content])) "CVS was trashed")
       ; purged counters

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -1,0 +1,21 @@
+(in-ns 'test.core)
+
+(deftest runner-install-program
+  "runner-install - Program; ensure costs are paid"
+  (do-game
+    (new-game (default-corp) (default-runner [(qty "Gordian Blade" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Gordian Blade")
+    (let [gord (get-in @state [:runner :rig :program 0])]
+      (is (= (- 5 (:cost gord)) (:credit (get-runner))) "Program cost was applied")
+      (is (= (- 4 (:memoryunits gord)) (:memory (get-runner))) "Program MU was applied"))))
+
+(deftest desactivate-program
+  "desactivate - Program; ensure MU are restored"
+  (do-game
+    (new-game (default-corp) (default-runner [(qty "Gordian Blade" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Gordian Blade")
+    (let [gord (get-in @state [:runner :rig :program 0])]
+      (core/trash state :runner gord)
+      (is (= 4 (:memory (get-runner))) "Trashing the program restored MU"))))

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -47,7 +47,8 @@
 
 (defn card-ability
   ([state side card ability] (card-ability state side card ability nil))
-  ([state side card ability targets] (core/play-ability state side {:card card :ability ability :targets targets})))
+  ([state side card ability targets] (core/play-ability state side {:card (core/get-card state card)
+                                                                    :ability ability :targets targets})))
 
 (defn play-from-hand
   ([state side title] (play-from-hand state side title nil))

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -56,4 +56,5 @@
     (core/play state side {:card (find-card title (get-in @state [side :hand]))
                            :server server})))
 
+(load "core-game")
 (load "cards")

--- a/src/clj/test/macros.clj
+++ b/src/clj/test/macros.clj
@@ -1,6 +1,8 @@
-(ns test.macros)
+(ns test.macros
+  (:require [game.core :as core]))
 
 (defmacro do-game [s & body]
   `(let [~'state ~s
          ~'get-corp (fn [] (:corp @~'state))
-         ~'get-runner (fn [] (:runner @~'state))] ~@body))
+         ~'get-runner (fn [] (:runner @~'state))
+         ~'refresh (fn [~'card] (core/get-card ~'state ~'card))] ~@body))


### PR DESCRIPTION
Iterating on the testing framework. Reducing the frequency of having to call `get-card` for the latest version of a card's data. Added the shorter `refresh` macro to replace `core/get-card` for brevity.

Added tests for #750 #744 #738.

Fixes Street Peddler issues: #708, #578 (for Peddler only).