### PR TITLE
Card Refactoring

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -627,24 +627,8 @@
                  :cost [:click 1]
                  :prompt "Select two pieces of ICE to swap positions"
                  :choices {:req #(and (installed? %) (ice? %)) :max 2}
-                 :effect (req (if (= (count targets) 2)
-                                (let [fndx (ice-index state (first targets))
-                                      sndx (ice-index state (second targets))
-                                      fnew (assoc (first targets) :zone (:zone (second targets)))
-                                      snew (assoc (second targets) :zone (:zone (first targets)))]
-                                  (swap! state update-in (cons :corp (:zone (first targets)))
-                                         #(assoc % fndx snew))
-                                  (swap! state update-in (cons :corp (:zone (second targets)))
-                                         #(assoc % sndx fnew))
-                                  (doseq [newcard [fnew snew]]
-                                    (doseq [h (:hosted newcard)]
-                                      (let [newh (-> h (assoc-in [:zone] '(:onhost))
-                                                     (assoc-in [:host :zone] (:zone newcard)))]
-                                        (update! state side newh)
-                                        (unregister-events state side h)
-                                        (register-events state side (:events (card-def newh)) newh))))
-                                  (update-ice-strength state side fnew)
-                                  (update-ice-strength state side snew))))
+                 :effect (req (when (= (count targets) 2)
+                                (swap-ice state side (first targets) (second targets))))
                  :msg "swap the positions of two ICE"}]}
 
    "Test Ground"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -137,8 +137,7 @@
               :effect (effect (trash target {:unpreventable true}))}}}
 
    "Cybernetics Court"
-   {:effect (effect (gain :hand-size-modification 4))
-    :leave-play (effect (lose :hand-size-modification 4))}
+   {:in-play [:hand-size-modification 4]}
 
    "Daily Business Show"
    {:events {:corp-draw
@@ -169,7 +168,7 @@
    {:recurring 2}
 
    "Director Haas"
-   {:effect (effect (gain :click 1 :click-per-turn 1)) :leave-play (effect (lose :click-per-turn 1))
+   {:in-play [:click 1 :click-per-turn 1]
     :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
 
    "Docklands Crackdown"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -1,14 +1,23 @@
 (in-ns 'game.core)
 
+(defn campaign
+  "Creates a Campaign with X counters draining Y per-turn.
+  Trashes itself when out of counters"
+  [counters per-turn]
+  {:data {:counter-type "Credit"}
+   :effect (effect (add-prop card :counter counters))
+   :derezzed-events {:runner-turn-ends corp-rez-toast}
+   :events {:corp-turn-begins {:msg (str "gain " per-turn " [Credits]")
+                               :counter-cost per-turn
+                               :effect (req (gain state :corp :credit per-turn)
+                                            (when (zero? (:counter card))
+                                              (trash state :corp card)))}}})
+
+;;; Card definitions
 (def cards-assets
   {"Adonis Campaign"
-   {:data {:counter-type "Credit"}
-    :effect (effect (add-prop card :counter 12))
-    :derezzed-events {:runner-turn-ends corp-rez-toast}
-    :events {:corp-turn-begins {:msg "gain 3 [Credits]" :counter-cost 3
-                                :effect (req (gain state :corp :credit 3)
-                                             (when (zero? (:counter card)) (trash state :corp card)))}}}
-
+   (campaign 12 3)
+   
    "Aggressive Secretary"
    {:advanceable :always
     :access {:optional
@@ -194,12 +203,8 @@
                          :effect (effect (trash-cost-bonus 1))}}}
 
    "Eve Campaign"
-   {:data {:counter-type "Credit"}
-    :effect (effect (add-prop card :counter 16))
-    :derezzed-events {:runner-turn-ends corp-rez-toast}
-    :events {:corp-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
-                                :effect (req (gain state :corp :credit 2)
-                                             (when (zero? (:counter card)) (trash state :corp card)))}}}
+   (campaign 16 2)
+
 
    "Executive Boot Camp"
    {:derezzed-events {:runner-turn-ends corp-rez-toast}
@@ -315,13 +320,8 @@
                                  (trash card {:cause :ability-cost}))}]}
 
    "Launch Campaign"
-   {:data {:counter-type "Credit"}
-    :effect (effect (add-prop card :counter 6))
-    :derezzed-events {:runner-turn-ends corp-rez-toast}
-    :events {:corp-turn-begins {:msg "gain 2 [Credits]" :counter-cost 2
-                                :effect (req (gain state :corp :credit 2)
-                                             (when (zero? (:counter card)) (trash state :corp card)))}}}
-
+   (campaign 6 2)
+   
    "Levy University"
    {:abilities [{:prompt "Choose an ICE"
                  :msg (msg "adds " (:title target) " to HQ")

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -192,20 +192,11 @@
                  :msg (msg "place 1 advancement token on " (card-str state target))}]}
 
    "Edge of World"
-   {:access {:req (req installed)
-             :effect (effect (show-wait-prompt :runner "Corp to use Edge of World")
-                             (resolve-ability
-                               {:optional
-                                {:prompt "Pay 3 [Credits] to use Edge of World ability?"
-                                 :yes-ability {:cost [:credit 3]
-                                               :msg (msg "do " (count (get-in corp [:servers (last (:server run)) :ices]))
-                                                         " brain damage")
-                                               :effect (effect (clear-wait-prompt :runner)
-                                                               (damage :brain
-                                                                       (count (get-in corp [:servers (last (:server (:run @state))) :ices]))
-                                                                       {:card card}))}
-                                 :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
-                               card nil))}}
+   (letfn [(ice-count [state]
+             (count (get-in (:corp @state) [:servers (last (:server (:run @state))) :ices])))] 
+       (installed-access-trigger 3 {:msg (msg "do " (ice-count state) " brain damage")
+                                    :effect (effect (damage :brain (ice-count state)
+                                                            {:card card}))}))
 
    "Elizabeth Mills"
    {:effect (effect (lose :bad-publicity 1)) :msg "remove 1 bad publicity"
@@ -588,13 +579,14 @@
    {:access {:req (req (not= (first (:zone card)) :discard))
              :effect (effect (show-wait-prompt :runner "Corp to use Snare!")
                              (resolve-ability
-                               {:optional {:prompt "Pay 4 [Credits] to use Snare! ability?"
-                                           :yes-ability {:cost [:credit 4]
-                                                         :msg "do 3 net damage and give the Runner 1 tag"
-                                                         :effect (effect (clear-wait-prompt :runner)
-                                                                         (damage :net 3 {:card card})
-                                                                         (tag-runner :runner 1))}
-                                           :no-ability {:effect (effect (clear-wait-prompt :runner))}}} card nil))}}
+                               {:optional
+                                {:prompt "Pay 4 [Credits] to use Snare! ability?"
+                                 :end-effect (effect (clear-wait-prompt :runner))
+                                 :yes-ability {:cost [:credit 4]
+                                               :msg "do 3 net damage and give the Runner 1 tag"
+                                               :effect (effect (damage :net 3 {:card card})
+                                                               (tag-runner :runner 1))}}}
+                               card nil))}}
 
    "Space Camp"
    {:access {:msg (msg "place 1 advancement token on " (card-str state target))

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -162,23 +162,15 @@
                        (register-events state side events (:identity corp))))}
 
    "Escher"
