### PR TITLE
Distinguish "placing advancements" from advancing cards

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -40,7 +40,7 @@
                                                   (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                                   (= (:type %) "Agenda"))}
                               :msg (msg "add " c " advancement tokens on a card")
-                              :effect (effect (add-prop :corp target :advance-counter c))} card nil)))}}
+                              :effect (effect (add-prop :corp target :advance-counter c {:placed true}))} card nil)))}}
 
    "Bifrost Array"
    {:req (req (not (empty? (filter #(not= (:title %) "Bifrost Array") (:scored corp)))))
@@ -229,7 +229,7 @@
                                                         (= (:type %) "Agenda")))}
                                :msg (msg "add " n " advancement tokens on "
                                          (if (:rezzed target) (:title target) "a card"))
-                               :effect (effect (add-prop :corp target :advance-counter n))} card nil)))}}}
+                               :effect (effect (add-prop :corp target :advance-counter n {:placed true}))} card nil)))}}}
 
    "House of Knives"
    {:data {:counter 3}

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -39,7 +39,7 @@
                              {:choices {:req #(or (= (:advanceable %) "always")
                                                   (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                                   (= (:type %) "Agenda"))}
-                              :msg (msg "add " c " advancement tokens on a card")
+                              :msg (msg "place " c " advancement tokens on " (if (:rezzed target) (:title target) "a card"))
                               :effect (effect (add-prop :corp target :advance-counter c {:placed true}))} card nil)))}}
 
    "Bifrost Array"
@@ -227,7 +227,7 @@
                                                     (or (= (:advanceable %) "always")
                                                         (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                                         (= (:type %) "Agenda")))}
-                               :msg (msg "add " n " advancement tokens on "
+                               :msg (msg "place " n " advancement tokens on "
                                          (if (:rezzed target) (:title target) "a card"))
                                :effect (effect (add-prop :corp target :advance-counter n {:placed true}))} card nil)))}}}
 

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -280,6 +280,7 @@
    "Oaktown Renovation"
    {:install-state :face-up
     :events {:advance {:req (req (= (:cid card) (:cid target)))
+                       :msg (msg "gain " (if (>= (:advance-counter (get-card state card)) 5) "3" "2") " [Credits]")
                        :effect (req (gain state side :credit
                                           (if (>= (:advance-counter (get-card state card)) 5) 3 2)))}}}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -508,7 +508,7 @@
    "Space Camp"
    {:access {:msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))
              :choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
-             :effect (effect (add-prop target :advance-counter 1))}}
+             :effect (effect (add-prop target :advance-counter 1 {:placed true}))}}
 
    "Sundew"
    {:events {:runner-spent-click {:req (req (not (= (:server run) (:zone card)))) :once :per-turn

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -149,7 +149,7 @@
                  :choices {:req #(or (= (:advanceable %) "always")
                                      (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                      (= (:type %) "Agenda"))}
-                 :effect (effect (add-prop target :advance-counter 1)) :once :per-turn
+                 :effect (effect (add-prop target :advance-counter 1 {:placed true})) :once :per-turn
                  :msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))}]}
 
    "Edge of World"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -461,7 +461,7 @@
                                            (= (last (:zone %)) :content)
                                            (not (:rezzed %)))}
                       :msg (msg "add " c " advancement tokens on a card and gain " (* 2 c) " [Credits]")
-                      :effect (effect (gain :credit (* 2 c)) (add-prop :corp target :advance-counter c))}
+                      :effect (effect (gain :credit (* 2 c)) (add-prop :corp target :advance-counter c {:placed true}))}
                      card nil)))}
 
    "Quest Completed"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -69,7 +69,7 @@
                 {:label "Place 1 advancement token on an ICE that can be advanced on this server"
                  :msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))
                  :choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
-                 :effect (effect (add-prop target :advance-counter 1))}]}
+                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "Bullfrog"
    {:abilities [{:msg "start a Psi game"
@@ -123,7 +123,7 @@
                                    :msg (msg "place 1 advancement token on "
                                              (if (:rezzed target) (:title target) "a card") " and end the run")
                                    :choices {:req #(= (first (:zone %)) :servers)}
-                                   :effect (effect (add-prop target :advance-counter 1) (end-run))}}}]}
+                                   :effect (effect (add-prop target :advance-counter 1 {:placed true}) (end-run))}}}]}
 
    "Chum"
    {:abilities [{:msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}]}

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -66,9 +66,11 @@
                  :cost [:click 1] :prompt "Choose a server" :choices (req servers)
                  :msg (msg "move it to the outermost position of " target)
                  :effect (effect (move card (conj (server->zone state target) :ices)))}
-                {:label "Place 1 advancement token on an ICE that can be advanced on this server"
+                {:label "Place 1 advancement token on an ICE that can be advanced protecting this server"
                  :msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))
-                 :choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
+                 :choices {:req #(and (= (last (:zone %)) :ices)
+                                      (or (= (:advanceable %) "always")
+                                          (and (= (:advanceable %) "while-rezzed") (:rezzed %))))}
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "Bullfrog"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -330,7 +330,8 @@
                  :msg (msg "flip their ID")}]}
 
    "Tennin Institute: The Secrets Within"
