### PR TITLE
Enforce architect untrashable

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -22,7 +22,10 @@
                 trash-program end-the-run]}
 
    "Architect"
-   {:abilities [{:msg "look at the top 5 cards of R&D"
+   {:flags {
+            :untrashable-while-rezzed true
+            }
+    :abilities [{:msg "look at the top 5 cards of R&D"
                  :prompt "Choose a card to install" :priority true
                  :activatemsg "uses Architect to look at the top 5 cards of R&D"
                  :req (req (and (not (string? target))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -39,6 +39,8 @@
    (let [username (get-in @state [side :user :username])]
     (say state side {:user "__system__" :text (str username " " text "." (when hr "[hr]"))}))))
 
+;Display a message related to a rules enforcement on a given card.
+;Example: Architect cannot be trashed while installed.
 (defn enforce-msg [state card text]
   (say state nil {:user (get-in card [:title]) :text (str (:title card) " " text ".")})
   )

--- a/src/clj/test/cards-ice.clj
+++ b/src/clj/test/cards-ice.clj
@@ -14,3 +14,21 @@
       (card-ability state :corp iwall 0)
       (is (not (:run @state)) "Run is ended")
       (is (get-in @state [:runner :register :unsuccessful-run]) "Run was unsuccessful"))))
+
+(deftest architect-untrashable
+  "Architect is untrashable while installed and rezzed, but trashable if derezzed or from HQ"
+  (do-game
+    (new-game (default-corp [(qty "Architect" 3)])
+              (default-runner))
+    (play-from-hand state :corp "Architect" "HQ")
+    (let [architect (get-in @state [:corp :servers :hq :ices 0])]
+      (core/rez state :corp architect)
+      (core/trash state :corp (refresh architect))
+      (is (not= nil (get-in @state [:corp :servers :hq :ices 0])) "Architect was trashed, but should be untrashable")
+      (core/derez state :corp (refresh architect))
+      (core/trash state :corp (refresh architect))
+      (is (= nil (get-in @state [:corp :servers :hq :ices 0])) "Architect was not trashed, but should be trashable")
+      (core/trash state :corp (get-in @state [:corp :hand 0]))
+      (is (= (get-in @state [:corp :discard 0 :title]) "Architect"))
+      (is (= (get-in @state [:corp :discard 1 :title]) "Architect"))
+      )))


### PR DESCRIPTION
Resolves #317.

Card definitions can now have a `:flags` map.  This map can be checked for a flag and its given value by using the `flag?` function.

Architect possesses the `:untrashable-while-rezzed` flag, which blocks trashing when a card is rezzed. Since the text of Architect is not in effect when it is derezzed (per [Lukas](https://twitter.com/rukasufox/status/487406756381749248)), it's effectively that, instead of when installed.  As an example (however unlikely), [Emergency Shutdown](http://netrunnerdb.com/en/card/02043) into [Apocalypse](http://netrunnerdb.com/en/card/09030) could trash an Architect.

Another new function added is `enforce-msg`. When passed a card and some message text, this displays an alert of the form "cardname message."
<img width="185" alt="4eijjah" src="https://cloud.githubusercontent.com/assets/475851/11491141/2db1f45a-97ad-11e5-98b3-796f6de747c4.png">

A test is included for attempting to trash architect when derezzed, rezzed, and from hand.