### PR TITLE
more Mumbad spoilers (seeking review)

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -428,6 +428,11 @@
    {:msg "gain 9 [Credits]"
     :effect (effect (gain :credit 9))}
 
+   "Making an Entrance"
+   {:msg "look at and trash or rearrange the top 6 cards of their Stack"
+    :effect (req (toast state :runner "Drag remaining untrashed cards from the Temporary Zone back onto your Stack" "info")
+                 (doseq [c (take 6 (:deck runner))] (move state side c :play-area)))}
+
    "Mass Install"
    (let [mhelper (fn mi [n] {:prompt "Select a program to install"
                              :choices {:req #(and (is-type? % "Program")

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -220,6 +220,10 @@
    "Asteroid Belt"
    (space-ice end-the-run)
 
+   "Bailiff"
+   {:abilities [(gain-credits 1)
+                end-the-run]}
+
    "Bandwidth"
    {:abilities [{:msg "give the Runner 1 tag"
                  :effect (effect (tag-runner :runner 1)

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -462,6 +462,15 @@
     :msg "shuffle a card from HQ into R&D"
     :effect (effect (move target :deck) (shuffle! :deck))}
 
+   "Salems Hospitality"
+   {:msg "name a card. The Runner reveals their Grip and must trash all copies of the named card"
+    :effect (req (show-wait-prompt state :corp "Runner to reveal their Grip")
+                 (prompt! state :runner card (str "Reveal your Grip after the Corp has named a card")
+                                                  ["Reveal Grip"]
+                                                  {:msg (msg "reveal the Runner's Grip: "
+                                                             (join ", " (map :title (:hand runner))))
+                                                   :effect (effect (clear-wait-prompt :corp))}))}
+
    "Scorched Earth"
    {:req (req tagged)
     :msg "do 4 meat damage"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -823,6 +823,22 @@
              :pre-advancement-cost {:effect (effect (advancement-cost-bonus 1))}
              :pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 3]))}}}
 
+   "The Turning Wheel"
+   {:events {:run {:req (req (#{:hq :rd} target))
+                   :effect (effect (register-run-flag! card :no-agenda-stolen (constantly true)))}
+             :agenda-stolen {:req (req (#{[:hq] [:rd]} (:server run)))
+                             :effect (effect (clear-run-flag! card :no-agenda-stolen)
+                                             (register-run-flag! card :no-agenda-stolen (constantly false)))}
+             :run-ends {:req (req (and (run-flag? state side card :no-agenda-stolen)
+                                       (#{:hq :rd} target)))
+                        :effect (effect (add-prop card :counter 1))}}
+    :abilities [{:req (req (and (:run @state)
+                                (#{[:hq] [:rd]} (:server run))
+                                (> (:counter card 0) 1)))
+                 :msg "access 1 additional card for the remainder of the run"
+                 :effect (effect (add-prop card :counter -2)
+                                 (access-bonus 1))}]}
+
    "Theophilius Bagbiter"
    {:effect (req (lose state :runner :credit :all)
                  (add-watch state :theophilius-bagbiter

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -105,6 +105,24 @@
                    :msg "gain 1 [Credits]"
                    :effect (effect (gain :runner :credit 1))}}}
 
+   "Councilman"
+   {:events {:rez {:req (req (and (#{"Asset" "Upgrade"} (:type target))
+                                  (can-pay? state :runner nil [:credit (rez-cost state :corp target)])))
+                   :effect (req (toast state :runner "Click Councilman to derez the asset or upgrade that was just rezzed" "info"))}}
+    :abilities [{:prompt "Choose an asset or upgrade that was just rezzed"
+                 :choices {:req #(and (rezzed? %)
+                                      (or (is-type? % "Asset") (is-type? % "Upgrade")))}
+                 :effect (req (let [c target
+                                    creds (rez-cost state :corp c)]
+                                (when (can-pay? state side nil [:credit creds])
+                                  (resolve-ability
+                                    state :runner
+                                    {:msg (msg "pay " creds " [Credit] and derez " (:title c) ". Councilman is trashed")
+                                     :effect (req (lose state :runner :credit creds)
+                                                  (derez state :corp c)
+                                                  (trash state side card {:unpreventable true}))}
+                                   card nil))))}]}
+
    "Crash Space"
    {:prevent {:damage [:meat]}
     :recurring 2

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -108,8 +108,8 @@
    "Councilman"
    {:events {:rez {:req (req (and (#{"Asset" "Upgrade"} (:type target))
                                   (can-pay? state :runner nil [:credit (rez-cost state :corp target)])))
-                   :effect (req (toast state :runner (str "Click Councilman to derez " (:title target)
-                                                          " just rezzed in " (zone->name (second (:zone target)))) "info"))}}
+                   :effect (req (toast state :runner (str "Click Councilman to derez " (card-str state target {:visible true})
+                                                          " that was just rezzed") "info"))}}
     :abilities [{:prompt "Choose an asset or upgrade that was just rezzed"
                  :choices {:req #(and (rezzed? %)
                                       (or (is-type? % "Asset") (is-type? % "Upgrade")))}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -323,6 +323,24 @@
                                         (assoc card :zone '(:discard))))}
       :events {:pre-steal-cost ab :run-ends nil}})
 
+   "Surat City Grid"
+   {:events
+    {:rez {:req (req (let [serv (card->server state card)
+                           servcards (concat (:ices serv) (:contents serv))]
+                       (and (= (card->server state target) serv)
+                            (not= (:cid target) (:cid card))
+                            (seq (filter #(not (rezzed? %)) servcards)))))
+           :effect (effect (resolve-ability
+                             {:optional
+                              {:prompt (msg "Rez another card in or protecting " (zone->name (second (:zone card)))
+                                            " with Surat City Grid?")
+                               :yes-ability {:prompt "Choose a card to rez"
+                                             :choices {:req #(= (card->server state %) (card->server state card))}
+                                             :msg (msg "rez " (:title target) ", lowering the rez cost by 2 [Credits]")
+                                             :effect (effect (rez-cost-bonus -2)
+                                                             (rez target))}}}
+                            card nil))}}}
+
    "The Twins"
    {:abilities [{:label "Reveal and trash a copy of the ICE just passed from HQ"
                  :req (req (and this-server

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -45,6 +45,12 @@
   [state]
   (swap! state assoc-in [:stack :current-run] nil))
 
+(defn clear-run-flag!
+  "Remove any entry associated with card for the given flag"
+  [state side card flag]
+  (swap! state update-in [:stack :current-run flag]
+         #(remove (fn [map] (= (:cid (map :card)) (:cid %2))) %1) card))
+
 (defn register-turn-flag!
   "As register-run-flag, but for the entire turn."
   [state side card flag condition]


### PR DESCRIPTION
Some notes on card choices...

**Councilman**: Based on early feedback, this doesn't automatically throw an optional use prompt at the Runner for every qualifying rez to avoid slowing the game down. Instead the Runner gets a toast only if they can afford to pay the cost, and then they just click to use. However, to avoid snafus it doesn't do tight enforcement of what you can target (beyond that it's a rezzed asset/upgrade), so players need to be accountable to each other.

**Guru Davinder**: Corp players need to slow down when applying multiple damage subroutines (e.g. Komainu) and let the Runner decide to whether or not to pay to keep it in play (could add a wait prompt for the Corp here). This will probably have a bad interaction with Gemini and have the same problems as Deus X highlighted in #1252.

**Salem's Hospitality**: The Runner gets a prompt that will perform the reveal of their Grip, but they should wait to use it until the Corp has named a card in game chat. Then any required trashing can be verified. 