### PR TITLE
Fixes: Test Run + Scavenge, Dracō, Product Recall

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -682,7 +682,7 @@
                                              ((if (= target "Heap") :discard :deck) runner))))
                       :effect (effect (runner-install (assoc-in target [:special :test-run] true) {:no-cost true}))
                       :end-turn
-                      {:req (req (find-cid (:cid target) (all-installed state :runner)))
+                      {:req (req (get-in (find-cid (:cid target) (all-installed state :runner)) [:special :test-run]))
                        :msg (msg "move " (:title target) " to the top of their Stack")
                        :effect (req (move state side (find-cid (:cid target) (all-installed state :runner))
                                           :deck {:front true}))}}

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -290,7 +290,7 @@
     :prevent {:damage [:meat :net :brain]}
     :abilities [{:msg "prevent 1 damage"
                  :choices {:req #(and (= (:side %) "Runner") (:installed %))}
-                 :priority true
+                 :priority 50
                  :effect (effect (trash target {:cause :ability-cost})
                                  (damage-prevent :brain 1)
                                  (damage-prevent :meat 1)
@@ -358,12 +358,13 @@
       :in-play [:memory 3]
       :effect (effect (resolve-ability (mhelper 1) card nil))
       :abilities [{:msg (msg "prevent 1 brain or net damage by trashing " (:title target))
-                   :priority true
+                   :priority 50
                    :choices {:req #(and (is-type? % "Program")
                                         (in-hand? %))}
-                   :prompt "Choose a program to trash from your grip" :effect (effect (trash target)
-                                                                       (damage-prevent :brain 1)
-                                                                       (damage-prevent :net 1))}]})
+                   :prompt "Choose a program to trash from your Grip"
+                   :effect (effect (trash target)
+                                   (damage-prevent :brain 1)
+                                   (damage-prevent :net 1))}]})
 
    "Muresh Bodysuit"
    {:events {:pre-damage {:once :per-turn :once-key :muresh-bodysuit

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -488,7 +488,7 @@
    {:prevent {:damage [:net :brain]}
     :abilities [{:effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
                                 (resolve-ability state side
-                                  {:prompt "Choose how much damage to prevent" :priority true
+                                  {:prompt "Choose how much damage to prevent" :priority 50
                                    :choices {:number (req (min n (count (:deck runner))))}
                                    :msg (msg "trash " target " cards from their Stack and prevent " target " damage")
                                    :effect (effect (damage-prevent :net target)

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -379,7 +379,7 @@
    {:prompt "How many power counters?"
     :choices :credit
     :msg (msg "add " target " power counters")
-    :effect (effect (set-prop card :counter target)
+    :effect (effect (add-prop card :counter target)
                     (update-ice-strength card))
     :strength-bonus (req (or (:counter card) 0))
     :abilities [(trace-ability 2 {:label "Give the Runner 1 tag and end the run"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -429,7 +429,8 @@
                      (gain state :corp :credit tcost)
                      (resolve-ability state side
                        {:msg (msg "trash " (card-str state c) " and gain " tcost " [Credits]")}
-                      card nil))))}
+                      card nil)
+                     (swap! state update-in [:bonus] dissoc :trash))))}
 
    "Psychographics"
    {:req (req tagged) :choices :credit :prompt "How many credits?"

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -210,7 +210,8 @@
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
-      (resolve-ability state side trash-effect moved-card (cons cause targets)))))
+      (resolve-ability state side trash-effect moved-card (cons cause targets)))
+    (swap! state update-in [:per-turn] dissoc (:cid moved-card))))
 
 (defn trash
   "Attempts to trash the given card, allowing for boosting/prevention effects."

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -505,6 +505,26 @@
               (take-credits state :runner)
               (is (= "Knight" (:title (first (:deck (get-runner))))) "Knight returned to Stack from host ICE"))))))))
 
+(deftest test-run-scavenge
+  "Test Run - Make sure program remains installed if Scavenged"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Test Run" 1) (qty "Morning Star" 1) (qty "Scavenge" 1)]))
+    (take-credits state :corp)
+    (core/move state :runner (find-card "Morning Star" (:hand (get-runner))) :discard)
+    (play-from-hand state :runner "Test Run")
+    (let [ms (find-card "Morning Star" (:discard (get-runner)))]
+      (prompt-choice :runner "Heap")
+      (prompt-choice :runner ms)
+      (is (= 2 (:credit (get-runner))) "Program installed for free")
+      (let [ms (get-in @state [:runner :rig :program 0])]
+        (play-from-hand state :runner "Scavenge")
+        (prompt-select :runner ms)
+        (prompt-select :runner (find-card "Morning Star" (:discard (get-runner))))
+        (take-credits state :runner)
+        (is (empty? (:deck (get-runner))) "Morning Star not returned to Stack")
+        (is (= "Morning Star" (:title (get-in @state [:runner :rig :program 0]))) "Morning Star still installed")))))
+
 (deftest vamp
   "Vamp - Run HQ and use replace access to pay credits to drain equal amount from Corp"
   (do-game


### PR DESCRIPTION
* Fix #1354: Restore working Test Run + Scavenge combo (includes a test)
* Fix #1345: Trashing a card should remove it from `[:per-turn]` so you could Scavenge or Clone Chip once-per-turn cards like Imp and use them again all within a single turn (includes a test)
* Fix Product Recall to swap out trash cost bonus after use so further plays of the card don't yield too many credits
* Fix Dracō to add counters instead of setting them in case it ever gets derezzed and re-rezzed. 
* Update Heartbeat and Monolith damage prevention ability prompts to numerical values that will bring them to the front of the queue