### PR TITLE
Play-Area changes.

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -17,22 +17,25 @@
    "Accelerated Beta Test"
    (letfn [(abt [n i]
              {:req (req (> i 0))
-              :prompt "Select a piece of ICE from the top of the play area to install"
-              :choices {:req #(and (:side % "Corp") (= (:type %) "ICE") (= (:zone %) [:play-area]))}
-              :effect (req (corp-install state side target nil {:no-install-cost true :install-state :rezzed-no-cost})
+              :prompt "Select a piece of ICE from the Temporary Zone to install"
+              :choices {:req #(and (:side % "Corp")
+                                   (= (:type %) "ICE")
+                                   (= (:zone %) [:play-area]))}
+              :effect (req (corp-install state side target nil
+                                         {:no-install-cost true :install-state :rezzed-no-cost})
                            (trigger-event state side :rez target)
                            (when (< n i)
                              (resolve-ability state side (abt (inc n) i) card nil)))})]
      {:optional {:prompt "Look at the top 3 cards of R&D?"
-                 :yes-ability {:effect (req (let [n (count (filter #(= (:type %) "ICE") (take 3 (:deck corp))))]
-                                              (resolve-ability state side
-                                                               {:msg (msg "install " n " ICE and trash " (- 3 n) " card" (when (< n 2) "s"))
-                                                                :effect (req (doseq [c (take 3 (:deck corp))]
-                                                                               (if (= (:type c) "ICE")
-                                                                                 (move state side c :play-area)
-                                                                                 (trash state side c)))
-                                                                             (resolve-ability state side (abt 1 n) card nil))}
-                                                               card nil)))}}})
+                 :yes-ability {:effect (req (let [n (count (filter #(= (:type %) "ICE")
+                                                                   (take 3 (:deck corp))))]
+                                              (resolve-ability
+                                               state side
+                                               {:msg "look at the top 3 cards of R&D"
+                                                :effect (req (doseq [c (take 3 (:deck corp))]
+                                                               (move state side c :play-area))
+                                                             (resolve-ability state side (abt 1 n) card nil))}
+                                               card nil)))}}})
 
    "Ancestral Imager"
    {:events {:jack-out {:msg "do 1 net damage" :effect (effect (damage :net 1))}}}

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -27,15 +27,13 @@
                            (when (< n i)
                              (resolve-ability state side (abt (inc n) i) card nil)))})]
      {:optional {:prompt "Look at the top 3 cards of R&D?"
-                 :yes-ability {:effect (req (let [n (count (filter #(= (:type %) "ICE")
-                                                                   (take 3 (:deck corp))))]
-                                              (resolve-ability
-                                               state side
-                                               {:msg "look at the top 3 cards of R&D"
-                                                :effect (req (doseq [c (take 3 (:deck corp))]
-                                                               (move state side c :play-area))
-                                                             (resolve-ability state side (abt 1 n) card nil))}
-                                               card nil)))}}})
+                 :yes-ability {:effect (req (let [n (count (filter #(= (:type %) "ICE") (take 3 (:deck corp))))]
+                                              (resolve-ability state side
+                                                               {:msg "look at the top 3 cards of R&D"
+                                                                :effect (req (doseq [c (take 3 (:deck corp))]
+                                                                               (move state side c :play-area))
+                                                                             (resolve-ability state side (abt 1 n) card nil))}
+                                                               card nil)))}}})
 
    "Ancestral Imager"
    {:events {:jack-out {:msg "do 1 net damage" :effect (effect (damage :net 1))}}}

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -113,7 +113,7 @@
     :abilities [{:msg (msg "trash " (:title (:card (first (get-in @state [side :prompt])))) " at no cost")
                  :effect (effect (trash-no-cost))}]
     :effect (effect (run target nil card)
-                    (prompt! card (str "Click Demolition Run in the play area to trash a card being accessed at no cost") ["OK"] {})
+                    (prompt! card (str "Click Demolition Run in the Temporary Zone to trash a card being accessed at no cost") ["OK"] {})
                     (resolve-ability
                       {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
                                       (card-init state side c false)
@@ -311,7 +311,7 @@
    {:effect (effect (run :rd {:replace-access
                               {:msg "rearrange the top 5 cards of R&D"
                                :effect (req (prompt! state side card
-                                                     (str "Drag cards from the play area back onto R&D") ["OK"] {})
+                                                     (str "Drag cards from the Temporary Zone back onto R&D") ["OK"] {})
                                             (doseq [c (take 5 (:deck corp))]
                                               (move state side c :play-area)))}} card))}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -16,18 +16,18 @@
    "Accelerated Diagnostics"
    (letfn [(ad [i n]
              {:prompt "Select an operation to play"
-              :choices {:req #(and (= (:side %) "Corp") (= (:type %) "Operation") (= (:zone %) [:play-area]))}
+              :choices {:req #(and (= (:side %) "Corp")
+                                   (= (:type %) "Operation")
+                                   (= (:zone %) [:play-area]))}
               :msg (msg "play " (:title target))
               :effect (req (when (< i n)
                              (resolve-ability state side (ad (inc i) n) card nil))
                            (play-instant state side target {:no-additional-cost true}))})]
      {:effect (req (let [n (count (filter #(= (:type %) "Operation") (take 3 (:deck corp))))]
                      (resolve-ability state side
-                                      {:msg (msg "play " n " operations and trash " (- 3 n) " card" (when (< n 2) "s"))
+                                      {:msg "look at the top 3 cards of R&D"
                                        :effect (req (doseq [c (take 3 (:deck corp))]
-                                                      (if (= (:type c) "Operation")
-                                                        (move state side c :play-area)
-                                                        (trash state side c)))
+                                                      (move state side c :play-area))
                                                     (resolve-ability state side (ad 1 n) card nil))}
                                       card nil)))})
 
@@ -329,8 +329,9 @@
                                     card nil)))}
 
    "Precognition"
-   {:effect (req (prompt! state side card
-                         (str "Drag cards from the play area back onto R&D") ["OK"] {})
+   {:msg "rearrange the top 5 cards of R&D"
+    :effect (req (prompt! state side card
+                         (str "Drag cards from the Temporary Zone back onto R&D") ["OK"] {})
                  (doseq [c (take 5 (:deck corp))] (move state side c :play-area)))}
 
    "Predictive Algorithm"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -521,7 +521,7 @@
 
    "Rolodex"
    {:effect (req (prompt! state side card
-                          (str "Drag cards from the play area back onto your Stack") ["OK"] {})
+                          (str "Drag cards from the Temporary Zone  back onto your Stack") ["OK"] {})
                  (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))}
 
    "Sacrificial Clone"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -520,7 +520,8 @@
                                     :msg (msg "expose " (:title target))} card nil))}]}
 
    "Rolodex"
