### PR TITLE
Markdown support for news items

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "jquery": "~2.0.3",
     "react": "0.14.3",
     "bootstrap": "~3.1.1",
-    "moment": "~2.6.0"
+    "moment": "~2.6.0",
+    "marked": "~0.3.5"
   }
 }

--- a/src/cljs/netrunner/news.cljs
+++ b/src/cljs/netrunner/news.cljs
@@ -2,6 +2,7 @@
   (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [om.core :as om :include-macros true]
             [sablono.core :as sab :include-macros true]
+            [netrunner.cardbrowser :refer [add-symbols] :as cb]
             [netrunner.ajax :refer [GET]]))
 
 (def app-state (atom {}))
@@ -16,6 +17,6 @@
       (for [d (:news cursor)]
         [:li.news-item
          [:span.date (-> (:date d) js/Date. js/moment (.format "dddd MMM Do - HH:mm"))]
-         [:span.title (:title d)]])]])))
+         [:span.title {:dangerouslySetInnerHTML #js {:__html (cb/add-symbols (js/marked (:title d)))}}]])]])))
 
 (om/root news app-state {:target (. js/document (getElementById "news"))})

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1568,6 +1568,9 @@ nav ul
   .news-item
     margin-bottom: 4px
 
+    .title p
+        display: inline
+
     .date
       margin-right: 10px
       font-weight: bold

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -12,6 +12,7 @@ html
     script(src='/lib/jquery/jquery.min.js')
     script(src='/lib/bootstrap/dist/js/bootstrap.js')
     script(src='/lib/moment/min/moment.min.js')
+    script(src='/lib/marked/marked.min.js')
     script(src='/socket.io/socket.io.js')
     script(type="text/javascript")!= "var user = " + JSON.stringify(user) + ";"
 


### PR DESCRIPTION
Adds Markdown and Netrunner icon support to news items via Trello. The client does all the rendering of Markdown into HTML, so no server resources are used. We can also use our Netrunner icons like [Credit], [Click], [Link], etc.