### PR TITLE
Server run restrictions

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -183,6 +183,15 @@
    {:events {:agenda-scored {:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}
              :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}}
 
+   "Jinteki: Replicating Perfection"
+   {:events
+    {:runner-turn-begins {:effect (req (apply prevent-run-on-server
+                                              state card (map first (get-remotes @state))))}
+     :run {:once :per-turn
+           :req (req (is-central? (:server run)))
+           :effect (req (apply enable-run-on-server
+                               state card (map first (get-remotes @state))))}}}
+
    "Jinteki Biotech: Life Imagined"
    {:events {:pre-first-turn {:req (req (= side :corp))
                               :prompt "Choose a copy of Jinteki Biotech to use this game"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -213,8 +213,11 @@
                          :effect (effect (trash-cost-bonus 3))}}}
 
    "Off the Grid"
-   {:events {:successful-run {:req (req (= target :hq))
+   {:effect (req (prevent-run-on-server state card (second (:zone card))))
+    :events {:successful-run {:req (req (= target :hq))
                               :effect (req (trash state :corp card)
+                                           (enable-run-on-server state card
+                                                                 (second (:zone card)))
                                            (system-msg state :corp (str "trashes Off the Grid")))}}}
 
    "Old Hollywood Grid"

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -4,7 +4,8 @@
 
 (declare card-str can-rez? corp-install enforce-msg gain-agenda-point get-remote-names
          jack-out move name-zone play-instant purge resolve-select run has-subtype?
-         runner-install trash update-breaker-strength update-ice-in-server update-run-ice win)
+         runner-install trash update-breaker-strength update-ice-in-server update-run-ice win
+         can-run-server?)
 
 ;;; Neutral actions
 (defn play
@@ -263,7 +264,9 @@
 (defn click-run
   "Click to start a run."
   [state side {:keys [server] :as args}]
-  (when (and (not (get-in @state [:runner :register :cannot-run])) (can-pay? state :runner "a run" :click 1))
+  (when (and (not (get-in @state [:runner :register :cannot-run]))
+             (can-run-server? state server)
+             (can-pay? state :runner "a run" :click 1))
     (system-msg state :runner (str "makes a run on " server))
     (run state side server)
     (pay state :runner nil :click 1)))

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -106,15 +106,6 @@
         (swap! state assoc-in [:runner :register :cannot-run-on-server server]
                reduced-card-map)))))
 
-#_(defn runable-servers
-  "Returns all servers that can be run on.
-  Servers will be returned as keywords."
-  [state]
-  (let [servers (keys (get-in @state [:corp :servers]))
-        restricted-servers (keys (get-in @state [:runner :register :cannot-run-on-server]))]
-    ;; remove restricted servers from all servers to just return allowed servers
-    (remove (set restricted-servers) (set servers))))
-
 (defn can-run-server?
   "Returns true if the specified server can be run on. Specified server must be string form."
   [state server]

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -23,17 +23,20 @@
   (or (pos? (get-in state [:runner :tag]))
       (pos? (get-in state [:runner :tagged]))))
 
-(defn register-run-flag! [state side card flag condition]
+(defn register-run-flag!
   "Registers a flag for the current run only. The flag gets cleared in end-run.
   Example: Blackmail flags the inability to rez ice."
+  [state side card flag condition]
   (let [stack (get-in @state [:stack :current-run flag])]
-    (swap! state assoc-in [:stack :current-run flag] (conj stack {:card card :condition condition}))))
+    (swap! state assoc-in [:stack :current-run flag]
+           (conj stack {:card card :condition condition}))))
 
