### PR TITLE
stop Apocalypse from triggering leave play effects of cards turned facedown

### DIFF
--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -27,6 +27,33 @@
     (is (= 5 (:credit (get-runner)))) ; no change in credits
     (is (= 8 (:credit (get-corp))))))
 
+(deftest apocalypse-turn-facedown
+  "Apocalypse - Turn Runner cards facedown without firing their leave play effects"
+  (do-game
+    (new-game (default-corp [(qty "Launch Campaign" 2) (qty "Ice Wall" 1)])
+              (default-runner [(qty "Tri-maf Contact" 3) (qty "Apocalypse" 3)]))
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (play-from-hand state :corp "Launch Campaign" "New remote")
+    (play-from-hand state :corp "Launch Campaign" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Tri-maf Contact")
+    (core/gain state :runner :click 2)
+    (core/click-run state :runner {:server "Archives"})
+    (core/no-action state :corp nil)
+    (core/successful-run state :runner nil)
+    (core/click-run state :runner {:server "R&D"})
+    (core/no-action state :corp nil)
+    (core/successful-run state :runner nil)
+    (core/click-run state :runner {:server "HQ"})
+    (core/no-action state :corp nil)
+    (core/successful-run state :runner nil)
+    (play-from-hand state :runner "Apocalypse")
+    (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
+    (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
+    (let [tmc (get-in @state [:runner :rig :facedown 0])]
+      (is (:facedown (refresh tmc)) "Tri-maf Contact is facedown")
+      (is (= 3 (count (:hand (get-runner)))) "No meat damage dealt by Tri-maf's leave play effect"))))
+
 (deftest demolition-run
   "Demolition Run - Trash at no cost"
   (do-game


### PR DESCRIPTION
Fixes #940 and #901. 

In the `move` function, we have to move the `desactivate` trigger for installed and facedown cards further down to after the card has been associated with its destination zone. 

Then in `desactivate` we have to refine when we dissociate `:facedown` and make sure to only fire `:leave-play` effects if the card _isn't_ facedown. 