### PR TITLE
add recursive installs to Accelerated Beta Test and Mass Install

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -5,6 +5,7 @@
    (let [abthelper (fn abt [n i] {:prompt "Select a piece of ICE to install"
                                   :choices {:req #(and (:side % "Corp") (= (:type %) "ICE") (= (:zone %) [:play-area]))}
                                   :effect (req (corp-install state side target nil {:no-install-cost true :install-state :rezzed})
+                                               (trigger-event state side :rez target)
                                                  (when (< n i)
                                                    (resolve-ability state side (abt (inc n) i) card nil)))})]
      {:optional {:prompt "Look at the top 3 cards of R&D?"


### PR DESCRIPTION
Extending @queueseven's recursive technique to ABT and Mass Install. This is especially needed for ABT so the Corp can order the ice installs, as well as allowing a new remote created with the first one to be available in the server choices for the rest of the ice. The cards are first moved to the play area and then can be selected for install from there. 