### PR TITLE
change Comet to a manually triggered ability

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -99,14 +99,16 @@
 
    "Comet"
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
-    :events {:play-event
-             {:optional {:prompt "Play another event?"
-                         :req (req (and (first-event state side :play-event)
-                                        (not (empty? (filter #(has? % :type "Event") (:hand runner))))))
-                         :yes-ability {:prompt "Choose an Event to play"
-                                       :choices (req (filter #(has? % :type "Event") (:hand runner)))
-                                       :msg (msg "play " (:title target))
-                                       :effect (effect (play-instant target))}}}}}
+    :events {:play-event {:req (req (first-event state side :play-event))
+                          :effect (req (system-msg state :runner
+                                                   (str "can play another event without spending a [Click] by clicking on Comet"))
+                                       (update! state side (assoc card :comet-event true)))}}
+    :abilities [{:req (req (:comet-event card))
+                 :prompt "Choose an Event in your Grip to play"
+                 :choices {:req #(and (= (:type %) "Event") (= (:zone %) [:hand]))}
+                 :msg (msg "play " (:title target))
+                 :effect (effect (play-instant target)
+                                 (update! (dissoc (get-card state card) :comet-event)))}]}
 
    "Cortez Chip"
    {:abilities [{:prompt "Choose a piece of ICE" :choices {:req #(and (not (:rezzed %)) (= (:type %) "ICE"))}

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -24,6 +24,22 @@
     (is (= 5 (count (:hand (get-runner)))) "Did not draw")
     (is (= 1 (count (:deck (get-runner)))) "1 card left in deck")))
   
+(deftest comet-event-play
+  "Comet - Play event without spending a click after first event played"
+  (do-game
+    (new-game (default-corp) (default-runner [(qty "Comet" 3) (qty "Easy Mark" 2)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Comet")
+    (let [comet (get-in @state [:runner :rig :hardware 0])]
+      (play-from-hand state :runner "Easy Mark")
+      (is (= true (:comet-event (core/get-card state comet)))) ; Comet ability enabled
+      (card-ability state :runner comet 0)
+      (is (= (:cid comet) (get-in @state [:runner :prompt 0 :card :cid])))
+      (core/select state :runner {:card (find-card "Easy Mark" (:hand (get-runner)))})
+      (is (= 7 (:credit (get-runner))))
+      (is (= 2 (:click (get-runner))))
+      (is (nil? (:comet-event (core/get-card state comet))) "Comet ability disabled"))))
+  
 (deftest turntable-swap
   "Turntable - Swap a stolen agenda for a scored agenda"
   (do-game


### PR DESCRIPTION
The first in a series of cards that will adopt the Laramy Fisk technique to become manually triggered, providing an interim solution for the widespread problem with the resolution of multiple simultaneous effects. Specifically with Comet, playing the first event of a turn unlocks the usage of the card ability. The Runner is prompted in the log how to activate it. This works with run events, allowing you to fully resolve them before triggering Comet. 

Fixes #322 and #691. 