### PR TITLE
Fix for #1240; incorrect EBC warning message

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -257,7 +257,7 @@
     :abilities [{:choices {:req (complement rezzed?)}
                  :label "Rez a card, lowering the cost by 1 [Credits]"
                  :msg (msg "rez " (:title target))
-                 :effect (effect (rez-cost-bonus -1) (rez target))}
+                 :effect (effect (rez-cost-bonus -1) (rez target {:no-warning true}))}
                 {:prompt "Choose an asset to add to HQ"
                  :msg (msg "add " (:title target) " to HQ")
                  :activatemsg "searches R&D for an asset"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -891,16 +891,18 @@
     :abilities [ability]})
 
    "Wyldside"
-   (let [ability {:msg "draw 2 cards and lose [Click]"
-                  :once :per-turn
-                  :effect (effect (lose :click 1) (draw 2))}]
    {:flags {:runner-turn-draw true
             :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :runner-turn-draw true)
                                                       (cons (get-in @state [:runner :identity])
                                                             (all-installed state :runner))))))}
 
-    :events {:runner-turn-begins ability}
-    :abilities [ability]})
+    :events {:runner-turn-begins {:effect (req (lose state side :click 1)
+                                               (when-not (get-in @state [:per-turn (:cid card)])
+                                                 (system-msg state side "uses Wyldside to draw 2 cards and lose [Click]")
+                                                 (draw state side 2)))}}
+    :abilities [{:msg "draw 2 cards and lose [Click]"
+                 :once :per-turn
+                 :effect (effect (draw 2))}]}
 
    "Xanadu"
    {:events {:pre-rez-cost {:req (req (ice? target))

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -176,7 +176,7 @@
 (defn rez
   "Rez a corp card."
   ([state side card] (rez state side card nil))
-  ([state side card {:keys [ignore-cost] :as args}]
+  ([state side card {:keys [ignore-cost no-warning] :as args}]
    (if (can-rez? state side card)
      (do
        (trigger-event state side :pre-rez card)
@@ -198,7 +198,7 @@
                                        (update-in [:host :zone] #(map to-keyword %)))))
              (system-msg state side (str (build-spend-msg cost-str "rez" "rezzes")
                                          (:title card) (when ignore-cost " at no cost")))
-             (when (:corp-phase-12 @state)
+             (when (and (not no-warning) (:corp-phase-12 @state))
                (toast state :corp "You are not allowed to rez cards between Start of Turn and Mandatory Draw.
                       Please rez prior to clicking Start Turn in the future." "warning"
                       {:time-out 0 :close-button true}))

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -129,7 +129,7 @@
     (swap! state assoc phase true)
     (if (not-empty start-cards)
       (toast state side
-                 (str "You may use " (clojure.string/join "," (map :title start-cards))
+                 (str "You may use " (clojure.string/join ", " (map :title start-cards))
                       (if (= side :corp)
                         " between the start of your turn and your mandatory draw."
                         " before taking your first click."))

--- a/src/clj/test/cards-identities.clj
+++ b/src/clj/test/cards-identities.clj
@@ -146,6 +146,34 @@
     (play-run-event state (first (:hand (get-runner))) :hq)
     (is (= 16 (:credit (get-runner))) "No credit gained for second Run event")))
 
+(deftest maxx-wyldside-start-of-turn
+  "MaxX and Wyldside - using Wyldside during Step 1.2 should lose 1 click"
+  (do-game
+    (new-game (default-corp)
+              (make-deck "MaxX: Maximum Punk Rock" [(qty "Wyldside" 3)
+                                                     (qty "Sure Gamble" 3)
+                                                     (qty "Infiltration" 3)
+                                                     (qty "Corroder" 3)
+                                                     (qty "Eater" 3)]))
+    (take-credits state :corp)
+    (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
+    (starting-hand state :runner ["Wyldside"])
+    (play-from-hand state :runner "Wyldside")
+    (take-credits state :runner 3)
+    (is (= 5 (:credit (get-runner))) "Runner has 5 credits at end of first turn")
+    (is (find-card "Wyldside" (get-in @state [:runner :rig :resource])) "Wyldside was installed")
+    (take-credits state :corp)
+    (is (= 0 (:click (get-runner))) "Runner has 0 clicks")
+    (is (:runner-phase-12 @state) "Runner is in Step 1.2")
+    (let [maxx (get-in @state [:runner :identity])
+          wyld (find-card "Wyldside" (get-in @state [:runner :rig :resource]))]
+      (card-ability state :runner maxx 0)
+      (card-ability state :runner wyld 0)
+      (core/end-phase-12 state :runner nil)
+      (is (= 4 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
+      (is (= 3 (:click (get-runner))) "Wyldside caused 1 click to be lost")
+      (is (= 3 (count (:hand (get-runner)))) "3 cards drawn total"))))
+
 (deftest nasir-ability-basic
   "Nasir Ability - Basic"
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -143,5 +143,14 @@
   [state side title]
   (core/trash state side (find-card title (get-in @state [side :hand]))))
 
+(defn starting-hand
+  "Moves all cards in the player's hand to their draw pile, then moves the specified card names
+  back into the player's hand."
+  [state side cards]
+  (doseq [c (get-in @state [side :hand])]
+    (core/move state side c :deck))
+  (doseq [ctitle cards]
+    (core/move state side (find-card ctitle (get-in @state [side :deck])) :hand)))
+
 (load "core-game")
 (load "cards")


### PR DESCRIPTION
Fix for MaxX interaction with Wyldside in #1240. Video here: https://www.livecoding.tv/nealpro/videos/E7eo3-jintekinet-testing-framework-fixing-a-bug

Fix for Executive Boot Camp incorrectly warning against rezzing during start of turn.