### PR TITLE
scroll to top for button bar on games list

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -945,6 +945,7 @@ nav ul
     padding-bottom: 15px
 
   .games .button-bar
+    box-sizing: initial
     padding: 0 15px 15px
 
   .game-list


### PR DESCRIPTION
Issue #1056: Adding the fix specifically for button bar on game list; the previous fix applied to deckbuilder button-bar