### PR TITLE
fully implement Immolation Script

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -253,7 +253,21 @@
                    :effect (effect (draw :runner 3)) :msg "draw 3 cards"}}
 
    "Immolation Script"
-   {:effect (effect (run :archives))}
+   {:effect (effect (run :archives) (register-events (:events (card-def card))
+                                                     (assoc card :zone '(:discard))))
+    :events {:successful-run-ends
+             {:prompt "Choose a piece of ICE in Archives"
+              :choices (req (filter #(= (:type %) "ICE") (:discard corp)))
+              :effect (req (let [icename (:title target)]
+                             (resolve-ability
+                               state side
+                               {:prompt (msg "Choose a rezzed copy of " icename " to trash")
+                                :choices {:req #(and (= (:type %) "ICE")
+                                                     (:rezzed %)
+                                                     (= (:title %) icename))}
+                                :msg (msg "trash " icename " protecting " (zone->name (second (:zone target))))
+                                :effect (req (trash state :corp target))} card nil)
+                             (unregister-events state side card)))}}}
 
    "Indexing"
    {:effect (effect (run :rd {:replace-access


### PR DESCRIPTION
The system currently glosses over the access of ice in Archives, so we don't really need to distinguish between accessing or not accessing a piece there. Therefore, this event just listens for the conclusion of the successful run on Archives before listing all the ice and then using the title of the chosen one as the basis for selecting a rezzed copy to trash. 