### PR TITLE
Several card fixes, add log message when the Corp is decked

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -255,7 +255,7 @@
 
    "Mandatory Upgrades"
    {:effect (effect (gain :click 1 :click-per-turn 1))
-    :leave-play (effect (lose :click-per-turn 1))}
+    :leave-play (req (lose state :corp :click 1 :click-per-turn 1))}
 
    "Market Research"
    {:req (req tagged) :effect (effect (set-prop card :counter 1 :agendapoints 3))}

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -449,7 +449,7 @@
                                                        (fn [coll] (conj (remove-once #(not= (:cid %) (:cid sw)) coll) st)))
                                                      (swap! state update-in [:runner :scored]
                                                        (fn [coll] (conj (remove-once #(not= (:cid %) (:cid st)) coll)
-                                                                        (dissoc sw :counter :abilities :events))))
+                                                                        (dissoc sw :abilities :events))))
                                                      (gain-agenda-point state :runner (- swpts stpts))
                                                      (gain-agenda-point state :corp (- stpts swpts))
                                                      (doseq [c (get-in @state [:corp :scored])]

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -170,7 +170,7 @@
                           :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Laramy Fisk: Savvy Investor"
-   {:events {:no-action {:effect (effect (system-msg "can be forced to draw by clicking on Laramy Fisk"))
+   {:events {:no-action {:effect (effect (system-msg "can be forced to draw by clicking on Laramy Fisk: Savvy Investor"))
                          :req (req (and run
                                         (is-central? (:server run))
                                         (not current-ice)

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -83,7 +83,7 @@
    "GRNDL: Power Unleashed"
    {:effect (effect (gain :credit 5 :bad-publicity 1))}
 
-   "Haarpsichord Studios"
+   "Haarpsichord Studios: Entertainment Unleashed"
    {:events {:pre-steal-cost {:req (req (:stole-agenda runner-reg))
                               :effect (effect (prevent-steal))}}}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -135,9 +135,9 @@
                           :once :per-turn :effect (effect (damage-bonus :brain 1))}}}
 
    "Diversified Portfolio"
-   {:msg (msg "gain " (count (filter #(not (empty? (cons % [:content]))) (get-remotes @state)))
+   {:msg (msg "gain " (count (filter #(not (empty? %)) (map #(:content (second %)) (get-remotes @state))))
               " [Credits]")
-    :effect (effect (gain :credit (count (filter #(not (empty? (cons % [:content]))) (get-remotes @state)))))}
+    :effect (effect (gain :credit (count (filter #(not (empty? %)) (map #(:content (second %)) (get-remotes @state))))))}
 
    "Fast Track"
    {:prompt "Choose an Agenda" :choices (req (filter #(has? % :type "Agenda") (:deck corp)))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -207,7 +207,7 @@
                  :effect (req (resolve-ability
                                 state :corp
                                 {:prompt "Choose a card to trash"
-                                 :choices (req (filter #(:hand corp)))
+                                 :choices (req (filter #(= (:side %) "Corp") (:hand corp)))
                                  :effect (effect (trash target))}
                                card nil))}]}
 

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -143,11 +143,13 @@
                               (lose state :runner :tag 1))}]}
 
    "Marcus Batty"
-   {:abilities [{:label "[Trash]: Start a Psi game" :msg "start a Psi game"
-                 :psi {:not-equal {:req (req this-server)
-                                   :choices {:req #(and (has? % :type "ICE") (:rezzed %))}
-                                   :msg (msg "resolve a subroutine on " (:title target))
-                                   :effect (effect (trash card {:cause :ability-cost}))}}}]}
+   {:abilities [{:req (req this-server)
+                 :label "[Trash]: Start a Psi game" :msg "start a Psi game"
+                 :psi {:not-equal {:prompt "Choose a rezzed piece of ICE to resolve one of its subroutines"
+                                   :choices {:req #(and (has? % :type "ICE")
+                                                        (:rezzed %))}
+                                   :msg (msg "resolve a subroutine on " (:title target))}}
+                 :effect (effect (trash card))}]}
 
    "Midori"
    {:abilities

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -274,6 +274,8 @@
 (defn draw
   ([state side] (draw state side 1))
   ([state side n]
+   (when (and (= side :corp) (> n (count (get-in @state [:corp :deck]))))
+     (system-msg state side "is decked and the Runner wins the game"))
    (let [active-player (get-in @state [:active-player])]
      (when-not (get-in @state [active-player :register :cannot-draw])
        (let [drawn (zone :hand (take n (get-in @state [side :deck])))]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -124,7 +124,7 @@
        (when (or (and (= (:side card) "Runner") (:installed card))
                  (:rezzed card)
                  (= (first (:zone card)) :current)
-                 (= (first (:zone card)) :scored))
+                 (not (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :scored])))))
          (leave-effect state side card nil)))
      (when-let [prevent (:prevent (card-def card))]
        (doseq [[ptype pvec] prevent]

--- a/src/clj/test/cards-operations.clj
+++ b/src/clj/test/cards-operations.clj
@@ -6,6 +6,19 @@
     (is (= 5 (:credit (get-corp))))
     (core/play state :corp {:card (first (:hand (get-corp)))})
     (is (= 9 (:credit (get-corp))))))
+
+(deftest diversified-portfolio
+  (do-game
+    (new-game (default-corp [(qty "Diversified Portfolio" 1) (qty "Paper Wall" 1)
+                             (qty "PAD Campaign" 3)])
+              (default-runner))
+    (core/gain state :corp :click 2)
+    (play-from-hand state :corp "Paper Wall" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "Diversified Portfolio")
+    (is (= 7 (:credit (get-corp))) "Ignored remote with ICE but no server contents")))
   
 (deftest news-cycle
   (do-game

--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -8,7 +8,8 @@
             [netrunner.main :as main]))
 
 (def app-state
-  (atom {:channels {:general [] :america [] :europe [] :asia-pacific [] :francais [] :español [] :italia [] :sverige []}}))
+  (atom {:channels {:general [] :america [] :europe [] :asia-pacific [] :français []
+                    :español [] :italia [] :português [] :sverige []}}))
 
 (def chat-channel (chan))
 (def chat-socket (.connect js/io (str js/iourl "/chat")))


### PR DESCRIPTION
Corp decked message solves #785. 

Card fixes are as follows: 

* Add the subtitle for Haarpsichord Studios (fixes #853)
* Diversified Portfolio was wrongly counting servers that had only ice and no contents
* Hemorrhage wasn't charging counters correctly
* Marcus Batty wasn't trashing himself or prompting to choose an ice
* Turntable needs to leave agenda counters in place when swapping (but still disables events/abilities)
* Mandatory Upgrades forces the Corp to lose a click when forfeited, and goes together with a fix to only fire the `:leave-play` effect on a forfeit if the agenda was in the Corp score area (fixes the Runner losing a click per turn when forfeiting a stolen Mandatory Upgrades)
