### PR TITLE
Remove closed games from state-diff support structure.

### DIFF
--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -78,7 +78,8 @@
       (try
         (case action
           "start" (core/init-game msg)
-          "remove" (swap! game-states dissoc gameid)
+          "remove" (do (swap! game-states dissoc gameid)
+                       (swap! last-states dissoc gameid))
           "do" (handle-do user command state side args)
           "notification" (when state
                            (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))


### PR DESCRIPTION
I believe I found the source of the server memory leak. When a game is over, the server correctly removes its state from memory. When I added state diffs, however, I introduced a second copy of the state -- used to calculate diffs -- and forgot to remove that structure on game end. So over the course of a week, with thousands of games played and closed, we are accumulating thousands of game state structures... yeah. One line fix.