### PR TITLE
Two fixes for Leela

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -266,17 +266,17 @@
    {:events {:agenda-scored
              {:effect (req (toast state :runner
                                   (str "Click Leela Patel: Trained Pragmatist to add 1 unrezzed card to HQ.") "info")
-                           (update! state :runner (assoc card :bounce-hq true)))}
+                           (update! state :runner (update-in card [:bounce-hq] #(inc (or % 0)))))}
              :agenda-stolen
              {:effect (req (toast state :runner
                                   (str "Click Leela Patel: Trained Pragmatist to add 1 unrezzed card to HQ.") "info")
-                           (update! state side (assoc card :bounce-hq true)))}}
-    :abilities [{:req (req (:bounce-hq card))
+                           (update! state :runner (update-in card [:bounce-hq] #(inc (or % 0)))))}}
+    :abilities [{:req (req (pos? (:bounce-hq card 0)))
                  :choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :player :runner
                  :priority true
                  :msg (msg "add " (card-str state target) " to HQ")
                  :effect (effect (move :corp target :hand)
-                                 (update! (dissoc (get-card state card) :bounce-hq)))}]}
+                                 (update! (update-in (get-card state card) [:bounce-hq] dec)))}]}
 
    "MaxX: Maximum Punk Rock"
    (let [ability {:msg "trash the top 2 cards from Stack and draw 1 card"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -263,7 +263,8 @@
                  :effect (req (draw state :corp) (swap! state assoc-in [:per-turn (:cid card)] true))}]}
 
    "Leela Patel: Trained Pragmatist"
-   {:events {:agenda-scored
+   {:flags {:slow-hq-access (req true)}
+    :events {:agenda-scored
              {:effect (req (toast state :runner
                                   (str "Click Leela Patel: Trained Pragmatist to add 1 unrezzed card to HQ.") "info")
                            (update! state :runner (update-in card [:bounce-hq] #(inc (or % 0)))))}

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare all-installed cards deactivate card-flag? get-card-hosted handle-end-run ice?
+(declare all-active all-installed cards deactivate card-flag? get-card-hosted handle-end-run ice?
          has-subtype? remove-from-host rezzed?
          trash update-hosted! update-ice-strength remove-icon)
 

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -72,6 +72,15 @@
     (let [servers (->> (:corp @state) :servers seq flatten)]
       (concat (mapcat :content servers) (mapcat :ices servers)))))
 
+(defn all-active
+  "Returns a vector of all active cards for the given side. Active cards are either installed, the identity,
+  or the corp's scored area."
+  [state side]
+  (if (= side :runner)
+    (cons (get-in @state [:runner :identity]) (all-installed state side))
+    (cons (get-in @state [:corp :identity]) (concat (all-installed state side)
+                                                    (get-in @state [:corp :scored])))))
+
 (defn installed-byname
   "Returns a truthy card map if a card matching title is installed"
   [state side title]

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -171,7 +171,7 @@
 
 (defn access-count [state side kw]
   (let [run (:run @state)
-        accesses (+ (get-in @state [:runner kw]) (:access-bonus run))]
+        accesses (+ (get-in @state [:runner kw]) (:access-bonus run 0))]
     (if-let [max-access (:max-access run)]
       (min max-access accesses) accesses)))
 
@@ -194,11 +194,10 @@
                   (handle-access state side cards)
                   (resolve-ability state side (access-helper-remote cards) card nil)))})
 
-(defn access-helper-hq [cards]
+(defn access-helper-hq [from-hq from-root already-accessed]
   {:prompt "Select a card to access."
-   :choices (concat (when (some #(= (first (:zone %)) :hand) cards) ["Card from hand"])
-                    (map #(if (rezzed? %) (:title %) "Unrezzed upgrade in HQ")
-                         (filter #(= (last (:zone %)) :content) cards)))
+   :choices (concat (when (pos? from-hq) ["Card from hand"])
+                    (map #(if (rezzed? %) (:title %) "Unrezzed upgrade in HQ") from-root))
    :effect (req (case target
                   "Unrezzed upgrade in HQ"
                   ;; accessing an unrezzed upgrade
@@ -207,38 +206,51 @@
                       ;; only one unrezzed upgrade; access it and continue
                       (do (system-msg state side (str "accesses " (:title (first unrezzed))))
                           (handle-access state side unrezzed)
-                          (when (< 1 (count cards))
+                          (when (or (pos? from-hq) (< 1 (count from-hq)))
                             (resolve-ability
-                              state side (access-helper-hq (filter #(not= (:cid %) (:cid (first unrezzed))) cards))
+                              state side (access-helper-hq from-hq
+                                                           (filter #(not= (:cid %) (:cid (first unrezzed))) from-root)
+                                                           already-accessed)
                               card nil)))
-                      ;; more than one unrezzed upgrade. allow user to select with mouse.
+                      ;; more than one unrezzed upgrade. allow user to select.
                       (resolve-ability state side
                                        {:prompt "Choose an upgrade in HQ to access."
                                         :choices {:req #(= (second (:zone %)) :hq)}
                                         :effect (effect (system-msg (str "accesses " (:title target)))
                                                         (handle-access [target])
                                                         (resolve-ability (access-helper-hq
+                                                                           from-hq
                                                                            (remove-once #(not= (:cid %) (:cid target))
-                                                                                        cards)) card nil))} card nil)))
-                  ;; accessing a card in hand or a rezzed upgade
+                                                                                        from-root)
+                                                                           already-accessed)
+                                                                         card nil))} card nil)))
+                  ;; accessing a card in hand
                   "Card from hand"
-                  (do (system-msg state side (str "accesses " (:title (first cards))))
-                      (handle-access state side [(first cards)])
-                      (when (< 1 (count cards))
-                        (resolve-ability state side (access-helper-hq (rest cards)) card nil)))
+                  (when-let [accessed (some #(when-not (contains? already-accessed %) %) (shuffle (get-in @state [:corp :hand])))]
+                    (system-msg state side (str "accesses " (:title accessed)))
+                    (handle-access state side [accessed])
+                    (when (or (< 1 from-hq) (not-empty from-root))
+                      (resolve-ability state side (access-helper-hq (dec from-hq)
+                                                                    from-root
+                                                                    (conj already-accessed accessed))
+                                         card nil)))
                   ;; accessing a rezzed upgrade
                   (do (system-msg state side (str "accesses " target))
                       (handle-access state side [(some #(when (= (:title %) target) %) cards)])
-                      (when (< 1 (count cards))
-                        (resolve-ability state side (access-helper-hq
-                                                      (remove-once #(not= (:title %) target) cards)) card nil)))))})
+                      (when (or (pos? from-hq) (< 1 (count from-hq)))
+                        (resolve-ability state side (access-helper-hq from-hq
+                                                                      (remove-once #(not= (:title %) target) cards)
+                                                                      already-accessed) card nil)))))})
 
 (defmethod choose-access :hq [cards server]
   {:effect (req (if (pos? (count cards))
-                  (if (= 1 (count cards))
+                  (if (and (= 1 (count cards)) (not (some #(card-flag-fn? state :runner % :slow-hq-access true)
+                                                          (all-active state :runner))))
                     (do (when (pos? (count cards)) (system-msg state side (str "accesses " (:title (first cards)))))
                         (handle-access state side cards))
-                    (resolve-ability state side (access-helper-hq cards) card nil))))})
+                    (let [in-root (filter #(= (last (:zone %)) :content) cards)
+                          from-hq (access-count state side :hq-access)]
+                      (resolve-ability state side (access-helper-hq from-hq in-root #{}) card nil)))))})
 
 (defn access-helper-rd [cards]
   {:prompt "Select a card to access."


### PR DESCRIPTION
1. If Leela has a multi-access on HQ and accesses an agenda first, she must immediately bounce an unrezzed card to HQ. That card is supposed to be eligible for the remaining access attempts, but the access code selects all the cards to be accessed the moment accessing begins; the "next card from HQ" UI is just a trick, as the cards to be accessed have been pre-determined, and any card added to HQ after that list is created would never be accessed. I reworked HQ access to pick a random card from whatever is currently in HQ with each access attempt.

    For this to work best, I added a new flag to Leela: `:slow-hq-access`. When this flag is true, then any HQ access will always show the "Select a card to access" prompt, even if the runner can only access one card. (Without this flag, if only one card is going to be accessed, it will be accessed immediately with no UI interaction.) Leela needs this to force the UI prompt to slow down access, allowing her to bounce whenever necessary. I think I can port this to Gagarin so that a runner can turn down accessing a single-card remote.

    Fixes #1271.

2. There is a specific interaction with Gang Sign by which Leela should be able to bounce more than one card during one access phase. If Leela has Gang Sign and HQ Interface installed, and the corp scores an agenda, Leela gains +1 bounce but can choose to Gang Sign first. If during Gang Sign she accesses another agenda, she must immediately bounce a card, but the original bounce that has been saved is currently being lost. I changed the card logic to keep track of a # of bounces allowed, rather than a boolean yes/no.

    Fixes a bug reported on reddit.