### PR TITLE
implement Genetics Pavilion

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -292,6 +292,14 @@
                       :msg "add it to their score area and gain 1 agenda point"
                       :effect (effect (as-agenda :corp card 1))}}}
 
+   "Genetics Pavilion"
+   {:msg "prevent the Runner from drawing more than 2 cards during their turn"
+    :effect (req (max-draw state :runner 2)
+                 (when (= 0 (remaining-draws state side))
+                   (prevent-draw state side)))
+    :events {:runner-turn-begins {:effect (effect (max-draw 2))}}
+    :leave-play (req (swap! state update-in [:runner :register] dissoc :max-draw))}
+
    "Ghost Branch"
    (advance-ambush 0 {:msg (msg "give the Runner " (:advance-counter card) " tag"
                                 (when (> (:advance-counter card) 1) "s"))

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -204,6 +204,33 @@
     (is (find-card "Franchise City" (:scored (get-corp))) "Franchise City in corp scored area")
     (is (= 1 (:agenda-point (get-corp))) "Corp has 1 point")))
 
+(deftest genetics-pavilion
+  (do-game
+    (new-game (default-corp [(qty "Genetics Pavilion" 1)])
+              (default-runner [(qty "Diesel" 2) (qty "Sure Gamble" 3)]))
+    (play-from-hand state :corp "Genetics Pavilion" "New remote")
+    (let [gp (get-content state :remote1 0)]
+      (take-credits state :corp)
+      (core/rez state :corp gp)
+      (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
+      (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
+      (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
+      (is (= 2 (count (:hand (get-runner)))))
+      (play-from-hand state :runner "Diesel")
+      (is (= 3 (count (:hand (get-runner)))) "Drew only 2 cards because of Genetics Pavilion")
+      (take-credits state :runner)
+      (core/derez state :corp (refresh gp))
+      (take-credits state :corp)
+      (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
+      (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
+      (core/move state :runner (find-card "Diesel" (:discard (get-runner))) :deck)
+      (is (= 1 (count (:hand (get-runner)))))
+      (play-from-hand state :runner "Diesel")
+      (is (= 3 (count (:hand (get-runner)))) "Drew 3 cards with Diesel")
+      (core/rez state :corp (refresh gp))
+      (core/draw state :runner)
+      (is (= 3 (count (:hand (get-runner)))) "No card drawn; GP counts cards drawn prior to rez"))))
+
 (deftest ghost-branch
   "Ghost Branch - Advanceable; give the Runner tags equal to advancements when accessed"
   (do-game


### PR DESCRIPTION
Seeking review on this one from the usual suspects...

I added a couple new draw-related functions and modified `draw` itself. Now the system will both track the number of cards drawn in a given turn and--if a maximum has been set--the number of remaining draws allowed. Then `draw` checks if the number passed to it needs to be reduced or not. 

Includes a test for the Corp rezzing Genetics Pavilion both prior to the Runner turn starting and after they've already drawn 2 or more cards to ensure that it accounts for prior draws when enforcing the maximum. I also tested interactions with I've Had Worse being hit by damage, allowing more than 2 Runner draws during the Corp turn (e.g., Sports Hopper), and that the maximum is lifted immediately if the Runner trashes GP. 