### PR TITLE
PRIORITY: fix HQ access with rezzed upgrades;  implement CBI Raid

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -340,6 +340,7 @@
                :prompt "Install a card from HQ in a new remote?"
                :yes-ability {:prompt "Choose a card in HQ to install"
                              :choices {:req #(and (not (is-type? % "Operation"))
+                                                  (not (is-type? % "ICE"))
                                                   (= (:side %) "Corp")
                                                   (in-hand? %))}
                              :msg (msg "install a card from HQ" (when (>= (:advance-counter (get-card state card)) 5)

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -381,14 +381,14 @@
    "Lakshmi Smartfabrics"
    {:events {:rez {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:req (req (seq (filter #(and (is-type? % "Agenda")
-                                              (= (get card :counter 0) (:agendapoints %))) (:hand corp))))
+                                              (>= (get card :counter 0) (:agendapoints %))) (:hand corp))))
                  :label "X power counters: Reveal an agenda worth X points from HQ"
                  :effect (req (let [c (:counter card)]
                                 (resolve-ability
                                   state side
-                                  {:prompt "Choose an agenda in HQ"
+                                  {:prompt "Choose an agenda in HQ to reveal"
                                    :choices {:req #(and (is-type? % "Agenda")
-                                                        (= c (:agendapoints %)))}
+                                                        (>= c (:agendapoints %)))}
                                    :msg (msg "reveal " (:title target) " from HQ")
                                    :effect (req (let [title (:title target)
                                                       pts (:agendapoints target)]

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -379,8 +379,7 @@
                                  (trash card {:cause :ability-cost}))}]}
 
    "Lakshmi Smartfabrics"
-   {:events {:rez {:req (req (not= (:cid card) (:cid target)))
-                   :effect (effect (add-prop card :counter 1))}}
+   {:events {:rez {:effect (effect (add-prop card :counter 1))}}
     :abilities [{:req (req (seq (filter #(and (is-type? % "Agenda")
                                               (= (get card :counter 0) (:agendapoints %))) (:hand corp))))
                  :label "X power counters: Reveal an agenda worth X points from HQ"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -72,6 +72,16 @@
                          (in-hand? %))}
     :effect (effect (install-cost-bonus [:credit -3]) (runner-install target))}
 
