### PR TITLE
Work-around for using Nisei MK II during 4.3.

### DIFF
--- a/src/clj/test/cards-agendas.clj
+++ b/src/clj/test/cards-agendas.clj
@@ -227,6 +227,24 @@
         (core/score state :corp {:card (refresh napd)})
         (is (= 2 (:agenda-point (get-corp))) "Scored NAPD for 2 points after 5 advancements"))))
 
+(deftest nisei-mk-ii-step-43
+  "Nisei MK II - Remove hosted counter to ETR, check this works in 4.3"
+  (do-game
+   (new-game (default-corp [(qty "Nisei MK II" 1)])
+             (default-runner))
+   (play-from-hand state :corp "Nisei MK II" "New remote")
+   (score-agenda state :corp (get-content state :remote1 0))
+   (let [scored-nisei (get-in @state [:corp :scored 0])]
+     (is (= 1 (:counter scored-nisei)) "Scored Nisei has one counter")
+     (take-credits state :corp)
+     
+     (run-on state "HQ")
+     (run-phase-43 state)
+     (card-ability state :corp (refresh scored-nisei) 0)
+     (prompt-choice :corp "Done") ; close 4.3 corp
+     (is (not (:run @state)) "Run ended by using Nisei counter")
+     (is (= 0 (:counter (refresh scored-nisei))) "Scored Nisei has no counters"))))
+
 (deftest oaktown-renovation
   "Oaktown Renovation - Installed face up, gain credits with each conventional advancement"
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -101,6 +101,12 @@
   (core/no-action state :corp nil)
   (core/continue state :runner nil))
 
+(defn run-phase-43
+  "Ask for triggered abilities phase 4.3"
+  [state]
+  (core/corp-phase-43 state :corp nil)
+  (core/successful-run state :runner nil))
+
 (defn run-successful
   "No action from corp and successful run for runner."
   [state]


### PR DESCRIPTION
Adds test, and additional test function.

Intends to fix #1336.

Root cause is that 4.3 is a prompt window, hence `handle-end-run` does not trigger all the ordinary end-run procedures and simply marks the run as `:ended true`. This does not actually end the run, or prevent a successful access. Additional work-around needed to fix the issue involving Net-Ready Eyes.