### PR TITLE
Fix interaction between Hostile Infrastructure and Apocalypse/Singularity

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -309,8 +309,11 @@
                  :cost [:click 1] :advance-counter-cost 1 :effect (effect (gain :click 2))}]}
 
    "Hostile Infrastructure"
-   {:events {:runner-trash {:req (req (= (:side target) "Corp"))
-                            :msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}
+   {:events {:runner-trash {:req (req (some #(card-is? % :side :corp) targets))
+                            :msg (msg (str "do " (count (filter #(card-is? % :side :corp) targets))
+                                           " net damage"))
+                            :effect (effect (damage :net (count (filter #(card-is? % :side :corp) targets))
+                                                    {:card card}))}}
     :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
 
    "Isabel McGuire"

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -195,7 +195,7 @@
 (defn trash
   "Attempts to trash the given card, allowing for boosting/prevention effects."
   ([state side {:keys [zone type] :as card}] (trash state side card nil))
-  ([state side {:keys [zone type] :as card} {:keys [unpreventable cause] :as args} & targets]
+  ([state side {:keys [zone type] :as card} {:keys [unpreventable cause suppress-event] :as args} & targets]
    (when (not (some #{:discard} zone))
      (if (untrashable-while-rezzed? card)
        (enforce-msg state card "cannot be trashed while installed")
@@ -203,7 +203,7 @@
        (let [ktype (keyword (clojure.string/lower-case type))]
          (when (and (not unpreventable) (not= cause :ability-cost))
            (swap! state update-in [:trash :trash-prevent] dissoc ktype))
-         (when (not= (last zone) :current) ; Trashing a current does not trigger a trash event.
+         (when (and (not suppress-event) (not= (last zone) :current)) ; Trashing a current does not trigger a trash event.
            (apply trigger-event state side (keyword (str (name side) "-trash")) card cause targets))
          (let [prevent (get-in @state [:prevent :trash ktype])]
            ;; Check for prevention effects

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -375,7 +375,6 @@
     (is (= 2 (:click (get-runner))) "Runner spends 2 clicks on double event")
     (is (= 1 (:credit (get-runner))) "Runner pays 4 credits for Singularity")
     (run-successful state)
-    (prompt-choice :runner "Run ability")
     (is (= 3 (count (:discard (get-corp)))) "All 3 cards trashed from Server 1")
     (is (= 1 (:credit (get-runner))) "No credits paid for trashing")
     (is (nil? (get-in @state [:corp :servers :remote1 :content])) "Server 1 no longer exists")))


### PR DESCRIPTION
See #1270. These cards now cause one bulk `:runner-trash` event to trigger by suppressing the event for each individual card that gets trashed. Hostile Infrastucture looks at how many cards were trashed by the event to calculate the damage.

Also fixes Singularity to be a mandatory on-access effect, instead of prompting for "Use card ability".