### PR TITLE
Card fixes; improvements to Chimera, Deep Red, Woman in the Red Dress, Pawn

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -206,15 +206,13 @@
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 3)) :msg "gain 3 [Credits]"}]}
 
    "Hades Fragment"
-   {:events {:corp-turn-begins
-             {:optional
-              {:prompt "Add 1 card from Archives to bottom of R&D?"
-               :yes-ability {:effect (effect (resolve-ability
-                                              {:prompt "Choose a card"
-                                               :choices (:discard corp)
-                                               :effect (effect (move target :deck))
-                                               :msg (msg "add " (if (:seen target) (:title target) "a card")
-                                                         " to the bottom of R&D")} card target))}}}}}
+   {:events {:runner-turn-ends
+             {:effect (req (toast state :corp
+                                  (str "Click Hades Fragment to add 1 card from Archives to the bottom of R&D.") "info"))}}
+    :abilities [{:prompt "Choose a card to add to the bottom of R&D"
+                 :choices (req (:discard corp))
+                 :effect (effect (move target :deck))
+                 :msg (msg "add " (if (:seen target) (:title target) "a card") " to the bottom of R&D")}]}
 
    "Helium-3 Deposit"
    {:choices ["0", "1", "2"] :prompt "How many power counters?"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -219,7 +219,11 @@
     :effect (effect (move target :hand) (shuffle! :deck))}
 
    "Feint"
-   {:effect (effect (run :hq nil card) (max-access 0))}
+   {:effect (effect (run :hq nil card) (register-events (:events (card-def card))
+                                                        (assoc card :zone '(:discard))))
+    :events {:successful-run {:msg "access 0 cards"
+                              :effect (effect (max-access 0))}
+             :run-ends {:effect (effect (unregister-events card))}}}
 
    "Fisk Investment Seminar"
    {:effect (effect (draw 3) (draw :corp 3))}

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -160,7 +160,15 @@
    {:recurring 1}
 
    "Deep Red"
-   {:effect (effect (gain :memory 3)) :leave-play (effect (lose :memory 3))}
+   {:effect (effect (gain :memory 3)) :leave-play (effect (lose :memory 3))
+    :events {:runner-install
+             {:optional
+              {:req (req (has-subtype? target "Caïssa"))
+               :prompt "Use Deep Red to trigger the [Click] ability of the installed Caïssa?"
+               :yes-ability {:effect (req (let [caissa (first (map last (turn-events state :runner :runner-install)))]
+                                            (system-msg state side (str "uses Deep Red to trigger the [Click] ability of " (:title caissa)))
+                                            (gain state :runner :click 1)
+                                            (play-ability state side {:card (get-card state caissa) :ability 0})))}}}}}
 
    "Desperado"
    {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -22,9 +22,7 @@
                 trash-program end-the-run]}
 
    "Architect"
-   {:flags {
-            :untrashable-while-rezzed true
-            }
+   {:flags {:untrashable-while-rezzed true}
     :abilities [{:msg "look at the top 5 cards of R&D"
                  :prompt "Choose a card to install"
                  :priority true
@@ -132,7 +130,16 @@
 
    "Chimera"
    {:prompt "Choose one subtype" :choices ["Barrier" "Code Gate" "Sentry"]
-    :msg (msg "change its subtype to " target) :end-turn {:effect (effect (derez card))}
+    :msg (msg "make it gain " target " until the end of the turn")
+    :effect (effect (update! (assoc card :subtype
+                                         (->> (vec (.split (:subtype card) " - "))
+                                              (concat [target])
+                                              (join " - "))))
+                    (update-ice-strength card))
+    :events {:runner-turn-ends {:effect (effect (derez :corp card)
+                                                (update! (assoc (get-card state card) :subtype "Mythic")))}
+             :corp-turn-ends {:effect (effect (derez :corp card)
+                                              (update! (assoc (get-card state card) :subtype "Mythic")))}}
     :abilities [end-the-run]}
 
    "Clairvoyant Monitor"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -730,8 +730,8 @@
    {:trace {:base 2 :msg "keep TMI rezzed" :unsuccessful {:effect (effect (derez card))}} :abilities [end-the-run]}
 
    "Tollbooth"
-   {:abilities [{:msg "force the Runner to lose 3 [Credits]"
-                 :effect (effect (lose :runner :credit 3))}
+   {:abilities [{:msg "make the Runner pay 3 [Credits], if able"
+                 :effect (effect (pay :runner :credit 3))}
                 end-the-run]}
 
    "Tour Guide"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -190,8 +190,9 @@
    "Data Mine"
    {:abilities [{:msg "do 1 net damage"
                  :effect (req (damage state :runner :net 1 {:card card})
-                              (trash state side card)
-                              (trash-ice-in-run state))}]}
+                              (when (= current-ice card)
+                                (trash-ice-in-run state))
+                              (trash state side card))}]}
 
    "Datapike"
    {:abilities [{:msg "force the Runner to pay 2 [Credits] if able"
@@ -402,8 +403,9 @@
    "Its a Trap!"
    {:expose {:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}
     :abilities [(assoc trash-installed :effect (req (trash state side target {:cause :subroutine})
-                                                    (trash state side card)
-                                                    (trash-ice-in-run state)))]}
+                                                    (when (= current-ice card)
+                                                      (trash-ice-in-run state))
+                                                    (trash state side card)))]}
 
    "Janus 1.0"
    {:abilities [{:msg "do 1 brain damage" :effect (effect (damage :brain 1 {:card card}))}]}
@@ -423,8 +425,9 @@
                                       :player :runner
                                       :msg (msg "force the Runner to trash " (:title target))
                                       :effect (req (trash state side target)
-                                                   (trash state side card)
-                                                   (trash-ice-in-run state)))]}
+                                                   (when (= current-ice card)
+                                                     (trash-ice-in-run state))
+                                                   (trash state side card)))]}
 
    "Lancelot"
    {:abilities [trash-program
@@ -698,8 +701,9 @@
    "Special Offer"
    {:abilities [{:label "Gain 5 [Credits] and trash Special Offer"
                  :effect (req (gain state :corp :credit 5)
+                              (when (= current-ice card)
+                                (trash-ice-in-run state))
                               (trash state side card)
-                              (trash-ice-in-run state)
                               (system-msg state side (str "gains 5 [Credits] and trashes Special Offer")))}]}
 
    "Spiderweb"
@@ -830,8 +834,9 @@
                                          (> (count (concat (:ices (card->server state card))
                                                            (:content (card->server state card)))) 1))
                                 (prevent-jack-out state side))
