### PR TITLE
Fix for multiple Team Sponsorships. Testing iteration.

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -547,15 +547,22 @@
                  :msg "swap the positions of two ICE"}]}
 
    "Team Sponsorship"
+   (let [thelper (fn ts [n] {:prompt "Install a card from Archives or HQ?" :choices ["Archives" "HQ"]
+                             :msg (msg "install a card from " target)
+                             :effect (effect (resolve-ability
+                                               {:prompt "Choose a card to install"
+                                                :choices (req (filter #(not= (:type %) "Operation")
+                                                                      ((if (= target "HQ") :hand :discard) corp)))
+                                                :effect (req (corp-install state side target nil {:no-install-cost true})
+                                                             (when (pos? (dec n))
+                                                               (resolve-ability state side (ts (dec n)) card nil)))}
+                                               card targets))})]
    {:events {:agenda-scored
-             {:prompt "Install a card from Archives or HQ?" :choices ["Archives" "HQ"]
-              :msg (msg "install a card from " target)
-              :effect (effect (resolve-ability
-                               {:prompt "Choose a card to install"
-                                :choices (req (filter #(not= (:type %) "Operation")
-                                                      ((if (= target "HQ") :hand :discard) corp)))
-                                :effect (effect (corp-install target nil {:no-install-cost true}))}
-                               card targets))}}}
+             {:req (req (not (get-in @state [:per-turn (keyword (str "team-sponsorship-" (:cid target)))]))) ; only one TS responds per score
+              :effect (req (let [ts (->> (:corp @state) :servers seq flatten (mapcat :content)
+                                         (filter #(and (:rezzed %) (= (:title %) "Team Sponsorship"))) count)]
+                             (swap! state assoc-in [:per-turn (keyword (str "team-sponsorship-" (:cid target)))] true)
+                             (resolve-ability state side (thelper ts) card nil)))}}})
 
    "Tech Startup"
    {:abilities [{:label "Install an asset from R&D"

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -14,3 +14,77 @@
       (card-ability state :corp jhow 0)
       (is (= 7 (count (:hand (get-corp)))) "Drew 2 cards")
       (is (= 1 (:click (get-corp)))))))
+
+(deftest team-sponsorship-hq
+  "Team Sponsorship - Install from HQ"
+  (do-game
+    (new-game (default-corp [(qty "Domestic Sleepers" 1) (qty "Team Sponsorship" 1) (qty "Adonis Campaign" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Team Sponsorship" "New remote")
+    (play-from-hand state :corp "Domestic Sleepers" "New remote")
+    (let [ag1 (get-in @state [:corp :servers :remote 1 :content 0])
+          tsp (get-in @state [:corp :servers :remote 0 :content 0])]
+      (core/rez state :corp tsp)
+      (core/gain state :corp :click 6 :credit 6)
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/score state :corp {:card (refresh ag1)})
+      ; TSP prompt should be active
+      (is (= (:cid tsp) (get-in @state [:corp :prompt 0 :card :cid])))
+      (prompt-choice :corp "HQ")
+      (prompt-card :corp (find-card "Adonis Campaign" (:hand (get-corp))))
+      (prompt-choice :corp "New remote")
+      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote 1 :content 0 :title])) "Adonis installed by Team Sponsorship")
+      (is (nil? (find-card "Adonis Campaign" (:hand (get-corp)))) "No Adonis in hand"))))
+
+(deftest team-sponsorship-archives
+  "Team Sponsorship - Install from Archives"
+  (do-game
+    (new-game (default-corp [(qty "Domestic Sleepers" 1) (qty "Team Sponsorship" 1) (qty "Adonis Campaign" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Team Sponsorship" "New remote")
+    (play-from-hand state :corp "Domestic Sleepers" "New remote")
+    (core/move state :corp (find-card "Adonis Campaign" (:hand (get-corp))) :discard)
+    (let [ag1 (get-in @state [:corp :servers :remote 1 :content 0])
+          tsp (get-in @state [:corp :servers :remote 0 :content 0])]
+      (core/rez state :corp tsp)
+      (core/gain state :corp :click 6 :credit 6)
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/score state :corp {:card (refresh ag1)})
+      ; TSP prompt should be active
+      (is (= (:cid tsp) (get-in @state [:corp :prompt 0 :card :cid])))
+      (prompt-choice :corp "Archives")
+      (prompt-card :corp (find-card "Adonis Campaign" (:discard (get-corp))))
+      (prompt-choice :corp "New remote")
+      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote 1 :content 0 :title])) "Adonis installed by Team Sponsorship")
+      (is (nil? (find-card "Adonis Campaign" (:discard (get-corp)))) "No Adonis in discard"))))
+
+(deftest team-sponsorship-multiple
+  "Team Sponsorship - Multiple installed"
+  (do-game
+    (new-game (default-corp [(qty "Domestic Sleepers" 1) (qty "Team Sponsorship" 2) (qty "Adonis Campaign" 2)])
+              (default-runner))
+    (play-from-hand state :corp "Team Sponsorship" "New remote")
+    (play-from-hand state :corp "Team Sponsorship" "New remote")
+    (play-from-hand state :corp "Domestic Sleepers" "New remote")
+    (core/move state :corp (find-card "Adonis Campaign" (:hand (get-corp))) :discard)
+    (let [ag1 (get-in @state [:corp :servers :remote 2 :content 0])
+          tsp1 (get-in @state [:corp :servers :remote 1 :content 0])
+          tsp2 (get-in @state [:corp :servers :remote 0 :content 0])]
+      (core/rez state :corp tsp1)
+      (core/rez state :corp tsp2)
+      (core/gain state :corp :click 6 :credit 6)
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/score state :corp {:card (refresh ag1)})
+      ; TSP prompt should be active
+      (prompt-choice :corp "Archives")
+      (prompt-card :corp (find-card "Adonis Campaign" (:discard (get-corp))))
+      (prompt-choice :corp "New remote")
+      ; second prompt should be active
+      (prompt-choice :corp "HQ")
+      (prompt-card :corp (find-card "Adonis Campaign" (:hand (get-corp))))
+      (prompt-choice :corp "New remote")
+      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote 2 :content 0 :title])) "Adonis installed by Team Sponsorship")
+      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote 3 :content 0 :title])) "Adonis installed by Team Sponsorship"))))

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -9,7 +9,7 @@
 
     ; play Account Siphon, use ability
     (play-run-event state (first (:hand (get-runner))) :hq)
