### PR TITLE
fix Franchise City, target and identify ice when installing Femme Fatale

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -201,8 +201,9 @@
                  :effect (effect (trash card) (lose :bad-publicity (:advance-counter card)))}]}
 
    "Franchise City"
-   {:events {:pre-steal-cost {:msg "add it to their score area and gain 1 agenda point"
-                              :effect (effect (as-agenda :corp card 1))}}}
+   {:events {:access {:req (req (= (:type target) "Agenda"))
+                      :msg "add it to their score area and gain 1 agenda point"
+                      :effect (effect (as-agenda :corp card 1))}}}
 
    "Ghost Branch"
    {:advanceable :always

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -200,7 +200,7 @@
                      state :corp
                      {:prompt (msg "Rez " (:title ice) " or trash it?") :choices ["Rez" "Trash"]
                       :effect (effect (resolve-ability
-                                        (if (and (= target "Rez") (<= (:cost ice) (:credit corp)))
+                                        (if (and (= target "Rez") (<= (rez-cost state :corp ice) (:credit corp)))
                                           {:msg (msg "force the rez of " (:title ice))
                                            :effect (effect (rez :corp ice))}
                                           {:msg "trash the ICE" :effect (effect (trash :corp ice))})

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -593,11 +593,7 @@
    {:prompt "Choose a piece of ICE"
     :choices {:req #(and (= (last (:zone %)) :ices) (= (:type %) "ICE"))}
     :effect (req (let [ice target
-                       serv (cond
-                             (= (second (:zone ice)) :hq) "HQ"
-                             (= (second (:zone ice)) :rd) "R&D"
-                             (= (second (:zone ice)) :archives) "Archives"
-                             :else (join " " ["Server" (last (butlast (:zone ice)))]))
+                       serv (zone->name (second (:zone ice)))
                        stypes (:subtype ice)]
               (resolve-ability
                  state :runner

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -91,11 +91,7 @@
    "Cortez Chip"
    {:abilities [{:prompt "Choose a piece of ICE" :choices {:req #(and (not (:rezzed %)) (= (:type %) "ICE"))}
                  :effect (req (let [ice target
-                                    serv (cond
-                                          (= (second (:zone ice)) :hq) "HQ"
-                                          (= (second (:zone ice)) :rd) "R&D"
-                                          (= (second (:zone ice)) :archives) "Archives"
-                                          :else (join " " ["Server" (last (butlast (:zone ice)))]))]
+                                    serv (zone->name (second (:zone ice)))]
                                 (update! state side (assoc card :cortez-target ice))
                                 (trash state side (get-card state card) {:cause :ability-cost})
                                 (system-msg state side

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -194,7 +194,13 @@
 
    "Femme Fatale"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [{:cost [:credit 1] :msg "break 1 sentry subroutine"}
+                    {:prompt "Choose a piece of ICE to target for bypassing" :choices {:req #(= (:type %) "ICE")}
+                     :effect (req (let [ice target
+                                        serv (zone->name (second (:zone ice)))]
+                                    (system-msg state side
+                                      (str "chooses " (if (:rezzed ice) (:title ice) "the ICE") " at position "
+                                        (ice-index state ice) " of " serv " for Femme Fatale's bypass ability"))))
+                     :abilities [{:cost [:credit 1] :msg "break 1 sentry subroutine"}
                                  {:cost [:credit 2] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]})
 
    "Force of Nature"


### PR DESCRIPTION
Fixes #793 by changing Franchise City to listen for a later trigger, allowing Film Critic to snipe the agenda first. Fixes #796 by using `rez-cost` on the targeted ice rather than its printed cost, to allow for bonuses from space ice, Xanadu, etc. 

Cortez Chip and Tinkering are refactored to use the new server name function, and Femme Fatale now prompts for and identifies the ice selected for bypassing in the log window. 