### PR TITLE
Fix for installing Parasite off Street Peddler with 1cr

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1447,9 +1447,9 @@
                                             (when host-card (str " on " (:title host-card)))
                                             (when no-cost " at no cost")))))
                  (trigger-event state side :runner-install installed-card)
-                 (when (has? c :subtype "Icebreaker") (update-breaker-strength state side c))))))))
-     (when (has? card :type "Resource") (swap! state assoc-in [:runner :register :installed-resource] true))
-     (swap! state update-in [:bonus] dissoc :install-cost))))
+                 (when (has? c :subtype "Icebreaker") (update-breaker-strength state side c))))))
+         (when (has? card :type "Resource") (swap! state assoc-in [:runner :register :installed-resource] true))
+         (swap! state update-in [:bonus] dissoc :install-cost))))))
 
 (defn rez
   ([state side card] (rez state side card nil))

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -111,6 +111,30 @@
       (is (= "Corroder" (:title (get-in @state [:runner :rig :program 0]))) "Corroder was installed")
       (is (= 3 (:memory (get-runner))) "Corroder cost 1 mu"))))
 
+
+(deftest street-peddler-parasite-1cr
+  "Street Peddler - Installing Parasite with only 1cr. Issue #491."
+  (do-game
+    (new-game (default-corp [(qty "Pop-up Window" 3)]) (default-runner [(qty "Street Peddler" 1) (qty "Parasite" 3)]))
+    (play-from-hand state :corp "Pop-up Window" "HQ")
+    (take-credits state :corp 2)
+    ; move Parasites back to deck
+    (core/move state :runner (find-card "Parasite" (:hand (get-runner))) :deck)
+    (core/move state :runner (find-card "Parasite" (:hand (get-runner))) :deck)
+    (core/move state :runner (find-card "Parasite" (:hand (get-runner))) :deck)
+    (core/lose state :runner :credit 4) ; go down to 1 credit
+    (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
+    (play-from-hand state :runner "Street Peddler")
+    (let [sp (get-in @state [:runner :rig :resource 0])
+          pu (get-in @state [:corp :servers :hq :ices 0])]
+      (core/rez state :corp pu)
+      (card-ability state :runner sp 0)
+      (prompt-card :runner (first (:hosted sp))) ; choose to install Parasite
+      (is (= "Parasite" (:title (:card (first (get-in @state [:runner :prompt]))))) "Parasite target prompt")
+      (prompt-select :runner pu)
+      (is (= 4 (count (:discard (get-runner)))) "3 Parasite, 1 Street Peddler in heap")
+      (is (= 1 (count (:discard (get-corp)))) "Pop-up Window in archives"))))
+
 (deftest the-supplier-ability
   "The Supplier - Ability"
   (do-game

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -145,10 +145,8 @@
       (core/no-action state :corp nil)
       (core/successful-run state :runner nil)
       ; runner now chooses which to access.
-      ;(prn (get-in @state [:events :pre-steal-cost]))
       (prompt-select :runner rh)
       (prompt-choice :runner "Yes") ; pay to trash
-      ;(prn (get-in @state [:events :pre-steal-cost]))
       (prompt-select :runner hok)
       ; should now have prompt to pay 5cr for HoK
       (prompt-choice :runner "Yes")
@@ -168,7 +166,6 @@
     (core/no-action state :corp nil)
     (core/successful-run state :runner nil)
     ; prompt should be asking to steal HoK
-    (prn (:prompt (get-runner)))
     (is (= "Steal" (first (:choices (first (:prompt (get-runner)))))) "Runner being asked to Steal")))
 
 (deftest red-herrings-other-server


### PR DESCRIPTION
The way install-on-host works was incompatible with install cost bonuses, as the initial call to `runner-install` would trigger another call to `runner-install` with additional arguments to select the host. The first call would remove Peddler's install cost bonus before Parasite was successfully installed. Fix and test for #491.