### PR TITLE
Made Aesop's not able to target itself

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -24,7 +24,7 @@
    "Aesops Pawnshop"
    {:flags {:runner-phase-12 (req (>= 2 (count (all-installed state :runner))))}
     :abilities [{:msg (msg "trash " (:title target) " and gain 3 [Credits]")
-                 :choices {:req #(and (= (:side %) "Runner") (:installed %))}
+                 :choices {:req #(and (= (:side %) "Runner") (:installed %) (not= (:title %) "Aesop's Pawnshop"))}
                  :effect (effect (gain :credit 3) (trash target {:unpreventable true}))}]}
 
    "Always Be Running"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -26,7 +26,7 @@
     :abilities [{:effect (req (resolve-ability
                                 state side
                                 {:msg (msg "trash " (:title target) " and gain 3 [Credits]")
-                                 :choices {:req #(and (= (:side %) "Runner") (:installed %) (not= (:cid card) (:cid %)))}
+                                 :choices {:req #(and (card-is? % :side :runner) (installed? %) (not (card-is? % :cid (:cid card))))}
                                  :effect (effect (gain :credit 3) (trash target {:unpreventable true}))}
                                card nil))}]}
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -23,9 +23,12 @@
 
    "Aesops Pawnshop"
    {:flags {:runner-phase-12 (req (>= 2 (count (all-installed state :runner))))}
-    :abilities [{:msg (msg "trash " (:title target) " and gain 3 [Credits]")
-                 :choices {:req #(and (= (:side %) "Runner") (:installed %) (not= (:title %) "Aesop's Pawnshop"))}
-                 :effect (effect (gain :credit 3) (trash target {:unpreventable true}))}]}
+    :abilities [{:effect (req (resolve-ability
+                                state side
+                                {:msg (msg "trash " (:title target) " and gain 3 [Credits]")
+                                 :choices {:req #(and (= (:side %) "Runner") (:installed %) (not= (:cid card) (:cid %)))}
+                                 :effect (effect (gain :credit 3) (trash target {:unpreventable true}))}
+                               card nil))}]}
 
    "Always Be Running"
    {:abilities [{:once :per-turn

--- a/src/clj/test/cards-resources.clj
+++ b/src/clj/test/cards-resources.clj
@@ -39,6 +39,27 @@
    (take-credits state :corp)
    (is (= 3 (:click (get-runner))) "Should have lost 3 clicks and gained 2 clicks")))
 
+(deftest aesops-pawnshop
+  "Tests use cases for Aesop's Pawnshop"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Aesop's Pawnshop" 1) (qty "Cache" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Aesop's Pawnshop")
+    (play-from-hand state :runner "Cache")
+    (let [orig-credits (:credit (get-runner))
+          ap (get-in @state [:runner :rig :resource 0])
+          cache (get-in @state [:runner :rig :program 0])]
+      (card-ability state :runner ap 0)
+      (prompt-select :runner cache)
+      (card-ability state :runner ap 0)
+      (prompt-select :runner ap)
+      (let [ap (get-in @state [:runner :rig :resource 0])
+            cache (get-in @state [:runner :discard 0])]
+        (is (= (+ 3 orig-credits) (:credit (get-runner))) "Should have only gained 3 credits")
+        (is (not= cache nil) "Cache should be in Heap")
+        (is (not= ap nil) "Aesops should still be installed")))))
+
 (deftest daily-casts
   "Play and tick through all turns of daily casts"
   (do-game


### PR DESCRIPTION
Fix for #1344.

Modified Aesop's Pawnshop to not be able to target cards with the title "Aesop's Pawnshop". Since this card is unique, this should guarantee that if Aesop's ever targets a card on the board with the title "Aesop's Pawnshop"  it is in fact trying to target itself, which is invalid.

I would have preferred to use the cid for this check, but I wasn't able to figure out how to retrieve the currently used card's cid in the :choices field of the card definition. If anyone knows how, or knows another card that does something similar, I'd love to know so I can make this less sloppy.

Edit: 
Thanks to @nealterrell and @JoelCFC25, the code is now properly using the card's cid to determine whether it's targeting itself.

Also added a test function that tests Aesop's used on another runner card and Aesop's used on itself.