-(defn run-flag? [state side card flag]
+(defn run-flag?
   "Execute all conditions for the given run flag
   The resulting collection is expected to be empty if nothing is blocking the action
   If the collection has any contents, the flag is considered to be false
   (consider it as something has flagged the action as not being allowed)"
+  [state side card flag]
   (empty?
     (for [condition (get-in @state [:stack :current-run flag])
           :let [result ((:condition condition) state side card)]
@@ -80,6 +83,44 @@
   [state side card flag]
   (swap! state update-in [:stack :persistent flag]
          #(remove (fn [map] (= (:cid (map :card)) (:cid %2))) %1) card))
+
+;;; Functions related to servers that can be run
+(defn prevent-run-on-server 
+  "Adds specified server to list of servers that cannot be run on.
+  The causing card is also specified"
+  [state card & servers]
+  (doseq [server servers]
+    (swap! state assoc-in [:runner :register :cannot-run-on-server server (:cid card)] true)))
+
+(defn enable-run-on-server
+  "Removes specified server from list of server for the associated card.
+  If other cards are associated with the same server that server will still be unable to be run
+  on."
+  [state card & servers]
+  (doseq [server servers]
+    (let [card-map (get-in @state [:runner :register :cannot-run-on-server server])
+          reduced-card-map (dissoc card-map (:cid card))]
+      (if (empty? reduced-card-map)
+        ;; removes server if no cards block it, otherwise updates the map
+        (swap! state update-in [:runner :register :cannot-run-on-server] dissoc server)
+        (swap! state assoc-in [:runner :register :cannot-run-on-server server]
+               reduced-card-map)))))
+
+#_(defn runable-servers
+  "Returns all servers that can be run on.
+  Servers will be returned as keywords."
+  [state]
+  (let [servers (keys (get-in @state [:corp :servers]))
+        restricted-servers (keys (get-in @state [:runner :register :cannot-run-on-server]))]
+    ;; remove restricted servers from all servers to just return allowed servers
+    (remove (set restricted-servers) (set servers))))
+
+(defn can-run-server?
+  "Returns true if the specified server can be run on. Specified server must be string form."
+  [state server]
+  (not-any? #{server}
+            (map zone->name (keys (get-in @state [:runner :register :cannot-run-on-server])))))
+
 
 ;;; Functions for preventing specific game actions.
 ;;; TODO: look into migrating these to turn-flags and run-flags.

--- a/src/clj/test/cards-identities.clj
+++ b/src/clj/test/cards-identities.clj
@@ -313,6 +313,18 @@
       (core/rez state :corp quan)
       (is (= 5 (:credit (get-corp))) "Rez cost increased by 1"))))
 
+(deftest replicating-perfection
+  "Replicating Perfection - Prevent runner from running on remotes unless they first run on a central"
+  (do-game
+   (new-game
+    (make-deck "Jinteki: Replicating Perfection" [(qty "Mental Health Clinic" 3)])
+    (default-runner))
+   (play-from-hand state :corp "Mental Health Clinic" "New remote")
+   (take-credits state :corp)
+   (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
+   (run-empty-server state "HQ")
+   (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")))
+
 (deftest spark-advertisements
   "Spark Agency - Rezzing advertisements"
   (do-game

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -176,6 +176,25 @@
       (is (= :waiting (-> @state :runner :prompt first :prompt-type))
           "Runner prompt is waiting for Corp"))))
 
+(deftest off-the-grid
+  "Off the Grid run ability - and interaction with RP"
+  (do-game
+   (new-game
+    (make-deck "Jinteki: Replicating Perfection" [(qty "Off the Grid" 3)
+                                                  (qty "Mental Health Clinic" 3)])
+    (default-runner))
+   (play-from-hand state :corp "Off the Grid" "New remote")
+   (play-from-hand state :corp "Mental Health Clinic" "Server 1")
+   (let [otg (get-content state :remote1 0)]
+     (take-credits state :corp)
+     (core/rez state :corp (refresh otg))
+     (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
+     (run-empty-server state "R&D")
+     (is (not (core/can-run-server? state "Server 1")) "Runner cannot run on Off the Grid")
+     (run-empty-server state "HQ")
+     (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on Server 1")
+     (is (= nil (refresh otg)) "Off the Grid trashed"))))
+
 (deftest old-hollywood-grid
   "Old Hollywood Grid - Ability"
   (do-game


### PR DESCRIPTION
Implements Replicating Perfection and Off the Grid. Prevents runs on blocked servers, and removes these servers from the run list (when clicking "Run" button).

Adds tests for Off the Grid and Replicating Perfection (and their interaction).

Note that the implementation of this flag system means that multiple cards can block the same server without the blocking being overridden. (Think RP and Off the Grid interaction).

Screen shot:
<img width="706" alt="screen shot 2016-02-29 at 23 29 20" src="https://cloud.githubusercontent.com/assets/13198563/13412717/10f8dd74-df3d-11e5-978d-57b969fcd63b.png">

NB: Have not tested what happens in run selection for run events.
