### PR TITLE
Add ability to request paid ability window at end of opponent's turn

### DIFF
--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -429,6 +429,7 @@
   (if (get-in @state [:run :corp-phase-43])
     ; if corp requests phase 4.3, then we do NOT fire :successful-run yet, which does not happen until 4.4
     (do (swap! state dissoc :no-action)
+        (system-msg state :corp "wants to act before the run is successful")
         (show-wait-prompt state :runner "Corp's actions")
         (show-prompt state :corp nil "Rez and take actions before Successful Run" ["Done"]
                      (fn [args-corp]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1,7 +1,7 @@
 (ns game.core
   (:require [game.utils :refer [remove-once has? merge-costs zone make-cid make-label to-keyword capitalize
                                 costs-to-symbol vdissoc distinct-by abs string->num safe-split
-                                dissoc-in cancellable card-is?
+                                dissoc-in cancellable card-is? side-str
                                 build-spend-msg cost-names remote->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side]]
             [game.macros :refer [effect req msg]]

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -37,6 +37,7 @@
    "run" core/click-run
    "no-action" core/no-action
    "corp-phase-43" core/corp-phase-43
+   "request-phase-32" core/request-phase-32
    "continue" core/continue
    "access" core/successful-run
    "jack-out" core/jack-out

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -118,6 +118,9 @@
 (defn other-side [side]
   (if (= side :corp) :runner :corp))
 
+(defn side-str [side]
+  (if (= side :corp) "Corp" "Runner"))
+
 ; Functions for working with zones.
 (defn remote->name [zone]
   "Converts a remote zone to a string"

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -793,7 +793,7 @@
     ;; remove restricted servers from all servers to just return allowed servers
     (remove (set restricted-servers) (set servers))))
 
-(defn gameboard [{:keys [side gameid active-player run end-turn runner-phase-12 corp-phase-12] :as cursor} owner]
+(defn gameboard [{:keys [side gameid active-player run end-turn runner-phase-12 corp-phase-12 phase-32] :as cursor} owner]
   (reify
     om/IWillMount
     (will-mount [this]
@@ -888,9 +888,9 @@
                                         #(send-command "jack-out"))]
                           [:div.panel.blue-shade
                            (when (zero? (:position run))
-                             (cond-button "Action before access" (not (:no-action run))
+                             (cond-button "Action Before Access" (not (:no-action run))
                                           #(send-command "corp-phase-43")))
-                           (cond-button "No more action" (not (:no-action run))
+                           (cond-button "No More Action" (not (:no-action run))
                                         #(send-command "no-action"))]))
                       [:div.panel.blue-shade
                        (if (= (keyword active-player) side)
@@ -898,6 +898,8 @@
                                [:button {:on-click #(handle-end-turn cursor owner)} "End Turn"])
                          (when end-turn
                            [:button {:on-click #(send-command "start-turn")} "Start Turn"]))
+                       (when (and (not= (keyword active-player) side) (not end-turn))
+                         (cond-button "Action Before Turn Ends" (not phase-32) #(send-command "request-phase-32")))
                        (when (and (= (keyword active-player) side)
                                   (or runner-phase-12 corp-phase-12))
                            [:button {:on-click #(send-command "end-phase-12")}


### PR DESCRIPTION
Brings functionality similar to the Step 4.3 code to Step 2.2/3.2 End of Runner/Corp's Turn.

At any point during your opponent's turn, a player may click a UI button titled "Action Before Turn Ends". If this is clicked, we silently wait until the opponent clicks End Turn; at this point we follow the same sequence as Step 4.3, in which:

* the opponent player (the one ending the turn) sees a "Waiting for opponent to take an action" prompt
* the user gets a prompt to take actions before opponent's turn ends
* the opponent gets one final window to act after the user indicates he is done
* after the opponent is done, the turn ends. Events are fired, cards react, etc.

If the Action Before Turn Ends button is not clicked, the turn ends as usual.

Our UI then corresponds to the Turn Timing steps in this approximate way:

* prior to pressing Start Turn: Step 1.1 (Window before turn starts, but "my" turn for ability conditions)
* press Start Turn: Step 1.2 into Step 1.3
    * if Step 1.2 is necessary, show Mandatory Draw/Take Clicks button to end Step 1.2. 
* after Start Turn is pressed: "start of turn" event triggers. I take clicks until none are left. Show "End Turn" button.
* press End Turn:
    * if opponent requested Action Before Turn Ends, then ability window 2.2/3.2 (Window before my turn ends)
* after End Turn is pressed: "end of turn" event triggers. It is now my opponent's turn.

There are only a few interactions that *really need* this code, most notably a Haley Kaplan who wants to trigger her ability at the end of the opponent's turn, and then again at Step 1.1 (window prior to "Start of Turn") of her own turn in order to install a card with a Start of Turn trigger, like Daily Casts. 

Example: at end of corp's turn, use Clone Chip to install Multithreader from heap, and Hayley install another Multithreader from hand. Use the recurring credits during opponent's turn to pump Study Guide. After corp turn ends, pop Street Peddler to install a resource, and Haley install Daily Casts from hand. Hit Start Turn: Multithreaders refresh their credits, Daily Casts ticks down.

This requires an explicit window to act while it is still considered the corp's turn, and another window to act in 1.1 before Start of Turn happens.