### PR TITLE
allow Apex to install a second console facedown

### DIFF
--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -167,7 +167,7 @@
    Checks uniqueness of card and installed console"
   [state side {:keys [uniqueness] :as card} facedown]
   (and (or (not uniqueness) (not (in-play? state card)) facedown) ; checks uniqueness
-       (or (not (has-subtype? card "Console"))
+       (or (not (and (has-subtype? card "Console") (not facedown)))
            (not (some #(has-subtype? % "Console") (all-installed state :runner)))) ; console check
        (if-let [req (:req (card-def card))]
          (or facedown (req state side card nil)) ; checks req for install

--- a/src/clj/test/cards-identities.clj
+++ b/src/clj/test/cards-identities.clj
@@ -1,5 +1,20 @@
 (in-ns 'test.core)
 
+(deftest apex-facedown-console
+  "Apex - Allow facedown install of a second console. Issue #1326"
+  (do-game
+    (new-game
+      (default-corp)
+      (make-deck "Apex: Invasive Predator" [(qty "Heartbeat" 2)]))
+    (take-credits state :corp)
+    (prompt-choice :runner "Done") ; no facedown install on turn 1
+    (play-from-hand state :runner "Heartbeat")
+    (is (= 1 (count (get-in @state [:runner :rig :hardware]))))
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (prompt-select :runner (find-card "Heartbeat" (:hand (get-runner))))
+    (is (= 1 (count (get-in @state [:runner :rig :facedown]))) "2nd console installed facedown")))
+
 (deftest argus-security
   "Argus Security - Runner chooses to take 1 tag or 2 meat damage when stealing an agenda"
   (do-game


### PR DESCRIPTION
Fixes #1326. 

`runner-can-install?` is modified so that the second `or` statement can come back true in the case of a 2nd console getting installed facedown when one is already installed faceup and active. Includes a test! 