### PR TITLE
Send diffs of game state to clients

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [environ "1.0.0"]
                  [com.novemberain/monger "3.0.0-rc2"]
                  [org.slf4j/slf4j-nop "1.7.12"]
-                 [org.clojure/core.match "0.3.0-alpha4"]]
+                 [org.clojure/core.match "0.3.0-alpha4"]
+                 [differ "0.2.1"]]
 
   :profiles {:dev {:dependencies [[figwheel "0.3.7"]]}}
 

--- a/server.coffee
+++ b/server.coffee
@@ -69,7 +69,10 @@ requester.connect("tcp://#{clojure_hostname}:1043")
 requester.on 'message', (data) ->
   response = JSON.parse(data)
   unless response is "ok"
-    lobby.to(response.gameid).emit("netrunner", {type: response.action, state: response.diff})
+    if response.diff
+      lobby.to(response.gameid).emit("netrunner", {type: response.action, diff: response.diff})
+    else
+      lobby.to(response.gameid).emit("netrunner", {type: response.action, state: response.state})
 
 # Socket.io
 io.set("heartbeat timeout", 30000)
@@ -203,6 +206,7 @@ app.configure ->
   app.use stylus.middleware({src: __dirname + '/src', dest: __dirname + '/resources/public'})
   app.use express.static(__dirname + '/resources/public')
   app.use app.router
+  app.locals.version = process.env['APP_VERSION'] || "0.1.0"
 
 # Auth
 passport.use new localStrategy (username, password, done) ->
@@ -432,7 +436,7 @@ app.configure 'development', ->
     if req.user
       db.collection('users').update {username: req.user.username}, {$set: {lastConnection: new Date()}}, (err) ->
       token = jwt.sign(req.user, config.salt)
-    res.render('index.jade', { user: req.user, env: 'dev', token: token})
+    res.render('index.jade', { user: req.user, env: 'dev', token: token, version: app.locals.version})
 
 app.configure 'production', ->
   console.log "Prod environment"
@@ -440,7 +444,7 @@ app.configure 'production', ->
     if req.user
       db.collection('users').update {username: req.user.username}, {$set: {lastConnection: new Date()}}, (err) ->
       token = jwt.sign(req.user, config.salt, {expiresInMinutes: 360})
-    res.render('index.jade', { user: req.user, env: 'prod', token: token})
+    res.render('index.jade', { user: req.user, env: 'prod', token: token, version: version})
 
 # Server
 terminate = () ->

--- a/server.coffee
+++ b/server.coffee
@@ -69,7 +69,7 @@ requester.connect("tcp://#{clojure_hostname}:1043")
 requester.on 'message', (data) ->
   response = JSON.parse(data)
   unless response is "ok"
-    lobby.to(response.gameid).emit("netrunner", {type: response.action, state: response})
+    lobby.to(response.gameid).emit("netrunner", {type: response.action, state: response.diff})
 
 # Socket.io
 io.set("heartbeat timeout", 30000)

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -4,11 +4,13 @@
             [cheshire.generate :refer [add-encoder encode-str]]
             [game.macros :refer [effect]]
             [game.core :refer [game-states system-msg pay gain draw end-run] :as core]
-            [environ.core :refer [env]])
+            [environ.core :refer [env]]
+            [differ.core :as differ])
   (:gen-class :main true))
 
 (add-encoder java.lang.Object encode-str)
 
