### PR TITLE
Prevent Lotus Field strength from being lowered.

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -133,7 +133,7 @@
                                   0 (flatten (seq (:servers corp)))))
                     (update-all-ice))
     :events {:pre-ice-strength {:req (req (has? target :subtype "Code Gate"))
-                                :effect (effect (ice-strength-bonus 1))}}}
+                                :effect (effect (ice-strength-bonus 1 target))}}}
 
    "Executive Retreat"
    {:data {:counter 1} :effect (effect (shuffle-into-deck :hand))
@@ -240,7 +240,7 @@
    "Improved Tracers"
    {:effect (req (update-all-ice state side))
     :events {:pre-ice-strength {:req (req (has? target :subtype "Tracer"))
-                                :effect (effect (ice-strength-bonus 1))}
+                                :effect (effect (ice-strength-bonus 1 target))}
              :pre-init-trace {:req (req (has? target :type "ICE"))
                               :effect (effect (init-trace-bonus 1))}}}
 
@@ -395,7 +395,7 @@
                                    0 (flatten (seq (:servers corp)))))
                      (update-all-ice state side)))
     :events {:pre-ice-strength {:req (req (has? target :subtype "Barrier"))
-                                :effect (effect (ice-strength-bonus 1))}}}
+                                :effect (effect (ice-strength-bonus 1 target))}}}
 
    "TGTBT"
    {:access {:msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -539,7 +539,7 @@
                  {:encounter-ice {:once :per-turn
                                   :effect (effect (update! (assoc card :scrubbed-target target)))}
                   :pre-ice-strength {:req (req (= (:cid target) (:cid (:scrubbed-target card))))
-                                     :effect (effect (ice-strength-bonus -2))}
+                                     :effect (effect (ice-strength-bonus -2 target))}
                   :pass-ice sc :run-ends sc})}
 
    "Showing Off"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -415,7 +415,8 @@
                  :msg "prevent the Runner from drawing cards" :effect (effect (prevent-draw))}]}
 
    "Lotus Field"
-   {:abilities [end-the-run]}
+   {:abilities [end-the-run]
+    :flags {:cannot-lower-strength true}}
 
    "Lycan"
    {:advanceable :always

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -378,7 +378,7 @@
     :events (let [wy {:effect (req (update! state side (dissoc card :wyrm-count)))}]
               {:pre-ice-strength {:req (req (and (= (:cid target) (:cid current-ice)) (:wyrm-count card)))
                                   :effect (req (let [c (:wyrm-count (get-card state card))]
-                                                 (ice-strength-bonus state side (- c))))}
+                                                 (ice-strength-bonus state side (- c) target)))}
                :pass-ice wy :run-ends wy})}
 
    "Yog.0"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -120,7 +120,7 @@
 
    "Haas-Bioroid: Stronger Together"
    {:events {:pre-ice-strength {:req (req (and (= (:type target) "ICE") (has? target :subtype "Bioroid")))
-                                :effect (effect (ice-strength-bonus 1))}}}
+                                :effect (effect (ice-strength-bonus 1 target))}}}
 
    "Harmony Medtech: Biomedical Pioneer"
    {:effect (effect (lose :agenda-point-req 1) (lose :runner :agenda-point-req 1))}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -227,7 +227,8 @@
             :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain :corp :bad-publicity 1))}}}
 
    "Lag Time"
-   {:events {:pre-ice-strength {:effect (effect (ice-strength-bonus 1))}}
+   {:effect (effect (update-all-ice))
+    :events {:pre-ice-strength {:effect (effect (ice-strength-bonus 1 target))}}
     :leave-play (effect (update-all-ice))}
 
    "Manhunt"
@@ -287,7 +288,7 @@
     :effect (effect (host target (assoc card :zone [:discard] :seen true :installed true))
                     (update-ice-strength (get-card state target)))
     :events {:pre-ice-strength {:req (req (= (:cid target) (:cid (:host card))))
-                                :effect (effect (ice-strength-bonus 2))}}}
+                                :effect (effect (ice-strength-bonus 2 target))}}}
 
    "Paywall Implementation"
    {:events {:successful-run {:msg "gain 1 [Credits]" :effect (effect (gain :corp :credit 1))}}}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -40,7 +40,7 @@
                                   :effect (effect (host target card))} card nil)))}]
     :events {:pre-ice-strength
              {:req (req (and (= (:cid target) (:cid (:host card))) (:rezzed target)))
-              :effect (effect (ice-strength-bonus -2))}}}
+              :effect (effect (ice-strength-bonus -2 target))}}}
 
    "Bug"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
