### PR TITLE
Fix grammar for game count when there are zero games

### DIFF
--- a/src/cljs/netrunner/main.cljs
+++ b/src/cljs/netrunner/main.cljs
@@ -50,7 +50,7 @@
     [:div
      [:div.float-right
       (let [c (count (:games cursor))]
-        (str c " Game" (when (> c 1) "s")))]
+        (str c " Game" (when (not= c 1) "s")))]
      (when-let [game (some #(when (= (:gameid cursor) (:gameid %)) %) (:games cursor))]
        (when (:started game)
          [:div.float-right


### PR DESCRIPTION
When no games are active the game count will display "0 Games" instead of "0 Game".

This is not going to be seen often by users.  But it may in the case when the game server is down.  It just bugs me when I'm running the service in development.