### PR TITLE
change Gang Sign to a manually triggered ability

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -166,9 +166,13 @@
                              (:agendapoints c) " agenda point" (when (> (:agendapoints c) 1) "s"))))}]}
 
    "Gang Sign"
-   {:events {:agenda-scored {:msg (msg "access " (get-in @state [:runner :hq-access]) " card from HQ")
-                             :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
-                                            (resolve-ability state :runner (choose-access c '(:hq)) card nil)))}}}
+   {:events {:agenda-scored {:effect (req (system-msg state :runner (str "can access cards in HQ by clicking on Gang Sign"))
+                                          (update! state side (assoc card :access-hq true)))}}
+    :abilities [{:req (req (:access-hq card))
+                 :msg (msg "access " (get-in @state [:runner :hq-access]) " card from HQ")
+                 :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
+                                (resolve-ability state :runner (choose-access c '(:hq)) card nil)
+                                (update! state side (dissoc (get-card state card) :access-hq))))}]}
 
    "Ghost Runner"
    {:data {:counter 3}


### PR DESCRIPTION
Gang Sign adopts the Laramy Fisk technique to become manually triggered. The Runner is prompted in the log to activate each Gang Sign. This works with multiple copies of Gang Sign and multiple copies of HQ Interface to get the correct outcomes--e.g. 2x Gang Sign and 1x HQI will yield: access 2 cards from HQ, return them, access 2 cards again (possibly seeing the same ones). Currently you get 4 accesses at once, which is wrong.

Leela Patel as a manually triggered effect is coming shortly, so Gang Signs will be able to be used before or after Leela's bounce to HQ ability. 

Fixes #519.