### PR TITLE
Fix for unreported Red Herrings issue

### DIFF
--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -189,7 +189,8 @@
                             (swap! state update-in [:runner :register] dissoc :cannot-steal)))}
          un {:effect (req (swap! state update-in [:runner :register] dissoc :cannot-steal))}]
      {:trash-effect
-      {:effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (= (:zone target)
+      {:req (req (= :servers (first (:previous-zone card))))
+       :effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (= (:zone target)
                                                                                 (:previous-zone card))))
                                          :run-ends {:effect (req (unregister-events state side card)
                                                                  (swap! state update-in [:runner :register] dissoc
@@ -208,7 +209,8 @@
    "Red Herrings"
    (let [ab {:req (req (= (:zone card) (:zone target)))
              :effect (effect (steal-cost-bonus [:credit 5]))}]
-     {:trash-effect {:effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (= (:zone target)
+     {:trash-effect {:req (req (= :servers (first (:previous-zone card))))
+                     :effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (= (:zone target)
                                                                                               (:previous-zone card))))
                                                        :run-ends {:effect (effect (unregister-events card))}}
                                                       (assoc card :zone '(:discard))))}
@@ -262,7 +264,8 @@
    "Strongbox"
    (let [ab {:req (req (= (:zone card) (:zone target)))
              :effect (effect (steal-cost-bonus [:click 1]))}]
-     {:trash-effect {:effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (= (:zone target)
+     {:trash-effect {:req (req (= :servers (first (:previous-zone card))))
+                     :effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (= (:zone target)
                                                                                               (:previous-zone card))))
                                                        :run-ends {:effect (effect (unregister-events card))}}
                                                       (assoc card :zone '(:discard))))}

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -155,6 +155,22 @@
       (is (= 0 (:credit (get-runner))) "Runner was charged 5cr")
       (is (= 1 (count (:scored (get-runner)))) "1 scored agenda"))))
 
+(deftest red-herrings-trash-from-hand
+  "Red Herrings - Trashed from Hand"
+  (do-game
+    (new-game (default-corp [(qty "Red Herrings" 1) (qty "House of Knives" 1)])
+              (default-runner))
+    (core/move-card state :corp {:card (find-card "Red Herrings" (:hand (get-corp))) :server "Archives"})
+    (is (= 1 (count (:discard (get-corp)))) "1 card in Archives")
+    (take-credits state :corp 2)
+
+    (core/click-run state :runner {:server "HQ"})
+    (core/no-action state :corp nil)
+    (core/successful-run state :runner nil)
+    ; prompt should be asking to steal HoK
+    (prn (:prompt (get-runner)))
+    (is (= "Steal" (first (:choices (first (:prompt (get-runner)))))) "Runner being asked to Steal")))
+
 (deftest red-herrings-other-server
   "Red Herrings - Don't affect runs on other servers"
   (do-game


### PR DESCRIPTION
Well, it was reported by @JoelCFC25  :P.

Red Herrings, Strongbox, and Old Hollywood Grid will fire during a run on HQ if the card was discarded from the corp's hand without being played. Fun times. Test to verify the issue, and a fix for the issue.