-                              (trash state side card)
-                              (trash-ice-in-run state))}]}
+                              (when (= current-ice card)
+                                (trash-ice-in-run state))
+                              (trash state side card))}]}
 
    "Woodcutter"
    {:advanceable :while-rezzed

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -190,7 +190,7 @@
    "Data Mine"
    {:abilities [{:msg "do 1 net damage"
                  :effect (req (damage state :runner :net 1 {:card card})
-                              (when (= current-ice card)
+                              (when current-ice
                                 (trash-ice-in-run state))
                               (trash state side card))}]}
 
@@ -403,7 +403,7 @@
    "Its a Trap!"
    {:expose {:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}
     :abilities [(assoc trash-installed :effect (req (trash state side target {:cause :subroutine})
-                                                    (when (= current-ice card)
+                                                    (when current-ice
                                                       (trash-ice-in-run state))
                                                     (trash state side card)))]}
 
@@ -425,7 +425,7 @@
                                       :player :runner
                                       :msg (msg "force the Runner to trash " (:title target))
                                       :effect (req (trash state side target)
-                                                   (when (= current-ice card)
+                                                   (when current-ice
                                                      (trash-ice-in-run state))
                                                    (trash state side card)))]}
 
@@ -701,7 +701,7 @@
    "Special Offer"
    {:abilities [{:label "Gain 5 [Credits] and trash Special Offer"
                  :effect (req (gain state :corp :credit 5)
-                              (when (= current-ice card)
+                              (when current-ice
                                 (trash-ice-in-run state))
                               (trash state side card)
                               (system-msg state side (str "gains 5 [Credits] and trashes Special Offer")))}]}
@@ -834,7 +834,7 @@
                                          (> (count (concat (:ices (card->server state card))
                                                            (:content (card->server state card)))) 1))
                                 (prevent-jack-out state side))
