### PR TITLE
Card fixes: Parasite, Blue Sun, Chronos Protocol, DaVinci, Beale/Sleepers, Hunting Grounds

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -75,7 +75,8 @@
     :msg (msg "trash " (:title target)) :effect (effect (trash target))}
 
    "Chronos Project"
-   {:effect (effect (move-zone :runner :discard :rfg))}
+   {:msg "remove all cards in the Runner's Heap from the game"
+    :effect (effect (move-zone :runner :discard :rfg))}
 
    "Clone Retirement"
    {:msg "remove 1 bad publicity" :effect (effect (lose :bad-publicity 1))
@@ -149,7 +150,7 @@
     :abilities [{:cost [:click 1] :counter-cost 1 :msg "draw 5 cards" :effect (effect (draw 5))}]}
 
    "Explode-a-palooza"
-   {:access {:optional {:prompt "Gain 5 [Credits] with Explode-a-Palooza ability?"
+   {:access {:optional {:prompt "Gain 5 [Credits] with Explode-a-palooza ability?"
                        :yes-ability {:msg "gain 5 [Credits]"
                                      :effect (effect (gain :corp :credit 5))}}}}
 
@@ -182,7 +183,6 @@
 
    "Global Food Initiative"
    {:agendapoints-runner (req (do 2))}
-
 
    "Glenn Station"
    {:abilities [{:label "Host a card from HQ on Glenn Station" :cost [:click 1]
@@ -224,7 +224,8 @@
                  :effect (effect (gain :credit (:credit runner)))}]}
 
    "Hostile Takeover"
-   {:effect (effect (gain :credit 7 :bad-publicity 1))}
+   {:msg "gain 7 [Credits] and take 1 bad publicity"
+    :effect (effect (gain :credit 7 :bad-publicity 1))}
 
    "Hollywood Renovation"
    {:install-state :face-up
@@ -265,7 +266,8 @@
     :effect (effect (corp-install target nil {:install-state :rezzed-no-cost}))}
 
    "Mandatory Upgrades"
-   {:effect (effect (gain :click 1 :click-per-turn 1))
+   {:msg "gain an additional [Click] per turn"
+    :effect (effect (gain :click 1 :click-per-turn 1))
     :leave-play (req (lose state :corp :click 1 :click-per-turn 1))}
 
    "Market Research"
@@ -439,7 +441,8 @@
                                              (steal-cost-bonus state side [:credit (* 2 counter)])))}}}
 
    "Veterans Program"
-   {:effect (effect (lose :bad-publicity 2))}
+   {:msg "lose 2 bad publicity"
+    :effect (effect (lose :bad-publicity 2))}
 
    "Vulcan Coverup"
    {:msg "do 2 meat damage" :effect (effect (damage :meat 2 {:card card}))

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -9,9 +9,7 @@
                                   (gain-agenda-point state agenda-owner (- (:agendapoints card))))
                                 ; refresh agendapoints to 1 before shuffle in case it was modified by e.g. The Board
                                 (move state :corp (dissoc (assoc card :agendapoints 1) :seen :rezzed) :deck {:front true})
-                                (shuffle! state :corp :deck)
-                                )
-                   }]
+                                (shuffle! state :corp :deck))}]
       :flags {:has-abilities-when-stolen true}}
 
    "Accelerated Beta Test"
@@ -120,7 +118,8 @@
                                :msg "create a new remote server, installing cards at no cost"}}})
 
    "Domestic Sleepers"
-   {:abilities [{:cost [:click 3] :msg "place 1 agenda counter on Domestic Sleepers"
+   {:agendapoints-runner (req (do 0))
+    :abilities [{:cost [:click 3] :msg "place 1 agenda counter on Domestic Sleepers"
                  :effect (req (when (zero? (:counter card))
                                 (gain-agenda-point state side 1))
                               (set-prop state side card :counter 1 :agendapoints 1))}]}
@@ -341,7 +340,8 @@
                  :effect (effect (move target :hand) (shuffle! :deck))}]}
 
    "Project Beale"
