### PR TITLE
proposed fix for Surfer

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -503,8 +503,9 @@
                                                       #(assoc % oldndx target))
                                                   (swap! state update-in [:run]
                                                       #(assoc % :position (inc tgtndx)))
-                                                  (update-ice-strength state side (cons :corp (:zone cice)))
-                                                  (update-run-ice state side)))}
+                                                  (update-all-ice state side)
+                                                  (update-run-ice state side)
+                                                  (trigger-event state side :approach-ice current-ice)))}
                                  card nil)))}]}
 
    "Trope"


### PR DESCRIPTION
Although I can't actually vouch that this will fix #789 because I still can't reproduce it, I think this is worth a shot. As was pointed out by @dlrowb in that issue, `update-ice-strength` is being passed the wrong thing. In its place we can try just updating all ice (in case the one being swapped changes its strength, e.g. Curtain Wall). I also triggered `:approach-ice` so that any breaker being used will recalculate the cost needed to match strength. 