### PR TITLE
Fix Edward Kim; add toast reminder for which Jinteki Biotech version was chosen

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -184,8 +184,17 @@
                               :choices ["[The Brewery~brewery]" "[The Tank~tank]" "[The Greenhouse~greenhouse]"]
                               :effect (effect (update! (assoc card :biotech-target target))
                                               (system-msg (str "has chosen a copy of Jinteki Biotech for this game ")))}}
-    :abilities [{:cost [:click 3]
+    :abilities [{:label "Check chosen flip identity"
+                 :effect (req (case (:biotech-target card)
+                                "[The Brewery~brewery]"
+                                (toast state :corp "Flip to: The Brewery (Do 2 net damage)" "info")
+                                "[The Tank~tank]"
+                                (toast state :corp "Flip to: The Tank (Shuffle Archives into R&D)" "info")
+                                "[The Greenhouse~greenhouse]"
+                                (toast state :corp "Flip to: The Greenhouse (Place 4 advancement tokens on a card)" "info")))}
+                {:cost [:click 3]
                  :req (req (not (:biotech-used card)))
+                 :label "Flip this identity"
                  :effect (req (let [flip (:biotech-target card)]
                                 (update! state side (assoc card :biotech-used true))
                                 (case flip

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -98,9 +98,14 @@
    "Edward Kim: Humanitys Hammer"
    {:effect (effect (gain :link 1))
     :events {:access {:once :per-turn
-                      :req (req (is-type? target "Operation"))
+                      :req (req (and (is-type? target "Operation")
+                                     (turn-flag? state side card :can-trash-operation)))
                       :effect (effect (trash target))
-                      :msg (msg "trash " (:title target) (if (some #{:discard} (:zone target)) ", but it is already trashed."))}}}
+                      :msg (msg "trash " (:title target))}
+             :successful-run-ends {:req (req (and (= target :archives)
+                                                  (not= (:max-access run) 0)
+                                                  (seq (filter #(is-type? % "Operation") (:discard corp)))))
+                                   :effect (effect (register-turn-flag! card :can-trash-operation (constantly false)))}}}
 
    "Exile: Streethawk"
    {:effect (effect (gain :link 1))


### PR DESCRIPTION
* Fix #1107: Uses the turn flag system to disallow Edward Kim's ability if the first operation accessed in a turn was in Archives. Includes a test, but admittedly there is a somewhat-remote corner case not accounted for--if you pop Hades Shard and there are operations in Archives, the ability would still work if you subsequently accessed one in HQ or R&D. 
* Add an ability to Jinteki Biotech to toast yourself a reminder of which version you picked. I've fielded a few requests for this from players who forget over the course of a long game. 

![image](https://cloud.githubusercontent.com/assets/10407969/13342181/af0df5e4-dc04-11e5-9b39-389707b7157a.png)
