### PR TITLE
update Resistor strength when Runner gains/loses tags; fix Darwin

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -738,7 +738,14 @@
    {:abilities [end-the-run]}
 
    "Resistor"
-   {:strength-bonus (req (get-in @state [:runner :tag]))
+   {:effect (req (add-watch state (keyword (str "resistor" (:cid card)))
+                   (fn [k ref old new]
+                     (let [tags (get-in new [:runner :tag])]
+                       (when (not= (get-in old [:runner :tag]) tags)
+                         (update! ref side (assoc (get-card ref card) :strength-bonus tags))
+                         (update-ice-strength ref side (get-card ref card)))))))
+    :strength-bonus (req (:tag runner))
+    :leave-play (req (remove-watch state (keyword (str "resistor" (:cid card)))))
     :abilities [(trace-ability 4 end-the-run)]}
 
    "Rototurret"

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -218,7 +218,7 @@
                                  (strength-pump 1 5)]})
 
    "Darwin"
-   {:flags {:runner-phase-12 true}
+   {:flags {:runner-phase-12 (req true)}
     :events {:purge {:effect (effect (update-breaker-strength card))}}
     :abilities [(break-sub 2 1 "ice")
                 {:label "Place 1 virus counter (start of turn)"

--- a/src/clj/test/cards-ice.clj
+++ b/src/clj/test/cards-ice.clj
@@ -270,6 +270,22 @@
       (is (= 3 (:current-strength (refresh nb2)))
           "NEXT Bronze at 3 strength: 3 rezzed NEXT ice"))))
 
+(deftest resistor
+  "Resistor - Strength equal to Runner tags, lose strength when Runner removes a tag"
+  (do-game
+    (new-game (default-corp [(qty "Resistor" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Resistor" "HQ")
+    (let [resistor (get-ice state :hq 0)]
+      (core/rez state :corp resistor)
+      (is (= 0 (:current-strength (refresh resistor))) "No Runner tags; 0 strength")
+      (core/tag-runner state :runner 2)
+      (is (= 2 (:tag (get-runner))))
+      (is (= 2 (:current-strength (refresh resistor))) "2 Runner tags; 2 strength")
+      (take-credits state :corp)
+      (core/remove-tag state :runner 1)
+      (is (= 1 (:current-strength (refresh resistor))) "Runner removed 1 tag; down to 1 strength"))))
+
 (deftest special-offer-trash-ice-during-run
   "Special Offer trashes itself and updates the run position"
   (do-game


### PR DESCRIPTION
Fix #1266: Adds a watch state to Resistor so it will instantly update its strength when the Runner spends a click to remove a tag or removes several tags at once with an event. Includes a test. 
Fix #1262: Darwin start-of-turn bug fixed as was done for Globalsec Security Clearance.
