### PR TITLE
Tweak corp spend msg when installing ice

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1661,10 +1661,11 @@
                      (system-msg state side (str "trashes " (if (:rezzed prev-card)
                                                               (:title prev-card) "a card") " in " server))
                      (trash state side prev-card {:keep-server-alive true})))
-                 (let [card-name (if (or (= :rezzed-no-cost install-state) (= :face-up install-state) (:rezzed c))
-                                   (:title card) "a card")]
+                 (let [is-ice (= (:type c) "ICE")
+                       card-name (if (or (= :rezzed-no-cost install-state) (= :face-up install-state) (:rezzed c))
+                                   (:title card) (if is-ice "ice" "a card"))]
                    (system-msg state side (str (build-spend-msg cost-str "install")
-                                                card-name " in " server)))
+                                                card-name (if is-ice " protecting " " in ") server)))
                  (let [moved-card (move state side c slot)]
                    (trigger-event state side :corp-install moved-card)
                    (when (= (:type c) "Agenda")


### PR DESCRIPTION
This is just a small tweak to change the system message when the Corp installs ice. Previously it would say "spends [Click] to install a card in {server}", which isn't really correct since ice are protecting servers, not in them. This makes it say "spends [Click] to install ice protecting {server}", which seems better to me, feel free to ignore if you disagree or this broke something else :grin:

Screenshot:

![screen shot 2015-12-14 at 11 30 37 pm](https://cloud.githubusercontent.com/assets/2532521/11803092/f633b3cc-a2bc-11e5-920f-fdeea9024118.jpg)
