### PR TITLE
implement Gyri Labyrinth and Valley Grid

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -267,6 +267,17 @@
                  :trace {:base 7 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]
     :strength-bonus (req (if (= (second (:zone card)) :rd) 3 0))}
 
+   "Gyri Labyrinth"
+   {:abilities [{:req (req (:run @state))
+                 :label "Reduce Runner's maximum hand size by 2 until start of next Corp turn"
+                 :msg "reduce the Runner's maximum hand size by 2 until the start of the next Corp turn"
+                 :effect (effect (lose :runner :max-hand-size 2)
+                                 (register-events {:corp-turn-begins
+                                                   {:msg "increase the Runner's maximum hand size by 2"
+                                                    :effect (effect (gain :runner :max-hand-size 2)
+                                                                    (unregister-events card))}} card))}]
+    :events {:corp-turn-begins nil}}
+
    "Hadrians Wall"
    {:advanceable :always
     :abilities [end-the-run]

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -306,6 +306,26 @@
                                 (has? current-ice :subtype "Bioroid"))) :effect (effect (trash card))
                  :msg (msg "prevent a subroutine on " (:title current-ice) " from being broken")}]}
 
+   "Valley Grid"
+   {:abilities [{:req (req this-server)
+                 :label "Reduce Runner's maximum hand size by 1 until start of next Corp turn"
+                 :msg "reduce the Runner's maximum hand size by 1 until the start of the next Corp turn"
+                 :effect (req (update! state side (assoc card :times-used (inc (get card :times-used 0))))
+                              (lose state :runner :max-hand-size 1))}]
+    :trash-effect {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
+                   :effect (req (when-let [n (:times-used card)]
+                                  (register-events state side
+                                                   {:corp-turn-begins
+                                                    {:msg (msg "increase the Runner's maximum hand size by " n)
+                                                     :effect (effect (gain :runner :max-hand-size n)
+                                                                     (unregister-events card)
+                                                                     (update! (dissoc card :times-used)))}}
+                                                   (assoc card :zone '(:discard)))))}
+    :events {:corp-turn-begins {:req (req (:times-used card))
+                                :msg (msg "increase the Runner's maximum hand size by " (:times-used card))
+                                :effect (effect (gain :runner :max-hand-size (:times-used card))
+                                                (update! (dissoc card :times-used)))}}}
+
    "Will-o-the-Wisp"
    {:abilities [{:label "[Trash]: Add an icebreaker to the bottom of Stack"
                  :choices {:req #(has? % :subtype "Icebreaker")}


### PR DESCRIPTION
Gyri Labyrinth has one small shortcoming in that it won't bump the Runner's max hand size back up in the somewhat unlikely event that it gets derezzed or trashed in between when the subroutine fires and the start of the next Corp turn. Possible causes would be death by Parasite, Emergency Shutdown, Crescentus, etc. In this case the Runner would need to adjust max hand size manually. 

Valley Grid, on the other hand, will store the number of times the Corp uses it and then increase the Runner's max hand size accordingly even if the Runner trashes it. 