### PR TITLE
partial implementation of Jak Sinclair

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -258,6 +258,15 @@
     :abilities [{:cost [:click 4] :msg "give the Corp 1 bad publicity"
                  :effect (effect (gain :corp :bad-publicity 1) (trash card {:cause :ability-cost}))}]}
 
+   "Jak Sinclair"
+   {:install-cost-bonus (req [:credit (* -1 (:link runner))])
+    :events {:runner-turn-begins
+              {:optional {:prompt "Use Jak Sinclair to make a run?"
+                          :yes-ability {:prompt "Choose a server"
+                                        :choices (req servers)
+                                        :msg (msg "make a run on " target " during which no programs can be used")
+                                        :effect (effect (run target))}}}}}
+
    "John Masanori"
    {:events {:successful-run {:req (req (first-event state side :successful-run))
                               :msg "draw 1 card" :once-key :john-masanori-draw


### PR DESCRIPTION
Trying to temporarily disable all installed programs proved way too difficult and would prevent required conditional abilities that should still occur (like gaining Datasucker tokens). Now that Medium and Nerve Agent can be set to do 0 additional accesses, the two programs with the potential to create the most annoying undos can be worked around (and still gain counters like they should). 

For most other programs the Runner just needs to avoid clicking them during the run, or adjust at the end if anything was gained or lost that shouldn't have been. 