### PR TITLE
stop Harbinger from installing if trashed from hand by the Runner

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -198,7 +198,7 @@
 
    "Harbinger"
    {:trash-effect
-     {:req (req (not (some #{:facedown} (:previous-zone card))))
+     {:req (req (not (some #{:facedown :hand} (:previous-zone card))))
        :effect (effect (runner-install card {:facedown true}))}}
 
    "Hemorrhage"


### PR DESCRIPTION
Reported by a user--Harbinger was installing facedown if trashed by the Runner from hand when discarding down to max hand size. 