### PR TITLE
Hand Size Split

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -395,8 +395,8 @@
                  :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
 
    "Self-Destruct Chips"
-   {:effect (effect (lose :runner :max-hand-size 1))
-    :leave-play (effect (gain :runner :max-hand-size 1))}
+   {:effect (effect (lose :runner :hand-size-modification 1))
+    :leave-play (effect (gain :runner :hand-size-modification 1))}
 
    "Sentinel Defense Program"
    {:events {:damage {:req (req (= target :brain)) :msg "to do 1 net damage"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -55,8 +55,8 @@
                                       :effect (effect (damage :brain (:advance-counter card) {:card card}))}}}}
 
    "Chairman Hiro"
-   {:effect (effect (lose :runner :max-hand-size 2))
-    :leave-play (effect (gain :runner :max-hand-size 2))
+   {:effect (effect (lose :runner :hand-size-modification 2))
+    :leave-play (effect (gain :runner :hand-size-modification 2))
     :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
 
    "City Surveillance"
@@ -106,7 +106,8 @@
               :effect (effect (trash target {:unpreventable true}))}}}
 
    "Cybernetics Court"
-   {:effect (effect (gain :max-hand-size 4)) :leave-play (effect (lose :max-hand-size 4))}
+   {:effect (effect (gain :hand-size-modification 4))
+    :leave-play (effect (lose :hand-size-modification 4))}
 
    "Daily Business Show"
    {:events {:corp-draw
@@ -358,8 +359,8 @@
    {:abilities [{:cost [:click 3] :effect (effect (gain :credit 7)) :msg "gain 7 [Credits]"}]}
 
    "Mental Health Clinic"
-   {:effect (effect (gain :runner :max-hand-size 1))
-    :leave-play (effect (lose :runner :max-hand-size 1))
+   {:effect (effect (gain :runner :hand-size-modification 1))
+    :leave-play (effect (lose :runner :hand-size-modification 1))
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     :events {:corp-turn-begins {:msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -261,8 +261,8 @@
     :effect (effect (trash-cards targets) (gain :credit (* 2 (count targets))))}
 
    "Game Day"
-   {:msg (msg "draw " (- (:max-hand-size runner) (count (:hand runner))) " cards")
-    :effect (effect (draw (- (:max-hand-size runner) (count (:hand runner)))))}
+   {:msg (msg "draw " (- (hand-size runner) (count (:hand runner))) " cards")
+    :effect (effect (draw (- (hand-size runner) (count (:hand runner)))))}
 
    "Hacktivist Meeting"
    {:events {:rez {:req (req (not (ice? target)))
@@ -346,17 +346,17 @@
    {:prompt "Choose a server" :choices (req servers) :effect (effect (run target nil card))}
 
    "Itinerant Protesters"
-   {:effect (req (lose state :corp :max-hand-size (:bad-publicity corp))
+   {:effect (req (lose state :corp :hand-size-modification (:bad-publicity corp))
                  (add-watch state :itin
                    (fn [k ref old new]
                      (let [bpnew (get-in new [:corp :bad-publicity])
                            bpold (get-in old [:corp :bad-publicity])]
                        (when (> bpnew bpold)
-                         (lose state :corp :max-hand-size (- bpnew bpold)))
+                         (lose state :corp :hand-size-modification (- bpnew bpold)))
                        (when (< bpnew bpold)
-                         (gain state :corp :max-hand-size (- bpold bpnew)))))))
+                         (gain state :corp :hand-size-modification (- bpold bpnew)))))))
     :leave-play (req (remove-watch state :itin)
-                     (gain state :corp :max-hand-size (:bad-publicity corp)))}
+                     (gain state :corp :hand-size-modification (:bad-publicity corp)))}
 
    "Knifed"
    {:prompt "Choose a server" :choices (req servers) :effect (effect (run target nil card))}

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -60,23 +60,30 @@
                               (trash state side (get-card state card) {:cause :ability-cost}))}]}
 
    "Box-E"
-   {:effect (effect (gain :memory 2 :max-hand-size 2))
-    :leave-play (effect (lose :memory 2 :max-hand-size 2))}
+   {:effect (effect (gain :memory 2 :hand-size-modification 2))
+    :leave-play (effect (lose :memory 2 :hand-size-modification 2))}
 
    "Brain Cage"