-                              (when (= current-ice card)
+                              (when current-ice
                                 (trash-ice-in-run state))
                               (trash state side card))}]}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -743,7 +743,7 @@
 
    "Tollbooth"
    {:abilities [{:msg "make the Runner pay 3 [Credits], if able"
-                 :effect (effect (pay :runner :credit 3))}
+                 :effect (effect (pay :runner card :credit 3))}
                 end-the-run]}
 
    "Tour Guide"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -685,7 +685,8 @@
                  :msg (msg "reveal " (join ", " (map :title (:hand runner))))}
                 {:label "Trace 3 - Place 1 power counter on Snoop"
                  :trace {:base 3 :msg "place 1 power counter on Snoop" :effect (effect (add-prop card :counter 1))}}
-                {:counter-cost 1 :label "Hosted power counter: Reveal all cards in Grip and trash 1 card"
+                {:req (req (> (get card :counter 0) 0))
+                 :counter-cost 1 :label "Hosted power counter: Reveal all cards in Grip and trash 1 card"
                  :msg (msg "look at all cards in Grip and trash " (:title target))
                  :choices (req (:hand runner)) :prompt "Choose a card to trash"
                  :effect (effect (trash target))}]}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -147,7 +147,8 @@
     :effect (effect (gain :credit (* 2 (count targets))))}
 
    "Cerebral Cast"
