### PR TITLE
Fix Blackmail/TMI interaction

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -32,13 +32,16 @@
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
     :msg "prevent ICE from being rezzed during this run"
     :effect (effect
-              (resolve-ability (register-run-flag! state :can-rez
-                                             (fn [state side card]
-                                               (if (has? card :type "ICE")
-                                                 ( (constantly false) (system-msg state side (str "is prevented from rezzing ICE on this run by Blackmail")))
-                                                 true
-                                                 )
-                                               ) card) card nil)
+              (register-run-flag!
+                          card
+                          :can-rez
+                                   (fn [state side card]
+                                     (if (has? card :type "ICE")
+                                       ( (constantly false) (system-msg state side (str "is prevented from rezzing ICE on this run by Blackmail")))
+                                       true
+                                       )
+                                     )
+                          )
               (run target nil card))}
 
    "Bribery"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -109,18 +109,20 @@
    {:abilities [{
                  :msg "prevent the corp from rezzing the outermost piece of ice during a run on any server this turn"
                  :effect (effect
-                           (resolve-ability (register-turn-flag! state :can-rez
-                                                                 (fn [state side card]
-                                                                   (if (and
-                                                                         (has? card :type "ICE")
-                                                                         (= (count (get-in @state [:run :ices])) (get-in @state [:run :position]))
-                                                                         )
-                                                                     ((constantly false)
-                                                                       (system-msg state side (str "is prevented from rezzing any outermost ICE by DDoS"))
-                                                                       )
-                                                                     true
-                                                                     )
-                                                                   ) card) card nil)
+                           (register-turn-flag!
+                                    card
+                                    :can-rez
+                                     (fn [state side card]
+                                       (if (and
+                                             (has? card :type "ICE")
+                                             (= (count (get-in @state [:run :ices])) (get-in @state [:run :position]))
+                                             )
+                                         ((constantly false)
+                                           (system-msg state side (str "is prevented from rezzing any outermost ICE by DDoS"))
+                                           )
+                                         true
+                                         )
+                                       ))
                            (trash card {:cause :ability-cost}))
                  }]
     }

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -142,7 +142,7 @@
   (swap! state assoc-in [:stack :current-run] nil)
   )
 
-(defn register-turn-flag! [state flag condition card]
+(defn register-turn-flag! [state side card flag condition]
   (let [stack (get-in @state [:stack :current-turn flag])]
     (swap! state assoc-in [:stack :current-turn flag] (conj stack {:card card :condition condition})
            ))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -118,7 +118,7 @@
 ;Register a flag for the current run only
 ;end-run clears this register, preventing state pollution between runs
 ;Example: Blackmail flags the current run as not allowing rezzing of ICE
-(defn register-run-flag! [state flag condition card]
+(defn register-run-flag! [state side card flag condition]
   (let [stack (get-in @state [:stack :current-run flag])]
       (swap! state assoc-in [:stack :current-run flag] (conj stack {:card card :condition condition})
       ))

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -114,3 +114,24 @@
       (core/rez state :corp iwall1)
       (is (get-in (refresh iwall1) [:rezzed]))
     )))
+
+(deftest blackmail-tmi-interaction
+  "Regression test for a rezzed tmi breaking game state on a blackmail run"
+  (do-game
+    (new-game (default-corp [(qty "TMI" 3)])
+              (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Blackmail" 3)]))
+    (is 1 (get-in @state [:corp :bad-publicity]))
+    (play-from-hand state :corp "TMI" "HQ")
+    (let [tmi (get-in @state [:corp :servers :hq :ices 0])]
+      (core/rez state :corp tmi)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (get-in (refresh tmi) [:rezzed]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Blackmail")
+      (prompt-choice :runner "HQ")
+      (core/no-action state :corp nil)
+      (core/continue state :runner nil)
+      (core/jack-out state :runner nil)
+      (core/click-run state :runner {:server "Archives"})
+      )))

--- a/src/clj/test/cards-ice.clj
+++ b/src/clj/test/cards-ice.clj
@@ -32,3 +32,30 @@
       (is (= (get-in @state [:corp :discard 0 :title]) "Architect"))
       (is (= (get-in @state [:corp :discard 1 :title]) "Architect"))
       )))
+
+(deftest tmi
+  "TMI ICE test"
+  (do-game
+    (new-game (default-corp [(qty "TMI" 3)])
+              (default-runner))
+    (play-from-hand state :corp "TMI" "HQ")
+    (let [tmi (get-in @state [:corp :servers :hq :ices 0])]
+      (core/rez state :corp tmi)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (get-in (refresh tmi) [:rezzed]))
+      )))
+
+
+(deftest tmi-derez
+  "TMI ICE trace derez"
+  (do-game
+    (new-game (default-corp [(qty "TMI" 3)])
+              (make-deck "Sunny Lebeau: Security Specialist" [(qty "Blackmail" 3)]))
+    (play-from-hand state :corp "TMI" "HQ")
+    (let [tmi (get-in @state [:corp :servers :hq :ices 0])]
+      (core/rez state :corp tmi)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (not (get-in (refresh tmi) [:rezzed])))
+      )))


### PR DESCRIPTION
Fixes the interaction between Blackmail and a rezzed TMI by removing the resolve-ability call in card defs and aligning the register calls with the function parameter order of most functions.