-   {:effect (effect (damage :brain 1 {:card card}) (gain :max-hand-size 3))
-    :leave-play (effect (lose :max-hand-size 3))}
+   {:effect (effect (damage :brain 1 {:card card})
+                    (gain :hand-size-modification 3))
+    :leave-play (effect (lose :hand-size-modification 3))}
 
    "Brain Chip"
    (let [runner-points (fn [s] (max (or (get-in s [:runner :agenda-point]) 0) 0))]
-     {:effect (req (gain state :runner :memory (runner-points @state) :max-hand-size (runner-points @state))
+     {:effect (req (gain state :runner
+                         :memory (runner-points @state)
+                         :hand-size-modification (runner-points @state))
                    (add-watch state (keyword (str "brainchip" (:cid card)))
                           (fn [k ref old new]
                             (let [bonus (- (runner-points new) (runner-points old))]
                               (when (not= 0 bonus)
-                               (gain state :runner :memory bonus :max-hand-size bonus))))))
+                               (gain state :runner
+                                     :memory bonus
+                                     :hand-size-modification bonus))))))
       :leave-play (req (remove-watch state (keyword (str "brainchip" (:cid card))))
-                       (lose state :runner :memory (runner-points @state) :max-hand-size (runner-points @state)))})
+                       (lose state :runner
+                             :memory (runner-points @state) 
+                             :hand-size-modification (runner-points @state)))})
 
    "Capstone"
    {:abilities [{:req (req (> (count (:hand runner)) 0))
@@ -294,8 +301,8 @@
    {:recurring 1}
 
    "Logos"
-   {:effect (effect (gain :memory 1 :max-hand-size 1))
-    :leave-play (effect (lose :memory 1 :max-hand-size 1))
+   {:effect (effect (gain :memory 1 :hand-size-modification 1))
+    :leave-play (effect (lose :memory 1 :hand-size-modification 1))
     :events {:agenda-scored
              {:player :runner :prompt "Choose a card" :msg (msg "add 1 card to Grip from Stack")
               :choices (req (:deck runner)) :effect (effect (move target :hand) (shuffle! :deck))}}}
@@ -534,7 +541,7 @@
 
    "Vigil"
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
-    :events {:runner-turn-begins {:req (req (= (count (:hand corp)) (:max-hand-size corp)))
+    :events {:runner-turn-begins {:req (req (= (count (:hand corp)) (hand-size state :corp)))
                                   :msg "draw 1 card" :effect (effect (draw 1))}}}
 
    "Window"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -292,10 +292,10 @@
    {:abilities [{:req (req (:run @state))
                  :label "Reduce Runner's maximum hand size by 2 until start of next Corp turn"
                  :msg "reduce the Runner's maximum hand size by 2 until the start of the next Corp turn"
-                 :effect (effect (lose :runner :max-hand-size 2)
+                 :effect (effect (lose :runner :hand-size-modification 2)
                                  (register-events {:corp-turn-begins
                                                    {:msg "increase the Runner's maximum hand size by 2"
-                                                    :effect (effect (gain :runner :max-hand-size 2)
+                                                    :effect (effect (gain :runner :hand-size-modification 2)
                                                                     (unregister-events card))}} card))}]
     :events {:corp-turn-begins nil}}
 

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -52,7 +52,7 @@
                             (fn [k ref old new]
                               (let [credit (get-in new [:corp :credit])]
                                 (when (not= (get-in old [:corp :credit]) credit)
-                                  (swap! ref assoc-in [:corp :max-hand-size] credit))))))}
+                                  (swap! ref assoc-in [:corp :hand-size-base] credit))))))}
 
    "Chaos Theory: Wünderkind"
    {:effect (effect (gain :memory 1))}
@@ -83,7 +83,8 @@
                                                                          {:unpreventable true :card card}))}}} card nil))}}}
 
    "Cybernetics Division: Humanity Upgraded"
-   {:effect (effect (lose :max-hand-size 1) (lose :runner :max-hand-size 1))}
+   {:effect (effect (lose :hand-size-modification 1)
+                    (lose :runner :hand-size-modification 1))}
 
    "Edward Kim: Humanitys Hammer"
    {:effect (effect (gain :link 1))
@@ -259,7 +260,7 @@
    {:recurring 2}
 
    "NBN: The World is Yours*"
-   {:effect (effect (gain :max-hand-size 1))}
+   {:effect (effect (gain :hand-size-modification 1))}
 
    "Near-Earth Hub: Broadcast Center"
    {:events {:server-created {:msg "draw 1 card" :once :per-turn :effect (effect (draw 1))}}}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -396,10 +396,10 @@
                  :effect (effect (damage-prevent :net 1))}]}
 
    "Origami"
