### PR TITLE
Allow rez to ignore just the rez cost, and not only all costs.

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -308,7 +308,7 @@
    "Priority Requisition"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)))}
     :msg (msg "rez " (:title target) " at no cost")
-    :effect (effect (rez target {:no-cost true}))}
+    :effect (effect (rez target {:ignore-cost :all-costs}))}
 
    "Private Security Force"
    {:abilities [{:req (req tagged) :cost [:click 1] :effect (effect (damage :meat 1 {:card card}))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -182,7 +182,7 @@
    "Elizas Toybox"
    {:abilities [{:cost [:click 3] :choices {:req #(not (:rezzed %))}
                  :label "Rez a card at no cost" :msg (msg "rez " (:title target) " at no cost")
-                 :effect (effect (rez target {:no-cost true}))}]}
+                 :effect (effect (rez target {:ignore-cost :all-costs}))}]}
 
    "Encryption Protocol"
    {:events {:pre-trash {:req (req (= (first (:zone target)) :servers))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -105,7 +105,7 @@
    "Bioroid Efficiency Research"
    {:choices {:req #(and (= (:type %) "ICE") (has? % :subtype "Bioroid") (not (:rezzed %)))}
     :msg (msg "rez " (card-str state target {:visible true}) " at no cost")
-    :effect (effect (rez target {:no-cost true})
+    :effect (effect (rez target {:ignore-cost :all-costs})
                     (host (get-card state target) (assoc card :zone [:discard] :seen true)))}
 
    "Biotic Labor"
@@ -281,7 +281,7 @@
    "Oversight AI"
    {:choices {:req #(and (= (:type %) "ICE") (not (:rezzed %)) (= (last (:zone %)) :ices))}
     :msg (msg "rez " (:title target) " at no cost")
-    :effect (effect (rez target {:no-cost true})
+    :effect (effect (rez target {:ignore-cost :all-costs})
                     (host (get-card state target) (assoc card :zone [:discard] :seen true)))}
 
    "Patch"
@@ -431,7 +431,7 @@
                                        (+ c (count (filter #(not (:rezzed %)) (:ices server)))))
                                      0 (flatten (seq (:servers corp))))))}
     :req (req tagged)
-    :effect (req (doseq [t targets] (rez state side t {:no-cost true})))}
+    :effect (req (doseq [t targets] (rez state side t {:ignore-cost :all-costs})))}
 
    "Snatch and Grab"
    {:trace {:msg "trash a connection" :base 3 :choices {:req #(has? % :subtype "Connection")}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -355,8 +355,7 @@
                        state :corp
                        {:prompt "Choose a card to rez, ignoring the rez cost"
                         :choices {:req #(not (:rezzed %))}
-                        :effect (req (gain state :corp :credit (rez-cost state side target))
-                                     (rez state side target)
+                        :effect (req (rez state side target {:ignore-cost :rez-cost})
                                      (system-msg state side (str "rezzes " (:title target) " at no cost")))}
                       card nil))
     :abilities [{:msg "draw 1 card"

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -94,7 +94,7 @@
                  (when (= (:type c) "Agenda")
                    (update-advancement-cost state side moved-card))
                  (when (= install-state :rezzed-no-cost)
-                   (rez state side moved-card {:no-cost true}))
+                   (rez state side moved-card {:ignore-cost :all-costs}))
                  (when (= install-state :rezzed)
                    (rez state side moved-card))
                  (when (= install-state :face-up)


### PR DESCRIPTION
Muertos Gang Member is the only card that allows something to be rezzed, ignoring just the _rez_ cost. Refactor `rez` to specify more exactly which costs should be ignored, if any. Muertos uses `:ignore-cost :rez-cost`, Oversight AI uses `:ignore-cost :all-costs`.