### PR TITLE
Ice refactoring

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -202,7 +202,7 @@
                                    :effect (effect (add-prop target :advance-counter 1 {:placed true}) (end-run))}}}]}
 
    "Chum"
-   {:abilities [{:msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}]}
+   {:abilities [(do-net-damage 3)]}
 
    "Cortex Lock"
    {:abilities [{:label "Do 1 net damage for each unused memory units the Runner has"
@@ -452,7 +452,7 @@
                  :effect (effect (handle-access targets) (trash card))}]}
 
    "Komainu"
-   {:abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
+   {:abilities [(do-net-damage 1)]}
 
    "Lab Dog"
    {:abilities [(assoc trash-hardware :label "Force the Runner to trash an installed piece of hardware"
@@ -491,7 +491,7 @@
       :events {:advance ab :advancement-placed ab}})
 
    "Mamba"
-   {:abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}
+   {:abilities [(do-net-damage 1)
                 {:msg "do 1 net damage using 1 power counter"
                  :counter-cost 1 :effect (effect (damage :net 1 {:card card}))}
                 {:msg "start a Psi game"
@@ -551,7 +551,7 @@
    {:abilities [{:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))} trash-program]}
 
    "Neural Katana"
-   {:abilities [{:msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}]}
+   {:abilities [(do-net-damage 3)]}
 
    "News Hound"
    {:abilities [(tag-trace 3)
@@ -605,7 +605,7 @@
    {:abilities [{:msg "gain 1 [Credits]" :effect (effect (gain :credit 1))} end-the-run]}
 
    "Pup"
-   {:abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
+   {:abilities [(do-net-damage 1)]}
 
    "Quandary"
    {:abilities [end-the-run]}
@@ -722,8 +722,7 @@
     :abilities [trash-program]}
 
    "Swordsman"
-   {:abilities [{:msg "do 1 net damage"
-                 :effect (effect (damage :net 1 {:card card}))}
+   {:abilities [(do-net-damage 1)
                 {:prompt "Choose an AI program to trash"
                  :msg (msg "trashes " (:title target))
                  :label "Trash an AI program"
@@ -758,7 +757,8 @@
                                         (system-msg state side "loses [Click]")))}}]}
 
    "Tsurugi"
-   {:abilities [end-the-run {:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
+   {:abilities [end-the-run
+                (do-net-damage 1)]}
 
    "Turing"
    {:abilities [end-the-run]
@@ -812,7 +812,8 @@
    {:abilities [end-the-run]}
 
    "Wall of Thorns"
-   {:abilities [end-the-run {:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}]}
+   {:abilities [end-the-run
+                (do-net-damage 2)]}
 
    "Wendigo"
    (let [ab {:req (req (= (:cid card) (:cid target)))
@@ -838,7 +839,7 @@
 
    "Woodcutter"
    {:advanceable :while-rezzed
-    :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
+    :abilities [(do-net-damage 1)]}
 
    "Wormhole"
    {:advanceable :always
@@ -857,7 +858,7 @@
               {:runner-install wr :trash wr :card-moved wr})}
 
    "Yagura"
-   {:abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}
+   {:abilities [(do-net-damage 1)
                 {:msg "look at the top card of R&D"
                  :optional {:prompt (msg "Add " (:title (first (:deck corp))) " to bottom of R&D?")
                             :msg "add the top card of R&D to the bottom"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -80,11 +80,11 @@
 ;;; For Advanceable ICE
 (def advance-counters
   "Number of advancement counters - for advanceable ICE."
-  (req (or (:advance-counter card) 0)))
+  (req (:advance-counter card 0)))
 
 (def space-ice-rez-bonus
   "Amount of rez reduction for the Space ICE."
-  (req (* -3 (or (:advance-counter card) 0))))
+  (req (* -3 (:advance-counter card 0))))
 
 (defn space-ice
   "Creates data for Space ICE with specified abilities."
@@ -95,22 +95,25 @@
 
 
 ;;; For Grail ICE
+(defn grail-in-hand
+  "Req that specified card is a Grail card in the Corp's hand."
+  [card]
+  (and (= (:side card) "Corp")
+       (in-hand? card)
+       (has-subtype? card "Grail")))
+
 (def reveal-grail
   "Ability for revealing Grail ICE from HQ."
   {:label "Reveal up to 2 Grail ICE from HQ"
    :choices {:max 2
-             :req #(and (:side % "Corp")
-                        (in-hand? %)
-                        (has-subtype? % "Grail"))}
+             :req grail-in-hand}
    :msg (let [sub-label #(:label (first (:abilities (card-def %))))]
          (msg "reveal " (join ", " (map #(str (:title %) " (" (sub-label %) ")") targets))))})
 
 (def resolve-grail
   "Ability for resolving a subroutine on a Grail ICE in HQ."
   {:label "Resolve a Grail ICE subroutine from HQ"
-   :choices {:req #(and (:side % "Corp")
-                        (in-hand? %)
-                        (has-subtype? % "Grail"))}
+   :choices {:req grail-in-hand}
    :effect (req (doseq [ice targets]
                   (let [subroutine (first (:abilities (card-def ice)))]
                     (resolve-ability state side subroutine card nil))))})

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -71,6 +71,11 @@
    :msg (str "start a psi game (" label ")")
    :psi {:not-equal ability}})
 
+(def take-bad-pub
+  "Bad pub on rez effect."
+  (effect (gain :bad-publicity 1)
+          (system-msg (str "takes 1 bad publicity from " (:title card)))))
+
 
 ;;; For Advanceable ICE
 (def advance-counters
@@ -260,7 +265,7 @@
    (morph-ice "Barrier" "Sentry" end-the-run)
    
    "Checkpoint"
-   {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
+   {:effect take-bad-pub
     :abilities [(trace-ability 5 {:label "Do 3 meat damage when this run is successful"
                                   :msg "do 3 meat damage when this run is successful"
                                   :effect (req (swap! state assoc-in [:run :run-effect :end-run]
@@ -392,7 +397,7 @@
                  :msg "prevent the Runner from making another run" :effect (effect (prevent-run))}]}
 
    "Fenris"
-   {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
+   {:effect take-bad-pub
     :abilities [(do-brain-damage 1)
                 end-the-run]}
 
@@ -422,7 +427,7 @@
    (constellation-ice (do-net-damage 1))
    
    "Grim"
-   {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
+   {:effect take-bad-pub
     :abilities [trash-program]}
 
    "Guard"
@@ -626,7 +631,7 @@
       :events {:rez ab :trash ab :derez ab}})
 
    "Muckraker"
-   {:effect (effect (gain :bad-publicity 1))
+   {:effect take-bad-pub
     :abilities [(tag-trace 1)
                 (tag-trace 2)
                 (tag-trace 3)
@@ -741,7 +746,7 @@
                          :effect (effect (move :runner target :deck {:front true}))}}]}
 
    "Shinobi"
-   {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
+   {:effect take-bad-pub
     :abilities [(trace-ability 1 (do-net-damage 1))
                 (trace-ability 2 (do-net-damage 2))
                 (trace-ability 3 {:label "Do 3 net damage and end the run"
@@ -795,7 +800,7 @@
                               (update-run-ice state side))}]}
 
    "Swarm"
-   {:effect (effect (gain :bad-publicity 1))
+   {:effect take-bad-pub
     :advanceable :always
     :abilities [trash-program]}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -118,6 +118,14 @@
      :abilities [ability]
      :events {:advance ab :advancement-placed ab}}))
 
+
+;;; For Constellation ICE
+(defn constellation-ice
+  "Generates map for Constellation ICE with specified effect."
+  [ability]
+  {:abilities [(trace-ability 2 (assoc ability :kicker (assoc ability :min 5)))]})
+
+
 ;;;; Card definitions
 (def cards-ice
   {"Archangel"
@@ -166,7 +174,7 @@
 
    "Assassin"
    {:abilities [(trace-ability 5 (do-net-damage 3))
-                (trace-ability 4 (assoc trash-program :msg "trash a program"))]}
+                (trace-ability 4 trash-program)]}
 
    "Asteroid Belt"
    (space-ice end-the-run)
@@ -388,10 +396,8 @@
    (grail-ice end-the-run)
 
    "Gemini"
-   {:abilities [{:label "Trace 2 - Do 1 net damage"
-                 :trace {:base 2 :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))
-                         :kicker {:min 5 :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}}]}
-
+   (constellation-ice (do-net-damage 1))
+   
    "Grim"
    {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
     :abilities [trash-program]}
@@ -683,9 +689,7 @@
    {:abilities [trash-program end-the-run]}
 
    "Sagittarius"
-   {:abilities [{:label "Trace 2 - Trash a program"
-                 :trace (assoc trash-program :base 2 :not-distinct true :msg "trash 1 program"
-                                             :kicker (assoc trash-program :min 5))}]}
+   (constellation-ice trash-program)
 
    "Salvage"
    {:advanceable :while-rezzed
@@ -788,10 +792,8 @@
                                       (has-subtype? % "AI"))}}]}
 
    "Taurus"
-   {:abilities [{:label "Trace 2 - Trash a piece of hardware"
-                 :trace (assoc trash-hardware :base 2 :not-distinct true :msg "trash 1 hardware"
-                                              :kicker (assoc trash-hardware :min 5))}]}
-
+   (constellation-ice trash-hardware)
+   
    "TMI"
    {:trace {:base 2
             :msg "keep TMI rezzed"
@@ -867,11 +869,10 @@
                 (trace-ability 3 end-the-run)]}
 
    "Virgo"
-   {:abilities [{:label "Trace 2 - Give the Runner 1 tag"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))
-                         :kicker {:min 5 :msg "give the Runner 1 tag"
-                                  :effect (effect (tag-runner :runner 1))}}}]}
-
+   (constellation-ice {:label "Give the Runner 1 tag"
+                       :msg "give the Runner 1 tag"
+                       :effect (effect (tag-runner :runner 1))})
+   
    "Wall of Static"
    {:abilities [end-the-run]}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -33,6 +33,23 @@
    :msg (str "gain " credits " [Credits]")
    :effect (effect (gain :credit credits))})
 
+;;; For Advanceable ICE
+(def advance-counters
+  "Number of advancement counters - for advanceable ICE."
+  (req (or (:advance-counter card) 0)))
+
+(def space-ice-rez-bonus
+  "Amount of rez reduction for the Space ICE."
+  (req (* -3 (or (:advance-counter card) 0))))
+
+(defn space-ice
+  "Creates data for Space ICE with specified abilities."
+  [& abilities]
+  {:advanceable :always
+   :abilities (vec abilities)
+   :rez-cost-bonus space-ice-rez-bonus})
+
+
 ;;; For Grail ICE
 (def reveal-grail
   "Ability for revealing Grail ICE from HQ."
@@ -118,9 +135,8 @@
                  :trace (assoc trash-program :base 4 :msg "trash a program")}]}
 
    "Asteroid Belt"
-   {:advanceable :always :abilities [end-the-run]
-    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
-
+   (space-ice end-the-run)
+   
    "Bandwidth"
    {:abilities [{:msg "give the Runner 1 tag"
                  :effect (effect (tag-runner :runner 1)
@@ -316,7 +332,7 @@
    "Fire Wall"
    {:advanceable :always
     :abilities [end-the-run]
-    :strength-bonus (req (or (:advance-counter card) 0))}
+    :strength-bonus advance-counters}
 
    "Flare"
    {:abilities [{:label "Trace 6 - Trash 1 hardware, do 2 meat damage, and end the run"
@@ -364,7 +380,7 @@
    "Hadrians Wall"
    {:advanceable :always
     :abilities [end-the-run]
-    :strength-bonus (req (or (:advance-counter card) 0))}
+    :strength-bonus advance-counters}
 
    "Himitsu-Bako"
    {:abilities [end-the-run {:msg "add it to HQ" :cost [:credit 1] :effect (effect (move card :hand))}]}
@@ -419,7 +435,7 @@
 
    "Ice Wall"
    {:advanceable :always :abilities [end-the-run]
-    :strength-bonus (req (or (:advance-counter card) 0))}
+    :strength-bonus advance-counters}
 
    "Ichi 1.0"
    {:abilities [trash-program
@@ -561,9 +577,7 @@
                  :effect (effect (end-run))}]}
 
    "Nebula"
-   {:advanceable :always
-    :abilities [trash-program]
-    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
+   (space-ice trash-program)
 
    "Negotiator"
    {:abilities [(gain-credits 2)
@@ -597,9 +611,9 @@
    {:abilities [end-the-run]}
 
    "Orion"
-   {:advanceable :always :abilities [trash-program end-the-run]
-    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
-
+   ;; TODO: wormhole subroutine
+   (space-ice trash-program end-the-run)
+   
    "Pachinko"
    {:abilities [{:label "End the run if the Runner is tagged"
                  :req (req tagged) :msg "end the run" :effect (effect (end-run))}]}
@@ -647,8 +661,9 @@
 
    "Searchlight"
    {:advanceable :always
+    ;; Could replace this with (tag-trace advance-counters).
     :abilities [{:label "Trace X - Give the Runner 1 tag"
-                 :trace {:base (req (or (:advance-counter card) 0)) :effect (effect (tag-runner :runner 1))
+                 :trace {:base advance-counters :effect (effect (tag-runner :runner 1))
                          :msg "give the Runner 1 tag"}}]}
 
    "Sensei"
@@ -659,7 +674,7 @@
    {:advanceable :always
     :abilities [(gain-credits 2)
                 (tag-trace 3)]
-    :strength-bonus (req (or (:advance-counter card) 0))}
+    :strength-bonus advance-counters}
 
    "Sherlock 1.0"
    {:abilities [{:label "Trace 4 - Add an installed program to the top of Stack"
@@ -849,9 +864,9 @@
     :abilities [(do-net-damage 1)]}
 
    "Wormhole"
-   {:advanceable :always
-    :rez-cost-bonus (req (* -3 (or (:advance-counter card) 0)))}
-
+   ;; TODO: create an ability for wormhole
+   (space-ice)
+   
    "Wotan"
    {:abilities [end-the-run]}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -18,6 +18,12 @@
    :msg "give the Runner 1 tag"
    :effect (effect (tag-runner :runner 1))}) 
 
+(def add-power-counter
+  "Adds 1 power counter to the card."
+  {:label "Add 1 power counter"
+   :msg "add 1 power counter"
+   :effect (effect (add-prop card :counter 1))})
+
 (defn trace-ability
   "Run a trace with specified base strength.
    If successful trigger specified ability"
@@ -50,6 +56,13 @@
   {:label (str "Gain " credits " [Credits]")
    :msg (str "gain " credits " [Credits]")
    :effect (effect (gain :credit credits))})
+
+(defn power-counter-ability
+  "Does specified ability using a power counter."
+  [{:keys [label msg] :as ability}]
+  (assoc ability :label (str "Hosted power counter: " label)
+                 :msg (str msg " using 1 power counter")
+                 :counter-cost 1))
 
 
 ;;; For Advanceable ICE
@@ -326,12 +339,8 @@
 
    "Data Raven"
    {:abilities [give-tag
-                {:msg "give the Runner 1 tag using 1 power counter"
-                 :counter-cost 1
-                 :effect (effect (tag-runner 1))}
-                (trace-ability 3 {:label "Add 1 power counter"
-                                  :msg "add 1 power counter"
-                                  :effect (effect (add-prop card :counter 1))})]}
+                (power-counter-ability give-tag)
+                (trace-ability 3 add-power-counter)]}
 
    "Dracō"
    {:prompt "How many power counters?"
@@ -566,12 +575,10 @@
    (morph-ice "Sentry" "Code Gate" trash-program)
 
    "Mamba"
-   {:abilities [(do-net-damage 1)
-                {:msg "do 1 net damage using 1 power counter"
-                 :counter-cost 1 :effect (effect (damage :net 1 {:card card}))}
+   {:abilities [(power-counter-ability (do-net-damage 1))
+                (do-net-damage 1)
                 {:msg "start a Psi game"
-                 :psi {:not-equal {:msg "add 1 power counter"
-                                   :effect (effect (add-prop :runner card :counter 1))}}}]}
+                 :psi {:not-equal add-power-counter}}]}
 
    "Markus 1.0"
    {:abilities [trash-installed end-the-run]}
@@ -746,16 +753,15 @@
    {:abilities [{:req (req (= current-ice card))
                  :label "Reveal all cards in the Runner's Grip"
                  :msg (msg "reveal " (join ", " (map :title (:hand runner))))}
-                (trace-ability 3 {:label "Place 1 power counter on Snoop"
-                                  :msg "place 1 power counter on Snoop"
-                                  :effect (effect (add-prop card :counter 1))})
                 {:req (req (> (:counter card 0) 0))
                  :counter-cost 1
                  :label "Hosted power counter: Reveal all cards in Grip and trash 1 card"
-                 :msg (msg "look at all cards in Grip and trash " (:title target))
+                 :msg (msg "look at all cards in Grip and trash " (:title target)
+                           " using 1 power counter")
                  :choices (req (:hand runner))
                  :prompt "Choose a card to trash"
-                 :effect (effect (trash target))}]}
+                 :effect (effect (trash target))}
+                (trace-ability 3 add-power-counter)]}
 
    "Snowflake"
    {:abilities [{:msg "start a Psi game"
@@ -858,12 +864,8 @@
                 end-the-run]}
 
    "Viktor 2.0"
-   {:abilities [{:msg "do 1 brain damage using 1 power counter"
-                 :counter-cost 1
-                 :effect (effect (damage :brain 1 {:card card}))}
-                (trace-ability 2 {:label "Add 1 power counter"
-                                  :msg "add 1 power counter"
-                                  :effect (effect (add-prop card :counter 1))})
+   {:abilities [(power-counter-ability (do-brain-damage 1))
+                (trace-ability 2 add-power-counter)
                 end-the-run]}
 
    "Viper"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -64,6 +64,13 @@
                  :msg (str msg " using 1 power counter")
                  :counter-cost 1))
 
+(defn do-psi
+  "Start a psi game, if not equal do ability"
+  [{:keys [label] :as ability}]
+  {:label (str "Psi Game - " label)
+   :msg (str "start a psi game (" label ")")
+   :psi {:not-equal ability}})
+
 
 ;;; For Advanceable ICE
 (def advance-counters
@@ -222,17 +229,19 @@
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "Bullfrog"
-   {:abilities [{:msg "start a Psi game"
-                 :psi {:not-equal
-                       {:player :corp :prompt "Choose a server" :choices (req servers)
-                        :msg (msg "move it to the outermost position of " target)
-                        :effect (req (let [dest (server->zone state target)]
-                                       (swap! state update-in [:run]
-                                              #(assoc % :position (count (get-in corp (conj dest :ices)))
-                                                        :server (rest dest))))
-                                     (move state side card (conj (server->zone state target) :ices))
-                                     (update-run-ice state side))}}}]}
-
+   {:abilities [(do-psi {:label "Move Bullfrog to another server"
+                         :player :corp
+                         :prompt "Choose a server"
+                         :choices (req servers)
+                         :msg (msg "move it to the outermost position of " target)
+                         :effect (req (let [dest (server->zone state target)]
+                                        (swap! state update-in [:run]
+                                               #(assoc % :position (count (get-in corp (conj dest :ices)))
+                                                       :server (rest dest))))
+                                      (move state side card
+                                            (conj (server->zone state target) :ices))
+                                      (update-run-ice state side))})]}
+   
    "Burke Bugs"
    {:abilities [(trace-ability 0 (assoc trash-program :not-distinct true
                                         :player :runner
@@ -278,13 +287,14 @@
       :abilities [end-the-run]})
    
    "Clairvoyant Monitor"
-   {:abilities [{:msg "start a Psi game"
-                 :psi {:not-equal {:player :corp
-                                   :prompt "Choose a target for Clairvoyant Monitor"
-                                   :msg (msg "place 1 advancement token on "
-                                             (card-str state target) " and end the run")
-                                   :choices {:req installed?}
-                                   :effect (effect (add-prop target :advance-counter 1 {:placed true}) (end-run))}}}]}
+   {:abilities [(do-psi {:label "Place 1 advancement token and end the run"
+                         :player :corp
+                         :prompt "Choose a target for Clairvoyant Monitor"
+                         :msg (msg "place 1 advancement token on "
+                                   (card-str state target) " and end the run")
+                         :choices {:req installed?}
+                         :effect (effect (add-prop target :advance-counter 1 {:placed true})
+                                         (end-run))})]}
 
    "Chum"
    {:abilities [(do-net-damage 3)]}
@@ -577,8 +587,7 @@
    "Mamba"
    {:abilities [(power-counter-ability (do-net-damage 1))
                 (do-net-damage 1)
-                {:msg "start a Psi game"
-                 :psi {:not-equal add-power-counter}}]}
+                (do-psi add-power-counter)]}
 
    "Markus 1.0"
    {:abilities [trash-installed end-the-run]}
@@ -764,8 +773,7 @@
                 (trace-ability 3 add-power-counter)]}
 
    "Snowflake"
-   {:abilities [{:msg "start a Psi game"
-                 :psi {:not-equal end-the-run}}]}
+   {:abilities [(do-psi end-the-run)]}
 
    "Special Offer"
    {:abilities [{:label "Gain 5 [Credits] and trash Special Offer"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -26,6 +26,13 @@
    :msg (str "do " dmg " net damage")
    :effect (effect (damage :net dmg {:card card}))})
 
+(defn do-brain-damage
+  "Do specified amount of brain damage."
+  [dmg]
+  {:label (str "Do " dmg " brain damage")
+   :msg (str "do " dmg " brain damage")
+   :effect (effect (damage :brain dmg {:card card}))})
+
 (defn gain-credits
   "Gain specified amount of credits"
   [credits]
@@ -304,7 +311,7 @@
    "Enforcer 1.0"
    {:additional-cost [:forfeit]
     :abilities [trash-program
-                {:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))}
+                (do-brain-damage 1)
                 {:label "Trash a console" :effect (effect (trash target))
                  :prompt "Choose a console to trash" :msg (msg "trash " (:title target))
                  :choices {:req #(has-subtype? % "Console")}}
@@ -327,7 +334,8 @@
 
    "Fenris"
    {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
-    :abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))} end-the-run]}
+    :abilities [(do-brain-damage 1)
+                end-the-run]}
 
    "Fire Wall"
    {:advanceable :always
@@ -389,10 +397,11 @@
    {:abilities [end-the-run]}
 
    "Heimdall 1.0"
-   {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))} end-the-run]}
+   {:abilities [(do-brain-damage 1)
+                end-the-run]}
 
    "Heimdall 2.0"
-   {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))}
+   {:abilities [(do-brain-damage 1)
                 {:msg "do 1 brain damage and end the run" :effect (effect (damage :brain 1 {:card card}) (end-run))}
                 end-the-run]}
 
@@ -476,7 +485,7 @@
                                                     (trash state side card)))]}
 
    "Janus 1.0"
