### PR TITLE
Add score/rez restrictions to Mushin No Shin and Dedication Ceremony targets

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -192,7 +192,13 @@
    {:prompt "Choose a faceup card"
     :choices {:req rezzed?}
     :msg (msg "place 3 advancement tokens on " (card-str state target))
-    :effect (effect (add-prop :corp target :advance-counter 3 {:placed true}))}
+    :effect (effect (add-prop :corp target :advance-counter 3 {:placed true})
+                    (register-turn-flag!
+                      target :can-score
+                      (fn [state side card]
+                        (if (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card)))
+                          ((constantly false) (toast state :corp "Cannot score due to Dedication Ceremony." "warning"))
+                          true))))}
 
    "Defective Brainchips"
    {:events {:pre-damage {:req (req (= target :brain)) :msg "to do 1 additional brain damage"
@@ -307,7 +313,17 @@
     :choices {:req #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))
                          (= (:side %) "Corp")
                          (in-hand? %))}
-    :effect (effect (corp-install (assoc target :advance-counter 3) "New remote"))}
+    :effect (effect (corp-install (assoc target :advance-counter 3) "New remote")
+                    (register-turn-flag!
+                      target :can-rez
+                      (fn [state side card]
+                        ((constantly false) (toast state :corp "Cannot rez due to Mushin No Shin." "warning"))))
+                    (register-turn-flag!
+                      target :can-score
+                      (fn [state side card]
+                        (if (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card)))
+                          ((constantly false) (toast state :corp "Cannot score due to Mushin No Shin." "warning"))
+                          true))))}
 
    "Mutate"
    {:req (req (seq (filter (every-pred rezzed? ice?) (all-installed state :corp))))

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -5,7 +5,7 @@
 (declare card-str can-rez? corp-install enforce-msg gain-agenda-point get-remote-names
          jack-out move name-zone play-instant purge resolve-select run has-subtype?
          runner-install trash update-breaker-strength update-ice-in-server update-run-ice win
-         can-run-server?)
+         can-run-server? can-score?)
 
 ;;; Neutral actions
 (defn play
@@ -233,20 +233,21 @@
   "Score an agenda."
   [state side args]
   (let [card (or (:card args) args)]
-    (when (and (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
-               (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))
-      (let [moved-card (move state :corp card :scored)
-            c (card-init state :corp moved-card)
-            points (get-agenda-points state :corp c)]
-        (system-msg state :corp (str "scores " (:title c) " and gains " points
-                                     " agenda point" (when (> points 1) "s")))
-        (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
-        (gain-agenda-point state :corp points)
-        (set-prop state :corp c :advance-counter 0)
-        (trigger-event state :corp :agenda-scored (assoc c :advance-counter 0))
-        (when-let [current (first (get-in @state [:runner :current]))]
-          (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
-          (trash state side current))))))
+    (when (can-score? state side card)
+      (when (and (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
+                 (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))
+        (let [moved-card (move state :corp card :scored)
+              c (card-init state :corp moved-card)
+              points (get-agenda-points state :corp c)]
+          (system-msg state :corp (str "scores " (:title c) " and gains " points
+                                       " agenda point" (when (> points 1) "s")))
+          (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
+          (gain-agenda-point state :corp points)
+          (set-prop state :corp c :advance-counter 0)
+          (trigger-event state :corp :agenda-scored (assoc c :advance-counter 0))
+          (when-let [current (first (get-in @state [:runner :current]))]
+            (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
+            (trash state side current)))))))
 
 (defn no-action
   "The corp indicates they have no more actions for the encounter."

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -206,6 +206,11 @@
           (rez-req state side card nil)
           true))))
 
+(defn can-score?
+  ([state side card] (can-score? state side card nil))
+  ([state side card {:as args}]
+   (turn-flag? state side card :can-score)))
+
 (defn can-be-advanced?
   "Returns true if the card can be advanced"
   [card]


### PR DESCRIPTION
Fix #1119.

This extends the flag system to checking for ability to score agendas. Includes a Mushin No Shin test that validates both the same-turn scoring and rezzing restrictions on the installed card. 