### PR TITLE
added identity check to legality deck check

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -266,7 +266,8 @@
   [deck]
   (and (valid? deck)
        (<= (influence-count deck) (deck-inf-limit deck))
-       (every? #(released? (:card %)) (:cards deck))))
+       (every? #(released? (:card %)) (:cards deck))
+       (released? (:identity deck))))
 
 (defn edit-deck [owner]
   (om/set-state! owner :edit true)


### PR DESCRIPTION
Comment made by @dodgepong made me realize that I forgot to check identity for its released status. So decks with Nero Severn or Harishchandra would be marked as TL - this is fixed.

As for marking draft IDs likewise, I'm hesitant - I don't want to make draft players any more neglected than they already are, since there actually are a few draft format A:NR tournaments in my area. This mistake is also instantly recognized, unlike ninja-Brainstorm ;-) So I hope it won't cause too much issues.