### PR TITLE
Drag & drop for touch devices

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -283,6 +283,59 @@
         side (if (#{"HQ" "R&D" "Archives"} server) "Corp" "Runner")]
     (send-command "move" {:card card :server server})))
 
+(defn abs [n] (max n (- n)))
+
+;; touch support
+(defonce touchmove (atom {}))
+
+(defn release-touch [card]
+  (-> card (.removeClass "disable-transition"))
+  (-> card (.css "position" ""))
+  (-> card (.css "top" "")))
+
+(defn update-card-position [card touch]
+  (-> card (.css "left" (str (- (int (aget touch "pageX")) 30) "px")))
+  (-> card (.css "top"  (str (- (int (aget touch "pageY")) 42) "px"))))
+
+(defn get-card [e server]
+  (-> e .-target js/$ (.closest ".card-wrapper")))
+
+(defn get-server-from-touch [touch]
+  (let [cX (.. touch -clientX)
+        cY (.. touch -clientY)
+        server (-> (js/document.elementFromPoint cX cY)
+                   js/$
+                   (.closest "[data-server]")
+                   (.attr "data-server"))]
+    [server (> (+ (abs (- (:x @touchmove) cX))
+                  (abs (- (:y @touchmove) cY)))
+               30)]))
+
+(defn handle-touchstart [e cursor]
+  (let [touch (aget (.. e -targetTouches) 0)
+        [server _] (get-server-from-touch touch)
+        card (get-card e server)]
+    (-> card (.addClass "disable-transition"))
+    (reset! touchmove {:card (.stringify js/JSON (clj->js @cursor))
+                       :x (.. touch -clientX)
+                       :y (.. touch -clientY)
+                       :start-server server})))
+
+(defn handle-touchmove [e]
+  (let [touch (aget (.. e -targetTouches) 0)
+        card (get-card e (:start-server @touchmove))]
+    (-> card (.css "position" "fixed"))
+    (update-card-position card touch)))
+
+(defn handle-touchend [e]
+  (let [touch (aget (.. e -changedTouches) 0)
+        card (get-card e (:start-server @touchmove))
+        [server moved-enough] (get-server-from-touch touch)]
+    (release-touch card)
+    (when (and server moved-enough (not= server (:start-server @touchmove)))
+      (let [cardinfo (-> @touchmove :card ((.-parse js/JSON)) (js->clj :keywordize-keys true))]
+        (send-command "move" {:card cardinfo :server server})))))
+
 (defn ability-costs [ab]
   (when-let [cost (:cost ab)]
     (str (clojure.string/join
@@ -349,6 +402,9 @@
       [:div.card-frame
        [:div.blue-shade.card {:class (when selected "selected")
                               :draggable (when (not-spectator? game-state app-state) true)
+                              :on-touch-start #(handle-touchstart % cursor)
+                              :on-touch-end   #(handle-touchend %)
+                              :on-touch-move  #(handle-touchmove %)
                               :on-drag-start #(handle-dragstart % cursor)
                               :on-drag-end #(-> % .-target js/$ (.removeClass "dragged"))
                               :on-mouse-enter #(when (or (not (or flipped facedown))
@@ -421,7 +477,8 @@
   (merge hmap {:on-drop #(handle-drop % server)
                :on-drag-enter #(-> % .-target js/$ (.addClass "dragover"))
                :on-drag-leave #(-> % .-target js/$ (.removeClass "dragover"))
-               :on-drag-over #(.preventDefault %)}))
+               :on-drag-over #(.preventDefault %)
+               :data-server server}))
 
 (defn label [cursor owner opts]
   (om/component

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1257,6 +1257,9 @@ nav ul
     &:last-child
       margin-right: 0
 
+   .disable-transition
+     transition: none
+
   .squeeze .card-wrapper
     position: absolute
 


### PR DESCRIPTION
Refreshed touch support from #496 by @queueseven. Tested using [excellent Chrome's touch screen simulator](https://developer.chrome.com/devtools/docs/device-mode) - drag & drop seems to be mostly working. Certainly a big step ahead from not working at all :)