### PR TITLE
Fix Sneakdoor Beta interaction with Crisium Grid, #1229.

### DIFF
--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -387,8 +387,10 @@
 (defn- successful-run-trigger
   "The real 'successful run' trigger."
   [state side]
-  (when-let [successful-run-effect (get-in @state [:run :run-effect :successful-run])]
-    (resolve-ability state side successful-run-effect (:card successful-run-effect) nil))
+  (let [successful-run-effect (get-in @state [:run :run-effect :successful-run])]
+    (when (and successful-run-effect (not (apply trigger-suppress state side :successful-run
+                                                 (get-in @state [:run :run-effect :card]))))
+      (resolve-ability state side successful-run-effect (:card successful-run-effect) nil)))
   (let [server (get-in @state [:run :server])]
     (register-successful-run state side server)
     (let [run-effect (get-in @state [:run :run-effect])

--- a/src/clj/test/cards-programs.clj
+++ b/src/clj/test/cards-programs.clj
@@ -312,6 +312,22 @@
       (run-successful state)
       (is (= 2 (:counter (refresh nerve)))))))
 
+(deftest sneakdoor-crisium
+  "Sneakdoor Beta - do not switch to HQ if Archives has Crisium Grid. Issue #1229."
+  (do-game
+    (new-game (default-corp [(qty "Crisium Grid" 1) (qty "Priority Requisition" 1) (qty "Private Security Force" 1)])
+              (default-runner [(qty "Sneakdoor Beta" 1)]))
+    (play-from-hand state :corp "Crisium Grid" "Archives")
+    (trash-from-hand state :corp "Priority Requisition")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Sneakdoor Beta")
+    (let [sb (get-in @state [:runner :rig :program 0])
+          cr (get-content state :archives 0)]
+      (core/rez state :corp cr)
+      (card-ability state :runner sb 0)
+      (run-successful state)
+      (is (= :archives (get-in @state [:run :server 0])) "Crisium Grid stopped Sneakdoor Beta from switching to HQ"))))
+
 (deftest surfer
   "Surfer - Swap position with ice before or after when encountering a barrier ice"
   (do-game


### PR DESCRIPTION
Don't fire a card's `:successful-run` ability (which is NOT an event that could've been suppressed by Crisium Grid, but is instead encoded into the `[:run :run-effect :successful-run]` state) if the `:successful-run` event would have been suppressed by some card source (namely Crisium Grid). Fixes #1229. Includes test.