### PR TITLE
Chakana needs to update advancement requirements after a purge

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -402,6 +402,8 @@
    "Reversed Accounts"
    {:advanceable :always
     :abilities [{:cost [:click 1]
+                 :label "Force the Runner to lose 4 [Credits] per advancement"
+                 :msg (msg "force the Runner to lose " (min (* 4 (:advance-counter card)) (:credit runner)) " [Credits]")
                  :effect (effect (lose :runner :credit (* 4 (:advance-counter card))) (trash card))}]}
 
    "Rex Campaign"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -56,7 +56,8 @@
                                     :effect (effect (advancement-cost-bonus 1))}
              :counter-added
              {:req (req (or (= (:title target) "Hivemind") (= (:cid target) (:cid card))))
-              :effect (effect (update-all-advancement-costs))}}}
+              :effect (effect (update-all-advancement-costs))}
+             :purge {:effect (effect (update-all-advancement-costs))}}}
 
    "Cloak"
    {:recurring 1}


### PR DESCRIPTION
Fix for #875. 

Chakana was doing `update-all-advancement-costs` when it got trashed, but not after a purge of viruses. Also added a small improvement to Reversed Accounts so it reports how many Runner credits were lost in the game log. 