-   {:abilities [{:msg "add 1 advancement counter on a card" :choices {:req #(= (first (:zone %)) :servers)}
+   {:abilities [{:msg (msg "place 1 advancement token on " (if (:rezzed target) (:title target) "a card"))
+                 :choices {:req #(= (first (:zone %)) :servers)}
                  :req (req (not (:successful-run runner-reg))) :once :per-turn
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -332,7 +332,7 @@
    "Tennin Institute: The Secrets Within"
    {:abilities [{:msg "add 1 advancement counter on a card" :choices {:req #(= (first (:zone %)) :servers)}
                  :req (req (not (:successful-run runner-reg))) :once :per-turn
-                 :effect (effect (add-prop target :advance-counter 1))}]}
+                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "The Foundry: Refining the Process"
    {:events

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -175,7 +175,7 @@
                                          :choices {:req #(or (= (:advanceable %) "always")
                                                              (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                                              (= (:type %) "Agenda"))}
-                                         :effect (effect (add-prop target :advance-counter 4))} card nil)))))}]}
+                                         :effect (effect (add-prop target :advance-counter 4 {:placed true}))} card nil)))))}]}
 
    "Kate \"Mac\" McCaffrey: Digital Tinker"
    {:effect (effect (gain :link 1))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -369,7 +369,7 @@
    {:choices {:max 2 :req #(or (= (:advanceable %) "always")
                                (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                (= (:type %) "Agenda"))}
-    :msg (msg "1 advancement tokens on " (count targets) " cards")
+    :msg (msg "place 1 advancement token on " (count targets) " cards")
     :effect (req (doseq [t targets] (add-prop state :corp t :advance-counter 1 {:placed true})))}
 
    "Shipment from MirrorMorph"
@@ -388,7 +388,7 @@
                      {:choices {:req #(or (= (:advanceable %) "always")
                                           (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                           (= (:type %) "Agenda"))}
-                      :msg (msg "add " c " advancement tokens on a card")
+                      :msg (msg "place " c " advancement tokens on " (if (:rezzed target) (:title target) "a card"))
                       :effect (effect (add-prop :corp target :advance-counter c {:placed true}))} card nil)))}
 
    "Shoot the Moon"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -229,7 +229,7 @@
                        [reveal r] (split-with (complement ice?) (get-in @state [:corp :deck]))
                        titles (->> (conj (vec reveal) (first r)) (filter identity) (map :title))]
                    (trash state side target {:cause :ability-cost})
-                   (when (seq titles) 
+                   (when (seq titles)
                      (system-msg state side (str "reveals " (clojure.string/join ", " titles) " from R&D")))
                    (if-let [ice (first r)]
                      (let [newice (assoc ice :zone (:zone target) :rezzed true)
@@ -308,7 +308,7 @@
                                     {:msg (msg "place " c " advancement tokens on "
                                                (if (:rezzed target) (:title target) "a card"))
                                      :choices {:req #(or (= (:type %) "Agenda") (:advanceable %))}
-                                     :effect (effect (add-prop target :advance-counter c))} card nil)))}
+                                     :effect (effect (add-prop target :advance-counter c {:placed true}))} card nil)))}
 
    "Punitive Counterstrike"
    {:trace {:base 5 :msg (msg "do " (or (:stole-agenda runner-reg) 0) " meat damage")
@@ -370,7 +370,7 @@
                                (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                (= (:type %) "Agenda"))}
     :msg (msg "1 advancement tokens on " (count targets) " cards")
-    :effect (req (doseq [t targets] (add-prop state :corp t :advance-counter 1)))}
+    :effect (req (doseq [t targets] (add-prop state :corp t :advance-counter 1 {:placed true})))}
 
    "Shipment from MirrorMorph"
    (let [shelper (fn sh [n] {:prompt "Select a card to install"
@@ -389,7 +389,7 @@
                                           (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                           (= (:type %) "Agenda"))}
                       :msg (msg "add " c " advancement tokens on a card")
-                      :effect (effect (add-prop :corp target :advance-counter c))} card nil)))}
+                      :effect (effect (add-prop :corp target :advance-counter c {:placed true}))} card nil)))}
 
    "Shoot the Moon"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))
@@ -510,8 +510,8 @@
                                                               (or (= (:advanceable %) "always")
                                                                   (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                                                   (= (:type %) "Agenda")))}
-                                         :effect  (effect (add-prop :corp target :advance-counter c)
-                                                          (add-prop :corp fr :advance-counter (- c))
+                                         :effect  (effect (add-prop :corp target :advance-counter c {:placed true})
+                                                          (add-prop :corp fr :advance-counter (- c) {:placed true})
                                                           (system-msg (str "moves " c " advancement tokens from "
                                                                            (if (:rezzed fr) (:title fr) "a card") " to "
                                                                            (if (:rezzed target) (:title target) "a card"))))}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -460,12 +460,15 @@
         (swap! state assoc-in [:runner :run-credit] 0)
         (swap! state assoc :run nil))))
 
-(defn add-prop [state side card key n]
-  (update! state side (update-in card [key] #(+ (or % 0) n)))
-  (if (= key :advance-counter)
-    (do (trigger-event state side :advance (get-card state card))
-        (when (and (#{"ICE"} (:type card)) (:rezzed card)) (update-ice-strength state side card)))
-    (trigger-event state side :counter-added (get-card state card))))
+(defn add-prop
+  ([state side card key n] (add-prop state side card key n nil))
+  ([state side card key n {:keys [placed] :as args}]
+    (update! state side (update-in card [key] #(+ (or % 0) n)))
+    (if (= key :advance-counter)
+      (do (when (and (#{"ICE"} (:type card)) (:rezzed card)) (update-ice-strength state side card))
+          (when (not placed)
+            (trigger-event state side :advance (get-card state card))))
+      (trigger-event state side :counter-added (get-card state card)))))
 
 (defn set-prop [state side card & args]
   (update! state side (apply assoc (cons card args))))


### PR DESCRIPTION
Fix for #898.

We refactor `add-prop` to accept an optional `:placed true` key, then use that to determine if the `:advance` event trigger should be fired. Then the whole list of cards that place advancement tokens are modified accordingly. 

A few cards got improved messages for the case when the card getting advancements is rezzed, and Oaktown Renovation gets a message to be more clear about how many credits are being gained when advanced conventionally. 