### PR TITLE
Update remaining trace messages to be descriptive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ pom.xml
 .lein-plugins/
 .repl
 .nrepl-port
+.idea/
+launch-web.bat
+mongo.bat
+netrunner.iml
 
 /resources/public/js/
 /resources/public/cljs/
@@ -19,5 +23,6 @@ pom.xml
 /resources/public/css/
 /resources/public/img/cards
 /data/andb-*.json
+/data/db
 /data/img
 /.lein-failures

--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,6 @@ pom.xml
 .lein-plugins/
 .repl
 .nrepl-port
-.idea/
-launch-web.bat
-mongo.bat
-netrunner.iml
 
 /resources/public/js/
 /resources/public/cljs/
@@ -23,6 +19,5 @@ netrunner.iml
 /resources/public/css/
 /resources/public/img/cards
 /data/andb-*.json
-/data/db
 /data/img
 /.lein-failures

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -48,7 +48,7 @@
    {:abilities [{:label "Trace 5 - Do 3 net damage"
                  :trace {:base 5 :msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}}
                 {:label "Trace 4 - Trash a program"
-                 :trace (assoc trash-program :base 4)}]}
+                 :trace (assoc trash-program :base 4 :msg "trash a program")}]}
 
    "Asteroid Belt"
    {:advanceable :always :abilities [end-the-run]

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -95,7 +95,7 @@
    {:abilities [{:label "Trace 0 - Force the Runner to trash a program"
                  :trace (assoc trash-program :base 0 :not-distinct true
                                              :player :runner
-                                             :msg (msg "force the Runner to trash " (:title target)))}]}
+                                             :msg "force the Runner to trash a program")}]}
 
    "Caduceus"
    {:abilities [{:label "Trace 3 - Gain 3 [Credits]"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -302,7 +302,7 @@
    {:effect (req (doseq [c (take 5 (:deck corp))] (move state side c :play-area)))}
 
    "Power Grid Overload"
-   {:trace {:base 2 :msg "trash 1 piece of hardware with install cost less than or equal to X"
+   {:trace {:base 2 :msg "trash 1 piece of hardware"
             :effect (req (let [max-cost (- target (second targets))]
                            (resolve-ability state side
                                             {:choices {:req #(and (has? % :type "Hardware")

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -199,8 +199,8 @@
    "Hellion Alpha Test"
    {:req (req (:installed-resource runner-reg))
     :trace {:base 2 :choices {:req #(and (:installed %) (= (:type %) "Resource"))}
-            :msg (msg "add " (:title target) " to the top of the Stack")
-            :effect (effect (move :runner target :deck {:front true}))
+            :msg "add a Resource to the top of the Stack"
+            :effect (effect (move :runner target :deck {:front true}) (system-msg (str "adds " (:title target) " to the top of the Stack")))
             :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain :corp :bad-publicity 1))}}}
 
    "Housekeeping"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -340,8 +340,8 @@
                                      :effect (effect (add-prop target :advance-counter c {:placed true}))} card nil)))}
 
    "Punitive Counterstrike"
-   {:trace {:base 5 :msg (msg "do " (or (:stole-agenda runner-reg) 0) " meat damage")
-            :effect (effect (damage :meat (or (get-in runner [:register :stole-agenda]) 0) {:card card}))}}
+   {:trace {:base 5 :msg "do meat damage equal to agenda points stolen last turn"
+            :effect (effect (damage :meat (or (get-in runner [:register :stole-agenda]) 0) {:card card}) (system-msg (str "does " (or (:stole-agenda runner-reg) 0) " meat damage")))}}
 
    "Reclamation Order"
    {:prompt "Choose a card from Archives" :msg (msg "add copies of " (:title target) " to HQ")

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -183,7 +183,7 @@
    {:trace {:base 7 :prompt "Choose 1 card to trash" :not-distinct true
             :choices {:req #(and (:installed %)
                                  (or (has? % :subtype "Virtual") (has? % :subtype "Link")))}
-            :msg (msg "trash " (:title target)) :effect (effect (trash target))}}
+            :msg "trash 1 virtual resource or link" :effect (effect (trash target) (system-msg (str "trashes " (:title target))))}}
 
    "Freelancer"
    {:req (req tagged) :msg (msg "trash " (join ", " (map :title targets)))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -431,8 +431,7 @@
     :effect (req (doseq [t targets] (rez state side t {:no-cost true})))}
 
    "Snatch and Grab"
-   {:trace {:base 3 :choices {:req #(has? % :subtype "Connection")}
-            :msg (msg "attempt to trash " (:title target))
+   {:trace {:msg "trash a connection" :base 3 :choices {:req #(has? % :subtype "Connection")}
             :effect (req (let [c target]
                            (resolve-ability
                              state side


### PR DESCRIPTION
This updates the remaining trace messages to list their effect alongside the declaration of the trace.

* Assassin
* Burke Bugs
* Foxfire
* Hellion Alpha Test
* Punitive Counterstrike
* Snatch and Grab

Also adds a trace message to Assassin's second subroutine, which it did not have.