-   {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)
+   {:agendapoints-runner (req (do 2))
+    :effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)
                               :agendapoints (+ 2 (quot (- (:advance-counter card) 3) 2))))}
 
    "Project Vitruvius"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -43,7 +43,7 @@
                               (let [cost (rez-cost state side target)]
                                 (gain state side :credit cost)
                                 (move state side target :hand)
-                                (system-msg state side (str "add " (:title target) " to HQ and gain " cost " [Credits]"))
+                                (system-msg state side (str "adds " (:title target) " to HQ and gains " cost " [Credits]"))
                                 (swap! state update-in [:bonus] dissoc :cost)))}]}
 
    "Cerebral Imaging: Infinite Frontiers"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -74,7 +74,7 @@
                                                                 (- (get-defer-damage state side :net nil) 1)
                                                                 " more net damage")))
                                                   :effect (effect (clear-wait-prompt :runner)
-                                                                  (trash target {:cause :net})
+                                                                  (trash target {:cause :net :unpreventable true})
                                                                   (damage :net (- (get-defer-damage state side :net nil) 1)
                                                                           {:unpreventable true :card card}))}
                                     :no-ability {:effect (effect (clear-wait-prompt :runner)

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -107,12 +107,13 @@
     :abilities [{:effect
                  (req (let [c card]
                         (resolve-ability state side
-                                         {:prompt "Choose a card to install from your grip"
+                                         {:prompt "Choose a card to install from your Grip"
                                           :choices {:req #(and (<= (:cost %) (get c :counter 0))
                                                                (#{"Hardware" "Program" "Resource"} (:type %))
                                                                (= (:zone %) [:hand]))}
                                           :msg (msg "install " (:title target) " at no cost")
-                                          :effect (effect (trash card) (runner-install target {:no-cost true}))}
+                                          :effect (effect (trash card {:cause :ability-cost})
+                                                          (runner-install target {:no-cost true}))}
                                          card nil)))}]}
 
    "Datasucker"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -440,7 +440,8 @@
                            (when (get-in card [:special :installing])
                              (update! state side (update-in card [:special] dissoc :installing))
                              (trigger-event state side :runner-install card))
-                           (trash state side target))
+                           (trash state side target)
+                           (trash-ice-in-run state))
               :msg (msg "trash " (:title target))}}}
 
    "Paricia"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -252,7 +252,8 @@
    {:abilities [{:label "Prevent a \"when encountered\" ability on a piece of ICE"
                  :msg "prevent a \"when encountered\" ability on a piece of ICE"
                  :once :per-turn}
-                 {:label "Install the top 3 cards of your Stack facedown"
+                 {:label "[Trash]: Install the top 3 cards of your Stack facedown"
+                  :msg "install the top 3 cards of their Stack facedown"
                   :effect (req (trash state side card {:cause :ability-cost})
                                (doseq [c (take 3 (:deck runner))]
                                   (runner-install state side c {:facedown true})))}]}


### PR DESCRIPTION
* Fix #1064: Make the specified card trashed by Chronos Protocol unpreventable so Fall Guy/Sacrificial Construct won't kick in to try and prevent cards lost from the Runner's Grip
* Fix #1065: Add a message when Hunting Grounds trash ability occurs so it doesn't happen silently.
* Fix #1090: Make DaVinci's self-trash trigger Geist
* Fix #1094: Change the tense of Blue Sun's log message
* Add `trash-ice-in-run` to Parasite so run position is automatically updated when ICE is destroyed--this will fix bugged runs that start with an immediate Ice Carver + Parasite instant ICE kill.
* Specify Runner agenda points of Project Beale and Domestic Sleepers so they will grant the Runner the correct number of points if ever Turntabled when they're worth increased points in the Corp score area. 