### PR TITLE
Redo on user-selected skill levels for games

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1007,6 +1007,12 @@ nav ul
   .game-title
     width: 250px
 
+  .game-skill
+    width: 150px
+
+  .game-type
+    width: 150px
+
   .deck-collection
     width: 496px
     max-height: 355px


### PR DESCRIPTION
Simplified and merged with the spectator server changes.

![Example](https://cloud.githubusercontent.com/assets/10083341/9391976/d054520e-472e-11e5-95b0-07e20a815a7b.png)

If you want to set your own game title, go ahead -- it's still editable.

Otherwise select a game type (Private, Friendly, Serious, Tournament) and skill level (Beginner, Intermediate, Expert), and the title gets automatically filled. No other changes to the server or user experience.

The assumption is that the average Jinteki player is looking for a friendly game with intermediates. Therefore we don't say anything when Intermediate is selected, only calling attention if Beginner or Expert is. Game titles then turn into things like

* Friendly game -- the default title
* Serious game -- "Intermediate" skill implied
* Private game
* Friendly game for beginners -- call attention to the fact you're a beginner
* Serious game for experts -- likewise.

"Tournament" was meant to be an indication of top-tier play/decks. I think the community will naturally discover which labels are appropriate to which types of games, so we don't need 100% definitions for each.