### PR TITLE
Have Kit update altered ICE and be able to match strength with an icebreaker

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -28,7 +28,8 @@
               :events (merge (:events cdef)
                              {:run breaker-auto-pump :pass-ice breaker-auto-pump
                               :run-ends breaker-auto-pump :ice-strength-changed breaker-auto-pump
-                              :breaker-strength-changed breaker-auto-pump :approach-ice breaker-auto-pump })))
+                              :ice-subtype-changed breaker-auto-pump :breaker-strength-changed breaker-auto-pump
+                              :approach-ice breaker-auto-pump })))
 
 (defn cloud-icebreaker [cdef]
   (assoc cdef :effect (req (add-watch state (keyword (str "cloud" (:cid card)))

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -297,7 +297,10 @@
                                                                     (join " - "))))
                                 (register-events state side {:run-ends
                                                              {:effect (effect (update! (assoc ice :subtype stypes))
-                                                                              (unregister-events card))}} card)))}]
+                                                                              (unregister-events card))}} card)
+                                (update-ice-strength state side ice)
+                                (update-run-ice state side)
+                                (trigger-event state side :ice-subtype-changed)))}]
     :events {:run-ends nil}}
 
    "Silhouette: Stealth Operative"


### PR DESCRIPTION
When Kit uses her ability to change an encountered ice and make it gain Code Gate, we should update the run ice and update the ice strength (extreme corner case of the ice suddenly getting a strength boost from a scored Encrypted Portals!). 

This also adds a new event trigger so Kit can now successfully match strength with an installed Decoder after changing the ice. 