### PR TITLE
Add cursive project files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ pom.xml
 /data/andb-*.json
 /data/img
 /.lein-failures
+
+# Add entries to prevent committing IntelliJ Cursive project configs
+/.idea
+netrunner.iml


### PR DESCRIPTION
IntelliJ creates a bunch of files in the root directory of the project that should not be committed, as they are specific to that particular developer.  Ignoring them prevents multiple users of Cursive from stomping all over each other's IDE preferences.