### PR TITLE
change Team Sponsorship to a manually triggered ability

### DIFF
--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -47,13 +47,13 @@
       (core/advance state :corp {:card (refresh ag1)})
       (core/advance state :corp {:card (refresh ag1)})
       (core/score state :corp {:card (refresh ag1)})
-      ; TSP prompt should be active
-      (is (= (:cid tsp) (get-in @state [:corp :prompt 0 :card :cid])))
-      (prompt-choice :corp "HQ")
-      (prompt-card :corp (find-card "Adonis Campaign" (:hand (get-corp))))
+      (is (= (:ts-active (refresh tsp)) true) "Team Sponsorship ability enabled")
+      (card-ability state :corp tsp 0)
+      (prompt-select :corp (find-card "Adonis Campaign" (:hand (get-corp))))
       (prompt-choice :corp "New remote")
       (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote3 :content 0 :title])) "Adonis installed by Team Sponsorship")
-      (is (nil? (find-card "Adonis Campaign" (:hand (get-corp)))) "No Adonis in hand"))))
+      (is (nil? (find-card "Adonis Campaign" (:hand (get-corp)))) "No Adonis in hand")
+      (is (nil? (:ts-active (refresh tsp))) "Team Sponsorship ability disabled"))))
 
 (deftest team-sponsorship-archives
   "Team Sponsorship - Install from Archives"
@@ -70,13 +70,13 @@
       (core/advance state :corp {:card (refresh ag1)})
       (core/advance state :corp {:card (refresh ag1)})
       (core/score state :corp {:card (refresh ag1)})
-      ; TSP prompt should be active
-      (is (= (:cid tsp) (get-in @state [:corp :prompt 0 :card :cid])))
-      (prompt-choice :corp "Archives")
-      (prompt-card :corp (find-card "Adonis Campaign" (:discard (get-corp))))
+      (is (= (:ts-active (refresh tsp)) true) "Team Sponsorship ability enabled")
+      (card-ability state :corp tsp 0)
+      (prompt-select :corp (find-card "Adonis Campaign" (:discard (get-corp))))
       (prompt-choice :corp "New remote")
       (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote3 :content 0 :title])) "Adonis installed by Team Sponsorship")
-      (is (nil? (find-card "Adonis Campaign" (:discard (get-corp)))) "No Adonis in discard"))))
+      (is (nil? (find-card "Adonis Campaign" (:discard (get-corp)))) "No Adonis in discard")
+      (is (nil? (:ts-active (refresh tsp))) "Team Sponsorship ability disabled"))))
 
 (deftest team-sponsorship-multiple
   "Team Sponsorship - Multiple installed"
@@ -88,21 +88,23 @@
     (play-from-hand state :corp "Domestic Sleepers" "New remote")
     (core/move state :corp (find-card "Adonis Campaign" (:hand (get-corp))) :discard)
     (let [ag1 (get-in @state [:corp :servers :remote3 :content 0])
-          tsp1 (get-in @state [:corp :servers :remote2 :content 0])
-          tsp2 (get-in @state [:corp :servers :remote1 :content 0])]
+          tsp2 (get-in @state [:corp :servers :remote2 :content 0])
+          tsp1 (get-in @state [:corp :servers :remote1 :content 0])]
       (core/rez state :corp tsp1)
       (core/rez state :corp tsp2)
       (core/gain state :corp :click 6 :credit 6)
       (core/advance state :corp {:card (refresh ag1)})
       (core/advance state :corp {:card (refresh ag1)})
       (core/score state :corp {:card (refresh ag1)})
-      ; TSP prompt should be active
-      (prompt-choice :corp "Archives")
-      (prompt-card :corp (find-card "Adonis Campaign" (:discard (get-corp))))
+      (is (= (:ts-active (refresh tsp1)) true) "Team Sponsorship 1 ability enabled")
+      (is (= (:ts-active (refresh tsp2)) true) "Team Sponsorship 2 ability enabled")
+      (card-ability state :corp tsp1 0)
+      (prompt-select :corp (find-card "Adonis Campaign" (:discard (get-corp))))
       (prompt-choice :corp "New remote")
-      ; second prompt should be active
-      (prompt-choice :corp "HQ")
-      (prompt-card :corp (find-card "Adonis Campaign" (:hand (get-corp))))
+      (card-ability state :corp tsp2 0)
+      (prompt-select :corp (find-card "Adonis Campaign" (:hand (get-corp))))
       (prompt-choice :corp "New remote")
       (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote4 :content 0 :title])) "Adonis installed by Team Sponsorship")
-      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote5 :content 0 :title])) "Adonis installed by Team Sponsorship"))))
+      (is (= "Adonis Campaign" (get-in @state [:corp :servers :remote5 :content 0 :title])) "Adonis installed by Team Sponsorship")
+      (is (nil? (:ts-active (refresh tsp1))) "Team Sponsorship 1 ability disabled")
+      (is (nil? (:ts-active (refresh tsp2))) "Team Sponsorship 2 ability disabled"))))


### PR DESCRIPTION
In the mold of the Leela, Gang Sign, and Comet revisions...

Team Sponsorship is currently really confusing when multiples are out and the Corp scores Accelerated Beta Test or Director Haas' Pet Project. The prompts get all tangled and interwoven, so you're bouncing back and forth responding to prompts from different cards. 

With this version, the Corp can defer use of Team Sponsorships until ABT or DHPP installs are fully resolved and then fire Team Sponsorships one by one. 

Addresses parts of #832, #765, #757, and #690. 