### PR TITLE
Special css class for virus counters and transparent counter colors

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -2,7 +2,8 @@
 
 (def cards-assets
   {"Adonis Campaign"
-   {:effect (effect (add-prop card :counter 12))
+   {:data {:counter-type "Credit"}
+    :effect (effect (add-prop card :counter 12))
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     :events {:corp-turn-begins {:msg "gain 3 [Credits]" :counter-cost 3
                                 :effect (req (gain state :corp :credit 3)
@@ -193,7 +194,8 @@
                          :effect (effect (trash-cost-bonus 1))}}}
 
    "Eve Campaign"
-   {:effect (effect (add-prop card :counter 16))
+   {:data {:counter-type "Credit"}
+    :effect (effect (add-prop card :counter 16))
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     :events {:corp-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
                                 :effect (req (gain state :corp :credit 2)
@@ -313,7 +315,8 @@
                                  (trash card {:cause :ability-cost}))}]}
 
    "Launch Campaign"
-   {:effect (effect (add-prop card :counter 6))
+   {:data {:counter-type "Credit"}
+    :effect (effect (add-prop card :counter 6))
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     :events {:corp-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
                                 :effect (req (gain state :corp :credit 2)
@@ -364,7 +367,8 @@
                                 card nil))}]}
 
    "Marked Accounts"
-   {:abilities [{:cost [:click 1] :msg "store 3 [Credits]"
+   {:data {:counter-type "Credit"}
+    :abilities [{:cost [:click 1] :msg "store 3 [Credits]"
                  :effect (effect (add-prop card :counter 3))}]
     :events {:corp-turn-begins {:msg "gain 1 [Credits]" :counter-cost 1
                                 :effect (effect (gain :credit 1))}}}
@@ -425,7 +429,8 @@
    {:recurring 3}
 
    "Private Contracts"
-   {:effect (effect (add-prop card :counter 14))
+   {:data {:counter-type "Credit"}
+    :effect (effect (add-prop card :counter 14))
     :abilities [{:cost [:click 1] :counter-cost 2 :msg "gain 2 [Credits]"
                  :effect (req (gain state :corp :credit 2)
                               (when (= (:counter card) 0) (trash state :corp card)))}]}

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -105,7 +105,7 @@
                  :effect (effect (trash card {:cause :ability-cost}) (derez current-ice))}]}
 
    "D4v1d"
-   {:data {:counter 3, :counter-type "Power"}
+   {:data {:counter 3}
     :abilities [{:counter-cost 1 :msg "break 1 subroutine"}]}
 
    "DaVinci"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -105,7 +105,8 @@
                  :effect (effect (trash card {:cause :ability-cost}) (derez current-ice))}]}
 
    "D4v1d"
-   {:data {:counter 3} :abilities [{:counter-cost 1 :msg "break 1 subroutine"}]}
+   {:data {:counter 3, :counter-type "Power"}
+    :abilities [{:counter-cost 1 :msg "break 1 subroutine"}]}
 
    "DaVinci"
    {:events {:successful-run {:effect (effect (add-prop card :counter 1))}}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -332,12 +332,12 @@
                                                   :msg "gain 1 tag"}}}}}}
 
    "Kati Jones"
-   {:abilities
-    [{:cost [:click 1] :msg "store 3 [Credits]" :once :per-turn
-      :effect (effect (add-prop card :counter 3))}
-     {:cost [:click 1] :msg (msg "gain " (:counter card) " [Credits]") :once :per-turn
-      :label "Take all credits"
-      :effect (effect (gain :credit (:counter card)) (set-prop card :counter 0))}]}
+   {:data {:counter-type "Credit"}
+    :abilities [{:cost [:click 1] :msg "store 3 [Credits]" :once :per-turn
+                 :effect (effect (add-prop card :counter 3))}
+                {:cost [:click 1] :msg (msg "gain " (:counter card) " [Credits]") :once :per-turn
+                 :label "Take all credits"
+                 :effect (effect (gain :credit (:counter card)) (set-prop card :counter 0))}]}
 
    "Liberated Account"
    {:data {:counter 16}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -45,13 +45,15 @@
                                           :effect (req (move state side (first (:deck runner)) :deck))}}}]}
 
    "Armitage Codebusting"
