### PR TITLE
A bunch of clarity changes

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -119,7 +119,7 @@
                             :effect (effect (gain :credit 1))}}}
 
    "Haas-Bioroid: Stronger Together"
-   {:events {:pre-ice-strength {:req (req (and (= (:type target) "ICE") (has? target :subtype "Bioroid")))
+   {:events {:pre-ice-strength {:req (req (and (ice? target) (has? target :subtype "Bioroid")))
                                 :effect (effect (ice-strength-bonus 1 target))}}}
 
    "Harmony Medtech: Biomedical Pioneer"
@@ -279,9 +279,9 @@
 
    "Reina Roja: Freedom Fighter"
    {:effect (effect (gain :link 1))
-    :events {:pre-rez {:req (req (and (= (:type target) "ICE") (not (get-in @state [:per-turn (:cid card)]))))
+    :events {:pre-rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
                        :effect (effect (rez-cost-bonus 1))}
-             :rez {:req (req (and (= (:type target) "ICE") (not (get-in @state [:per-turn (:cid card)]))))
+             :rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
                               :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
 
    "Rielle \"Kit\" Peddler: Transhuman"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -490,7 +490,8 @@
                      (resolve-ability state side (sunhelp serv) card nil)))})
 
    "Sweeps Week"
-   {:effect (effect (gain :credit (count (:hand runner))))}
+   {:effect (effect (gain :credit (count (:hand runner))))
+    :msg (msg "gain " (count (:hand runner)) " [Credits]")}
 
    "Targeted Marketing"
    {:abilities [{:req (req (= (:zone card) [:current]))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -46,7 +46,8 @@
    "Aggressive Negotiation"
    {:req (req (:scored-agenda corp-reg)) :prompt "Choose a card"
     :choices (req (cancellable (:deck corp) :sorted))
-    :effect (effect (move target :hand) (shuffle! :deck))}
+    :effect (effect (move target :hand) (shuffle! :deck))
+    :msg "search R&D for a card and add it to HQ"}
 
    "An Offer You Cant Refuse"
    {:prompt "Choose a server" :choices ["HQ" "R&D" "Archives"]
@@ -83,7 +84,7 @@
    "Back Channels"
    {:prompt "Choose an installed card in a server to trash" :choices {:req #(= (last (:zone %)) :content)}
     :effect (effect (gain :credit (* 3 (:advance-counter target))) (trash target))
-    :msg (msg "trash " (if (:rezzed target) (:title target) " a card") " and gain "
+    :msg (msg "trash " (card-str state target) " and gain "
               (* 3 (:advance-counter target)) " [Credits]")}
 
    "Bad Times"
@@ -103,7 +104,7 @@
 
    "Bioroid Efficiency Research"
    {:choices {:req #(and (= (:type %) "ICE") (has? % :subtype "Bioroid") (not (:rezzed %)))}
-    :msg (msg "rez " (:title target) " at no cost")
+    :msg (msg "rez " (card-str state target {:visible true}) " at no cost")
     :effect (effect (rez target {:no-cost true})
                     (host (get-card state target) (assoc card :zone [:discard] :seen true)))}
 
@@ -374,7 +375,7 @@
 
    "Restoring Face"
    {:prompt "Choose a Sysop, Executive or Clone to trash"
-    :msg (msg "trash " (:title target) " to remove 2 bad publicity")
+    :msg (msg "trash " (card-str state target) " to remove 2 bad publicity")
     :choices {:req #(and (:rezzed %)
                          (or (has? % :subtype "Clone") (has? % :subtype "Executive")
                              (has? % :subtype "Sysop")))}
@@ -423,7 +424,7 @@
                      {:choices {:req #(or (card-is? % :advanceable :always)
                                           (and (card-is? % :advanceable :while-rezzed) (:rezzed %))
                                           (= (:type %) "Agenda"))}
-                      :msg (msg "place " c " advancement tokens on " (if (:rezzed target) (:title target) "a card"))
+                      :msg (msg "place " c " advancement tokens on " (card-str state target))
                       :effect (effect (add-prop :corp target :advance-counter c {:placed true}))} card nil)))}
 
    "Shoot the Moon"
@@ -548,8 +549,7 @@
                                          :effect  (effect (add-prop :corp target :advance-counter c {:placed true})
                                                           (add-prop :corp fr :advance-counter (- c) {:placed true})
                                                           (system-msg (str "moves " c " advancement tokens from "
-                                                                           (if (:rezzed fr) (:title fr) "a card") " to "
-                                                                           (if (:rezzed target) (:title target) "a card"))))}
+                                                                           (card-str state fr) " to " (card-str state target))))}
                                         tol nil)))}
                       card nil)))}
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1966,6 +1966,7 @@
         "/counter"    #(command-counter %1 %2 value)
         "/adv-counter" #(command-adv-counter %1 %2 value)
         "/jack-out"   #(when (= %2 :runner) (jack-out %1 %2 nil))