-   {:effect (effect (gain :max-hand-size
+   {:effect (effect (gain :hand-size-modification
                           (dec (* 2 (count (filter #(= (:title %) "Origami")
                                                    (all-installed state :runner)))))))
-    :leave-play (effect (lose :max-hand-size
+    :leave-play (effect (lose :hand-size-modification
                               (dec (* 2 (count (filter #(= (:title %) "Origami")
                                                        (all-installed state :runner)))))))}
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -63,12 +63,13 @@
                                 (trash state :runner card {:unpreventable true})))}]}
 
    "Beach Party"
-   {:effect (effect (gain :max-hand-size 5)) :leave-play (effect (lose :max-hand-size 5))
+   {:effect (effect (gain :hand-size-modification 5))
+    :leave-play (effect (lose :hand-size-modification 5))
     :events {:runner-turn-begins {:msg "lose [Click]" :effect (effect (lose :click 1))}}}
 
    "Borrowed Satellite"
-   {:effect (effect (gain :link 1 :max-hand-size 1))
-    :leave-play (effect (lose :link 1 :max-hand-size 1))}
+   {:effect (effect (gain :link 1 :hand-size-modification 1))
+    :leave-play (effect (lose :link 1 :hand-size-modification 1))}
 
    "Chrome Parlor"
    {:events
@@ -510,7 +511,8 @@
                  :msg "gain 1 [Credits] and draw 1 card"}]}
 
    "Public Sympathy"
-   {:effect (effect (gain :max-hand-size 2)) :leave-play (effect (lose :max-hand-size 2))}
+   {:effect (effect (gain :hand-size-modification 2))
+    :leave-play (effect (lose :hand-size-modification 2))}
 
    "Rachel Beckman"
    {:effect (req (gain state :runner :click 1 :click-per-turn 1)
@@ -563,9 +565,9 @@
                                  (trash card {:cause :ability-cost}))}]}
 
    "Safety First"
