### PR TITLE
More cards fixed to work with remote servers

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -495,7 +495,8 @@
     :effect (req (doseq [c targets] (expose state side c)))}
 
    "Scavenge"
-   {:choices {:req #(= (:type %) "Program")}
+   {:req (req (> (count (filter #(= (:type %) "Program") (all-installed state :runner))) 0))
+    :choices {:req #(= (:type %) "Program")}
     :effect (req (let [trashed target]
                    (trash state side trashed)
                    (resolve-ability

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -172,19 +172,19 @@
    "Laramy Fisk: Savvy Investor"
    {:events {:no-action {:effect (effect (system-msg "can be forced to draw by clicking on Laramy Fisk"))
                          :req (req (and run
-                                        (some #{:hq :rd :archives} (:server run))
+                                        (is-central? (:server run))
                                         (not current-ice)
                                         (not (get-in @state [:per-turn (:cid card)]))
-                                        (empty? (let [successes (map first (turn-events state side :successful-run))]
-                                                  (filter #(not (= % :remote)) successes)))))}}
+                                        (empty? (let [successes (turn-events state side :successful-run)]
+                                                  (filter #(is-central? %) successes)))))}}
     :abilities [{:msg "force the Corp to draw 1 card"
                  :req (req (and run
-                                (some #{:hq :rd :archives} (:server run))
+                                (is-central? (:server run))
                                 (:no-action run)
                                 (not current-ice)
                                 (not (get-in @state [:per-turn (:cid card)]))
-                                (empty? (let [successes (map first (turn-events state side :successful-run))]
-                                          (filter #(not (= % :remote)) successes)))))
+                                (empty? (let [successes (turn-events state side :successful-run)]
+                                          (filter #(is-central? %) successes)))))
                  :effect (req (draw state :corp) (swap! state assoc-in [:per-turn (:cid card)] true))}]}
 
    "Leela Patel: Trained Pragmatist"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -77,7 +77,7 @@
                               :effect (effect (gain :credit 2)) :req (req (= target :hq))}}}
 
    "Gagarin Deep Space: Expanding the Horizon"
-   {:events {:pre-access-card {:req (req (= (second (:zone target)) :remote))
+   {:events {:pre-access-card {:req (req (is-remote? (second (:zone target))))
                                :effect (effect (access-cost-bonus [:credit 1]))}}}
 
    "GRNDL: Power Unleashed"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -22,14 +22,14 @@
    {:abilities [{:cost [:click 1]
                  :effect (req (let [b (get-card state card)
                                     hosted? (:host b)
-                                    remote? (some #{:remote} (rest (butlast (:zone (:host b)))))]
+                                    remote? (is-remote? (second (:zone (:host b))))]
                                 (resolve-ability state side
                                  {:prompt (msg "Host Bishop on a piece of ICE protecting "
                                             (if hosted? (if remote? "a central" "a remote") "any") " server")
                                   :choices {:req #(if hosted?
-                                                    (and (if (some #{:remote} (rest (butlast (:zone (:host b)))))
-                                                           (some #{:hq :rd :archives} (rest (butlast (:zone %))))
-                                                           (some #{:remote} (rest (butlast (:zone %)))))
+                                                    (and (if remote?
+                                                           (is-central? (second (:zone %)))
+                                                           (is-remote? (second (:zone %))))
                                                          (= (:type %) "ICE")
                                                          (= (last (:zone %)) :ices)
                                                          (not (some (fn [c] (has? c :subtype "Caïssa")) (:hosted %))))


### PR DESCRIPTION
Some people in chat uncovered a couple more cards that don't work with the new remote server system. Gagarin Deep Space, Laramy Fisk (fixing #820), and Bishop use `is-central?` and `is-remote?` now. 

This also adds a requirement of at least 1 program installed to play Scavenge, which addresses #801. 