### PR TITLE
implement Heinlein Grid

### DIFF
--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -93,6 +93,19 @@
                                                                (get-in corp (:zone card))))))
                                 :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
+   "Heinlein Grid"
+   {:effect (req (add-watch state (keyword (str "heinlein" (:cid card)))
+                   (fn [k ref old new]
+                     (let [clicknew (get-in new [:runner :click])
+                           clickold (get-in old [:runner :click])]
+                       (when (< clicknew clickold)
+                         (resolve-ability ref side
+                           {:req (req this-server)
+                            :msg "force the Runner to lose all credits" :once :per-turn
+                            :effect (effect (lose :runner :credit :all))}
+                          card nil))))))
+    :leave-play (req (remove-watch state (keyword (str "heinlein" (:cid card)))))}
+
    "Hokusai Grid"
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"
                               :effect (req (damage state side :net 1 {:card card}))}}}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -102,7 +102,7 @@
                        (when (< clicknew clickold)
                          (resolve-ability ref side
                            {:req (req this-server)
-                            :msg "force the Runner to lose all credits" :once :per-turn
+                            :msg "force the Runner to lose all credits" :once :per-run
                             :effect (effect (lose :runner :credit :all))}
                           card nil))))))
     :leave-play (req (remove-watch state (keyword (str "heinlein" (:cid card)))))}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -102,7 +102,7 @@
                        (when (< clicknew clickold)
                          (resolve-ability ref side
                            {:req (req this-server)
-                            :msg "force the Runner to lose all credits" :once :per-run
+                            :msg (msg "force the Runner to lose all " (:credit runner) " [Credits]") :once :per-run
                             :effect (effect (lose :runner :credit :all))}
                           card nil))))))
     :leave-play (req (remove-watch state (keyword (str "heinlein" (:cid card)))))}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -122,7 +122,7 @@
                               (lose state :runner :tag 1))}]}
                             
    "Marcus Batty"
-   {:abilities [{:label "[Trash: Start a Psi game" :msg "start a Psi game"
+   {:abilities [{:label "[Trash]: Start a Psi game" :msg "start a Psi game"
                  :psi {:not-equal {:req (req this-server)
                                    :choices {:req #(and (has? % :type "ICE") (:rezzed %))}
                                    :msg (msg "resolve a subroutine on " (:title target))

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -42,7 +42,7 @@
                                 :msg "give the Runner 1 tag"}}}
 
    "Corporate Troubleshooter"
-   {:abilities [{:label "Add strength to a rezzed ICE protecting this server" :choices :credit
+   {:abilities [{:label "[Trash]: Add strength to a rezzed ICE protecting this server" :choices :credit
                  :prompt "How many credits?"
                  :effect (req (let [boost target]
                                 (resolve-ability
@@ -76,7 +76,8 @@
    {:access {:optional {:prompt "Purge viruses with Cyberdex Virus Suite?"
                         :yes-ability {:msg (msg "purge viruses")
                                       :effect (effect (purge))}}}
-    :abilities [{:msg "purge viruses" :effect (effect (purge) (trash card))}]}
+    :abilities [{:label "[Trash]: Purge virus counters"
+                 :msg "purge viruses" :effect (effect (purge) (trash card))}]}
 
    "Dedicated Technician Team"
    {:recurring 2}
@@ -121,7 +122,7 @@
                               (lose state :runner :tag 1))}]}
                             
    "Marcus Batty"
-   {:abilities [{:msg "start a Psi game"
+   {:abilities [{:label "[Trash: Start a Psi game" :msg "start a Psi game"
                  :psi {:not-equal {:req (req this-server)
                                    :choices {:req #(and (has? % :type "ICE") (:rezzed %))}
                                    :msg (msg "resolve a subroutine on " (:title target))
@@ -161,7 +162,8 @@
                               :effect (effect (init-trace-bonus 2))}}}
     
    "Ryon Knight"
-   {:abilities [{:msg "do 1 brain damage" :req (req (and this-server (zero? (:click runner))))
+   {:abilities [{:label "[Trash]: Do 1 brain damage"
+                 :msg "do 1 brain damage" :req (req (and this-server (zero? (:click runner))))
                  :effect (effect (trash card) (damage :brain 1 {:card card}))}]}
 
    "SanSan City Grid"
@@ -174,7 +176,7 @@
 
    "Self-destruct"
    {:abilities [{:req (req this-server)
-                 :label "Trace X - Do 3 net damage"
+                 :label "[Trash]: Trace X - Do 3 net damage"
                  :effect (req (let [serv (card->server state card)
                                     cards (concat (:ices serv) (:content serv))]
                                 (trash state side card)
@@ -219,13 +221,13 @@
                                  card nil)))}]}
 
    "Tyrs Hand"
-   {:abilities [{:label "Prevent a subroutine on a Bioroid from being broken"
+   {:abilities [{:label "[Trash]: Prevent a subroutine on a Bioroid from being broken"
                  :req (req (and (= (butlast (:zone current-ice)) (butlast (:zone card)))
                                 (has? current-ice :subtype "Bioroid"))) :effect (effect (trash card))
                  :msg (msg "prevent a subroutine on " (:title current-ice) " from being broken")}]}
 
    "Will-o-the-Wisp"
-   {:abilities [{:label "Add an icebreaker to the bottom of Stack"
+   {:abilities [{:label "[Trash]: Add an icebreaker to the bottom of Stack"
                  :choices {:req #(has? % :subtype "Icebreaker")}
                  :msg (msg "add " (:title target) " to the bottom of Stack")
                  :effect (effect (trash card) (move :runner target :deck))}]}})


### PR DESCRIPTION
Pretty straightforward addition of a watch state to zero out the Runner's credits the first time they lose/spend a click during a run on the server. Conforms to the [Heinlein Grid multiple triggers ruling](http://ancur.wikia.com/wiki/Heinlein_Grid_Trigger_Multiple_Times_Ruling) and only happens once per run. 

Tidied up a few self-trashing upgrade labels to include the snazzy trash icon. 