-   {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))}]}
+   {:abilities [(do-brain-damage 1)]}
 
    "Kitsune"
    {:abilities [{:prompt "Choose a card in HQ to force access"
@@ -808,13 +817,17 @@
                  :trace {:base 4 :msg "end the run" :effect (effect (end-run))}}]}
 
    "Viktor 1.0"
-   {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))} end-the-run]}
+   {:abilities [(do-brain-damage 1)
+                end-the-run]}
 
    "Viktor 2.0"
-   {:abilities [{:msg "do 1 brain damage using 1 power counter" :counter-cost 1
+   {:abilities [{:msg "do 1 brain damage using 1 power counter"
+                 :counter-cost 1
                  :effect (effect (damage :brain 1 {:card card}))}
                 {:label "Trace 2 - Add 1 power counter"
-                 :trace {:base 2 :msg "add 1 power counter" :effect (effect (add-prop card :counter 1))}}
+                 :trace {:base 2
+                         :msg "add 1 power counter"
+                         :effect (effect (add-prop card :counter 1))}}
                 end-the-run]}
 
    "Viper"
@@ -887,4 +900,4 @@
                             :yes-ability {:effect (effect (move (first (:deck corp)) :deck))}}}]}
 
    "Zed 1.0"
-   {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))}]}})
+   {:abilities [(do-brain-damage 1)]}})

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -11,6 +11,13 @@
    :msg "end the run"
    :effect (effect (end-run))})
 
