### PR TITLE
Don't allow self hosting

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -456,7 +456,8 @@
                  :prompt "Choose a program to host on Scheherazade"
                  :choices {:req #(and (= (:type %) "Program") (:installed %))}
                  :msg (msg "host " (:title target) " and gain 1 [Credits]")
-                 :effect (effect (host card target) (gain :credit 1))}]}
+                 :effect (req (when (host state side card target) 
+                                (gain state side :credit 1)))}]}
 
    "Self-modifying Code"
    {:abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))


### PR DESCRIPTION
Fixes #739 and #381.

It's not perfect as Scheherazade will still print its message, but adjusting that is a rather big change. Also, we have to way to check the `:cid` of the hostin `{:choices {:req ....`, so there's no easy way to prevent a card from selecting itself.

At least the cards don' disappear any longer.