### PR TITLE
Casting Call fix

### DIFF
--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -153,8 +153,10 @@
                  (when (= install-state :rezzed)
                    (rez state side moved-card))
                  (when (= install-state :face-up)
-                   (card-init state side
-                              (assoc (get-card state moved-card) :rezzed true :seen true) false))
+                   (if (:install-state cdef)
+                     (card-init state side
+                                (assoc (get-card state moved-card) :rezzed true :seen true) false)
+                     (update! state side (assoc (get-card state moved-card) :rezzed true :seen true))))
                  (when-let [dre (:derezzed-events cdef)]
                    (when-not (:rezzed (get-card state moved-card))
                      (register-events state side dre moved-card))))))


### PR DESCRIPTION
Fixes #1128. 

Adds some logic to `corp-install` to only initialize events on cards being installed faceup if the actual card definition says they get installed that way (as opposed to on the fly at install time via Casting Call)--otherwise just flip them faceup and do nothing else. 

Includes a full test for using Casting Call on a Public agenda that should have working events and one that shouldn't (Improved Tracers as in the initial report). 