### PR TITLE
Eden Fragment implementation (manual trigger)

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -154,6 +154,8 @@
 
    "Eden Fragment"
    {:abilities [{:cost [:click 1] :msg "install the first piece of ICE this turn at no cost"
+                 :req (req (empty? (let [cards (map first (turn-events state side :corp-install))]
+                                     (filter #(is-type? % "ICE") cards))))
                  :prompt "Select a piece of ICE from HQ to install"
                  :choices {:req #(and (:side % "Corp")
                                       (ice? %)

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -154,12 +154,12 @@
 
    "Eden Fragment"
    {:abilities [{:cost [:click 1] :msg "install the first piece of ICE this turn at no cost"
-                :prompt "Select a piece of ICE to install from the HQ"
-                :choices {:req #(and (:side % "Corp")
-                                   (ice? %)
-                                   (= (:zone %) [:hand]))}
-                :effect (req (corp-install state side target nil
-                                           {:no-install-cost true}))}]}
+                 :prompt "Select a piece of ICE from HQ to install"
+                 :choices {:req #(and (:side % "Corp")
+                                      (ice? %)
+                                      (= (:zone %) [:hand]))}
+                 :effect (req (corp-install state side target nil
+                                            {:no-install-cost true}))}]}
 
    "Efficiency Committee"
    {:effect (effect (add-prop card :counter 3))

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -152,6 +152,15 @@
                                 (gain-agenda-point state side 1))
                               (set-prop state side card :counter 1 :agendapoints 1))}]}
 
+   "Eden Fragment"
+   {:abilities [{:cost [:click 1] :msg "install the first piece of ICE this turn at no cost"
+                :prompt "Select a piece of ICE to install from the HQ"
+                :choices {:req #(and (:side % "Corp")
+                                   (ice? %)
+                                   (= (:zone %) [:hand]))}
+                :effect (req (corp-install state side target nil
+                                           {:no-install-cost true}))}]}
+
    "Efficiency Committee"
    {:effect (effect (add-prop card :counter 3))
     :abilities [{:cost [:click 1] :counter-cost 1 :effect (effect (gain :click 2))

--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -103,6 +103,28 @@
     (take-credits state :corp)
     (is (= 0 (get-in @state [:runner :tag]))) "Two tags removed at the end of the turn"))
 
+(deftest eden-fragment
+  "Test that Eden Fragment ignores the install cost of the first ice"
+  (do-game
+    (new-game (default-corp [(qty "Eden Fragment" 3) (qty "Ice Wall" 3)])
+              (default-runner))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Eden Fragment" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (take-credits state :runner)
+    (take-credits state :runner)
+    (take-credits state :runner)
+    (is (= 3 (get-in @state [:corp :click])) "It's the beginning of the corp's turn")
+    (let [hriscored (get-in @state [:corp :scored 0])
+          hqice (find-card "Ice Wall" (get-in @state [:corp :hand]))]
+      (card-ability state :corp hriscored 0)
+      (prompt-select :corp hqice)
+      (prompt-choice :corp "HQ")
+      (is (not (nil? (get-ice state :hq 1))) "Corp has two ice installed on HQ")
+      (is (= 6 (get-in @state [:corp :credit])) "Corp does not pay for installing the first ICE of the turn"))))
+
 (deftest fetal-ai-damage
   "Fetal AI - damage on access"
   (do-game

--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -116,10 +116,9 @@
     (take-credits state :runner)
     (take-credits state :runner)
     (take-credits state :runner)
-    (is (= 3 (get-in @state [:corp :click])) "It's the beginning of the corp's turn")
-    (let [hriscored (get-in @state [:corp :scored 0])
+    (let [efscored (get-in @state [:corp :scored 0])
           hqice (find-card "Ice Wall" (get-in @state [:corp :hand]))]
-      (card-ability state :corp hriscored 0)
+      (card-ability state :corp efscored 0)
       (prompt-select :corp hqice)
       (prompt-choice :corp "HQ")
       (is (not (nil? (get-ice state :hq 1))) "Corp has two ice installed on HQ")


### PR DESCRIPTION
I was trying to play [Eden Fragment](http://netrunnerdb.com/en/card/06030) and realized its mechanics weren't implemented. The workaround requires a manual credit (edit: ~~click~~) adjustment to install ICE after it is scored.

I have added a 1-click ability to Eden Fragment that lets the corp install a piece of ICE for free. The implementation does not exactly match the card text, but the end result is essentially the same (as long as the players use it properly). I've implemented it this way because I am new to Clojure and there seem to be several problems automating the mechanics.

Screenshot of implementation:
![screenshot](http://i.imgur.com/FftIzSt.png)