-    (core/resolve-prompt state :runner {:choice "Run ability"})
+    (prompt-choice :runner "Run ability")
     (is (= 2 (:tag (get-runner)))) ; gained 2 tags
     (is (= 15 (:credit (get-runner)))) ; gained 10 credits
     (is (= 3 (:credit (get-corp)))))) ; corp lost 5 credits
@@ -22,7 +22,7 @@
     (is (= 8 (:credit (get-corp))))
     ; play another Siphon, do not use ability
     (play-run-event state (first (get-in @state [:runner :hand])) :hq)
-    (core/resolve-prompt state :runner {:choice "Access"})
+    (prompt-choice :runner "Access")
     (is (= 0 (:tag (get-runner)))) ; no new tags
     (is (= 5 (:credit (get-runner)))) ; no change in credits
     (is (= 8 (:credit (get-corp))))))

--- a/src/clj/test/cards-icebreakers.clj
+++ b/src/clj/test/cards-icebreakers.clj
@@ -6,7 +6,7 @@
     (new-game (default-corp) (default-runner [(qty "Atman" 1)]))
     (take-credits state :corp)
     (play-from-hand state :runner "Atman")
-    (core/resolve-prompt state :runner {:choice 2}) ; pay 2 credits
+    (prompt-choice :runner 2)
     (is (= 3 (:memory (get-runner))))
     (let [atman (get-in @state [:runner :rig :program 0])]
       (is (= 2 (:counter atman)) "2 power counters")
@@ -18,7 +18,7 @@
     (new-game (default-corp) (default-runner [(qty "Atman" 1)]))
     (take-credits state :corp)
     (play-from-hand state :runner "Atman")
-    (core/resolve-prompt state :runner {:choice 0}) ; pay 2 credits
+    (prompt-choice :runner 0)
     (is (= 3 (:memory (get-runner))))
     (let [atman (get-in @state [:runner :rig :program 0])]
       (is (= 0 (:counter atman)) "0 power counters")

--- a/src/clj/test/cards-programs.clj
+++ b/src/clj/test/cards-programs.clj
@@ -12,7 +12,7 @@
           agenda (get-in @state [:corp :servers :remote 0 :content 0])]
       (is agenda "Agenda was installed")
       (card-ability state :runner djinn 1)
-      (core/resolve-prompt state :runner {:card (find-card "Chakana" (:hand (get-runner)))})
+      (prompt-card :runner (find-card "Chakana" (:hand (get-runner))))
       (let [chak (first (:hosted (refresh djinn)))]
         (is (= "Chakana" (:title chak)) "Djinn has a hosted Chakana")
         (core/add-prop state :runner (first (:hosted (refresh djinn))) :counter 3) ; manually add 3 counters
@@ -30,7 +30,7 @@
     (is (= 3 (:memory (get-runner))))
     (let [djinn (get-in @state [:runner :rig :program 0])]
       (card-ability state :runner djinn 1)
-      (core/resolve-prompt state :runner {:card (find-card "Chakana" (:hand (get-runner)))})
+      (prompt-card :runner (find-card "Chakana" (:hand (get-runner))))
       (is (= 3 (:memory (get-runner))) "No memory used to host on Djinn")
       (is (= "Chakana" (:title (first (:hosted (refresh djinn))))) "Djinn has a hosted Chakana")
       (is (= 1 (:credit (get-runner))) "Full cost to host on Djinn"))))
