### PR TITLE
Identity Cyber-Cypher server selection with CSS overlay

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -140,7 +140,10 @@
 
    "Cyber-Cypher"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [{:cost [:credit 1] :msg "break 1 code gate subroutine"}
+                    {:prompt "Choose a server where this copy of Cyber-Cypher can be used" :choices (req servers)
+                     :effect (effect (update! (assoc card :named-target target)))
+                     :leave-play (effect (update! (dissoc card :named-target)))
+                     :abilities [{:cost [:credit 1] :msg "break 1 code gate subroutine"}
                                  {:cost [:credit 1] :msg "add 1 strength" :effect (effect (pump card 1)) :pump 1}]})
 
    "Dagger"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -118,7 +118,7 @@
   ([state side card] (desactivate state side card nil))
   ([state side card keep-counter]
    (let [c (dissoc card :current-strength :abilities :rezzed :special :facedown)
-         c (if (= (:side c) "Runner") (dissoc c :installed :counter :rec-counter :pump) c)
+         c (if (= (:side c) "Runner") (dissoc c :installed :counter :rec-counter :pump :named-target) c)
          c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
      (when-let [leave-effect (:leave-play (card-def card))]
        (when (or (and (= (:side card) "Runner") (:installed card))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -269,7 +269,7 @@
   
 (defn card-view [{:keys [zone code type abilities counter advance-counter advancementcost current-cost subtype
                          advanceable rezzed strength current-strength title remotes selected hosted
-                         side rec-counter facedown]
+                         side rec-counter facedown named-target]
                   :as cursor}
                  owner {:keys [flipped] :as opts}]
   (om/component
@@ -296,6 +296,7 @@
          (when (> advance-counter 0) [:div.darkbg.advance.counter advance-counter])]
         (when (and current-strength (not= strength current-strength))
               current-strength [:div.darkbg.strength current-strength])
+        (when named-target [:div.darkbg.named-target named-target])
         (when (and (= zone ["hand"]) (#{"Agenda" "Asset" "ICE" "Upgrade"} type))
           (let [centrals ["HQ" "R&D" "Archives"]
                 remotes (conj (remote-list remotes) "New remote")

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1108,6 +1108,19 @@ nav ul
     height: 24px
     width: 24px
 
+  .named-target
+    position: absolute
+    z-index: 10
+    padding: 0
+    text-align: center
+    background-color: sienna
+    line-height: 16px
+    font-size: 10px
+    top: 3px
+    right: 3px
+    height: 16px
+    width: auto
+
   .abilities, .servers-menu, .menu
     display: none
     position: absolute


### PR DESCRIPTION
Feel free to adjust the color...I just picked something not being used and that had good contrast. It should go in the upper right I think to avoid clashing with strength boosts. Later on we can figure out how to extend this to Femme Fatale, which is slightly trickier because the overlay needs to remain even if the ice is derezzed, but be removed if either Femme Fatale is trashed or the targeted ice is trashed. 

![screen shot 2015-11-30 at 2 35 38 pm](https://cloud.githubusercontent.com/assets/10407969/11485119/a3ea5170-9777-11e5-9d55-83e7602e5cab.png)

![screen shot 2015-11-30 at 3 31 17 pm](https://cloud.githubusercontent.com/assets/10407969/11485126/aaa7fa08-9777-11e5-85ce-0b9ce81770d7.png)
