### PR TITLE
Runner cards turned facedown keep :installed, do agenda scored effects before trashing a Runner current

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -118,7 +118,7 @@
   ([state side card] (desactivate state side card nil))
   ([state side card keep-counter]
    (let [c (dissoc card :current-strength :abilities :rezzed :special :facedown)
-         c (if (= (:side c) "Runner") (dissoc c :installed :counter :rec-counter :pump) c)
+         c (if (= (:side c) "Runner") (dissoc c :counter :rec-counter :pump) c)
          c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
      (when-let [leave-effect (:leave-play (card-def card))]
        (when (or (and (= (:side card) "Runner") (:installed card))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -886,10 +886,10 @@
         (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) (:agendapoints c)))
         (gain-agenda-point state :corp (:agendapoints c))
         (set-prop state :corp c :advance-counter 0)
+        (trigger-event state :corp :agenda-scored (assoc c :advance-counter 0))
         (when-let [current (first (get-in @state [:runner :current]))]
           (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
-          (trash state side current))
-        (trigger-event state :corp :agenda-scored (assoc c :advance-counter 0))))))
+          (trash state side current))))))
 
 (defn as-agenda [state side card n]
   (move state side (assoc card :agendapoints n) :scored)


### PR DESCRIPTION
Fixes #866. 

When the Runner plays Apocalypse, cards get moved to `[:rig :facedown]` and have `desactivate` called on them. This was wrongly dropping `:installed true`, leaving facedown cards later unable to be sacrificed to Chop Bot, Aesop's, Heartbeat, and other cards that were targeting with `(all-installed :runner)`. 

I was also alerted that Jinteki:PE scoring an agenda was dealing 1 net damage even with Employee Strike active. A Runner current in play shouldn't get trashed until after the `:agenda-scored` trigger.