### PR TITLE
allow free install of Shards from hand to count as successful runs

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -189,7 +189,7 @@
                  :label "Rez a card, lowering the cost by 1 [Credits]" :msg (msg "rez " (:title target))
                  :effect (effect (rez-cost-bonus -1) (rez target))}
                 {:prompt "Choose an asset to add to HQ" :msg (msg "add " (:title target) " to HQ")
-                 :activatemsg "searches HQ for an asset"
+                 :activatemsg "searches R&D for an asset"
                  :choices (req (filter #(has? % :type "Asset") (:deck corp)))
                  :cost [:credit 1] :label "Search R&D for an asset"
                  :effect (effect (trash card) (move target :hand) (shuffle! :deck))}]}
@@ -197,7 +197,7 @@
    "Exposé"
    {:advanceable :always
     :abilities [{:label "Remove 1 bad publicity for each advancement token on Exposé"
-                 :msg (msg "remove " (:advance-counter card) " bad publicities")
+                 :msg (msg "remove " (:advance-counter card) " bad publicity")
                  :effect (effect (trash card) (lose :bad-publicity (:advance-counter card)))}]}
 
    "Franchise City"
@@ -267,16 +267,6 @@
                             :effect (req (doseq [c targets] (move state side c :deck))
                                          (shuffle! state side :deck))}
                            card nil))}]}
-
-   "Keegan Lane"
-   {:abilities [{:label "Remove a tag and trash to trash a program"
-                 :req (req (and this-server
-                                (> (get-in @state [:runner :tag]) 0)
-                                (not (empty? (filter #(has? % :type "Program") (all-installed state :runner))))))
-                 :msg (msg "remove 1 tag")
-                 :effect (req (resolve-ability state side trash-program card nil)
-                              (trash state side card {:cause :ability-cost})
-                              (lose state :runner :tag 1))}]}
 
    "Launch Campaign"
    {:effect (effect (add-prop card :counter 6))

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -158,7 +158,7 @@
                :prompt "Use Doppelgänger to run again?" :player :runner
                :yes-ability {:prompt "Choose a server" 
                              :choices (req servers)
-                             :msg (msg "to make a run on " target)
+                             :msg (msg "make a run on " target)
                              :effect (effect (update! (dissoc card :dopp-active)) (run target))}}}}}
 
    "Dorm Computer"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -6,10 +6,10 @@
 
    "Activist Support"
    {:events
-    {:corp-turn-begins {:req (req (not tagged)) 
-                        :msg "take 1 tag" 
+    {:corp-turn-begins {:req (req (not tagged))
+                        :msg "take 1 tag"
                         :effect (effect (tag-runner :runner 1))}
-     :runner-turn-begins {:req (req (zero? (:bad-publicity corp))) 
+     :runner-turn-begins {:req (req (zero? (:bad-publicity corp)))
                           :msg "give the Corp 1 bad publicity"
                           :effect (effect (gain :corp :bad-publicity 1))}}}
 
@@ -124,6 +124,7 @@
     :install-cost-bonus (req (if (and run (= (:server run) [:rd]) (= 0 (:position run)))
                                [:credit -7 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:rd]) (= 0 (:position run)))
+                   (register-successful-run state side (:server run))
                    (swap! state update-in [:runner :prompt] rest)
                    (handle-end-run state side)))}
 
@@ -161,7 +162,7 @@
                  :effect (req (let [c (move state :runner (first (:hosted card)) :scored)]
                                 (gain-agenda-point state :runner (:agendapoints c))))
                  :msg (msg (let [c (first (:hosted card))]
-                             (str "add " (:title c) " to his/her score area and gain "
+                             (str "add " (:title c) " to their score area and gain "
                              (:agendapoints c) " agenda point" (when (> (:agendapoints c) 1) "s"))))}]}
 
    "Gang Sign"
