### PR TITLE
fixes for Nerve Agent, Immolation Script

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -267,18 +267,21 @@
    {:effect (effect (run :archives nil card) (register-events (:events (card-def card))
                                                               (assoc card :zone '(:discard))))
     :events {:successful-run-ends
-             {:prompt "Choose a piece of ICE in Archives"
-              :choices (req (filter #(= (:type %) "ICE") (:discard corp)))
-              :effect (req (let [icename (:title target)]
-                             (resolve-ability
-                               state side
-                               {:prompt (msg "Choose a rezzed copy of " icename " to trash")
-                                :choices {:req #(and (= (:type %) "ICE")
-                                                     (:rezzed %)
-                                                     (= (:title %) icename))}
-                                :msg (msg "trash " icename " protecting " (zone->name (second (:zone target))))
-                                :effect (req (trash state :corp target))} card nil)
-                             (unregister-events state side card)))}}}
+             {:req (req (= target :archives))
+              :effect (effect (resolve-ability
+                                {:prompt "Choose a piece of ICE in Archives"
+                                 :choices (req (filter #(= (:type %) "ICE") (:discard corp)))
+                                 :effect (req (let [icename (:title target)]
+                                                (resolve-ability
+                                                  state side
+                                                  {:prompt (msg "Choose a rezzed copy of " icename " to trash")
+                                                   :choices {:req #(and (= (:type %) "ICE")
+                                                                        (:rezzed %)
+                                                                        (= (:title %) icename))}
+                                                   :msg (msg "trash " icename " protecting " (zone->name (second (:zone target))))
+                                                   :effect (req (trash state :corp target))} card nil)))}
+                               card nil)
+                              (unregister-events card))}}}
 
    "Indexing"
    {:effect (effect (run :rd {:replace-access

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -324,7 +324,7 @@
                          :effect (req (system-msg state :runner (str "may choose fewer than all additional HQ accesses"
                                                                      " by clicking on Nerve Agent"))
                                       (update! state side (assoc card :nerve-active true)))}
-             :successful-run {:req (req (and (= target :rd)
+             :successful-run {:req (req (and (= target :hq)
                                              (or (:nerve-active card) (nil? (:counter card)))))
                               :effect (effect (add-prop card :counter 1))}
              :pre-access {:req (req (and (= target :hq) (:nerve-active card)))


### PR DESCRIPTION
I copied the code from Medium but missed one place where `:rd` needed to be changed to `:hq`...how embarrassing. 

Also fixes #894 by adding the Archives requirement to Immolation Script's event hook so it won't fire on later runs if the Runner jacks out on the first one.