### PR TITLE
Enforce Blackmail no rez

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -32,7 +32,7 @@
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
     :msg "prevent ICE from being rezzed during this run"
     :effect (effect
-              (resolve-ability (register-run-flag! state :no-rez-ice true card) card nil)
+              (resolve-ability (register-run-flag! state :no-rez-ice card) card nil)
               (run target nil card))}
 
    "Bribery"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -30,7 +30,10 @@
 
    "Blackmail"
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
-    :effect (effect (run target nil card))}
+    :msg "prevent ICE from being rezzed during this run"
+    :effect (effect
+              (resolve-ability (register-run-flag! state :no-rez-ice true card) card nil)
+              (run target nil card))}
 
    "Bribery"
    {:prompt "How many [Credits]?" :choices :credit

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -97,7 +97,7 @@
 ;Register a flag for the current run only
 ;end-run clears this register, preventing state pollution between runs
 ;Example: Blackmail flags the current run as not allowing rezzing of ICE
-(defn register-run-flag! [state flag value card]
+(defn register-run-flag! [state flag card]
   (swap! state assoc-in [:register :current-run flag] card)
   )
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -94,6 +94,17 @@
       (swap! state assoc-in [side (first r)] 0)
       (deduce state side r))))
 
+;Register a flag for the current run only
+;Example: Blackmail flags the current run as not allowing rezzing of ICE
+(defn register-run-flag! [state flag value]
+  (swap! state assoc-in [:register :current-run flag] value)
+  )
+
+;Clear the current run register
+(defn clear-run-register! [state]
+  (swap! state assoc-in [:register :current-run] nil)
+  )
+
 (defn register-suppress [state side events card]
   (doseq [e events]
     (swap! state update-in [:suppress (first e)] #(conj % {:ability (last e) :card card}))))
@@ -467,7 +478,8 @@
               (resolve-ability state side end-run-effect (:card run-effect) [(first server)]))))
         (swap! state update-in [:runner :credit] - (get-in @state [:runner :run-credit]))
         (swap! state assoc-in [:runner :run-credit] 0)
-        (swap! state assoc :run nil))))
+        (swap! state assoc :run nil)
+        (clear-run-register! state))))
 
 (defn add-prop
   ([state side card key n] (add-prop state side card key n nil))


### PR DESCRIPTION
These changes enforce Blackmail preventing the rezzing of ICE.

This is done through use of a "current run" register on the game state. Within this register (`:register :current-run` on the game state), Blackmail sets the `:no-rez-ice` flag. This is checked by the `rez` function, which prevents rezzing if this is set.

To prevent any state pollution between runs, `handle-end-run` wipes this register at the end of every run.