### PR TITLE
Adds counter for Femme Fatale.

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -1,5 +1,7 @@
 (in-ns 'game.core)
 
+(declare add-icon remove-icon)
+
 (def breaker-auto-pump
   "Updates an icebreaker's abilities with a pseudo-ability to trigger the auto-pump routine in
   core, IF we are encountering a rezzed ice with a subtype we can break."
@@ -271,8 +273,10 @@
    (auto-icebreaker ["Sentry"]
                     {:prompt "Choose a piece of ICE to target for bypassing"
                      :choices {:req ice?}
+                     :leave-play (req (remove-icon state side card))
                      :effect (req (let [ice target
                                         serv (zone->name (second (:zone ice)))]
+                                    (add-icon state side card ice "F" "blue")
                                     (system-msg state side
                                                 (str "chooses " (card-str state ice)
                                                      " for Femme Fatale's bypass ability"))))

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -2,7 +2,7 @@
 
 (declare all-installed cards deactivate card-flag? get-card-hosted handle-end-run ice?
          has-subtype? remove-from-host rezzed?
-         trash update-hosted! update-ice-strength)
+         trash update-hosted! update-ice-strength remove-icon)
 
 ; Functions for loading card information.
 (defn card-def
@@ -84,6 +84,9 @@
                  (handle-end-run state side)))
              (swap! state dissoc-in z)))
          (trigger-event state side :card-moved card moved-card)
+         (when-let [icon-card (get-in moved-card [:icon :card])]
+           ;; remove icon if card moved to :discard or :hand
+           (when (#{:discard :hand} to) (remove-icon state side icon-card moved-card)))
          moved-card)))))
 
 (defn move-zone

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -1,5 +1,7 @@
 (in-ns 'game.core)
 
+(declare set-prop)
+
 ; Stuff that doesn't go in other files.
 
 ; No idea what these are for. @justinliew?
@@ -87,3 +89,18 @@
         base (get side' :hand-size-base 0)
         mod (get side' :hand-size-modification 0)]
     (+ base mod)))
+
+(defn add-icon
+  "Adds an icon to a card. E.g. a Femme Fatal token"
+  [state side card target char color]
+  ;; add icon
+  (set-prop state side target :icon {:char char :color color})
+  ;; specify icon target on card
+  (set-prop state side card :icon-target target))
+
+(defn remove-icon
+  "Remove the icon associated with the card."
+  [state side card]
+  (when-let [target (get-card state (:icon-target card))]
+    (set-prop state side target :icon nil)
+    (set-prop state side card :icon-target nil)))

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -90,17 +90,19 @@
         mod (get side' :hand-size-modification 0)]
     (+ base mod)))
 
+;;; Functions for icons associated with special cards - e.g. Femme Fatale
 (defn add-icon
-  "Adds an icon to a card. E.g. a Femme Fatal token"
+  "Adds an icon to a card. E.g. a Femme Fatale token.
+  Card is the card adding the icon, target is card receiving the icon."
   [state side card target char color]
   ;; add icon
-  (set-prop state side target :icon {:char char :color color})
+  (set-prop state side target :icon {:char char :color color :card card})
   ;; specify icon target on card
   (set-prop state side card :icon-target target))
 
 (defn remove-icon
-  "Remove the icon associated with the card."
-  [state side card]
-  (when-let [target (get-card state (:icon-target card))]
-    (set-prop state side target :icon nil)
-    (set-prop state side card :icon-target nil)))
+  "Remove the icon associated with the card and target."
+  ([state side card] (remove-icon state side card (get-card state (:icon-target card))))
+  ([state side card target]
+   (set-prop state side target :icon nil)
+   (set-prop state side card :icon-target nil)))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -2,7 +2,7 @@
 
 (declare card-init card-str deactivate enforce-msg gain-agenda-point get-agenda-points
          handle-end-run is-type? resolve-steal-events show-prompt untrashable-while-rezzed?
-         in-corp-scored? update-all-ice win)
+         in-corp-scored? update-all-ice win remove-icon)
 
 ;;;; Functions for applying core Netrunner game rules.
 
@@ -189,7 +189,9 @@
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
-      (resolve-ability state side trash-effect moved-card (cons cause targets)))))
+      (resolve-ability state side trash-effect moved-card (cons cause targets)))
+    (when-let [icon-card (get-in moved-card [:icon :card])]
+      (remove-icon state side icon-card moved-card))))
 
 (defn trash
   "Attempts to trash the given card, allowing for boosting/prevention effects."

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -2,7 +2,7 @@
 
 (declare card-init card-str deactivate enforce-msg gain-agenda-point get-agenda-points
          handle-end-run is-type? resolve-steal-events show-prompt untrashable-while-rezzed?
-         in-corp-scored? update-all-ice win remove-icon)
+         in-corp-scored? update-all-ice win)
 
 ;;;; Functions for applying core Netrunner game rules.
 