+(def give-tag
+  "Basic give runner 1 tag subroutine
+   Mostly used with tag-trace"
+  {:label "Give the Runner 1 tag"
+   :msg "give the Runner 1 tag"
+   :effect (effect (tag-runner :runner 1))}) 
+
 (defn trace-ability
   "Run a trace with specified base strength.
    If successful trigger specified ability"
@@ -21,9 +28,7 @@
 (defn tag-trace
   "Trace ability for giving a tag, at specified base strength"
   [base]
-  (trace-ability base {:label "Give the Runner 1 tag"
-                       :msg "give the Runner 1 tag"
-                       :effect (effect (tag-runner :runner 1))}))
+  (trace-ability base give-tag))
 
 (defn do-net-damage
   "Do specified amount of net-damage."
@@ -320,8 +325,7 @@
                 end-the-run]}
 
    "Data Raven"
-   {:abilities [{:msg "give the Runner 1 tag"
-                 :effect (effect (tag-runner 1))}
+   {:abilities [give-tag
                 {:msg "give the Runner 1 tag using 1 power counter"
                  :counter-cost 1
                  :effect (effect (tag-runner 1))}
@@ -869,9 +873,7 @@
                 (trace-ability 3 end-the-run)]}
 
    "Virgo"
-   (constellation-ice {:label "Give the Runner 1 tag"
-                       :msg "give the Runner 1 tag"
-                       :effect (effect (tag-runner :runner 1))})
+   (constellation-ice give-tag)
    
    "Wall of Static"
    {:abilities [end-the-run]}

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -11,6 +11,14 @@
    :msg "end the run"
    :effect (effect (end-run))})
 
