### PR TITLE
Fix deck collection formatting issue with long ID names

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -476,7 +476,7 @@
      [:img {:src (image-url (:identity deck))}]
      [:div.float-right (deck-status-span deck)]
      [:h4 (:name deck)]
-     [:div.float-right (-> (:date deck) js/Date. js/moment (.format "MMM Do YYYY - HH:mm"))]
+     [:div.float-right (-> (:date deck) js/Date. js/moment (.format "YYYY-MM-DD"))]
      [:p (get-in deck [:identity :title])]]))
 
 (defn deck-builder [{:keys [decks decks-loaded] :as cursor} owner]

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -141,7 +141,7 @@
              [:img {:src (image-url (:identity deck))}]
              [:div.float-right (deck-status-span deck)]
              [:h4 (:name deck)]
-             [:div.float-right (-> (:date deck) js/Date. js/moment (.format "MMM Do YYYY - HH:mm"))]
+             [:div.float-right (-> (:date deck) js/Date. js/moment (.format "YYYY-MM-DD"))]
              [:p (get-in deck [:identity :title])]])])]]])))
 
 (defn faction-icon

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -135,7 +135,7 @@
                               [:li "familiarity with the site's interface"]
                               [:li "a " [:span.legal "tournament legal"] " deck"]
                               [:li "enough time reserved for a full game and no distractions"]]]
-                            [:p "Games with players not able or willing to follow above recommendations are propably better suited to the Casual room."
+                            [:p "Games with players not able or willing to follow above recommendations are propably better suited to the Casual room. "
                              "Some examples would be: learning the game, learning the site's interface, testing a completely new and crazy deck idea, "
                              "testing future spoilers, playing on a touchscreen, playing at work and likely to have to quit on short notice, etc. "
                              "All of these circumstances may cause needless frustration of players expecting to play a game in a competitive setting."])}


### PR DESCRIPTION
Primarily to solve this issue:

![capture](https://cloud.githubusercontent.com/assets/840021/13091477/ba1552a8-d4fb-11e5-9a5d-574fe0bbb365.PNG)

Solved by changing format of displayed date for decks to ISO format, e.g. 2016-02-16. Hour probably isn't very important in this case, so it was stripped.