### PR TITLE
Change a variety of cards to use the card targeting system (allowing easier cancellation)

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -385,8 +385,9 @@
      {:effect (effect (resolve-ability (mhelper 1) card nil))})
 
    "Modded"
-   {:prompt "Choose a card to install"
-    :choices (req (filter #(#{"Hardware" "Program"} (:type %)) (:hand runner)))
+   {:prompt "Choose a program or piece of hardware to install from your Grip"
+    :choices {:req #(and (or (= (:type %) "Hardware") (= (:type %) "Program"))
+                         (= (:zone %) [:hand]))}
     :effect (effect (install-cost-bonus [:credit -3]) (runner-install target))}
 
    "Net Celebrity"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -45,8 +45,8 @@
                                                  (all-installed state :runner)))))}
 
    "Career Fair"
-   {:prompt "Choose a Resource to install"
-    :choices (req (filter #(#{"Resource"} (:type %)) (:hand runner)))
+   {:prompt "Choose a resource to install from your Grip"
+    :choices {:req #(and (= (:type %) "Resource") (= (:zone %) [:hand]))}
     :effect  (effect (install-cost-bonus [:credit -3]) (runner-install target))}
 
    "Code Siphon"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -91,10 +91,10 @@
                                                    (lose state side :tag 1)))} card nil))}]}
 
    "Clone Chip"
