### PR TITLE
Miscellaneous card fixes

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -29,7 +29,7 @@
                  :choices {:req #(or (= (:advanceable %) "always")
                                      (and (= (:advanceable %) "while-rezzed") (:rezzed %))
                                      (= (:type %) "Agenda"))}
-                 :effect (effect (add-prop target :advance-counter 1))}]}
+                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "Award Bait"
    {:access {:choices ["0", "1", "2"] :prompt "How many advancement tokens?"
@@ -285,7 +285,8 @@
                                           (if (>= (:advance-counter (get-card state card)) 5) 3 2)))}}}
 
    "Philotic Entanglement"
-   {:msg (msg "do " (count (:scored runner)) " net damage")
+   {:req (req (> (count (:scored runner)) 0))
+    :msg (msg "do " (count (:scored runner)) " net damage")
     :effect (effect (damage :net (count (:scored runner)) {:card card}))}
 
    "Posted Bounty"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -435,11 +435,11 @@
    {:abilities [{:label "Store any number of [Credits] on Sealed Vault" :cost [:credit 1]
                  :prompt "How many [Credits]?" :choices :credit :msg (msg "store " target " [Credits]")
                  :effect (effect (add-prop card :counter target))}
-                {:label "Spend [Click] to move any number of [Credits] to your credit pool"
+                {:label "Move any number of [Credits] to your credit pool"
                  :cost [:click 1] :prompt "How many [Credits]?"
-                 :choices :counter :msg (msg "spend [Click] to gain " target " [Credits]")
+                 :choices :counter :msg (msg "gain " target " [Credits]")
                  :effect (effect (gain :credit target))}
-                {:label "Trash Sealed Vault to move any number of [Credits] to your credit pool"
+                {:label "[Trash]: Move any number of [Credits] to your credit pool"
                  :prompt "How many [Credits]?" :choices :counter
                  :msg (msg "trash it and gain " target " [Credits]")
                  :effect (effect (gain :credit target) (trash card))}]}
@@ -596,7 +596,7 @@
    "Victoria Jenkins"
    {:effect (effect (lose :runner :click-per-turn 1)) :leave-play (effect (gain :runner :click-per-turn 1))
     :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
-  
+
    "Worlds Plaza"
    {:abilities [{:label "Install an asset on Worlds Plaza"
                  :req (req (< (count (:hosted card)) 3)) :cost [:click 1]

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -154,7 +154,8 @@
     [{:cost [:click 1] :msg "make a run on HQ"
       :effect (effect (run :hq {:req (req (= target :hq))
                                 :replace-access
-                                {:msg (msg "reveal cards in HQ: " (map :title (:hand corp)))}} card))}]}
+                                {:msg (msg "reveal cards in HQ: "
+                                           (join ", " (map :title (:hand corp))))}} card))}]}
 
    "False Echo"
    {:abilities [{:req (req (and (:run @state)

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -50,10 +50,15 @@
 
    "Bank Job"
    {:data {:counter 8}
-    :abilities [{:label "Take any number of [Credits] on Bank Job"
+    :abilities [{:req (req (and (:run @state) (= (:position run) 0)))
+                 :label "Take any number of [Credits] on Bank Job"
                  :prompt "How many [Credits]?" :choices :counter :msg (msg "gain " target " [Credits]")
                  :effect (req (gain state side :credit target)
-                              (when (= target (:counter card)) (trash state :runner card {:unpreventable true})))}]}
+                              (register-successful-run state side (:server run))
+                              (swap! state update-in [:runner :prompt] rest)
+                              (handle-end-run state side)
+                              (when (= target (:counter card))
+                                (trash state :runner card {:unpreventable true})))}]}
 
    "Beach Party"
    {:effect (effect (gain :max-hand-size 5)) :leave-play (effect (lose :max-hand-size 5))
@@ -690,7 +695,7 @@
    "Wireless Net Pavilion"
    {:effect (effect (trash-resource-bonus -2))
     :leave-play (effect (trash-resource-bonus 2))}
- 
+
    "Woman in the Red Dress"
    {:events {:runner-turn-begins
              {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")
@@ -719,4 +724,3 @@
                                 (remove-watch ref (keyword (str "zona-sul-shipping" (:cid card))))
                                 (trash ref :runner card)
                                 (system-msg ref side "trashes Zona Sul Shipping for being tagged")))))}})
-

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -191,7 +191,7 @@
                             (swap! state update-in [:runner :register] dissoc :cannot-steal)))}
          un {:effect (req (swap! state update-in [:runner :register] dissoc :cannot-steal))}]
      {:trash-effect
-      {:req (req (= :servers (first (:previous-zone card))))
+      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
        :effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (or (= (:zone target) (:previous-zone card))
                                                                                  (= (central->zone (:zone target))
                                                                                     (butlast (:previous-zone card))))))
@@ -213,7 +213,7 @@
    (let [ab {:req (req (or (= (:zone card) (:zone target)) (= (central->zone (:zone target)) (butlast (:zone card)))))
              :effect (effect (steal-cost-bonus [:credit 5]))}]
      {:trash-effect
-      {:req (req (= :servers (first (:previous-zone card))))
+      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
        :effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (or (= (:zone target) (:previous-zone card))
                                                                                  (= (central->zone (:zone target))
                                                                                     (butlast (:previous-zone card))))))
@@ -270,7 +270,7 @@
    (let [ab {:req (req (or (= (:zone card) (:zone target)) (= (central->zone (:zone target)) (butlast (:zone card)))))
              :effect (effect (steal-cost-bonus [:click 1]))}]
      {:trash-effect
-      {:req (req (= :servers (first (:previous-zone card))))
+      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
        :effect (effect (register-events {:pre-steal-cost (assoc ab :req (req (or (= (:zone target) (:previous-zone card))
                                                                                  (= (central->zone (:zone target))
                                                                                     (butlast (:previous-zone card))))))


### PR DESCRIPTION
* Expert Schedule Analyzer was missing `join` and not writing card titles from HQ to the log
* Cosmetic changes to Sealed Vault's menu and messages
* Only fire Philotic Entanglement's effect when damage will be > 0 (fixes #913)
* Fixed Bank Job to register a successful run and end the run if you take credits, and only be triggerable during a run (fixes #337)
* Yet more fixes for Old Hollywood Grid, Red Herrings, and Strongbox--if the Corp was voluntarily trashing them (even unrezzed) or if they got trashed by Drive By, their steal cost effects were persisting, which they shouldn't. The effects only persist now if trashed during a run. 