### PR TITLE
Assorted fixes: Turntable, Sneakdoor, Film Critic, 24/7 News Cycle

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -59,7 +59,7 @@
    {:events {:jack-out {:msg "do 1 net damage" :effect (effect (damage :net 1))}}}
 
    "AstroScript Pilot Program"
-   {:data {:counter 1}
+   {:effect (effect (add-prop card :counter 1))
     :abilities [{:counter-cost 1 :msg (msg "place 1 advancement token on "
                                            (card-str state target))
                  :choices {:req can-be-advanced?}
@@ -187,7 +187,8 @@
                                 :effect (effect (ice-strength-bonus 1 target))}}}
 
    "Executive Retreat"
-   {:data {:counter 1} :effect (effect (shuffle-into-deck :hand))
+   {:effect (effect (add-prop card :counter 1)
+                    (shuffle-into-deck :hand))
     :abilities [{:cost [:click 1] :counter-cost 1 :msg "draw 5 cards" :effect (effect (draw 5))}]}
 
    "Explode-a-palooza"
@@ -205,7 +206,7 @@
     :steal-cost-bonus (req [:credit 2])}
 
    "Firmware Updates"
-   {:data [:counter 3]
+   {:effect (effect (add-prop card :counter 3))
     :abilities [{:counter-cost 1 :choices {:req #(and (ice? %) (can-be-advanced? %))}
                  :req (req (< 0 (:counter card 0)))
                  :msg (msg "place 1 advancement token on " (card-str state target))
@@ -216,7 +217,7 @@
     :effect (effect (add-prop target :counter 1))}
 
    "Geothermal Fracking"
-   {:data {:counter 2}
+   {:effect (effect (add-prop card :counter 2))
     :abilities [{:cost [:click 1] :counter-cost 1 :msg "gain 7 [Credits] and take 1 bad publicity"
                  :effect (effect (gain :credit 7 :bad-publicity 1))}]}
 
@@ -258,7 +259,7 @@
                       :effect (effect (add-prop target :counter c))} card nil)))}
 
    "High-Risk Investment"
-   {:data {:counter 1}
+   {:effect (effect (add-prop card :counter 1))
     :abilities [{:cost [:click 1] :counter-cost 1 :msg (msg "gain " (:credit runner) " [Credits]")
                  :effect (effect (gain :credit (:credit runner)))}]}
 
@@ -280,7 +281,7 @@
                                :effect (effect (add-prop :corp target :advance-counter n {:placed true}))} card nil)))}}}
 
    "House of Knives"
-   {:data {:counter 3}
+   {:effect (effect (add-prop card :counter 3))
     :abilities [{:counter-cost 1 :msg "do 1 net damage" :req (req (:run @state)) :once :per-run
                  :effect (effect (damage :net 1 {:card card}))}]}
 
@@ -298,7 +299,7 @@
                               :effect (effect (init-trace-bonus 1))}}}
 
    "Labyrinthine Servers"
-   {:data {:counter 2}
+   {:effect (effect (add-prop card :counter 2))
     :abilities [{:counter-cost 1 :effect (effect (prevent-jack-out))
                  :msg "prevent the Runner from jacking out"}]}
 
@@ -332,7 +333,7 @@
     :advancement-cost-bonus (req (:bad-publicity corp))}
 
    "Nisei MK II"
-   {:data {:counter 1}
+   {:effect (effect (add-prop card :counter 1))
     :abilities [{:req (req (:run @state)) :counter-cost 1 :msg "end the run"
                  :effect (effect (end-run))}]}
 
@@ -404,7 +405,7 @@
                  :choices (req (:discard corp)) :effect (effect (move target :hand))}]}
 
    "Project Wotan"
-   {:data [:counter 3]
+   {:effect (effect (add-prop card :counter 3))
     :abilities [{:counter-cost 1 :msg "add an 'End the run' subroutine to the approached ICE"}]}
 
    "Quantum Predictive Model"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -572,13 +572,13 @@
                                                                      (dissoc sw :abilities :events))))
                                                   (gain-agenda-point state :runner (- swpts-runner stpts-runner))
                                                   (gain-agenda-point state :corp (- stpts-corp swpts-corp))
