### PR TITLE
Enables access selection for Hades Shard

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -240,7 +240,7 @@
    {:abilities [{:msg "access all cards in Archives"
                  :effect (req (trash state side card {:cause :ability-cost})
                               (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
-                              (handle-access state side (get-in @state [:corp :discard])))}]
+                              (resolve-ability state :runner (choose-access (get-in @state [:corp :discard]) '(:archives)) card nil))}]
     :install-cost-bonus (req (if (and run (= (:server run) [:archives]) (= 0 (:position run)))
                                [:credit -7 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:archives]) (= 0 (:position run)))


### PR DESCRIPTION
Using Hades Shard now brings up selection choice like normal Archives access, and correctly works with Haarpsichord (can only steal one agenda). (Fixes half of #902).

Tried to get stealing on Corp turn to work but couldn't find a work-around for prevent-steal disabling taking agendas.