### PR TITLE
Traces list their effect in the chat log

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -13,8 +13,8 @@
                             :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}}}
     :abilities [{:label "Trace 6 - Add 1 installed card to the Runner's Grip"
                  :trace {:base 6 :choices {:req #(:installed %)}
-                         :msg (msg "add " (:title target) " to the Runner's Grip")
-                         :effect (effect (move :runner target :hand true))}}]}
+                         :msg "add 1 installed card to the Runner's Grip"
+                         :effect (effect (move :runner target :hand true) (system-msg (str "adds " (:title target) " to the Runner's Grip")))}}]}
 
    "Archer"
    {:additional-cost [:forfeit]
@@ -110,7 +110,7 @@
    "Checkpoint"
    {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
     :abilities [{:label "Trace 5 - Do 3 meat damage when this run is successful"
-                 :trace {:base 5
+                 :trace {:base 5 :msg "do 3 meat damage when this run is successful"
                          :effect (req (swap! state assoc-in [:run :run-effect :end-run]
                                              {:req (req (:successful run)) :msg "do 3 meat damage"
                                               :effect (effect (damage :meat 3 {:card card}))})
@@ -159,9 +159,11 @@
 
    "Data Hound"
    {:abilities [{:label "Trace 2 - Look at the top of Stack"
-                 :trace {:base 2 :msg (msg "look at the top " (- target (second targets)) " cards of Stack")
+                 :trace {:base 2 :msg "look at top X cards of Stack"
                          :effect (req (doseq [c (take (- target (second targets)) (:deck runner))]
-                                        (move state side c :play-area)))}}]}
+                                        (move state side c :play-area))
+                                      (system-msg state :corp (str "looks at the top " (- target (second targets)) " cards of Stack"))
+                                      )}}]}
 
    "Data Mine"
    {:abilities [{:msg "do 1 net damage" :effect (effect (trash card) (damage :net 1 {:card card}))}]}
@@ -556,7 +558,7 @@
 
    "Sagittarius"
    {:abilities [{:label "Trace 2 - Trash a program"
-                 :trace (assoc trash-program :base 2 :not-distinct true
+                 :trace (assoc trash-program :base 2 :not-distinct true :msg "trash 1 program"
                                              :kicker (assoc trash-program :min 5))}]}
 
    "Salvage"
@@ -650,11 +652,11 @@
 
    "Taurus"
    {:abilities [{:label "Trace 2 - Trash a piece of hardware"
-                 :trace (assoc trash-hardware :base 2 :not-distinct true
+                 :trace (assoc trash-hardware :base 2 :not-distinct true :msg "trash 1 hardware"
                                               :kicker (assoc trash-hardware :min 5))}]}
 
    "TMI"
-   {:trace {:base 2 :unsuccessful {:effect (effect (derez card))}} :abilities [end-the-run]}
+   {:trace {:base 2 :msg "keep TMI rezzed" :unsuccessful {:effect (effect (derez card))}} :abilities [end-the-run]}
 
    "Tollbooth"
    {:abilities [{:msg "force the Runner to lose 3 [Credits]"
@@ -667,6 +669,7 @@
    "Troll"
    {:abilities [{:label "Trace 2 - Force the Runner to lose [Click] or end the run"
                  :trace {:base 2 :player :runner
+                         :msg "force the Runner to lose [Click] or end the run"
                          :prompt "Choose one" :choices ["Lose [Click]" "End the run"]
                          :effect (req (if-not (and (= target "Lose [Click]") (pay state side card :click 1))
                                         (do (end-run state side) (system-msg state side "ends the run"))
@@ -719,7 +722,7 @@
                  :trace {:base 3 :msg "end the run" :effect (effect (end-run))}}]}
 
    "Virgo"
-   {:abilities [{:label "Trace 2"
+   {:abilities [{:label "Trace 2 - Give the Runner 1 tag"
                  :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))
                          :kicker {:min 5 :msg "give the Runner 1 tag"
                                   :effect (effect (tag-runner :runner 1))}}}]}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -302,7 +302,7 @@
    {:effect (req (doseq [c (take 5 (:deck corp))] (move state side c :play-area)))}
 
    "Power Grid Overload"
-   {:trace {:base 2 :msg "trash 1 piece of hardware with install cost less than or equal to X"
+   {:trace {:base 2 :msg "trash 1 piece of hardware"
             :effect (req (let [max-cost (- target (second targets))]
                            (resolve-ability state side
                                             {:choices {:req #(and (has? % :type "Hardware")

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -217,9 +217,10 @@
     :effect (effect (corp-install target nil {:no-install-cost true}))}
 
    "Invasion of Privacy"
-   {:trace {:base 2 :msg (msg "reveal the Runner's Grip and trash up to " (- target (second targets)) " resources or events")
+   {:trace {:base 2 :msg "reveal the Runner's Grip and trash up to X resources or events"
             :effect (req (doseq [c (:hand runner)]
-                           (move state side c :play-area)))
+                           (move state side c :play-area))
+                           (system-msg state :corp (str "reveals the Runner's Grip and can trash up to " (- target (second targets)) " resources or events")))
             :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain :corp :bad-publicity 1))}}}
 
    "Lag Time"
@@ -236,8 +237,9 @@
 
    "Midseason Replacements"
    {:req (req (:stole-agenda runner-reg))
-    :trace {:base 6 :msg (msg "give the Runner " (- target (second targets)) " tags")
-            :effect (effect (tag-runner :runner (- target (second targets))))}}
+    :trace {:base 6 :msg "give the Runner X tags"
+            :effect (effect (tag-runner :runner (- target (second targets)))
+                            (system-msg (str "gives the Runner " (- target (second targets)) " tags")))}}
 
    "Mushin No Shin"
    {:prompt "Choose a card to install from HQ"
@@ -300,15 +302,15 @@
    {:effect (req (doseq [c (take 5 (:deck corp))] (move state side c :play-area)))}
 
    "Power Grid Overload"
-   {:trace {:base 2 :msg (msg "trash 1 piece of hardware with install cost less than or equal to "
-                              (- target (second targets)))
+   {:trace {:base 2 :msg "trash 1 piece of hardware with install cost less than or equal to X"
             :effect (req (let [max-cost (- target (second targets))]
                            (resolve-ability state side
                                             {:choices {:req #(and (has? % :type "Hardware")
                                                                   (<= (:cost %) max-cost))}
                                              :msg (msg "trash " (:title target))
                                              :effect (effect (trash target))}
-                                            card nil)))}}
+                                            card nil))
+                         (system-msg state :corp (str "trashes 1 piece of hardware with install cost less than or equal to " (- target (second targets)))))}}
 
    "Power Shutdown"
    {:req (req (:made-run runner-reg)) :prompt "Trash how many cards from the top R&D?"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -359,7 +359,7 @@
                                  " to initiate a trace with strength " total
                                  " (" base
                                  (when (> bonus 0) (str " + " bonus " bonus"))
-                                 " + " boost " [Credits])"))
+                                 " + " boost " [Credits]) (" (:msg ability) ")"))
     (swap! state update-in [:bonus] dissoc :trace)
     (show-prompt state :runner card (str "Boost link strength?") :credit #(resolve-trace state side %))
     (swap! state assoc :trace {:strength total :ability ability :card card})


### PR DESCRIPTION
resolves https://github.com/mtgred/netrunner/issues/893

This will print the traces' effects at the same time as the trace's strength in the chat log.

![image](https://cloud.githubusercontent.com/assets/4015791/11460429/ccbcf6e8-96a0-11e5-9203-6a6b59173db3.png)

It does this by modifying the message that `init-trace` in `core.clj` spits out. (https://github.com/mtgred/netrunner/commit/79be59225d71e11504eba16d71db5803e1e949f5)

There are a very small number of trace events that will have a calculated cost as part of their resolution. The current handling of traces will fire the associated `:msg` event at the time of resolution, meaning the calculated cost (final trace amounts from both Corp and Runner) will be known. If we try to print this `:msg` before we know these values, we get an error.
* **Archangel** *(add [card name] to grip)*
* **Data Hound** *(look at [x] cards)*
* **Midseason Replacements** *(give [x] tags)*
* **Invasion of Privacy** *(trash [x] resources/events from grip)*
* **Power Grid Overload** *(trash hardware of [x] cost)*

https://github.com/mtgred/netrunner/commit/509b38b439964ccf89e6dd4c212ca5ba215bc279 alters these problem cards' `:msg` values to just list "X" instead of the calculated cost, and include the calculated cost declaration as a `(system-msg)` in the cards' `:effects`. This gets around the problem, but adds some slight repetition to the chatlog.

![02](https://cloud.githubusercontent.com/assets/4015791/11460691/08b74540-96a6-11e5-8436-bf5002d29216.png)
*this is probably the worst-case scenario*

This duplication could be avoided by not ever listing the calculated cost (leaving it up to the reader to read both link/trace strengths declared in the chat log), but that seems like loss of functionality.