### PR TITLE
Split game lobby into casual/competitive rooms

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -120,7 +120,7 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
     switch msg.action
       when "create"
         gameid = uuid.v1()
-        game = {date: new Date(), gameid: gameid, title: msg.title, allowspectator: msg.allowspectator,\
+        game = {date: new Date(), gameid: gameid, title: msg.title, allowspectator: msg.allowspectator, lobby: msg.lobby,\
                 players: [{user: socket.request.user, id: socket.id, side: msg.side}], spectators: []}
         games[gameid] = game
         socket.join(gameid)

--- a/server.coffee
+++ b/server.coffee
@@ -120,7 +120,7 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
     switch msg.action
       when "create"
         gameid = uuid.v1()
-        game = {date: new Date(), gameid: gameid, title: msg.title, allowspectator: msg.allowspectator, lobby: msg.lobby,\
+        game = {date: new Date(), gameid: gameid, title: msg.title, allowspectator: msg.allowspectator, room: msg.room,\
                 players: [{user: socket.request.user, id: socket.id, side: msg.side}], spectators: []}
         games[gameid] = game
         socket.join(gameid)

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -255,7 +255,7 @@
              (<= min (agenda-points deck) (inc min))))))
 
 (defn released?
-  "Returns false if the card comes from a spoiled set or is out of competetive rotation."
+  "Returns false if the card comes from a spoiled set or is out of competitive rotation."
   [card]
   (let [cid (js/parseInt (:code card))]
     ;; Cards up to Kala Ghoda are currently released

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -186,12 +186,12 @@
      [:h4 "No game"]
      (for [game games]
        [:div.gameline {:class (when (= gameid (:gameid game)) "active")}
-        (when-not (or gameid (= (count (:players game)) 2) (:started game))
-          (let [id (:gameid game)]
-            [:button {:on-click #(join-game id owner)} "Join"]))
         (when (and (:allowspectator game) (not gameid))
           (let [id (:gameid game)]
             [:button {:on-click #(watch-game id owner)} "Watch"]))
+        (when-not (or gameid (= (count (:players game)) 2) (:started game))
+          (let [id (:gameid game)]
+            [:button {:on-click #(join-game id owner)} "Join"]))
         (let [c (count (:spectators game))]
           [:h4 (str (:title game)
                     (when (pos? c)

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -204,7 +204,7 @@
   (reify
     om/IInitState
     (init-state [this]
-      {:current-lobby "Casual"})
+      {:current-lobby "casual"})
 
     om/IRenderState
     (render-state [this state]
@@ -218,8 +218,8 @@
           [:div.float-right "Lobby: "
            [:select {:value (om/get-state owner :current-lobby)
                      :on-change #(om/set-state! owner :current-lobby (.. % -target -value))}
-            [:option "Casual"]
-            [:option "Competitive"]]]]
+            [:option {:value "casual"} (str "Casual (" (count (filter #(= "casual" (:lobby %)) games)) ")")]
+            [:option {:value "competitive"} (str "Competitive (" (count (filter #(= "competitive" (:lobby %)) games)) ")")]]]]
          (game-list cursor owner)]
 
         [:div.game-panel

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -80,7 +80,7 @@
            (send {:action "create" :title (om/get-state owner :title)
                   :allowspectator (om/get-state owner :allowspectator)
                   :side (om/get-state owner :side)
-                  :lobby (om/get-state owner :current-lobby)}))))))
+                  :room (om/get-state owner :current-room)}))))))
 
 (defn join-game [gameid owner]
   (authenticated
@@ -182,11 +182,11 @@
           [:button "Send"]]]]))))
 
 (defn game-list [{:keys [games gameid] :as cursor} owner]
-  (let [lobbygames (filter #(= (:lobby %) (om/get-state owner :current-lobby)) games)]
+  (let [roomgames (filter #(= (:room %) (om/get-state owner :current-room)) games)]
     [:div.game-list
-     (if (empty? lobbygames)
+     (if (empty? roomgames)
        [:h4 "No games"]
-       (for [game lobbygames]
+       (for [game roomgames]
          [:div.gameline {:class (when (= gameid (:gameid game)) "active")}
           (when (and (:allowspectator game) (not gameid))
             (let [id (:gameid game)]
@@ -204,7 +204,7 @@
   (reify
     om/IInitState
     (init-state [this]
-      {:current-lobby "casual"})
+      {:current-room "casual"})
 
     om/IRenderState
     (render-state [this state]
@@ -215,10 +215,10 @@
           (if gameid
             [:button {:class "disabled"} "New game"]
             [:button {:on-click #(new-game cursor owner)} "New game"])
-          [:div.float-right "Lobby: "
-           (let [count-games (fn [lobby] (count (filter #(= lobby (:lobby %)) games)))]
-             [:select.lobbies {:value (om/get-state owner :current-lobby)
-                               :on-change #(om/set-state! owner :current-lobby (.. % -target -value))}
+          [:div.float-right "Room: "
+           (let [count-games (fn [room] (count (filter #(= room (:room %)) games)))]
+             [:select.rooms {:value (om/get-state owner :current-room)
+                               :on-change #(om/set-state! owner :current-room (.. % -target -value))}
               [:option {:value "casual"} (str "Casual (" (count-games "casual") ")")]
               [:option {:value "competitive"} (str "Competitive (" (count-games "competitive") ")")]])]]
          (game-list cursor owner)]

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -216,7 +216,7 @@
             [:button {:class "disabled"} "New game"]
             [:button {:on-click #(new-game cursor owner)} "New game"])
           [:div.float-right "Lobby: "
-           [:select {:value (om/get-state owner :current-lobby)
+           [:select.lobbies {:value (om/get-state owner :current-lobby)
                      :on-change #(om/set-state! owner :current-lobby (.. % -target -value))}
             [:option {:value "casual"} (str "Casual (" (count (filter #(= "casual" (:lobby %)) games)) ")")]
             [:option {:value "competitive"} (str "Competitive (" (count (filter #(= "competitive" (:lobby %)) games)) ")")]]]]

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -213,14 +213,18 @@
         [:div.games
          [:div.button-bar
           (if gameid
-            [:button {:class "disabled"} "New game"]
-            [:button {:on-click #(new-game cursor owner)} "New game"])
-          [:div.float-right "Room: "
-           (let [count-games (fn [room] (count (filter #(= room (:room %)) games)))]
-             [:select.rooms {:value (om/get-state owner :current-room)
-                               :on-change #(om/set-state! owner :current-room (.. % -target -value))}
-              [:option {:value "casual"} (str "Casual (" (count-games "casual") ")")]
-              [:option {:value "competitive"} (str "Competitive (" (count-games "competitive") ")")]])]]
+            [:button.float-left {:class "disabled"} "New game"]
+            [:button.float-left {:on-click #(new-game cursor owner)} "New game"])
+          (let [count-games (fn [room] (count (filter #(= room (:room %)) games)))
+                room-tab (fn [room roomname]
+                           [:span.roomtab
+                            (if (= room (om/get-state owner :current-room))
+                              {:class "current"}
+                              {:on-click #(om/set-state! owner :current-room room)})
+                            roomname " (" (count-games room) ")"])]
+            [:div.rooms
+             (room-tab "competitive" "Competitive")
+             (room-tab "casual" "Casual")])]
          (game-list cursor owner)]
 
         [:div.game-panel

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -216,10 +216,11 @@
             [:button {:class "disabled"} "New game"]
             [:button {:on-click #(new-game cursor owner)} "New game"])
           [:div.float-right "Lobby: "
-           [:select.lobbies {:value (om/get-state owner :current-lobby)
-                     :on-change #(om/set-state! owner :current-lobby (.. % -target -value))}
-            [:option {:value "casual"} (str "Casual (" (count (filter #(= "casual" (:lobby %)) games)) ")")]
-            [:option {:value "competitive"} (str "Competitive (" (count (filter #(= "competitive" (:lobby %)) games)) ")")]]]]
+           (let [count-games (fn [lobby] (count (filter #(= lobby (:lobby %)) games)))]
+             [:select.lobbies {:value (om/get-state owner :current-lobby)
+                               :on-change #(om/set-state! owner :current-lobby (.. % -target -value))}
+              [:option {:value "casual"} (str "Casual (" (count-games "casual") ")")]
+              [:option {:value "competitive"} (str "Competitive (" (count-games "competitive") ")")]])]]
          (game-list cursor owner)]
 
         [:div.game-panel

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -153,7 +153,7 @@
                          "Decks that fit within the printed influence limit, but not within the tournament restrictions, "
                          "are marked " [:span.casual "Casual play only"] ". Decks that do not fit basic deckbuilding rules are marked " [:span.invalid "Invalid"] "."]
                         [:p "Putting cards in your deck that are not yet available for sale (i.e. future spoilers) or ones that are "
-                         "out of competetive rotation will also result in your deck being marked as " [:span.casual "Casual play only"] ". Such cards "
+                         "out of competitive rotation will also result in your deck being marked as " [:span.casual "Casual play only"] ". Such cards "
                          "should be easy to identify - they are " [:span.casual "highlighted"] " in the deckbuilder."])}
             {:id "rezaccess"
              :title "How do I rez cards as Corp in the 4.3 run timing window?"

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -149,12 +149,12 @@
                          "the influence printed on the ID by 1, with a minimum of 1 (so Professor is unaffected). For "
                          "more information about the MWL read Tournament Rules from "
                          [:a {:href "https://www.fantasyflightgames.com/en/products/android-netrunner-the-card-game/"} "the official FFG page"] "."]
-                        [:p "Decks that are valid and fit within tournament restrictions are marked \"Tournament legal\". "
+                        [:p "Decks that are valid and fit within tournament restrictions are marked " [:span.legal "Tournament legal" ] ". "
                          "Decks that fit within the printed influence limit, but not within the tournament restrictions, "
-                         "are marked \"Casual play only\". Decks that do not fit basic deckbuilding rules are marked \"Invalid\"."]
+                         "are marked " [:span.casual "Casual play only"] ". Decks that do not fit basic deckbuilding rules are marked " [:span.invalid "Invalid"] "."]
                         [:p "Putting cards in your deck that are not yet available for sale (i.e. future spoilers) or ones that are "
-                         "out of competetive rotation will also result in your deck being marked as casual. Such cards "
-                         "should be easy to identify - they are highlighted in the deckbuilder."])}
+                         "out of competetive rotation will also result in your deck being marked as " [:span.casual "Casual play only"] ". Such cards "
+                         "should be easy to identify - they are " [:span.casual "highlighted"] " in the deckbuilder."])}
             {:id "rezaccess"
              :title "How do I rez cards as Corp in the 4.3 run timing window?"
              :content [:p "Sadly, this window is currently unimplemented - you need to ask the Runner manually. "

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -948,6 +948,9 @@ nav ul
     box-sizing: initial
     padding: 0 15px 15px
 
+    .lobbies
+      min-width: 145px
+
   .game-list
     padding: 0 15px
     overflow: auto

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -948,8 +948,23 @@ nav ul
     box-sizing: initial
     padding: 0 15px 15px
 
-    .rooms
-      min-width: 145px
+    .rooms .roomtab
+      display: block
+      padding: 5px 10px
+      border: 1px solid white
+      border-radius: 4px
+      color: white
+      margin-right: 1px
+      cursor: pointer
+      float: right
+
+      &:hover
+        border-color: orange
+        color: orange
+
+      &.current
+        border-color: orange
+        cursor: default
 
   .game-list
     padding: 0 15px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -948,7 +948,7 @@ nav ul
     box-sizing: initial
     padding: 0 15px 15px
 
-    .lobbies
+    .rooms
       min-width: 145px
 
   .game-list


### PR DESCRIPTION
Fact: platform is often pushing over 100 games at peak times currently and the game list gets pretty long sometimes. A some way of splitting that would be nice.

To do that, and to help players that are having mismatched expectations when coming into the game, lo and behold, a competitive room (for the beginning, it's super easy to add more):

http://i.share.pho.to/b1549035_o.png

If we want to do that, creating custom rooms using this logic would be trivial - just allow the room name to be a text field. That is a sort-of replacement for passworded games ;-)

Could be enhanced by merging #1047, so we finally have user profiles and user could select their default lobby in their profile. Currently the default is the casual room.

Since there are changes to `server.coffee`, its restart will be needed.

Fixes #345 (kind of).