### PR TITLE
Stop spectators from viewing facedown cards in Archives, fix for seen cards returned to R&D/HQ

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -248,7 +248,9 @@
                             (not (:facedown c))))
                  (desactivate state side c) c)
              c (if (= dest [:rig :facedown])(assoc c :facedown true) (dissoc c :facedown))
-             moved-card (assoc c :zone dest :host nil :hosted nil :previous-zone (:zone c))]
+             moved-card (assoc c :zone dest :host nil :hosted nil :previous-zone (:zone c))
+             moved-card (if (and (= side :corp) (#{:hand :deck} (first dest)))
+                          (dissoc moved-card :seen) moved-card)]
          (if front
            (swap! state update-in (cons side dest) #(cons moved-card (vec %)))
            (swap! state update-in (cons side dest) #(conj (vec %) moved-card)))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -458,7 +458,7 @@
       (for [c discard]
         (if (or (:seen c) (:rezzed c))
           (om/build card-view c)
-          (if (= (:side @game-state) :runner)
+          (if (not= (:side @game-state) :corp)
             [:img.card {:src "/img/corp.png"}]
             [:div.unseen (om/build card-view c)])))]
 


### PR DESCRIPTION
Fixes #781 so spectators can no longer view facedown cards in Archives as if they were the Corp. 

The `core.clj` fix is for the current flaw in using Jackson Howard or Archived Memories to return faceup cards in Archives to R&D or HQ. Right now faceup cards are retaining `:seen true` when moved to these destinations, which results in them being faceup again if later milled (e.g., by Noise or DLR), or named in the log if manually dragged to Archives--neither of which should happen. 