-   (let [eshelp (fn es [] {:prompt "Select two pieces of ICE to swap positions"
-                           :choices {:req #(and (installed? %) (ice? %)) :max 2}
-                           :effect (req (if (= (count targets) 2)
-                                          (let [fndx (ice-index state (first targets))
-                                                sndx (ice-index state (second targets))
-                                                fnew (assoc (first targets) :zone (:zone (second targets)))
-                                                snew (assoc (second targets) :zone (:zone (first targets)))]
-                                            (swap! state update-in (cons :corp (:zone (first targets)))
-                                                   #(assoc % fndx snew))
-                                            (swap! state update-in (cons :corp (:zone (second targets)))
-                                                   #(assoc % sndx fnew))
-                                            (update-ice-strength state side fnew)
-                                            (update-ice-strength state side snew)
-                                            (resolve-ability state side (es) card nil))
-                                          (system-msg state side "has finished rearranging ICE")))})]
-     {:effect (effect (run :hq {:replace-access {:msg "rearrange installed ICE"
-                                                 :effect (effect (resolve-ability (eshelp) card nil))}} card))})
+   (letfn [(es [] {:prompt "Select two pieces of ICE to swap positions"
+                   :choices {:req #(and (installed? %) (ice? %)) :max 2}
+                   :effect (req (if (= (count targets) 2)
+                                  (do (swap-ice state side (first targets) (second targets))
+                                      (resolve-ability state side (es) card nil))
+                                  (system-msg state side "has finished rearranging ICE")))})]
+     {:effect (effect (run :hq {:replace-access
+                                {:msg "rearrange installed ICE"
+                                 :effect (effect (resolve-ability (es) card nil))}} card))})
 
    "Eureka!"
    {:effect

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -20,8 +20,7 @@
                                card nil))}]}
 
    "Astrolabe"
-   {:effect (effect (gain :memory 1))
-    :leave-play (effect (lose :memory 1))
+   {:in-play [:memory 1]
     :events {:server-created {:msg "draw 1 card"
                               :effect (effect (draw :runner))}}}
 
@@ -39,7 +38,7 @@
                                                 (system-msg "trashes Autoscripter"))}}}
 
    "Blackguard"
-   {:effect (effect (gain :memory 2)) :leave-play (effect (lose :memory 2))
+   {:in-play [:memory 2]
     :events {:expose {:msg (msg "attempt to force the rez of " (:title target))
                       :effect (effect (rez :corp target))}}}
 
@@ -60,13 +59,11 @@
                               (trash state side (get-card state card) {:cause :ability-cost}))}]}
 
    "Box-E"
-   {:effect (effect (gain :memory 2 :hand-size-modification 2))
-    :leave-play (effect (lose :memory 2 :hand-size-modification 2))}
+   {:in-play [:memory 2 :hand-size-modification 2]}
 
    "Brain Cage"
-   {:effect (effect (damage :brain 1 {:card card})
-                    (gain :hand-size-modification 3))
-    :leave-play (effect (lose :hand-size-modification 3))}
+   {:in-play [:hand-size-modification 3]
+    :effect (effect (damage :brain 1 {:card card}))}
 
    "Brain Chip"
    (let [runner-points (fn [s] (max (or (get-in s [:runner :agenda-point]) 0) 0))]
@@ -126,8 +123,7 @@
                  :effect (effect (trash card {:cause :ability-cost}) (runner-install target))}]}
 
    "Comet"