+(defn tag-trace
+  "Trace ability for giving a tag, at specified base strength"
+  [base]
+  {:label (str "Trace " base " - Give the Runner 1 tag")
+   :trace {:base base
+           :msg "give the Runner 1 tag"
+           :effect (effect (tag-runner :runner 1))}})
+
 (defn do-net-damage
   "Do specified amount of net-damage."
   [dmg]
@@ -321,8 +329,7 @@
    {:abilities [end-the-run]}
 
    "Gutenberg"
-   {:abilities [{:label "Trace 7 - Give the Runner 1 tag"
-                 :trace {:base 7 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]
+   {:abilities [(tag-trace 7)]
     :strength-bonus (req (if (= (second (:zone card)) :rd) 3 0))}
 
    "Gyri Labyrinth"
@@ -390,8 +397,7 @@
                  :effect (effect (max-access 1))}]}
 
    "Hunter"
-   {:abilities [{:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
+   {:abilities [(tag-trace 3)]}
 
    "Ice Wall"
    {:advanceable :always :abilities [end-the-run]
@@ -422,8 +428,7 @@
     :leave-play (req (remove-watch state (keyword (str "iq" (:cid card)))))}
 
    "Information Overload"
-   {:abilities [{:label "Trace 1 - Give the Runner 1 tag"
-                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
+   {:abilities [(tag-trace 1)
                 trash-installed]}
 
    "Ireress"
@@ -501,8 +506,7 @@
                  :msg (msg "place 1 advancement token on " (card-str state target))
                  :choices {:req can-be-advanced?}
                  :cost [:credit 1] :effect (effect (add-prop target :advance-counter 1))}
-                {:label "Trace 2 - Give the Runner 1 tag"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
+                (tag-trace 2)]}
 
    "Merlin"
    (grail-ice (do-net-damage 2))
@@ -532,12 +536,9 @@
 
    "Muckraker"
    {:effect (effect (gain :bad-publicity 1))
-    :abilities [{:label "Trace 1 - Give the Runner 1 tag"
-                 :trace {:base 1 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
-                {:label "Trace 2 - Give the Runner 1 tag"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
-                {:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
+    :abilities [(tag-trace 1)
+                (tag-trace 2)
+                (tag-trace 3)
                 {:msg "end the run if the Runner is tagged" :req (req tagged)
                  :effect (effect (end-run))}]}
 
@@ -553,8 +554,7 @@
    {:abilities [{:msg "do 3 net damage" :effect (effect (damage :net 3 {:card card}))}]}
 
    "News Hound"
-   {:abilities [{:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
+   {:abilities [(tag-trace 3)
                 {:label "End the run if a Current is active"
                  :req (req (or (not (empty? (runner :current)))
                                (not (empty? (corp :current)))))
@@ -636,8 +636,7 @@
 
    "Salvage"
    {:advanceable :while-rezzed
-    :abilities [{:label "Trace 2 - Give the Runner 1 tag"
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
+    :abilities [(tag-trace 2)]}
 
    "Searchlight"
    {:advanceable :always
@@ -652,8 +651,7 @@
    "Shadow"
    {:advanceable :always
     :abilities [{:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))}
-                {:label "Trace 3 - Give the Runner 1 tag"
-                 :trace {:base 3 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]
+                (tag-trace 3)]
     :strength-bonus (req (or (:advance-counter card) 0))}
 
    "Sherlock 1.0"
@@ -769,8 +767,7 @@
    "Turnpike"
    {:abilities [{:msg "force the Runner to lose 1 [Credits]"
                  :effect (effect (lose :runner :credit 1))}
-                {:label "Trace 5 - Give the Runner 1 tag"
-                 :trace {:base 5 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
+                (tag-trace 5)]}
 
    "Tyrant"
    {:advanceable :while-rezzed :abilities [end-the-run]}

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -341,7 +341,7 @@
                                  " to initiate a trace with strength " total
                                  " (" base
                                  (when (pos? bonus) (str " + " bonus " bonus"))
-                                 " + " boost " [Credits]) (" (:msg ability) ")"))
+                                 " + " boost " [Credits]) (" (:label ability) ")"))
     (swap! state update-in [:bonus] dissoc :trace)
     (show-prompt state :runner card (str "Boost link strength?") :credit #(resolve-trace state side %) {:priority 2})
     (swap! state assoc :trace {:strength total :ability ability :card card})


### PR DESCRIPTION
Refactors `cards-ice` structure.

Please review :smile: 

Each commit should deal with one change as described, please let me know if anything seems unnecessary or less readable than before.

Does two major changes:
- Refactors out commonly used subroutines, like "end the run" and traces.
- Extracts stuff common to "sets" of ice (like the constellation "kicker" ice).