### PR TITLE
Extends toast functionality

### DIFF
--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -28,12 +28,20 @@
 
 (defn toast
   "Adds a message to toast with specified severity (default as a warning) to the toast msg list.
-  If message is nil, removes first toast in the list."
-  ([state side msg] (toast state side msg "warning"))
-  ([state side msg type]
+  If message is nil, removes first toast in the list.
+  For options see http://codeseven.github.io/toastr/demo.html
+  Currently implemented options:
+    - type (warning, info etc)
+    - time-out (sets both timeOut and extendedTimeOut currently)
+    - close-button
+    - prevent-duplicates"
+  ([state side msg] (toast state side msg "warning" nil))
+  ([state side msg type] (toast state side msg type nil))
+  ([state side msg type options]
+   ;; Allows passing just the toast type as the options parameter
    (if msg
      ;; normal toast - add to list
-     (swap! state update-in [side :toast] #(conj % {:type type :msg msg}))
+     (swap! state update-in [side :toast] #(conj % {:msg msg :type type :options options}))
      ;; no msg - remove top toast from list
      (swap! state update-in [side :toast] #(rest %)))))
 


### PR DESCRIPTION
Allows passing in options to toast specifying the time-out duration, whether it should have a close-button and whether duplicate toasts should be prevented.

Create a constant toast using `:time-out 0` - recommend that `:close-button` is also on so the toast can be (visibly) closed.

Turning off prevent-duplicates could be useful for toasting on taking tag, in case multiple tags are taken within close succession.