### PR TITLE
implement Ad Blitz

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -4,7 +4,7 @@
   {"Accelerated Beta Test"
    (let [abthelper (fn abt [n i] {:prompt "Select a piece of ICE from the top of the play area to install"
                                   :choices {:req #(and (:side % "Corp") (= (:type %) "ICE") (= (:zone %) [:play-area]))}
-                                  :effect (req (corp-install state side target nil {:no-install-cost true :install-state :rezzed})
+                                  :effect (req (corp-install state side target nil {:no-install-cost true :install-state :rezzed-no-cost})
                                                (trigger-event state side :rez target)
                                                  (when (< n i)
                                                    (resolve-ability state side (abt (inc n) i) card nil)))})]
@@ -251,7 +251,7 @@
                       {:prompt "Choose a card to install" :msg (msg "install and rez " (:title target))
                        :choices (req (filter #(#{"Asset" "Upgrade"} (:type %))
                                              ((if (= target "HQ") :hand :discard) corp)))
-                       :effect (effect (corp-install target nil {:install-state :rezzed}))} card targets))}
+                       :effect (effect (corp-install target nil {:install-state :rezzed-no-cost}))} card targets))}
 
    "Mandatory Upgrades"
    {:effect (effect (gain :click 1 :click-per-turn 1))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -14,7 +14,7 @@
    "Ad Blitz"
    (let [abhelp (fn ab [n total]
                   {:prompt "Select an advertisement to install and rez" :show-discard true
-                   :choices {:req #(and (:side % "Corp")
+                   :choices {:req #(and (= (:side %) "Corp")
                                         (has? % :subtype "Advertisement")
                                         (or (= (:zone %) [:hand]) (= (:zone %) [:discard])))}
                    :effect (req (corp-install state side target nil {:install-state :rezzed})

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -11,6 +11,18 @@
                       :effect (effect (card-init target))}
                     card nil)))}
 
+   "Ad Blitz"
+   (let [abhelp (fn ab [n total]
+                  {:prompt "Select an advertisement to install and rez" :show-discard true
+                   :choices {:req #(and (:side % "Corp")
+                                        (has? % :subtype "Advertisement")
+                                        (or (= (:zone %) [:hand]) (= (:zone %) [:discard])))}
+                   :effect (req (corp-install state side target nil {:install-state :rezzed})
+                                (when (< n total)
+                                  (resolve-ability state side (ab (inc n) total) card nil)))})]
+   {:prompt "How many advertisements?" :choices :credit :msg (msg "install and rez " target " advertisements")
+    :effect (effect (resolve-ability (abhelp 1 target) card nil))})
+
    "Aggressive Negotiation"
    {:req (req (:scored-agenda corp-reg)) :prompt "Choose a card" :choices (req (:deck corp))
     :effect (effect (move target :hand) (shuffle! :deck))}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1497,7 +1497,7 @@
                      (system-msg state side (str "trashes " (if (:rezzed prev-card)
                                                               (:title prev-card) "a card") " in " server))
                      (trash state side prev-card {:keep-server-alive true})))
-                 (let [card-name (if (or (= :rezzed install-state) (= :face-up install-state) (:rezzed c))
+                 (let [card-name (if (or (= :rezzed-no-cost install-state) (= :face-up install-state) (:rezzed c))
                                    (:title card) "a card")]
                    (system-msg state side (str (build-spend-msg cost-str "install")
                                                 card-name " in " server)))
@@ -1505,8 +1505,10 @@
                    (trigger-event state side :corp-install moved-card)
                    (when (= (:type c) "Agenda")
                      (update-advancement-cost state side moved-card))
-                   (when (= install-state :rezzed)
+                   (when (= install-state :rezzed-no-cost)
                      (rez state side moved-card {:no-cost true}))
+                   (when (= install-state :rezzed)
+                     (rez state side moved-card))
                    (when (= install-state :face-up)
                      (card-init state side (assoc (get-card state moved-card) :rezzed true) false))))))))))
 


### PR DESCRIPTION
Changes the `:install-state` option of a `corp-install` from `:rezzed` to `:rezzed-no-cost` so that Ad Blitz (and any future cards that install and immediately rez normally) can use `:rezzed`. Accelerated Beta Test and License Acquisition are modified accordingly to use `:rezzed-no-cost`. 

Ad Blitz brings up Archives and lets the user recursively do an install and rez of the specified number of advertisements. Now all the Spark players can go crazy with Rebranding Team decks. ;) 