@@ -46,7 +46,7 @@
     (is (zero? (count (:hand (get-runner)))) "No cards in hand after moving Parasite to deck")
     (let [djinn (get-in @state [:runner :rig :program 0])]
       (card-ability state :runner djinn 0)
-      (core/resolve-prompt state :runner {:card (find-card "Parasite" (:deck (get-runner)))})
+      (prompt-card :runner (find-card "Parasite" (:deck (get-runner))))
       (is (= "Parasite" (:title (first (:hand (get-runner))))) "Djinn moved Parasite to hand")
       (is (= 2 (:credit (get-runner))) "1cr to use Djinn ability")
       (is (= 2 (:click (get-runner))) "1click to use Djinn ability"))))
@@ -76,7 +76,7 @@
     (let [prog (get-in @state [:runner :rig :program 0])
           vbg (get-in @state [:runner :rig :resource 0])]
       (card-ability state :runner prog 0)
-      (core/resolve-prompt state :runner {:card (find-card "Hivemind" (:hand (get-runner)))})
+      (prompt-card :runner (find-card "Hivemind" (:hand (get-runner))))
       (is (= 4 (:memory (get-runner))) "No memory used to host on Progenitor")
       (let [hive (first (:hosted (refresh prog)))]
         (is (= "Hivemind" (:title hive)) "Hivemind is hosted on Progenitor")

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -41,7 +41,7 @@
       (is (= 3 (count (:hosted sp))) "Street Peddler is hosting 3 cards")
       (card-ability state :runner sp 0)
       (is (= 1 (count (:choices (first (:prompt (get-runner)))))) "Only 1 choice to install off Peddler")
-      (core/resolve-prompt state :runner {:card (find-card "Gordian Blade" (:hosted sp))}) ; choose to install Gordian
+      (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
       (is (= "Gordian Blade" (:title (get-in @state [:runner :rig :program 0]))) "Gordian Blade was installed")
       (is (= 3 (:memory (get-runner))) "Gordian cost 1 mu"))))
 
@@ -60,7 +60,7 @@
       (core/lose state :runner :credit 3) ; should still be able to afford Gordian w/ Kate discount
       (card-ability state :runner sp 0)
       (is (= 1 (count (:choices (first (:prompt (get-runner)))))) "Only 1 choice to install off Peddler")
-      (core/resolve-prompt state :runner {:card (find-card "Gordian Blade" (:hosted sp))}) ; choose to install Gordian
+      (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
       (is (= "Gordian Blade" (:title (get-in @state [:runner :rig :program 0]))) "Gordian Blade was installed")
       (is (= 3 (:memory (get-runner))) "Gordian cost 1 mu"))))
 
@@ -78,7 +78,7 @@
     (let [sp (get-in @state [:runner :rig :resource 0])]
       (is (= "Corroder" (:title (first (:hosted sp)))) "Street Peddler is hosting Corroder")
       (card-ability state :runner sp 0)
-      (core/resolve-prompt state :runner {:card (first (:hosted sp))}) ; choose to install Gordian
+      (prompt-card :runner (first (:hosted sp))) ; choose to install Gordian
       (is (= "Corroder" (:title (get-in @state [:runner :rig :program 0]))) "Corroder was installed")
       (is (= 3 (:memory (get-runner))) "Corroder cost 1 mu"))))
 

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -40,9 +40,9 @@
     (core/no-action state :corp nil)
     (core/successful-run state :runner nil)
     ; corp now has optional prompt to trigger virus purge
-    (core/resolve-prompt state :corp {:choice "Yes"})
+    (prompt-choice :corp "Yes")
     ; runner has prompt to trash CVS
-    (core/resolve-prompt state :runner {:choice "Yes"})
+    (prompt-choice :runner "Yes")
     ; purged counters
     (is (zero? (core/get-virus-counters state :runner (find-card "Cache" (get-in @state [:runner :rig :program]))))
         "Cache has no counters")

--- a/src/clj/test/macros.clj
+++ b/src/clj/test/macros.clj
@@ -5,4 +5,6 @@
   `(let [~'state ~s
          ~'get-corp (fn [] (:corp @~'state))
          ~'get-runner (fn [] (:runner @~'state))
-         ~'refresh (fn [~'card] (core/get-card ~'state ~'card))] ~@body))
+         ~'refresh (fn [~'card] (core/get-card ~'state ~'card))
+         ~'prompt-choice (fn [~'side ~'choice] (core/resolve-prompt ~'state ~'side {:choice ~'choice}))
+         ~'prompt-card (fn [~'side ~'card] (core/resolve-prompt ~'state ~'side {:card ~'card}))] ~@body))


### PR DESCRIPTION
Rather than let each Team Sponsorship fire individually, we make the first one to fire do all the work by counting how many TS are installed and rezzed, then recursively resolving the TS ability once for each installed copy. This forces Corp to decide on a server for the first install before the next install location is selected.

Fixes #748.