### PR TITLE
Fix refresh of recurring credits on cards hosted after installation

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1404,9 +1404,8 @@
                            :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
                            :previous-zone (:zone target))]
        (update! state side (update-in card [:hosted] #(conj % c)))
-       (when-let [events (:events (card-def target))]
-         (when installed
-           (register-events state side events c)))
+       (when installed
+         (card-init state side c false))
        c))))
 
 (defn is-tagged? [state]


### PR DESCRIPTION
Fix for #712. As @queueseven noted in that issue, if the card being hosted is already installed, we have to `card-init` without resolving instead of registering events. 

Tested with Scheherazade and Off-Campus Apartment as hosts for installed Pheromones and Compromised Employee to ensure that credits recur *and* they're listening for their event triggers. 