### PR TITLE
Have ice that self-trash during runs modify the run position

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -170,7 +170,10 @@
                                       )}}]}
 
    "Data Mine"
-   {:abilities [{:msg "do 1 net damage" :effect (effect (trash card) (damage :net 1 {:card card}))}]}
+   {:abilities [{:msg "do 1 net damage"
+                 :effect (req (damage state :runner :net 1 {:card card})
+                              (trash state side card)
+                              (trash-ice-in-run state))}]}
 
    "Datapike"
    {:abilities [{:msg "force the Runner to pay 2 [Credits] if able"
@@ -373,7 +376,9 @@
 
    "Its a Trap!"
    {:expose {:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}
-    :abilities [(assoc trash-installed :effect (effect (trash card) (trash target {:cause :subroutine})))]}
+    :abilities [(assoc trash-installed :effect (req (trash state side target {:cause :subroutine})
+                                                    (trash state side card)
+                                                    (trash-ice-in-run state)))]}
 
    "Janus 1.0"
    {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))}]}
@@ -391,8 +396,10 @@
    "Lab Dog"
    {:abilities [(assoc trash-hardware :label "Force the Runner to trash an installed piece of hardware"
                                       :player :runner
-                                      :msg (msg "force the runner to trash " (:title target))
-                                      :effect (effect (trash target) (trash card)))]}
+                                      :msg (msg "force the Runner to trash " (:title target))
+                                      :effect (req (trash state side target)
+                                                   (trash state side card)
+                                                   (trash-ice-in-run state)))]}
 
    "Lancelot"
    {:abilities [trash-program
@@ -641,8 +648,10 @@
 
    "Special Offer"
    {:abilities [{:label "Gain 5 [Credits] and trash Special Offer"
-                 :effect (effect (gain :corp :credit 5) (trash card)
-                                 (system-msg (str "gains 5 [Credits] and trashes Special Offer")))}]}
+                 :effect (req (gain state :corp :credit 5)
+                              (trash state side card)
+                              (trash-ice-in-run state)
+                              (system-msg state side (str "gains 5 [Credits] and trashes Special Offer")))}]}
 
    "Spiderweb"
    {:abilities [end-the-run]}
@@ -760,8 +769,7 @@
                                                            (:content (card->server state card)))) 1))
                                 (prevent-jack-out state side))
                               (trash state side card)
-                              (when (:run @state)
-                                (swap! state update-in [:run] #(assoc % :position (dec (:position run))))))}]}
+                              (trash-ice-in-run state))}]}
 
    "Woodcutter"
    {:advanceable :while-rezzed

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -984,6 +984,10 @@
 (defn trash-cards [state side cards]
   (doseq [c cards] (trash state side c)))
 
+(defn trash-ice-in-run [state]
+  (when-let [run (:run @state)]
+    (swap! state update-in [:run :position] dec)))
+
 (defn all-installed [state side]
   (if (= side :runner)
     (let [installed (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))]

--- a/src/clj/test/cards-ice.clj
+++ b/src/clj/test/cards-ice.clj
@@ -58,6 +58,23 @@
       (take-credits state :corp 2)
       (is (= 5 (:current-strength (refresh lotus))) "Lotus Field strength increased"))))
 
+(deftest special-offer-trash-ice-during-run
+  "Special Offer trashes itself and updates the run position"
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 1) (qty "Special Offer" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Special Offer" "HQ")
+    (take-credits state :corp 1)
+    (core/click-run state :runner {:server "HQ"})
+    (is (= 2 (:position (get-in @state [:run]))) "Initial position approaching Special Offer")
+    (let [special (get-in @state [:corp :servers :hq :ices 1])]
+      (core/rez state :corp special)
+      (is (= 4 (:credit (get-corp))))
+      (card-ability state :corp special 0)
+      (is (= 9 (:credit (get-corp))) "Special Offer paid 5 credits")
+      (is (= 1 (:position (get-in @state [:run]))) "Run position updated; now approaching Ice Wall"))))
+
 (deftest tmi
   "TMI ICE test"
   (do-game
@@ -69,7 +86,6 @@
       (prompt-choice :corp 0)
       (prompt-choice :runner 0)
       (is (get-in (refresh tmi) [:rezzed])))))
-
 
 (deftest tmi-derez
   "TMI ICE trace derez"


### PR DESCRIPTION
Adds a new core function to update run position when a piece of ICE self-trashes during a run, and updates the 5 existing ICE that currently do this to use it. Includes a test for Special Offer. 