### PR TITLE
Card fixes: Medium/Nerve Agent, 24/7 News Cycle, News Team, Dr. Lovegood

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -343,10 +343,12 @@
                                 :prompt "Take 2 tags or take News Team as -1 agenda point?"
                                 :choices ["Take 2 tags" "Add News Team to score area"]
                                 :effect (req (if (= target "Add News Team to score area")
-                                                 (do (as-agenda state :runner card -1)
+                                               (do (or (move state :runner (assoc card :agendapoints -1) :scored)
+                                                       (move state :runner (assoc card :agendapoints -1 :zone [:discard]) :scored))
+                                                   (gain-agenda-point state :runner -1)
                                                    (system-msg state side
                                                     (str "adds News Team to their score area as -1 agenda point")))
-                                                 (do (tag-runner state :runner 2)
+                                               (do (tag-runner state :runner 2)
                                                    (system-msg state side (str "takes 2 tags from News Team")))))}
                               card targets))}}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -5,8 +5,10 @@
    {:req (req (> (count (:scored corp)) 1)) :additional-cost [:forfeit]
     :effect (req (let [agendas (get-in @state [:corp :scored])]
                    (resolve-ability state side
-                     {:prompt "Choose an agenda to trigger its \"when scored\" ability"
-                      :choices (req (cancellable (filter #(= (:type %) "Agenda") agendas)))
+                     {:prompt "Choose an agenda in your score area to trigger its \"when scored\" ability"
+                      :choices {:req #(and (= (:type %) "Agenda")
+                                           (= (first (:zone %)) :scored)
+                                           (:abilities %))}
                       :msg (msg "trigger the \"when scored\" ability of " (:title target))
                       :effect (effect (card-init target))}
                     card nil)))}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -305,7 +305,7 @@
    {:events {:no-action {:req (req (and run
                                         (= (first (get-in @state [:run :server])) :rd)
                                         (not current-ice)
-                                        (and (:counter card) (> (:counter card) 0))))
+                                        (> (get-virus-counters state side card) 0)))
                          :effect (req (system-msg state :runner (str "may choose fewer than all additional R&D accesses"
                                                                      " by clicking on Medium"))
                                       (update! state side (assoc card :medium-active true)))}
@@ -314,7 +314,10 @@
                               :effect (effect (add-prop card :counter 1))}
              :pre-access {:req (req (and (= target :rd) (:medium-active card)))
                           :effect (effect (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}
-    :abilities [{:req (req (:medium-active card))
+    :abilities [{:req (req (and run
+                                (= (first (get-in @state [:run :server])) :rd)
+                                (not current-ice)
+                                (:medium-active card)))
                  :effect (effect (add-prop card :counter 1)
                                  (resolve-ability
                                    {:prompt "Choose how many additional R&D accesses to make"
@@ -330,7 +333,7 @@
    {:events {:no-action {:req (req (and run
                                         (= (first (get-in @state [:run :server])) :hq)
                                         (not current-ice)
-                                        (and (:counter card) (> (:counter card) 0))))
+                                        (> (get-virus-counters state side card) 0)))
                          :effect (req (system-msg state :runner (str "may choose fewer than all additional HQ accesses"
                                                                      " by clicking on Nerve Agent"))
                                       (update! state side (assoc card :nerve-active true)))}
@@ -339,7 +342,10 @@
                               :effect (effect (add-prop card :counter 1))}
              :pre-access {:req (req (and (= target :hq) (:nerve-active card)))
                           :effect (effect (access-bonus (max 0 (dec (get-virus-counters state side (get-card state card))))))}}
-    :abilities [{:req (req (:nerve-active card))
+    :abilities [{:req (req (and run
+                                (= (first (get-in @state [:run :server])) :hq)
+                                (not current-ice)
+                                (:nerve-active card)))
                  :effect (effect (add-prop card :counter 1)
                                  (resolve-ability
                                    {:prompt "Choose how many additional HQ accesses to make"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -118,7 +118,7 @@
                                 (desactivate state side target)
                                 (register-events state side
                                                  {:runner-turn-ends
-                                                  {:effect (effect (card-init (get-card state c) false)
+                                                  {:effect (effect (card-init (get-card state c))
                                                                    (unregister-events card))}} card)))}]
     :events {:runner-turn-ends nil}}
 

--- a/src/clj/test/cards-operations.clj
+++ b/src/clj/test/cards-operations.clj
@@ -41,5 +41,5 @@
       (play-from-hand state :corp "24/7 News Cycle")
       (prompt-card :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 1 (:agenda-point (get-corp))) "Forfeited Breaking News")
-      (prompt-card :corp (find-card "Breaking News" (:scored (get-corp))))
+      (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner given 2 tags"))))

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -19,3 +19,26 @@
     (let [gord (get-in @state [:runner :rig :program 0])]
       (core/trash state :runner gord)
       (is (= 4 (:memory (get-runner))) "Trashing the program restored MU"))))
+
+(deftest refresh-recurring-credits-hosted
+  "host - Recurring credits on cards hosted after install refresh properly"
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 3) (qty "Hedge Fund" 3)])
+              (default-runner [(qty "Compromised Employee" 1) (qty "Off-Campus Apartment" 1)]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp 2)
+    (play-from-hand state :runner "Off-Campus Apartment")
+    (play-from-hand state :runner "Compromised Employee")
+    (let [iwall (get-in @state [:corp :servers :hq :ices 0])
+          apt (get-in @state [:runner :rig :resource 0])]
+      (card-ability state :runner apt 1) ; use Off-Campus option to host an installed card
+      (prompt-select :runner (find-card "Compromised Employee" (get-in @state [:runner :rig :resource])))
+      (let [cehosted (first (:hosted (refresh apt)))]
+        (card-ability state :runner cehosted 0) ; take Comp Empl credit
+        (is (= 4 (:credit (get-runner))))
+        (is (= 0 (:rec-counter (refresh cehosted))))
+        (core/rez state :corp iwall)
+        (is (= 5 (:credit (get-runner))) "Compromised Employee gave 1 credit from ice rez")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 1 (:rec-counter (refresh cehosted))) "Compromised Employee recurring credit refreshed")))))


### PR DESCRIPTION
Fixes for #930, #926, #916, and #809. 

* Medium and Nerve Agent have to use `get-virus-counters` so they'll see a Hivemind even when they have 0 counters
* 24/7 News Cycle switched to use card targeting so you can't trigger the agenda you just forfeited
* News Team receives the same fix that Shi.Kyu got so that Neutralize All Threats can take it as -1 agenda point from Archives
* Dr. Lovegood has to do a full card-init on its target at turn end so all the cards that modify hand size, HQ access, etc via `:effect` will turn back on properly

Also did a test for refresh of recurring credits on hosted cards, since it took me 4 tries to get it right...