### PR TITLE
implement Port Anson Grid

### DIFF
--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -233,6 +233,16 @@
    {:init {:root "HQ"} :abilities [{:cost [:credit 1] :label "Draw 1 card" :effect (effect (draw))
                                     :req (req (and run (= (first (:server run)) :hq)))}]}
 
+   "Port Anson Grid"
+   {:msg "prevent the Runner from jacking out unless they trash an installed program"
+    :effect (req (when this-server
+                   (prevent-jack-out state side)))
+    :events {:run {:req (req this-server)
+                   :msg "prevent the Runner from jacking out unless they trash an installed program"
+                   :effect (effect (prevent-jack-out))}
+             :runner-trash {:req (req (and this-server (is-type? target "Program")))
+                            :effect (req (swap! state update-in [:run] dissoc :cannot-jack-out))}}}
+
    "Product Placement"
    {:access {:req (req (not= (first (:zone card)) :discard))
              :msg "gain 2 [Credits]" :effect (effect (gain :corp :credit 2))}}

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -219,6 +219,29 @@
       (prompt-choice :runner "OK")
       (is (= 0 (count (:scored (get-runner)))) "No scored agendas"))))
 
+(deftest port-anson-grid
+  "Port Anson Grid - Prevent the Runner from jacking out until they trash a program"
+  (do-game
+    (new-game (default-corp [(qty "Port Anson Grid" 1) (qty "Data Raven" 1)])
+              (default-runner [(qty "Faerie" 1) (qty "Technical Writer" 1)]))
+    (play-from-hand state :corp "Port Anson Grid" "New remote")
+    (play-from-hand state :corp "Data Raven" "Server 1")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Technical Writer")
+    (play-from-hand state :runner "Faerie")
+    (let [pag (get-content state :remote1 0)
+          fae (get-in @state [:runner :rig :program 0])
+          tw (get-in @state [:runner :rig :resource 0])]
+      (run-on state "Server 1")
+      (core/rez state :corp pag)
+      (is (:cannot-jack-out (get-in @state [:run])) "Jack out disabled for Runner") ; UI button greyed out
+      (core/trash state :runner tw)
+      (is (:cannot-jack-out (get-in @state [:run])) "Resource trash didn't disable jack out prevention")
+      (core/trash state :runner fae)
+      (is (nil? (:cannot-jack-out (get-in @state [:run]))) "Jack out enabled by program trash")
+      (run-on state "Server 1")
+      (is (:cannot-jack-out (get-in @state [:run])) "Prevents jack out when upgrade is rezzed prior to run"))))
+
 (deftest product-placement
   "Product Placement - Gain 2 credits when Runner accesses it"
   (do-game


### PR DESCRIPTION
Includes a test to ensure jacking out is prevented both when rezzed during a run and when it's already rezzed prior to the start of a run on the server. 