-   {:psi {:not-equal {:player :runner :prompt "Take 1 tag or 1 brain damage?"
+   {:req (req (:successful-run runner-reg))
+    :psi {:not-equal {:player :runner :prompt "Take 1 tag or 1 brain damage?"
                       :choices ["1 tag" "1 brain damage"] :msg (msg "give the Runner " target)
                       :effect (req (if (= target "1 tag")
                                      (tag-runner state side 1)
@@ -488,6 +489,7 @@
                                                 (concat ["Barrier"])
                                                 distinct
                                                 (join " - "))))
+                    (update-ice-strength target)
                     (host (get-card state target) (assoc card :zone [:discard] :seen true)))}
 
    "Subliminal Messaging"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -457,26 +457,32 @@
    {:recurring 2}
 
    "Pawn"
-   {:abilities [{:prompt "Host Pawn on the outermost ICE of a central server" :cost [:click 1]
+   {:abilities [{:label "Host Pawn on the outermost ICE of a central server"
+                 :prompt "Host Pawn on the outermost ICE of a central server" :cost [:click 1]
                  :choices {:req #(and (ice? %)
                                       (= (last (:zone %)) :ices)
-                                      (some #{:hq :rd :archives} (rest (butlast (:zone %)))))}
+                                      (is-central? (second (:zone %))))}
                  :msg (msg "host it on " (card-str state target))
-                 :effect (effect (host target card))}]
-    :events {:successful-run
-             {:req (req (ice? card))
-              :effect (req (let [i (ice-index state (:host card))
-                                 nextice (when (> i 0) (nth (get-in @state
-                                                            (vec (concat [:corp] (:zone (:host card))))) (dec i)))]
-                             (if (pos? i)
-                               (host state side nextice card)
-                               (do (resolve-ability state side
-                                     {:prompt "Choose a Caïssa program to install from your Grip or Heap"
-                                      :show-discard true
-                                      :choices {:req #(and (has-subtype? % "Caïssa")
-                                                           (#{[:hand] [:discard]} (:zone %)))}
-                                      :effect (effect (runner-install target {:no-cost true}))} card nil)
-                                    (trash state side card)))))}}}
+                 :effect (effect (host target card))}
+                {:label "Advance to next ICE"
+                 :prompt "Choose the next innermost ICE to host Pawn on it"
+                 :choices {:req #(and (ice? %)
+                                      (= (last (:zone %)) :ices)
+                                      (is-central? (second (:zone %))))}
+                 :msg (msg "host it on " (card-str state target))
+                 :effect (effect (host target card))}
+                {:label "Trash Pawn and install a Caïssa from your Grip or Heap, ignoring all costs"
+                 :effect (req (let [this-pawn (:cid card)]
+                                (resolve-ability
+                                  state side
+                                  {:prompt "Choose a Caïssa program to install from your Grip or Heap"
+                                   :show-discard true
+                                   :choices {:req #(and (has-subtype? % "Caïssa")
+                                                        (not= (:cid %) this-pawn)
+                                                        (#{[:hand] [:discard]} (:zone %)))}
+                                   :msg (msg "install " (:title target))
+                                   :effect (effect (runner-install target {:no-cost true}))} card nil)
+                                (trash state side card)))}]}
 
    "Pheromones"
    {:recurring (req (when (< (get card :rec-counter 0) (:counter card))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -479,7 +479,8 @@
                                     (trash state side card)))))}}}
 
    "Pheromones"
-   {:recurring (effect (set-prop card :rec-counter (:counter card)))
+   {:recurring (req (when (< (get card :rec-counter 0) (:counter card))
+                      (set-prop state side card :rec-counter (:counter card))))
     :events {:successful-run {:req (req (= target :hq))
                               :effect (effect (add-prop card :counter 1))}}}
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -52,6 +52,8 @@
 
    "Bank Job"
    {:data {:counter 8}
+    :events {:no-action {:effect (req (toast state :runner "Click Bank Job to take credits from it instead of accessing" "info"))
+                         :req (req (and (is-remote? (:server run)) (not current-ice)))}}
     :abilities [{:req (req (and (:run @state) (= (:position run) 0)))
                  :label "Take any number of [Credits] on Bank Job"
                  :prompt "How many [Credits]?" :choices :counter :msg (msg "gain " target " [Credits]")

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -766,11 +766,17 @@
    "Woman in the Red Dress"
    {:events {:runner-turn-begins
              {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")
-              :optional {:player :corp
-                         :prompt (msg "Draw " (:title (first (:deck corp))) "?")
-                         :msg (msg "draw " (:title (first (:deck corp))))
-                         :yes-ability {:effect (effect (draw))}
-                         :no-ability {:effect (effect (system-msg "doesn't draw with Woman in the Red Dress"))}}}}}
+              :effect (effect (show-wait-prompt :runner "Corp to decide whether or not to draw with Woman in the Red Dress")
+                              (resolve-ability
+                                {:optional
+                                 {:player :corp
+                                  :prompt (msg "Draw " (:title (first (:deck corp))) "?")
+                                  :yes-ability {:effect (effect (clear-wait-prompt :runner)
+                                                                (system-msg (str "draws " (:title (first (:deck corp)))))
+                                                                (draw))}
+                                  :no-ability {:effect (effect (clear-wait-prompt :runner)
+                                                               (system-msg "doesn't draw with Woman in the Red Dress"))}}}
+                               card nil))}}}
 
    "Wyldside"
    {:events {:runner-turn-begins {:msg "draw 2 cards and lose [Click]"

--- a/src/clj/game/core-ice.clj
+++ b/src/clj/game/core-ice.clj
@@ -52,7 +52,8 @@
   "Decreases the position of each ice in the run. For when an ice is trashed mid-run."
   [state]
   (when-let [run (:run @state)]
-    (swap! state update-in [:run :position] dec)))
+    (swap! state update-in [:run :position] dec)
+    (trigger-event state :runner :pass-ice nil)))
 
 
 ;;; Icebreaker functions.


### PR DESCRIPTION
* Fix #1129: Have `trash-ice-in-run` trigger the `:pass-ice` event to stop strength lowering from persisting
* Fix #1124: Adds missing prerequisite for play of Cerebral Cast
* Fix #1116: Require Snoop to have at least 1 counter before doing its look and trash ability
* Fix #1106: Change Tollbooth to use `pay` so Runner can't lose credits if they have only 1 or 2. 
* Fix #1072, fix #1021: Removes automation from Pawn entirely--it just proved too problematic. Users should now advance Pawns one by one, and trashing one will prevent the just-trashed one from being targeted for install.
* Fix Pheromones so unspent credits don't get zeroed out the turn after the Corp purges viruses (per Lukas ruling as seen on BGG)
* Fix Feint to access 0 cards only if the run is successful (fixes interaction with Crisium Grid)
* Add handling of subtype gain/loss and proper end-of-turn derezzing to Chimera
* Add Runner wait prompt and `:yes-ability` message to Woman in the Red Dress
* Add Deep Red ability to fire the click ability of a just-installed Caissa
* Add Runner toast to Bank Job (users frequently ask how to use it)
* Require self-trashing ICE to be currently encountered before they fire `trash-ice-in-run` (prevents a run arrow bug where neither player can end the run)
* Make Hades Fragment manually triggered, avoiding a "Corp is decked" loss being registered with an empty R&D and a scored copy
* Make Sub Boost do an `update-ice-strength` to account for a scored Superior Cyberwalls
