### PR TITLE
implement Corporate Scandal (seeking review)

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -42,7 +42,7 @@
                        (gain state :runner :memory (:memoryunits c))))))}
 
    "Blackmail"
-   {:req (req (> (:bad-publicity corp) 0)) :prompt "Choose a server" :choices (req runnable-servers)
+   {:req (req has-bad-pub) :prompt "Choose a server" :choices (req runnable-servers)
     :msg "prevent ICE from being rezzed during this run"
     :effect (effect (register-run-flag!
                       card

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -90,6 +90,11 @@
                            :effect (effect (install-cost-bonus [:credit (* -3 (count (get-in corp [:servers :rd :ices])))])
                                            (runner-install target) (tag-runner 1) (shuffle! :deck))}} card))}
 
+   "Corporate Scandal"
+   {:msg "give the Corp 1 additional bad publicity"
+    :effect (req (swap! state update-in [:corp :has-bad-pub] inc))
+    :leave-play (req (swap! state update-in [:corp :has-bad-pub] dec))}
+
    "Cyber Threat"
    {:prompt "Choose a server" :choices (req runnable-servers)
     :effect (req (let [serv target

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -9,7 +9,7 @@
     {:corp-turn-begins {:req (req (not tagged))
                         :msg "take 1 tag"
                         :effect (effect (tag-runner :runner 1))}
-     :runner-turn-begins {:req (req (zero? (:bad-publicity corp)))
+     :runner-turn-begins {:req (req (not has-bad-pub))
                           :msg "give the Corp 1 bad publicity"
                           :effect (effect (gain :corp :bad-publicity 1))}}}
 
@@ -386,7 +386,7 @@
    {:recurring 2}
 
    "Investigative Journalism"
-   {:req (req (> (:bad-publicity corp) 0))
+   {:req (req has-bad-pub)
     :abilities [{:cost [:click 4] :msg "give the Corp 1 bad publicity"
                  :effect (effect (gain :corp :bad-publicity 1) (trash card {:cause :ability-cost}))}]}
 
@@ -782,7 +782,8 @@
 
    "Tallie Perrault"
    {:abilities [{:label "Draw 1 card for each Corp bad publicity"
-                 :effect (effect (trash card {:cause :ability-cost}) (draw (:bad-publicity corp)))
+                 :effect (effect (trash card {:cause :ability-cost})
+                                 (draw (+ (:bad-publicity corp) (:has-bad-pub corp))))
                  :msg (msg "draw " (:bad-publicity corp) " cards")}]
     :events {:play-operation
              {:req (req (or (has-subtype? target "Black Ops")

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -17,7 +17,7 @@
        (swap! state assoc :per-run nil
               :run {:server s :position (count ices) :ices ices :access-bonus 0
                     :run-effect (assoc run-effect :card card)})
-       (gain-run-credits state side (get-in @state [:corp :bad-publicity]))
+       (gain-run-credits state side (+ (get-in @state [:corp :bad-publicity]) (get-in @state [:corp :has-bad-pub])))
        (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
        (update-all-ice state :corp)
        (trigger-event state :runner :run s)))))

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -21,7 +21,7 @@
                         :hand (zone :hand (take 5 corp-deck))
                         :discard [] :scored [] :rfg [] :play-area []
                         :servers {:hq {} :rd{} :archives {}}
-                        :click 0 :credit 5 :bad-publicity 0
+                        :click 0 :credit 5 :bad-publicity 0 :has-bad-pub 0
                         :hand-size-base 5 :hand-size-modification 0
                         :agenda-point 0
                         :click-per-turn 3 :agenda-point-req 7 :keep false}

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -33,6 +33,7 @@
                                                      (keys (get-in @state [:runner :register :cannot-run-on-server])))]
                                  (remove (set restricted) (set servers)))
             'tagged '(or (> (:tagged runner) 0) (> (:tag runner) 0))
+            'has-bad-pub '(or (> (:bad-publicity corp) 0) (> (:has-bad-pub corp) 0))
             'this-server '(let [s (-> card :zone rest butlast)
                                 r (:server run)]
                             (and (= (first r) (first s))

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -161,6 +161,31 @@
       (run-jack-out state)
       (run-on state "Archives"))))
 
+(deftest corporate-scandal
+  "Corporate Scandal - Corp has 1 additional bad pub even with 0"
+  (do-game
+    (new-game (default-corp [(qty "Elizabeth Mills" 1)])
+              (default-runner [(qty "Corporate Scandal" 1) (qty "Activist Support" 1)
+                               (qty "Raymond Flint" 1) (qty "Investigative Journalism" 1)]))
+    (play-from-hand state :corp "Elizabeth Mills" "New remote")
+    (take-credits state :corp)
+    (core/gain state :runner :credit 5 :click 1)
+    (play-from-hand state :runner "Raymond Flint")
+    (play-from-hand state :runner "Corporate Scandal")
+    (is (empty? (:prompt (get-runner))) "No BP taken, so no HQ access from Raymond")
+    (play-from-hand state :runner "Investigative Journalism")
+    (is (= "Investigative Journalism" (:title (get-in @state [:runner :rig :resource 1]))) "IJ able to be installed")
+    (run-on state "HQ")
+    (is (= 1 (:run-credit (get-runner))) "1 run credit from bad publicity")
+    (run-jack-out state)
+    (play-from-hand state :runner "Activist Support")
+    (take-credits state :runner)
+    (let [em (get-content state :remote1 0)]
+      (core/rez state :corp em)
+      (is (= 1 (:has-bad-pub (get-corp))) "Corp still has BP")
+      (take-credits state :corp)
+      (is (= 0 (:bad-publicity (get-corp))) "Corp has BP, didn't take 1 from Activist Support"))))
+
 (deftest demolition-run
   "Demolition Run - Trash at no cost"
   (do-game

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -707,7 +707,7 @@
        [:div (str credit " Credit" (if (not= credit 1) "s" "")) (when me? (controls :credit))]
        [:div (str agenda-point " Agenda Point" (when (not= agenda-point 1) "s"))
         (when me? (controls :agenda-point))]
-       [:div (str (+ bad-publicity has-bad-pub) " Bad Publicity") (when (or (pos? bad-publicity) (pos? has-bad-pub)) [:div.warning "!"])
+       [:div (str (+ bad-publicity has-bad-pub) " Bad Publicity")
         (when me? (controls :bad-publicity))]
        [:div (str (+ hand-size-base hand-size-modification) " Max hand size")
         (when me? (controls :hand-size-modification))]]))))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -696,7 +696,7 @@
        [:div (str (+ hand-size-base hand-size-modification) " Max hand size")
         (when me? (controls :hand-size-modification))]]))))
 