-   {:effect (effect (lose :runner :max-hand-size 2))
-    :leave-play (effect (gain :runner :max-hand-size 2))
-    :events {:runner-turn-ends {:req (req (< (count (:hand runner)) (:max-hand-size runner)))
+   {:effect (effect (lose :runner :hand-size-modification 2))
+    :leave-play (effect (gain :runner :hand-size-modification 2))
+    :events {:runner-turn-ends {:req (req (< (count (:hand runner)) (hand-size state :runner)))
                                 :msg (msg "draw a card")
                                 :effect (effect (draw 1))}}}
 
@@ -714,7 +716,7 @@
                             (fn [k ref old new]
                               (let [credit (get-in new [:runner :credit])]
                                 (when (not= (get-in old [:runner :credit]) credit)
-                                  (swap! ref assoc-in [:runner :max-hand-size] credit))))))
+                                  (swap! ref assoc-in [:runner :hand-size-base] credit))))))
     :leave-play (req (remove-watch state :theophilius-bagbiter))}
 
    "Tri-maf Contact"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -227,7 +227,8 @@
 
    "Research Station"
    {:init {:root "HQ"}
-    :effect (effect (gain :max-hand-size 2)) :leave-play (effect (lose :max-hand-size 2))}
+    :effect (effect (gain :hand-size-modification 2))
+    :leave-play (effect (lose :hand-size-modification 2))}
 
    "Rutherford Grid"
    {:events {:pre-init-trace {:req (req this-server)
@@ -314,19 +315,21 @@
                  :label "Reduce Runner's maximum hand size by 1 until start of next Corp turn"
                  :msg "reduce the Runner's maximum hand size by 1 until the start of the next Corp turn"
                  :effect (req (update! state side (assoc card :times-used (inc (get card :times-used 0))))
-                              (lose state :runner :max-hand-size 1))}]
+                              (lose state :runner :hand-size-modification 1))}]
     :trash-effect {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
                    :effect (req (when-let [n (:times-used card)]
                                   (register-events state side
                                                    {:corp-turn-begins
                                                     {:msg (msg "increase the Runner's maximum hand size by " n)
-                                                     :effect (effect (gain :runner :max-hand-size n)
+                                                     :effect (effect (gain :runner :hand-size-modification n)
                                                                      (unregister-events card)
                                                                      (update! (dissoc card :times-used)))}}
                                                    (assoc card :zone '(:discard)))))}
     :events {:corp-turn-begins {:req (req (:times-used card))
-                                :msg (msg "increase the Runner's maximum hand size by " (:times-used card))
-                                :effect (effect (gain :runner :max-hand-size (:times-used card))
+                                :msg (msg "increase the Runner's maximum hand size by "
+                                          (:times-used card))
+                                :effect (effect (gain :runner :hand-size-modification
+                                                      (:times-used card))
                                                 (update! (dissoc card :times-used)))}}}
 
    "Will-o-the-Wisp"

--- a/src/clj/game/core-costs.clj
+++ b/src/clj/game/core-costs.clj
@@ -5,8 +5,10 @@
 (defn deduce
   "Deduct the value from the player's attribute."
   [state side [attr value]]
-  (swap! state update-in [side attr] (if (= attr :memory)
-                                       #(- % value) ;; memoryunits may be negative
+  (swap! state update-in [side attr] (if (or (= attr :memory)
+                                             (= attr :hand-size-modification))
+                                       ;; Memory or hand size mod may be negative
+                                       #(- % value)
                                        #(max 0 (- % value))))
   (when (and (= attr :credit) (= side :runner) (get-in @state [:runner :run-credit]))
     (swap! state update-in [:runner :run-credit] #(max 0 (- % value))))

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -99,8 +99,7 @@
         "/tag"        #(swap! %1 assoc-in [%2 :tag] (max 0 value))
         "/bp"         #(swap! %1 assoc-in [%2 :bad-publicity] (max 0 value))
         "/link"       #(swap! %1 assoc-in [%2 :link] (max 0 value))
-        ;; removed until a good implementation has been though of
-        ;; "/handsize"   #(swap! %1 assoc-in [%2 :max-hand-size] (max 0 value))
+        "/handsize"   #(swap! %1 assoc-in [%2 :hand-size-modification] (- (max 0 value) (:hand-size-base %2)))
         "/take-meat"  #(when (= %2 :runner) (damage %1 %2 :meat  (max 0 value)))
         "/take-net"   #(when (= %2 :runner) (damage %1 %2 :net   (max 0 value)))
         "/take-brain" #(when (= %2 :runner) (damage %1 %2 :brain (max 0 value)))

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -99,7 +99,8 @@
         "/tag"        #(swap! %1 assoc-in [%2 :tag] (max 0 value))
         "/bp"         #(swap! %1 assoc-in [%2 :bad-publicity] (max 0 value))
         "/link"       #(swap! %1 assoc-in [%2 :link] (max 0 value))
-        "/handsize"   #(swap! %1 assoc-in [%2 :max-hand-size] (max 0 value))
+        ;; removed until a good implementation has been though of
+        ;; "/handsize"   #(swap! %1 assoc-in [%2 :max-hand-size] (max 0 value))
         "/take-meat"  #(when (= %2 :runner) (damage %1 %2 :meat  (max 0 value)))
         "/take-net"   #(when (= %2 :runner) (damage %1 %2 :net   (max 0 value)))
         "/take-brain" #(when (= %2 :runner) (damage %1 %2 :brain (max 0 value)))

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -79,3 +79,11 @@
   "Returns a truthy card map if the given card is in play (installed)."
   [state card]
   (installed-byname state (to-keyword (:side card)) (:title card)))
+
+(defn hand-size
+  "Returns the current maximum handsize of the specified side."
+  [state side]
+  (let [side' (get @state side)
+        base (get side' :hand-size-base 0)
+        mod (get side' :hand-size-modification 0)]
+    (+ base mod)))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -98,7 +98,7 @@
         (flatline state))
       (when (= type :brain)
         (swap! state update-in [:runner :brain-damage] #(+ % n))
-        (swap! state update-in [:runner :max-hand-size] #(- % n)))
+        (swap! state update-in [:runner :hand-size-modification] #(- % n)))
       (doseq [c (take n (shuffle hand))]
         (trash state side c {:unpreventable true :cause type} type))
       (trigger-event state side :damage type card))))

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -64,7 +64,7 @@
     (is (= 0 (:agenda-point (get-runner))) "No points for Runner if trashed by Corp")
     (let [hiro (first (get-in @state [:corp :servers :remote1 :content]))]
       (core/rez state :corp hiro)
-      (is (= 3 (:max-hand-size (get-runner))) "Runner max hand size reduced by 2")
+      (is (= 3 (core/hand-size state :runner)) "Runner max hand size reduced by 2")
       (take-credits state :corp)
       (take-credits state :runner 3)
       (core/click-run state :runner {:server :remote1})
@@ -72,7 +72,7 @@
       (core/successful-run state :runner nil)
       (prompt-choice :runner "Yes") ; trash Hiro
       (is (= 2 (:credit (get-runner))) "Runner paid 6 credits to trash")
-      (is (= 5 (:max-hand-size (get-runner))) "Runner max hand size restored to 5")
+      (is (= 5 (core/hand-size state :runner)) "Runner max hand size restored to 5")
       (is (= 1 (count (get-in @state [:runner :scored]))) "Chairman Hiro added to Runner score area")
       (is (= 2 (:agenda-point (get-runner))) "Runner gained 2 agenda points"))))
 
@@ -279,7 +279,7 @@
     (play-from-hand state :corp "Mental Health Clinic" "New remote")
     (let [mhc (first (get-in @state [:corp :servers :remote1 :content]))]
       (core/rez state :corp mhc)
-      (is (= 6 (:max-hand-size (get-runner))) "Runner max hand size increased by 1")
+      (is (= 6 (core/hand-size state :runner)) "Runner max hand size increased by 1")
       (take-credits state :corp)
       (take-credits state :runner)
       (is (= 8 (:credit (get-corp))) "Gained 1 credit at start of turn"))))

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -37,7 +37,7 @@
     (is (empty? (:prompt (get-runner))) "Feedback Filter brain damage prevention opportunity not given")
     (is (= 5 (:click (get-runner))))
     (is (= 2 (count (:discard (get-runner)))))
-    (is (= 4 (:max-hand-size (get-runner))))
+    (is (= 4 (core/hand-size state :runner)))
     (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")))
 
 (deftest apocalypse-turn-facedown
@@ -322,7 +322,7 @@
     (is (and (= 0 (count (:hand (get-corp)))) (= 1 (count (:discard (get-corp))))) "Corp hand empty and Eve in Archives")
     (is (= 5 (:credit (get-runner))))
     (is (= 0 (count (:hand (get-runner)))) "Lost card from Grip to brain damage")
-    (is (= 4 (:max-hand-size (get-runner))))
+    (is (= 4 (core/hand-size state :runner)))
     (is (= 1 (:brain-damage (get-runner))))))
 
 (deftest sure-gamble

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -31,13 +31,13 @@
    (take-credits state :corp)
    (play-from-hand state :runner "Brain Chip")
    (swap! state assoc-in [:runner :agenda-point] -2) ; hard set ap
-   (is (= (get-in @state [:runner :max-hand-size]) 5) "Hand size unaffected")
+   (is (= (core/hand-size state :runner) 5) "Hand size unaffected")
    (is (= (get-in @state [:runner :memory]) 4) "Memory limit unaffected")
    (swap! state assoc-in [:runner :agenda-point] 2)
-   (is (= (get-in @state [:runner :max-hand-size]) 7) "Hand size increased by 2")
+   (is (= (core/hand-size state :runner) 7) "Hand size increased by 2")
    (is (= (get-in @state [:runner :memory]) 6) "Memory limit increased by 2")
    (core/move state :runner (get-in @state [:runner :rig :hardware 0]) :discard)
-   (is (= (get-in @state [:runner :max-hand-size]) 5) "Hand size reset")
+   (is (= (core/hand-size state :runner) 5) "Hand size reset")
    (is (= (get-in @state [:runner :memory]) 4) "Memory limit reset")))
 
 (deftest clone-chip

--- a/src/clj/test/cards-ice.clj
+++ b/src/clj/test/cards-ice.clj
@@ -146,7 +146,7 @@
       (card-ability state :corp fen 0)
       (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")
       (is (= 1 (count (:discard (get-runner)))))
-      (is (= 4 (:max-hand-size (get-runner)))))))
+      (is (= 4 (core/hand-size state :runner))))))
 
 (deftest gemini-kicker
   "Gemini - Successfully trace to do 1 net damage; do 1 net damage if trace strength is 5 or more regardless of success"

--- a/src/clj/test/cards-identities.clj
+++ b/src/clj/test/cards-identities.clj
@@ -33,7 +33,7 @@
     (play-from-hand state :corp "Hedge Fund")
     (play-from-hand state :corp "Hedge Fund")
     (is (= 13 (:credit (get-corp))) "Has 13 credits")
-    (is (= 13 (:max-hand-size (get-corp))) "Max hand size is 13")))
+    (is (= 13 (core/hand-size state :corp)) "Max hand size is 13")))
 
 (deftest haas-bioroid-stronger-together
   "Stronger Together - +1 strength for Bioroid ice"

--- a/src/clj/test/cards-programs.clj
+++ b/src/clj/test/cards-programs.clj
@@ -148,9 +148,9 @@
               (default-runner [(qty "Origami" 2)]))
     (take-credits state :corp)
     (play-from-hand state :runner "Origami")
-    (is (= 6 (:max-hand-size (get-runner))))
+    (is (= 6 (core/hand-size state :runner)))
     (play-from-hand state :runner "Origami")
-    (is (= 9 (:max-hand-size (get-runner))) "Max hand size increased by 2 for each copy installed")))
+    (is (= 9 (core/hand-size state :runner)) "Max hand size increased by 2 for each copy installed")))
 
 (deftest paintbrush
   "Paintbrush - Give rezzed ICE a chosen subtype until the end of the next run"

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -389,10 +389,10 @@
       (core/rez state :corp vg)
       (card-ability state :corp vg 0)
       (card-ability state :corp vg 0) ; only need the run to exist for test, just pretending the Runner has broken all subs on 2 ice
-      (is (= 3 (:max-hand-size (get-runner))) "Runner max hand size reduced by 2")
+      (is (= 3 (core/hand-size state :runner)) "Runner max hand size reduced by 2")
       (is (= 2 (get-in (refresh vg) [:times-used])) "Saved number of times Valley Grid used")
       (core/no-action state :corp nil)
       (core/successful-run state :runner nil)
       (prompt-choice :runner "Yes") ; pay to trash
       (take-credits state :runner 3)
-      (is (= 5 (:max-hand-size (get-runner))) "Runner max hand size increased by 2 at start of Corp turn"))))
+      (is (= 5 (core/hand-size state :runner)) "Runner max hand size increased by 2 at start of Corp turn"))))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -576,8 +576,9 @@
 
 (defmulti stats-view #(get-in % [:identity :side]))
 
-(defmethod stats-view "Runner" [{:keys [user click credit run-credit memory link tag brain-damage agenda-point
-                                        tagged max-hand-size]} owner]
+(defmethod stats-view "Runner" [{:keys [user click credit run-credit memory link tag
+                                        brain-damage agenda-point tagged hand-size-base
+                                        hand-size-modification]} owner]
   (om/component
    (sab/html
     (let [me? (= (:side @game-state) :runner)]
@@ -595,9 +596,11 @@
        [:div (str tag " Tag" (if (> tag 1) "s" "")) (when (or (pos? tag) (pos? tagged)) [:div.warning "!"]) (when me? (controls :tag))]
        [:div (str brain-damage " Brain Damage" (if (> brain-damage 1) "s" ""))
         (when me? (controls :brain-damage))]
-       [:div (str max-hand-size " Max hand size") (when me? (controls :max-hand-size))]]))))
+       [:div (str (+ hand-size-base hand-size-modification) " Max hand size")
+        (when me? (controls :hand-size-modification))]]))))
 
