### PR TITLE
Feature/better password hash

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -361,7 +361,7 @@ app.post '/reset/:token', (req, res) ->
     res.redirect('/')
 
 hashPassword = (password, cb) ->
-    bcrypt.hash password, 3, cb
+    bcrypt.hash password, 10, cb
 
 app.get '/messages/:channel', (req, res) ->
   db.collection('messages').find({channel: req.params.channel}).sort(date: -1).limit(100).toArray (err, data) ->

--- a/server.coffee
+++ b/server.coffee
@@ -242,7 +242,7 @@ app.post '/register', (req, res) ->
       req.body.emailhash = crypto.createHash('md5').update(email).digest('hex')
       req.body.registrationDate = new Date()
       req.body.lastConnection = new Date()
-      bcrypt.hash req.body.password, 3, (err, hash) ->
+      hashPassword req.body.password, (err, hash) ->
         req.body.password = hash
         db.collection('users').insert req.body, (err) ->
           res.send "error: #{err}" if err
@@ -329,7 +329,7 @@ app.post '/reset/:token', (req, res) ->
         #if (req.body.password != req.body.confirm)
         #  res.send {message: 'Password does not match Confirm'}, 412
 
-        bcrypt.hash req.body.password, 3, (err, hash) ->
+        hashPassword req.body.password, (err, hash) ->
           password = hash
           resetPasswordToken = undefined;
           resetPasswordExpires = undefined
@@ -359,6 +359,9 @@ app.post '/reset/:token', (req, res) ->
   ], (err) ->
     throw err if err
     res.redirect('/')
+
+hashPassword = (password, cb) ->
+    bcrypt.hash password, 3, cb
 
 app.get '/messages/:channel', (req, res) ->
   db.collection('messages').find({channel: req.params.channel}).sort(date: -1).limit(100).toArray (err, data) ->


### PR DESCRIPTION
1. Deduplicate the `salt` parameter constant for `bcrypt.hash(…)` by extracting it to a function.
2. `3` is a _really weak_ setting for the number of rounds. See the [`brcrypt` readme](https://github.com/ncb000gt/node.bcrypt.js#a-note-on-rounds) for details. I've increased it to the default `10` which means `2^10` rounds.

This change will make login/registration marginally slower but the effect should be mitigated by #763 (moving the expensive login operation to an async worker).