-   {:effect (req (prompt! state side card
+   {:msg "look at the top 5 cards of their Stack"
+    :effect (req (prompt! state side card
                           (str "Drag cards from the Temporary Zone  back onto your Stack") ["OK"] {})
                  (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))}
 

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -492,6 +492,22 @@
                          [:div (om/build card-view card)]])
                       cards)])))))
 
+(defn play-area-view [{:keys [name player] :as cursor}]
+  (om/component
+   (sab/html
+    (let [cards (:play-area player)
+          size (count cards)
+          side (get-in player [:identity :side])]
+      (when-not (empty? cards)
+        [:div.panel.blue-shade.rfg {:class (when (> size 2) "squeeze")}
+         (om/build label cards {:opts {:name name}})
+         (map-indexed (fn [i card]
+                        [:div.card-wrapper {:style {:left (* (/ 128 size) i)}}
+                         (if (= (:user player) (:user @app-state))
+                           (om/build card-view card)
+                           [:img.card {:src (str "/img/" (.toLowerCase side) ".png")}])])
+                      cards)])))))
+
 (defn scored-view [{:keys [scored] :as cursor}]
   (om/component
    (sab/html
@@ -660,7 +676,8 @@
                [:div
                 (om/build rfg-view {:cards (:rfg opponent) :name "Removed from the game"})
                 (om/build rfg-view {:cards (:rfg me) :name "Removed from the game"})
-                (when (not-spectator? game-state app-state) (om/build rfg-view {:cards (:play-area me)}))
+                (om/build play-area-view {:player opponent :name "Temporary Zone"})
+                (om/build play-area-view {:player me :name "Temporary Zone"})
                 (om/build rfg-view {:cards (:current opponent) :name "Current"})
                 (om/build rfg-view {:cards (:current me) :name "Current"})]
                (when-not (= side :spectator)


### PR DESCRIPTION
Makes the `:play-area` visible (with card backs) to players and spectators. Labels it as Temporary Zone.

Changes how a few cards (mainly Accelerated Diagnostics and Accelerated Beta Test) works in regards to the `:play-area`, and updates references to "the play area" to "the Temporary Zone".

Intends to alleviate #204.

Note that the way ABT and AD have been changed means that cards not installed / played are left in the Temporary Zone and have to be manually trashed / moved to archives.