### PR TITLE
Added 'flipping archives faceup' effect to /rez-all command

### DIFF
--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -95,10 +95,10 @@
                    {:title "/counter command"} nil))
 
 (defn command-rezall [state side value]
-  (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
   (resolve-ability state side
     {:optional {:prompt "Rez all cards and turn cards in archives faceup?"
                 :yes-ability {:effect (req
+                                        (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                                         (doseq [c (all-installed state side)]
                                           (when-not (:rezzed c)
                                             (rez state side c {:ignore-cost :all-costs}))))}}}

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -52,7 +52,7 @@
                         [:li [:code "/link n"] " - Set your link to n"]
                         [:li [:code "/handsize n"] " - Set your handsize to n"]
                         [:li [:code "/rez"] " - Select a card to rez, ignoring all costs (Corp only)"]
-                        [:li [:code "/rez-all"] " - Rez all cards, ignoring all costs (Corp only). For revealing your servers at the end of a game."]
+                        [:li [:code "/rez-all"] " - Rez all cards, ignoring all costs and flip cards in archives faceup (Corp only). For revealing your servers at the end of a game."]
                         [:li [:code "/take-meat n"] " - Take n meat damage (Runner only)"]
                         [:li [:code "/take-net n"] " - Take n net damage (Runner only)"]
                         [:li [:code "/take-brain n"] " - Take n brain damage (Runner only)"]


### PR DESCRIPTION
In the most common use case of the command you just want to reveal the whole info after the game ends for easier post-game discussion. This change facilitates that.