### PR TITLE
fix High-Stakes Job identification of valid servers

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -282,8 +282,8 @@
    "High-Stakes Job"
    {:prompt "Choose a server"
     :choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
-                        ok-servs (filter unrezzed-ice runnable-servers)]
-                    (map (comp zone->name first) ok-servs)))
+                        ok-servs (filter unrezzed-ice (get-in @state [:corp :servers]))]
+                    (filter #(can-run-server? state %) (map (comp zone->name first) ok-servs))))
     :effect (effect (run target {:end-run {:req (req (:successful run)) :msg " gain 12 [Credits]"
                                            :effect (effect (gain :runner :credit 12))}} card))}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -880,10 +880,11 @@
                                   :prompt "Choose one"
                                   :choices ["Lose [Click]" "End the run"]
                                   :effect (req (if-not (and (= target "Lose [Click]")
-                                                            (pay state side card :click 1))
+                                                            (apply pay state side card [:click 1]))
                                                  (do (end-run state side)
                                                      (system-msg state side "ends the run"))
-                                                 (system-msg state side "loses [Click]")))})]}
+                                                 (do (lose state side :click 1)
+                                                     (system-msg state side "loses [Click]"))))})]}
 
    "Tsurugi"
    {:abilities [end-the-run


### PR DESCRIPTION
The edit made to High-Stakes Job in #1298 resulted in an empty set of valid server targets and the event just going to the Heap with nothing else happening. Oops! 

Fix #1297: Runner should gain back a click if Adjusted Chronotype is installed and they lose a click from Troll. 