### PR TITLE
fully implement Demolition Run

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -95,7 +95,18 @@
                                      :effect (effect (move target :hand))} card nil)))}
 
    "Demolition Run"
-   {:prompt "Choose a server" :choices ["HQ" "R&D"] :effect (effect (run target))}
+   {:prompt "Choose a server" :choices ["HQ" "R&D"]
+    :abilities [{:msg (msg "trash " (:title (:card (first (get-in @state [side :prompt])))) " at no cost")
+                 :effect (effect (trash-no-cost))}]
+    :effect (effect (run target)
+                    (prompt! card (str "Click Demolition Run in the play area to trash a card being accessed at no cost") ["OK"] {})
+                    (resolve-ability
+                      {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
+                                      (card-init state side c false)
+                                      (register-events state side
+                                                       {:run-ends {:effect (effect (trash c))}} c)))}
+                     card nil))
+    :events {:run-ends nil}}
 
    "Diesel"
    {:effect (effect (draw 3))}

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -27,6 +27,31 @@
     (is (= 5 (:credit (get-runner)))) ; no change in credits
     (is (= 8 (:credit (get-corp))))))
 
+(deftest demolition-run
+  "Demolition Run - Trash at no cost"
+  (do-game
+    (new-game (default-corp [(qty "False Lead" 1) (qty "Shell Corporation" 1)(qty "Hedge Fund" 3)])
+              (default-runner [(qty "Demolition Run" 1)]))
+    (core/move state :corp (find-card "False Lead" (:hand (get-corp))) :deck) ; put False Lead back in R&D
+    (play-from-hand state :corp "Shell Corporation" "R&D") ; install upgrade with a trash cost in root of R&D
+    (take-credits state :corp 2) ; pass to runner's turn by taking credits
+    (play-from-hand state :runner "Demolition Run")
+    (is (= 3 (:credit (get-runner))) "Paid 2 credits for the event")
+    (prompt-choice :runner "R&D")
+    (is (= [:rd] (get-in @state [:run :server])) "Run initiated on R&D")
+    (prompt-choice :runner "OK") ; dismiss instructional prompt for Demolition Run
+    (core/no-action state :corp nil)
+    (core/successful-run state :runner nil)
+    (let [demo (get-in @state [:runner :play-area 0])] ; Demolition Run "hack" is to put it out in the play area
+      (prompt-choice :runner "Unrezzed upgrade in R&D")
+      (card-ability state :runner demo 0)
+      (is (= 3 (:credit (get-runner))) "Trashed Shell Corporation at no cost")
+      (prompt-choice :runner "Card from deck")
+      (card-ability state :runner demo 0)  ; trash False Lead instead of stealing
+      (is (= 0 (:agenda-point (get-runner))) "Didn't steal False Lead")
+      (is (= 2 (count (:discard (get-corp)))) "2 cards in Archives")
+      (is (empty? (:prompt (get-runner))) "Run concluded"))))
+
 (deftest sure-gamble
   "Sure Gamble"
   (do-game

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -114,7 +114,7 @@
                        (when (:installed card)
                          (handle-abilities card owner))
                        (send-command "play" {:card card}))
-              ("rig" "current" "onhost") (handle-abilities card owner)
+              ("rig" "current" "onhost" "play-area") (handle-abilities card owner)
               nil)
             (case (first zone)
               "hand" (case type


### PR DESCRIPTION
This is a weird one, but needed--it seems that a lot more people have been asking about it recently. The card is given abilities which are of course discarded upon play because of `desactivate`--but then we pull it back out to the play area and do a `card-init` to restore the on-click ability to trash at no cost. The Runner gets a prompt so they'll know what to do with it, and `gameboard.cljs` is modified to allow it to be clickable when in the play area. As each accessed card comes up, the Runner can access normally or trash by clicking Demolition Run. When the run ends, the card goes into the Heap! 