-(defmethod stats-view "Corp" [{:keys [user click credit agenda-point bad-publicity max-hand-size]} owner]
+(defmethod stats-view "Corp" [{:keys [user click credit agenda-point bad-publicity
+                                      hand-size-base hand-size-modification]} owner]
   (om/component
    (sab/html
     (let [me? (= (:side @game-state) :corp)]
@@ -609,7 +612,8 @@
         (when me? (controls :agenda-point))]
        [:div (str bad-publicity " Bad Publicit" (if (> bad-publicity 1) "ies" "y"))
         (when me? (controls :bad-publicity))]
-       [:div (str max-hand-size " Max hand size") (when me? (controls :max-hand-size))]]))))
+       [:div (str (+ hand-size-base hand-size-modification) " Max hand size")
+        (when me? (controls :hand-size-modification))]]))))
 
 (defn server-view [{:keys [server central run] :as cursor} owner opts]
   (om/component
@@ -679,7 +683,7 @@
 
 (defn handle-end-turn [cursor owner]
   (let [me ((:side @game-state) @game-state)
-        max-size (max (:max-hand-size me) 0)]
+        max-size (max (+ (:hand-size-base me) (:hand-size-modification me)) 0)]
     (if (> (count (:hand me)) max-size)
       (toast (str "Discard to " max-size " cards") "warning")
       (send-command "end-turn"))))


### PR DESCRIPTION
Splits previous `:max-hand-size` variable into:
- `:hand-size-base` for cards that uses "hand size is" (Bagbiter and Cerebral Imaging)
- `:hand-size-modification` for all other cards that modify the hand size
Should fix #1015 and #1131.