### PR TITLE
tweak for refresh of recurring credits on cards hosted after install

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1435,7 +1435,7 @@
                            :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
                            :previous-zone (:zone target))]
        (update! state side (update-in card [:hosted] #(conj % c)))
-       (when installed
+       (when (and installed (:recurring (card-def c)))
          (card-init state side c false))
        c))))
 


### PR DESCRIPTION
Follow up to #840--the `card-init` must occur only if the hosted card has recurring credits, otherwise a Cache that gets Clone Chipped into play with Grimoire installed (getting 4 credits), will drop back down to 3 credits when hosted on Scheherazade. 