### PR TITLE
fixes for all-installed: hosted Corp cards; include Runner cards hosted on ICE

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -180,8 +180,8 @@
               :once-key :daily-business-show
               :req (req (first-event state side :corp-draw))
               :effect (req
-                        (let [dbs (->> (:corp @state) :servers seq flatten (mapcat :content)
-                                       (filter #(and (:rezzed %) (= (:title %) "Daily Business Show")))  count)
+                        (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
+                                                  (all-installed state :corp))) 
                               newcards (take dbs (:deck corp))
                               drawn (conj newcards (last (:hand corp)))]
                           (doseq [c newcards] (move state side c :hand))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -183,7 +183,7 @@
                         (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
                                                   (all-installed state :corp))) 
                               newcards (take dbs (:deck corp))
-                              drawn (conj newcards (last (:hand corp)))]
+                              (concat newcards (take-last target (:hand corp)))]
                           (doseq [c newcards] (move state side c :hand))
                           (resolve-ability
                             state side

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -183,7 +183,7 @@
                         (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
                                                   (all-installed state :corp))) 
                               newcards (take dbs (:deck corp))
-                              (concat newcards (take-last target (:hand corp)))]
+                              drawn (concat newcards (take-last target (:hand corp)))]
                           (doseq [c newcards] (move state side c :hand))
                           (resolve-ability
                             state side

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -664,7 +664,7 @@
     :effect (req (add-prop state :runner target :counter 2))}
 
    "Test Run"
