### PR TITLE
Fixes Paige Piper.

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -426,25 +426,26 @@
     :leave-play (req (remove-watch state :order-of-sol))}
 
    "Paige Piper"
-   (let [pphelper (fn [card cards]
+   (let [pphelper (fn [title cards]
                     (let [num (count cards)]
                       {:optional
-                       {:prompt (str "Use Paige Piper to trash copies of " (:title card) "?")
+                       {:prompt (str "Use Paige Piper to trash copies of " title "?")
                         :yes-ability {:prompt "How many would you like to trash?"
                                       :choices {:number (req num)}
                                       :msg "shuffle their Stack"
                                       :effect (req (doseq [c (take (int target) cards)]
-                                                               (trash state side c))
+                                                     (trash state side c {:unpreventable true}))
                                                    (shuffle! state :runner :deck)
                                                    (when (> (int target) 0)
                                                      (system-msg state side (str "trashes " (int target)
                                                                                  " cop" (if (> (int target) 1) "ies" "y")
-                                                                                 " of " (:title card)))))}}}))]
+                                                                                 " of " title))))}}}))]
      {:events {:runner-install {:req (req (first-event state side :runner-install))
                                 :effect (effect (resolve-ability
-                                                 (pphelper target (->> (:deck runner)
-                                                                       (filter #(has? % :title (:title target)))
-                                                                       (vec)))
+                                                 (pphelper (:title target) 
+                                                           (->> (:deck runner)
+                                                                (filter #(has? % :title (:title target)))
+                                                                (vec)))
                                                  card nil))}}})
 
    "Paparazzi"


### PR DESCRIPTION
Changes the `pphelper` function to just take the card title. Clash happened in the use of the `req` macro overwriting the previous `card` definition (or something like that). 

Also made the trash `:unpreventable true`.

Fixes #1013.