### PR TITLE
another fix for Turntable

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -453,7 +453,11 @@
                                                      (gain-agenda-point state :runner (- swpts stpts))
                                                      (gain-agenda-point state :corp (- stpts swpts))
                                                      (doseq [c (get-in @state [:corp :scored])]
-                                                       (card-init state :corp c false))
+                                                       (let [abilities (:abilities (card-def c))
+                                                             c (merge c {:abilities abilities})]
+                                                         (update! state :corp c)
+                                                         (when-let [events (:events (card-def c))]
+                                                           (register-events state side events c))))
                                                      (doseq [r (get-in @state [:runner :scored])]
                                                        (desactivate state :corp r))
                                                      (system-msg state side


### PR DESCRIPTION
Fixes #867. 

It doesn't work to call `card-init` on agendas in the Corp's area when swapping one back to them, because it will make "when scored" effects fire--so it would replenish any spent agenda counters from AstroScript Pilot Program, Nisei Mk II, House of Knives, etc. 

But we still need to hook up events and abilities so things like a Gila Hands are usable by the Corp when getting swapped back--I stole the relevant bits of the `card-init` function to accomplish this. 