### PR TITLE
Implement DDoS and Blackmail with turn/run flag registers

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -34,9 +34,10 @@
     :effect (effect
               (resolve-ability (register-run-flag! state :can-rez-ice
                                              (fn [state side card]
-                                               ( (constantly false)
-                                                 (system-msg state side (str "is prevented from rezzing ICE on this run by "
-                                                                             (:title card))))
+                                               (if (has? card :type "ICE")
+                                                 ( (constantly false) (system-msg state side (str "is prevented from rezzing ICE on this run by Blackmail")))
+                                                 true
+                                                 )
                                                ) card) card nil)
               (run target nil card))}
 

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -32,7 +32,7 @@
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
     :msg "prevent ICE from being rezzed during this run"
     :effect (effect
-              (resolve-ability (register-run-flag! state :can-rez-ice
+              (resolve-ability (register-run-flag! state :can-rez
                                              (fn [state side card]
                                                (if (has? card :type "ICE")
                                                  ( (constantly false) (system-msg state side (str "is prevented from rezzing ICE on this run by Blackmail")))

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -32,7 +32,7 @@
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
     :msg "prevent ICE from being rezzed during this run"
     :effect (effect
-              (resolve-ability (register-run-flag! state :no-rez-ice true card) card nil)
+              (resolve-ability (register-run-flag! state :no-rez-ice card) card nil)
               (run target nil card))}
 
    "Bribery"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -30,7 +30,10 @@
 
    "Blackmail"
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
-    :effect (effect (run target nil card))}
+    :msg "prevent ICE from being rezzed during this run"
+    :effect (effect
+              (resolve-ability (register-run-flag! state :no-rez-ice true card) card nil)
+              (run target nil card))}
 
    "Bribery"
    {:prompt "How many [Credits]?" :choices :credit

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -32,7 +32,12 @@
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
     :msg "prevent ICE from being rezzed during this run"
     :effect (effect
-              (resolve-ability (register-run-flag! state :no-rez-ice card) card nil)
+              (resolve-ability (register-run-flag! state :can-rez-ice
+                                             (fn [state side card]
+                                               ( (constantly false)
+                                                 (system-msg state side (str "is prevented from rezzing ICE on this run by "
+                                                                             (:title card))))
+                                               ) card) card nil)
               (run target nil card))}
 
    "Bribery"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -109,7 +109,7 @@
    {:abilities [{
                  :msg "prevent the corp from rezzing the outermost piece of ice during a run on any server this turn"
                  :effect (effect
-                           (resolve-ability (register-turn-flag! state :can-rez-ice
+                           (resolve-ability (register-turn-flag! state :can-rez
                                                                  (fn [state side card]
                                                                    (if (and
                                                                          (has? card :type "ICE")

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -109,7 +109,18 @@
    {:abilities [{
                  :msg "prevent the corp from rezzing the outermost piece of ice during a run on any server this turn"
                  :effect (effect
-                           (resolve-ability (register-turn-flag! state :no-rez-outermost-ice card) card nil)
+                           (resolve-ability (register-turn-flag! state :can-rez-ice
+                                                                 (fn [state side card]
+                                                                   (if (and
+                                                                         (has? card :type "ICE")
+                                                                         (= (count (get-in @state [:run :ices])) (get-in @state [:run :position]))
+                                                                         )
+                                                                     ((constantly false)
+                                                                       (system-msg state side (str "is prevented from rezzing any outermost ICE by DDoS"))
+                                                                       )
+                                                                     true
+                                                                     )
+                                                                   ) card) card nil)
                            (trash card {:cause :ability-cost}))
                  }]
     }

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -105,6 +105,15 @@
     :abilities [{:req (req tagged) :cost [:click 1] :effect (effect (mill :corp))
                  :msg "force the Corp to trash the top card of R&D"}]}
 
+   "DDoS"
+   {:abilities [{
+                 :msg "prevent the corp from rezzing the outermost piece of ice during a run on any server this turn"
+                 :effect (effect
+                           (resolve-ability (register-turn-flag! state :no-rez-outermost-ice card) card nil)
+                           (trash card {:cause :ability-cost}))
+                 }]
+    }
+
    "Decoy"
    {:prevent {:tag [:all]}
     :abilities [{:msg "avoid 1 tag" :effect (effect (tag-prevent 1) (trash card {:cause :ability-cost}))}]}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -99,9 +99,7 @@
 ;Example: Blackmail flags the current run as not allowing rezzing of ICE
 (defn register-run-flag! [state flag condition card]
   (let [stack (get-in @state [:stack :current-run flag])]
-    (if (= stack nil)
-      (swap! state assoc-in [:stack :current-run flag] (list {:card card :condition condition}))
-      (swap! state assoc-in [:stack :current-run flag] (conj stack {:card card :condition condition}))
+      (swap! state assoc-in [:stack :current-run flag] (conj stack {:card card :condition condition})
       ))
   )
 
@@ -120,7 +118,7 @@
 
 ;Clear the current run register
 (defn clear-run-register! [state]
-  (swap! state assoc-in [:register :current-run] (list))
+  (swap! state assoc-in [:stack :current-run] nil)
   )
 
 (defn register-turn-flag! [state flag card]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1559,10 +1559,9 @@
 (defn can-rez?
   ([state side card] (can-rez? state side card nil))
   ([state side card {:as args}]
-   (cond
-     (run-flag? state side card :can-rez-ice) true
-     (turn-flag? state side card :can-rez-ice) true
-     :else false)))
+   (and
+     (run-flag? state side card :can-rez-ice)
+     (turn-flag? state side card :can-rez-ice))))
 
 (defn rez
   ([state side card] (rez state side card nil))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1547,7 +1547,7 @@
                                     (system-msg state side (str "is prevented from rezzing ICE on this run by "
                                                                 (:title (run-flag state :no-rez-ice)))))
      ;DDoS
-     (and (turn-flag state :no-rez-outermost-ice) (= 1 (get-in @state [:run :position]))) ( (constantly false)
+     (and (turn-flag state :no-rez-outermost-ice) (= (count (get-in @state [:run :ices])) (get-in @state [:run :position]))) ( (constantly false)
                                                (system-msg state side (str "is prevented from rezzing outermost ice by "
                                                                            (:title (turn-flag state :no-rez-outermost-ice)))))
      :else true)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -97,7 +97,7 @@
 ;Register a flag for the current run only
 ;end-run clears this register, preventing state pollution between runs
 ;Example: Blackmail flags the current run as not allowing rezzing of ICE
-(defn register-run-flag! [state flag value card]
+(defn register-run-flag! [state flag card]
   (swap! state assoc-in [:register :current-run flag] card)
   )
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -110,6 +110,18 @@
   (swap! state assoc-in [:register :current-run] nil)
   )
 
+(defn register-turn-flag! [state flag card]
+  (swap! state assoc-in [:register :current-turn flag] card)
+  )
+
+(defn turn-flag [state flag]
+  (get-in @state [:register :current-turn flag])
+  )
+
+(defn clear-turn-register! [state]
+  (swap! state assoc-in [:register :current-turn] nil)
+  )
+
 (defn register-suppress [state side events card]
   (doseq [e events]
     (swap! state update-in [:suppress (first e)] #(conj % {:ability (last e) :card card}))))
@@ -1394,6 +1406,7 @@
       (doseq [a (get-in @state [side :register :end-turn])]
         (resolve-ability state side (:ability a) (:card a) (:targets a)))
       (swap! state assoc :end-turn true)
+      (clear-turn-register! state)
       (swap! state dissoc :turn-events))))
 
 (defn purge [state side]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1561,6 +1561,7 @@
   ([state side card {:as args}]
    (cond
      (run-flag? state side card :can-rez-ice) true
+     (turn-flag? state side card :can-rez-ice) true
      :else false)))
 
 (defn rez

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -94,6 +94,17 @@
       (swap! state assoc-in [side (first r)] 0)
       (deduce state side r))))
 
+;Register a flag for the current run only
+;Example: Blackmail flags the current run as not allowing rezzing of ICE
+(defn register-run-flag! [state flag value]
+  (swap! state assoc-in [:register :current-run flag] value)
+  )
+
+;Clear the current run register
+(defn clear-run-register! [state]
+  (swap! state assoc-in [:register :current-run] nil)
+  )
+
 (defn register-suppress [state side events card]
   (doseq [e events]
     (swap! state update-in [:suppress (first e)] #(conj % {:ability (last e) :card card}))))
@@ -467,7 +478,8 @@
               (resolve-ability state side end-run-effect (:card run-effect) [(first server)]))))
         (swap! state update-in [:runner :credit] - (get-in @state [:runner :run-credit]))
         (swap! state assoc-in [:runner :run-credit] 0)
-        (swap! state assoc :run nil))))
+        (swap! state assoc :run nil)
+        (clear-run-register! state))))
 
 (defn add-prop
   ([state side card key n] (add-prop state side card key n nil))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1586,8 +1586,8 @@
   ([state side card] (can-rez? state side card nil))
   ([state side card {:as args}]
    (and
-     (run-flag? state side card :can-rez-ice)
-     (turn-flag? state side card :can-rez-ice))))
+     (run-flag? state side card :can-rez)
+     (turn-flag? state side card :can-rez))))
 
 (defn rez
   ([state side card] (rez state side card nil))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -121,16 +121,23 @@
   (swap! state assoc-in [:stack :current-run] nil)
   )
 
-(defn register-turn-flag! [state flag card]
-  (swap! state assoc-in [:register :current-turn flag] card)
+(defn register-turn-flag! [state flag condition card]
+  (let [stack (get-in @state [:stack :current-turn flag])]
+    (swap! state assoc-in [:stack :current-turn flag] (conj stack {:card card :condition condition})
+           ))
   )
 
-(defn turn-flag [state flag]
-  (get-in @state [:register :current-turn flag])
-  )
+(defn turn-flag? [state side card flag]
+  (empty?
+    (for [
+          condition (get-in @state [:stack :current-turn flag])
+          :let [result ((:condition condition) state side card)]
+          :when (not result)
+          ]
+      [result])))
 
 (defn clear-turn-register! [state]
-  (swap! state assoc-in [:register :current-turn] nil)
+  (swap! state assoc-in [:stack :current-turn] nil)
   )
 
 (defn register-suppress [state side events card]

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -214,3 +214,30 @@
       (is (= 2 (get (refresh hive) :counter 0)) "Hivemind gained 1 counter")
       (is (= 0 (get (refresh vbg) :counter 0)) "Virus Breeding Ground lost 1 counter"))))
 
+(deftest ddos
+  "Prevent rezzing of outermost ice for the rest of the turn"
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 3)]) (default-runner [(qty "DDoS" 1)]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "DDoS")
+    (let [ddos (get-in @state [:runner :rig :resource 0])
+          iwall (get-in @state [:corp :servers :hq :ices 0])]
+      (card-ability state :runner ddos 0)
+      (is (= (:title ddos) (get-in @state [:runner :discard 0 :title]) ))
+      (core/click-run state :runner {:server "HQ"})
+      (core/rez state :corp iwall)
+      (is (not (get-in (refresh iwall) [:rezzed])))
+      (core/end-run state :runner)
+      (core/click-run state :runner {:server "HQ"})
+      (core/rez state :corp iwall)
+      (is (not (get-in (refresh iwall) [:rezzed])))
+      (core/end-run state :runner)
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (core/click-run state :runner {:server "HQ"})
+      (core/rez state :corp iwall)
+      (is (get-in (refresh iwall) [:rezzed]))
+      )))
+


### PR DESCRIPTION
This creates two new sets of automatically managed stacks of flagged conditions to be provided by card implementations. Both exist at the root of the game state. The first is a `current-turn` group- anything in `:stack :current-turn` is wiped when the current turn ends. The second is a `current-run` group- anything in `:stack :current-run` is wiped when the current run ends.  DDoS and Blackmail are implemented as demonstrations of these two stack groups.

The general idea of this is to provide hooks for conditions that are transient in nature, and generally provide negative conditions.  For example, both of the examples (DDoS and Blackmail) prevent rezzing ice temporarily.

To implement these cards, a "can-rez?" check was added to `core/rez`. This function is responsible for checking the `can-rez` stacks in current-turn and current-run groups.  If all of the conditions pass, it will allow the rezzing of the card.  In the case of DDoS and Blackmail, the functions they provide to the stack are coded to only trigger on ICE.

While only rezzing is currently using this system, it would be fairly trivial to provide hooks in other locations (such as run, install, etc).  `register-run-flag!` and `register-turn-flag!` both expect a keyword as a flag, but it can be anything.

Tests are provided for DDoS and Blackmail.