+(def last-states (atom {}))
 (def ctx (ZMQ/context 1))
 
 (def commands
@@ -62,7 +64,12 @@
           "notification" (when state
                            (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))
         (if-let [state (@game-states gameid)]
-          (.send socket (generate-string (assoc (dissoc @state :events :turn-events) :action action)))
+          (let [strip #(dissoc % :events :turn-events :per-turn :prevent :damage)]
+            (case action
+              ("start" "reconnect") (.send socket (generate-string {:action action :diff (strip @state) :gameid gameid}))
+              (let [diff (differ/diff (strip (@last-states gameid)) (strip @state))]
+                (.send socket (generate-string {:action action :diff diff :gameid gameid}))))
+            (swap! last-states assoc gameid (strip @state)))
           (.send socket (generate-string "ok")))
         (catch Exception e
           (println "Error " action command (get-in args [:card :title]) e "\nStack trace:"

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -66,7 +66,7 @@
         (if-let [state (@game-states gameid)]
           (let [strip #(dissoc % :events :turn-events :per-turn :prevent :damage)]
             (case action
-              ("start" "reconnect") (.send socket (generate-string {:action action :diff (strip @state) :gameid gameid}))
+              ("start" "reconnect" "notification") (.send socket (generate-string {:action action :state (strip @state) :gameid gameid}))
               (let [diff (differ/diff (strip (@last-states gameid)) (strip @state))]
                 (.send socket (generate-string {:action action :diff diff :gameid gameid}))))
             (swap! last-states assoc gameid (strip @state)))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -55,7 +55,8 @@
       (let [msg (<! socket-channel)]
         (reset! lock false)
         (case (:type msg)
-          ("do" "notification" "quit") (do (swap! game-state #(differ/patch @last-state (:state msg)))
+          ("do" "notification" "quit") (do (swap! game-state (if (:diff msg) #(differ/patch @last-state (:diff msg))
+                                                                             #(assoc (:state msg) :side (:side @game-state))))
                                            (swap! last-state #(identity @game-state)))
           nil))))
 

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -6,15 +6,18 @@
             [clojure.string :refer [capitalize]]
             [netrunner.main :refer [app-state]]
             [netrunner.auth :refer [avatar] :as auth]
-            [netrunner.cardbrowser :refer [image-url add-symbols] :as cb]))
+            [netrunner.cardbrowser :refer [image-url add-symbols] :as cb]
+            [differ.core :as differ]))
 
 (defonce game-state (atom {}))
+(defonce last-state (atom {}))
 (defonce lock (atom false))
 
 (defn init-game [game side]
   (.setItem js/localStorage "gameid" (:gameid @app-state))
   (swap! game-state merge game)
-  (swap! game-state assoc :side side))
+  (swap! game-state assoc :side side)
+  (swap! last-state #(identity @game-state)))
 
 (defn notify [text]
   (swap! game-state update-in [:log] #(conj % {:user "__system__" :text text})))
@@ -52,7 +55,8 @@
       (let [msg (<! socket-channel)]
         (reset! lock false)
         (case (:type msg)
-          ("do" "notification" "quit") (swap! game-state merge (:state msg))
+          ("do" "notification" "quit") (do (swap! game-state #(differ/patch @last-state (:state msg)))
+                                           (swap! last-state #(identity @game-state)))
           nil))))
 
 (defn send [msg]
@@ -582,7 +586,6 @@
   (om/component
    (sab/html
     [:div.dashboard
-     (js/console.log (str "ZONE:" (count remotes)))
      (om/build hand-view {:player player :remotes remotes})
      (om/build discard-view player)
      (om/build deck-view player)

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -32,7 +32,7 @@ html
     if env === 'dev'
       script(src='/lib/react/react.js')
       script(src="/cljs/goog/base.js", type="text/javascript")
-      script(src="/cljs/app.js", type="text/javascript")
+      script(src="/cljs/app.js?v=#{version}", type="text/javascript")
       script(type="text/javascript").
         goog.require("netrunner.main");
         goog.require("netrunner.ajax");
@@ -47,7 +47,7 @@ html
         goog.require("dev.figwheel");
     else
       script(src='/lib/react/react.min.js')
-      script(src="js/app.js", type="text/javascript")
+      script(src="js/app.js?v=#{version}", type="text/javascript")
       script.
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
### State diffs
Rather than send the entire game state to each client after an action is performed, we send a much smaller diff structure that the client can apply to its copy of the state.

There are a few changes here:

1. The Clojure library `differ` calculates and applies diffs of the state map. I evaluated two different libraries for this and found `differ` to be best. It's not perfect -- it will send an entire vector if one element of the vector is removed, as when drawing a card (will send the entire new deck in the diff) -- but it consistently sent smaller diffs than the other library with no drawbacks.
2. In addition to storing the current game state for each game in progress, the server now also saves the "last state" sent to the clients of the game. Diffs are calculated from this last-state. This __effectively doubles__ the server's memory requirements for tracking game states, but historically that has not been an issue. If this becomes a concern, we can try making a duplicate of the state upon receiving a message and then using that to calculate the diff after applying the message command; the current implementation was just a little more simple.
3. In the game engine core, we send the full state when starting a game or receiving a "notification" (sent when a player joins or reconnects to the game -- necessary for observers and people with bad connections). Otherwise we send a diff relative to the last-state.
4. When the client receives a message from the server, it examines the message to see if it contains a state or a diff. If a state, it overrides its local state as before; otherwise, it uses `differ` to "patch" the local state with the diff from the server.

#### Bandwidth effect

A typical game starts with a state size of about 30Kb (prior to compression over the WebSocket from #731), and this size tends to grow over time due to log messages, new corp servers, etc. The size of a diff depends on what has changed, naturally. Brief experiments showed these approximate sizes:

* Drawing a card: 10Kb (depends on how many cards are left in deck/hand)
* Playing an instant: 0.5Kb
* Installing to Corp: 1.5Kb
* Installing to Runner: 1.3Kb
* Click for credit: 0.4Kb
* Adjusting player values (clicks, credits, points): 0.4Kb
* End turn: 0.5Kb
* New chat message: 0.4Kb
* Rez a card: 1Kb
* Each step of a run: 0.5Kb
* Accessing a card: 1Kb

Not bad :sunglasses:, since the "old" code would send the full 30Kb+ state for each of these.

### App version number

I took the time to add a version string to the coffee server, which gets appended as a query parameter to the JavaScript include for `app.js`. The string is pulled from environment variable `APP_VERSION`, or falls back to a default string; the string is sent to `layout.jade` for doing the `app.js` include. Browsers will see the query parameter and request a new version of the app script any time the version string changes. With this, we can force browsers to download changes to the client scripts without having to beg people in chat. This is especially important for the diff changes; without a refresh, they simply won't be able to play the game. @mtgred, you can decide if you want to update the environment variable yourself, or if you would like us to manually increment the string any time client code changes.