-                                                  (doseq [c (get-in @state [:corp :scored])]
+                                                  (let [c (find-cid (:cid st) (get-in @state [:corp :scored]))]
                                                     (let [abilities (:abilities (card-def c))
                                                           c (merge c {:abilities abilities})]
                                                       (update! state :corp c)
                                                       (when-let [events (:events (card-def c))]
                                                         (register-events state side events c))))
-                                                  (doseq [r (get-in @state [:runner :scored])]
+                                                  (let [r (find-cid (:cid sw) (get-in @state [:runner :scored]))]
                                                     (deactivate state :corp r))
                                                   (system-msg state side (str "uses Turntable to swap "
                                                                               (:title st) " for " (:title sw)))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -151,7 +151,7 @@
     :events {:purge {:effect (effect (trash card))}}}
 
    "Djinn"
-   {:abilities [{:label "Add a virus program to your Grip from your Stack"
+   {:abilities [{:label "Search your Stack for a virus program and add it to your Grip"
                  :prompt "Choose a Virus"
                  :msg (msg "adds " (:title target) " to their Grip")
                  :choices (req (cancellable (filter #(and (is-type? % "Program")
@@ -590,6 +590,7 @@
                                    {:req (req (= target :archives))
                                     :successful-run
                                     {:effect (req (swap! state assoc-in [:run :server] [:hq])
+                                                  (trigger-event state :corp :no-action)
                                                   (update-run-ice state side)
                                                   (system-msg state side
                                                               (str "uses Sneakdoor Beta to make a successful run on HQ")))}}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -245,7 +245,8 @@
                                 (swap! state update-in [side :prompt] rest)
                                 (when-let [run (:run @state)]
                                   (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
-                                    (handle-end-run state :runner)))))
+                                    (handle-end-run state :runner)
+                                    (swap! state dissoc :access)))))
                  :msg (msg "host " (:title (:card (first (get-in @state [side :prompt])))) " instead of accessing it")}
                 {:cost [:click 2] :label "Add hosted agenda to your score area"
                  :req (req (not (empty? (:hosted card))))

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -27,6 +27,11 @@
                   (get-in @state (cons (to-keyword side) zones))))))
       card)))
 
+(defn find-cid
+  "Return a card with specific :cid from given sequence"
+  [cid from]
+  (some #(when (= (:cid %) cid) %) from))
+
 ; Functions for updating cards
 (defn update!
   "Updates the state so that its copy of the given card matches the argument given."

--- a/src/clj/test/cards-programs.clj
+++ b/src/clj/test/cards-programs.clj
@@ -294,6 +294,24 @@
         (is (= 2 (get (refresh hive) :counter 0)) "Hivemind gained 1 counter")
         (is (= 0 (get (refresh vbg) :counter 0)) "Virus Breeding Ground lost 1 counter")))))
 
+(deftest sneakdoor-nerve-agent
+  "Sneakdoor Beta - Allow Nerve Agent to gain counters. Issue #1158/#955"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Sneakdoor Beta" 1) (qty "Nerve Agent" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 10)
+    (play-from-hand state :runner "Nerve Agent")
+    (play-from-hand state :runner "Sneakdoor Beta")
+    (let [nerve (get-in @state [:runner :rig :program 0])
+          sb (get-in @state [:runner :rig :program 1])]
+      (card-ability state :runner sb 0)
+      (run-successful state)
+      (is (= 1 (:counter (refresh nerve))))
+      (card-ability state :runner sb 0)
+      (run-successful state)
+      (is (= 2 (:counter (refresh nerve)))))))
+
 (deftest surfer
   "Surfer - Swap position with ice before or after when encountering a barrier ice"
   (do-game

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -94,6 +94,24 @@
       (core/rez state :corp iwall)
       (is (get-in (refresh iwall) [:rezzed])))))
 
+(deftest film-critic-discarded-executives
+  "Film Critic - Prevent Corp-trashed execs going to Runner scored. Issues #1181/#1042"
+  (do-game
+    (new-game (default-corp [(qty "Director Haas" 3) (qty "Project Vitruvius" 3) (qty "Hedge Fund" 1)])
+              (default-runner [(qty "Film Critic" 1)]))
+    (play-from-hand state :corp "Project Vitruvius" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Film Critic")
+    (let [fc (first (get-in @state [:runner :rig :resource]))]
+      (run-empty-server state "Server 1")
+      (card-ability state :runner fc 0)
+      (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+      (take-credits state :runner)
+      (trash-from-hand state :corp "Director Haas")
+      (is (= 1 (count (:discard (get-corp)))) "Director Haas stayed in Archives")
+      (is (= 0 (:agenda-point (get-runner))) "No points gained by Runner")
+      (is (empty? (:scored (get-runner))) "Nothing in Runner scored"))))
+
 (deftest film-critic-fetal-ai
   "Film Critic - Fetal AI interaction"
   (do-game


### PR DESCRIPTION
I've collected another strange mish-mash of fixes. We're going deep into the weeds on some of these...

* Fix #1181, fix #1042: After using Film Critic, `:access true` was incorrectly lingering on in the state, resulting in the "as agenda" executives teleporting to the Runner score area and granting them 2 points even if voluntarily trashed by the Corp. Includes a test.
* Fix #955, fix #1158: This is a bit of a hack, but triggering a fake `:no-action` in Sneakdoor Beta will allow Nerve Agent to gain counters. The Runner can't use the "choose fewer accesses" option even though they'll still see a toast about it, but this is better than nothing. Includes a test.
* Fix #1276. I can only partially improve the situation for #1260 and #1125. I wrote a new function to find a single `:cid` so that Turntable can activate/deactivate *only* the 2 cards that are swapped instead of everything in each score area. 24/7 News Cycle still won't be able to target an agenda that has previously been swapped back to the Corp. 
* Speaking of 24/7 News Cycle, it should be able to "top up" agenda counters on things like House of Knives, Geothermal Fracking, etc. This is probably pretty rare, but it doesn't work at all with these agendas currently using the form `:data X`. Changing to `(effect (add-prop card :counter X))` allows it. 