### PR TITLE
Implementation and test for Maya

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -315,6 +315,22 @@
              {:player :runner :prompt "Choose a card" :msg (msg "add 1 card to Grip from Stack")
               :choices (req (:deck runner)) :effect (effect (move target :hand) (shuffle! :deck))}}}
 
+   "Maya"
+   {:effect (effect (gain :memoryunits 2)) :leave-play (effect (lose :memoryunits 2))
+    :abilities [{:once :per-turn
+                 :req (req (when-let [c (:card (first (get-in @state [:runner :prompt])))]
+                             (in-deck? c)))
+                 :msg "move the card just accessed to the bottom of R&D"
+                 :effect (req (let [c (:card (first (get-in @state [:runner :prompt])))]
+                                (when (is-type? c "Agenda") ; trashing before the :access events actually fire; fire them manually
+                                  (resolve-steal-events state side c))
+                                (move state :corp c :deck)
+                                (tag-runner state :runner 1)
+                                (swap! state update-in [side :prompt] rest)
+                                (when-let [run (:run @state)]
+                                  (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
+                                    (handle-end-run state :runner)))))}]}
+
    "MemStrips"
    {:effect (effect (gain :memory 3))}
 

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -103,6 +103,11 @@
   [card]
   (= (:zone card) [:hand]))
 
+(defn in-deck?
+  "Checks if the specified card is in the draw deck."
+  [card]
+  (= (:zone card) [:deck]))
+
 (defn is-type?
   "Checks if the card is of the specified type, where the type is a string."
   [card type]


### PR DESCRIPTION
Like Imp and Film Critic, we expect the Runner to click Maya during the "You accessed ..." prompt to return it to the bottom of R&D.

I tested:

* Maya an Operation or ICE during the "You accessed ..." prompt.
* Maya an Upgrade or Asset during the "Pay X to trash?" prompt. If the asset is an ambush, using Maya before the ambush is fired does not affect its resolution. Some assets like Snare! even show a "Waiting for Corp..." prompt which prevents Maya's use until the Corp finishes the ambush. More ambushes are moving towards this style too.
* Maya an Agenda during the "You accessed ... Steal?" prompt. If this is chosen, the agenda's on-access effects (if any) are fired when Maya is clicked, because at this point they haven't been fired due to needing to support Film Critic.