### PR TITLE
Global food initiative

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -170,6 +170,10 @@
    "Gila Hands Arcology"
    {:abilities [{:cost [:click 2] :effect (effect (gain :credit 3)) :msg "gain 3 [Credits]"}]}
 
+   "Global Food Initiative"
+   {:agendapoints-runner (req (do 2))}
+
+
    "Glenn Station"
    {:abilities [{:label "Host a card from HQ on Glenn Station" :cost [:click 1]
                  :prompt "Choose a card to host on Glenn Station" :choices (req (:hand corp))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -569,11 +569,11 @@
 
    "The Board"
    {:effect (effect (lose :runner :agenda-point
-                          (count (filter #(> (:agendapoints %) 0) (:scored runner)))))
+                          (count (filter #(> (get-agenda-points state :runner %) 0) (:scored runner)))))
     :leave-play (effect (gain :runner :agenda-point
-                              (count (filter #(> (:agendapoints %) 0) (:scored runner)))))
+                              (count (filter #(> (get-agenda-points state :runner %) 0) (:scored runner)))))
     :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}
-    :events {:agenda-stolen {:req (req (> (:agendapoints target) 0))
+    :events {:agenda-stolen {:req (req (> (get-agenda-points state :runner target) 0))
                              :effect (effect (lose :runner :agenda-point 1))}}}
 
    "The News Now Hour"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -452,8 +452,8 @@
                                                      (swap! state update-in [:runner :scored]
                                                        (fn [coll] (conj (remove-once #(not= (:cid %) (:cid st)) coll)
                                                                         (dissoc sw :abilities :events))))
-                                                     (gain-agenda-point state :runner (- swpts stpts))
-                                                     (gain-agenda-point state :corp (- stpts swpts))
+                                                     (gain-agenda-point state :runner (- swpts-runner stpts-runner))
+                                                     (gain-agenda-point state :corp (- stpts-corp swpts-corp))
                                                      (doseq [c (get-in @state [:corp :scored])]
                                                        (card-init state :corp c false))
                                                      (doseq [r (get-in @state [:runner :scored])]

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -443,15 +443,17 @@
                                       :choices {:req #(some (fn [c] (= (:cid %) (:cid c))) agendas)}
                                       :effect (req (let [st (last (get-in runner [:scored]))
                                                          sw target
-                                                         stpts (:agendapoints st)
-                                                         swpts (:agendapoints sw)]
+                                                         stpts-corp (get-agenda-points state :corp st)
+                                                         swpts-corp (get-agenda-points state :corp sw)
+                                                         stpts-runner (get-agenda-points state :runner st)
+                                                         swpts-runner (get-agenda-points state :runner sw)]
                                                      (swap! state update-in [:corp :scored]
                                                        (fn [coll] (conj (remove-once #(not= (:cid %) (:cid sw)) coll) st)))
                                                      (swap! state update-in [:runner :scored]
                                                        (fn [coll] (conj (remove-once #(not= (:cid %) (:cid st)) coll)
                                                                         (dissoc sw :counter :abilities :events))))
-                                                     (gain-agenda-point state :runner (- swpts stpts))
-                                                     (gain-agenda-point state :corp (- stpts swpts))
+                                                     (gain-agenda-point state :runner (- swpts-runner stpts-runner))
+                                                     (gain-agenda-point state :corp (- stpts-corp swpts-corp))
                                                      (doseq [c (get-in @state [:corp :scored])]
                                                        (card-init state :corp c false))
                                                      (doseq [r (get-in @state [:runner :scored])]

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -451,7 +451,7 @@
                                                        (fn [coll] (conj (remove-once #(not= (:cid %) (:cid sw)) coll) st)))
                                                      (swap! state update-in [:runner :scored]
                                                        (fn [coll] (conj (remove-once #(not= (:cid %) (:cid st)) coll)
-                                                                        (dissoc sw :counter :abilities :events))))
+                                                                        (dissoc sw :abilities :events))))
                                                      (gain-agenda-point state :runner (- swpts stpts))
                                                      (gain-agenda-point state :corp (- stpts swpts))
                                                      (doseq [c (get-in @state [:corp :scored])]

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -160,10 +160,10 @@
                 {:cost [:click 2] :label "Add hosted agenda to your score area"
                  :req (req (not (empty? (:hosted card))))
                  :effect (req (let [c (move state :runner (first (:hosted card)) :scored)]
-                                (gain-agenda-point state :runner (:agendapoints c))))
+                                (gain-agenda-point state :runner (get-agenda-points state :runner c))))
                  :msg (msg (let [c (first (:hosted card))]
                              (str "add " (:title c) " to their score area and gain "
-                             (:agendapoints c) " agenda point" (when (> (:agendapoints c) 1) "s"))))}]}
+                             (:agendapoints c) " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]}
 
    "Gang Sign"
    {:events {:agenda-scored {:msg (msg "access " (get-in @state [:runner :hq-access]) " card from HQ")
@@ -207,10 +207,10 @@
                                   :effect (effect (lose :click 1) (gain :credit 2))}}}
 
    "Human First"
-   {:events {:agenda-scored {:msg (msg "gain " (:agendapoints target) " [Credits]")
-                             :effect (effect (gain :runner :credit (:agendapoints target)))}
-             :agenda-stolen {:msg (msg "gain " (:agendapoints target) " [Credits]")
-                             :effect (effect (gain :credit (:agendapoints target)))}}}
+   {:events {:agenda-scored {:msg (msg "gain " (get-agenda-points state :runner target) " [Credits]")
+                             :effect (effect (gain :runner :credit (get-agenda-points state :runner target)))}
+             :agenda-stolen {:msg (msg "gain " (get-agenda-points state :runner target) " [Credits]")
+                             :effect (effect (gain :credit (get-agenda-points state :runner target)))}}}
    "Hunting Grounds"
    {:abilities [{:label "Prevent a \"when encountered\" ability on a piece of ICE"
                  :msg "prevent a \"when encountered\" ability on a piece of ICE"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -874,6 +874,14 @@
     (update-breaker-strength state side (get-card state card))))
 
 (defn get-agenda-points [state side card]
+  (let [base-points (:agendapoints card)
+        runner-fn (:agendapoints-runner (card-def card))
+        corp-fn (:agendapoints-corp (card-def card))]
+    (if (and (= side :runner) (not (nil? runner-fn)))
+      (runner-fn state side card nil)
+        (if (and (= side :corp) (not  (nil? corp-fn)))
+          (corp-fn state side card nil)
+          base-points)
   ))
 )
 


### PR DESCRIPTION
Added a get-agenda-points function.
Changed all refs to :agendapoints to use this function.
GFI overrides :agendappoints-runner function to return 2.

Tested GFI, Turntable, Humans First.