### PR TITLE
Do not trigger leave-effect for runner cards put facedown

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -118,7 +118,7 @@
   ([state side card] (desactivate state side card nil))
   ([state side card keep-counter]
    (let [c (dissoc card :current-strength :abilities :rezzed :special :facedown)
-         c (if (= (:side c) "Runner") (dissoc c :installed :counter :rec-counter :pump) c)
+         c (if (and (= (:side c) "Runner") (not (:facedown card))) (dissoc c :installed :counter :rec-counter :pump) c)
          c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
      (when-let [leave-effect (:leave-play (card-def card))]
        (when (or (and (= (:side card) "Runner") (:installed card))


### PR DESCRIPTION
:information_desk_person: This intends to prevent `leave-effects` from being triggered when a runner card is put facedown.

Solves https://github.com/mtgred/netrunner/issues/901

**NOTE:** I'm a newbie at `clj`, so I'm happy for you guys to give me some good feedback on what/how to do stuff, but I'm keen to improve `jinteki.net` and help the community :family: .