### PR TITLE
enable High-Stakes Job; small Turntable/Aesop's tweaks

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -32,18 +32,14 @@
    "Blackmail"
    {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req servers)
     :msg "prevent ICE from being rezzed during this run"
-    :effect (effect
-              (register-run-flag!
-                          card
-                          :can-rez
-                                   (fn [state side card]
-                                     (if (ice? card)
-                                       ( (constantly false) (system-msg state side (str "is prevented from rezzing ICE on this run by Blackmail")))
-                                       true
-                                       )
-                                     )
-                          )
-              (run target nil card))}
+    :effect (effect (register-run-flag!
+                      card
+                      :can-rez
+                      (fn [state side card]
+                        (if (ice? card)
+                          ((constantly false) (system-msg state side (str "is prevented from rezzing ICE on this run by Blackmail")))
+                          true)))
+                    (run target nil card))}
 
    "Bribery"
    {:prompt "How many [Credits]?" :choices :credit
@@ -265,14 +261,14 @@
                    :msg "force the Corp to trash 1 card from HQ at random"
                    :effect (effect (trash (first (shuffle (:hand corp)))))}}}
 
-   "High-stakes Job"
+   "High-Stakes Job"
    {:prompt "Choose a server"
     :choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
                         ok-servs (filter unrezzed-ice (get-in @state [:corp :servers]))]
                     (map (comp zone->name first) ok-servs)))
     :effect (effect (run target {:end-run {:req (req (:successful run)) :msg " gain 12 [Credits]"
                                            :effect (effect (gain :runner :credit 12))}} card))}
-   
+
    "Hostage"
    {:prompt "Choose a Connection"
     :choices (req (cancellable (filter #(has-subtype? % "Connection") (:deck runner)) :sorted))

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -524,13 +524,13 @@
              :runner-spent-click {:req (req (:swap card))
                                   :effect (effect (update! (dissoc card :swap)))}}
     :abilities [{:req (req (:swap card))
-                 :effect (req (let [agendas (get-in corp [:scored])
-                                    st (last (get-in runner [:scored]))]
+                 :effect (req (let [st (last (get-in runner [:scored]))]
                                 (resolve-ability
                                   state side
                                   {:req (req (is-type? st "Agenda"))
                                    :prompt (msg "Choose a scored Corp agenda to swap for " (:title st))
-                                   :choices {:req #(some (fn [c] (= (:cid %) (:cid c))) agendas)}
+                                   :priority true
+                                   :choices {:req #(in-corp-scored? state side %)}
                                    :effect (req (let [sw target
                                                       stpts-corp (get-agenda-points state :corp st)
                                                       swpts-corp (get-agenda-points state :corp sw)

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -24,7 +24,7 @@
    "Aesops Pawnshop"
    {:abilities [{:msg (msg "trash " (:title target) " and gain 3 [Credits]")
                  :choices {:req #(and (= (:side %) "Runner") (:installed %))}
-                 :effect (effect (gain :credit 3) (trash target))}]}
+                 :effect (effect (gain :credit 3) (trash target {:unpreventable true}))}]}
 
    "Always Be Running"
    {:abilities [{:once :per-turn


### PR DESCRIPTION
High-Stakes Job isn't working due to an adjustment in NRDB data (it was in there initially as High-stakes Job, so that's how @Saintis titled it). 

Made a small adjustment to Turntable to push its prompt to the front of the queue during multi-access just like was done to Leela Patel. Aesop's trashing is made unpreventable so Fall Guy won't interfere.