### PR TITLE
Show updated ice strengths (Quicksand, Encrypted Portals) immediately

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -129,8 +129,8 @@
                           (reduce (fn [c server]
                                     (+ c (count (filter (fn [ice] (and (has? ice :subtype "Code Gate")
                                                                        (:rezzed ice))) (:ices server)))))
-                                  0 (flatten (seq (:servers corp))))))
-
+                                  0 (flatten (seq (:servers corp)))))
+                    (update-all-ice))
     :events {:pre-ice-strength {:req (req (has? target :subtype "Code Gate"))
                                 :effect (effect (ice-strength-bonus 1))}}}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -526,7 +526,8 @@
    "Quicksand"
    {:abilities [{:req (req (and this-server (= (dec (:position run)) (ice-index state card))))
                  :label "Add 1 power counter"
-                 :effect (effect (add-prop card :counter 1))}
+                 :effect (effect (add-prop card :counter 1)
+                                 (update-all-ice))}
                  end-the-run]
     :strength-bonus (req (or (:counter card) 0))}
 


### PR DESCRIPTION
Addressing the request in #790--these cards now call `update-all-ice` so you don't have to wait until the next encounter or Parasite install to see the new strength. 