### PR TITLE
Two damage fixes

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -26,9 +26,8 @@
     :effect (req (let [allcorp (->> (all-installed state :corp)
                                     (sort-by #(vec (:zone %)))
                                     (reverse))]
-                   (apply trigger-event state side :runner-trash allcorp)
                    (doseq [c allcorp]
-                     (trash state side c {:suppress-event true})))
+                     (trash state side c)))
 
                  ;; do hosted cards first so they don't get trashed twice
                  (doseq [c (all-installed state :runner)]
@@ -616,9 +615,8 @@
                        {:msg "trash all cards in the server at no cost"
                         :mandatory true
                         :effect (req (let [allcorp (get-in (:servers corp) (conj (:server run) :content))]
-                                       (apply trigger-event state side :runner-trash allcorp)
                                        (doseq [c allcorp]
-                                         (trash state side c {:suppress-event true}))))}} card))}
+                                         (trash state side c))))}} card))}
 
    "Social Engineering"
    {:prompt "Choose an unrezzed piece of ICE"

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -308,8 +308,8 @@
 (defn clear-wait-prompt
   "Removes the first 'Waiting for...' prompt from the given side's prompt queue."
   [state side]
-  (when (= :waiting (-> @state side :prompt first :prompt-type))
-    (swap! state update-in [side :prompt] rest)))
+  (when-let [wait (some #(when (= :waiting (:prompt-type %)) %) (-> @state side :prompt))]
+    (swap! state update-in [side :prompt] (fn [pr] (filter #(not= % wait) pr)))))
 
 ;;; Psi games
 (defn psi-game

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -144,7 +144,8 @@
                                  (str "prevents " (if (= prevent Integer/MAX_VALUE) "all" prevent )
                                       " " (name type) " damage")
                                  "will not prevent damage"))
-                   (resolve-damage state side type (max 0 (- n (or prevent 0))) args)))))
+                   (resolve-damage state side type (max 0 (- n (or prevent 0))) args)))
+               {:priority 10}))
          (resolve-damage state side type n args))))))
 
 
@@ -190,7 +191,8 @@
                                  (str "avoids " (if (= prevent Integer/MAX_VALUE) "all" prevent)
                                       (if (< 1 prevent) " tags" " tag"))
                                  "will not avoid tags"))
-                   (resolve-tag state side (max 0 (- n (or prevent 0))) args)))))
+                   (resolve-tag state side (max 0 (- n (or prevent 0))) args)))
+               {:priority 10}))
          (resolve-tag state side n args))))))
 
 
@@ -234,7 +236,8 @@
                                   (do (system-msg state :runner (str "prevents the trashing of " (:title card)))
                                       (swap! state update-in [:trash :trash-prevent] dissoc ktype))
                                   (do (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
-                                      (apply resolve-trash state side card args targets))))))
+                                      (apply resolve-trash state side card args targets))))
+                              {:priority 10}))
              ;; No prevention effects; resolve the trash.
              (apply resolve-trash state side card args targets))))))))
 

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -122,9 +122,9 @@
         (is (= 4 (:credit (get-runner))))
         (run-successful state)
         (prompt-choice :corp "Yes") ; pay 3 to fire Overwriter
-        (prompt-choice :runner "Yes") ; trash Overwriter for 0 to get to prevention prompt
         (card-ability state :runner ff 1)
         (prompt-choice :runner "Done")
+        (prompt-choice :runner "Yes") ; trash Overwriter for 0
         (is (= 1 (:brain-damage (get-runner))) "2 of the 3 brain damage prevented")
         (is (= 2 (count (:hand (get-runner)))))
         (is (empty? (get-in @state [:runner :rig :hardware])) "Feedback Filter trashed")))))


### PR DESCRIPTION
Revert fix in #1270 as per Reddit discussion with Jakodrako.

Fix #1252 by giving prevention prompts a higher priority (10) than all other prompts, forcing them to the front so they don't get inter-weaved with other prompts.