### PR TITLE
Installing from archives message consistency

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -97,7 +97,8 @@
                               :effect (req (corp-install state side target
                                             (last (get-remote-names @state)) {:no-install-cost true})
                                            (when (< n 2)
-                                             (resolve-ability state side (dpp (inc n)) card nil)))})]
+                                             (resolve-ability state side (dpp (inc n)) card nil)))
+                              :msg (msg (corp-install-msg target))})]
      {:optional {:prompt "Create a new remote server?"
                  :yes-ability {:prompt "Select a card to install"
                                :show-discard true

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -539,7 +539,7 @@
                  :prompt "Choose a card from Archives or HQ to install" :show-discard true
                  :choices {:req #(and (not= (:type %) "Operation")
                                       (#{[:hand] [:discard]} (:zone %)))}
-                 :msg (msg "install " (if (:seen target) (:title target) "an unseen card") (if (= (:zone target) [:hand]) " from HQ" " from Archives"))
+                 :msg (msg "install " (if (:seen target) (:title target) "an unseen card") " from " (name-zone :corp (:zone target)))
                  :effect (effect (corp-install target nil {:no-install-cost true})
                                  (update! (dissoc (get-card state card) :ts-active)))}]}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -539,7 +539,7 @@
                  :prompt "Choose a card from Archives or HQ to install" :show-discard true
                  :choices {:req #(and (not= (:type %) "Operation")
                                       (#{[:hand] [:discard]} (:zone %)))}
-                 :msg (msg "install " (if (:seen target) (:title target) "an unseen card") " from " (name-zone :corp (:zone target)))
+                 :msg (msg (corp-install-msg target))
                  :effect (effect (corp-install target nil {:no-install-cost true})
                                  (update! (dissoc (get-card state card) :ts-active)))}]}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -539,7 +539,7 @@
                  :prompt "Choose a card from Archives or HQ to install" :show-discard true
                  :choices {:req #(and (not= (:type %) "Operation")
                                       (#{[:hand] [:discard]} (:zone %)))}
-                 :msg (msg "install " (if (:seen target) (:title target) "an unseen card"))
+                 :msg (msg "install " (if (:seen target) (:title target) "an unseen card") (if (= (:zone target) [:hand]) " from HQ" " from Archives"))
                  :effect (effect (corp-install target nil {:no-install-cost true})
                                  (update! (dissoc (get-card state card) :ts-active)))}]}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -142,13 +142,14 @@
                  :effect (effect (damage :net (:memory runner) {:card card}))}]}
 
    "Crick"
-   {:abilities [{:msg (msg (corp-install-msg target))
-                  :prompt "Choose a card to install from Archives"
-                  :show-discard true :priority true
-                  :choices {:req #(and (not= (:type %) "Operation")
-                                       (#{[:hand] [:discard]} (:zone %))
-                                       (= (:side %) "Corp"))}
-                  :effect (effect (corp-install target nil))}]
+   {:abilities [{:label "install a card from Archives"
+                 :msg (msg (corp-install-msg target))
+                 :prompt "Choose a card to install from Archives"
+                 :show-discard true :priority true
+                 :choices {:req #(and (not= (:type %) "Operation")
+                                      (= (:zone %) [:discard])
+                                      (= (:side %) "Corp"))}
+                 :effect (effect (corp-install target nil))}]
     :strength-bonus (req (if (= (second (:zone card)) :archives) 3 0))}
 
    "Curtain Wall"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -39,7 +39,7 @@
                                       (#{[:hand] [:discard]} (:zone %))
                                       (= (:side %) "Corp"))}
                  :effect (effect (corp-install target nil))
-                 :msg (msg "install a card from " (zone->name (central->zone (:zone target))))}]}
+                 :msg (msg (corp-install-msg target))}]}
 
    "Ashigaru"
    {:abilities [end-the-run]}
@@ -142,7 +142,7 @@
                  :effect (effect (damage :net (:memory runner) {:card card}))}]}
 
    "Crick"
-   {:abilities [{:msg "install a card from Archives"
+   {:abilities [{:msg (msg (corp-install-msg target))
                   :prompt "Choose a card to install from Archives"
                   :show-discard true :priority true
                   :choices {:req #(and (not= (:type %) "Operation")

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -216,7 +216,8 @@
     :choices {:req #(and (not= (:type %) "Operation")
                          (= (:side %) "Corp")
                          (#{[:hand] [:discard]} (:zone %)))}
-    :effect (effect (corp-install target nil {:no-install-cost true}))}
+    :effect (effect (corp-install target nil {:no-install-cost true}))
+    :msg (msg "install " (if (:seen target) (:title target) "an unseen card") (if (= (:zone target) [:hand]) " from HQ" " from Archives"))}
 
    "Invasion of Privacy"
    {:trace {:base 2 :msg "reveal the Runner's Grip and trash up to X resources or events"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -217,7 +217,7 @@
                          (= (:side %) "Corp")
                          (#{[:hand] [:discard]} (:zone %)))}
     :effect (effect (corp-install target nil {:no-install-cost true}))
-    :msg (msg "install " (if (:seen target) (:title target) "an unseen card") (if (= (:zone target) [:hand]) " from HQ" " from Archives"))}
+    :msg (msg "install " (if (:seen target) (:title target) "an unseen card") " from " (name-zone :corp (:zone target)))}
 
    "Invasion of Privacy"
    {:trace {:base 2 :msg "reveal the Runner's Grip and trash up to X resources or events"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -78,7 +78,7 @@
    {:prompt "Choose a card from Archives to add to HQ" :show-discard true
     :choices {:req #(and (= (:side %) "Corp") (= (:zone %) [:discard]))}
     :effect (effect (move target :hand)
-                    (system-msg (str "adds " (if (:seen target) (:title target) "a card") " to HQ")))}
+                    (system-msg (str "adds " (if (:seen target) (:title target) "an unseen card") " to HQ")))}
 
    "Back Channels"
    {:prompt "Choose an installed card in a server to trash" :choices {:req #(= (last (:zone %)) :content)}
@@ -217,7 +217,7 @@
                          (= (:side %) "Corp")
                          (#{[:hand] [:discard]} (:zone %)))}
     :effect (effect (corp-install target nil {:no-install-cost true}))
-    :msg (msg "install " (if (:seen target) (:title target) "an unseen card") " from " (name-zone :corp (:zone target)))}
+    :msg (msg (corp-install-msg target))}
 
    "Invasion of Privacy"
    {:trace {:base 2 :msg "reveal the Runner's Grip and trash up to X resources or events"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1766,6 +1766,9 @@
     [:servers :remote id _] (str "Remote Server " id)
     :else nil))
 
+(defn corp-install-msg [card]
+  (str "install " (if (:seen card) (:title card) "an unseen card") " from " (name-zone :corp (:zone card))))
+
 (defn move-card [state side {:keys [card server]}]
   (let [c (update-in card [:zone] #(map to-keyword %))
         last-zone (last (:zone c))


### PR DESCRIPTION
Improved archives install message consistency of following cards: 

Interns
Team Sponsorship
Crick
Architect
Director Haas' Pet Project
Archived Memories

also fixed Crick being able to install from HQ