### PR TITLE
Fix for not affording optional abilities

### DIFF
--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -128,11 +128,11 @@
 (defn optional-ability
   "Shows a 'Yes/No' prompt and resolves the given ability if Yes is chosen."
   [state side card msg ability targets]
-  (show-prompt state side card msg ["Yes" "No"] #(if (= % "Yes")
-                                                  (when-let [yes-ability (:yes-ability ability)]
-                                                    (resolve-ability state side yes-ability card targets))
-                                                  (when-let [no-ability (:no-ability ability)]
-                                                    (resolve-ability state side no-ability card targets)))))
+  (show-prompt state side card msg ["Yes" "No"] #(let [yes-ability (:yes-ability ability)]
+                                                  (if (and (= % "Yes") yes-ability (can-pay? state side (:cost yes-ability)))
+                                                    (resolve-ability state side yes-ability card targets)
+                                                    (when-let [no-ability (:no-ability ability)]
+                                                      (resolve-ability state side no-ability card targets))))))
 
 
 ; Prompts

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -291,4 +291,4 @@
   [state card trace]
   (show-wait-prompt state :runner (str "Corp to initiate a trace from " (:title card)) {:priority 2})
   (show-prompt state :corp card "Boost trace strength?" :credit
-               #(init-trace state :corp card trace %)))
+               #(init-trace state :corp card trace %) {:priority 2}))

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -385,6 +385,7 @@
       (prompt-choice :corp "Yes")
       (is (= 0 (:tag (get-runner))) "Runner has 0 tags")
       (prompt-choice :runner "Yes")
+      (is (empty? (:prompt (get-runner))) "Runner waiting prompt is cleared")
       (is (= 0 (count (:discard (get-runner)))) "Runner took no damage"))))
 
 (deftest snare-dedicated-response-team

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -141,6 +141,32 @@
       (prompt-choice :runner "Yes")
       (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage"))))
 
+(deftest marcus-batty-security-nexus
+  "Marcus Batty - Simultaneous Interaction with Security Nexus"
+  (do-game
+    (new-game (default-corp [(qty "Marcus Batty" 1) (qty "Enigma" 1)])
+              (default-runner [(qty "Security Nexus" 1)]))
+    (play-from-hand state :corp "Marcus Batty" "HQ")
+    (play-from-hand state :corp "Enigma" "HQ")
+    (take-credits state :corp)
+    (core/gain state :runner :credit 8)
+    (play-from-hand state :runner "Security Nexus")
+    (let [mb (-> @state :corp :servers :hq :content first)
+          en (-> @state :corp :servers :hq :ices first)
+          sn (-> @state :runner :rig :hardware first)]
+      (core/click-run state :runner {:server "HQ"})
+      (core/rez state :corp mb)
+      (core/rez state :corp en)
+      (card-ability state :corp mb 0)
+      (card-ability state :runner sn 0)
+      ; both prompts should be on Batty
+      (is (= (:cid mb) (-> @state :corp :prompt first :card :cid)) "Corp prompt is on Marcus Batty")
+      (is (= (:cid mb) (-> @state :runner :prompt first :card :cid)) "Runner prompt is on Marcus Batty")
+      (prompt-choice :corp "0")
+      (prompt-choice :runner "0")
+      (is (= (:cid sn) (-> @state :corp :prompt first :card :cid)) "Corp prompt is on Security Nexus")
+      (is (= :waiting (-> @state :runner :prompt first :prompt-type)) "Runner prompt is waiting for Corp"))))
+
 (deftest old-hollywood-grid
   "Old Hollywood Grid - Ability"
   (do-game


### PR DESCRIPTION
If a player says Yes to resolve an optional ability that has a cost but can't afford that cost, then we get this weird behavior where neither the `:yes-ability` nor the `:no-ability` of the optional gets resolved. This makes the "waiting for..." behavior introduced to Snare! and Ghost Branch difficult to implement. 

This core change will only trigger an optional's `:yes-ability` if the player can afford to pay its costs. Otherwise, the `:no-ability` will be triggered. Summary:

* If the player selected "Yes", and there is a `:yes-ability`, and the `:cost` of that ability can be paid, then trigger `:yes-ability`
* Otherwise, trigger `:no-ability` if there is one.