### PR TITLE
Make Heinlein Grid manually triggered, fix Mr. Li

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -347,7 +347,7 @@
                                          (:title (first (:deck runner)))) ["OK"] {}))}}}
    "Mr. Li"
    {:abilities [{:cost [:click 1] :prompt "Card to keep?"
-                 :choices (req (take 2 (:deck runner))) :msg "choose 1 card to draw"
+                 :choices (req (take 2 (:deck runner))) :not-distinct true :msg "choose 1 card to draw"
                  :effect (req (move state side target :hand)
                               (if (= target (first (:deck runner)))
                                 (move state side (second (:deck runner)) :deck)

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -117,17 +117,10 @@
                                 :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Heinlein Grid"
-   {:effect (req (add-watch state (keyword (str "heinlein" (:cid card)))
-                   (fn [k ref old new]
-                     (let [clicknew (get-in new [:runner :click])
-                           clickold (get-in old [:runner :click])]
-                       (when (< clicknew clickold)
-                         (resolve-ability ref side
-                           {:req (req this-server)
-                            :msg (msg "force the Runner to lose all " (:credit runner) " [Credits]") :once :per-run
-                            :effect (effect (lose :runner :credit :all))}
-                          card nil))))))
-    :leave-play (req (remove-watch state (keyword (str "heinlein" (:cid card)))))}
+   {:abilities [{:req (req this-server)
+                 :label "Force the Runner to lose all [Credits] from spending or losing a [Click]"
+                 :msg (msg "force the Runner to lose all " (:credit runner) " [Credits]") :once :per-run
+                 :effect (effect (lose :runner :credit :all))}]}
 
    "Hokusai Grid"
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"


### PR DESCRIPTION
Heinlein Grid is proving too problematic in fully automated form, because the watch state will wrongly zero out the Runner's credits when the Grid is already rezzed and the Runner initiates a run on its server. 

Added a small fix for #987 so Mr. Li will show both card titles when he draws 2 copies of the same card. 