### PR TITLE
fix for cvs ability on gravedigger

### DIFF
--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -102,7 +102,7 @@
                         :yes-ability {:msg (msg "purge viruses")
                                       :effect (effect (purge))}}}
     :abilities [{:label "[Trash]: Purge virus counters"
-                 :msg "purge viruses" :effect (effect (purge) (trash card))}]}
+                 :msg "purge viruses" :effect (effect (trash card) (purge))}]}
 
    "Dedicated Technician Team"
    {:recurring 2}


### PR DESCRIPTION
Fix #1255: trashing Cyberdex Virus Suite to purge puts a counter on Gravedigger