### PR TITLE
Card fixes and improvements

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -231,8 +231,10 @@
     :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
 
    "Isabel McGuire"
-   {:abilities [{:label "Add an installed card to HQ" :choices {:req #(= (first (:zone %)) :servers)}
-                 :msg (msg "move " (:title target) " to HQ") :effect (effect (move target :hand))}]}
+   {:abilities [{:cost [:click 1] :label "Add an installed card to HQ"
+                 :choices {:req #(= (first (:zone %)) :servers)}
+                 :msg (msg "move " (if (:rezzed target) (:title target) "a card") " to HQ")
+                 :effect (effect (move target :hand))}]}
 
    "IT Department"
    {:abilities [{:counter-cost 1 :label "Add strength to a rezzed ICE"
@@ -423,11 +425,13 @@
                              (resolve-ability state side
                                               {:prompt "Remove 1 bad publicity or gain 5 [Credits]?"
                                                :choices ["Remove 1 bad publicity" "Gain 5 [Credits]"]
-                                               :msg (msg (.toLowerCase target))
+                                               :msg (msg (if (= target "Remove 1 bad publicity")
+                                                           "remove 1 bad publicity" "gain 5 [Credits]"))
                                                :effect (req (if (= target "Remove 1 bad publicity")
                                                               (lose state side :bad-publicity 1)
                                                               (gain state side :credit 5)))}
                                               card targets)))}}}
+
    "Ronald Five"
    {:events {:runner-trash {:req (req (and (= (:side target) "Corp") (> (:click runner) 0)))
                             :msg "force the runner to lose 1 [Click]" :effect (effect (lose :runner :click 1))}}}
@@ -486,7 +490,7 @@
                                                         :effect (effect (trash-cards targets))) shat nil)))}}}}
 
    "Shi.Kyū"
-   {:access 
+   {:access
     {:optional {:req (req (not= (first (:zone card)) :deck))
                 :prompt "Pay [Credits] to use Shi.Kyū?"
                 :yes-ability {:prompt "How many [Credits] for Shi.Kyū?" :choices :credit
@@ -498,7 +502,7 @@
                                 :effect (let [dmg target]
                                           (req (if (= target "Add Shi.Kyū to score area")
                                                  (do (or (move state :runner (assoc card :agendapoints -1) :scored) ; if the runner did not trash the card on access, then this will work
-                                                         (move state :runner (assoc card :agendapoints -1 :zone [:discard]) :scored)) ;if the runner did trash it, then this will work 
+                                                         (move state :runner (assoc card :agendapoints -1 :zone [:discard]) :scored)) ;if the runner did trash it, then this will work
                                                    (gain-agenda-point state :runner -1)
                                                    (system-msg state side
                                                     (str "adds Shi.Kyū to their score area as -1 agenda point")))
@@ -618,4 +622,4 @@
                               (host state side card target)
                               (rez-cost-bonus state side -2) (rez state side (last (:hosted (get-card state card))))
                               (when (:rezzed (last (:hosted (get-card state card))))
-                                (update! state side (dissoc (get-card state (last (:hosted card)) :facedown)))))}]}})
+                                (update! state side (dissoc (get-card state (last (:hosted card))) :facedown))))}]}})

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -500,13 +500,11 @@
    "Unregistered S&W 35"
    {:abilities
     [{:cost [:click 2] :req (req (some #{:hq} (:successful-run runner-reg)))
-      :label "trash a Bioroid, Clone, Executive or Sysop" :prompt "Choose a card to trash"
-      :choices (req (let [contents (mapcat :content (flatten (seq (:servers corp))))
-                          hosted (mapcat :hosted contents)]
-                      (filter #(and (:rezzed %)
-                                    (or (has? % :subtype "Bioroid") (has? % :subtype "Clone")
-                                        (has? % :subtype "Executive") (has? % :subtype "Sysop")))
-                               (concat hosted contents))))
+      :label "trash a Bioroid, Clone, Executive or Sysop" :prompt "Choose a Bioroid, Clone, Executive, or Sysop to trash"
+      :choices {:req #(and (:rezzed %)
+                           (or (has? % :subtype "Bioroid") (has? % :subtype "Clone")
+                               (has? % :subtype "Executive") (has? % :subtype "Sysop"))
+                           (or (= (last (:zone %)) :content) (= (last (:zone %)) :onhost)))}
       :msg (msg "trash " (:title target)) :effect (effect (trash target))}]}
 
    "Vigil"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -300,9 +300,6 @@
                                     (+ c (count (filter (fn [ice] (:rezzed ice)) (:ices server)))))
                                   0 (flatten (seq (:servers corp))))))}
 
-   "Precognition"
-   {:effect (req (doseq [c (take 5 (:deck corp))] (move state side c :play-area)))}
-
    "Power Grid Overload"
    {:trace {:base 2 :msg "trash 1 piece of hardware"
             :effect (req (let [max-cost (- target (second targets))]
@@ -326,6 +323,11 @@
                                                           (<= (:cost %) n))}
                                      :msg (msg "trash " (:title target)) :effect (effect (trash target))}
                                     card nil)))}
+
+   "Precognition"
+   {:effect (req (prompt! state side card
+                         (str "Drag cards from the play area back onto R&D") ["OK"] {})
+                 (doseq [c (take 5 (:deck corp))] (move state side c :play-area)))}
 
    "Predictive Algorithm"
    {:events {:pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 2]))}}}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -508,8 +508,9 @@
                                     :msg (msg "expose " (:title target))} card nil))}]}
 
    "Rolodex"
-   {:effect (req (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))
-    :leave-play (effect (mill :runner 3))}
+   {:effect (req (prompt! state side card
+                          (str "Drag cards from the play area back onto your Stack") ["OK"] {})
+                 (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -510,7 +510,7 @@
    "Rolodex"
    {:effect (req (prompt! state side card
                           (str "Drag cards from the play area back onto your Stack") ["OK"] {})
-                 (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))
+                 (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))}
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}


### PR DESCRIPTION
_Fixes_
* Isabel McGuire no longer revealing unrezzed cards returned to HQ, added missing click cost
* Fixed Worlds Plaza hosting an asset bug (misplaced closing parens)
* Fixed redundant Wanton Destruction log message
* Cleaned up Rex Campaign message when taking the credits (lowercase was making it log [credits] instead of credit symbol)

_Improvements_
* Add instructional prompts to Indexing, Precognition, and Rolodex (users are asking all the time what to do when these cards are played). 
* Changed Unregistered S&W '35 to use card targeting