+        "/end-run"    #(when (= %2 :corp) (end-run %1 %2))
         "/discard"    #(move %1 %2 (nth (get-in @%1 [%2 :hand]) num nil) :discard)
         "/deck"       #(move %1 %2 (nth (get-in @%1 [%2 :hand]) num nil) :deck {:front true})
         nil

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -275,13 +275,13 @@
 
 (defn card-str
   ([state card] (card-str state card nil))
-  ([state card {:keys [visible] :as args}]
+  ([state card {:keys [visible where] :as args}]
    (str (if (card-is? card :side :corp)
          ; Corp card messages
          (str (if (or (rezzed? card) visible) (:title card) (if (ice? card) "ICE" "a card"))
               (if (ice? card) " protecting " " in ")
               ;TODO add naming of scoring area of corp/runner
-              (zone->name (second (:zone card)))
+              (or where (zone->name (second (:zone card))))
               (if (ice? card) (str " at position " (ice-index state card))))
          ; Runner card messages
          (if (or (:facedown card) visible) "a facedown card" (:title card)))
@@ -1691,7 +1691,8 @@
                      (trash state side prev-card {:keep-server-alive true})))
                  (let [visible (or (= :rezzed-no-cost install-state) (= :face-up install-state))]
                    ; TODO code above could be simplified, check whether visible is really needed here or if card-str is smart enough to figure it out on its own
-                   (system-msg state side (str (build-spend-msg cost-str "install") (card-str state c {:visible visible}))))
+                   (system-msg state side (str (build-spend-msg cost-str "install")
+                                               (card-str state c {:visible visible :where server }))))
                  (let [moved-card (move state side c slot)]
                    (trigger-event state side :corp-install moved-card)
                    (when (= (:type c) "Agenda")

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1,6 +1,6 @@
 (ns game.core
   (:require [game.utils :refer [remove-once has? merge-costs zone make-cid to-keyword capitalize
-                                costs-to-symbol vdissoc distinct-by abs String->Num safe-split
+                                costs-to-symbol vdissoc distinct-by abs string->num safe-split
                                 dissoc-in cancellable card-is?]]
             [game.macros :refer [effect req msg]]
             [clojure.string :refer [split-lines split join]]
@@ -263,7 +263,6 @@
 (defn zone->name [zone]
   (or (central->name zone)
       (remote->name zone)))
-
 
 (defn ice? [card]
   (= (:type card) "ICE"))
@@ -1934,8 +1933,8 @@
 
 (defn parse-command [text]
   (let [[command & args] (split text #" ");"
-        value (if-let [n (String->Num (first args))] n 1)
-        num   (if-let [n (-> args first (safe-split #"#") second String->Num)] (dec n) 0)]
+        value (if-let [n (string->num (first args))] n 1)
+        num   (if-let [n (-> args first (safe-split #"#") second string->num)] (dec n) 0)]
     (when (<= (count args) 1)
       (case command
         "/draw"       #(draw %1 %2 (max 0 value))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1,7 +1,7 @@
 (ns game.core
   (:require [game.utils :refer [remove-once has? merge-costs zone make-cid to-keyword capitalize
                                 costs-to-symbol vdissoc distinct-by abs String->Num safe-split
-                                dissoc-in cancellable card-is? side-key side-str]]
+                                dissoc-in cancellable card-is?]]
             [game.macros :refer [effect req msg]]
             [clojure.string :refer [split-lines split join]]
             [clojure.core.match :refer [match]]))
@@ -275,8 +275,7 @@
   (first (keep-indexed #(when (= (:cid %2) (:cid ice)) %1) (get-in @state (cons :corp (:zone ice))))))
 
 (defn card-str [state card]
-  ; using side-key since card can be both clicked (strings) or passed (keys)
-  (str (if (= (side-key (:side card)) :corp)
+  (str (if (card-is? card :side :corp)
          (str (if (rezzed? card) (:title card) (if (ice? card) "ICE" "a card"))
               (if (ice? card) " protecting " " in ")
               ;TODO add naming of scoring area of corp/runner
@@ -1923,14 +1922,14 @@
   (resolve-ability state side
                    {:effect (effect (set-prop target :advance-counter value)
                                     (system-msg (str "sets advancement counters to " value " on " (card-str state target))))
-                    :choices {:req (fn [t] (= (:side t) (side-str side)))}}
+                    :choices {:req (fn [t] (card-is? t :side side))}}
                    {:title "/adv-counter command"} nil))
 
 (defn command-counter [state side value]
     (resolve-ability state side
                    {:effect (effect (set-prop target :counter value)
                                     (system-msg (str "sets counters to " value " on " (card-str state target))))
-                    :choices {:req (fn [t] (= (:side t) (side-str side)))}}
+                    :choices {:req (fn [t] (card-is? t :side side))}}
                    {:title "/counter command"} nil))
 
 (defn parse-command [text]
@@ -1961,7 +1960,7 @@
                                                  :msg "resolve successful trace effect"}))
         "/card-info"  #(resolve-ability %1 %2 {:effect (effect (system-msg (str "shows card-info of "
                                                                                 (card-str state target) ": " (get-card state target))))
-                                               :choices {:req (fn [t] (= (:side t) (side-str %2)))}}
+                                               :choices {:req (fn [t] (card-is? t :side %2))}}
                                         {:title "/card-info command"} nil)
         "/counter"    #(command-counter %1 %2 value)
         "/adv-counter" #(command-adv-counter %1 %2 value)

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -38,25 +38,6 @@
     (keyword (.toLowerCase string))
     string))
 
-(defn side-str [k]
-  "Takes a side key and converts it to a string (Runner/Corp)."
-  (case k
-    "Corp" "Corp"
-    "Runner" "Runner"
-    :corp "Corp"
-    :runner "Runner"
-    nil))
-
-(defn side-key [s]
-  "Takes a side string and converts it to a key (:runner/:corp)."
-  (case s
-    "Corp" :corp
-    "Runner" :runner
-    :corp :corp
-    :runner :runner
-    nil))
-
-
 (defn capitalize [string]
   (str (Character/toUpperCase (first string)) (subs string 1)))
 

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -60,7 +60,7 @@
                             (cons x (step more (conj seen k))))))))]
     (step coll #{})))
 
-(defn String->Num [s]
+(defn string->num [s]
   (try
     (let [num (bigdec s)]
       (if (and (> num Integer/MIN_VALUE) (< num Integer/MAX_VALUE)) (int num) num))

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -74,6 +74,7 @@
       (is (= (core/card-str state (refresh hqiwall0)) "Ice Wall protecting HQ at position 0"))
       (is (= (core/card-str state (refresh hqiwall1)) "ICE protecting HQ at position 1"))
       (is (= (core/card-str state (refresh rdiwall)) "ICE protecting R&D at position 0"))
+      (is (= (core/card-str state (refresh rdiwall) {:visible true}) "Ice Wall protecting R&D at position 0"))
       (is (= (core/card-str state (refresh jh1)) "Jackson Howard in Server 1"))
       (is (= (core/card-str state (refresh jh2)) "a card in Server 2"))
       (is (= (core/card-str state (refresh corr)) "Corroder"))


### PR DESCRIPTION
Increased clarity of many card messages (currently mostly Operations) by using previously-implemented `card-str`. Now you don't have to wonder which ICE was advanced or where exactly the tokens from Trick of Light were moved from/to ;-)

Tried to incorporate `card-str` in `corp-install` message too, but had to revert that change - there were a few issues regarding location of install, `ice-index`... Will probably come back to that later, so the card naming could be more unified.