### PR TITLE
Tests for Scorched Earth, The Cleaners

### DIFF
--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -61,10 +61,8 @@
     (new-game (default-corp [(qty "The Cleaners" 1) (qty "Scorched Earth" 1)])
               (default-runner [(qty "Sure Gamble" 3) (qty "Diesel" 3)]))
     (play-from-hand state :corp "The Cleaners" "New remote")
-    (core/gain state :corp :click 5 :credit 5)
     (let [clean (first (get-in @state [:corp :servers :remote1 :content]))]
-      (advance-card clean 5)
-      (core/score state :corp {:card (refresh clean)})
+      (score-agenda state :corp clean)
       (core/gain state :runner :tag 1)
       (play-from-hand state :corp "Scorched Earth")
       (is (= 0 (count (:hand (get-runner)))) "5 damage dealt to Runner"))))

--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -29,3 +29,17 @@
     (prompt-choice :runner "Yes")
     (is (= 3 (count (:hand (get-runner)))) "Runner took 2 net damage from Fetal AI")
     (is (= 0 (count (:scored (get-runner)))) "Runner could not steal Fetal AI")))
+
+(deftest the-cleaners
+  "The Cleaners - Bonus damage"
+  (do-game
+    (new-game (default-corp [(qty "The Cleaners" 1) (qty "Scorched Earth" 1)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Diesel" 3)]))
+    (play-from-hand state :corp "The Cleaners" "New remote")
+    (core/gain state :corp :click 5 :credit 5)
+    (let [clean (first (get-in @state [:corp :servers :remote1 :content]))]
+      (advance-card clean 5)
+      (core/score state :corp {:card (refresh clean)})
+      (core/gain state :runner :tag 1)
+      (play-from-hand state :corp "Scorched Earth")
+      (is (= 0 (count (:hand (get-runner)))) "5 damage dealt to Runner"))))

--- a/src/clj/test/cards-operations.clj
+++ b/src/clj/test/cards-operations.clj
@@ -43,3 +43,32 @@
       (is (= 1 (:agenda-point (get-corp))) "Forfeited Breaking News")
       (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner given 2 tags"))))
+
+(deftest scorched-earth
+  "Scorched Earth - burn 'em"
+  (do-game
+    (new-game (default-corp [(qty "Scorched Earth" 1)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
+    (core/gain state :runner :tag 1)
+    (play-from-hand state :corp "Scorched Earth")
+    (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")))
+
+(deftest scorched-earth-no-tag
+  "Scorched Earth - not tagged"
+  (do-game
+    (new-game (default-corp [(qty "Scorched Earth" 1)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
+    (play-from-hand state :corp "Scorched Earth")
+    (is (= 3 (:click (get-corp))) "Corp not charged a click")
+    (is (= 5 (count (:hand (get-runner)))) "Runner did not take damage")))
+
+(deftest scorched-earth-flatline
+  "Scorched Earth - murderize 'em"
+  (do-game
+    (new-game (default-corp [(qty "Scorched Earth" 1)])
+              (default-runner))
+    (core/gain state :runner :tag 1)
+    (play-from-hand state :corp "Scorched Earth")
+    (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+    (is (= :corp (:winner @state)) "Corp wins")
+    (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))

--- a/src/clj/test/macros.clj
+++ b/src/clj/test/macros.clj
@@ -8,4 +8,7 @@
          ~'refresh (fn [~'card] (core/get-card ~'state ~'card))
          ~'prompt-choice (fn [~'side ~'choice] (core/resolve-prompt ~'state ~'side {:choice (~'refresh ~'choice)}))
          ~'prompt-card (fn [~'side ~'card] (core/resolve-prompt ~'state ~'side {:card (~'refresh ~'card)}))
-         ~'prompt-select (fn [~'side ~'card] (core/select ~'state ~'side {:card (~'refresh ~'card)}))] ~@body))
+         ~'prompt-select (fn [~'side ~'card] (core/select ~'state ~'side {:card (~'refresh ~'card)}))
+         ~'advance-card (fn [~'card ~'count]
+                          (dotimes [~'n ~'count]
+                            (core/advance ~'state :corp {:card (~'refresh ~'card)})))] ~@body))

--- a/src/clj/test/macros.clj
+++ b/src/clj/test/macros.clj
@@ -8,7 +8,5 @@
          ~'refresh (fn [~'card] (core/get-card ~'state ~'card))
          ~'prompt-choice (fn [~'side ~'choice] (core/resolve-prompt ~'state ~'side {:choice (~'refresh ~'choice)}))
          ~'prompt-card (fn [~'side ~'card] (core/resolve-prompt ~'state ~'side {:card (~'refresh ~'card)}))
-         ~'prompt-select (fn [~'side ~'card] (core/select ~'state ~'side {:card (~'refresh ~'card)}))
-         ~'advance-card (fn [~'card ~'count]
-                          (dotimes [~'n ~'count]
-                            (core/advance ~'state :corp {:card (~'refresh ~'card)})))] ~@body))
+         ~'prompt-select (fn [~'side ~'card] (core/select ~'state ~'side {:card (~'refresh ~'card)}))]
+     ~@body))

--- a/src/clj/test/utils.clj
+++ b/src/clj/test/utils.clj
@@ -5,8 +5,10 @@
 (defn load-card [title]
   (let [conn (mg/connect {:host "127.0.0.1" :port 27017})
         db (mg/get-db conn "netrunner")
-        card (mc/find-maps db "cards" {:title title})]
-    (first card)))
+        card (mc/find-maps db "cards" {:title title})
+        ret (first card)]
+    (mg/disconnect conn)
+    ret))
 
 (defn make-deck [identity deck]
   {:identity identity :deck deck})


### PR DESCRIPTION
Damage has broken once or twice in the past, so I wrote some tests for Scorched Earth and The Cleaners.

I also fixed the testing framework's `load-card` method to close the database connection when finished. Whoops.

Needs @dersam's Pull Request #966 for the `score-agenda` method.