### PR TITLE
Improvement to agenda forfeiting; fix Turntable + Mandatory Upgrades interaction

### DIFF
--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -108,6 +108,16 @@
   [card]
   (= (:zone card) [:deck]))
 
+(defn in-corp-scored?
+  "Checks if the specified card is in the Corp score area."
+  [state side card]
+  (not (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :scored])))))
+
+(defn in-runner-scored?
+  "Checks if the specified card is in the Runner score area."
+  [state side card]
+  (not (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:runner :scored])))))
+
 (defn is-type?
   "Checks if the card is of the specified type, where the type is a string."
   [card type]

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -18,7 +18,7 @@
        (when (or (and (= (:side card) "Runner") (:installed card) (not (:facedown card)))
                  (:rezzed card)
                  (= (first (:zone card)) :current)
-                 (not (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :scored])))))
+                 (= (first (:zone card)) :scored))
          (leave-effect state side card nil)))
      (when-let [prevent (:prevent (card-def card))]
        (doseq [[ptype pvec] prevent]

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -2,7 +2,7 @@
 
 (declare card-init card-str deactivate enforce-msg gain-agenda-point get-agenda-points
          handle-end-run is-type? resolve-steal-events show-prompt untrashable-while-rezzed?
-         update-all-ice win)
+         in-corp-scored? update-all-ice win)
 
 ;;;; Functions for applying core Netrunner game rules.
 
@@ -284,7 +284,8 @@
 (defn forfeit
   "Forfeits the given agenda to the :rfg zone."
   [state side card]
-  (let [c (deactivate state side card)]
+  (let [c (if (in-corp-scored? state side card)
+            (deactivate state side card) card)]
     (system-msg state side (str "forfeits " (:title c)))
     (gain-agenda-point state side (- (get-agenda-points state side c)))
     (move state :corp c :rfg)))

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -236,3 +236,23 @@
         (is (= 2 (:agenda-point (get-runner))) "Took Project Vitruvius from Corp")
         (is (= 0 (:agenda-point (get-corp))) "Swapped Domestic Sleepers to Corp")
         (is (nil? (:swap (core/get-card state tt))) "Turntable ability disabled")))))
+
+(deftest turntable-mandatory-upgrades
+  "Turntable - Swap a Mandatory Upgrades away from the Corp reduces Corp clicks per turn"
+  (do-game
+    (new-game (default-corp [(qty "Mandatory Upgrades" 1) (qty "Project Vitruvius" 1)])
+              (default-runner [(qty "Turntable" 1)]))
+    (play-from-hand state :corp "Mandatory Upgrades" "New remote")
+    (let [manups (get-content state :remote1 0)]
+      (score-agenda state :corp manups)
+      (is (= 4 (:click-per-turn (get-corp))) "Up to 4 clicks per turn")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Turntable")
+      (let [tt (get-in @state [:runner :rig :hardware 0])]
+        (run-empty-server state "HQ")
+        (prompt-choice :runner "Steal")
+        (is (= 2 (:agenda-point (get-runner))) "Stole Project Vitruvius")
+        (card-ability state :runner tt 0)
+        (prompt-select :runner (find-card "Mandatory Upgrades" (:scored (get-corp))))
+        (is (= 3 (:click-per-turn (get-corp))) "Back down to 3 clicks per turn")
+        (is (nil? (:swap (core/get-card state tt))) "Turntable ability disabled")))))


### PR DESCRIPTION
Fixes #1142. 

Adds a couple new flags for verifying a card's presence in Corp or Runner scored areas, then uses them to only deactivate forfeited agendas if they came from the Corp area. The logic to make forfeiting a Mandatory Upgrades or Self-destruct Chips work while simultaneously allowing Turntabled agendas to be deactivated needed to go into `forfeit` instead of `deactivate`. 

Includes tests for forfeiting a Mandatory Upgrades as both sides and for using Turntable to swap a scored one away from the Corp. 