### PR TITLE
improvements to Whirlpool and Clot, fix Bookmark and Pawn

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -43,7 +43,7 @@
                       :effect (effect (rez :corp target))}}}
 
    "Bookmark"
-   {:abilities [{:label "Host 3 cards from your Grip facedown"
+   {:abilities [{:label "Host up to 3 cards from your Grip facedown"
                  :cost [:click 1] :msg "host up to 3 cards from their Grip facedown"
                  :choices {:max 3 :req #(and (:side % "Runner") (= (:zone %) [:hand]))}
                  :effect (req (doseq [c targets]
@@ -54,7 +54,8 @@
                 {:label "[Trash]: Add all hosted cards to Grip" :msg "add all hosted cards to their Grip"
                  :effect (req (doseq [c (:hosted card)]
                                 (move state side c :hand))
-                              (trash state side card {:cause :ability-cost}))}]}
+                              (update! state side (dissoc card :hosted))
+                              (trash state side (get-card state card) {:cause :ability-cost}))}]}
 
    "Box-E"
    {:effect (effect (gain :memory 2 :max-hand-size 2))

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -184,7 +184,7 @@
    {:prompt "How many power counters?" :choices :credit :msg (msg "add " target " power counters")
     :effect (effect (set-prop card :counter target))
     :strength-bonus (req (or (:counter card) 0))
-    :abilities [{:label "Trace 2"
+    :abilities [{:label "Trace 2 - Give the Runner 1 tag and end the run"
                  :trace {:base 2 :msg "give the Runner 1 tag and end the run"
                          :effect (effect (tag-runner :runner 1) (end-run))}}]}
 
@@ -595,7 +595,7 @@
                  :trace {:base 1 :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}
                 {:label "Trace 2 - Do 2 net damage"
                  :trace {:base 2 :msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}}
-                {:label "Trace 3 - Do 3 net damage"
+                {:label "Trace 3 - Do 3 net damage and end the run"
                  :trace {:base 3 :msg "do 3 net damage and end the run"
                          :effect (effect (damage :net 3 {:card card}) (end-run))}}]}
 
@@ -739,7 +739,13 @@
 
    "Whirlpool"
    {:abilities [{:msg "prevent the Runner from jacking out"
-                 :effect (effect (trash card) (prevent-jack-out))}]}
+                 :effect (req (when (and (is-remote? (second (:zone card)))
+                                         (> (count (concat (:ices (card->server state card))
+                                                           (:content (card->server state card)))) 1))
+                                (prevent-jack-out state side))
+                              (trash state side card)
+                              (when (:run @state)
+                                (swap! state update-in [:run] #(assoc % :position (dec (:position run))))))}]}
 
    "Woodcutter"
    {:advanceable :while-rezzed

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -275,7 +275,7 @@
    {:req (req (:made-run runner-reg)) :effect (effect (damage :net 1 {:card card}))}
 
    "Oversight AI"
-   {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))}
+   {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)) (= (last (:zone %)) :ices))}
     :msg (msg "rez " (:title target) " at no cost")
     :effect (effect (rez target {:no-cost true})
                     (host (get-card state target) (assoc card :zone [:discard] :seen true)))}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -424,22 +424,19 @@
                  :msg (msg "host it on " (if (:rezzed target) (:title target) "a piece of ICE"))
                  :effect (effect (host target card))}]
     :events {:successful-run
-             {:effect (req (let [i (ice-index state (:host card))
+             {:req (req (= (:type (:host card)) "ICE"))
+              :effect (req (let [i (ice-index state (:host card))
                                  nextice (when (> i 0) (nth (get-in @state
-                                                              (vec (concat [:corp] (:zone (:host card))))) (dec i)))]
+                                                            (vec (concat [:corp] (:zone (:host card))))) (dec i)))]
                              (if (pos? i)
                                (host state side nextice card)
                                (do (resolve-ability state side
-                                     {:prompt "Install a Caïssa program from Grip or Heap?" :choices ["Grip" "Heap"]
-                                      :msg (msg "install a Caïssa program from " target)
-                                      :effect (req (let [p target]
-                                                     (resolve-ability state side
-                                                       {:prompt "Choose a Caïssa program to install"
-                                                        :choices (req (filter #(has? % :subtype "Caïssa")
-                                                                        ((if (= p "Heap") :discard :hand) runner)))
-                                                        :effect (effect (runner-install target {:no-cost true}))} card nil)))}
-                                    card nil)
-                                   (trash state side card)))))}}}
+                                     {:prompt "Choose a Caïssa program to install from your Grip or Heap"
+                                      :show-discard true
+                                      :choices {:req #(and (has? % :subtype "Caïssa")
+                                                           (#{[:hand] [:discard]} (:zone %)))}
+                                      :effect (effect (runner-install target {:no-cost true}))} card nil)
+                                    (trash state side card)))))}}}
 
    "Pheromones"
    {:recurring (effect (set-prop card :rec-counter (:counter card)))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -68,7 +68,8 @@
     :events {:purge {:effect (req (swap! state update-in [:corp :register] dissoc :cannot-score)
                                   (trash state side card))}
              :corp-install {:req (req (= (:type target) "Agenda"))
-                            :effect (req (swap! state update-in [:corp :register :cannot-score] #(cons target %)))}}}
+                            :effect (req (swap! state update-in [:corp :register :cannot-score] #(cons target %)))}}
+    :leave-play (req (swap! state update-in [:corp :register] dissoc :cannot-score))}
 
    "Collective Consciousness"
    {:events {:rez {:req (req (= (:type target) "ICE")) :msg "draw 1 card"


### PR DESCRIPTION
Fixes #816. 

Only execute `prevent-jack-out` if it's a remote server and there are more cards than just Whirlpool in it so the server will continue to exist after Whirlpool trashes. Also added a bit to update the run position after Whirlpool trashes and the run is ongoing (because the server is still there). 

I was alerted that Clot needs a `:leave-play` for cases where the Runner installs it having missed the correct paid ability window--if pulled back to the Grip it was still preventing the Corp from scoring. 

* Bookmark no longer duplicates hosted cards when using the option to trash it and return all hosted cards to your Grip.
* Pawn no longer blocks the ability to make successful runs when hosted on non-ice and uses the card targeting system now for installs so you can do multiple installs when 2 or more Pawns advance past all ice simultaneously.
* Oversight AI tightened up to only allow targeting installed ice (could target ice in hand before)