### PR TITLE
Add :pre-corp-install event to implement install-cost bonuses for the corp

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -162,7 +162,7 @@
                {:req (req (and (is-type? target "ICE")
                                (empty? (let [cards (map first (turn-events state side :corp-install))]
                                          (filter #(is-type? % "ICE") cards)))))
-                :msg (msg "ignore the install cost of " (:title target))}}}
+                :msg (msg "ignore the install cost of the first ICE this turn")}}}
 
    "Efficiency Committee"
    {:effect (effect (add-prop card :counter 3))

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -157,10 +157,7 @@
                {:req (req (and (is-type? target "ICE")
                                (empty? (let [cards (map first (turn-events state side :corp-install))]
                                          (filter #(is-type? % "ICE") cards)))))
-                ;; Install cost is decreased only by the number of ICE on the
-                ;; server.  Any additional credit costs must still be paid.
-                :effect (effect (install-cost-bonus
-                                  [:credit (- (count (:dest-zone (second targets))))]))}
+                :effect (effect (ignore-install-cost true))}
              :corp-install
                {:req (req (and (is-type? target "ICE")
                                (empty? (let [cards (map first (turn-events state side :corp-install))]

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -157,11 +157,10 @@
                {:req (req (and (is-type? target "ICE")
                                (empty? (let [cards (map first (turn-events state side :corp-install))]
                                          (filter #(is-type? % "ICE") cards)))))
-                ;; FIXME:
-                ;; The credit cost adjustment is incorrect.  It should be
-                ;; decreased only by the number of ICE on the server.  Any
-                ;; additional credit costs must still be paid.
-                :effect (effect (install-cost-bonus [:credit -1000]))}
+                ;; Install cost is decreased only by the number of ICE on the
+                ;; server.  Any additional credit costs must still be paid.
+                :effect (effect (install-cost-bonus
+                                  [:credit (- (count (:dest-zone (second targets))))]))}
              :corp-install
                {:req (req (and (is-type? target "ICE")
                                (empty? (let [cards (map first (turn-events state side :corp-install))]

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -153,15 +153,20 @@
                               (set-prop state side card :counter 1 :agendapoints 1))}]}
 
    "Eden Fragment"
-   {:abilities [{:cost [:click 1] :msg "install the first piece of ICE this turn at no cost"
-                 :req (req (empty? (let [cards (map first (turn-events state side :corp-install))]
-                                     (filter #(is-type? % "ICE") cards))))
-                 :prompt "Select a piece of ICE from HQ to install"
-                 :choices {:req #(and (:side % "Corp")
-                                      (ice? %)
-                                      (= (:zone %) [:hand]))}
-                 :effect (req (corp-install state side target nil
-                                            {:no-install-cost true}))}]}
+   {:events {:pre-corp-install
+               {:req (req (and (is-type? target "ICE")
+                               (empty? (let [cards (map first (turn-events state side :corp-install))]
+                                         (filter #(is-type? % "ICE") cards)))))
+                ;; FIXME:
+                ;; The credit cost adjustment is incorrect.  It should be
+                ;; decreased only by the number of ICE on the server.  Any
+                ;; additional credit costs must still be paid.
+                :effect (effect (install-cost-bonus [:credit -1000]))}
+             :corp-install
+               {:req (req (and (is-type? target "ICE")
+                               (empty? (let [cards (map first (turn-events state side :corp-install))]
+                                         (filter #(is-type? % "ICE") cards)))))
+                :msg (msg "ignore the install cost of " (:title target))}}}
 
    "Efficiency Committee"
    {:effect (effect (add-prop card :counter 3))

--- a/src/clj/game/core-costs.clj
+++ b/src/clj/game/core-costs.clj
@@ -95,7 +95,8 @@
 (defn install-cost [state side card all-cost]
   (vec (map #(if (keyword? %) % (max % 0))
             (-> (concat (get-in @state [:bonus :install-cost]) all-cost
-                        (when-let [instfun (:install-cost-bonus (card-def card))] (instfun state side card nil)))
+                        (when-let [instfun (:install-cost-bonus (card-def card))]
+                          (instfun state side card nil)))
                 merge-costs flatten))))
 
 (defn modified-install-cost

--- a/src/clj/game/core-costs.clj
+++ b/src/clj/game/core-costs.clj
@@ -92,6 +92,16 @@
 (defn install-cost-bonus [state side n]
   (swap! state update-in [:bonus :install-cost] #(merge-costs (concat % n))))
 
+(defn ignore-install-cost [state side b]
+  (swap! state assoc-in [:bonus :ignore-install-cost] b))
+
+(defn ignore-install-cost? [state side]
+  (get-in @state [:bonus :ignore-install-cost]))
+
+(defn clear-install-cost-bonus [state side]
+  (swap! state update-in [:bonus] dissoc :install-cost)
+  (swap! state update-in [:bonus] dissoc :ignore-install-cost))
+
 (defn install-cost [state side card all-cost]
   (vec (map #(if (keyword? %) % (max % 0))
             (-> (concat (get-in @state [:bonus :install-cost]) all-cost
@@ -108,4 +118,5 @@
    (trigger-event state side :pre-install card)
    (let [cost (install-cost state side card (merge-costs (concat additional [:credit (:cost card)])))]
      (swap! state update-in [:bonus] dissoc :install-cost)
+     (swap! state update-in [:bonus] dissoc :ignore-install-cost)
      cost)))

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -132,7 +132,9 @@
          ;; trigger :pre-corp-install before computing install costs so that
          ;; event handlers may adjust the cost.
          (trigger-event state side :pre-corp-install card {:server server :dest-zone dest-zone})
-         (let [ice-cost (if (and (ice? c) (not no-install-cost))
+         (let [ice-cost (if (and (ice? c)
+                                 (not no-install-cost)
+                                 (not (ignore-install-cost? state side)))
                             (count dest-zone) 0)
                all-cost (concat extra-cost [:credit ice-cost])
                end-cost (install-cost state side card all-cost)
@@ -155,7 +157,8 @@
                    (card-init state side
                               (assoc (get-card state moved-card) :rezzed true :seen true) false))
                  (when-let [dre (:derezzed-events cdef)]
-                   (register-events state side dre moved-card)))))))))))
+                   (register-events state side dre moved-card)))))
+           (clear-install-cost-bonus state side)))))))
 
 
 ;;; Installing a runner card
@@ -227,4 +230,4 @@
                      (update-breaker-strength state side c))))))
            (when (is-type? card "Resource")
              (swap! state assoc-in [:runner :register :installed-resource] true))
-           (swap! state update-in [:bonus] dissoc :install-cost))))))
+           (clear-install-cost-bonus state side))))))

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -122,34 +122,40 @@
    (if-not server
      (prompt! state side card (str "Choose a server to install " (:title card))
               (server-list state card) {:effect (effect (corp-install card target args))})
-     (do (when (= server "New remote")
-           (trigger-event state side :server-created card))
-         (let [cdef (card-def card)
-               c (-> card
-                     (assoc :advanceable (:advanceable cdef))
-                     (dissoc :seen))
-               slot (conj (server->zone state server) (if (ice? c) :ices :content))
-               dest-zone (get-in @state (cons :corp slot))
-               install-cost (if (and (ice? c) (not no-install-cost))
-                              (count dest-zone) 0)
-               install-state (or install-state (:install-state cdef))]
-           (when (corp-can-install? card dest-zone)
-             (when-let [cost-str (pay state side card extra-cost :credit install-cost)]
-               (corp-install-asset-agenda state side c dest-zone)
-               (corp-install-message state side c server install-state cost-str)
-               (let [moved-card (move state side c slot)]
-                 (trigger-event state side :corp-install moved-card)
-                 (when (is-type? c "Agenda")
-                   (update-advancement-cost state side moved-card))
-                 (when (= install-state :rezzed-no-cost)
-                   (rez state side moved-card {:ignore-cost :all-costs}))
-                 (when (= install-state :rezzed)
-                   (rez state side moved-card))
-                 (when (= install-state :face-up)
-                   (card-init state side
-                              (assoc (get-card state moved-card) :rezzed true :seen true) false))
-                 (when-let [dre (:derezzed-events cdef)]
-                   (register-events state side dre moved-card))))))))))
+     (do
+       ;; trigger :pre-corp-install, allowing cards to adjust the install cost
+       ;; of the card.
+       (trigger-event state side :pre-corp-install card server)
+       (let [cdef (card-def card)
+             c (-> card
+                   (assoc :advanceable (:advanceable cdef))
+                   (dissoc :seen))
+             slot (conj (server->zone state server) (if (ice? c) :ices :content))
+             dest-zone (get-in @state (cons :corp slot))
+             ice-cost (if (and (ice? c) (not no-install-cost))
+                        (count dest-zone) 0)
+             all-cost (concat extra-cost [:credit ice-cost])
+             end-cost (install-cost state side card all-cost)
+             install-state (or install-state (:install-state cdef))]
+         (when (corp-can-install? card dest-zone)
+           (when-let [cost-str (pay state side card end-cost)]
+             (when (= server "New remote")
+               (trigger-event state side :server-created card))
+             (corp-install-asset-agenda state side c dest-zone)
+             (corp-install-message state side c server install-state cost-str)
+             (let [moved-card (move state side c slot)]
+               (trigger-event state side :corp-install moved-card)
+               (when (is-type? c "Agenda")
+                 (update-advancement-cost state side moved-card))
+               (when (= install-state :rezzed-no-cost)
+                 (rez state side moved-card {:ignore-cost :all-costs}))
+               (when (= install-state :rezzed)
+                 (rez state side moved-card))
+               (when (= install-state :face-up)
+                 (card-init state side
+                            (assoc (get-card state moved-card) :rezzed true :seen true) false))
+               (when-let [dre (:derezzed-events cdef)]
+                 (register-events state side dre moved-card))))))))))
 
 
 ;;; Installing a runner card

