### PR TITLE
implement Dedication Ceremony and Heritage Committee

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -175,6 +175,12 @@
    "Cyberdex Trial"
    {:effect (effect (purge))}
 
+   "Dedication Ceremony"
+   {:prompt "Choose a faceup card"
+    :choices {:req rezzed?}
+    :msg (msg "place 3 advancement tokens on " (card-str state target))
+    :effect (effect (add-prop :corp target :advance-counter 3 {:placed true}))}
+
    "Defective Brainchips"
    {:events {:pre-damage {:req (req (= target :brain)) :msg "to do 1 additional brain damage"
                           :once :per-turn :effect (effect (damage-bonus :brain 1))}}}
@@ -224,6 +230,15 @@
                             (system-msg (str "adds " (:title target) " to the top of the Stack")))
             :unsuccessful {:msg "take 1 bad publicity"
                            :effect (effect (gain :corp :bad-publicity 1))}}}
+
+   "Heritage Committee"
+   {:effect (effect (draw 3)
+                    (resolve-ability
+                      {:prompt "Choose a card in HQ to put on top of R&D"
+                       :choices (req (:hand corp)) :not-distinct true
+                       :msg "draw 3 cards and add 1 card from HQ to the top of R&D"
+                       :effect (effect (move target :deck {:front true}))}
+                     card nil))}
 
    "Housekeeping"
    {:events {:runner-install {:req (req (= side :runner))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -235,7 +235,8 @@
    {:effect (effect (draw 3)
                     (resolve-ability
                       {:prompt "Choose a card in HQ to put on top of R&D"
-                       :choices (req (:hand corp)) :not-distinct true
+                       :choices {:req #(and (in-hand? %)
+                                            (= (:side %) "Corp"))}
                        :msg "draw 3 cards and add 1 card from HQ to the top of R&D"
                        :effect (effect (move target :deck {:front true}))}
                      card nil))}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -77,14 +77,15 @@
    {:abilities [{:cost [:click 1] :label "Place 1 power counter"
                  :msg "place 1 power counter on it"
                  :effect (effect (add-prop card :counter 1))}
-                {:req (req (> (get card :counter 0) 0))
+                {:req (req (>= (get card :counter 0) 0))
                  :cost [:click 1] :label "Install a program from your Grip"
                  :prompt "Choose a program to install from your Grip"
                  :choices {:req #(and (is-type? % "Program") (in-hand? %))}
                  :msg (msg "install " (:title target))
-                 :effect (effect (install-cost-bonus [:credit (* -1 (:counter card))])
-                                 (runner-install target)
-                                 (add-prop card :counter -1))}]}
+                 :effect (req (install-cost-bonus state side [:credit (* -1 (:counter card))])
+                              (runner-install state side target)
+                              (when (pos? (:counter card))
+                                (add-prop state side card :counter -1)))}]}
 
    "Chrome Parlor"
    {:events

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -77,8 +77,7 @@
    {:abilities [{:cost [:click 1] :label "Place 1 power counter"
                  :msg "place 1 power counter on it"
                  :effect (effect (add-prop card :counter 1))}
-                {:req (req (>= (get card :counter 0) 0))
-                 :cost [:click 1] :label "Install a program from your Grip"
+                {:cost [:click 1] :label "Install a program from your Grip"
                  :prompt "Choose a program to install from your Grip"
                  :choices {:req #(and (is-type? % "Program") (in-hand? %))}
                  :msg (msg "install " (:title target))


### PR DESCRIPTION
New implementations for Dedication Ceremony and Heritage Committee. Also includes a small update to Chatterjee University to account for the pack-specific Unofficial FAQ that came out indicating you can use it to install a program when it has 0 counters. 