### PR TITLE
Have Team Sponsorship prompt show duplicate entries

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -541,6 +541,7 @@
                              :msg (msg "install a card from " target)
                              :effect (effect (resolve-ability
                                                {:prompt "Choose a card to install"
+                                                :not-distinct true
                                                 :choices (req (filter #(not= (:type %) "Operation")
                                                                       ((if (= target "HQ") :hand :discard) corp)))
                                                 :effect (req (corp-install state side target nil {:no-install-cost true})

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -28,7 +28,8 @@
                  :choices (req (conj (take 5 (:deck corp)) "No install"))
                  :effect (effect (corp-install (move state side target :play-area) nil {:no-install-cost true}))}
                 {:msg "install a card from Archives" :choices (req (:discard corp))
-                 :prompt "Choose a card to install" :effect (effect (corp-install target nil))}
+                 :prompt "Choose a card to install" :not-distinct true
+                 :effect (effect (corp-install target nil))}
                 {:msg "install a card from HQ" :choices (req (:hand corp))
                  :prompt "Choose a card to install" :effect (effect (corp-install target nil))}]}
 
@@ -131,7 +132,8 @@
                  :effect (effect (damage :net (:memory runner) {:card card}))}]}
 
    "Crick"
-   {:abilities [{:msg "install a card from Archives" :choices (req (:discard corp))
+   {:abilities [{:msg "install a card from Archives"
+                 :choices (req (filter #(not= (:type %) "Operation") (:discard corp))) :not-distinct true
                  :prompt "Choose a card to install" :effect (effect (corp-install target nil))}]
     :strength-bonus (req (if (= (second (:zone card)) :archives) 3 0))}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -177,6 +177,7 @@
     :msg (msg "install a card from " target)
     :effect (effect (resolve-ability
                       {:prompt "Choose a card to install"
+                       :not-distinct true
                        :choices (req (filter #(not= (:type %) "Operation")
                                              ((if (= target "HQ") :hand :discard) corp)))
                        :effect (effect (corp-install target nil {:no-install-cost true}))}


### PR DESCRIPTION
... to address #765. Installing a card from Archives requires knowing more than just the card title, as we may want to choose a card that is specifically face up or face down. Without `:not-distinct`, we only get one entry for each card title even if there is more than one card in Archives; now, we choose which card we want based on the order it appears in Archives.

I have also applied this to other cards that install things from Archives: Interns, Crick (fixed to only show non-Operations), Architect.