### PR TITLE
manual trigger for Leela, Gang Sign, Comet, Team Sponsorship; Corp decked message; card fixes

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -79,14 +79,16 @@
 
    "Comet"
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
-    :events {:play-event
-             {:optional {:prompt "Play another event?"
-                         :req (req (and (first-event state side :play-event)
-                                        (not (empty? (filter #(has? % :type "Event") (:hand runner))))))
-                         :yes-ability {:prompt "Choose an Event to play"
-                                       :choices (req (filter #(has? % :type "Event") (:hand runner)))
-                                       :msg (msg "play " (:title target))
-                                       :effect (effect (play-instant target))}}}}}
+    :events {:play-event {:req (req (first-event state side :play-event))
+                          :effect (req (system-msg state :runner
+                                                   (str "can play another event without spending a [Click] by clicking on Comet"))
+                                       (update! state side (assoc card :comet-event true)))}}
+    :abilities [{:req (req (:comet-event card))
+                 :prompt "Choose an Event in your Grip to play"
+                 :choices {:req #(and (= (:type %) "Event") (= (:zone %) [:hand]))}
+                 :msg (msg "play " (:title target))
+                 :effect (effect (play-instant target)
+                                 (update! (dissoc (get-card state card) :comet-event)))}]}
 
    "Cortez Chip"
    {:abilities [{:prompt "Choose a piece of ICE" :choices {:req #(and (not (:rezzed %)) (= (:type %) "ICE"))}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -170,7 +170,7 @@
                           :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Laramy Fisk: Savvy Investor"
-   {:events {:no-action {:effect (effect (system-msg "can be forced to draw by clicking on Laramy Fisk"))
+   {:events {:no-action {:effect (effect (system-msg "can be forced to draw by clicking on Laramy Fisk: Savvy Investor"))
                          :req (req (and run
                                         (is-central? (:server run))
                                         (not current-ice)
@@ -188,12 +188,19 @@
                  :effect (req (draw state :corp) (swap! state assoc-in [:per-turn (:cid card)] true))}]}
 
    "Leela Patel: Trained Pragmatist"
-   {:events {:agenda-scored {:choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :msg "add 1 unrezzed card to HQ"
-                             :player :runner :effect (effect (move :corp target :hand))}
-             :agenda-stolen {:choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :msg "add 1 unrezzed card to HQ"
-                             :effect (req (move state :corp target :hand)
-                                          (swap! state update-in [:runner :prompt] rest)
-                                          (handle-end-run state side))}}}
+   {:events {:agenda-scored
+             {:effect (req (system-msg state :runner
+                                       (str "can add 1 unrezzed card to HQ by clicking on Leela Patel: Trained Pragmatist"))
+                           (update! state :runner (assoc card :bounce-hq true)))}
+             :agenda-stolen
+             {:effect (req (system-msg state :runner
+                                       (str "can add 1 unrezzed card to HQ by clicking on Leela Patel: Trained Pragmatist"))
+                           (update! state side (assoc card :bounce-hq true)))}}
+    :abilities [{:req (req (:bounce-hq card))
+                 :choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :player :runner
+                 :msg "add 1 unrezzed card to HQ"
+                 :effect (effect (move :corp target :hand)
+                                 (update! (dissoc (get-card state card) :bounce-hq)))}]}
 
    "MaxX: Maximum Punk Rock"
    {:events {:runner-turn-begins {:msg "trash the top 2 cards from Stack and draw 1 card"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -132,9 +132,9 @@
                           :once :per-turn :effect (effect (damage-bonus :brain 1))}}}
 
    "Diversified Portfolio"
-   {:msg (msg "gain " (count (filter #(not (empty? (cons % [:content]))) (get-remotes @state)))
+   {:msg (msg "gain " (count (filter #(not (empty? %)) (map #(:content (second %)) (get-remotes @state))))
               " [Credits]")
-    :effect (effect (gain :credit (count (filter #(not (empty? (cons % [:content]))) (get-remotes @state)))))}
+    :effect (effect (gain :credit (count (filter #(not (empty? %)) (map #(:content (second %)) (get-remotes @state))))))}
 
    "Fast Track"
    {:prompt "Choose an Agenda" :choices (req (filter #(has? % :type "Agenda") (:deck corp)))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -207,7 +207,7 @@
                  :effect (req (resolve-ability
                                 state :corp
                                 {:prompt "Choose a card to trash"
-                                 :choices (req (filter #(:hand corp)))
+                                 :choices (req (filter #(= (:side %) "Corp") (:hand corp)))
                                  :effect (effect (trash target))}
                                card nil))}]}
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -166,9 +166,13 @@
                              (:agendapoints c) " agenda point" (when (> (:agendapoints c) 1) "s"))))}]}
 
    "Gang Sign"
-   {:events {:agenda-scored {:msg (msg "access " (get-in @state [:runner :hq-access]) " card from HQ")
-                             :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
-                                            (resolve-ability state :runner (choose-access c '(:hq)) card nil)))}}}
+   {:events {:agenda-scored {:effect (req (system-msg state :runner (str "can access cards in HQ by clicking on Gang Sign"))
+                                          (update! state side (assoc card :access-hq true)))}}
+    :abilities [{:req (req (:access-hq card))
+                 :msg (msg "access " (get-in @state [:runner :hq-access]) " card from HQ")
+                 :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
+                                (resolve-ability state :runner (choose-access c '(:hq)) card nil)
+                                (update! state side (dissoc (get-card state card) :access-hq))))}]}
 
    "Ghost Runner"
    {:data {:counter 3}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -264,6 +264,8 @@
 (defn draw
   ([state side] (draw state side 1))
   ([state side n]
+   (when (and (= side :corp) (> n (count (get-in @state [:corp :deck]))))
+     (system-msg state side "is decked and the Runner wins the game"))
    (let [active-player (get-in @state [:active-player])]
      (when-not (get-in @state [active-player :register :cannot-draw])
        (let [drawn (zone :hand (take n (get-in @state [side :deck])))]

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -47,13 +47,16 @@
       (core/advance state :corp {:card (refresh ag1)})
       (core/advance state :corp {:card (refresh ag1)})
       (core/score state :corp {:card (refresh ag1)})
+      (is (= true (:ts-install (core/get-card state tsp)))) ; TSP ability enabled by score
+      (card-ability state :corp tsp 0)
       ; TSP prompt should be active
       (is (= (:cid tsp) (get-in @state [:corp :prompt 0 :card :cid])))
       (prompt-choice :corp "HQ")
       (prompt-card :corp (find-card "Adonis Campaign" (:hand (get-corp))))
       (prompt-choice :corp "New remote")
       (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote3 :content 0 :title])) "Adonis installed by Team Sponsorship")
-      (is (nil? (find-card "Adonis Campaign" (:hand (get-corp)))) "No Adonis in hand"))))
+      (is (nil? (find-card "Adonis Campaign" (:hand (get-corp)))) "No Adonis in hand")
+      (is (nil? (:ts-install (core/get-card state tsp))) "Team Sponsorship ability disabled"))))
 
 (deftest team-sponsorship-archives
   "Team Sponsorship - Install from Archives"
@@ -70,13 +73,16 @@
       (core/advance state :corp {:card (refresh ag1)})
       (core/advance state :corp {:card (refresh ag1)})
       (core/score state :corp {:card (refresh ag1)})
+      (is (= true (:ts-install (core/get-card state tsp)))) ; TSP ability enabled by score
+      (card-ability state :corp tsp 0)
       ; TSP prompt should be active
       (is (= (:cid tsp) (get-in @state [:corp :prompt 0 :card :cid])))
       (prompt-choice :corp "Archives")
       (prompt-card :corp (find-card "Adonis Campaign" (:discard (get-corp))))
       (prompt-choice :corp "New remote")
       (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote3 :content 0 :title])) "Adonis installed by Team Sponsorship")
-      (is (nil? (find-card "Adonis Campaign" (:discard (get-corp)))) "No Adonis in discard"))))
+      (is (nil? (find-card "Adonis Campaign" (:discard (get-corp)))) "No Adonis in discard")
+      (is (nil? (:ts-install (core/get-card state tsp))) "Team Sponsorship ability disabled"))))
 
 (deftest team-sponsorship-multiple
   "Team Sponsorship - Multiple installed"
@@ -96,13 +102,21 @@
       (core/advance state :corp {:card (refresh ag1)})
       (core/advance state :corp {:card (refresh ag1)})
       (core/score state :corp {:card (refresh ag1)})
-      ; TSP prompt should be active
+      (is (= true (:ts-install (core/get-card state tsp1)))) ; TSP1 ability enabled by score
+      (is (= true (:ts-install (core/get-card state tsp2)))) ; TSP2 ability enabled by score
+      (card-ability state :corp tsp1 0)
+      ; TSP1 prompt should be active
+      (is (= (:cid tsp1) (get-in @state [:corp :prompt 0 :card :cid])))
       (prompt-choice :corp "Archives")
       (prompt-card :corp (find-card "Adonis Campaign" (:discard (get-corp))))
       (prompt-choice :corp "New remote")
-      ; second prompt should be active
+      (card-ability state :corp tsp2 0)
+      ; TSP2 prompt should be active
+      (is (= (:cid tsp2) (get-in @state [:corp :prompt 0 :card :cid])))
       (prompt-choice :corp "HQ")
       (prompt-card :corp (find-card "Adonis Campaign" (:hand (get-corp))))
       (prompt-choice :corp "New remote")
       (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote4 :content 0 :title])) "Adonis installed by Team Sponsorship")
-      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote5 :content 0 :title])) "Adonis installed by Team Sponsorship"))))
+      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote5 :content 0 :title])) "Adonis installed by Team Sponsorship")
+      (is (nil? (:ts-install (core/get-card state tsp1))) "Team Sponsorship 1 ability disabled")
+      (is (nil? (:ts-install (core/get-card state tsp2))) "Team Sponsorship 2 ability disabled"))))

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -23,3 +23,19 @@
     (core/play state :corp {:card (first (:hand (get-corp))) :server "Server 0"})
     (is (= 5 (count (:hand (get-runner)))) "Did not draw")
     (is (= 1 (count (:deck (get-runner)))) "1 card left in deck")))
+  
+  (deftest comet-event-play
+  "Comet - Play event without spending a click after first event played"
+  (do-game
+    (new-game (default-corp) (default-runner [(qty "Comet" 3) (qty "Easy Mark" 2)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Comet")
+    (let [comet (get-in @state [:runner :rig :hardware 0])]
+      (play-from-hand state :runner "Easy Mark")
+      (is (= true (:comet-event (core/get-card state comet)))) ; Comet ability enabled
+      (card-ability state :runner comet 0)
+      (is (= (:cid comet) (get-in @state [:runner :prompt 0 :card :cid])))
+      (core/select state :runner {:card (find-card "Easy Mark" (:hand (get-runner)))})
+      (is (= 7 (:credit (get-runner))))
+      (is (= 2 (:click (get-runner))))
+      (is (nil? (:comet-event (core/get-card state comet))) "Comet ability disabled"))))

--- a/src/clj/test/cards-operations.clj
+++ b/src/clj/test/cards-operations.clj
@@ -1,5 +1,18 @@
 (in-ns 'test.core)
 
+(deftest diversified-portfolio
+  (do-game
+    (new-game (default-corp [(qty "Diversified Portfolio" 1) (qty "Paper Wall" 1)
+                             (qty "PAD Campaign" 3)])
+              (default-runner))
+    (core/gain state :corp :click 2)
+    (play-from-hand state :corp "Paper Wall" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "Diversified Portfolio")
+    (is (= 7 (:credit (get-corp))) "Ignored remote with ICE but no server contents")))
+
 (deftest hedge-fund
   (do-game
     (new-game (default-corp) (default-runner))

--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -8,7 +8,8 @@
             [netrunner.main :as main]))
 
 (def app-state
-  (atom {:channels {:general [] :america [] :europe [] :asia-pacific [] :francais [] :español [] :italia [] :sverige []}}))
+  (atom {:channels {:general [] :america [] :europe [] :asia-pacific [] :français []
+                    :español [] :italia [] :português [] :sverige []}}))
 
 (def chat-channel (chan))
 (def chat-socket (.connect js/io (str js/iourl "/chat")))


### PR DESCRIPTION
People have had it up to their eyeballs with multiple Gang Signs not working correctly, and I don't blame them. This changes each Gang Sign to a manually triggered effect using the technique from Laramy Fisk (print a message in the log informing the Runner what to do). Until there is a global fix for multiple simultaneous effects, this fixes #806 and #519. 

Leela Patel is also switched to work this way so a Runner can use Gang Sign(s) first before doing the bounce to HQ. Leela's click ability doesn't work right when you steal an agenda from a remote that also has 1 or more upgrades--you'll have to proceed with accessing all cards before clicking her. But the current implementation doesn't work right in this regard either, so we aren't going backwards. The Runner can ask the Corp to drag a remaining unrezzed card in the server back to HQ manually if that's what they want to bounce. 

Comet is changed to a manual trigger to allow a Runner to play a Run event and wait until it resolves before playing another event by clicking Comet. Addresses #322 and #691.  

Team Sponsorship with a manual trigger allows it to work correctly with a scored Accelerated Beta Test--instead of the prompts of ABT and TS getting interleaved, you can fully complete the ABT installs before firing Team Sponsorships. 

There's a new log message for when the Corp is decked, addressing #785. I fixed Diversified Portfolio, which was counting servers even if they only had ice but no server contents, and fixed Hemorrhage which wasn't charging the 2 counters correctly. 