### PR TITLE
Allow Parasite to keep gaining counters on Architect; more card tests

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -433,7 +433,9 @@
              {:req (req (= (:cid target) (:cid (:host card))))
               :effect (effect (ice-strength-bonus (- (get-virus-counters state side card)) target))}
              :ice-strength-changed
-             {:req (req (and (= (:cid target) (:cid (:host card))) (<= (:current-strength target) 0)))
+             {:req (req (and (= (:cid target) (:cid (:host card)))
+                             (not (card-flag? (:host card) :untrashable-while-rezzed true))
+                             (<= (:current-strength target) 0)))
               :effect (req (unregister-events state side card)
                            (when (get-in card [:special :installing])
                              (update! state side (update-in card [:special] dissoc :installing))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -192,8 +192,8 @@
                  :effect (req (let [c (move state :runner (first (:hosted card)) :scored)]
                                 (gain-agenda-point state :runner (get-agenda-points state :runner c))))
                  :msg (msg (let [c (first (:hosted card))]
-                             (str "add " (:title c) " to their score area and gain "
-                             (:agendapoints c) " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]}
+                             (str "add " (:title c) " to their score area and gain " (get-agenda-points state :runner c)
+                                  " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]}
 
    "Gang Sign"
    {:events {:agenda-scored {:effect (req (system-msg state :runner (str "can access cards in HQ by clicking on Gang Sign"))

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -199,7 +199,7 @@
       :events {:pre-steal-cost ab :run-ends un}})
 
    "Panic Button"
-   {:init {:root "HQ"} :abilities [{:cost [:credit 1] :effect (effect (draw))
+   {:init {:root "HQ"} :abilities [{:cost [:credit 1] :label "Draw 1 card" :effect (effect (draw))
                                     :req (req (and run (= (first (:server run)) :hq)))}]}
 
    "Product Placement"


### PR DESCRIPTION
* Fixes #1057. Film Critic's message will report the correct number of agenda points gained if adding a hosted Global Food Initiative to the score area. 
* Modifies Parasite to check if the host ICE is untrashable before unregistering events and trying to trash it--this will allow Parasite to keep gaining counters and make Architect's strength go negative instead of stopping at 0. Includes tests to make sure standard Parasite ICE trashing and instant ICE trashing (with a loaded Hivemind) continue to work.
* Adds missing ability label for Panic Button
* Finally, another big batch of individual card unit tests. 

Happy New Year! 