### PR TITLE
UI fixes for start-turn changes.

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -113,36 +113,33 @@
                  :effect (effect (trash card {:cause :ability-cost}) (damage-prevent :meat 3))}]}
 
    "Daily Casts"
-   (let [ability (req (gain state :runner :credit 2)
-                      (when (zero? (:counter card))
-                        (trash state :runner card {:unpreventable true})))]
+   (let [ability {:once :per-turn
+                  :label "Take 2 [Credits] (start of turn)"
+                  :msg "gain 2 [Credits]"
+                  :req (req (:runner-phase-12 @state))
+                  :counter-cost 2
+                  :effect (req (gain state :runner :credit 2)
+                               (when (zero? (:counter card))
+                                 (trash state :runner card {:unpreventable true})))}]
    {:data {:counter 8
            :counter-type "Credit"}
     :flags {:drip-economy true}
-    :abilities [{:once :per-turn
-                 :label "Take 2 [Credits] (start of turn)"
-                 :msg "gain 2 [Credits]"
-                 :req (req (:runner-phase-12 @state))
-                 :counter-cost 2
-                 :effect ability}]
-    :events {:runner-turn-begins {:once :per-turn
-                                  :msg "gain 2 [Credits]"
-                                  :counter-cost 2
-                                  :effect ability}}})
+    :abilities [ability]
+    :events {:runner-turn-begins ability}})
 
    "Data Dealer"
    {:abilities [{:cost [:click 1 :forfeit] :effect (effect (gain :credit 9))
                  :msg (msg "gain 9 [Credits]")}]}
 
    "Data Folding"
-   {:flags {:drip-economy true}
-    :abilities [{:label "Gain 1 [Credits]"
-                 :once :per-turn
-                 :req (req (and (>= (:memory runner) 2) (:runner-phase-12 @state)))
-                 :effect (effect (gain :credit 1))}]
-    :events {:runner-turn-begins {:msg "gain 1 [Credits]" :req (req (>= (:memory runner) 2))
-                                  :once :per-turn
-                                  :effect (effect (gain :credit 1))}}}
+   (let [ability {:label "Gain 1 [Credits] (start of turn)"
+                  :msg "gain 1 [Credits]"
+                  :once :per-turn
+                  :req (req (and (>= (:memory runner) 2) (:runner-phase-12 @state)))
+                  :effect (effect (gain :credit 1))}]
+    {:flags {:drip-economy true}
+    :abilities [ability]
+    :events {:runner-turn-begins ability}})
 
    "Data Leak Reversal"
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
@@ -815,14 +812,14 @@
                  :cost [:click 2] :effect (effect (move target :hand) (shuffle! :deck))}]}
 
    "Underworld Contact"
+   (let [ability {:label "Gain 1 [Credits] (start of turn)"
+                  :msg "gain 1 [Credits]"
+                  :once :per-turn
+                  :req (req (and (>= (:link runner) 2) (:runner-phase-12 @state)))
+                  :effect (effect (gain :credit 1))}]
    {:flags {:drip-economy true}
-    :abilities [{:label "Gain 1 [Credits]"
-                 :once :per-turn
-                 :req (req (and (>= (:link runner) 2) (:runner-phase-12 @state)))
-                 :effect (effect (gain :credit 1))}]
-    :events {:runner-turn-begins {:msg "gain 1 [Credits]" :req (req (>= (:link runner) 2))
-                                  :once :per-turn
-                                  :effect (effect (gain :credit 1))}}}
+    :abilities [ability]
+    :events {:runner-turn-begins ability}})
 
    "Utopia Shard"
    {:abilities [{:effect (effect (trash-cards :corp (take 2 (shuffle (:hand corp))))

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -199,8 +199,9 @@
              (system-msg state side (str (build-spend-msg cost-str "rez" "rezzes")
                                          (:title card) (when ignore-cost " at no cost")))
              (when (:corp-phase-12 @state)
-               (toast state :corp "You are not allowed to rez cards at this time. Please rez prior to clicking
-                  Start Turn in the future." "warning"))
+               (toast state :corp "You are not allowed to rez cards between Start of Turn and Mandatory Draw.
+                      Please rez prior to clicking Start Turn in the future." "warning"
+                      {:time-out 0 :close-button true}))
              (when (ice? card)
                (update-ice-strength state side card)
                (update-run-ice state side))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -419,7 +419,8 @@
                      (fn [args-corp]
                        (clear-wait-prompt state :runner)
                        (show-prompt state :runner nil "The run is now successful" ["Continue"]
-                                    (fn [args-runner] (successful-run-trigger state :runner))))))
+                                    (fn [args-runner] (successful-run-trigger state :runner))))
+                     {:priority -1}))
     (successful-run-trigger state side)))
 
 (defn corp-phase-43

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -873,7 +873,7 @@
                                [:button {:on-click #(handle-end-turn cursor owner)} "End Turn"])
                          (when end-turn
                            [:button {:on-click #(send-command "start-turn")} "Start Turn"]))
-                       (when (and (= (keyword active-player side))
+                       (when (and (= (keyword active-player) side)
                                   (or runner-phase-12 corp-phase-12))
                            [:button {:on-click #(send-command "end-phase-12")}
                             (if (= side :corp) "Mandatory Draw" "Take Clicks")])


### PR DESCRIPTION
Fix runner seeing "Take Clicks" while corp is in his Start of Turn phase.

Fix the order of corp's "No Action" / "Action before access" buttons for consistency (No Action always in the same vertical position).

Add log messages for Daily Casts, Data Folding, Underworld Contacts when used in Step 1.2.

Give the Step 4.3 "Take actions, then click Done" prompt for corp a negative priority, so all other prompts hide it. (Like Jackson Howard.)

Use @Saintis's new toast functionality from #1219 to give a stronger warning when corp rezzes during Step 1.2, as a warning toast that does not go away until clicked.