### PR TITLE
Fix recurring credits not refilling during Step 1.2.

### DIFF
--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -73,7 +73,7 @@
                  (effect (set-prop card :rec-counter recurring))
                  recurring)]
          (register-events state side
-                          {(if (= side :corp) :corp-turn-begins :runner-turn-begins)
+                          {(if (= side :corp) :corp-phase-12 :runner-phase-12)
                            {:effect r}} c)))
      (when-let [prevent (:prevent cdef)]
        (doseq [[ptype pvec] prevent]

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -127,6 +127,7 @@
                                           (all-installed state side))
                                     (when (= side :corp) (get-in @state [side :scored]))))]
     (swap! state assoc phase true)
+    (trigger-event state side phase nil)
     (if (not-empty start-cards)
       (toast state side
                  (str "You may use " (clojure.string/join ", " (map :title start-cards))

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -519,6 +519,24 @@
       (is (nil? (:ts-active (refresh tsp1))) "Team Sponsorship 1 ability disabled")
       (is (nil? (:ts-active (refresh tsp2))) "Team Sponsorship 2 ability disabled"))))
 
+(deftest the-root
+  "The Root - recurring credits refill at Step 1.2"
+  (do-game
+    (new-game (make-deck "Blue Sun: Powering the Future" [(qty "The Root" 1)])
+              (default-runner))
+    (play-from-hand state :corp "The Root" "New remote")
+    (core/gain state :corp :credit 6)
+    (let [root (get-content state :remote1 0)]
+      (core/rez state :corp root)
+      (card-ability state :corp (refresh root) 0)
+      (is (= 2 (:rec-counter (refresh root))) "Took 1 credit from The Root")
+       (is (= 6 (:credit (get-corp))) "Corp took Root credit into credit pool")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      ; we expect Step 1.2 to have triggered because of Blue Sun
+      (is (:corp-phase-12 @state) "Corp is in Step 1.2")
+      (is (= 3 (:rec-counter (refresh root))) "Recurring credits were refilled before Step 1.2 window"))))
+
 (deftest toshiyuki-sakai
   "Toshiyuki Sakai - Swap with an asset/agenda from HQ; Runner can choose to access new card or not"
   (do-game


### PR DESCRIPTION
These credits should refill during Step 1.2 before the user can use any other abilities. Without this fix, they refill after Step 1.2 is finished, and so aren't available to use during that step if they were used on the previous turn.