### PR TITLE
Fix cards that broke due to the restructuring of remote servers

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -94,7 +94,7 @@
                                                    (or (= (:zone %) [:hand])
                                                        (= (:zone %) [:discard])))}
                               :effect (req (corp-install state side target
-                                            (str "Server " (dec (count (get-in @state [:corp :servers :remote])))) {:no-install-cost true})
+                                            (last (get-remote-names @state)) {:no-install-cost true})
                                            (when (< n 2)
                                              (resolve-ability state side (dpp (inc n)) card nil)))})]
      {:optional {:prompt "Create a new remote server?"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -374,9 +374,9 @@
 
    "Project Junebug"
    {:advanceable :always
-    :access {:optional {:prompt "Pay 1 [Credits] to use Project Junebug ability?" :cost [:credit 1]
-                        :req (req installed)
-                        :yes-ability {:msg (msg "do " (* 2 (:advance-counter card)) " net damage")
+    :access {:optional {:prompt "Pay 1 [Credits] to use Project Junebug ability?"
+                        :req (req (and installed (> (:credit corp) 0)))
+                        :yes-ability {:cost [:credit 1] :msg (msg "do " (* 2 (:advance-counter card)) " net damage")
                                       :effect (effect (damage :net (* 2 (:advance-counter card)) {:card card}))}}}}
 
    "Psychic Field"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -157,10 +157,10 @@
              {:req (req installed)
               :prompt "Pay 3 [Credits] to use Edge of World ability?"
               :yes-ability {:cost [:credit 3]
-                            :msg (msg "do " (count (get-in corp [:servers :remote (last (:server run)) :ices]))
+                            :msg (msg "do " (count (get-in corp [:servers (last (:server run)) :ices]))
                                       " brain damage")
                             :effect (req (damage state side :brain
-                                        (count (get-in corp [:servers :remote (last (:server run)) :ices])) {:card card}))}}}}
+                                        (count (get-in corp [:servers (last (:server run)) :ices])) {:card card}))}}}}
 
    "Elizabeth Mills"
    {:effect (effect (lose :bad-publicity 1)) :msg "remove 1 bad publicity"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -117,7 +117,7 @@
                                            :effect (effect (gain :runner :credit 5))}} card))}
 
    "Drive By"
-   {:choices {:req #(and (= (second (:zone %)) :remote)
+   {:choices {:req #(and (is-remote? (second (:zone %)))
                          (= (last (:zone %)) :content)
                          (not (:rezzed %)))}
     :msg (msg "expose " (:title target) (when (#{"Asset" "Upgrade"} (:type target)) " and trash it"))
@@ -453,7 +453,7 @@
     :effect (req (let [c (Integer/parseInt target)]
                    (resolve-ability
                      state side
-                     {:choices {:req #(and (= (second (:zone %)) :remote)
+                     {:choices {:req #(and (is-remote? (second (:zone %)))
                                            (= (last (:zone %)) :content)
                                            (not (:rezzed %)))}
                       :msg (msg "add " c " advancement tokens on a card and gain " (* 2 c) " [Credits]")
@@ -534,7 +534,7 @@
    "Singularity"
    {:prompt "Choose a server" :choices (req remotes)
     :effect (effect (run target
-                      {:req (req (= target :remote))
+                      {:req (req (is-remote? target))
                        :replace-access
                        {:msg "trash all cards in the server at no cost"
                         :effect (req (doseq [c (get-in (:servers corp) (conj (:server run) :content))]
@@ -544,11 +544,7 @@
    {:prompt "Choose an unrezzed piece of ICE"
     :choices {:req #(and (= (last (:zone %)) :ices) (not (:rezzed %)) (= (:type %) "ICE"))}
     :effect (req (let [ice target
-                       serv (cond
-                             (= (second (:zone ice)) :hq) "HQ"
-                             (= (second (:zone ice)) :rd) "R&D"
-                             (= (second (:zone ice)) :archives) "Archives"
-                             :else (join " " ["Server" (last (butlast (:zone ice)))]))]
+                       serv (zone->name (second (:zone ice)))]
               (resolve-ability
                  state :runner
                  {:msg (msg "choose the ICE at position " (ice-index state ice) " of " serv)

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -662,7 +662,7 @@
 
    "Turing"
    {:abilities [end-the-run]
-    :strength-bonus (req (if (= (second (:zone card)) :remote) 3 0))}
+    :strength-bonus (req (if (is-remote? (second (:zone card))) 3 0))}
 
    "Turnpike"
    {:abilities [{:msg "force the Runner to lose 1 [Credits]"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -132,10 +132,9 @@
                           :once :per-turn :effect (effect (damage-bonus :brain 1))}}}
 
    "Diversified Portfolio"
-   {:msg (msg "gain " (count (filter #(not (empty? (:content %))) (get-in corp [:servers :remote])))
+   {:msg (msg "gain " (count (filter #(not (empty? (cons % [:content]))) (get-remotes @state)))
               " [Credits]")
-    :effect (effect (gain :credit (count (filter #(not (empty? (:content %)))
-                                                 (get-in corp [:servers :remote])))))}
+    :effect (effect (gain :credit (count (filter #(not (empty? (cons % [:content]))) (get-remotes @state)))))}
 
    "Fast Track"
    {:prompt "Choose an Agenda" :choices (req (filter #(has? % :type "Agenda") (:deck corp)))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -103,7 +103,7 @@
 
    "Cerebral Cast"
    {:psi {:not-equal {:player :runner :prompt "Take 1 tag or 1 brain damage?"
-                      :choices ["1 tag" "1 brain damage"] :msg (msg "The Runner takes " target)
+                      :choices ["1 tag" "1 brain damage"] :msg (msg "give the Runner " target)
                       :effect (req (if (= target "1 tag")
                                      (tag-runner state side 1)
                                      (damage state side :brain 1 {:card card})))}}}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -509,7 +509,7 @@
 
    "Trope"
    {:events {:runner-turn-begins {:effect (effect (add-prop card :counter 1))}}
-    :abilities [{:label "Remove Trope from the game to reshuffle cards from Heap back into Stack"
+    :abilities [{:cost [:click 1] :label "[Click], remove Trope from the game: Reshuffle cards from Heap back into Stack"
                  :effect (effect
                           (move card :rfg)
                           (resolve-ability

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -365,7 +365,10 @@
                                                (swap! state assoc-in [:per-turn (:cid card)] true))}
              :corp-turn-begins {:req (req (= (:credit runner) 0)) :msg "gain 1 [Credits]"
                                 :effect (req (gain state :runner :credit 1)
-                                             (swap! state assoc-in [:per-turn (:cid card)] true))}}
+                                             (swap! state assoc-in [:per-turn (:cid card)] true))}
+             :runner-install {:req (req (and (= target card) (= (:credit runner) 0))) :msg "gain 1 [Credits]"
+                              :effect (req (gain state :runner :credit 1)
+                                           (swap! state assoc-in [:per-turn (:cid card)] true))}}
     :leave-play (req (remove-watch state :order-of-sol))}
 
    "Paige Piper"


### PR DESCRIPTION
Several cards are no longer functioning or only semi-functioning due to the new way that remote servers are stored in the game state. 

This patch also contains a couple small items not related to that: a simplification to Social Engineering to use a newer, more concise core function and a fix for the wonky message of Cerebral Cast. 

Added fixes for Project Junebug, Trope, and Order of Sol (see #812).