### PR TITLE
Improvements to Sundew, Fetal AI.

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -523,7 +523,7 @@
              :effect (effect (add-prop target :advance-counter 1 {:placed true}))}}
 
    "Sundew"
-   {:events {:runner-spent-click {:req (req (not (= (:server run) (:zone card)))) :once :per-turn
+   {:events {:runner-spent-click {:req (req (not this-server)) :once :per-turn
                                   :msg "gain 2 [Credits]" :effect (effect (gain :corp :credit 2))}}}
 
    "Team Sponsorship"

--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -1,0 +1,31 @@
+(in-ns 'test.core)
+
+(deftest fetal-ai-damage
+  "Fetal AI - damage on access"
+  (do-game
+    (new-game (default-corp [(qty "Fetal AI" 3)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Diesel" 3) (qty "Quality Time" 3)]))
+    (play-from-hand state :corp "Fetal AI" "New remote")
+    (take-credits state :corp 2)
+    (core/click-run state :runner {:server :remote1})
+    (core/no-action state :corp nil)
+    (core/successful-run state :runner nil)
+    (prompt-choice :runner "Yes")
+    (is (= 3 (count (:hand (get-runner)))) "Runner took 2 net damage from Fetal AI")
+    (is (= 3 (:credit (get-runner))) "Runner paid 2cr to steal Fetal AI")
+    (is (= 1 (count (:scored (get-runner)))) "Runner stole Fetal AI")))
+
+(deftest fetal-ai-cant-afford
+  "Fetal AI - can't afford to steal"
+  (do-game
+    (new-game (default-corp [(qty "Fetal AI" 3)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Diesel" 3) (qty "Quality Time" 3)]))
+    (play-from-hand state :corp "Fetal AI" "New remote")
+    (take-credits state :corp 2)
+    (core/lose state :runner :credit 5)
+    (core/click-run state :runner {:server :remote1})
+    (core/no-action state :corp nil)
+    (core/successful-run state :runner nil)
+    (prompt-choice :runner "Yes")
+    (is (= 3 (count (:hand (get-runner)))) "Runner took 2 net damage from Fetal AI")
+    (is (= 0 (count (:scored (get-runner)))) "Runner could not steal Fetal AI")))

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -33,6 +33,38 @@
       (is (= 7 (count (:hand (get-corp)))) "Drew 2 cards")
       (is (= 1 (:click (get-corp)))))))
 
+(deftest sundew
+  "Sundew"
+  (do-game
+    (new-game (default-corp [(qty "Sundew" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Sundew" "New remote")
+    (let [sund (first (get-in @state [:corp :servers :remote1 :content]))]
+      (core/rez state :corp sund)
+      (take-credits state :corp 2)
+      (is (= 5 (:credit (get-corp))) "Cost 2cr to rez")
+      ; spend a click not on a run
+      (take-credits state :runner)
+      (is (= 7 (:credit (get-corp))) "Corp gained 2cr from Sundew")
+      (take-credits state :corp)
+      (core/click-run state :runner {:server :remote1})
+      (is (= 10 (:credit (get-corp))) "Corp did not gain 2cr from run on Sundew")
+      (is (= 3 (:click (get-runner))) "Runner spent 1 click to start run"))))
+
+;(deftest sundew-dirty-laundry
+;  "Sundew - Dirty Laundry"
+;  (do-game
+;    (new-game (default-corp [(qty "Sundew" 1)])
+;              (default-runner [(qty "Dirty Laundry" 1)]))
+;    (play-from-hand state :corp "Sundew" "New remote")
+;    (let [sund (first (get-in @state [:corp :servers :remote1 :content]))]
+;      (core/rez state :corp sund)
+;      (take-credits state :corp 2)
+;      (is (= 5 (:credit (get-corp))) "Cost 2cr to rez")
+;      ; spend a click on a run through a card, not through click-run.
+;      (play-run-event state (find-card "Dirty Laundry" (:hand (get-runner))) :remote1)
+;      (is (= 5 (:credit (get-corp))) "Corp did not gain 2cr from run on Sundew"))))
+
 (deftest team-sponsorship-hq
   "Team Sponsorship - Install from HQ"
   (do-game

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -1,5 +1,26 @@
 (in-ns 'test.core)
 
+(deftest film-critic-fetal-ai
+  "Film Critic - Fetal AI interaction"
+  (do-game
+    (new-game (default-corp [(qty "Fetal AI" 3)])
+              (default-runner [(qty "Film Critic" 1) (qty "Sure Gamble" 3)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Film Critic")
+    (let [fc (first (get-in @state [:runner :rig :resource]))]
+      (core/click-run state :runner {:server :hq})
+      (core/no-action state :corp nil)
+      (core/successful-run state :runner nil)
+      ; should not have taken damage yet
+      (is (= 3 (count (:hand (get-runner)))) "No damage dealt yet")
+      (card-ability state :runner fc 0)
+      (is (= 3 (count (:hand (get-runner)))) "No damage dealt")
+      (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+      (card-ability state :runner fc 1)
+      (is (= 1 (count (:scored (get-runner)))) "Agenda added to runner scored")
+      (is (= 3 (count (:hand (get-runner)))) "No damage dealt"))))
+
+
 (deftest kati-jones
   "Kati Jones - Click to store and take"
   (do-game

--- a/src/clj/test/cards.clj
+++ b/src/clj/test/cards.clj
@@ -1,4 +1,5 @@
 (in-ns 'test.core)
+(load "cards-agendas")
 (load "cards-assets")
 (load "cards-events")
 (load "cards-hardware")


### PR DESCRIPTION
This doesn't completely fix #301, but does improve it so that Sundew won't trigger on a click-run. Cards that trigger runs (Dirty Laundry) etc. will still grant 2credits if initiated on Sundew's server first click, but this is at least a minor improvement. I added a test for this scenario, and left one test commented out to verify the Dirty Laundry failure.

I attempted to validate a reported bug with Fetal AI dealing net damage when hosted on Film Critic, but my tests did not reproduce the issue. I did encounter an issue where choosing "Yes" to pay the 2cr to steal would cause the damage to not trigger if you did not have 2cr to pay. I fixed that and added tests.