--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -116,11 +116,12 @@
     (take-credits state :runner)
     (take-credits state :runner)
     (take-credits state :runner)
-    (let [efscored (get-in @state [:corp :scored 0])
-          hqice (find-card "Ice Wall" (get-in @state [:corp :hand]))]
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (is (not (nil? (get-ice state :hq 1))) "Corp has two ice installed on HQ")
-      (is (= 6 (get-in @state [:corp :credit])) "Corp does not pay for installing the first ICE of the turn"))))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (is (not (nil? (get-ice state :hq 1))) "Corp has two ice installed on HQ")
+    (is (= 6 (get-in @state [:corp :credit])) "Corp does not pay for installing the first ICE of the turn")
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (is (not (nil? (get-ice state :hq 2))) "Corp has three ice installed on HQ")
+    (is (= 4 (get-in @state [:corp :credit])) "Corp pays for installing the second ICE of the turn")))
 
 (deftest fetal-ai-damage
   "Fetal AI - damage on access"

--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -118,9 +118,7 @@
     (take-credits state :runner)
     (let [efscored (get-in @state [:corp :scored 0])
           hqice (find-card "Ice Wall" (get-in @state [:corp :hand]))]
-      (card-ability state :corp efscored 0)
-      (prompt-select :corp hqice)
-      (prompt-choice :corp "HQ")
+      (play-from-hand state :corp "Ice Wall" "HQ")
       (is (not (nil? (get-ice state :hq 1))) "Corp has two ice installed on HQ")
       (is (= 6 (get-in @state [:corp :credit])) "Corp does not pay for installing the first ICE of the turn"))))
 


### PR DESCRIPTION
Fixes #1177

Cards can hook up to a `:pre-corp-install` event to deduct or add cost for installs using the `install-cost-bonus` function. This event is triggered just before install costs are calculated during `corp-install`.

I ended up also adding a `ignore-install-cost` function for cards like Eden Fragment. My reasoning was that Eden Fragment cannot assist in any **additional cost** that might be incurred for installing ICE. So, a straight deduction may not be accurate. I'm definitely open to any critique on that choice before merging.

I have fully automated/tested Eden Fragment.

![eden fragment](http://i.imgur.com/bBGZr5v.png)
(edit: I clearly didn't playtest it much. I've fixed the text in a later commit)

**Open questions**:

- Is that event name correct? Should it be `:corp-pre-install`?

- Did I over complicate things with the added `ignore-install-cost` functions? Are there other cards that place additional cost on ICE installs? I couldn't find any.

- The Eden Fragment message is modeled after Kate and shows up after the install. Should it show up before?