### PR TITLE
Refresh of recurring credits on hosted cards (3rd try)

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1435,8 +1435,14 @@
                            :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
                            :previous-zone (:zone target))]
        (update! state side (update-in card [:hosted] #(conj % c)))
+       (when-let [events (:events (card-def target))]
+         (register-events state side events c))
        (when (and installed (:recurring (card-def c)))
          (card-init state side c false))
+       (when-let [events (:events (card-def target))]
+         (when (and installed (:recurring (card-def c)))
+           (unregister-events state side target)
+           (register-events state side events c)))
        c))))
 
 (defn is-tagged? [state]


### PR DESCRIPTION
The previous attempts in #840 and #895 both had problems--either rendering Caissa programs useless or putting credits back on a used up Cache, etc. 

This time events are registered again (making the Caissa work when hosted on ice after being installed to the Runner's rig initially). For the special cases of Pheromones and Compromised Employee that have recurring credits *and* events, if they get hosted after install (i.e. from a Clone Chip or off Street Peddler), we have touch them again to unregister their events and re-register them, otherwise the preceding `card-init` leaves them with events registered twice, which would have Pheromones gain 2 counters on every HQ run and Compromised Employee giving 2 credits every time an ice gets rezzed. 

I tested this extensively to make sure recurring credits and event hooks work with these cards both installed normally, hosted directly from the Grip, and hosted post-install. 