### PR TITLE
Modified all-installed to handle nested hosted cards

### DIFF
--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -69,8 +69,7 @@
   (if (= side :runner)
     (let [top-level-cards (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))
           hosted-on-ice (->> (:corp @state) :servers seq flatten (mapcat :ices) (mapcat :hosted))]
-      (concat top-level-cards
-              (filter #(= (:side %) "Runner") hosted-on-ice))
+      (concat top-level-cards (filter #(= (:side %) "Runner") hosted-on-ice))
       (loop [unchecked top-level-cards installed ()]
         (if (empty? unchecked)
           (filter :installed installed)

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -79,8 +79,12 @@
     (let [servers (->> (:corp @state) :servers seq flatten)
           content (mapcat :content servers)
           ice (mapcat :ices servers)
-          hosted-on-content (mapcat :hosted content)]
-      (concat ice content hosted-on-content))))
+          top-level-cards (concat ice content)]
+      (loop [unchecked top-level-cards installed ()]
+        (if (empty? unchecked)
+          installed
+          (let [[card & remaining] unchecked]
+            (recur (filter identity (into remaining (:hosted card))) (into installed [card]))))))))
 
 (defn all-active
   "Returns a vector of all active cards for the given side. Active cards are either installed, the identity,

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -67,11 +67,15 @@
   but not including 'inactive hosting' like Personal Workshop."
   [state side]
   (if (= side :runner)
-    (let [installed (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))
+    (let [top-level-cards (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))
           hosted-on-ice (->> (:corp @state) :servers seq flatten (mapcat :ices) (mapcat :hosted))]
-      (concat installed
-              (filter :installed (mapcat :hosted installed))
-              (filter #(= (:side %) "Runner") hosted-on-ice)))
+      (concat top-level-cards
+              (filter #(= (:side %) "Runner") hosted-on-ice))
+      (loop [unchecked top-level-cards installed ()]
+        (if (empty? unchecked)
+          (filter :installed installed)
+          (let [[card & remaining] unchecked]
+            (recur (filter identity (into remaining (:hosted card))) (into installed [card]))))))
     (let [servers (->> (:corp @state) :servers seq flatten)
           content (mapcat :content servers)
           ice (mapcat :ices servers)

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -69,8 +69,7 @@
   (if (= side :runner)
     (let [top-level-cards (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))
           hosted-on-ice (->> (:corp @state) :servers seq flatten (mapcat :ices) (mapcat :hosted))]
-      (concat top-level-cards (filter #(= (:side %) "Runner") hosted-on-ice))
-      (loop [unchecked top-level-cards installed ()]
+      (loop [unchecked (concat top-level-cards (filter #(= (:side %) "Runner") hosted-on-ice)) installed ()]
         (if (empty? unchecked)
           (filter :installed installed)
           (let [[card & remaining] unchecked]
@@ -81,7 +80,7 @@
           top-level-cards (concat ice content)]
       (loop [unchecked top-level-cards installed ()]
         (if (empty? unchecked)
-          installed
+          (filter #(= (:side %) "Corp") installed)
           (let [[card & remaining] unchecked]
             (recur (filter identity (into remaining (:hosted card))) (into installed [card]))))))))
 

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -231,7 +231,7 @@
             (is (not-empty (filter #(= (:title %) "Mimic") all-installed)) "Mimic is in all-installed")
             (is (not-empty (filter #(= (:title %) "Omni-Drive") all-installed)) "Omni-Drive is in all-installed")
             (is (not-empty (filter #(= (:title %) "Knight") all-installed)) "Knight is in all-installed")
-            (is (empty (filter #(= (:title %) "Corroder") all-installed)) "Corrder is not in all-installed")))))))
+            (is (empty (filter #(= (:title %) "Corroder") all-installed)) "Corroder is not in all-installed")))))))
 
 (deftest counter-manipulation-commands
   "Test interactions of various cards with /counter and /adv-counter commands"


### PR DESCRIPTION
As described in #1160, all-installed was not returning cards that were hosted on already hosted cards. Now the function searches recursively for any hosted cards, and should handle any level of nesting.

Though #1160 only mentioned it as a bug for the runner, the problem also seemed to exist for the corp when I tested it, so I made the same changes to the corp-side as well.

I should mention that this is the first time I'm writing clojure code (though I've written some functional programming code before), so please review the code and let me know if there's anything I should fix up. 

Edit: Also added a test for all-installed for the runner-side.