### PR TITLE
implement Turntable, undo effects of Corp agendas that are forfeited or Turntabled

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -254,7 +254,8 @@
                        :effect (effect (corp-install target nil {:install-state :rezzed}))} card targets))}
 
    "Mandatory Upgrades"
-   {:effect (effect (gain :click 1 :click-per-turn 1))}
+   {:effect (effect (gain :click 1 :click-per-turn 1))
+    :leave-play (effect (lose :click-per-turn 1))}
 
    "Market Research"
    {:req (req tagged) :effect (effect (set-prop card :counter 1 :agendapoints 3))}
@@ -366,7 +367,8 @@
                  :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
 
    "Self-Destruct Chips"
-   {:effect (effect (lose :runner :max-hand-size 1))}
+   {:effect (effect (lose :runner :max-hand-size 1))
+    :leave-play (effect (gain :runner :max-hand-size 1))}
 
    "Sentinel Defense Program"
    {:events {:damage {:req (req (= target :brain)) :msg "to do 1 net damage"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -123,7 +123,8 @@
      (when-let [leave-effect (:leave-play (card-def card))]
        (when (or (and (= (:side card) "Runner") (:installed card))
                  (:rezzed card)
-                 (= (first (:zone card)) :current))
+                 (= (first (:zone card)) :current)
+                 (= (first (:zone card)) :scored))
          (leave-effect state side card nil)))
      (when-let [prevent (:prevent (card-def card))]
        (doseq [[ptype pvec] prevent]
@@ -1549,9 +1550,10 @@
     (add-prop state side (get-card state card) :advance-counter 1)))
 
 (defn forfeit [state side card]
-  (system-msg state side (str "forfeits " (:title card)))
-  (gain state side :agenda-point (- (:agendapoints card)))
-  (move state :corp card :rfg))
+  (let [c (desactivate state side card)]
+    (system-msg state side (str "forfeits " (:title c)))
+    (gain state side :agenda-point (- (:agendapoints c)))
+    (move state :corp c :rfg)))
 
 (defn expose [state side target]
   (system-msg state side

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -23,3 +23,34 @@
     (core/play state :corp {:card (first (:hand (get-corp))) :server "Server 0"})
     (is (= 5 (count (:hand (get-runner)))) "Did not draw")
     (is (= 1 (count (:deck (get-runner)))) "1 card left in deck")))
+  
+(deftest turntable-swap
+  "Turntable - Swap a stolen agenda for a scored agenda"
+  (do-game
+    (new-game (default-corp [(qty "Domestic Sleepers" 1) (qty "Project Vitruvius" 1)])
+              (default-runner [(qty "Turntable" 1)]))
+    (play-from-hand state :corp "Project Vitruvius" "New remote")
+    (let [ag1 (get-in @state [:corp :servers :remote1 :content 0])]
+      (core/gain state :corp :click 1)
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/advance state :corp {:card (refresh ag1)})
+      (core/score state :corp {:card (refresh ag1)})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Turntable")
+      (is (= 3 (:credit (get-runner))))
+      (let [tt (get-in @state [:runner :rig :hardware 0])]
+        (core/click-run state :runner {:server "HQ"})
+        (core/no-action state :corp nil)
+        (core/successful-run state :runner nil)
+        (prompt-choice :runner "Steal")
+        (is (= 0 (:agenda-point (get-runner))) "Stole Domestic Sleepers")
+        (is (= true (:swap (core/get-card state tt)))) ; Turntable ability enabled by steal
+        (card-ability state :runner tt 0)
+        ; Turntable prompt should be active
+        (is (= (:cid tt) (get-in @state [:runner :prompt 0 :card :cid])))
+        (prompt-choice :runner "Yes")
+        (core/select state :runner {:card (find-card "Project Vitruvius" (:scored (get-corp)))})
+        (is (= 2 (:agenda-point (get-runner))) "Took Project Vitruvius from Corp")
+        (is (= 0 (:agenda-point (get-corp))) "Swapped Domestic Sleepers to Corp")
+        (is (nil? (:swap (core/get-card state tt))) "Turntable ability disabled")))))


### PR DESCRIPTION
After what seems like months of pecking at Turntable off and on, I think this does it. This is a click-to-trigger effect after a steal, like what has been done to Gang Sign, Leela, Team Sponsorship, etc. 

The scored agenda chosen from the Corp's area will have any counters, effects, and abilities dissociated, and then will get `desactivate` as well--this is the part that will drop the Corp back down to 3 clicks per turn if the Runner Turntables away a Mandatory Upgrades, or restores the Runner's max hand size to 5 if Turntabling away a Self-Destruct Chips. 

Similarly, the act of forfeiting either of these two agendas doesn't currently reverse their effects, so `forfeit` and `desactivate` got small tweaks to support that in addition to the use of Turntable. 