@@ -189,9 +189,7 @@
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
-      (resolve-ability state side trash-effect moved-card (cons cause targets)))
-    (when-let [icon-card (get-in moved-card [:icon :card])]
-      (remove-icon state side icon-card moved-card))))
+      (resolve-ability state side trash-effect moved-card (cons cause targets)))))
 
 (defn trash
   "Attempts to trash the given card, allowing for boosting/prevention effects."

--- a/src/clj/test/cards-icebreakers.clj
+++ b/src/clj/test/cards-icebreakers.clj
@@ -85,6 +85,26 @@
       (prompt-card :runner (find-card "Armitage Codebusting" (:hand (get-runner))))
       (is (empty? (:prompt (get-runner))) "No trash-prevention prompt for resource"))))
 
+(deftest femme-counter
+  "Femme Fatale counter test"
+  (do-game
+   (new-game (default-corp [(qty "Ice Wall" 1)])
+             (default-runner [(qty "Femme Fatale" 2)]))
+   (play-from-hand state :corp "Ice Wall" "HQ")
+   (take-credits state :corp)
+   (core/gain state :runner :credit 18)
+   (let [iw (get-ice state :hq 0)]
+    (play-from-hand state :runner "Femme Fatale")
+    (prompt-select :runner iw)
+    (is (:icon (refresh iw)) "Ice Wall has an icon")
+    (core/trash state :runner (get-in @state [:runner :rig :program 0]))
+    (is (not (:icon (refresh iw))) "Ice Wall does not have an icon after Femme trashed")
+    (play-from-hand state :runner "Femme Fatale")
+    (prompt-select :runner iw)
+    (is (:icon (refresh iw)) "Ice Wall has an icon")
+    (core/trash state :corp iw)
+    (is (not (:icon (refresh iw))) "Ice Wall does not have an icon after itself trashed"))))
+
 (deftest overmind-counters
   "Overmind - Start with counters equal to unused MU"
   (do-game

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -339,7 +339,7 @@
 
 (defn card-view [{:keys [zone code type abilities counter advance-counter advancementcost current-cost subtype
                          advanceable rezzed strength current-strength title remotes selected hosted
-                         side rec-counter facedown named-target]
+                         side rec-counter facedown named-target icon]
                   :as cursor}
                  owner {:keys [flipped] :as opts}]
   (om/component
@@ -370,6 +370,7 @@
          (when (pos? advance-counter) [:div.darkbg.advance-counter.counter advance-counter])]
         (when (and current-strength (not= strength current-strength))
               current-strength [:div.darkbg.strength current-strength])
+        (when-let [{:keys [char color]} icon] [:div.darkbg.icon {:class color} char])
         (when named-target [:div.darkbg.named-target named-target])
         (when (and (= zone ["hand"]) (#{"Agenda" "Asset" "ICE" "Upgrade"} type))
           (let [centrals ["HQ" "R&D" "Archives"]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1132,6 +1132,24 @@ nav ul
     height: 24px
     width: 24px
 
+  .icon
+    position: absolute
+    z-index: 10
+    padding: 0
+    text-align: center
+    line-height: 24px
+    font-size: 12px
+    top: 3px
+    right: 3px
+    height: 24px
+    width: 24px
+
+    &.blue
+      background-color: blue
+    
+    &.red
+      background-color: red
+
   .named-target
     position: absolute
     z-index: 10
@@ -1377,6 +1395,9 @@ nav ul
             .strength
               transform(rotate(90deg))
 
+            .icon
+              transform(rotate(90deg))
+
             .run-arrow
               position: absolute
               z-index: 10
@@ -1471,6 +1492,9 @@ nav ul
             left: 13px
 
           .strength
+            transform(rotate(-90deg))
+
+          .icon
             transform(rotate(-90deg))
 
           .ices


### PR DESCRIPTION
Creates functions and styling for having cards putting a "counter" on a different card.

Colour of counter has to be implemented in base.styl (red and blue so far).

Currently only used for Femme Fatale.

Counter is removed if the card that placed the counter (Femme Fatale) is trashed, or the card with the counter is moved to `:discard` or `:hand` as it's implemented now.

Cases above are tested in the new test `femme-counter`. Blue-Sun interaction works correctly but is not tested for.