### PR TITLE
give Chronos Protocol prompt only to the Corp player

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -56,14 +56,14 @@
    "Chaos Theory: Wünderkind"
    {:effect (effect (gain :memory 1))}
 
-"Chronos Protocol: Selective Mind-mapping"
+   "Chronos Protocol: Selective Mind-mapping"
    {:events
     {:pre-resolve-damage
      {:once :per-turn
       :effect (effect (damage-defer :net (last targets))
                       (resolve-ability
                         {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                                 "grip to select the first card trashed?")
+                                                 "grip to select the first card trashed?") :player :corp
                                     :yes-ability {:prompt (msg "Choose a card to trash")
                                                   :choices (req (:hand runner)) :not-distinct true
                                                   :msg (msg "trash " (:title target) " and deal "


### PR DESCRIPTION
Fix for #876. 

The prompt generated from the identity needs to be given explicitly to the Corp player if the ability kicks in on the Runner's turn. 