### PR TITLE
partial implementation of Targeted Marketing

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -458,6 +458,21 @@
    "Sweeps Week"
    {:effect (effect (gain :credit (count (:hand runner))))}
 
+   "Targeted Marketing"
+   {:abilities [{:req (req (= (:zone card) [:current]))
+                 :label "Gain 10 [Credits] because the Runner installed the named card"
+                 :prompt "Choose the card you named in the Runner's rig"
+                 :choices {:req #(and (= (:side %) "Runner")
+                                      (not (:facedown %))
+                                      (not= (first (:zone %)) :discard)
+                                      (not= (:type %) "Identity"))}
+                 :msg (msg "gain 10 [Credits] from the Runner playing " (:title target))
+                 :effect (effect (gain :credit 10))}
+                {:req (req (and (= (:zone card) [:current]) (= (:type (last (:discard runner))) "Event")))
+                 :label "Gain 10 [Credits] because the Runner played the named Event"
+                 :msg (msg "gain 10 [Credits] from the Runner playing " (:title (last (:discard runner))))
+                 :effect (effect (gain :credit 10))}]}
+
    "The All-Seeing I"
    (let [trash-all-resources {:player :runner
                               :effect (req (doseq [resource (get-in runner [:rig :resource])]


### PR DESCRIPTION
I don't have any idea how to get user input and store it, so this is just a small improvement for the Corp player to avoid manually adjusting credits. Targeted Marketing gets 2 abilities: either target a Runner program/resource/hardware on the board and gain 10 credits, or identify the Event on top of the Heap and gain 10 credits. 

Obviously this relies on the honor system, but so does the current lack of any implementation. 

![image](https://cloud.githubusercontent.com/assets/10407969/11170160/db8c972e-8b91-11e5-989f-90b18c7472e6.png)
