### PR TITLE
fix conditions for Medium and Nerve Agent activation messages

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -99,8 +99,10 @@
    "Corporate Town"
    {:additional-cost [:forfeit]
     :events {:corp-turn-begins
-             {:choices {:req #(and (= (:type %) "Resource"))} :msg (msg "trash " (:title target))
-              :effect (effect (trash target))}}}
+             {:prompt "Choose a resource to trash with Corporate Town"
+              :choices {:req #(and (= (:type %) "Resource"))}
+              :msg (msg "trash " (:title target))
+              :effect (effect (trash target {:unpreventable true}))}}}
 
    "Cybernetics Court"
    {:effect (effect (gain :max-hand-size 4)) :leave-play (effect (lose :max-hand-size 4))}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -296,8 +296,10 @@
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 
    "Medium"
-   {:events {:no-action {:req (req (and run (= (:server run) [:rd]) (not current-ice))
-                                        (and (:counter card) (> (:counter card) 0)))
+   {:events {:no-action {:req (req (and run
+                                        (= (first (get-in @state [:run :server])) :rd)
+                                        (not current-ice)
+                                        (and (:counter card) (> (:counter card) 0))))
                          :effect (req (system-msg state :runner (str "may choose fewer than all additional R&D accesses"
                                                                      " by clicking on Medium"))
                                       (update! state side (assoc card :medium-active true)))}
@@ -319,8 +321,10 @@
    {:recurring 2}
 
    "Nerve Agent"
-   {:events {:no-action {:req (req (and run (= (:server run) [:hq]) (not current-ice))
-                                        (and (:counter card) (> (:counter card) 0)))
+   {:events {:no-action {:req (req (and run
+                                        (= (first (get-in @state [:run :server])) :hq)
+                                        (not current-ice)
+                                        (and (:counter card) (> (:counter card) 0))))
                          :effect (req (system-msg state :runner (str "may choose fewer than all additional HQ accesses"
                                                                      " by clicking on Nerve Agent"))
                                       (update! state side (assoc card :nerve-active true)))}


### PR DESCRIPTION
When both Medium and Nerve Agent are installed and each has 1 or more counters, the log messages for both are triggering on either HQ or R&D runs due to a faulty `:req`. 

Also threw in a small fix to make Corporate Town's resource trash unpreventable.