-   {:data {:counter 12}
+   {:data {:counter 12
+           :count-type "Credit"}
     :abilities [{:cost [:click 1] :counter-cost 2 :msg "gain 2 [Credits]"
                  :effect (req (gain state :runner :credit 2)
                               (when (zero? (:counter card)) (trash state :runner card {:unpreventable true})))}]}
 
    "Bank Job"
-   {:data {:counter 8}
+   {:data {:counter 8
+           :counter-type "Credit"}
     :events {:no-action {:effect (req (toast state :runner "Click Bank Job to take credits from it instead of accessing" "info"))
                          :req (req (and (is-remote? (:server run)) (not current-ice)))}}
     :abilities [{:req (req (and (:run @state) (= (:position run) 0)))
@@ -105,7 +107,8 @@
                  :effect (effect (trash card {:cause :ability-cost}) (damage-prevent :meat 3))}]}
 
    "Daily Casts"
-   {:data {:counter 8}
+   {:data {:counter 8
+           :counter-type "Credit"}
     :events {:runner-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
                                   :effect (req (gain state :runner :credit 2)
                                                (when (zero? (:counter card)) (trash state :runner card
@@ -340,7 +343,8 @@
                  :effect (effect (gain :credit (:counter card)) (set-prop card :counter 0))}]}
 
    "Liberated Account"
-   {:data {:counter 16}
+   {:data {:counter 16
+           :counter-type "Credit"}
     :abilities [{:cost [:click 1] :counter-cost 4 :msg "gain 4 [Credits]"
                  :effect (req (gain state :runner :credit 4)
                               (when (<= (:counter card) 0) (trash state :runner card {:unpreventable true})))}]}
@@ -677,7 +681,8 @@
                                             (has-subtype? target "Gray Ops")))}}}
 
    "Technical Writer"
-   {:events {:runner-install {:req (req (some #(= % (:type target)) '("Hardware" "Program")))
+   {:data {:counter-type "Credit"}
+    :events {:runner-install {:req (req (some #(= % (:type target)) '("Hardware" "Program")))
                               :effect (effect (add-prop :runner card :counter 1)
                                               (system-msg (str "places 1 [Credits] on Technical Writer")))}}
     :abilities [{:cost [:click 1] :msg (msg "gain " (:counter card) " [Credits]")

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -346,7 +346,9 @@
              [:span.cardname title]
              [:img.card.bg {:src url :onError #(-> % .-target js/$ .hide)}]]))
         [:div.counters
-         (when (pos? counter) [:div.darkbg.counter counter])
+         (when (pos? counter) (if (> (.indexOf subtype "Virus") -1)
+                                  [:div.darkbg.virus.counter counter]
+                                  [:div.darkbg.counter counter]))
          (when (pos? rec-counter) [:div.darkbg.recurring.counter rec-counter])
          (when (pos? advance-counter) [:div.darkbg.advance.counter advance-counter])]
         (when (and current-strength (not= strength current-strength))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -346,7 +346,8 @@
              [:span.cardname title]
              [:img.card.bg {:src url :onError #(-> % .-target js/$ .hide)}]]))
         [:div.counters
-         (when (pos? counter) (if (> (.indexOf subtype "Virus") -1)
+         (when (pos? counter) (if (and (:installed @cursor)
+                                       (> (.indexOf subtype "Virus") -1))
                                   [:div.darkbg.virus.counter counter]
                                   [:div.darkbg.counter counter]))
          (when (pos? rec-counter) [:div.darkbg.recurring.counter rec-counter])

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -3,7 +3,7 @@
   (:require [om.core :as om :include-macros true]
             [sablono.core :as sab :include-macros true]
             [cljs.core.async :refer [chan put! <!] :as async]
-            [clojure.string :refer [capitalize]]
+            [clojure.string :refer [capitalize lower-case]]
             [netrunner.main :refer [app-state]]
             [netrunner.auth :refer [avatar] :as auth]
             [netrunner.cardbrowser :refer [image-url add-symbols] :as cb]
@@ -347,8 +347,8 @@
              [:img.card.bg {:src url :onError #(-> % .-target js/$ .hide)}]]))
         [:div.counters
          (when (pos? counter) (let [counter-type (or (card-counter-type @cursor) "")
-                                    norm-type (clojure.string/lower-case counter-type)
-                                    selector (clojure.string/format "div.darkbg.%s-counter.counter" norm-type)]
+                                    norm-type (lower-case counter-type)
+                                    selector (str "div.darkbg." norm-type "-counter.counter")]
                                 [(keyword selector) counter]))
          (when (pos? rec-counter) [:div.darkbg.recurring-counter.counter rec-counter])
          (when (pos? advance-counter) [:div.darkbg.advance-counter.counter advance-counter])]

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -346,10 +346,21 @@
              [:span.cardname title]
              [:img.card.bg {:src url :onError #(-> % .-target js/$ .hide)}]]))
         [:div.counters
-         (when (pos? counter) (if (and (:installed @cursor)
-                                       (> (.indexOf subtype "Virus") -1))
-                                  [:div.darkbg.virus.counter counter]
-                                  [:div.darkbg.counter counter]))
+         (when (pos? counter) (let [counter-type (:counter-type @cursor)]
+                                ;; Determine the appropriate type of counter
+                                ;; for styling, falling back to a default grey
+                                ;; counter when no type is known.
+                                (cond
+                                  ;; Scored agendas with counters are not :installed.
+                                  (= "Agenda" type) [:div.darkbg.agenda.counter counter]
+                                  ;; Check for cards hosted on Personal Workshop before the rest.
+                                  (not (:installed @cursor)) [:div.darkbg.power.counter counter]
+                                  (or (> (.indexOf subtype "Virus") -1)
+                                      (= "Virus" counter-type))
+                                    [:div.darkbg.virus.counter counter]
+                                  (= "Power" counter-type) [:div.darkbg.power.counter counter]
+                                  (= "Credit" counter-type) [:div.darkbg.credit.counter counter]
+                                  :else [:div.darkbg.counter counter])))
          (when (pos? rec-counter) [:div.darkbg.recurring.counter rec-counter])
          (when (pos? advance-counter) [:div.darkbg.advance.counter advance-counter])]
         (when (and current-strength (not= strength current-strength))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -348,10 +348,10 @@
         [:div.counters
          (when (pos? counter) (let [counter-type (or (card-counter-type @cursor) "")
                                     norm-type (clojure.string/lower-case counter-type)
-                                    selector (clojure.string/join "." ["div.darkbg" norm-type "counter"])]
+                                    selector (clojure.string/format "div.darkbg.%s-counter.counter" norm-type)]
                                 [(keyword selector) counter]))
-         (when (pos? rec-counter) [:div.darkbg.recurring.counter rec-counter])
-         (when (pos? advance-counter) [:div.darkbg.advance.counter advance-counter])]
+         (when (pos? rec-counter) [:div.darkbg.recurring-counter.counter rec-counter])
+         (when (pos? advance-counter) [:div.darkbg.advance-counter.counter advance-counter])]
         (when (and current-strength (not= strength current-strength))
               current-strength [:div.darkbg.strength current-strength])
         (when named-target [:div.darkbg.named-target named-target])

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1132,7 +1132,7 @@ nav ul
     z-index: 10
     padding: 0
     text-align: center
-    background-color: transparent-orange
+    background-color: transparent-orange-bright
     line-height: 24px
     font-size: 12px
     bottom: 3px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1109,22 +1109,22 @@ nav ul
     text-align: center
     margin: 2px
 
-  .advance
+  .advance-counter
     background-color: transparent-lightblue
 
-  .recurring
+  .recurring-counter
     background-color: transparent-green
 
-  .virus
+  .virus-counter
     background-color: transparent-red
 
-  .agenda
+  .agenda-counter
     background-color: transparent-blue
 
-  .power
+  .power-counter
     background-color: transparent-purple
 
-  .credit
+  .credit-counter
     background-color: transparent-gold
 
   .strength

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1110,10 +1110,13 @@ nav ul
     margin: 2px
 
   .advance
-    background-color: blue
+    background-color: transparent-lightblue
 
   .recurring
-    background-color: limegreen
+    background-color: transparent-green
+
+  .virus
+    background-color: transparent-red
 
   .strength
     position: absolute

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1118,12 +1118,21 @@ nav ul
   .virus
     background-color: transparent-red
 
+  .agenda
+    background-color: transparent-blue
+
+  .power
+    background-color: transparent-purple
+
+  .credit
+    background-color: transparent-gold
+
   .strength
     position: absolute
     z-index: 10
     padding: 0
     text-align: center
-    background-color: orange
+    background-color: transparent-orange
     line-height: 24px
     font-size: 12px
     bottom: 3px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1118,15 +1118,6 @@ nav ul
   .virus-counter
     background-color: transparent-red
 
-  .agenda-counter
-    background-color: transparent-blue
-
-  .power-counter
-    background-color: transparent-purple
-
-  .credit-counter
-    background-color: transparent-gold
-
   .strength
     position: absolute
     z-index: 10

--- a/src/css/variables.styl
+++ b/src/css/variables.styl
@@ -11,7 +11,7 @@ transparent-green = rgba(50, 205, 50, 0.85)
 transparent-red = rgba(255, 0, 0, 0.85)
 transparent-purple = rgba(164, 0, 205, 0.8)
 transparent-orange = rgba(255, 165, 0, 0.90)
-transparent-gold = rgba(255, 165, 0, 0.90)
+transparent-gold = rgba(200, 130, 0, 0.90)
 
 light-grey= #ddd
 grey= #999

--- a/src/css/variables.styl
+++ b/src/css/variables.styl
@@ -6,6 +6,9 @@ text-color = #333
 orange = #FFA500
 transparent-orange = rgba(255, 165, 0, 0.35)
 transparent-blue = rgba(39, 56, 76, 0.82)
+transparent-lightblue = rgba(0, 174, 255, 0.85)
+transparent-green = rgba(50, 205, 50, 0.85)
+transparent-red = rgba(255, 0, 0, 0.85)
 
 light-grey= #ddd
 grey= #999

--- a/src/css/variables.styl
+++ b/src/css/variables.styl
@@ -10,7 +10,7 @@ transparent-lightblue = rgba(0, 174, 255, 0.85)
 transparent-green = rgba(50, 205, 50, 0.85)
 transparent-red = rgba(255, 0, 0, 0.85)
 transparent-purple = rgba(164, 0, 205, 0.8)
-transparent-orange = rgba(255, 165, 0, 0.90)
+transparent-orange-bright = rgba(255, 165, 0, 0.90)
 transparent-gold = rgba(200, 130, 0, 0.90)
 
 light-grey= #ddd

--- a/src/css/variables.styl
+++ b/src/css/variables.styl
@@ -9,7 +9,6 @@ transparent-blue = rgba(39, 56, 76, 0.82)
 transparent-lightblue = rgba(0, 174, 255, 0.85)
 transparent-green = rgba(50, 205, 50, 0.85)
 transparent-red = rgba(255, 0, 0, 0.85)
-transparent-purple = rgba(164, 0, 205, 0.8)
 transparent-orange-bright = rgba(255, 165, 0, 0.90)
 transparent-gold = rgba(200, 130, 0, 0.90)
 

--- a/src/css/variables.styl
+++ b/src/css/variables.styl
@@ -9,6 +9,9 @@ transparent-blue = rgba(39, 56, 76, 0.82)
 transparent-lightblue = rgba(0, 174, 255, 0.85)
 transparent-green = rgba(50, 205, 50, 0.85)
 transparent-red = rgba(255, 0, 0, 0.85)
+transparent-purple = rgba(164, 0, 205, 0.8)
+transparent-orange = rgba(255, 165, 0, 0.90)
+transparent-gold = rgba(255, 165, 0, 0.90)
 
 light-grey= #ddd
 grey= #999


### PR DESCRIPTION
Fixes #522 

This change adds a css class for counters on **Virus** cards to give a more clear visual indication of which counters can be purged.

To make counters a little more consistent I added subtle transparency for the special counters (recurring, advancement, and now virus). 

Screenshot (see the [comment](https://github.com/mtgred/netrunner/pull/1174#issuecomment-179019900) below for a more recent shot):
![screenshot](http://i.imgur.com/TCL73rX.png)