### PR TITLE
Notification on unable to pay cost

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -528,7 +528,7 @@
                      {:prompt "Choose a program to install from your grip or heap" :show-discard true
                       :choices {:req #(and (= (:type %) "Program")
                                            (#{[:hand] [:discard]} (:zone %))
-                                           (can-pay? st si (modified-install-cost st si % [:credit tcost])))}
+                                           (can-pay? st si (:title %) (modified-install-cost st si % [:credit tcost])))}
                       :effect (effect (install-cost-bonus [:credit (- (:cost trashed))])
                                       (runner-install target))
                       :msg (msg "trash " (:title trashed) " and install " (:title target))} card nil)))}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -610,7 +610,7 @@
                    (host state side (get-card state card) c {:facedown true})))
     :abilities [{:prompt "Choose a card on Street Peddler to install"
                  :choices (req (cancellable (filter #(and (not= (:type %) "Event")
-                                                          (can-pay? state side (modified-install-cost state side % [:credit -1])))
+                                                          (can-pay? state side (:title %) (modified-install-cost state side % [:credit -1])))
                                                     (:hosted card))))
                  :msg (msg "install " (:title target) " lowering its install cost by 1 [Credits]")
                  :effect (effect
@@ -670,7 +670,7 @@
                  :effect (effect (host card target)) :msg (msg "host " (:title target) "")}]
     :events {:runner-turn-begins
              {:prompt "Choose a card on The Supplier to install"
-              :choices (req (let [hosted (filter #(can-pay? state side (modified-install-cost state side % [:credit -2]))
+              :choices (req (let [hosted (filter #(can-pay? state side (:title %) (modified-install-cost state side % [:credit -2]))
                                                  (:hosted card))]
                               (if (empty? hosted)
                                 hosted (conj hosted "No install"))))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -64,6 +64,19 @@
 (defn can-pay? [state side pay-for & args]
   (let [costs (merge-costs (remove #(or (nil? %) (= % [:forfeit])) args))
         forfeit-cost (some #{[:forfeit] :forfeit} args)
+        scored (get-in @state [side :scored])
+        can-pay-prompt (fn [msg] (do (prompt! state side nil msg ["OK"] {}) false))]
+    (if (and (every? #(let [value (last %)
+                            attr (first %)
+                            cover-cost? (>= (- (get-in @state [side attr]) value) 0)]
+                        (if (= attr :memory) ;; memoryunits may be negative
+                            (do (when-not cover-cost? (can-pay-prompt (str "Above memory limit after installing " pay-for))) true)
+                            (if cover-cost? true
+                                (can-pay-prompt (str "Unable to pay " (cost-names value attr) " for " pay-for)))))
+                       costs)
+             (if (or (not forfeit-cost) (not (empty? scored))) true
+                 (can-pay-prompt (str "Unable to forfeit an Agenda for " pay-for))))
+        {:costs costs, :forfeit-cost forfeit-cost, :scored scored})))
 
 (defn build-spend-msg
   ([cost-str verb] (build-spend-msg cost-str verb nil))
@@ -83,6 +96,7 @@
     cost-name))
 
 (defn pay [state side card & args]
+  (when-let [{:keys [costs forfeit-cost scored]} (can-pay? state side (:title card) args)]
     (when forfeit-cost
          (if (= (count scored) 1)
            (forfeit state side (first scored))
@@ -1115,6 +1129,7 @@
                       (if (pos? (count cost))
                         (optional-ability state :runner c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
                                           {:yes-ability
+                                            {:effect (req (if (can-pay? state side (:title c) cost)
                                                             (do (pay state side nil cost)
                                                                 (system-msg state side (str "pays " (costs-to-symbol cost)
                                                                                       " to steal " (:title c)))
@@ -1134,6 +1149,7 @@
                     (if-let [trash-cost (trash-cost state side c)]
                       (let [card (assoc c :seen true)]
                         (if (and (get-in @state [:runner :register :force-trash])
+                                 (can-pay? state :runner (:title c) :credit trash-cost))
                           (resolve-ability state :runner {:cost [:credit trash-cost]
                                                           :effect (effect (trash card)
                                                                           (system-msg (str "is forced to pay " trash-cost
@@ -1418,6 +1434,7 @@
              (get-in cdef [:abilities ability]))
         cost (:cost ab)]
     (when (or (nil? cost)
+              (can-pay? state side (:title card) cost))
         (when-let [activatemsg (:activatemsg ab)] (system-msg state side activatemsg))
         (resolve-ability state side ab card targets))))
 
@@ -1790,6 +1807,7 @@
         nil))))
 
 (defn click-run [state side {:keys [server] :as args}]
+  (when (and (not (get-in @state [:runner :register :cannot-run])) (can-pay? state :runner "Run" nil :click 1))
     (system-msg state :runner (str "makes a run on " server))
     (run state side server)
     (pay state :runner nil :click 1)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -54,15 +54,16 @@
 (declare prompt! forfeit trigger-event handle-end-run trash update-advancement-cost update-all-advancement-costs
          update! get-card update-all-ice update-ice-strength update-breaker-strength all-installed resolve-steal-events)
 
-(defn can-pay? [state side & args]
+(defn cost-names [value attr]
+  (when (> value 0)
+    (case attr
+      :credit (str value " [$]")
+      :click  (->> "[Click]" repeat (take value) (apply str))
+      nil)))
+
+(defn can-pay? [state side pay-for & args]
   (let [costs (merge-costs (remove #(or (nil? %) (= % [:forfeit])) args))
         forfeit-cost (some #{[:forfeit] :forfeit} args)
-        scored (get-in @state [side :scored])]
-    (if (and (every? #(or (>= (- (get-in @state [side (first %)]) (last %)) 0)
-                          (= (first %) :memory)) ;; memoryunits may be negative
-                     costs)
-             (or (not forfeit-cost) (not (empty? scored))))
-      {:costs costs, :forfeit-cost forfeit-cost, :scored scored})))
 
 (defn build-spend-msg
   ([cost-str verb] (build-spend-msg cost-str verb nil))
@@ -71,13 +72,6 @@
             (= "" cost-str))
       (str (or verb2 (str verb "s")) " ")
       (str "spends " cost-str " to " verb " "))))
-
-(defn cost-names [value attr]
-  (when (> value 0)
-    (case attr
-      :credit (str value " [$]")
-      :click  (->> "[Click]" repeat (take value) (apply str))
-      nil)))
 
 (defn deduce [state side [attr value]]
   (swap! state update-in [side attr] (if (= attr :memory)
@@ -89,7 +83,6 @@
     cost-name))
 
 (defn pay [state side card & args]
-  (when-let [{:keys [costs forfeit-cost scored]} (apply can-pay? state side args)]
     (when forfeit-cost
          (if (= (count scored) 1)
            (forfeit state side (first scored))
@@ -1122,7 +1115,6 @@
                       (if (pos? (count cost))
                         (optional-ability state :runner c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
                                           {:yes-ability
-                                            {:effect (req (if (can-pay? state side cost)
                                                             (do (pay state side nil cost)
                                                                 (system-msg state side (str "pays " (costs-to-symbol cost)
                                                                                       " to steal " (:title c)))
@@ -1142,7 +1134,6 @@
                     (if-let [trash-cost (trash-cost state side c)]
                       (let [card (assoc c :seen true)]
                         (if (and (get-in @state [:runner :register :force-trash])
-                                 (can-pay? state :runner :credit trash-cost))
                           (resolve-ability state :runner {:cost [:credit trash-cost]
                                                           :effect (effect (trash card)
                                                                           (system-msg (str "is forced to pay " trash-cost
@@ -1427,7 +1418,6 @@
              (get-in cdef [:abilities ability]))
         cost (:cost ab)]
     (when (or (nil? cost)
-              (apply can-pay? state side cost))
         (when-let [activatemsg (:activatemsg ab)] (system-msg state side activatemsg))
         (resolve-ability state side ab card targets))))
 
@@ -1800,7 +1790,6 @@
         nil))))
 
 (defn click-run [state side {:keys [server] :as args}]
-  (when (and (not (get-in @state [:runner :register :cannot-run])) (can-pay? state :runner nil :click 1))
     (system-msg state :runner (str "makes a run on " server))
     (run state side server)
     (pay state :runner nil :click 1)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1511,8 +1511,8 @@
                             (get-in @state [side :register :cannot-play-current])))
                   (not (and (has? card :subtype "Priority")
                             (get-in @state [side :register :spent-click]))))
-         (when-let [cost-str (pay state side card :credit (:cost card) extra-cost
-                              (when-not no-additional-cost additional-cost))]
+         (when-let [cost-str (pay state side card (concat [:credit (:cost card)] extra-cost
+                              (when-not no-additional-cost additional-cost)))]
            (let [c (move state side (assoc card :seen true) :play-area)]
              (system-msg state side (str (build-spend-msg cost-str "play") title))
              (trigger-event state side (if (= side :corp) :play-operation :play-event) c)

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -79,13 +79,13 @@
 (deftest street-peddler-ability
   "Street Peddler - Ability"
   (do-game
-    (new-game (default-corp) (default-runner [(qty "Street Peddler" 1) (qty "Gordian Blade" 1) (qty "Torch" 1)
+    (new-game (default-corp) (default-runner [(qty "Street Peddler" 1) (qty "Gordian Blade" 1) (qty "Yog.0" 1)
                                               (qty "Sure Gamble" 2)]))
     (take-credits state :corp)
     ; move Gordian back to deck
     (core/move state :runner (find-card "Gordian Blade" (:hand (get-runner))) :deck)
     (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
-    (core/move state :runner (find-card "Torch" (:hand (get-runner))) :deck)
+    (core/move state :runner (find-card "Yog.0" (:hand (get-runner))) :deck)
     (play-from-hand state :runner "Street Peddler")
     (let [sp (get-in @state [:runner :rig :resource 0])]
       (is (= 3 (count (:hosted sp))) "Street Peddler is hosting 3 cards")


### PR DESCRIPTION
(The next instalment in my UI bloating series…)

Prompts a warning / notification if player tries to do an action or ability that they cannot pay for.

Displays card that asked and the cost unable to pay.

Attempts to alleviate #842. Discuss! :smile: