### PR TITLE
Adam deckbuilding fixes

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -8,7 +8,7 @@
    {:effect (req (let [directives (-> (:deck runner) (concat (:hand runner)) (get-directives) one-of-each)]
                    (when (not= 3 (count directives))
                      (toast state :runner
-                            "Your deck doesn't contain enough directives for Adam's ability. The deck needs to contain at least one copy of each directive. They are not counted against the decksize limit."
+                            "Your deck doesn't contain enough directives for Adam's ability. The deck needs to contain at least one copy of each directive. They are not counted against the printed decksize limit, so minimal Adam's decksize on this site is 48 cards."
                             "warning"
                             {:time-out 0 :close-button true}))
                    (doseq [c directives]

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -8,7 +8,9 @@
    {:effect (req (let [directives (-> (:deck runner) (concat (:hand runner)) (get-directives) one-of-each)]
                    (when (not= 3 (count directives))
                      (toast state :runner
-                            "Your deck doesn't contain enough directives for Adam's ability. The deck needs to contain one copy of each directive. They are not counted against the decksize limit." "warning"))
+                            "Your deck doesn't contain enough directives for Adam's ability. The deck needs to contain at least one copy of each directive. They are not counted against the decksize limit."
+                            "warning"
+                            {:time-out 0 :close-button true}))
                    (doseq [c directives]
                      (runner-install state side c {:no-cost true
                                                    :custom-message (str "starts with " (:title c) " in play")}))

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -6,6 +6,9 @@
          one-of-each   (fn [cards] (->> cards (group-by :title) (map second) (map first)))
          get-directives (fn [source] (filter #(some #{(:title %)} titles) source))]
    {:effect (req (let [directives (-> (:deck runner) (concat (:hand runner)) (get-directives) one-of-each)]
+                   (when (not= 3 (count directives))
+                     (toast state :runner
+                            "Your deck doesn't contain enough directives for Adam's ability. The deck needs to contain one copy of each directive. They are not counted against the decksize limit." "warning"))
                    (doseq [c directives]
                      (runner-install state side c {:no-cost true
                                                    :custom-message (str "starts with " (:title c) " in play")}))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -22,11 +22,15 @@
           "newestOnTop" false
           "progressBar" false
           "positionClass" "toast-card"
+          ;; preventDuplicates - identical toasts don't stack when the property is set to true.
+          ;; Duplicates are matched to the previous toast based on their message content.
           "preventDuplicates" (:prevent-duplicates options true)
           "onclick" nil
           "showDuration" 300
           "hideDuration" 1000
+          ;; timeOut - how long the toast will display without user interaction
           "timeOut" (:time-out options 3000)
+          ;; extendedTimeOut - how long the toast will display after a user hovers over it
           "extendedTimeOut" (:time-out options 1000)
           "showEasing" "swing"
           "hideEasing" "linear"


### PR DESCRIPTION
- a persistent toast message when starting a game without enough directives
- validity check for directives in deckbuilder and minimum 48 cards for Adam's decks
- warning messages when the constraints aren't met