-   {:prompt "Install a program from Stack or Heap?"
+   {:prompt "Install a program from your Stack or Heap?"
     :choices (cancellable ["Stack" "Heap"])
     :msg (msg "install a program from " target)
     :effect (effect (resolve-ability
@@ -674,12 +674,9 @@
                                              ((if (= target "Heap") :discard :deck) runner))))
                       :effect (effect (runner-install (assoc-in target [:special :test-run] true) {:no-cost true}))
                       :end-turn
-                      {:req (req (some #(when (and (= (:cid target) (:cid %))
-                                                   (get-in % [:special :test-run])) %)
-                                       (get-in runner [:rig :program])))
-                       :msg (msg "move " (:title target) " on top of their Stack")
-                       :effect (req (move state side (some #(when (= (:cid target) (:cid %)) %)
-                                                           (get-in runner [:rig :program]))
+                      {:req (req (find-cid (:cid target) (all-installed state :runner)))
+                       :msg (msg "move " (:title target) " to the top of their Stack")
+                       :effect (req (move state side (find-cid (:cid target) (all-installed state :runner))
                                           :deck {:front true}))}}
                      card targets))}
 

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -306,16 +306,17 @@
 
    "LLDS Processor"
    {:events
-             (let [llds {:effect (req (let [cards (:llds-target card)]
-                                           (update! state side (dissoc card :llds-target))
-                                           (doseq [c cards]
-                                             (update-breaker-strength state side c))))}]
-               {:runner-turn-ends llds :corp-turn-ends llds
-                :runner-install {:req (req (has-subtype? target "Icebreaker"))
-                                 :effect (effect (update! (update-in card [:llds-target] #(conj % target)))
-                                                 (update-breaker-strength target))}
-                :pre-breaker-strength {:req (req (some #(= (:cid target) (:cid %)) (:llds-target card)))
-                                       :effect (effect (breaker-strength-bonus 1))}})}
+     (let [llds {:effect (req (let [cards (:llds-target card)]
+                                (update! state side (dissoc card :llds-target))
+                                (doseq [c cards]
+                                (update-breaker-strength state side
+                                                         (find-cid (:cid c) (all-installed state :runner))))))}]
+       {:runner-turn-ends llds :corp-turn-ends llds
+        :runner-install {:req (req (has-subtype? target "Icebreaker"))
+                         :effect (effect (update! (update-in card [:llds-target] #(conj % target)))
+                                         (update-breaker-strength target))}
+        :pre-breaker-strength {:req (req (some #(= (:cid target) (:cid %)) (:llds-target card)))
+                               :effect (effect (breaker-strength-bonus 1))}})}
 
    "Lockpick"
    {:recurring 1}

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -43,7 +43,7 @@
    (unregister-events state side card)
    (when (and (:memoryunits card) (:installed card) (not (:facedown card)))
      (gain state :runner :memory (:memoryunits card)))
-   (when (:installed card)
+   (when (find-cid (:cid card) (all-installed state side))
      (when-let [in-play (:in-play (card-def card))]
        (apply lose state side in-play)))
    (dissoc-card card keep-counter)))

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -69,8 +69,11 @@
   (if (= side :runner)
     (let [installed (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))]
       (concat installed (filter :installed (mapcat :hosted installed))))
-    (let [servers (->> (:corp @state) :servers seq flatten)]
-      (concat (mapcat :content servers) (mapcat :ices servers)))))
+    (let [servers (->> (:corp @state) :servers seq flatten)
+          content (mapcat :content servers)
+          ice (mapcat :ices servers)
+          hosted-on-content (mapcat :hosted content)]
+      (concat ice content hosted-on-content))))
 
 (defn all-active
   "Returns a vector of all active cards for the given side. Active cards are either installed, the identity,

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -67,8 +67,11 @@
   but not including 'inactive hosting' like Personal Workshop."
   [state side]
   (if (= side :runner)
-    (let [installed (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))]
-      (concat installed (filter :installed (mapcat :hosted installed))))
+    (let [installed (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))
+          hosted-on-ice (->> (:corp @state) :servers seq flatten (mapcat :ices) (mapcat :hosted))]
+      (concat installed
+              (filter :installed (mapcat :hosted installed))
+              (filter #(= (:side %) "Runner") hosted-on-ice)))
     (let [servers (->> (:corp @state) :servers seq flatten)
           content (mapcat :content servers)
           ice (mapcat :ices servers)

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -135,6 +135,26 @@
       (core/score state :corp {:card (refresh ai)})
       (is (not (nil? (get-content state :remote1 0)))))))
 
+(deftest trash-corp-hosted
+  "Hosted Corp cards are included in all-installed and fire leave-play effects when trashed"
+  (do-game
+    (new-game (default-corp [(qty "Worlds Plaza" 1) (qty "Director Haas" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Worlds Plaza" "New remote")
+    (let [wp (get-content state :remote1 0)]
+      (core/rez state :corp wp)
+      (card-ability state :corp wp 0)
+      (prompt-select :corp (find-card "Director Haas" (:hand (get-corp))))
+      (is (= 4 (:click-per-turn (get-corp))) "Corp has 4 clicks per turn")
+      (is (= 2 (count (core/all-installed state :corp))) "all-installed counting hosted Corp cards")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (let [dh (first (:hosted (refresh wp)))]
+        (prompt-select :runner dh)
+        (prompt-choice :runner "Yes") ; trash Director Haas
+        (prompt-choice :runner "Done")
+        (is (= 3 (:click-per-turn (get-corp))) "Corp down to 3 clicks per turn")))))
+
 (deftest trash-seen-and-unseen
   "Trash installed assets that are both seen and unseen by runner"
   (do-game


### PR DESCRIPTION
Worlds Plaza has generated a couple of fairly obscure issues. The current `all-installed` function is not counting Corp cards being hosted on things like Worlds Plaza, Awakening Center, or the upcoming Full Immersion RecStudio. As a result, copies of Daily Business Show getting hosted on Worlds Plaza aren't counting toward the extra number of cards to be drawn by the Corp. 

The other WP issue is that `:leave-play` effects aren't firing for hosted cards that get trashed. The `deactivate` function is checking the card itself to see if it's installed--I cannot for the life of me come up with a way to do this using the `installed?` function for the case of hosted Corp cards. So instead I am checking to see if the card's `:cid` is found in the now all-inclusive list from `all-installed`. 

Fixes #1233. Use the target from the `:corp-draw` event to help identify which cards in the Corp hand are eligible to be put back into R&D. 

Fixes #1227. Includes a test for the Director Haas on Worlds Plaza issue and for the new modification to `all-installed`. 

Fixes #1081: While I was mucking around with `all-installed`, I realized we should be scanning Corp ICE for things like Parasite and Caissa which weren't being counted. This led to a fix for the Test Run issue--includes a test for returning installed programs that subsequently got hosted on Runner cards or ICE. This will cover the vast majority of cases, but if `all-installed` is further modified as being discussed in #1160 to search multiple levels of nested hosting we'll have a 100% solution. 