### PR TITLE
implement Worlds Plaza and Awakening Center

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -34,7 +34,7 @@
    "Blacklist"
    {:effect (effect (lock-zone (:cid card) :runner :discard))
     :leave-play (effect (release-zone (:cid card) :runner :discard))}
-                 
+
    "Brain-Taping Warehouse"
    {:events {:pre-rez
              {:req (req (and (= (:type target) "ICE") (has? target :subtype "Bioroid")))
@@ -291,8 +291,8 @@
                  :req (req (> (get-in @state [:runner :tag]) 0))
                  :effect (req (if (not= target "No Operation found")
                                 (let [c (move state :corp target :play-area)]
-                                  (shuffle! state :corp :deck) 
-                                  (move state :corp c :deck {:front true}) 
+                                  (shuffle! state :corp :deck)
+                                  (move state :corp c :deck {:front true})
                                   (system-msg state side (str "uses Lily Lockwell to put " (:title c) " on top of R&D")))
                                 (do (shuffle! state :corp :deck)
                                     (system-msg state side (str "uses Lily Lockwell, but did not find an Operation in R&D"))))
@@ -353,7 +353,7 @@
    "Plan B"
    {:advanceable :always
     :access {:optional
-             {:prompt "Score an Agenda from HQ?" 
+             {:prompt "Score an Agenda from HQ?"
               :req (req installed)
               :yes-ability {:prompt "Choose an Agenda to score"
                            :choices (req (filter #(and (has? % :type "Agenda")

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -600,7 +600,7 @@
   
    "Worlds Plaza"
    {:abilities [{:label "Install an asset on Worlds Plaza"
-                 :req (req (<= (count (:hosted card)) 3)) :cost [:click 1]
+                 :req (req (< (count (:hosted card)) 3)) :cost [:click 1]
                  :prompt "Choose an asset to install on Worlds Plaza"
                  :choices (req (filter #(and (= (:type %) "Asset")
                                              (<= (- (:cost %) 2) (:credit corp))) (:hand corp)))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -596,4 +596,16 @@
 
    "Victoria Jenkins"
    {:effect (effect (lose :runner :click-per-turn 1)) :leave-play (effect (gain :runner :click-per-turn 1))
-    :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}})
+    :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
+  
+   "Worlds Plaza"
+   {:abilities [{:label "Install an asset on Worlds Plaza"
+                 :req (req (<= (count (:hosted card)) 3)) :cost [:click 1]
+                 :prompt "Choose an asset to install on Worlds Plaza"
+                 :choices (req (filter #(and (= (:type %) "Asset")
+                                             (<= (- (:cost %) 2) (:credit corp))) (:hand corp)))
+                 :msg (msg "host " (:title target))
+                 :effect (effect (trigger-event :corp-install target)
+                                 (host card target)
+                                 (rez-cost-bonus -2) (rez (last (:hosted (get-card state card))))
+                                 (update! (dissoc (get-card state (last (:hosted card))) :facedown)))}]}})

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -419,10 +419,12 @@
    {:abilities
     [{:cost [:click 2] :req (req (some #{:hq} (:successful-run runner-reg)))
       :label "trash a Bioroid, Clone, Executive or Sysop" :prompt "Choose a card to trash"
-      :choices (req (filter #(and (:rezzed %)
-                                  (or (has? % :subtype "Bioroid") (has? % :subtype "Clone")
-                                      (has? % :subtype "Executive") (has? % :subtype "Sysop")))
-                            (mapcat :content (flatten (seq (:servers corp))))))
+      :choices (req (let [contents (mapcat :content (flatten (seq (:servers corp))))
+                          hosted (mapcat :hosted contents)]
+                      (filter #(and (:rezzed %)
+                                    (or (has? % :subtype "Bioroid") (has? % :subtype "Clone")
+                                        (has? % :subtype "Executive") (has? % :subtype "Sysop")))
+                               (concat hosted contents))))
       :msg (msg "trash " (:title target)) :effect (effect (trash target))}]}
 
    "Vigil"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -23,6 +23,27 @@
                                                          {:effect (effect (handle-access [ash])) :card ash}))))
                          :msg "prevent the Runner from accessing cards other than Ash 2X3ZB9CY"}}]}
 
+   "Awakening Center"
+   {:abilities [{:label "Host a piece of bioroid ICE"
+                 :cost [:click 1] :prompt "Choose a piece of bioroid ICE to host on Awakening Center"
+                 :choices (req (filter #(and (= (:type %) "ICE")
+                                             (has? % :subtype "Bioroid")) (:hand corp)))
+                 :msg "host a piece of bioroid ICE"
+                 :effect (effect (trigger-event :corp-install target)
+                                 (host card target {:facedown true}))}
+                {:req (req (and this-server (= (get-in @state [:run :position]) 0)))
+                 :label "Rez a hosted piece of bioroid ICE"
+                 :prompt "Choose a piece of bioroid ICE to rez" :choices (req (:hosted card))
+                 :msg (msg "lower the rez cost of " (:title target) " by 7 [Credits] and force the Runner to encounter it")
+                 :effect (effect (rez-cost-bonus -7) (rez target)
+                                 (update! (dissoc (get-card state target) :facedown))
+                                 (register-events {:run-ends
+                                                    {:effect (req (doseq [c (:hosted card)]
+                                                                    (when (:rezzed c)
+                                                                      (trash state side c)))
+                                                                  (unregister-events state side card))}} card))}]
+    :events {:run-ends nil}}
+
    "Bernice Mai"
    {:events {:successful-run {:req (req this-server)
                               :trace {:base 5 :msg "give the Runner 1 tag"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1192,7 +1192,8 @@
   (concat (get-in @state [:corp :discard]) (get-in @state [:corp :servers :archives :content])))
 
 (defmethod access :remote [state side server]
-  (get-in @state [:corp :servers (first server) :content]))
+  (let [contents (get-in @state [:corp :servers (first server) :content])]
+    (concat contents (mapcat :hosted contents))))
 
 (defn access-bonus [state side n]
   (swap! state update-in [:run :access-bonus] #(+ % n)))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -125,7 +125,7 @@
                                             (send-command "play" {:card card :server "New remote"})
                                             (-> (om/get-node owner "servers") js/$ .toggle))
                        (send-command "play" {:card card}))
-              ("servers" "scored" "current") (handle-abilities card owner)
+              ("servers" "scored" "current" "onhost") (handle-abilities card owner)
               nil)))))))
 
 (defn in-play? [card]


### PR DESCRIPTION
These cards caused a series of other tweaks to support them. The `gameboard.cljs` needed an addition to allow hosted Corp cards to be clickable so abilities would work (e.g., Private Contracts). The access helper for remotes in `core.clj` needed to account for all hosted cards in addition to server contents--this way you could first access and trash one of the scoreable hosted executives instead of just trashing Worlds Plaza and all the hosted assets with it. Unregistered S&W also needs to filter on hosted cards in case someone wanted to shoot a qualifying hosted card. 

Awakening Center uses a funky `doseq` toward the end to get any rezzed hosted ice to trash, but there should only ever be 1 rezzed at a time. There is probably a more artful way of doing this, but it seems to work fine. 