### PR TITLE
Fix for /counter command and Public Support interaction

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -401,7 +401,7 @@
    {:effect (effect (add-prop card :counter 3))
     :events {:corp-turn-begins
              {:effect (req (add-prop state side card :counter -1)
-                           (when (<= (:counter card) 1)
+                           (when (= (:counter card) 1)
                              (system-msg state :corp "adds Public Support to his scored area and gains 1 agenda point")
                              (as-agenda state :corp (dissoc card :counter) 1)))} }}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -401,7 +401,7 @@
    {:effect (effect (add-prop card :counter 3))
     :events {:corp-turn-begins
              {:effect (req (add-prop state side card :counter -1)
-                           (when (= (:counter card) 1)
+                           (when (<= (:counter card) 1)
                              (system-msg state :corp "adds Public Support to his scored area and gains 1 agenda point")
                              (as-agenda state :corp (dissoc card :counter) 1)))} }}
 
@@ -422,7 +422,7 @@
    {:effect (effect (add-prop card :counter 3))
     :events {:corp-turn-begins
              {:effect (req (add-prop state side card :counter -1)
-                           (when (= (:counter card) 1)
+                           (when (<= (:counter card) 1)
                              (trash state side card)
                              (resolve-ability state side
                                               {:prompt "Remove 1 bad publicity or gain 5 [Credits]?"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -323,7 +323,7 @@
    {:data {:counter 16}
     :abilities [{:cost [:click 1] :counter-cost 4 :msg "gain 4 [Credits]"
                  :effect (req (gain state :runner :credit 4)
-                              (when (= (:counter card) 0) (trash state :runner card {:unpreventable true})))}]}
+                              (when (<= (:counter card) 0) (trash state :runner card {:unpreventable true})))}]}
 
    "London Library"
    {:abilities [{:label "Install a non-virus program on London Library" :cost [:click 1]
@@ -457,7 +457,7 @@
    (let [remove-counter
          {:req (req (not (empty? (:hosted card))))
           :msg (msg "remove 1 counter from " (:title target)) :choices {:req #(:host %)}
-          :effect (req (if (= (:counter target) 1)
+          :effect (req (if (<= (:counter target) 1)
                          (runner-install state side (dissoc target :counter) {:no-cost true})
                          (add-prop state side target :counter -1)))}]
      {:abilities [{:label "Host a program or piece of hardware" :cost [:click 1]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1925,12 +1925,11 @@
                    {:title "/adv-counter command"} nil))
 
 (defn command-counter [state side value]
-  (let [value (int value)]
-  (resolve-ability state side
+    (resolve-ability state side
                    {:effect (effect (set-prop target :counter value)
                                     (system-msg (str "sets counters to " value " on " (card-str state target) (get-card state target))))
                     :choices {:req (fn [t] (= (:side t) (side-str side)))}}
-                   {:title "/counter command"} nil)))
+                   {:title "/counter command"} nil))
 
 (defn parse-command [text]
   (let [[command & args] (split text #" ");"
@@ -1962,7 +1961,6 @@
                                                                                 (card-str state target) ": " (get-card state target))))
                                                :choices {:req (fn [t] (= (:side t) (side-str %2)))}}
                                         {:title "/card-info command"} nil)
-        "/state"  #(system-msg %1 %2 (str @%1))
         "/counter"    #(command-counter %1 %2 value)
         "/adv-counter" #(command-adv-counter %1 %2 value)
         "/jack-out"   #(when (= %2 :runner) (jack-out %1 %2 nil))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1927,7 +1927,7 @@
 (defn command-counter [state side value]
     (resolve-ability state side
                    {:effect (effect (set-prop target :counter value)
-                                    (system-msg (str "sets counters to " value " on " (card-str state target) (get-card state target))))
+                                    (system-msg (str "sets counters to " value " on " (card-str state target))))
                     :choices {:req (fn [t] (= (:side t) (side-str side)))}}
                    {:title "/counter command"} nil))
 

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -72,7 +72,8 @@
 
 (defn String->Num [s]
   (try
-    (bigdec s)
+    (let [num (bigdec s)]
+      (if (and (> num Integer/MIN_VALUE) (< num Integer/MAX_VALUE)) (int num) num))
   (catch Exception e nil)))
 
 (def safe-split (fnil clojure.string/split ""))

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -140,6 +140,7 @@
       ; Corp turn 2, creds, check if supports are ticking
       (is (= 2 (get-in (refresh publics1) [:counter])))
       (is (= 0 (:agenda-point (get-corp))))
+      (is (nil? (:agendapoints (refresh publics1))))
       (take-credits state :corp)
       ; Runner turn 2, run and trash publics2
       (core/click-run state :runner {:server :remote2})

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -120,6 +120,48 @@
       (is (= 4 (get-in (refresh launch) [:counter])))
       )))
 
+(deftest public-support
+  "Public support scoring and trashing"
+  ;TODO could also test for NOT triggering "when scored" events
+  (do-game
+    (new-game (default-corp [(qty "Public Support" 2)]) (default-runner))
+    ; Corp turn 1, install and rez public supports
+    (play-from-hand state :corp "Public Support" "New remote")
+    (play-from-hand state :corp "Public Support" "New remote")
+    (let [publics1 (first (get-in @state [:corp :servers :remote1 :content]))
+          publics2 (first (get-in @state [:corp :servers :remote2 :content]))]
+      (core/rez state :corp (refresh publics1))
+      (core/rez state :corp (refresh publics2))
+      (take-credits state :corp)
+      ; Runner turn 1, creds
+      (is (= 2 (:credit (get-corp))))
+      (is (= 3 (get-in (refresh publics1) [:counter])))
+      (take-credits state :runner)
+      ; Corp turn 2, creds, check if supports are ticking
+      (is (= 2 (get-in (refresh publics1) [:counter])))
+      (is (= 0 (:agenda-point (get-corp))))
+      (take-credits state :corp)
+      ; Runner turn 2, run and trash publics2
+      (core/click-run state :runner {:server :remote2})
+      (core/no-action state :corp nil)
+      (core/successful-run state :runner nil)
+      (prompt-choice :runner "Yes") ; pay to trash
+      (is (= 5 (:credit (get-runner))))
+      (take-credits state :runner)
+      ; Corp turn 3, check how publics1 is doing
+      (is (= 1 (get-in (refresh publics1) [:counter])))
+      (is (= 0 (:agenda-point (get-corp))))
+      (take-credits state :corp)
+      ; Runner turn 3, boring
+      (take-credits state :runner)
+      ; Corp turn 4, check the delicious agenda points
+      (is (= 1 (:agenda-point (get-corp))))
+      (is (= (:zone (refresh publics1) :scored)))
+      (is (= (:zone (refresh publics2) :discard)))
+      (is (= "Public Support" (:title (first (get-in @state [:corp :scored])))))
+      (is (= 1 (:agendapoints (first (get-in @state [:corp :scored])))))
+      )))
+
 (deftest sundew
   "Sundew"
   (do-game

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -158,9 +158,9 @@
   (do-game
     (new-game (default-corp [(qty "Red Herrings" 1) (qty "House of Knives" 1)])
               (default-runner))
-    (core/move-card state :corp {:card (find-card "Red Herrings" (:hand (get-corp))) :server "Archives"})
+    (trash-from-hand state :corp "Red Herrings")
     (is (= 1 (count (:discard (get-corp)))) "1 card in Archives")
-    (take-credits state :corp 2)
+    (take-credits state :corp)
 
     (core/click-run state :runner {:server "HQ"})
     (core/no-action state :corp nil)

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -143,6 +143,7 @@
   (do-game
     (new-game (default-corp [(qty "Adonis Campaign" 1) (qty "Public Support" 2) (qty "Oaktown Renovation" 1)])
               (default-runner))
+    ; Turn 1 Corp, install oaktown and assets
     (core/gain state :corp :click 4)
     (play-from-hand state :corp "Adonis Campaign" "New remote")
     (play-from-hand state :corp "Public Support" "New remote")
@@ -156,21 +157,39 @@
     (core/advance state :corp {:card (refresh oaktown)})
     (core/advance state :corp {:card (refresh oaktown)})
     (is (= 8 (:credit (get-corp))))
+    (core/end-turn state :corp nil)
+    ; Turn 1 Runner
+    (core/start-turn state :runner nil)
+    (take-credits state :runner 3)
+    (core/click-credit state :runner nil)
+    (core/end-turn state :runner nil)
     (core/rez state :corp (refresh adonis))
     (core/rez state :corp (refresh publics1))
+    ; Turn 2 Corp
+    (core/start-turn state :corp nil)
     (core/rez state :corp (refresh publics2))
-    (take-credits state :runner 4)
     (is (= 3 (:click (get-corp))))
     (is (= 3 (:credit (get-corp))))
     (is (= 9 (:counter (refresh adonis))))
     (is (= 2 (:counter (refresh publics1))))
+    (is (= 3 (:counter (refresh publics2))))
+    ; oops, forgot to rez 2nd public support before start of turn, let me fix it with a /command
+    (core/command-counter state :corp 2)
+    (prompt-select :corp (refresh publics2))
     (is (= 2 (:counter (refresh publics2))))
+    ; Oaktown checks
     (is (= 3 (:advance-counter (refresh oaktown))))
+    (core/command-adv-counter state :corp 2)
+    (prompt-select :corp (refresh oaktown))
+    (core/score state :corp (refresh oaktown)) ; shouldn't be able to score with 2 advancement tokens
+    (is (= 0 (:agenda-point (get-corp))))
     (core/command-adv-counter state :corp 4)
-    (prompt-select :corp oaktown)
+    (prompt-select :corp (refresh oaktown))
     (is (= 4 (:advance-counter (refresh oaktown))))
     (is (= 3 (:credit (get-corp))))
     (is (= 3 (:click (get-corp))))
-    (core/score state :corp (refresh oaktown))
+    (core/score state :corp (refresh oaktown)) ; now the score should go through
     (is (= 2 (:agenda-point (get-corp))))
+
+
     )))

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -156,7 +156,7 @@
     (core/advance state :corp {:card (refresh oaktown)})
     (core/advance state :corp {:card (refresh oaktown)})
     (core/advance state :corp {:card (refresh oaktown)})
-    (is (= 8 (:credit (get-corp))))
+    (is (= 8 (:credit (get-corp))) "Corp 5+3 creds from Oaktown")
     (core/end-turn state :corp nil)
     ; Turn 1 Runner
     (core/start-turn state :runner nil)
@@ -169,7 +169,7 @@
     (core/start-turn state :corp nil)
     (core/rez state :corp (refresh publics2))
     (is (= 3 (:click (get-corp))))
-    (is (= 3 (:credit (get-corp))))
+    (is (= 3 (:credit (get-corp))) "only Adonis money")
     (is (= 9 (:counter (refresh adonis))))
     (is (= 2 (:counter (refresh publics1))))
     (is (= 3 (:counter (refresh publics2))))
@@ -177,11 +177,11 @@
     (core/command-counter state :corp 2)
     (prompt-select :corp (refresh publics2))
     (is (= 2 (:counter (refresh publics2))))
-    ; Oaktown checks
+    ; Oaktown checks and manipulation
     (is (= 3 (:advance-counter (refresh oaktown))))
     (core/command-adv-counter state :corp 2)
     (prompt-select :corp (refresh oaktown))
-    (core/score state :corp (refresh oaktown)) ; shouldn't be able to score with 2 advancement tokens
+    (core/score state :corp (refresh oaktown)) ; score should fail, shouldn't be able to score with 2 advancement tokens
     (is (= 0 (:agenda-point (get-corp))))
     (core/command-adv-counter state :corp 4)
     (prompt-select :corp (refresh oaktown))
@@ -190,6 +190,24 @@
     (is (= 3 (:click (get-corp))))
     (core/score state :corp (refresh oaktown)) ; now the score should go through
     (is (= 2 (:agenda-point (get-corp))))
-
-
+    (take-credits state :corp)
+    ; Turn 2 Runner
+    (core/command-counter state :corp 1) ; cheating with publics1 going too fast. Why? because I can
+    (prompt-select :corp (refresh publics1))
+    (core/command-counter state :corp 3) ; let's adjust Adonis while at it
+    (prompt-select :corp (refresh adonis))
+    (take-credits state :runner)
+    ; Turn 3 Corp
+    (is (= 3 (:agenda-point (get-corp)))) ; cheated PS1 should get scored
+    (is (= 9 (:credit (get-corp))) "twice Adonis money and money turn")
+    (is (= (:zone (refresh publics1) :scored)))
+    (is (= (:zone (refresh publics2)) [:servers :remote3 :content]))
+    (is (= (:zone (refresh adonis) :discard)))
+    (take-credits state :corp)
+    ; Turn 3 Runner
+    (take-credits state :runner)
+    ; Turn 4 Corp
+    (is (= 4 (:agenda-point (get-corp)))) ; PS2 should get scored
+    (is (= (:zone (refresh publics2) :scored)))
+    (is (= 12 (:credit (get-corp))) "twice Adonis money and 2xmoney turn, no third Adonis")
     )))

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -48,7 +48,7 @@
   (is (get-in @state [:run :successful]))) ; the run was marked successful)
 
 (defn find-card [title from]
-  "Return true if there is a card with given title in given sequence"
+  "Return a card with given title from given sequence"
   (some #(when (= (:title %) title) %) from))
 
 (defn card-ability

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -10,6 +10,7 @@
             [clojure.test :refer :all]))
 
 (defn new-game [corp runner]
+  "Init a new game using given corp and runner. Keep starting hands (no mulligan) and start Corp's turn."
   (let [states (core/init-game
                  {:gameid 1
                   :players [{:side "Corp"
@@ -25,13 +26,17 @@
     state))
 
 (defn take-credits
+  "Take credits for n clicks, or if no n given, for all remaining clicks of a side. If all clicks are used up,
+  end turn and start the opponent's turn."
   ([state side] (take-credits state side nil))
   ([state side n]
-    (let [n (or n (if (= side :corp) 3 4))
-          other (if (= side :corp) :runner :corp)]
+    (let  [remaining-clicks (get-in @state [side :click])
+           n (or n remaining-clicks)
+           other (if (= side :corp) :runner :corp)]
       (dotimes [i n] (core/click-credit state side nil))
-      (core/end-turn state side nil)
-      (core/start-turn state other nil))))
+      (if (= (get-in @state [side :click]) 0)
+        (do (core/end-turn state side nil)
+            (core/start-turn state other nil))))))
 
 (defn play-run-event [state card server]
   (core/play state :runner {:card card})
@@ -43,6 +48,7 @@
   (is (get-in @state [:run :successful]))) ; the run was marked successful)
 
 (defn find-card [title from]
+  "Return true if there is a card with given title in given sequence"
   (some #(when (= (:title %) title) %) from))
 
 (defn card-ability


### PR DESCRIPTION
Fixes #1002. Also features:
- a few docstrings for functions, as a part of documentation effort
- two unit tests for Public Support and /counter commands
- fix for `String->Num` using `bigdec` when not strictly necessary
- a more versatile `take-credits` test utility function