### PR TITLE
Card fixes: Trope, Nisei Mk II, IT Department, Crisium Grid

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -282,7 +282,9 @@
     :advancement-cost-bonus (req (:bad-publicity corp))}
 
    "Nisei MK II"
-   {:data {:counter 1} :abilities [{:counter-cost 1 :msg "end the run" :effect (effect (end-run))}]}
+   {:data {:counter 1}
+    :abilities [{:req (req (:run @state)) :counter-cost 1 :msg "end the run"
+                 :effect (effect (end-run))}]}
 
    "Oaktown Renovation"
    {:install-state :face-up

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -250,7 +250,7 @@
               {:pre-ice-strength {:req (req (get-in card [:it-targets (keyword (str (:cid target)))]))
                                   :effect (effect (ice-strength-bonus
                                                     (* (get-in card [:it-targets (keyword (str (:cid target)))])
-                                                       (inc (:counter card)))))}
+                                                       (inc (:counter card))) target))}
                :runner-turn-ends it :corp-turn-ends it})}
 
    "Jackson Howard"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -197,7 +197,8 @@
 
    "Dracō"
    {:prompt "How many power counters?" :choices :credit :msg (msg "add " target " power counters")
-    :effect (effect (set-prop card :counter target))
+    :effect (effect (set-prop card :counter target)
+                    (update-ice-strength card))
     :strength-bonus (req (or (:counter card) 0))
     :abilities [{:label "Trace 2 - Give the Runner 1 tag and end the run"
                  :trace {:base 2 :msg "give the Runner 1 tag and end the run"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -584,6 +584,7 @@
     :abilities [{:cost [:click 1] :label "[Click], remove Trope from the game: Reshuffle cards from Heap back into Stack"
                  :effect (effect
                           (move card :rfg)
+                          (gain :memory 1)
                           (resolve-ability
                            {:show-discard true
                             :choices {:max (:counter card) :req #(and (:side % "Runner") (= (:zone %) [:discard]))}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -92,7 +92,7 @@
     :events {:successful-run {:req (req this-server)
                               :effect (req (swap! state update-in [:run :run-effect] dissoc :replace-access)
                                            (swap! state update-in [:run] dissoc :successful)
-                                           (swap! state update-in [:runner :register :successful-run] #(butlast %)))}}}
+                                           (swap! state update-in [:runner :register :successful-run] #(rest %)))}}}
 
    "Cyberdex Virus Suite"
    {:access {:optional {:prompt "Purge viruses with Cyberdex Virus Suite?"


### PR DESCRIPTION
* Fixes #1036: IT Department was calling `ice-strength-bonus` but passing too few arguments. 
* Fixes #941: Crisium Grid was removing the wrong end of the vector of successfully run servers
* Fixes Trope to restore 1 MU to the Runner when it is removed from the game
* Adds a requirement that a run exist before spending a Nisei Mk II counter to end a run (mostly to prevent accidentally losing one from a misclick). 
* Updates Draco's strength immediately after choosing the number of counters