-(defmethod stats-view "Corp" [{:keys [user click credit agenda-point bad-publicity
+(defmethod stats-view "Corp" [{:keys [user click credit agenda-point bad-publicity has-bad-pub
                                       hand-size-base hand-size-modification]} owner]
   (om/component
    (sab/html
@@ -707,7 +707,7 @@
        [:div (str credit " Credit" (if (not= credit 1) "s" "")) (when me? (controls :credit))]
        [:div (str agenda-point " Agenda Point" (when (not= agenda-point 1) "s"))
         (when me? (controls :agenda-point))]
-       [:div (str bad-publicity " Bad Publicity")
+       [:div (str (+ bad-publicity has-bad-pub) " Bad Publicity") (when (or (pos? bad-publicity) (pos? has-bad-pub)) [:div.warning "!"])
         (when me? (controls :bad-publicity))]
        [:div (str (+ hand-size-base hand-size-modification) " Max hand size")
         (when me? (controls :hand-size-modification))]]))))


### PR DESCRIPTION
Corporate Scandal adds a new bad publicity key to the Corp state in similar fashion to how Paparazzi was done for the Runner. 

Includes a test to validate the non-combo with Raymond Flint, that rezzing Elizabeth Mills doesn't reduce this bad publicity, the Runner gaining a run credit, and updated bad publicity requirements of Activist Support and Investigative Journalism. 

The gameboard is updated to show a blue alert in the stats area when the Corp has bad publicity. 