### PR TITLE
More fixes for Sneakdoor Beta: Ash trace, Security Testing

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -590,6 +590,9 @@
                                    {:req (req (= target :archives))
                                     :successful-run
                                     {:effect (req (swap! state assoc-in [:run :server] [:hq])
+                                                  ; remove the :req from the run-effect, so that other cards that replace
+                                                  ; access don't use Sneakdoor's req. (Security Testing, Ash 2X).
+                                                  (swap! state dissoc-in [:run :run-effect :req])
                                                   (trigger-event state :corp :no-action)
                                                   (update-run-ice state side)
                                                   (system-msg state side

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -715,14 +715,14 @@
                   :effect (effect (update! (assoc card :testing-target (vec (next (server->zone state target))))))}]
    {:events {:runner-turn-begins ability
              :successful-run
-             {:req (req (= (get-in @state [:run :server]) (get (get-card state card) :testing-target)))
+             {:req (req (= (get-in @state [:run :server]) (:testing-target (get-card state card))))
               :once :per-turn
               :effect (req (let [st card]
                              (swap! state assoc-in [:run :run-effect :replace-access]
                                     {:mandatory true
                                      :effect (effect (resolve-ability
-                                                      {:msg "gain 2 [Credits] instead of accessing"
-                                                       :effect (effect (gain :credit 2))} st nil))})))}}
+                                                       {:msg "gain 2 [Credits] instead of accessing"
+                                                        :effect (effect (gain :credit 2))} st nil))})))}}
     :abilities [ability]})
 
    "Spoilers"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -19,8 +19,9 @@
                          :effect (req (max-access state side 0)
                                       (let [ash card]
                                         (swap! state update-in [:run :run-effect]
-                                               #(assoc % :successful-run
-                                                         {:effect (effect (handle-access [ash])) :card ash}))))
+                                               #(assoc % :replace-access
+                                                         {:mandatory true
+                                                          :effect (effect (handle-access [ash])) :card ash}))))
                          :msg "prevent the Runner from accessing cards other than Ash 2X3ZB9CY"}}]}
 
    "Awakening Center"


### PR DESCRIPTION
Fixes Sneakdoor Beta interactions with Ash and Security Testing. Improves all three cards involved.

For Sneakdoor, upon successful run the card switches the `:run :server` to `:hq`, which is great. Then the run code checks to see if there is a `:replace-access` function defined, and if so, the `:req` for that function is tested and then it is executed instead of access if the `:req` is true. Security Testing uses this `:replace-access` function to grant the 2 credits, which sounds perfect. So why was this interaction broken? `:replace-access` doesn't get its own `:req`, it reuses the key from `:run-effect`, which is the function set by Sneakdoor Beta to make sure the run is successful on Archives before doing the switch to HQ. So Security Testing's replace-access effect was using Sneakdoor's function to make sure the run was still on Archives, which of course it's not by the time Security Testing kicks in. Fix: Sneakdoor removes its `:req` from `:run-effect`, fixing its interaction with Security Testing and any other future cards that replace access as a permanent effect.

For Ash, the card simply needs to use `:replace-access` in `:run-effect` instead of `:successful-run`. Using the latter competes with Sneakdoor's `:successful-run`, so that the run is not switched to HQ (because Sneakdoor's effect was overridden by Ash's). Ash's effect really belongs in `:replace-access`, where it works much better.