### PR TITLE
Alert players to invalid opponent decks in game lobby

### DIFF
--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -237,6 +237,9 @@
                         (if (= (:user player) user)
                           (:name deck)
                           "Deck selected")])
+                     (when-let [deck (:deck player)]
+                       (when-not (valid? deck)
+                         [:span.invalid "Invalid deck"]))
                      (when (= (:user player) user)
                        [:span.fake-link.deck-load
                         {:data-target "#deck-select" :data-toggle "modal"} "Select deck"])])]


### PR DESCRIPTION
Following up to address #884. 

Add a check in the game lobby code to show the red "Invalid deck" text if applicable after a player has loaded a deck. This way you can have some more peace of mind when playing random people but still play testing decks or draft format games if you and the opponent are both aware of the situation and agree to proceed. 

![screen shot 2015-11-30 at 12 05 52 pm](https://cloud.githubusercontent.com/assets/10407969/11480139/65493b32-975b-11e5-82f9-dc698869956b.png)