-   {:effect (effect (gain :memory 1))
-    :leave-play (effect (lose :memory 1))
+   {:in-play [:memory 1]
     :events {:play-event {:req (req (first-event state side :play-event))
                           :effect (req (system-msg state :runner
                                                    (str "can play another event without spending a [Click] by clicking on Comet"))
@@ -161,13 +157,13 @@
    {:recurring 1}
 
    "CyberSolutions Mem Chip"
-   {:effect (effect (gain :memory 2)) :leave-play (effect (lose :memory 2))}
+   {:in-play [:memory 2]}
 
    "Cybsoft MacroDrive"
    {:recurring 1}
 
    "Deep Red"
-   {:effect (effect (gain :memory 3)) :leave-play (effect (lose :memory 3))
+   {:in-play [:memory 3]
     :events {:runner-install
              {:optional
               {:req (req (has-subtype? target "Caïssa"))
@@ -178,7 +174,7 @@
                                             (play-ability state side {:card (get-card state caissa) :ability 0})))}}}}}
 
    "Desperado"
-   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
+   {:in-play [:memory 1]
     :events {:successful-run {:msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Dinosaurus"
@@ -209,7 +205,7 @@
                                           (lose :memory (:memoryunits target)))}}}
 
    "Doppelgänger"
-   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
+   {:in-play [:memory 1]
     :events {:runner-install
              {:req (req (= card target))
               :effect (effect (update! (assoc card :dopp-active true)))}
@@ -241,7 +237,7 @@
    {:recurring 1}
 
    "Dyson Mem Chip"
-   {:effect (effect (gain :link 1 :memory 1)) :leave-play (effect (lose :link 1 :memory 1))}
+   {:in-play [:memory 1 :link 1]}
 
    "e3 Feedback Implants"
    {:abilities [{:cost [:credit 1] :msg "break 1 additional subroutine"}]}
@@ -262,19 +258,19 @@
 
    "Forger"
    {:prevent {:tag [:all]}
-    :effect (effect (gain :link 1)) :leave-play (effect (lose :link 1))
+    :in-play [:link 1]
     :abilities [{:msg "avoid 1 tag" :label "[Trash]: Avoid 1 tag"
                  :effect (effect (tag-prevent 1) (trash card {:cause :ability-cost}))}
                 {:msg "remove 1 tag" :label "[Trash]: Remove 1 tag"
                  :effect (effect (trash card {:cause :ability-cost}) (lose :tag 1))}]}
 
    "Grimoire"
-   {:effect (effect (gain :memory 2)) :leave-play (effect (lose :memory 2))
+   {:in-play [:memory 2]
     :events {:runner-install {:req (req (has-subtype? target "Virus"))
                               :effect (effect (add-prop target :counter 1))}}}
 
    "Heartbeat"
-   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
+   {:in-play [:memory 1]
     :prevent {:damage [:meat :net :brain]}
     :abilities [{:msg "prevent 1 damage"
                  :choices {:req #(and (= (:side %) "Runner") (:installed %))}
@@ -285,7 +281,7 @@
                                  (damage-prevent :net 1))}]}
 
    "HQ Interface"
-   {:effect (effect (gain :hq-access 1)) :leave-play (effect (lose :hq-access 1))}
+   {:in-play [:hq-access 1]}
 
    "Lemuria Codecracker"
    {:abilities [{:cost [:click 1 :credit 1] :req (req (some #{:hq} (:successful-run runner-reg)))
@@ -309,14 +305,13 @@
    {:recurring 1}
 
    "Logos"
-   {:effect (effect (gain :memory 1 :hand-size-modification 1))
-    :leave-play (effect (lose :memory 1 :hand-size-modification 1))
+   {:in-play [:memory 1 :hand-size-modification 1]
     :events {:agenda-scored
              {:player :runner :prompt "Choose a card" :msg (msg "add 1 card to Grip from Stack")
               :choices (req (:deck runner)) :effect (effect (move target :hand) (shuffle! :deck))}}}
 
    "Maya"
-   {:effect (effect (gain :memoryunits 2)) :leave-play (effect (lose :memoryunits 2))
+   {:in-play [:memory 2]
     :abilities [{:once :per-turn
                  :req (req (when-let [c (:card (first (get-in @state [:runner :prompt])))]
                              (in-deck? c)))
@@ -332,7 +327,7 @@
                                     (handle-end-run state :runner)))))}]}
 
    "MemStrips"
-   {:effect (effect (gain :memory 3))}
+   {:in-play [:memory 3]}
 
    "Monolith"
    (let [mhelper (fn mh [n] {:prompt "Choose a program to install"
@@ -343,9 +338,8 @@
                                             (when (< n 3)
                                               (resolve-ability state side (mh (inc n)) card nil)))})]
      {:prevent {:damage [:net :brain]}
-      :effect (effect (gain :memory 3)
-                      (resolve-ability (mhelper 1) card nil))
-      :leave-play (effect (lose :memory 3))
+      :in-play [:memory 3]
+      :effect (effect (resolve-ability (mhelper 1) card nil))
       :abilities [{:msg (msg "prevent 1 brain or net damage by trashing " (:title target))
                    :priority true
                    :choices {:req #(and (is-type? % "Program")
@@ -418,19 +412,18 @@
                        :effect (effect (tag-prevent 1) (update! (dissoc card :qianju-active)))}}}
 
    "R&D Interface"
-   {:effect (effect (gain :rd-access 1)) :leave-play (effect (lose :rd-access 1))}
+   {:in-play [:rd-access 1]}
 
    "Rabbit Hole"
-   {:effect
-    (effect (gain :link 1)
-            (resolve-ability
+   {:in-play [:link 1]
+    :effect
+    (effect (resolve-ability
              {:optional {:req (req (some #(when (= (:title %) "Rabbit Hole") %) (:deck runner)))
                          :prompt "Install another Rabbit Hole?" :msg "install another Rabbit Hole"
                          :yes-ability {:effect (req (when-let [c (some #(when (= (:title %) "Rabbit Hole") %)
                                                                       (:deck runner))]
                                                      (runner-install state side c)
-                                                     (shuffle! state :runner :deck)))}}} card nil))
-    :leave-play (effect (lose :link 1))}
+                                                     (shuffle! state :runner :deck)))}}} card nil))}
 
    "Ramujan-reliant 550 BMI"
    {:prevent {:damage [:net :brain]}
@@ -489,8 +482,7 @@
                               (trash state side (get-card state card) {:cause :ability-cost}))}]}
 
    "Security Nexus"
-   {:effect (effect (gain :link 1) (gain :memory 1))
-    :leave-play (effect (lose :link 1) (lose :memory 1))
+   {:in-play [:memory 1 :link 1]
     :abilities [{:req (req (:run @state))
                  :msg "force the Corp to initiate a trace"
                  :label "Trace 5 - Give the Runner 1 tag and end the run"
@@ -506,7 +498,8 @@
     :events {:pre-trash {:effect (effect (trash-cost-bonus -1))}}}
 
    "Spinal Modem"
-   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1)) :recurring 2
+   {:in-play [:memory 1]
+    :recurring 2
     :events {:successful-trace {:req (req run) :effect (effect (damage :brain 1 {:card card}))}}}
 
    "The Personal Touch"
@@ -517,15 +510,14 @@
                                     :effect (effect (breaker-strength-bonus 1))}}}
 
    "The Toolbox"
-   {:effect (effect (gain :link 2 :memory 2)) :leave-play (effect (lose :link 2 :memory 2))
+   {:in-play [:link 2 :memory 2]
     :recurring 2}
 
    "Titanium Ribs"
    {:effect (effect (damage :meat 2 {:card card}))}
 
    "Turntable"
-   {:effect (effect (gain :memory 1))
-    :leave-play (effect (lose :memory 1))
+   {:in-play [:memory 1]
     :events {:agenda-stolen {:req (req (not (empty? (:scored corp))))
                              :effect (req (toast state :runner "Click Turntable to swap for a scored Corp agenda." "info")
                                           (update! state side (assoc card :swap true)))}
@@ -577,7 +569,7 @@
       :msg (msg "trash " (:title target)) :effect (effect (trash target))}]}
 
    "Vigil"
-   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
+   {:in-play [:memory 1]
     :events {:runner-turn-begins {:req (req (= (count (:hand corp)) (hand-size state :corp)))
                                   :msg "draw 1 card" :effect (effect (draw 1))}}}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -134,6 +134,13 @@
 
 
 ;;; For Morph ICE
+(defn morph [state side card new old]
+  (update! state side (assoc card :subtype
+                             (->> (remove #(= old %) (.split (:subtype card) " - "))
+                                  vec (concat [new]) distinct (join " - "))))
+  (update-ice-strength state side card)
+  (update-run-ice state side))
+
 (defn morph-effect
   "Creates morph effect for ICE. Morphs from base type to other type"
   [base other]

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -78,6 +78,16 @@
               " subroutine" (when (> num 1) "s"))
     :cost [:credit cost]}))
 
+;;; Breaker sets
+(defn- cerberus
+  "Breaker from the dog set"
+  [type]
+  (auto-icebreaker [type]
+                   {:data {:counter 4}
+                    :abilities [{:counter-cost 1
+                                 :msg (str "break up to 2 " (lower-case type) " subroutines")}
+                                (strength-pump 1 1)]}))
+
 ;;; Icebreaker definitions
 (def cards-icebreakers
   {"Alpha"
@@ -131,22 +141,13 @@
                                  (strength-pump 2 4)]})
 
    "Cerberus \"Cuj.0\" H3"
-   (auto-icebreaker ["Sentry"]
-                    {:data {:counter 4}
-                     :abilities [{:counter-cost 1 :msg "break up to 2 sentry subroutines"}
-                                 (strength-pump 1 1)]})
+   (cerberus "Sentry")
 
    "Cerberus \"Rex\" H2"
