### PR TITLE
refactor Haarpsichord Studios and Old Hollywood Grid

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -131,8 +131,14 @@
    {:effect (effect (gain :credit 5 :bad-publicity 1))}
 
    "Haarpsichord Studios: Entertainment Unleashed"
-   {:events {:pre-steal-cost {:req (req (:stole-agenda runner-reg))
-                              :effect (effect (prevent-steal))}}}
+   {:events {:agenda-stolen
+             {:effect (effect (register-turn-flag!
+                                card :can-steal
+                                (fn [state side card]
+                                  (if (is-type? card "Agenda")
+                                    ((constantly false)
+                                     (toast state :runner "Cannot steal due to Haarpsichord Studios." "warning"))
+                                    true))))}}}
 
    "Haas-Bioroid: Engineering the Future"
    {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -276,10 +276,11 @@
                                   " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]}
 
    "Gang Sign"
-   {:events {:agenda-scored {:effect (req (system-msg state :runner (str "can access cards in HQ by clicking on Gang Sign"))
+   {:events {:agenda-scored {:effect (req (toast state :runner "Click on Gang Sign to access 1 card from HQ" "info")
                                           (update! state side (assoc card :access-hq true)))}}
     :abilities [{:req (req (:access-hq card))
-                 :msg (msg "access " (get-in @state [:runner :hq-access]) " card from HQ")
+                 :msg (msg "access " (get-in @state [:runner :hq-access]) " card"
+                           (when (< 1 (get-in @state [:runner :hq-access])) "s") " from HQ")
                  :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
                                 (resolve-ability state :runner (choose-access c '(:hq)) card nil)
                                 (update! state side (dissoc (get-card state card) :access-hq))))}]}

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -91,7 +91,7 @@
          #(remove (fn [map] (= (:cid (map :card)) (:cid %2))) %1) card))
 
 ;;; Functions related to servers that can be run
-(defn prevent-run-on-server 
+(defn prevent-run-on-server
   "Adds specified server to list of servers that cannot be run on.
   The causing card is also specified"
   [state card & servers]
@@ -205,6 +205,12 @@
         (if-let [rez-req (:rez-req (card-def card))]
           (rez-req state side card nil)
           true))))
+
+(defn can-steal?
+  ([state side card] (can-steal? state side card nil))
+  ([state side card {:as args}]
+   (and (turn-flag? state side card :can-steal)
+        (run-flag? state side card :can-steal))))
 
 (defn can-score?
   ([state side card] (can-score? state side card nil))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -3,7 +3,7 @@
 (declare clear-run-register!
          gain-run-credits update-ice-in-server update-all-ice
          get-agenda-points gain-agenda-point optional-ability
-         get-remote-names card-name)
+         get-remote-names card-name can-steal?)
 
 ;;; Steps in the run sequence
 (defn run
@@ -109,7 +109,7 @@
           (when-let [name (:title c)]
             (if (is-type? c "Agenda") ; accessing an agenda
               (do (trigger-event state side :pre-steal-cost c)
-                  (if (get-in @state [:runner :register :cannot-steal])
+                  (if-not (can-steal? state side c)
                     ;; The runner cannot steal this agenda.
                     (do (resolve-steal-events state side c)
                         (prompt! state :runner c (str "You accessed but cannot steal " (:title c)) ["OK"] {}))

--- a/src/clj/test/cards-identities.clj
+++ b/src/clj/test/cards-identities.clj
@@ -62,6 +62,28 @@
       (run-empty-server state "HQ")
       (is (= 4 (count (:discard (get-corp)))) "1 operation trashed from HQ; accessed non-operation in Archives first"))))
 
+(deftest haarpsichord-studios
+  "Haarpsichord Studios - Prevent stealing more than 1 agenda per turn"
+  (do-game
+    (new-game
+      (make-deck "Haarpsichord Studios: Entertainment Unleashed" [(qty "15 Minutes" 3)])
+      (default-runner [(qty "Gang Sign" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Gang Sign")
+    (run-empty-server state "HQ")
+    (prompt-choice :runner "Steal")
+    (is (= 1 (:agenda-point (get-runner))))
+    (run-empty-server state "HQ")
+    (prompt-choice :runner "Steal")
+    (is (= 1 (:agenda-point (get-runner))) "Second steal of turn prevented")
+    (take-credits state :runner)
+    (play-from-hand state :corp "15 Minutes" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (let [gs (get-in @state [:runner :rig :resource 0])]
+      (card-ability state :runner gs 0)
+      (prompt-choice :runner "Steal")
+      (is (= 2 (:agenda-point (get-runner))) "Steal prevention didn't carry over to Corp turn"))))
+
 (deftest haas-bioroid-stronger-together
   "Stronger Together - +1 strength for Bioroid ice"
   (do-game


### PR DESCRIPTION
Fixes #1091. 

The old Haarp implementation was carrying over steal prevention into the Corp's turn because it was going into the Runner's register. Haarp is refactored to use the turn-flag system, and as a result of changing `handle-access` Old Hollywood Grid gets refactored to a much simpler form as well. 

This also makes Gang Sign use a toast instead of the now old-fashioned "print to the log" effect. 