### PR TITLE
Sort the games list so open games show first, then games in progress.

### DIFF
--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -31,7 +31,10 @@
         (case (:type msg)
           "game" (do (swap! app-state assoc :gameid (:gameid msg))
                      (when (:started msg) (launch-game nil)))
-          "games" (do (swap! app-state assoc :games (sort-by :date > (vals (:games msg))))
+          "games" (do (swap! app-state assoc :games
+                             (sort-by #(vec (map (assoc % :started (not (:started %)))
+                                                 [:started :date]))
+                                      > (vals (:games msg))))
                       (when-let [sound (:notification msg)]
                         (when-not (:gameid @app-state)
                           (.play (.getElementById js/document sound)))))


### PR DESCRIPTION
Requested a few times in chat. Rather than sorting games list strictly on Creation Time, sort it to show unstarted games first, then started games, both sections sorted by Creation Time internally. No change to the UI itself, just a change to the sort order.

The `sort-by` function takes each game map, negates the `:started` key (we want started=0 to be "bigger" than started=1 for the sort), then takes the `:started` and `:date` keys and places them into a vector. Clojure sorts vectors in a lexicographic ordering, which enforces our "multi-column" sort criteria.

Should help people who feel like their games get buried when the server is very active.