-   (auto-icebreaker ["Code Gate"]
-                    {:data {:counter 4}
-                     :abilities [{:counter-cost 1 :msg "break up to 2 code gate subroutines"}
-                                 (strength-pump 1 1)]})
+   (cerberus "Code Gate")
 
    "Cerberus \"Lady\" H1"
-   (auto-icebreaker ["Barrier"]
-                    {:data {:counter 4}
-                     :abilities [{:counter-cost 1 :msg "break up to 2 barrier subroutines"}
-                                 (strength-pump 1 1)]})
+   (cerberus "Barrier")
 
    "Chameleon"
    {:prompt "Choose one subtype"

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -88,6 +88,17 @@
                                  :msg (str "break up to 2 " (lower-case type) " subroutines")}
                                 (strength-pump 1 1)]}))
 
+(defn- break-and-enter
+  "Breakers from the Break and Entry set"
+  [type]
+  (cloud-icebreaker {:abilities [{:msg (str "break up to 3 " (lower-case type) " subroutines")
+                                  :effect (effect (trash card {:cause :ability-cost}))}]
+                      :events (let [cloud {:req (req (has-subtype? target "Icebreaker"))
+                                           :effect (effect (update-breaker-strength card))}]
+                                {:runner-install cloud :trash cloud :card-moved cloud})
+                      :strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
+                                                          (all-installed state :runner))))}))
+
 ;;; Icebreaker definitions
 (def cards-icebreakers
   {"Alpha"
@@ -169,13 +180,7 @@
                                    (strength-pump 1 1)]}))
 
    "Crowbar"
-   (cloud-icebreaker {:abilities [{:msg "break up to 3 code gate subroutines"
-                                   :effect (effect (trash card {:cause :ability-cost}))}]
-                      :events (let [cloud {:req (req (has-subtype? target "Icebreaker"))
-                                           :effect (effect (update-breaker-strength card))}]
-                                {:runner-install cloud :trash cloud :card-moved cloud})
-                      :strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
-                                                          (all-installed state :runner))))})
+   (break-and-enter "Code Gate")
 
    "Crypsis"
    (auto-icebreaker ["All"]
@@ -400,20 +405,10 @@
                                  (strength-pump 1 2)]})
 
    "Shiv"
-   (cloud-icebreaker {:abilities [{:msg "break up to 3 sentry subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
-                      :events (let [cloud {:req (req (has-subtype? target "Icebreaker"))
-                                           :effect (effect (update-breaker-strength card))}]
-                                {:runner-install cloud :trash cloud :card-moved cloud})
-                      :strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
-                                                          (all-installed state :runner))))})
+   (break-and-enter "Sentry")
 
    "Spike"
-   (cloud-icebreaker {:abilities [{:msg "break up to 3 barrier subroutines" :effect (effect (trash card {:cause :ability-cost}))}]
-                      :events (let [cloud {:req (req (has-subtype? target "Icebreaker"))
-                                           :effect (effect (update-breaker-strength card))}]
-                                {:runner-install cloud :trash cloud :card-moved cloud})
-                      :strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
-                                                          (all-installed state :runner))))})
+   (break-and-enter "Barrier")
 
    "Study Guide"
    {:abilities [(break-sub 1 1 "code gate")

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -71,11 +71,14 @@
     :pump strength}))
 
 (defn- break-sub
-  "Creates a break subroutine ability."
+  "Creates a break subroutine ability.
+  If num = 0 then any number of subs are broken."
   ([cost num] (break-sub cost num nil))
   ([cost num subtype]
-   {:msg (str "break " (when (> num 1) "up to ") num (when subtype (str " " subtype))
-              " subroutine" (when (> num 1) "s"))
+   {:msg (str "break " (when (> num 1) "up to ")
+              (if (pos? num) num "any number of")
+              (when subtype (str " " subtype))
+              " subroutine" (when-not (= num 1) "s"))
     :cost [:credit cost]}))
 
 ;;; Breaker sets
@@ -98,6 +101,12 @@
                                 {:runner-install cloud :trash cloud :card-moved cloud})
                       :strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
                                                           (all-installed state :runner))))}))
+
+(defn- global-sec-breaker
+  "GlobalSec breakers for Sunny"
+  [type]
+  (cloud-icebreaker (auto-icebreaker [type] {:abilities [(break-sub 2 0 (lower-case type))
+                                                         (strength-pump 2 3)]})))
 
 ;;; Icebreaker definitions
 (def cards-icebreakers
@@ -291,25 +300,13 @@
                                  (strength-pump 2 3)]})
 
    "GS Sherman M3"
-   (cloud-icebreaker
-     (auto-icebreaker ["Barrier"]
-                      {:abilities [{:cost [:credit 2]
-                                    :msg "break any number of barrier subroutines"}
-                                   (strength-pump 2 3)]}))
+   (global-sec-breaker "Barrier")
 
    "GS Shrike M2"
-   (cloud-icebreaker
-     (auto-icebreaker ["Sentry"]
-                      {:abilities [{:cost [:credit 2]
-                                    :msg "break any number of sentry subroutines"}
-                                   (strength-pump 2 3)]}))
+   (global-sec-breaker "Sentry")
 
    "GS Striker M1"
-   (cloud-icebreaker
-     (auto-icebreaker ["Code Gate"]
-                      {:abilities [{:cost [:credit 2]
-                                    :msg "break any number of code gate subroutines"}
-                                   (strength-pump 2 3)]}))
+   (global-sec-breaker "Code Gate")
 
    "Inti"
    (auto-icebreaker ["Barrier"]
@@ -332,7 +329,7 @@
                                  (strength-pump 3 5)]})
 
    "Morning Star"
-   {:abilities [{:cost [:credit 1] :msg "break any number of barrier subroutines"}]}
+   {:abilities [(break-sub 1 0 "barrier")]}
 
    "Mimic"
    {:abilities [(break-sub 1 1 "sentry")]}
@@ -419,7 +416,7 @@
 
    "Switchblade"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [{:cost [:credit 1] :msg "break any number of sentry subroutines"}
+                    {:abilities [(break-sub 1 0 "sentry")
                                  (strength-pump 1 7)]})
 
    "Torch"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -518,25 +518,19 @@
    {:req (req (:unsuccessful-run runner-reg)) :effect (effect (gain :credit 7))}
 
    "Sunset"
