### PR TITLE
Small styling fixes

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -92,6 +92,11 @@ input, select, textarea
 
 input[type="checkbox"]
   height: auto
+  vertical-align: middle
+  margin-right: 6px
+  
+input[type="radio"]
+  vertical-align: middle
   margin-right: 6px
 
 button, a.button


### PR DESCRIPTION
Radio buttons and checkboxes are not correctly aligned, with radio buttons looking particularly wonky.

This is just a small CSS fix to make them both align in the same way and look consistent.

Zaroth was kind enough to apply this fix to his environment and provide a screenshot of how it looks post fix:

![image](https://cloud.githubusercontent.com/assets/1053365/11994501/9b1935fc-aa37-11e5-8676-4da27600e386.png)