### PR TITLE
fix Chronos Protocol to fire on net damage only

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -60,15 +60,18 @@
    {:events
     {:pre-resolve-damage
      {:once :per-turn
+      :req (req (= target :net))
       :effect (effect (damage-defer :net (last targets))
                       (resolve-ability
                         {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
                                                  "grip to select the first card trashed?") :player :corp
                                     :yes-ability {:prompt (msg "Choose a card to trash")
                                                   :choices (req (:hand runner)) :not-distinct true
-                                                  :msg (msg "trash " (:title target) " and deal "
-                                                            (- (get-defer-damage state side :net nil) 1)
-                                                            " more net damage")
+                                                  :msg (msg "trash " (:title target)
+                                                         (when (> (- (get-defer-damage state side :net nil) 1) 0)
+                                                           (str " and deal "
+                                                                (- (get-defer-damage state side :net nil) 1)
+                                                                " more net damage")))
                                                   :effect (effect (trash target)
                                                                   (damage :net (- (get-defer-damage state side :net nil) 1)
                                                                           {:unpreventable true :card card}))}


### PR DESCRIPTION
Fix for #888. 

Chronos Protocol wasn't checking for net damage only, so this will stop it from firing on meat or brain. I also suppressed the portion of the log message about remaining net damage if there is none left over to do. 