-   (let [sunhelp (fn sun [serv] {:prompt "Select two pieces of ICE to swap positions"
-                                 :choices {:req #(and (= serv (rest (butlast (:zone %))))
-                                                      (ice? %)) :max 2}
-                                 :effect (req (if (= (count targets) 2)
-                                                (let [fndx (ice-index state (first targets))
-                                                      sndx (ice-index state (second targets))
-                                                      fnew (assoc (first targets) :zone (:zone (second targets)))
-                                                      snew (assoc (second targets) :zone (:zone (first targets)))]
-                                                  (swap! state update-in (cons :corp (:zone (first targets)))
-                                                         #(assoc % fndx snew))
-                                                  (swap! state update-in (cons :corp (:zone (second targets)))
-                                                         #(assoc % sndx fnew))
-                                                  (update-ice-strength state side fnew)
-                                                  (update-ice-strength state side snew)
-                                                  (resolve-ability state side (sun serv) card nil))
-                                                (system-msg state side "has finished rearranging ICE")))})]
-     {:prompt "Choose a server" :choices (req servers) :msg (msg "rearrange ICE protecting " target)
+   (letfn [(sun [serv]
+             {:prompt "Select two pieces of ICE to swap positions"
+              :choices {:req #(and (= serv (rest (butlast (:zone %)))) (ice? %))
+                        :max 2}
+              :effect (req (if (= (count targets) 2)
+                             (do (swap-ice state side (first targets) (second targets))
+                                 (resolve-ability state side (sun serv) card nil))
+                             (system-msg state side "has finished rearranging ICE")))})]
+     {:prompt "Choose a server"
+      :choices (req servers)
+      :msg (msg "rearrange ICE protecting " target)
       :effect (req (let [serv (next (server->zone state target))]
-                     (resolve-ability state side (sunhelp serv) card nil)))})
+                     (resolve-ability state side (sun serv) card nil)))})
 
    "Sweeps Week"
    {:effect (effect (gain :credit (count (:hand runner))))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -2,7 +2,7 @@
 
 (def cards-resources
   {"Access to Globalsec"
-   {:effect (effect (gain :link 1)) :leave-play (effect (lose :link 1))}
+   {:in-play [:link 1]}
 
    "Activist Support"
    {:events
@@ -67,13 +67,11 @@
                                 (trash state :runner card {:unpreventable true})))}]}
 
    "Beach Party"
