### PR TITLE
fix Troll and Sealed Vault bugs

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -295,7 +295,7 @@
    {:effect (req (update-all-ice state side))
     :events {:pre-ice-strength {:req (req (has-subtype? target "Tracer"))
                                 :effect (effect (ice-strength-bonus 1 target))}
-             :pre-init-trace {:req (req (ice? target))
+             :pre-init-trace {:req (req (has-subtype? target "Tracer"))
                               :effect (effect (init-trace-bonus 1))}}}
 
    "Labyrinthine Servers"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -659,8 +659,10 @@
 
    "Sealed Vault"
    {:abilities [{:label "Store any number of [Credits] on Sealed Vault" :cost [:credit 1]
-                 :prompt "How many [Credits]?" :choices :credit :msg (msg "store " target " [Credits]")
-                 :effect (effect (add-prop card :counter target))}
+                 :prompt "How many [Credits]?" :choices {:number (req (- (:credit corp) 1))}
+                 :msg (msg "store " target " [Credits]")
+                 :effect (effect (lose :credit target)
+                                 (add-prop card :counter target))}
                 {:label "Move any number of [Credits] to your credit pool"
                  :cost [:click 1] :prompt "How many [Credits]?"
                  :choices :counter :msg (msg "gain " target " [Credits]")

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -880,7 +880,7 @@
                                   :prompt "Choose one"
                                   :choices ["Lose [Click]" "End the run"]
                                   :effect (req (if-not (and (= target "Lose [Click]")
-                                                            (apply pay state side card [:click 1]))
+                                                            (can-pay? state :runner nil [:click 1]))
                                                  (do (end-run state side)
                                                      (system-msg state side "ends the run"))
                                                  (do (lose state side :click 1)

--- a/src/clj/test/cards-assets.clj
+++ b/src/clj/test/cards-assets.clj
@@ -400,6 +400,33 @@
       (is (= 3 (count (:discard (get-runner)))) "Ronin did 3 net damage")
       (is (= 2 (count (:discard (get-corp)))) "Ronin trashed"))))
 
+(deftest sealed-vault
+  "Sealed Vault - Store credits for 1c, retrieve credits by trashing or spending click"
+  (do-game
+    (new-game (default-corp [(qty "Sealed Vault" 1) (qty "Hedge Fund" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Sealed Vault" "New remote")
+    (play-from-hand state :corp "Hedge Fund")
+    (let [sv (get-content state :remote1 0)]
+      (core/rez state :corp sv)
+      (card-ability state :corp sv 0)
+      (prompt-choice :corp 8)
+      (is (= 8 (:counter (refresh sv))) "8 credits stored on Sealed Vault")
+      (is (= 0 (:credit (get-corp))))
+      (card-ability state :corp sv 1)
+      (prompt-choice :corp 8)
+      (is (= 0 (:counter (refresh sv))) "Credits removed from Sealed Vault")
+      (is (= 8 (:credit (get-corp))))
+      (is (= 0 (:click (get-corp))) "Spent a click")
+      (card-ability state :corp sv 0)
+      (prompt-choice :corp 7)
+      (is (= 7 (:counter (refresh sv))) "7 credits stored on Sealed Vault")
+      (is (= 0 (:credit (get-corp))))
+      (card-ability state :corp sv 2)
+      (prompt-choice :corp 7)
+      (is (= 7 (:credit (get-corp))))
+      (is (= 2 (count (:discard (get-corp)))) "Sealed Vault trashed"))))
+
 (deftest snare-cant-afford
   "Snare! - Can't afford"
   (do-game


### PR DESCRIPTION
I goofed on the previous fix to Troll and now it's docking 2 clicks when the Runner has 2 or more remaining. Also, a scored Improved Tracers should not boost Troll's trace because it is not from a subroutine. 

Sealed Vault isn't deducting credits from the Corp total when doing the storage ability. 