### PR TITLE
Card fixes: 24/7 News Cycle, Mutate, Human First

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -252,12 +252,13 @@
 
    "Mutate"
    {:req (req (seq (filter (every-pred rezzed? ice?) (all-installed state :corp))))
+    :prompt "Choose a rezzed piece of ICE to trash"
     :choices {:req (every-pred rezzed? ice?)}
     :msg (msg "to trash " (:title target))
     :effect (req (let [i (ice-index state target)
                        [reveal r] (split-with (complement ice?) (get-in @state [:corp :deck]))
                        titles (->> (conj (vec reveal) (first r)) (filter identity) (map :title))]
-                   (trash state side target {:cause :ability-cost})
+                   (trash state side target {:cause :ability-cost :keep-server-alive true})
                    (when (seq titles)
                      (system-msg state side (str "reveals " (clojure.string/join ", " titles) " from R&D")))
                    (if-let [ice (first r)]

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -10,7 +10,7 @@
                                            (= (first (:zone %)) :scored)
                                            (:abilities %))}
                       :msg (msg "trigger the \"when scored\" ability of " (:title target))
-                      :effect (effect (card-init target))}
+                      :effect (effect (resolve-ability (dissoc (card-def target) :end-turn) card nil))}
                     card nil)))}
 
    "Accelerated Diagnostics"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -516,9 +516,11 @@
                  :effect (effect (run :archives
                                    {:req (req (= target :archives))
                                     :successful-run
-                                    {:msg "make a successful run on HQ"
-                                     :effect (req (swap! state assoc-in [:run :server] [:hq])
-                                                  (update-run-ice state side))}} card))}]}
+                                    {:effect (req (swap! state assoc-in [:run :server] [:hq])
+                                                  (update-run-ice state side)
+                                                  (system-msg state side
+                                                              (str "uses Sneakdoor Beta to make a successful run on HQ")))}}
+                                  card))}]}
 
    "Snitch"
    {:abilities [{:once :per-run :req (req current-ice) :msg (msg "expose " (:title current-ice))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -253,10 +253,11 @@
                                   :effect (effect (lose :click 1) (gain :credit 2))}}}
 
    "Human First"
-   {:events {:agenda-scored {:msg (msg "gain " (get-agenda-points state :runner target) " [Credits]")
-                             :effect (effect (gain :runner :credit (get-agenda-points state :runner target)))}
+   {:events {:agenda-scored {:msg (msg "gain " (get-agenda-points state :corp target) " [Credits]")
+                             :effect (effect (gain :runner :credit (get-agenda-points state :corp target)))}
              :agenda-stolen {:msg (msg "gain " (get-agenda-points state :runner target) " [Credits]")
                              :effect (effect (gain :credit (get-agenda-points state :runner target)))}}}
+
    "Hunting Grounds"
    {:abilities [{:label "Prevent a \"when encountered\" ability on a piece of ICE"
                  :msg "prevent a \"when encountered\" ability on a piece of ICE"

--- a/src/clj/test/cards-operations.clj
+++ b/src/clj/test/cards-operations.clj
@@ -42,4 +42,6 @@
       (prompt-card :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 1 (:agenda-point (get-corp))) "Forfeited Breaking News")
       (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
-      (is (= 2 (:tag (get-runner))) "Runner given 2 tags"))))
+      (is (= 2 (:tag (get-runner))) "Runner given 2 tags")
+      (take-credits state :corp 2)
+      (is (= 2 (:tag (get-runner))) "Tags remained after Corp ended turn"))))


### PR DESCRIPTION
* Fix #961: 24/7 News Cycle tags given from Breaking News remain when the Corp turn ends; updated unit test
* Fix #958: Human First now gives the Runner 3 credits when the Corp scores Global Food Initiative
* Fix #957: Mutate to use `:keep-server-alive` so it won't bug the game when you trash ice that is the only card in a server

Also added a small tweak to Sneakdoor Beta so its log message will read right when the run is successful. 