### PR TITLE
Batch of miscellaneous card fixes

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -77,9 +77,10 @@
                                   :effect (effect (pump card 1 :all-run)) :pump 1}]})
 
    "BlacKat"
-   (auto-icebreaker ["Barrier"]
-                    {:abilities [{:cost [:credit 1] :msg "break 1 barrier subroutine"}
-                                 {:cost [:credit 1] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]})
+   {:abilities [{:cost [:credit 1] :msg "break 1 barrier subroutine"}
+                {:cost [:credit 1] :msg "break up to 3 barrier subroutines (using a stealth [Credits])"}
+                {:cost [:credit 2] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}
+                {:cost [:credit 2] :msg "add 2 strength (using at least 1 stealth [Credits])" :effect (effect (pump card 2)) :pump 2}]}
 
    "Breach"
    (auto-icebreaker ["Barrier"]

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -2,10 +2,10 @@
 
 (def cards-operations
   {"24/7 News Cycle"
-   {:req (req (> (count (:scored corp)) 1))
-    :additional-cost [:forfeit]
-    :prompt "Choose an agenda to trigger"
-    :msg (msg "trigger the score ability on " (:title target))
+   {:req (req (> (count (:scored corp)) 1)) :additional-cost [:forfeit]
+    :prompt "Choose an agenda to trigger its \"when scored\" ability"
+    :choices (req (filter #(= (:type %) "Agenda") (:scored corp)))
+    :msg (msg "trigger the \"when scored\" ability of " (:title target))
     :effect (effect (card-init target))}
 
    "Aggressive Negotiation"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -21,7 +21,7 @@
    "Bishop"
    {:abilities [{:cost [:click 1]
                  :effect (req (let [b (get-card state card)
-                                    hosted? (:host b)
+                                    hosted? (= (:type (:host b)) "ICE")
                                     remote? (is-remote? (second (:zone (:host b))))]
                                 (resolve-ability state side
                                  {:prompt (msg "Host Bishop on a piece of ICE protecting "

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -179,8 +179,9 @@
    "Globalsec Security Clearance"
    {:req (req (> (:link runner) 1))
     :events {:runner-turn-begins
-             {:optional {:prompt "Use Globalsec Security Clearance to lose [Click]?" :msg "lose [Click]"
-                         :yes-ability {:effect (effect (lose :click 1)
+             {:optional {:prompt "Use Globalsec Security Clearance to lose [Click]?"
+                         :yes-ability {:msg "lose [Click] and look at the top card of R&D"
+                                       :effect (effect (lose :click 1)
                                                        (prompt! card (str "The top card of R&D is "
                                                                           (:title (first (:deck corp)))) ["OK"] {}))}}}}}
 


### PR DESCRIPTION
##### Bug fixes
Pawn must be hosted on ice in order to start responding to successful runs. 24/7 News Cycle was missing a `:choices` completely and probably never worked--it works now (fixing #817). 

##### Enhancements
* BlacKat ditches `auto-icebreaker` since there are two different ways to pump it, one of which was missing.
* People reported having confusion about how to work the revised Accelerated Beta Test, so some language was added to the prompt telling the player to look at the top of the play area.
* Thanks to the just-released FAQ, the Caissa can now be moved off Scheherazade. Bishop now checks to see if it's being hosted on ice.
* Tweaked the Quantum Predictive Model message to be in line with other cards that use `as-agenda`
* Added a message to the log when the Runner opts to use Global Security Clearance (it was happening silently before, which is confusing to the Corp)
* Rebranding Team is greatly simplified, after I got confirmation that it should apply Advertisement to all assets in R&D, Archives, HQ, and ones already installed. This provides support for Ad Blitz (hopefully coming soon...)