-   {:abilities [{:prompt "Choose a program to install" :msg (msg "install " (:title target))
-                 :priority true
+   {:abilities [{:prompt "Choose a program to install from your Heap" :msg (msg "install " (:title target))
+                 :priority true :show-discard true
                  :req (req (not (seq (get-in @state [:runner :locked :discard]))))
-                 :choices (req (filter #(has? % :type "Program") (:discard runner)))
+                 :choices {:req #(and (= (:type %) "Program") (= (:zone %) [:discard]))}
                  :effect (effect (trash card {:cause :ability-cost}) (runner-install target))}]}
 
    "Comet"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -100,14 +100,14 @@
 
    "Hayley Kaplan: Universal Scholar"
    {:events {:runner-install
-             {:optional {:prompt (msg "Install another " (:type target) " from Grip?")
-                         :req (req (and (first-event state side :runner-install) ;; If this is the first installation of the turn
-                                        (some #(= (:type  %) (:type target)) (:hand runner)))) ;; and there are additional cards of that type in hand
+             {:optional {:prompt (msg "Install another " (:type target) " from your Grip?")
+                         :req (req (and (first-event state side :runner-install)
+                                        (some #(= (:type %) (:type target)) (:hand runner))))
                          :yes-ability {:effect (req (let [type (:type target)]
                                               (resolve-ability
                                                state side
-                                               {:prompt (msg "Choose a " type " to install")
-                                                :choices (req (filter #(has? % :type type) (:hand runner)))
+                                               {:prompt (msg "Choose another " type " to install from your Grip")
+                                                :choices {:req #(and (= (:type %) type) (= (:zone %) [:hand]))}
                                                 :msg (msg "install " (:title target))
                                                 :effect (effect (runner-install target))} card nil)))}}}}}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -176,15 +176,10 @@
                               :effect (effect (trash target))}}}
 
    "Interns"
-   {:prompt "Install a card from Archives or HQ?" :choices ["Archives" "HQ"]
-    :msg (msg "install a card from " target)
-    :effect (effect (resolve-ability
-                      {:prompt "Choose a card to install"
-                       :not-distinct true
-                       :choices (req (filter #(not= (:type %) "Operation")
-                                             ((if (= target "HQ") :hand :discard) corp)))
-                       :effect (effect (corp-install target nil {:no-install-cost true}))}
-                      card targets))}
+   {:prompt "Choose a card to install from Archives or HQ" :show-discard true
+    :choices {:req #(and (not= (:type %) "Operation")
+                         (or (= (:zone %) [:hand]) (= (:zone %) [:discard])))}
+    :effect (effect (corp-install target nil {:no-install-cost true}))}
 
    "Invasion of Privacy"
    {:trace {:base 2 :msg (msg "reveal the Runner's Grip and trash up to " (- target (second targets)) " resources or events")

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -42,7 +42,8 @@
    {:effect (effect (draw 3))}
 
    "Archived Memories"
-   {:prompt "Choose a card from Archives" :choices (req (:discard corp))
+   {:prompt "Choose a card from Archives" :show-discard true
+    :choices {:req #(and (= (:side %) "Corp") (= (:zone %) [:discard]))}
     :effect (effect (move target :hand)
                     (system-msg (str "adds " (if (:seen target) (:title target) "a card") " to HQ")))}
 

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -449,19 +449,16 @@
                  :effect (effect (runner-install target))}]}
 
    "Scheherazade"
-   {:abilities [{:label "Install and host a program from Grip"
-                 :cost [:click 1] :prompt "Choose a program to install on Scheherazade"
-                 :choices (req (filter #(and (has? % :type "Program")
-                                             (<= (:cost %) (:credit runner))
-                                             (<= (:memoryunits %) (:memory runner)))
-                                       (:hand runner)))
+   {:abilities [{:label "Install and host a program from your Grip"
+                 :cost [:click 1] :prompt "Choose a program from your Grip to install on Scheherazade"
+                 :choices {:req #(and (= (:type %) "Program") (= (:zone %) [:hand]))}
                  :msg (msg "host " (:title target) " and gain 1 [Credits]")
                  :effect (effect (runner-install target {:host-card card}) (gain :credit 1))}
                 {:label "Host an installed program"
                  :prompt "Choose a program to host on Scheherazade"
                  :choices {:req #(and (= (:type %) "Program") (:installed %))}
                  :msg (msg "host " (:title target) " and gain 1 [Credits]")
-                 :effect (req (when (host state side card target) 
+                 :effect (req (when (host state side card target)
                                 (gain state side :credit 1)))}]}
 
    "Self-modifying Code"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -406,10 +406,9 @@
    {:abilities [{:label "Install a virus program on Progenitor"
                  :cost [:click 1] :req (req (empty? (:hosted card)))
                  :prompt "Choose a Virus program to install on Progenitor"
-                 :choices (req (filter #(and (= (:type %) "Program")
-                                             (has? % :subtype "Virus")
-                                             (<= (:cost %) (:credit runner)))
-                                       (:hand runner)))
+                 :choices :choices {:req #(and (= (:type %) "Program")
+                                               (has? % :subtype "Virus")
+                                               (= (:zone %) [:hand]))}
                  :msg (msg "host " (:title target))
                  :effect (effect (gain :memory (:memoryunits target))
                                  (runner-install target {:host-card card}))}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -406,9 +406,9 @@
    {:abilities [{:label "Install a virus program on Progenitor"
                  :cost [:click 1] :req (req (empty? (:hosted card)))
                  :prompt "Choose a Virus program to install on Progenitor"
-                 :choices :choices {:req #(and (= (:type %) "Program")
-                                               (has? % :subtype "Virus")
-                                               (= (:zone %) [:hand]))}
+                 :choices {:req #(and (= (:type %) "Program")
+                                      (has? % :subtype "Virus")
+                                      (= (:zone %) [:hand]))}
                  :msg (msg "host " (:title target))
                  :effect (effect (gain :memory (:memoryunits target))
                                  (runner-install target {:host-card card}))}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -123,7 +123,7 @@
    {:events {:successful-run {:effect (effect (add-prop card :counter 1)) :req (req (= target :rd))}
              :runner-turn-begins
                              {:req (req (>= (get-virus-counters state side card) 3)) :msg "look at the top card of R&D"
-                              :effect (effect (prompt! card (str "The top card of your R&D is "
+                              :effect (effect (prompt! card (str "The top card of R&D is "
                                                                  (:title (first (:deck corp)))) ["OK"] {}))}}}
 
    "Djinn"
@@ -134,11 +134,10 @@
                                        (:deck runner)))
                  :cost [:click 1 :credit 1] :effect (effect (move target :hand) (shuffle! :deck))}
                 {:label "Install a non-Icebreaker program on Djinn" :cost [:click 1]
-                 :prompt "Choose a non-Icebreaker program to install on Djinn"
-                 :choices (req (filter #(and (= (:type %) "Program")
-                                             (not (has? % :subtype "Icebreaker"))
-                                             (<= (:cost %) (:credit runner)))
-                                       (:hand runner)))
+                 :prompt "Choose a non-Icebreaker program from your Grip to install on Djinn"
+                 :choices {:req #(and (= (:type %) "Program")
+                                      (not (has? % :subtype "Icebreaker"))
+                                      (= (:zone %) [:hand]))}
                  :msg (msg "install and host " (:title target))
                  :effect (effect (gain :memory (:memoryunits target))
                                  (runner-install target {:host-card card}))}
@@ -276,10 +275,8 @@
    "Leprechaun"
    {:abilities [{:label "Install a program on Leprechaun"
                  :req (req (<= (count (:hosted card)) 2)) :cost [:click 1]
-                 :prompt "Choose a program to install on Leprechaun"
-                 :choices (req (filter #(and (= (:type %) "Program")
-                                             (<= (:cost %) (:credit runner)))
-                                       (:hand runner)))
+                 :prompt "Choose a program from your Grip to install on Leprechaun"
+                 :choices {:req #(and (= (:type %) "Program") (= (:zone %) [:hand]))}
                  :msg (msg "host " (:title target))
                  :effect (effect (gain :memory (:memoryunits target))
                                  (runner-install target {:host-card card}))}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -331,10 +331,8 @@
 
    "Off-Campus Apartment"
    {:abilities [{:label "Install and host a connection on Off-Campus Apartment"
-                 :cost [:click 1] :prompt "Choose a connection to install on Off-Campus Apartment"
-                 :choices (req (filter #(and (has? % :subtype "Connection")
-                                             (<= (:cost %) (:credit runner)))
-                                       (:hand runner)))
+                 :cost [:click 1] :prompt "Choose a connection in your Grip to install on Off-Campus Apartment"
+                 :choices {:req #(and (has? % :subtype "Connection") (= (:zone %) [:hand]))}
                  :msg (msg "host " (:title target) " and draw 1 card")
                  :effect (effect (runner-install target {:host-card card}) (draw))}
                 {:label "Host an installed connection"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -271,11 +271,8 @@
 
    "London Library"
    {:abilities [{:label "Install a non-virus program on London Library" :cost [:click 1]
-                 :prompt "Choose a non-virus program to install on London Library"
-                 :choices (req (filter #(and (= (:type %) "Program")
-                                             (not (has? % :subtype "Virus"))
-                                             (<= (:memoryunits %) (:memory runner)))
-                                       (:hand runner)))
+                 :prompt "Choose a non-virus program from your Grip to install on London Library"
+                 :choices {:req #(and (= (:type %) "Program") (not (has? % :subtype "Virus")) (= (:zone %) [:hand]))}
                  :msg (msg "host " (:title target))
                  :effect (effect (runner-install target {:host-card card :no-cost true}))}
                 {:label "Add a program hosted on London Library to your Grip" :cost [:click 1]
@@ -590,8 +587,9 @@
 
    "The Supplier"
    {:abilities [{:label "Host a resource or piece of hardware" :cost [:click 1]
-                 :prompt "Choose a card to host on The Supplier"
-                 :choices (req (filter #(#{"Resource" "Hardware"} (:type %)) (:hand runner)))
+                 :prompt "Choose a resource or piece of hardware from your Grip to host on The Supplier"
+                 :choices {:req #(and (or (= (:type %) "Hardware") (= (:type %) "Resource"))
+                                      (= (:zone %) [:hand]))}
                  :effect (effect (host card target)) :msg (msg "host " (:title target) "")}]
     :events {:runner-turn-begins
              {:prompt "Choose a card on The Supplier to install"

--- a/src/clj/test/cards-programs.clj
+++ b/src/clj/test/cards-programs.clj
@@ -12,7 +12,7 @@
           agenda (get-in @state [:corp :servers :remote1 :content 0])]
       (is agenda "Agenda was installed")
       (card-ability state :runner djinn 1)
-      (prompt-card :runner (find-card "Chakana" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Chakana" (:hand (get-runner))))
       (let [chak (first (:hosted (refresh djinn)))]
         (is (= "Chakana" (:title chak)) "Djinn has a hosted Chakana")
         (core/add-prop state :runner (first (:hosted (refresh djinn))) :counter 3) ; manually add 3 counters
@@ -30,7 +30,7 @@
     (is (= 3 (:memory (get-runner))))
     (let [djinn (get-in @state [:runner :rig :program 0])]
       (card-ability state :runner djinn 1)
-      (prompt-card :runner (find-card "Chakana" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Chakana" (:hand (get-runner))))
       (is (= 3 (:memory (get-runner))) "No memory used to host on Djinn")
       (is (= "Chakana" (:title (first (:hosted (refresh djinn))))) "Djinn has a hosted Chakana")
       (is (= 1 (:credit (get-runner))) "Full cost to host on Djinn"))))
@@ -76,7 +76,7 @@
     (let [prog (get-in @state [:runner :rig :program 0])
           vbg (get-in @state [:runner :rig :resource 0])]
       (card-ability state :runner prog 0)
-      (prompt-card :runner (find-card "Hivemind" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Hivemind" (:hand (get-runner))))
       (is (= 4 (:memory (get-runner))) "No memory used to host on Progenitor")
       (let [hive (first (:hosted (refresh prog)))]
         (is (= "Hivemind" (:title hive)) "Hivemind is hosted on Progenitor")

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -144,10 +144,8 @@
     (play-from-hand state :runner "The Supplier")
     (let [ts (get-in @state [:runner :rig :resource 0])]
       (card-ability state :runner ts 0)
-      (is (= 2 (count (get-in @state [:runner :prompt 0 :choices]))) "Only resources and hardware in The Supplier prompt")
       (prompt-select :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
       (card-ability state :runner ts 0)
-      (is (= 1 (count (get-in @state [:runner :prompt 0 :choices]))))
       (prompt-select :runner (find-card "Utopia Shard" (:hand (get-runner))))
       (is (= 2 (count (:hosted (refresh ts)))) "The Supplier is hosting 2 cards")
       (core/end-turn state :runner nil)

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -145,10 +145,10 @@
     (let [ts (get-in @state [:runner :rig :resource 0])]
       (card-ability state :runner ts 0)
       (is (= 2 (count (get-in @state [:runner :prompt 0 :choices]))) "Only resources and hardware in The Supplier prompt")
-      (prompt-card :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
       (card-ability state :runner ts 0)
       (is (= 1 (count (get-in @state [:runner :prompt 0 :choices]))))
-      (prompt-card :runner (find-card "Utopia Shard" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Utopia Shard" (:hand (get-runner))))
       (is (= 2 (count (:hosted (refresh ts)))) "The Supplier is hosting 2 cards")
       (core/end-turn state :runner nil)
       (take-credits state :corp)
@@ -173,7 +173,7 @@
     (play-from-hand state :runner "The Supplier")
     (let [ts (get-in @state [:runner :rig :resource 0])]
       (card-ability state :runner ts 0)
-      (prompt-card :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
       (core/lose state :runner :credit (:credit (get-runner)))
       (core/end-turn state :runner nil)
       (take-credits state :corp)


### PR DESCRIPTION
Getting rid of the pop-up prompt with card titles and switching to card targeting will resolve the potential for UI errors as seen in #167 and #180. 

Also changed a number of cards to the card targeting system to allow more flexibility with cancelling the action once initiated--anything using the old card selection prompt doesn't allow a cancel option and causes varying degrees of headache to undo after the fact. Operations like Modded, Archived Memories, Career Fair, and Interns will still charge clicks and put the card in the discard, but the user won't face having to reveal anything if they change their mind after playing the event--they can just take clicks back and retrieve the card. 