### PR TITLE
improvements to Snoop and Architect

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -596,8 +596,11 @@
                                 (handle-access state side [c])))}]}
 
    "Snoop"
-   {:abilities [{:msg "place 1 power counter on Snoop" :effect (effect (add-prop card :counter 1))}
-                {:counter-cost 1 :label "Look at all cards in Grip and trash 1 card"
+   {:abilities [{:req (req (= current-ice card)) :label "Reveal all cards in the Runner's Grip"
+                 :msg (msg "reveal " (join ", " (map :title (:hand runner))))}
+                {:label "Trace 3 - Place 1 power counter on Snoop"
+                 :trace {:base 3 :msg "place 1 power counter on Snoop" :effect (effect (add-prop card :counter 1))}}
+                {:counter-cost 1 :label "Hosted power counter: Reveal all cards in Grip and trash 1 card"
                  :msg (msg "look at all cards in Grip and trash " (:title target))
                  :choices (req (:hand runner)) :prompt "Choose a card to trash"
                  :effect (effect (trash target))}]}

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -22,15 +22,17 @@
 
    "Architect"
    {:abilities [{:msg "look at the top 5 cards of R&D"
-                 :prompt "Choose a card to install"
+                 :prompt (msg "You saw but could not install "
+                           (join ", " (map :title (filter #(= (:type %) "Operation") (take 5 (:deck corp)))))
+                           ". Choose a card to install")
                  :activatemsg "uses Architect to look at the top 5 cards of R&D"
                  :req (req (not (string? target))) :not-distinct true
-                 :choices (req (conj (take 5 (:deck corp)) "No install"))
+                 :choices (req (conj (filter #(not= (:type %) "Operation") (take 5 (:deck corp))) "No install"))
                  :effect (effect (corp-install (move state side target :play-area) nil {:no-install-cost true}))}
-                {:msg "install a card from Archives" :choices (req (:discard corp))
+                {:msg "install a card from Archives" :choices (req (filter #(not= (:type %) "Operation") (:discard corp)))
                  :prompt "Choose a card to install" :not-distinct true
                  :effect (effect (corp-install target nil))}
-                {:msg "install a card from HQ" :choices (req (:hand corp))
+                {:msg "install a card from HQ" :choices (req (filter #(not= (:type %) "Operation") (:hand corp)))
                  :prompt "Choose a card to install" :effect (effect (corp-install target nil))}]}
 
    "Ashigaru"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -22,12 +22,11 @@
 
    "Architect"
    {:abilities [{:msg "look at the top 5 cards of R&D"
-                 :prompt (msg "You saw but could not install "
-                           (join ", " (map :title (filter #(= (:type %) "Operation") (take 5 (:deck corp)))))
-                           ". Choose a card to install")
+                 :prompt "Choose a card to install"
                  :activatemsg "uses Architect to look at the top 5 cards of R&D"
-                 :req (req (not (string? target))) :not-distinct true
-                 :choices (req (conj (filter #(not= (:type %) "Operation") (take 5 (:deck corp))) "No install"))
+                 :req (req (and (not (string? target))
+                                (not= (:type target) "Operation"))) :not-distinct true
+                 :choices (req (conj (take 5 (:deck corp)) "No install"))
                  :effect (effect (corp-install (move state side target :play-area) nil {:no-install-cost true}))}
                 {:msg "install a card from Archives" :choices (req (filter #(not= (:type %) "Operation") (:discard corp)))
                  :prompt "Choose a card to install" :not-distinct true


### PR DESCRIPTION
Addresses #803 by adding the trace to Snoop and the on-encounter reveal (not automatic). 

To fix #363/#802, Architect removes operations from the "look at the top 5 of R&D" subroutine prompt choices, instead moving them into the text (the Corp will still want to know what was seen). Operations are also filtered out of the choices for the install from Archives/HQ abilities. 