### PR TITLE
Toast on taking a tag.

### DIFF
--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -150,6 +150,7 @@
 (defn resolve-tag [state side n args]
   (when (pos? n)
     (gain state :runner :tag n)
+    (toast state side (str "Took " n " tag" (when (> n 1) "s") "!") "info")
     (trigger-event state side :runner-gain-tag n)))
 
 (defn tag-runner


### PR DESCRIPTION
Simple 1-line change.

Sorry for the short PR.

Suggested use of toasts to inform Runner when they have taken a tag. Lets the runner know additionally when they take a tag, and how many.