@@ -122,7 +122,7 @@
                :pre-ice-strength {:req (req (and (= (:cid target) (:cid current-ice))
                                                  (:datasucker-count card)))
                                   :effect (req (let [c (:datasucker-count (get-card state card))]
-                                                 (ice-strength-bonus state side (- c))))}
+                                                 (ice-strength-bonus state side (- c) target)))}
                :pass-ice ds :run-ends ds})
     :abilities [{:counter-cost 1 :msg (msg "give -1 strength to " (:title current-ice))
                  :req (req (and current-ice (:rezzed current-ice)))
@@ -427,7 +427,7 @@
               :effect (effect (update-ice-strength (:host card)))}
              :pre-ice-strength
              {:req (req (= (:cid target) (:cid (:host card))))
-              :effect (effect (ice-strength-bonus (- (get-virus-counters state side card))))}
+              :effect (effect (ice-strength-bonus (- (get-virus-counters state side card)) target))}
              :ice-strength-changed
              {:req (req (and (= (:cid target) (:cid (:host card))) (<= (:current-strength target) 0)))
               :effect (req (unregister-events state side card)

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -276,7 +276,7 @@
    "Ice Carver"
    {:events {:pre-ice-strength
              {:req (req (and (= (:cid target) (:cid current-ice)) (:rezzed target)))
-              :effect (effect (ice-strength-bonus -1))}}}
+              :effect (effect (ice-strength-bonus -1 target))}}}
 
    "Inside Man"
    {:recurring 2}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -84,7 +84,7 @@
                                                       (update-ice-strength state side (:troubleshooter-target card)))}]
                                  {:pre-ice-strength
                                                     {:req (req (= (:cid target) (:cid (:troubleshooter-target card))))
-                                                     :effect (effect (ice-strength-bonus (:troubleshooter-amount card)))}
+                                                     :effect (effect (ice-strength-bonus (:troubleshooter-amount card) target))}
                                   :runner-turn-ends ct :corp-turn-ends ct}) card))}}
 
    "Crisium Grid"
@@ -107,7 +107,7 @@
    "Experiential Data"
    {:effect (req (update-ice-in-server state side (card->server state card)))
     :events {:pre-ice-strength {:req (req (= (card->server state card) (card->server state target)))
-                                :effect (effect (ice-strength-bonus 1))}}
+                                :effect (effect (ice-strength-bonus 1 target))}}
     :derez-effect {:effect (req (update-ice-in-server state side (card->server state card)))}
     :trash-effect {:effect (req (update-all-ice state side))}}
 

--- a/src/clj/test/cards-identities.clj
+++ b/src/clj/test/cards-identities.clj
@@ -11,6 +11,17 @@
     (is (= 13 (:credit (get-corp))) "Has 13 credits")
     (is (= 13 (:max-hand-size (get-corp))) "Max hand size is 13")))
 
+(deftest haas-bioroid-stronger-together
+  "Stronger Together - +1 strength for Bioroid ice"
+  (do-game
+    (new-game
+      (make-deck "Haas-Bioroid: Stronger Together" [(qty "Eli 1.0" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Eli 1.0" "Archives")
+    (let [eli (first (get-in @state [:corp :servers :archives :ices]))]
+      (core/rez state :corp eli)
+      (is (= 5 (:current-strength (refresh eli))) "Eli 1.0 at 5 strength"))))
+
 (deftest iain-stirling-credits
   "Iain Stirling - Gain 2 credits when behind"
   (do-game

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -20,6 +20,20 @@
       (is (= 1 (count (:scored (get-runner)))) "Agenda added to runner scored")
       (is (= 3 (count (:hand (get-runner)))) "No damage dealt"))))
 
+(deftest ice-carver
+  "Ice Carver - lower ice strength on encounter"
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 1)])
+              (default-runner [(qty "Ice Carver" 1)]))
+    (play-from-hand state :corp "Ice Wall" "Archives")
+    (take-credits state :corp 2)
+    (let [iwall (first (get-in @state [:corp :servers :archives :ices]))]
+      (core/rez state :corp iwall)
+      (play-from-hand state :runner "Ice Carver")
+      (core/click-run state :runner {:server "Archives"})
+      (is (= 0 (:current-strength (refresh iwall))) "Ice Wall strength at 0 for encounter")
+      (core/jack-out state :runner nil)
+      (is (= 1 (:current-strength (refresh iwall))) "Ice Wall strength at 1 after encounter"))))
 
 (deftest kati-jones
   "Kati Jones - Click to store and take"


### PR DESCRIPTION
Fixes #1009. Includes a few tests for Lotus Field, Ice Carver, and Stronger Together.

Had to make a few minor changes to core, mostly to more frequently update ice strength (when starting a run, or when jacking out, for example).