### PR TITLE
Checks if cards have subtype before re-find

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1465,8 +1465,9 @@
         (doseq [card (concat rig-cards hosted-cards hosted-on-ice)]
           ;Clear the added-virus-counter flag for each virus in play.
           ;We do this even on the corp's turn to prevent shenanigans with something like Gorman Drip and Surge
+          (if-not (nil? (:subtype card))
           (when (re-find #"Virus" (:subtype card))
-            (set-prop state :runner card :added-virus-counter false))))
+            (set-prop state :runner card :added-virus-counter false)))))
       (swap! state assoc :end-turn true)
       (clear-turn-register! state)
       (swap! state dissoc :turn-events))))


### PR DESCRIPTION
fixes https://github.com/mtgred/netrunner/issues/962

When all the cards have their subtypes checked, any cards without a subtype would return nil, which would lock the game up as you click "End turn".

This adds a small check to see if the card has a subtype. If not, then there is no need to check if it has the word "Virus" within the subtype.