+   "CBI Raid"
+   {:effect (effect (run :hq {:req (req (= target :hq))
+                              :replace-access
+                              {:msg "force the Corp to add all cards in HQ to the top of R&D"
+                               :effect (req (show-wait-prompt state :runner "Corp to add all cards in HQ to the top of R&D")
+                                            (prompt! state :corp card
+                                                    (str "Click Done when finished moving cards from HQ to R&D")
+                                                    ["Done"]
+                                                    {:effect (effect (clear-wait-prompt :runner))}))}} card))}
+
    "Code Siphon"
    {:effect (effect (run :rd
                          {:replace-access

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -370,7 +370,8 @@
                               :req (req (has-subtype? target "Virus"))}}}
 
    "Pālanā Foods: Sustainable Growth"
-   {:events {:runner-draw {:msg "gain 1 [Credits]"
+   {:events {:runner-draw {:req (req (not= 0 (:turn @state)))
+                           :msg "gain 1 [Credits]"
                            :once :per-turn
                            :effect (effect (gain :corp :credit 1))}}}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -422,9 +422,14 @@
    {:prompt "Choose a rezzed asset or upgrade to trash"
     :choices {:req #(and (rezzed? %)
                          (or (is-type? % "Asset") (is-type? % "Upgrade")))}
-    :msg (msg "trash " (card-str state target) " and gain " (:trash target) " [Credits]")
-    :effect (effect (trash target)
-                    (gain :credit (:trash target)))}
+    :effect (req (let [c target]
+                   (trigger-event state side :pre-trash c)
+                   (let [tcost (trash-cost state side c)]
+                     (trash state side c)
+                     (gain state :corp :credit tcost)
+                     (resolve-ability state side
+                       {:msg (msg "trash " (card-str state c) " and gain " tcost " [Credits]")}
+                      card nil))))}
 
    "Psychographics"
    {:req (req tagged) :choices :credit :prompt "How many credits?"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -192,13 +192,15 @@
    {:prompt "Choose a faceup card"
     :choices {:req rezzed?}
     :msg (msg "place 3 advancement tokens on " (card-str state target))
-    :effect (effect (add-prop :corp target :advance-counter 3 {:placed true})
-                    (register-turn-flag!
-                      target :can-score
-                      (fn [state side card]
-                        (if (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card)))
-                          ((constantly false) (toast state :corp "Cannot score due to Dedication Ceremony." "warning"))
-                          true))))}
+    :effect (req (add-prop state :corp target :advance-counter 3 {:placed true})
+                 (let [tgtcid (:cid target)]
+                   (register-turn-flag! state side
+                     target :can-score
+                     (fn [state side card]
+                       (if (and (= (:cid card) tgtcid)
+                                (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))
+                         ((constantly false) (toast state :corp "Cannot score due to Dedication Ceremony." "warning"))
+                         true)))))}
 
    "Defective Brainchips"
    {:events {:pre-damage {:req (req (= target :brain)) :msg "to do 1 additional brain damage"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -472,7 +472,8 @@
                  :effect (req (move state side target :hand)
                               (if (= target (first (:deck runner)))
                                 (move state side (second (:deck runner)) :deck)
-                                (move state side (first (:deck runner)) :deck)))}]}
+                                (move state side (first (:deck runner)) :deck))
+                              (trigger-event state side :runner-draw))}]}
 
    "Muertos Gang Member"
    {:effect (req (resolve-ability

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -202,12 +202,12 @@
    :effect (req (case target
                   "Unrezzed upgrade in HQ"
                   ;; accessing an unrezzed upgrade
-                  (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) cards)]
+                  (let [unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %))) from-root)]
                     (if (= 1 (count unrezzed))
                       ;; only one unrezzed upgrade; access it and continue
                       (do (system-msg state side (str "accesses " (:title (first unrezzed))))
                           (handle-access state side unrezzed)
-                          (when (or (pos? from-hq) (< 1 (count from-hq)))
+                          (when (or (pos? from-hq) (< 1 (count from-root)))
                             (resolve-ability
                               state side (access-helper-hq from-hq
                                                            (filter #(not= (:cid %) (:cid (first unrezzed))) from-root)
@@ -237,10 +237,10 @@
                                          card nil)))
                   ;; accessing a rezzed upgrade
                   (do (system-msg state side (str "accesses " target))
-                      (handle-access state side [(some #(when (= (:title %) target) %) cards)])
-                      (when (or (pos? from-hq) (< 1 (count from-hq)))
+                      (handle-access state side [(some #(when (= (:title %) target) %) from-root)])
+                      (when (or (pos? from-hq) (< 1 (count from-root)))
                         (resolve-ability state side (access-helper-hq from-hq
-                                                                      (remove-once #(not= (:title %) target) cards)
+                                                                      (remove-once #(not= (:title %) target) from-root)
                                                                       already-accessed) card nil)))))})
 
 (defmethod choose-access :hq [cards server]


### PR DESCRIPTION
The access helper function for HQ has a bunch of problems from @nealterrell's work on getting Leela bounce w/ multiaccess working. He diagnosed it in chat this afternoon. This could also potentially take care of #1325 and #1247, but we'll have to wait and see.  

CBI Raid is fairly straightforward--decided to give the Runner a wait prompt that's only cleared when the Corp signals they're done putting everything from their hand onto R&D. 

Fixes #1332, fixes #1333, fixes #1334. Dedication Ceremony had a turn-flag that was too broad--preventing *any* agenda from being scored that turn, even if it was not the card targeted by the operation. Added a few small Business First touchups: New Construction shouldn't be able to install ICE, Lakshmi gets a counter for rezzing itself and had an agenda targeting goof, Product Recall needs to factor in trash cost modifiers, Mr. Li missing event trigger to combo with Palana Foods. 