@@ -196,6 +197,7 @@
     :install-cost-bonus (req (if (and run (= (:server run) [:archives]) (= 0 (:position run)))
                                [:credit -7 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:archives]) (= 0 (:position run)))
+                   (register-successful-run state side (:server run))
                    (swap! state update-in [:runner :prompt] rest)
                    (handle-end-run state side)))}
 
@@ -209,10 +211,10 @@
              :agenda-stolen {:msg (msg "gain " (:agendapoints target) " [Credits]")
                              :effect (effect (gain :credit (:agendapoints target)))}}}
    "Hunting Grounds"
-   {:abilities [{:label "Prevent a \"when encountered\" ability on a piece of ice"
-                 :msg "prevent a \"when encountered\" ability on a piece of ice"
+   {:abilities [{:label "Prevent a \"when encountered\" ability on a piece of ICE"
+                 :msg "prevent a \"when encountered\" ability on a piece of ICE"
                  :once :per-turn}
-                 {:label "Install the top 3 cards of your stack facedown"
+                 {:label "Install the top 3 cards of your Stack facedown"
                   :effect (req (trash state side card {:cause :ability-cost})
                                (doseq [c (take 3 (:deck runner))]
                                   (runner-install state side c {:facedown true})))}]}
@@ -636,6 +638,7 @@
     :install-cost-bonus (req (if (and run (= (:server run) [:hq]) (= 0 (:position run)))
                                [:credit -7 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:hq]) (= 0 (:position run)))
+                   (register-successful-run state side (:server run))
                    (swap! state update-in [:runner :prompt] rest)
                    (handle-end-run state side)))}
 
@@ -658,7 +661,7 @@
    "Wireless Net Pavilion"
    {:effect (effect (trash-resource-bonus -2))
     :leave-play (effect (trash-resource-bonus 2))}
-                     
+ 
    "Woman in the Red Dress"
    {:events {:runner-turn-begins
              {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -97,6 +97,16 @@
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"
                               :effect (req (damage state side :net 1 {:card card}))}}}
 
+   "Keegan Lane"
+   {:abilities [{:label "[Trash], remove a tag: Trash a program"
+                 :req (req (and this-server
+                                (> (get-in @state [:runner :tag]) 0)
+                                (not (empty? (filter #(has? % :type "Program") (all-installed state :runner))))))
+                 :msg (msg "remove 1 tag")
+                 :effect (req (resolve-ability state side trash-program card nil)
+                              (trash state side card {:cause :ability-cost})
+                              (lose state :runner :tag 1))}]}
+                            
    "Marcus Batty"
    {:abilities [{:msg "start a Psi game"
                  :psi {:not-equal {:req (req this-server)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1198,13 +1198,16 @@
   (resolve-ability state side ability card nil)
   (handle-end-run state side))
 
+(defn register-successful-run [state side server]
+  (swap! state update-in [:runner :register :successful-run] #(conj % (first server)))
+  (swap! state assoc-in [:run :successful] true)
+  (trigger-event state side :successful-run (first server)))
+
 (defn successful-run [state side args]
   (when-let [successful-run-effect (get-in @state [:run :run-effect :successful-run])]
     (resolve-ability state side successful-run-effect (:card successful-run-effect) nil))
   (let [server (get-in @state [:run :server])]
-    (swap! state update-in [:runner :register :successful-run] #(conj % (first server)))
-    (swap! state assoc-in [:run :successful] true)
-    (trigger-event state side :successful-run (first server))
+    (register-successful-run state side server)
     (let [run-effect (get-in @state [:run :run-effect])
           r (:req run-effect)
           card (:card run-effect)


### PR DESCRIPTION
Fix for #753. Some code in `(defn successful-run` is split off into a separate function which can then be called by the Shards when installing from hand. 

This will let Datasucker tokens accrue, update `[:runner :register]` for Notoriety/Quest Completed, etc. 

Added a fix for Executive Boot Camp's asset search message, and shifted Keegan Lane out of the assets file into upgrades. 