### PR TITLE
Minor fixes: Mutate, Turntable, Leela Patel

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -510,42 +510,43 @@
    "Turntable"
    {:effect (effect (gain :memory 1))
     :leave-play (effect (lose :memory 1))
-    :events {:agenda-stolen {:effect (req (toast state :runner "Click Turntable to swap for a scored Corp agenda." "info")
-                                          (update! state side (assoc card :swap true)))}}
-    :abilities [{:optional
-                  {:req (req (:swap card))
-                   :prompt "Swap for a scored Corp agenda?"
-                   :yes-ability
-                   {:effect (req (let [agendas (get-in corp [:scored])]
-                                   (resolve-ability
-                                     state side
-                                     {:prompt "Choose a scored Corp agenda"
-                                      :choices {:req #(some (fn [c] (= (:cid %) (:cid c))) agendas)}
-                                      :effect (req (let [st (last (get-in runner [:scored]))
-                                                         sw target
-                                                         stpts-corp (get-agenda-points state :corp st)
-                                                         swpts-corp (get-agenda-points state :corp sw)
-                                                         stpts-runner (get-agenda-points state :runner st)
-                                                         swpts-runner (get-agenda-points state :runner sw)]
-                                                     (swap! state update-in [:corp :scored]
-                                                       (fn [coll] (conj (remove-once #(not= (:cid %) (:cid sw)) coll) st)))
-                                                     (swap! state update-in [:runner :scored]
-                                                       (fn [coll] (conj (remove-once #(not= (:cid %) (:cid st)) coll)
-                                                                        (dissoc sw :abilities :events))))
-                                                     (gain-agenda-point state :runner (- swpts-runner stpts-runner))
-                                                     (gain-agenda-point state :corp (- stpts-corp swpts-corp))
-                                                     (doseq [c (get-in @state [:corp :scored])]
-                                                       (let [abilities (:abilities (card-def c))
-                                                             c (merge c {:abilities abilities})]
-                                                         (update! state :corp c)
-                                                         (when-let [events (:events (card-def c))]
-                                                           (register-events state side events c))))
-                                                     (doseq [r (get-in @state [:runner :scored])]
-                                                       (deactivate state :corp r))
-                                                     (system-msg state side
-                                                       (str "uses Turntable to swap " (:title st) " for " (:title sw)))
-                                                     (update! state side (dissoc (get-card state card) :swap))))}
-                                    card nil)))}}}]}
+    :events {:agenda-stolen {:req (req (not (empty? (:scored corp))))
+                             :effect (req (toast state :runner "Click Turntable to swap for a scored Corp agenda." "info")
+                                          (update! state side (assoc card :swap true)))}
+             :runner-spent-click {:req (req (:swap card))
+                                  :effect (effect (update! (dissoc card :swap)))}}
+    :abilities [{:req (req (:swap card))
+                 :effect (req (let [agendas (get-in corp [:scored])
+                                    st (last (get-in runner [:scored]))]
+                                (resolve-ability
+                                  state side
+                                  {:req (req (is-type? st "Agenda"))
+                                   :prompt (msg "Choose a scored Corp agenda to swap for " (:title st))
+                                   :choices {:req #(some (fn [c] (= (:cid %) (:cid c))) agendas)}
+                                   :effect (req (let [sw target
+                                                      stpts-corp (get-agenda-points state :corp st)
+                                                      swpts-corp (get-agenda-points state :corp sw)
+                                                      stpts-runner (get-agenda-points state :runner st)
+                                                      swpts-runner (get-agenda-points state :runner sw)]
+                                                  (swap! state update-in [:corp :scored]
+                                                    (fn [coll] (conj (remove-once #(not= (:cid %) (:cid sw)) coll) st)))
+                                                  (swap! state update-in [:runner :scored]
+                                                    (fn [coll] (conj (remove-once #(not= (:cid %) (:cid st)) coll)
+                                                                     (dissoc sw :abilities :events))))
+                                                  (gain-agenda-point state :runner (- swpts-runner stpts-runner))
+                                                  (gain-agenda-point state :corp (- stpts-corp swpts-corp))
+                                                  (doseq [c (get-in @state [:corp :scored])]
+                                                    (let [abilities (:abilities (card-def c))
+                                                          c (merge c {:abilities abilities})]
+                                                      (update! state :corp c)
+                                                      (when-let [events (:events (card-def c))]
+                                                        (register-events state side events c))))
+                                                  (doseq [r (get-in @state [:runner :scored])]
+                                                    (deactivate state :corp r))
+                                                  (system-msg state side (str "uses Turntable to swap "
+                                                                              (:title st) " for " (:title sw)))
+                                                  (update! state side (dissoc (get-card state card) :swap))))}
+                                 card nil)))}]}
 
    "Unregistered S&W 35"
    {:abilities

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -166,7 +166,8 @@
              {:req (req (not= (first (:zone card)) :discard))
               :prompt "Pay 3 [Credits] to force Runner to encounter Archangel?"
               :yes-ability {:cost [:credit 3]
-                            :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}}}
+                            :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}
+              :no-ability {:effect (req (system-msg state :corp "declines to force the Runner to encounter Archangel"))}}}
     :abilities [(trace-ability 6 {:choices {:req installed?}
                                   :label "Add 1 installed card to the Runner's Grip"
                                   :msg "add 1 installed card to the Runner's Grip"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -236,6 +236,7 @@
                            (update! state side (assoc card :bounce-hq true)))}}
     :abilities [{:req (req (:bounce-hq card))
                  :choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :player :runner
+                 :priority true
                  :msg (msg "add " (card-str state target) " to HQ")
                  :effect (effect (move :corp target :hand)
                                  (update! (dissoc (get-card state card) :bounce-hq)))}]}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -294,6 +294,7 @@
                        (swap! state assoc-in (cons :corp (:zone target)) newices)
                        (swap! state update-in [:corp :deck] (fn [coll] (remove-once #(not= (:cid %) (:cid newice)) coll)))
                        (trigger-event state side :corp-install newice)
+                       (card-init state side newice false)
                        (system-msg state side (str "uses Mutate to install and rez " (:title newice) " from R&D at no cost")))
                      (system-msg state side (str "does not find any ICE to install from R&D")))
                    (shuffle! state :corp :deck)))}

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -200,7 +200,6 @@
         (card-ability state :runner tt 0)
         ;; Turntable prompt should be active
         (is (= (:cid tt) (-> @state :runner :prompt first :card :cid)))
-        (prompt-choice :runner "Yes")
         (prompt-select :runner (find-card "Project Vitruvius" (:scored (get-corp))))
         (is (= 2 (:agenda-point (get-runner))) "Took Project Vitruvius from Corp")
         (is (= 0 (:agenda-point (get-corp))) "Swapped Domestic Sleepers to Corp")


### PR DESCRIPTION
* Fix #1169: Add `:priority true` to Leela's ability so it jumps to the front of the prompt queue in a multi-access situation (avoiding interwoven prompts)
* Fix #1165: Mutate needs to call `card-init` on the ICE swapped in from R&D to enable its abilities and event hooks
* Fix #1152: Ensure that the thing you are about to swap with Turntable is an agenda, and add safeguards to stop delayed usage of Turntable (dissociates the enabling key if the Runner spends a click to do anything else). Updates Turntable's test.
* Adds a message to the log when the Corp declines to trigger the forced Archangel encounter