### PR TITLE
fully implement Clot

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -62,7 +62,12 @@
    {:recurring 1}
 
    "Clot"
-   {:events {:purge {:effect (effect (trash card))}}}
+   {:effect (req (let [agendas (map first (filter #(= (:type (first %) "Agenda")) (turn-events state :corp :corp-install)))]
+                   (swap! state assoc-in [:corp :register :cannot-score] agendas)))
+    :events {:purge {:effect (req (swap! state update-in [:corp :register] dissoc :cannot-score)
+                                  (trash state side card))}
+             :corp-install {:req (req (= (:type target) "Agenda"))
+                            :effect (req (swap! state update-in [:corp :register :cannot-score] #(cons target %)))}}}
 
    "Collective Consciousness"
    {:events {:rez {:req (req (= (:type target) "ICE")) :msg "draw 1 card"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -884,13 +884,12 @@
   (gain-agenda-point state side n))
 
 (defn steal [state side card]
-  (let [c (move state :runner card :scored)]
+  (let [c (move state :runner (dissoc card :advance-counter) :scored)]
     (resolve-ability state :runner (:stolen (card-def c)) c nil)
     (system-msg state :runner (str "steals " (:title c) " and gains " (:agendapoints c)
                                    " agenda point" (when (> (:agendapoints c) 1) "s")))
     (swap! state update-in [:runner :register :stole-agenda] #(+ (or % 0) (:agendapoints c)))
     (gain-agenda-point state :runner (:agendapoints c))
-    (set-prop state :runner c :advance-counter 0)
     (when-let [current (first (get-in @state [:corp :current]))]
       (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
       (trash state side current))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -865,7 +865,8 @@
 
 (defn score [state side args]
   (let [card (or (:card args) args)]
-    (when (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card)))
+    (when (and (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
+               (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))
       (let [moved-card (move state :corp card :scored)
             c (card-init state :corp moved-card)]
         (system-msg state :corp (str "scores " (:title c) " and gains " (:agendapoints c)


### PR DESCRIPTION
When Clot is installed, it checks `[:turn-events]` for all Corp installs of agendas this turn and writes that list to the Corp's register, as well as continuing to listen for other agendas installed later. When the Corp attempts to score, it will fail if the `:cid` of the agenda is found in the list. 

Also fixes #777 by dissociating advancements when an agenda is stolen.