### PR TITLE
Business First cards

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -332,6 +332,24 @@
    {:steal-cost-bonus (req [:credit 4])
     :advancement-cost-bonus (req (:bad-publicity corp))}
 
+   "New Construction"
+   {:install-state :face-up
+    :events {:advance
+             {:optional
+              {:req (req (= (:cid card) (:cid target)))
+               :prompt "Install a card from HQ in a new remote?"
+               :yes-ability {:prompt "Choose a card in HQ to install"
+                             :choices {:req #(and (not (is-type? % "Operation"))
+                                                  (= (:side %) "Corp")
+                                                  (in-hand? %))}
+                             :msg (msg "install a card from HQ" (when (>= (:advance-counter (get-card state card)) 5)
+                                       " and rez it, ignoring all costs"))
+                             :effect (req (if (>= (:advance-counter (get-card state card)) 5)
+                                            (do (corp-install state side target "New remote"
+                                                              {:install-state :rezzed-no-cost})
+                                                (trigger-event state side :rez target))
+                                            (corp-install state side target "New remote")))}}}}}
+
    "Nisei MK II"
    {:effect (effect (add-prop card :counter 1))
     :abilities [{:req (req (:run @state)) :counter-cost 1 :msg "end the run"
@@ -426,6 +444,11 @@
                                                    distinct
                                                    (join " - "))))))
     :msg "make all assets gain Advertisement"}
+
+   "Remote Data Farm"
+   {:msg "increase their maximum hand size by 2"
+    :effect (effect (gain :hand-size-modification 2))
+    :leave-play (effect (lose :hand-size-modification 2))}
 
    "Research Grant"
    {:req (req (not (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp)))))

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -251,6 +251,21 @@
                                                  (swap! ref assoc-in [:runner :memory] hand-size))))))
     :leave-play (req (remove-watch state :ekomind))}
 
+   "EMP Device"
+   {:abilities [{:req (req (:run @state))
+                 :msg "prevent the Corp from rezzing more than 1 piece of ICE for the remainder of the run"
+                 :effect (effect (register-events
+                                   {:rez {:req (req (ice? target))
+                                          :effect (effect (register-run-flag!
+                                                            card :can-rez
+                                                            (fn [state side card]
+                                                              (if (ice? card)
+                                                                ((constantly false)
+                                                                 (toast state :corp "Cannot rez ICE the rest of this run due to EMP Device"))
+                                                                true))))}
+                                    :run-ends {:effect (effect (unregister-events card))}} (assoc card :zone '(:discard)))
+                                 (trash card {:cause :ability-cost}))}]}
+
    "Feedback Filter"
    {:prevent {:damage [:net :brain]}
     :abilities [{:cost [:credit 3] :msg "prevent 1 net damage" :effect (effect (damage-prevent :net 1))}

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -362,6 +362,44 @@
                    :msg (msg "give " (:title target) " +1 strength")
                    :effect (effect (pump target 1 :all-run))}}}
 
+   "NetChip"
+   {:abilities [{:label "Install a program on NetChip"
+                 :cost [:click 1]
+                 :req (req (empty? (:hosted card)))
+                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
+                                (resolve-ability state side
+                                  {:prompt "Choose a program in your Grip to install on NetChip"
+                                   :choices {:req #(and (is-type? % "Program")
+                                                        (<= (:memoryunits %) n)
+                                                        (in-hand? %))}
+                                   :msg (msg "host " (:title target))
+                                   :effect (effect (gain :memory (:memoryunits target))
+                                                   (runner-install target {:host-card card})
+                                                   (update! (assoc (get-card state card)
+                                                                   :hosted-programs
+                                                                   (cons (:cid target) (:hosted-programs card)))))}
+                                 card nil)))}
+                {:label "Host an installed program on NetChip"
+                 :req (req (empty? (:hosted card)))
+                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
+                                (resolve-ability state side
+                                  {:prompt "Choose an installed program to host on NetChip"
+                                   :choices {:req #(and (is-type? % "Program")
+                                                        (<= (:memoryunits %) n)
+                                                        (installed? %))}
+                                   :msg (msg "host " (:title target))
+                                   :effect (effect (host card target)
+                                                   (gain :memory (:memoryunits target))
+                                                   (update! (assoc (get-card state card)
+                                                                   :hosted-programs
+                                                                   (cons (:cid target) (:hosted-programs card)))))}
+                                 card nil)))}]
+    :events {:card-moved {:req (req (some #{(:cid target)} (:hosted-programs card)))
+                          :effect (effect (update! (assoc card
+                                                          :hosted-programs
+                                                          (remove #(= (:cid target) %) (:hosted-programs card))))
+                                          (lose :memory (:memoryunits target)))}}}
+
    "Omni-Drive"
    {:recurring 1
     :abilities [{:label "Install and host a program of 1[Memory Unit] or less on Omni-Drive"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -372,7 +372,7 @@
    "Pālanā Foods: Sustainable Growth"
    {:events {:runner-draw {:msg "gain 1 [Credits]"
                            :once :per-turn
-                           :effect (effect (gain [:credit 1]))}}}
+                           :effect (effect (gain :corp :credit 1))}}}
 
    "Quetzal: Free Spirit"
    {:abilities [{:once :per-turn :msg "break 1 barrier subroutine"}]}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -416,6 +416,14 @@
    "Predictive Algorithm"
    {:events {:pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 2]))}}}
 
+   "Product Recall"
+   {:prompt "Choose a rezzed asset or upgrade to trash"
+    :choices {:req #(and (rezzed? %)
+                         (or (is-type? % "Asset") (is-type? % "Upgrade")))}
+    :msg (msg "trash " (card-str state target) " and gain " (:trash target) " [Credits]")
+    :effect (effect (trash target)
+                    (gain :credit (:trash target)))}
+
    "Psychographics"
    {:req (req tagged) :choices :credit :prompt "How many credits?"
     :effect (req (let [c (min target (:tag runner))]

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -156,7 +156,8 @@
                    (card-init state side
                               (assoc (get-card state moved-card) :rezzed true :seen true) false))
                  (when-let [dre (:derezzed-events cdef)]
-                   (register-events state side dre moved-card)))))
+                   (when-not (:rezzed (get-card state moved-card))
+                     (register-events state side dre moved-card))))))
            (clear-install-cost-bonus state side)))))))
 
 


### PR DESCRIPTION
Adds 9 new cards from Business First and a fix for Palana Foods not giving the Corp a credit on the Runner's first draw of a turn. There is also a minor tweak to `corp-install` that I discovered when testing New Construction to install Mumbad Construction Co. and rez it for free--derezzed events should not be registered if the installed card is immediately rezzed. 

I'll double back and add some unit tests soon...