-   {:effect (effect (gain :hand-size-modification 5))
-    :leave-play (effect (lose :hand-size-modification 5))
+   {:in-play [:hand-size-modification 5]
     :events {:runner-turn-begins {:msg "lose [Click]" :effect (effect (lose :click 1))}}}
 
    "Borrowed Satellite"
-   {:effect (effect (gain :link 1 :hand-size-modification 1))
-    :leave-play (effect (lose :link 1 :hand-size-modification 1))}
+   {:in-play [:hand-size-modification 1 :link 1]}
 
    "Chatterjee University"
    {:abilities [{:cost [:click 1] :label "Place 1 power counter"
@@ -398,8 +396,7 @@
                  :effect (effect (trash card {:cause :ability-cost}) (draw))}]}
 
    "Neutralize All Threats"
-   {:effect (effect (gain :hq-access 1))
-    :leave-play (effect (lose :hq-access 1))
+   {:in-play [:hq-access 1]
     :events {:access {:effect (req (swap! state assoc-in [:runner :register :force-trash] false))}
              :pre-trash {:req (req (let [cards (map first (turn-events state side :pre-trash))]
                                      (empty? (filter #(not (nil? (:trash %))) cards))))
@@ -530,18 +527,16 @@
                  :msg "gain 1 [Credits] and draw 1 card"}]}
 
    "Public Sympathy"
-   {:effect (effect (gain :hand-size-modification 2))
-    :leave-play (effect (lose :hand-size-modification 2))}
+   {:in-play [:hand-size-modification 2]}
 
    "Rachel Beckman"
-   {:effect (req (gain state :runner :click 1 :click-per-turn 1)
-                 (add-watch state :rachel-beckman
+   {:in-play [:click 1 :click-per-turn 1]
+    :effect (req (add-watch state :rachel-beckman
                             (fn [k ref old new]
                               (when (is-tagged? new)
                                 (remove-watch ref :rachel-beckman)
                                 (trash ref :runner card)
-                                (system-msg ref side "trashes Rachel Beckman for being tagged")))))
-    :leave-play (effect (lose :click 1 :click-per-turn 1))}
+                                (system-msg ref side "trashes Rachel Beckman for being tagged")))))}
 
    "Raymond Flint"
    {:effect (req (add-watch state :raymond-flint
@@ -584,8 +579,7 @@
                                  (trash card {:cause :ability-cost}))}]}
 
    "Safety First"
-   {:effect (effect (lose :runner :hand-size-modification 2))
-    :leave-play (effect (gain :runner :hand-size-modification 2))
+   {:in-play [:hand-size-modification -2]
     :events {:runner-turn-ends {:req (req (< (count (:hand runner)) (hand-size state :runner)))
                                 :msg (msg "draw a card")
                                 :effect (effect (draw 1))}}}
@@ -689,7 +683,7 @@
                  :effect (effect (gain :credit (:counter card)) (trash card {:cause :ability-cost}))}]}
 
    "The Helpful AI"
-   {:effect (effect (gain :link 1)) :leave-play (effect (lose :link 1))
+   {:in-play [:link 1]
     :abilities [{:msg (msg "give +2 strength to " (:title target))
                  :choices {:req #(and (has-subtype? % "Icebreaker")
                                       (installed? %))}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -251,8 +251,7 @@
 
    "Research Station"
    {:init {:root "HQ"}
-    :effect (effect (gain :hand-size-modification 2))
-    :leave-play (effect (lose :hand-size-modification 2))}
+    :in-play [:hand-size-modification 2]}
 
    "Rutherford Grid"
    {:events {:pre-init-trace {:req (req this-server)

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1,11 +1,5 @@
 (in-ns 'game.core)
 
-(defn morph [state side card new old]
-  (update! state side (assoc card :subtype (->> (remove #(= old %) (.split (:subtype card) " - "))
-                                                vec (concat [new]) distinct (join " - "))))
-  (update-ice-strength state side card)
-  (update-run-ice state side))
-
 (def trash-program {:prompt "Choose a program to trash"
                     :label "Trash a program"
                     :msg (msg "trash " (:title target))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -27,6 +27,26 @@
   triggers"
   {:effect (req (toast state :corp "Reminder: You have unrezzed cards with \"when turn begins\" abilities." "info"))})
 
+(defn swap-ice
+  "Swaps two pieces of ICE."
+  [state side a b]
+  (let [a-index (ice-index state a)
+        b-index (ice-index state b)
+        a-new (assoc a :zone (:zone b))
+        b-new (assoc b :zone (:zone a))]
+    (swap! state update-in (cons :corp (:zone a)) #(assoc % a-index b-new))
+    (swap! state update-in (cons :corp (:zone b)) #(assoc % b-index a-new))
+    (doseq [newcard [a-new b-new]]
+      (doseq [h (:hosted newcard)]
+        (let [newh (-> h
+                       (assoc-in [:zone] '(:onhost))
+                       (assoc-in [:host :zone] (:zone newcard)))]
+          (update! state side newh)
+          (unregister-events state side h)
+          (register-events state side (:events (card-def newh)) newh))))
+    (update-ice-strength state side a-new)
+    (update-ice-strength state side b-new)))
+
 ;; Load all card definitions into the current namespace.
 (load "cards-agendas")
 (load "cards-assets")

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -88,8 +88,8 @@
   (win state (if (= side :corp) :runner :corp) "Concede"))
 
 (defn resolve-prompt
-  "Resolves a prompt by invoking its effect funtion with the selected target of the prompt. Triggered
-  by a selection of a prompt choice button in the UI."
+  "Resolves a prompt by invoking its effect funtion with the selected target of the prompt.
+  Triggered by a selection of a prompt choice button in the UI."
   [state side {:keys [choice card] :as args}]
   (let [prompt (first (get-in @state [side :prompt]))
         choice (if (= (:choices prompt) :credit)
@@ -103,9 +103,12 @@
             (add-prop state side (:card prompt) :counter (- choice)))
           ;; trigger the prompt's effect function
           ((:effect prompt) (or choice card)))
-      (when (:cancel-effect prompt)
+      (when-let [cancel-effect (:cancel-effect prompt)]
         ;; the user chose "cancel" -- trigger the cancel effect.
-        ((:cancel-effect prompt) choice)))
+        (cancel-effect choice)))
+    ;; trigger end-effect if present
+    (when-let [end-effect (:end-effect prompt)]
+      (end-effect state side card nil))
 
     ;; remove the prompt from the queue
     (swap! state update-in [side :prompt] (fn [pr] (filter #(not= % prompt) pr)))

--- a/src/clj/game/core-ice.clj
+++ b/src/clj/game/core-ice.clj
@@ -80,7 +80,8 @@
 (defn update-breaker-strength
   "Updates a breaker's current strength by triggering updates and applying their effects."
   [state side breaker]
-  (let [breaker (get-card state breaker) oldstren (or (:current-strength breaker) (:strength breaker))]
+  (let [breaker (get-card state breaker)
+        oldstren (or (:current-strength breaker) (:strength breaker))]
     (swap! state update-in [:bonus] dissoc :breaker-strength)
     (trigger-event state side :pre-breaker-strength breaker)
     (update! state side (assoc breaker :current-strength (breaker-strength state side breaker)))
@@ -89,7 +90,7 @@
 (defn pump
   "Increase a breaker's strength by n for the given duration of :encounter or :all-run"
   ([state side card n] (pump state side card n :encounter))
-  ([state side {:keys [strength current-strength] :as card} n duration]
+  ([state side card n duration]
    (update! state side (update-in card [:pump duration] (fnil #(+ % n) 0)))
    (update-breaker-strength state side (get-card state card))))
 

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -1,49 +1,74 @@
 (in-ns 'game.core)
 
-(declare host in-play? make-rid rez run-flag? server-list server->zone set-prop system-msg turn-flag?
-         update-breaker-strength update-ice-strength update-run-ice)
+(declare host in-play? make-rid rez run-flag? server-list server->zone set-prop system-msg
+         turn-flag? update-breaker-strength update-ice-strength update-run-ice)
 
-; Functions for the installation and deactivation of cards.
+;;;; Functions for the installation and deactivation of cards.
+
+;;; Deactivate a card
+(defn- dissoc-card
+  "Dissoc relevant keys in card"
+  [card keep-counter]
+  (let [c (dissoc card :current-strength :abilities :rezzed :special :added-virus-counter)
+        c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
+    (if (and (= (:side c) "Runner") (not= (last (:zone c)) :facedown))
+      (dissoc c :installed :facedown :counter :rec-counter :pump :named-target) c)))
+
+(defn- trigger-leave-effect
+  "Triggers leave effects for specified card if relevant"
+  [state side card]
+  (when-let [leave-effect (:leave-play (card-def card))]
+    (when (or (and (= (:side card) "Runner") (:installed card) (not (:facedown card)))
+              (:rezzed card)
+              (= (first (:zone card)) :current)
+              (= (first (:zone card)) :scored))
+      (leave-effect state side card nil))))
+
+(defn- handle-prevent-effect
+  "Handles prevent effects on the card"
+  [state card]
+  (when-let [prevent (:prevent (card-def card))]
+     (doseq [[ptype pvec] prevent]
+       (doseq [psub pvec]
+         (swap! state update-in [:prevent ptype psub]
+                (fn [pv] (remove #(= (:cid %) (:cid card)) pv)))))))
 
 (defn deactivate
   "Deactivates a card, unregistering its events, removing certain attribute keys, and triggering
   some events."
   ([state side card] (deactivate state side card nil))
   ([state side card keep-counter]
-   (let [c (dissoc card :current-strength :abilities :rezzed :special :added-virus-counter)
-         c (if (and (= (:side c) "Runner") (not= (last (:zone c)) :facedown))
-             (dissoc c :installed :facedown :counter :rec-counter :pump :named-target) c)
-         c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
-     (when-let [leave-effect (:leave-play (card-def card))]
-       (when (or (and (= (:side card) "Runner") (:installed card) (not (:facedown card)))
-                 (:rezzed card)
-                 (= (first (:zone card)) :current)
-                 (= (first (:zone card)) :scored))
-         (leave-effect state side card nil)))
-     (when-let [prevent (:prevent (card-def card))]
-       (doseq [[ptype pvec] prevent]
-         (doseq [psub pvec]
-           (swap! state update-in [:prevent ptype psub] (fn [pv] (remove #(= (:cid %) (:cid card)) pv))))))
-     (unregister-events state side card)
-     (when (and (:memoryunits card) (:installed card) (not (:facedown card)))
-       (gain state :runner :memory (:memoryunits card)))
-     c)))
+   (trigger-leave-effect state side card)
+   (handle-prevent-effect state card)
+   (unregister-events state side card)
+   (when (and (:memoryunits card) (:installed card) (not (:facedown card)))
+     (gain state :runner :memory (:memoryunits card)))
+   (when-let [in-play (:in-play (card-def card))]
+     (apply lose state side in-play))
+   (dissoc-card card keep-counter)))
+
+
+;;; Initialising a card
+(defn- ability-init
+  "Gets abilities associated with the card"
+  [cdef]
+  (let [make-label #(or (:label %) (and (string? (:msg %)) (capitalize (:msg %))) "")
+        abilities (if (:recurring cdef)
+                    (conj (:abilities cdef) {:msg "Take 1 [Recurring Credits]"})
+                    (:abilities cdef))]
+    (for [ab abilities]
+      (assoc (select-keys ab [:cost :pump :breaks]) :label (make-label ab)))))
 
 (defn card-init
   "Initializes the abilities and events of the given card."
   ([state side card] (card-init state side card true))
   ([state side card resolve]
    (let [cdef (card-def card)
-         abilities (if (:recurring cdef)
-                     (conj (:abilities cdef) {:msg "Take 1 [Recurring Credits]"})
-                     (:abilities cdef))
-         abilities (for [ab abilities]
-                     (assoc (select-keys ab [:cost :pump :breaks])
-                       :label (or (:label ab) (and (string? (:msg ab)) (capitalize (:msg ab))) "")))
+         recurring (:recurring cdef)
+         abilities (ability-init cdef)
          c (merge card (:data cdef) {:abilities abilities})
-         c (if-let [r (:recurring cdef)]
-             (if (number? r) (assoc c :rec-counter r) c) c)]
-     (when-let [recurring (:recurring cdef)]
+         c (if (number? recurring) (assoc c :rec-counter recurring) c)]
+     (when recurring
        (let [r (if (number? recurring)
                  (effect (set-prop card :rec-counter recurring))
                  recurring)]
@@ -59,7 +84,36 @@
        (register-events state side events c))
      (when resolve
        (resolve-ability state side cdef c nil))
+     (when-let [in-play (:in-play cdef)]
+       (apply gain state side in-play))
      (get-card state c))))
+
+
+;;; Intalling a corp card
+(defn- corp-can-install?
+  "Checks region restrictions"
+  [card dest-zone]
+  (not (and (has-subtype? card "Region")
+            (some #(has-subtype? % "Region") dest-zone))))
+
+(defn- corp-install-asset-agenda
+  "Takes care of installing an asset or agenda in a server"
+  [state side card dest-zone]
+  (when (#{"Asset" "Agenda"} (:type card))
+    (when-let [prev-card (some #(when (#{"Asset" "Agenda"} (:type %)) %) dest-zone)]
+      (system-msg state side (str "trashes " (card-str state prev-card)))
+      (trash state side prev-card {:keep-server-alive true}))))
+
+(defn- corp-install-message
+  "Prints the correct install message."
+  [state side card server install-state cost-str]
+  (let [card-name (if (or (= :rezzed-no-cost install-state)
+                          (= :face-up install-state)
+                          (:rezzed card))
+                    (:title card)
+                    (if (ice? card) "ICE" "a card"))]
+    (system-msg state side (str (build-spend-msg cost-str "install") card-name
+                                (if (ice? card) " protecting " " in ") server))))
 
 (defn corp-install
   ([state side card server] (corp-install state side card server nil))
@@ -78,20 +132,10 @@
                install-cost (if (and (ice? c) (not no-install-cost))
                               (count dest-zone) 0)
                install-state (or install-state (:install-state cdef))]
-           (when (not (and (has-subtype? c "Region")
-                           (some #(has-subtype? % "Region") dest-zone)))
+           (when (corp-can-install? card dest-zone)
              (when-let [cost-str (pay state side card extra-cost :credit install-cost)]
-               (when (#{"Asset" "Agenda"} (:type c))
-                 (when-let [prev-card (some #(when (#{"Asset" "Agenda"} (:type %)) %) dest-zone)]
-                   (system-msg state side (str "trashes " (card-str state prev-card)))
-                   (trash state side prev-card {:keep-server-alive true})))
-               (let [card-name (if (or (= :rezzed-no-cost install-state)
-                                       (= :face-up install-state)
-                                       (:rezzed c))
-                                 (:title card)
-                                 (if (ice? c) "ICE" "a card"))]
-                 (system-msg state side (str (build-spend-msg cost-str "install")
-                                             card-name (if (ice? c) " protecting " " in ") server)))
+               (corp-install-asset-agenda state side c dest-zone)
+               (corp-install-message state side c server install-state cost-str)
                (let [moved-card (move state side c slot)]
                  (trigger-event state side :corp-install moved-card)
                  (when (is-type? c "Agenda")
@@ -106,45 +150,74 @@
                  (when-let [dre (:derezzed-events cdef)]
                    (register-events state side dre moved-card))))))))))
 
+
+;;; Installing a runner card
+(defn- runner-can-install?
+  "Checks if the specified card can be installed.
+  Uses uniqueness of card"
+  [state side {:keys [uniqueness] :as card} facedown]
+  (and (or (not uniqueness) (not (in-play? state card)) facedown) ; checks uniqueness
+       (if-let [req (:req (card-def card))]
+         (or facedown (req state side card nil)) ; checks req for install
+         true)))
+
+(defn- runner-get-cost
+  "Get the total install cost for specified card"
+  [state side {:keys [cost memoryunits] :as card}
+   {:keys [extra-cost no-cost facedown] :as params}]
+  (install-cost state side card
+                (concat extra-cost
+                        (when (and (not no-cost) (not facedown)) [:credit cost])
+                        (when (and memoryunits (not facedown)) [:memory memoryunits]))))
+
+(defn- runner-install-message
+  "Prints the correct msg for the card install"
+  [state side card-title cost-str
+   {:keys [no-cost host-card facedown custom-message] :as params}]
+  (if facedown
+    (system-msg state side "installs a card facedown")
+    (if custom-message
+      (system-msg state side custom-message)
+      (system-msg state side
+                  (str (build-spend-msg cost-str "install") card-title
+                       (when host-card (str " on " (:title host-card)))
+                       (when no-cost " at no cost"))))))
+
+(defn- handle-virus-counter-flag
+  "Deal with setting the added-virus-counter flag"
+  [state side installed-card]
+  (if (and (has-subtype? installed-card "Virus")
+           (pos? (:counter installed-card 0)))
+    (update! state side (assoc installed-card :added-virus-counter true))))
+
 (defn runner-install
+  "Installs specified runner card if able
+  Params include extra-cost, no-cost, host-card, facedown and custom-message."
   ([state side card] (runner-install state side card nil))
-  ([state side {:keys [title type cost memoryunits uniqueness ] :as card}
-    {:keys [extra-cost no-cost host-card facedown custom-message] :as params}]
-   (when (not (seq (get-in @state [side :locked (-> card :zone first)])))
+  ([state side card
+    {:keys [host-card facedown] :as params}]
+   (when (empty? (get-in @state [side :locked (-> card :zone first)]))
      (if-let [hosting (and (not host-card) (not facedown) (:hosting (card-def card)))]
        (resolve-ability state side
                         {:choices hosting
-                         :effect (effect (runner-install card (assoc params :host-card target)))} card nil)
-       (do
-         (trigger-event state side :pre-install card)
-         (let [cost (install-cost state side card
-                                  (concat extra-cost (when (and (not no-cost) (not facedown)) [:credit cost])
-                                          (when (and memoryunits (not facedown)) [:memory memoryunits])))]
-           (when (and (or (not uniqueness) (not (in-play? state card)) facedown)
-                      (if-let [req (:req (card-def card))]
-                        (or facedown (req state side card nil)) true))
-             (when-let [cost-str (pay state side card cost)]
-               (let [c (if host-card
-                         (host state side host-card card)
-                         (move state side card [:rig (if facedown :facedown (to-keyword type))]))
-                     installed-card (if facedown
-                                      (update! state side (assoc c :installed true))
-                                      (card-init state side (assoc c :installed true) true))]
-                 (if facedown
-                   (system-msg state side "installs a card facedown")
-                   (if custom-message
-                     (system-msg state side custom-message)
-                     (system-msg state side (str (build-spend-msg cost-str "install") title
-                                                 (when host-card (str " on " (:title host-card)))
-                                                 (when no-cost " at no cost")))))
-                 ;Apply added-virus-counter flag for this turn if the card enters play with a counter
-                 (if (and (contains? installed-card :counter)
-                          (contains? installed-card :subtype)
-                          (has-subtype? card "Virus")
-                          (pos? (:counter installed-card)))
-                   (update! state side (assoc installed-card :added-virus-counter true)))
-                 (trigger-event state side :runner-install installed-card)
-                 (when (has-subtype? c "Icebreaker") (update-breaker-strength state side c))))))
-         (when (is-type? card "Resource")
-           (swap! state assoc-in [:runner :register :installed-resource] true))
-         (swap! state update-in [:bonus] dissoc :install-cost))))))
+                         :effect (effect (runner-install card (assoc params :host-card target)))}
+                        card nil)
+       (do (trigger-event state side :pre-install card)
+           (let [cost (runner-get-cost state side card params)]
+             (when (runner-can-install? state side card facedown)
+               (when-let [cost-str (pay state side card cost)]
+                 (let [c (if host-card
+                           (host state side host-card card)
+                           (move state side card
+                                 [:rig (if facedown :facedown (to-keyword (:type card)))]))
+                       installed-card (if facedown
+                                        (update! state side (assoc c :installed true))
+                                        (card-init state side (assoc c :installed true) true))]
+                   (runner-install-message state side (:title card) cost-str params)
+                   (handle-virus-counter-flag state side installed-card)
+                   (trigger-event state side :runner-install installed-card)
+                   (when (has-subtype? c "Icebreaker")
+                     (update-breaker-strength state side c))))))
+           (when (is-type? card "Resource")
+             (swap! state assoc-in [:runner :register :installed-resource] true))
+           (swap! state update-in [:bonus] dissoc :install-cost))))))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -5,7 +5,7 @@
                                 build-spend-msg cost-names remote->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side]]
             [game.macros :refer [effect req msg]]
-            [clojure.string :refer [split-lines split join]]
+            [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))
 
 (declare get-card resolve-ability say system-msg trigger-event update!)

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -65,6 +65,30 @@
       (is (= 3 (count (:hand (get-runner))))
           "No meat damage dealt by Tri-maf's leave play effect"))))
 
+(deftest apocalypse-in-play-ability
+  "Apocalypse - Turn Runner cards facedown and reduce memory and hand-size gains"
+  (do-game
+    (new-game (default-corp [(qty "Launch Campaign" 2) (qty "Ice Wall" 1)])
+              (default-runner [(qty "Logos" 3) (qty "Apocalypse" 3)]))
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (play-from-hand state :corp "Launch Campaign" "New remote")
+    (play-from-hand state :corp "Launch Campaign" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Logos")
+    (is (= 1 (:hand-size-modification (get-runner))) "Hand-size increased from Logos")
+    (is (= 5 (:memory (get-runner))) "Memory increased from Logos")
+    (core/gain state :runner :click 1 :credit 2)
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (run-empty-server state "HQ")
+    (play-from-hand state :runner "Apocalypse")
+    (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
+    (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
+    (let [logos (get-in @state [:runner :rig :facedown 0])]
+      (is (:facedown (refresh logos)) "Logos is facedown")
+      (is (= 0 (:hand-size-modification (get-runner))) "Hand-size reset with Logos facedown")
+      (is (= 4 (:memory (get-runner))) "Memory reset with Logos facedown"))))
+
 (deftest blackmail
   "Prevent rezzing of ice for one run"
   (do-game

--- a/src/clj/test/cards-icebreakers.clj
+++ b/src/clj/test/cards-icebreakers.clj
@@ -80,3 +80,20 @@
     (is (= 5 (:memory (get-runner))))
     (let [ov (get-in @state [:runner :rig :program 0])]
       (is (= 5 (:counter (refresh ov))) "Overmind has 5 counters"))))
+
+(deftest wyrm
+  "Wyrm reduces strength of ice"
+  (do-game
+   (new-game (default-corp [(qty "Ice Wall" 1)])
+             (default-runner [(qty "Wyrm" 1)]))
+   (play-from-hand state :corp "Ice Wall" "HQ")
+   (take-credits state :corp)
+   (play-from-hand state :runner "Wyrm")
+   (run-on state "HQ")
+   (let [ice-wall (get-ice state :hq 0)
+         wyrm (get-in @state [:runner :rig :program 0])]
+     (core/rez state :corp ice-wall)
+     (card-ability state :runner wyrm 1)
+     (is (= 0 (:current-strength (refresh ice-wall))) "Strength of Ice Wall reduced to 0")
+     (card-ability state :runner wyrm 1)
+     (is (= -1 (:current-strength (refresh ice-wall))) "Strength of Ice Wall reduced to -1"))))

--- a/src/clj/test/cards-icebreakers.clj
+++ b/src/clj/test/cards-icebreakers.clj
@@ -26,6 +26,25 @@
       (is (= 0 (:counter atman)) "0 power counters")
       (is (= 0 (:current-strength atman)) "0 current strength"))))
 
+(deftest cerberus
+  "Cerberus - boost 1 for 1 cred. Break for 1 counter"
+  (do-game
+   (new-game (default-corp)
+             (default-runner [(qty "Cerberus \"Rex\" H2" 1)]))
+   (take-credits state :corp)
+   (play-from-hand state :runner "Cerberus \"Rex\" H2")
+   (is (= 2 (:credit (get-runner))) "2 credits left after install")
+   (let [rex (get-in @state [:runner :rig :program 0])]
+     (is (= 4 (:counter rex)) "Start with 4 counters")
+     ;; boost strength
+     (card-ability state :runner rex 1)
+     (is (= 1 (:credit (get-runner))) "Spend 1 credit to boost")
+     (is (= 2 (:current-strength (refresh rex))) "At strength 2 after boost")
+     ;; break
+     (card-ability state :runner rex 0)
+     (is (= 1 (:credit (get-runner))) "No credits spent to break")
+     (is (= 3 (:counter (refresh rex))) "One counter used to break"))))
+
 (deftest faust-pump
   "Faust - Pump by discarding"
   (do-game


### PR DESCRIPTION
Please review :smile: 

- Ice swap function
- `:end-effect` to prompts -- triggers at the end of the prompt (useful for waiting prompts)
- Adonis / Eve / Launch campaign refactor
- Ambush refactor
- Refactors the installing functions
- Adds `:in-play` key to cards for effects that are passive while in play -- such as memory and hand-size
- Refactors Icebreakers -- creates strength and break ability factory functions and breaker set functions (Dogs, B&E, GlobalSec)
- Tests:
 - Apocalypse interaction with installed consoles etc reducing MU correctly
 - Wyrm reducing strength of ice
 - Dog breakers -- specifically Rex, also for ensuring boosting and counter use works properly

NB: The new icebreaker functions take arguments in the order shown on cards: cost then effect (broken subs or strength boosted).