### PR TITLE
Employee Strike and Cerebral Static rework

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -177,9 +177,8 @@
 
    "Employee Strike"
    {:msg "disable the Corp's identity"
-    :effect (req (unregister-events state side (:identity corp)))
-    :leave-play (req (when-let [events (:events (card-def (:identity corp)))]
-                       (register-events state side events (:identity corp))))}
+    :effect (effect (disable-identity :corp))
+    :leave-play (effect (enable-identity :corp))}
 
    "Escher"
    (letfn [(es [] {:prompt "Select two pieces of ICE to swap positions"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -157,7 +157,7 @@
                        :choices {:req #(and (installed? %) (ice? %))}
                        :effect (req (add-prop state :corp target :advance-counter 1 {:placed true}))}]
               {:runner-turn-begins fap
-               :pre-start-game {:effect draft-points-target})}
+               :pre-start-game {:effect draft-points-target}})}
 
    "Gabriel Santiago: Consummate Professional"
    {:events {:successful-run {:msg "gain 2 [Credits]" :once :per-turn

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -10,19 +10,26 @@
    (let [titles #{"Safety First" "Always Be Running" "Neutralize All Threats"}
          one-of-each   (fn [cards] (->> cards (group-by :title) (map second) (map first)))
          get-directives (fn [source] (filter #(some #{(:title %)} titles) source))]
-   {:effect (req (let [directives (-> (:deck runner) (concat (:hand runner)) (get-directives) one-of-each)]
-                   (when (not= 3 (count directives))
-                     (toast state :runner
-                            "Your deck doesn't contain enough directives for Adam's ability. The deck needs to contain at least one copy of each directive. They are not counted against the printed decksize limit, so minimal Adam's decksize on this site is 48 cards."
-                            "warning"
-                            {:time-out 0 :close-button true}))
-                   (doseq [c directives]
-                     (runner-install state side c {:no-cost true
-                                                   :custom-message (str "starts with " (:title c) " in play")}))
-                   (draw state :runner (count (filter in-hand? directives)))))})
+   {:events {:pre-start-game
+             {:req (req (= side :runner))
+              :effect (req (let [directives (-> (:deck runner) (concat (:hand runner)) (get-directives) one-of-each)]
+                             (when (not= 3 (count directives))
+                               (toast state :runner
+                                      (str "Your deck doesn't contain enough directives for Adam's ability. The deck "
+                                           "needs to contain at least one copy of each directive. They are not counted "
+                                           "against the printed decksize limit, so minimal Adam's decksize on this site is 48 cards.")
+                                      "warning"
+                                      {:time-out 0 :close-button true}))
+                             (doseq [c directives]
+                               (runner-install state side c {:no-cost true
+                                                             :custom-message (str "starts with " (:title c) " in play")}))
+                             (draw state :runner (count (filter in-hand? directives)))))}}})
 
    "Andromeda: Dispossessed Ristie"
-   {:effect (effect (gain :link 1) (draw 4)) :mulligan (effect (draw 4))}
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1)
+                                              (draw 4))}}
+    :mulligan (effect (draw 4))}
 
    "Apex: Invasive Predator"
    (let [ability {:prompt "Select a card to install facedown"
@@ -46,13 +53,15 @@
                                  (system-msg state side "suffers 2 meat damage"))))}}}
 
    "Armand \"Geist\" Walker: Tech Lord"
-   {:effect (effect (gain :link 1))
-    :events {:runner-trash {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}
+             :runner-trash {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
                             :msg "draw a card"
                             :effect (effect (draw 1))}}}
 
    "Blue Sun: Powering the Future"
-   {:flags {:corp-phase-12 (req (some #(rezzed? %) (all-installed state :corp)))}
+   {:flags {:corp-phase-12 (req (and (not (:disabled card))
+                                     (some #(rezzed? %) (all-installed state :corp))))}
     :abilities [{:choices {:req #(:rezzed %)}
                  :effect (req (trigger-event state side :pre-rez-cost target)
                               (let [cost (rez-cost state side target)]
@@ -62,25 +71,27 @@
                                 (swap! state update-in [:bonus] dissoc :cost)))}]}
 
    "Boris \"Syfr\" Kovac: Crafty Veteran"
-   {:effect draft-points-target
-    :events (let [bor {:req (req (let [facs (frequencies (map :faction (all-installed state :runner)))
+   {:events (let [bor {:req (req (let [facs (frequencies (map :faction (all-installed state :runner)))
                                        an (get facs "Anarch" 0)
                                        sh (get facs "Shaper" 0)
                                        cr (get facs "Criminal" 0)]
                                    (and (> cr sh) (> cr an) (pos? (:tag runner)))))
                        :msg "remove 1 tag"
                        :effect (effect (lose :tag 1))}]
-              {:runner-turn-begins bor})}
+              {:runner-turn-begins bor
+               :pre-start-game {:effect draft-points-target}})}
 
    "Cerebral Imaging: Infinite Frontiers"
    {:effect (req (add-watch state :cerebral-imaging
                             (fn [k ref old new]
                               (let [credit (get-in new [:corp :credit])]
                                 (when (not= (get-in old [:corp :credit]) credit)
-                                  (swap! ref assoc-in [:corp :hand-size-base] credit))))))}
+                                  (swap! ref assoc-in [:corp :hand-size-base] credit))))))
+    :leave-play (effect (remove-watch state :cerebral-imaging))}
 
    "Chaos Theory: Wünderkind"
-   {:effect (effect (gain :memory 1))}
+   {:effect (effect (gain :memory 1))
+    :leave-play (effect (lose :runner :memory 1))}
 
    "Chronos Protocol: Selective Mind-mapping"
    {:events
@@ -109,11 +120,14 @@
 
    "Cybernetics Division: Humanity Upgraded"
    {:effect (effect (lose :hand-size-modification 1)
-                    (lose :runner :hand-size-modification 1))}
+                    (lose :runner :hand-size-modification 1))
+    :leave-play (effect (gain :hand-size-modification 1)
+                        (gain :runner :hand-size-modification 1))}
 
    "Edward Kim: Humanitys Hammer"
-   {:effect (effect (gain :link 1))
-    :events {:access {:once :per-turn
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}
+             :access {:once :per-turn
                       :req (req (and (is-type? target "Operation")
                                      (turn-flag? state side card :can-trash-operation)))
                       :effect (effect (trash target))
@@ -124,15 +138,15 @@
                                    :effect (effect (register-turn-flag! card :can-trash-operation (constantly false)))}}}
 
    "Exile: Streethawk"
-   {:effect (effect (gain :link 1))
-    :events {:runner-install {:req (req (and (is-type? target "Program")
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}
+             :runner-install {:req (req (and (is-type? target "Program")
                                              (some #{:discard} (:previous-zone target))))
                               :msg (msg "draw a card")
                               :effect (effect (draw 1))}}}
 
    "Fringe Applications: Tomorrow, Today"
-   {:effect draft-points-target
-    :events (let [fap {:req (req (let [facs (frequencies (map :faction (filter :rezzed (all-installed state :corp))))
+   {:events (let [fap {:req (req (let [facs (frequencies (map :faction (filter :rezzed (all-installed state :corp))))
                                        hb (get facs "Haas-Bioroid" 0)
                                        ji (get facs "Jinteki" 0)
                                        nb (get facs "NBN" 0)
@@ -142,34 +156,36 @@
                        :prompt "Choose a piece of ICE to place 1 advancement token on it" :player :corp
                        :choices {:req #(and (installed? %) (ice? %))}
                        :effect (req (add-prop state :corp target :advance-counter 1 {:placed true}))}]
-              {:runner-turn-begins fap})}
+              {:runner-turn-begins fap
+               :pre-start-game {:effect draft-points-target})}
 
    "Gabriel Santiago: Consummate Professional"
    {:events {:successful-run {:msg "gain 2 [Credits]" :once :per-turn
                               :effect (effect (gain :credit 2)) :req (req (= target :hq))}}}
 
    "Gagarin Deep Space: Expanding the Horizon"
-   {:flags {:slow-remote-access (req true)}
+   {:flags {:slow-remote-access (req (not (:disabled card)))}
     :events {:pre-access-card {:req (req (is-remote? (second (:zone target))))
                                :effect (effect (access-cost-bonus [:credit 1]))
-                               :msg  (msg (if
-                                      (= (get-in @state [:runner :credit]) 0)
-                                      "prevent access"
-                                      "make the Runner spend 1 [Credits] to access"
-                                      ))}}}
+                               :msg "make the Runner spend 1 [Credits] to access"}}}
 
    "GRNDL: Power Unleashed"
-   {:effect (effect (gain :credit 5 :bad-publicity 1))}
+   {:events {:pre-start-game {:req (req (= :corp side))
+                              :effect (req (gain state :corp :credit 5)
+                                           (when (= 0 (:bad-publicity corp))
+                                             (gain state :corp :bad-publicity 1)))}}}
 
    "Haarpsichord Studios: Entertainment Unleashed"
+   (let [haarp (fn [state side card]
+                 (if (is-type? card "Agenda")
+                   ((constantly false)
+                     (toast state :runner "Cannot steal due to Haarpsichord Studios." "warning"))
+                   true))]
    {:events {:agenda-stolen
-             {:effect (effect (register-turn-flag!
-                                card :can-steal
-                                (fn [state side card]
-                                  (if (is-type? card "Agenda")
-                                    ((constantly false)
-                                     (toast state :runner "Cannot steal due to Haarpsichord Studios." "warning"))
-                                    true))))}}}
+             {:effect (effect (register-turn-flag! card :can-steal haarp))}}
+    :effect (req (when-not (first-event state side :agenda-stolen)
+                   (register-turn-flag! state side card :can-steal haarp)))
+    :leave-play (effect (clear-turn-flag! card :can-steal))})
 
    "Haas-Bioroid: Engineering the Future"
    {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"
@@ -180,7 +196,8 @@
                                 :effect (effect (ice-strength-bonus 1 target))}}}
 
    "Harmony Medtech: Biomedical Pioneer"
-   {:effect (effect (lose :agenda-point-req 1) (lose :runner :agenda-point-req 1))}
+   {:effect (effect (lose :agenda-point-req 1) (lose :runner :agenda-point-req 1))
+    :leave-play (effect (gain :agenda-point-req 1) (gain :runner :agenda-point-req 1))}
 
    "Hayley Kaplan: Universal Scholar"
    {:events {:runner-install
@@ -202,8 +219,9 @@
                   :msg "gain 2 [Credits]"
                   :effect (effect (gain :credit 2))}]
    {:flags {:drip-economy true}
-    :effect (effect (gain :link 1))
-    :events {:runner-turn-begins ability}
+    :events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}
+             :runner-turn-begins ability}
     :abilities [ability]})
 
    "Industrial Genomics: Growing Solutions"
@@ -211,8 +229,7 @@
                                            (count (filter #(not (:seen %)) (:discard corp)))))}}}
 
    "Information Dynamics: All You Need To Know"
-   {:effect draft-points-target
-    :events (let [inf {:req (req (let [facs (frequencies (map :faction (filter :rezzed (all-installed state :corp))))
+   {:events (let [inf {:req (req (let [facs (frequencies (map :faction (filter :rezzed (all-installed state :corp))))
                                        hb (get facs "Haas-Bioroid" 0)
                                        ji (get facs "Jinteki" 0)
                                        nb (get facs "NBN" 0)
@@ -220,11 +237,11 @@
                                    (and (> nb ji) (> nb hb) (> nb we))))
                        :msg "give the Runner 1 tag"
                        :effect (effect (tag-runner :runner 1))}]
-              {:agenda-scored inf :agenda-stolen inf})}
+              {:agenda-scored inf :agenda-stolen inf
+               :pre-start-game {:effect draft-points-target}})}
 
    "Jamie \"Bzzz\" Micken: Techno Savant"
-   {:effect draft-points-target
-    :events (let [jam {:req (req (let [facs (frequencies (map :faction (all-installed state :runner)))
+   {:events (let [jam {:req (req (let [facs (frequencies (map :faction (all-installed state :runner)))
                                        an (get facs "Anarch" 0)
                                        sh (get facs "Shaper" 0)
                                        cr (get facs "Criminal" 0)]
@@ -232,7 +249,8 @@
                        :msg "draw 1 card"
                        :once :per-turn
                        :effect (effect (draw 1))}]
-              {:runner-install jam})}
+              {:runner-install jam
+               :pre-start-game {:effect draft-points-target}})}
 
    "Jesminder Sareen: Girl Behind the Curtain"
    {:events {:pre-tag {:once :per-run
@@ -251,7 +269,8 @@
      :run {:once :per-turn
            :req (req (is-central? (:server run)))
            :effect (req (apply enable-run-on-server
-                               state card (map first (get-remotes @state))))}}}
+                               state card (map first (get-remotes @state))))}}
+    :leave-play (req (apply enable-run-on-server state card (map first (get-remotes @state))))}
 
    "Jinteki Biotech: Life Imagined"
    {:events {:pre-first-turn {:req (req (= side :corp))
@@ -292,8 +311,9 @@
                                          :effect (effect (add-prop target :advance-counter 4 {:placed true}))} card nil)))))}]}
 
    "Kate \"Mac\" McCaffrey: Digital Tinker"
-   {:effect (effect (gain :link 1))
-    :events {:pre-install {:req (req (and (#{"Hardware" "Program"} (:type target))
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}
+             :pre-install {:req (req (and (#{"Hardware" "Program"} (:type target))
                                           (not (get-in @state [:per-turn (:cid card)]))))
                            :effect (effect (install-cost-bonus [:credit -1]))}
              :runner-install {:req (req (and (#{"Hardware" "Program"} (:type target))
@@ -345,13 +365,15 @@
                   :once :per-turn
                   :effect (effect (mill 2) (draw))}]
    {:flags {:runner-turn-draw true
-            :runner-phase-12 (req (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner)))}
+            :runner-phase-12 (req (and (not (:disabled card))
+                                       (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner))))}
     :events {:runner-turn-begins ability}
     :abilities [ability]})
 
    "Nasir Meidan: Cyber Explorer"
-   {:effect (effect (gain :link 1))
-    :events {:rez {:req (req (and (:run @state)
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}
+             :rez {:req (req (and (:run @state)
                                   ;; check that the rezzed item is the encountered ice
                                   (= (:cid target)
                                      (:cid (get-card state current-ice)))))
@@ -371,13 +393,15 @@
    {:recurring 2}
 
    "NBN: The World is Yours*"
-   {:effect (effect (gain :hand-size-modification 1))}
+   {:effect (effect (gain :hand-size-modification 1))
+    :leave-play (effect (lose :hand-size-modification 1))}
 
    "Near-Earth Hub: Broadcast Center"
    {:events {:server-created {:msg "draw 1 card" :once :per-turn :effect (effect (draw 1))}}}
 
    "Nero Severn: Information Broker"
-   {:effect (effect (gain :link 1))
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}}
     :abilities [{:req (req (has-subtype? current-ice "Sentry"))
                  :once :per-turn
                  :msg "jack out when encountering a sentry"
@@ -433,8 +457,9 @@
    {:abilities [{:once :per-turn :msg "break 1 barrier subroutine"}]}
 
    "Reina Roja: Freedom Fighter"
-   {:effect (effect (gain :link 1))
-    :events {:pre-rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 1))}
+             :pre-rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
                        :effect (effect (rez-cost-bonus 1))}
              :rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
                               :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
@@ -473,14 +498,15 @@
            :msg (msg "make the Runner lose 1 [Credits] by rezzing an advertisement")}}}
 
    "Strategic Innovations: Future Forward"
-   {:effect draft-points-target
-    :events {:runner-turn-ends
+   {:events {:pre-start-game {:effect draft-points-target}
+             :runner-turn-ends
              {:req (req (let [facs (frequencies (map :faction (filter :rezzed (all-installed state :corp))))
                               hb (get facs "Haas-Bioroid" 0)
                               ji (get facs "Jinteki" 0)
                               nb (get facs "NBN" 0)
                               we (get facs "Weyland Consortium" 0)]
-                          (and (> hb ji) (> hb nb) (> hb we) (pos? (count (:discard corp))))))
+                          (and (not (:disabled card))
+                               (> hb ji) (> hb nb) (> hb we) (pos? (count (:discard corp))))))
               :prompt "Choose a card in Archives to shuffle into R&D"
               :choices {:req #(and (card-is? % :side :corp) (= (:zone %) [:discard]))}
               :player :corp :show-discard true :priority true
@@ -490,7 +516,8 @@
                               (shuffle! :corp :deck))}}}
 
    "Sunny Lebeau: Security Specialist"
-   {:effect (effect (gain :link 2))}
+   {:events {:pre-start-game {:req (req (= side :runner))
+                              :effect (effect (gain :link 2))}}}
 
    "SYNC: Everything, Everywhere"
    {:events {:pre-first-turn {:req (req (= side :corp))
@@ -506,13 +533,14 @@
                  :msg (msg "flip their ID")}]}
 
    "Synthetic Systems: The World Re-imagined"
-   {:effect draft-points-target
+   {:events {:pre-start-game {:effect draft-points-target}}
     :flags {:corp-phase-12 (req (let [facs (frequencies (map :faction (filter :rezzed (all-installed state :corp))))
                                       hb (get facs "Haas-Bioroid" 0)
                                       ji (get facs "Jinteki" 0)
                                       nb (get facs "NBN" 0)
                                       we (get facs "Weyland Consortium" 0)]
-                                  (and (> ji hb) (> ji nb) (> ji we)
+                                  (and (not (:disabled (get-card state card)))
+                                       (> ji hb) (> ji nb) (> ji we)
                                        (> (count (filter #(ice? %) (all-installed state :corp))) 1))))}
     :abilities [{:prompt "Select two pieces of ICE to swap positions"
                  :choices {:req #(and (installed? %) (ice? %)) :max 2}
@@ -523,7 +551,8 @@
                            " and " (card-str state (second targets)))}]}
 
    "Tennin Institute: The Secrets Within"
-   {:flags {:corp-phase-12 (req (and (not= 1 (:turn @state)) (not (:successful-run runner-reg))))}
+   {:flags {:corp-phase-12 (req (and (not (:disabled (get-card state card)))
+                                     (not= 1 (:turn @state)) (not (:successful-run runner-reg))))}
     :abilities [{:msg (msg "place 1 advancement token on " (card-str state target))
                  :choices {:req installed?}
                  :req (req (not (:successful-run runner-reg)))
@@ -543,18 +572,20 @@
                                           (shuffle! :deck))}}}}}
 
    "The Masque: Cyber General"
-   {:effect draft-points-target}
+   {:events {:pre-start-game {:effect draft-points-target}}}
 
    "The Shadow: Pulling the Strings"
-   {:effect draft-points-target}
+   {:events {:pre-start-game {:effect draft-points-target}}}
 
    "Titan Transnational: Investing In Your Future"
    {:events {:agenda-scored {:msg (msg "add 1 agenda counter to " (:title target))
                              :effect (effect (add-prop target :counter 1))}}}
 
    "Valencia Estevez: The Angel of Cayambe"
-   {:req (req (zero? (get-in @state [:corp :bad-publicity])))
-    :effect (effect (gain :corp :bad-publicity 1))}
+   {:events {:pre-start-game
+             {:req (req (and (= side :runner)
+                             (zero? (get-in @state [:corp :bad-publicity]))))
+              :effect (effect (gain :corp :bad-publicity 1))}}}
 
    "Weyland Consortium: Because We Built It"
    {:recurring 1}
@@ -568,8 +599,7 @@
    {:recurring 3}
 
    "Wyvern: Chemically Enhanced"
-   {:effect draft-points-target
-    :events (let [wyv {:req (req (let [facs (frequencies (map :faction (all-installed state :runner)))
+   {:events (let [wyv {:req (req (let [facs (frequencies (map :faction (all-installed state :runner)))
                                        an (get facs "Anarch" 0)
                                        sh (get facs "Shaper" 0)
                                        cr (get facs "Criminal" 0)]
@@ -578,4 +608,5 @@
                        :msg (msg "shuffle " (:title (last (:discard runner))) " into their Stack")
                        :effect (effect (move :runner (last (:discard runner)) :deck)
                                        (shuffle! :runner :deck))}]
-              {:runner-trash wyv})}})
+              {:pre-start-game {:effect draft-points-target}
+               :runner-trash wyv})}})

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -162,9 +162,8 @@
 
    "Cerebral Static"
    {:msg "disable the Runner's identity"
-    :effect (req (unregister-events state side (:identity runner)))
-    :leave-play (req (when-let [events (:events (card-def (:identity runner)))]
-                       (register-events state side events (:identity runner))))}
+    :effect (effect (disable-identity :runner))
+    :leave-play (effect (enable-identity :runner))}
 
    "\"Clones are not People\""
    {:events {:agenda-scored {:msg "add it to their score area and gain 1 agenda point"

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -70,6 +70,12 @@
 (defn clear-turn-register! [state]
   (swap! state assoc-in [:stack :current-turn] nil))
 
+(defn clear-turn-flag!
+  "Remove any entry associated with card for the given flag"
+  [state side card flag]
+  (swap! state update-in [:stack :current-turn flag]
+         #(remove (fn [map] (= (:cid (map :card)) (:cid %2))) %1) card))
+
 (defn register-persistent-flag!
   "A flag that persists until cleared."
   [state side card flag condition]

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -38,6 +38,8 @@
     (card-init state :corp corp-identity)
     (card-init state :runner runner-identity)
     (swap! game-states assoc gameid state)
+    (trigger-event state :corp :pre-start-game)
+    (trigger-event state :runner :pre-start-game)
     (when (and (-> @state :corp :identity :title) (-> @state :runner :identity :title))
       (show-wait-prompt state :runner "Corp to keep hand or mulligan"))
     (doseq [s [:corp :runner]]

--- a/src/clj/test/cards-events.clj
+++ b/src/clj/test/cards-events.clj
@@ -239,7 +239,19 @@
       (is (= 1 (count (get-in @state [:corp :servers :remote3 :content])))
           "Project Atlas not trashed from Server 3"))))
 
-(deftest freelance-coding-contract
+(deftest employee-strike-blue-sun
+  "Employee Strike - vs Blue Sun, suppress Step 1.2"
+  (do-game
+    (new-game (make-deck "Blue Sun: Powering the Future" [(qty "Ice Wall" 1)])
+              (default-runner [(qty "Employee Strike" 1) (qty "Scrubbed" 1)]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Employee Strike")
+    (take-credits state :runner)
+    (is (not (:corp-phase-12 @state)) "Employee Strike suppressed Blue Sun step 1.2")))
+
+    (deftest freelance-coding-contract
   "Freelance Coding Contract - Gain 2 credits per program trashed from Grip"
   (do-game
     (new-game (default-corp)

--- a/src/clj/test/cards-operations.clj
+++ b/src/clj/test/cards-operations.clj
@@ -61,6 +61,17 @@
           (prompt-choice :runner "Steal")
           (is (= 2 (:tag (get-runner))) "Runner took 2 tags from accessing agenda with Casting Call hosted on it"))))))
 
+(deftest cerebral-static-chaos-theory
+  "Cerebral Static - vs Chaos Theory"
+  (do-game
+    (new-game (default-corp [(qty "Cerebral Static" 1) (qty "Lag Time" 1)])
+              (make-deck "Chaos Theory: Wünderkind" [(qty "Sure Gamble" 3)]))
+    (is (= 5 (:memory (get-runner))) "CT starts with 5 memory")
+    (play-from-hand state :corp "Cerebral Static")
+    (is (= 4 (:memory (get-runner))) "Cerebral Static causes CT to have 4 memory")
+    (play-from-hand state :corp "Lag Time")
+    (is (= 5 (:memory (get-runner))) "CT 5 memory restored")))
+
 (deftest closed-accounts
   "Closed Accounts - Play if Runner is tagged to make Runner lose all credits"
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -23,10 +23,10 @@
                                       :cards (:deck runner)}}]})
           state (second (last states))]
       (if (#{:both :corp} mulligan)
-        (core/mulligan state :corp nil)
+        (core/resolve-prompt state :corp {:choice "Mulligan"})
         (core/resolve-prompt state :corp {:choice "Keep"}))
       (if (#{:both :runner} mulligan)
-        (core/mulligan state :runner nil)
+        (core/resolve-prompt state :runner {:choice "Mulligan"})
         (core/resolve-prompt state :runner {:choice "Keep"}))
       (core/start-turn state :corp nil)
       state)))

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -11,20 +11,25 @@
 
 (defn new-game
   "Init a new game using given corp and runner. Keep starting hands (no mulligan) and start Corp's turn."
-  [corp runner]
-  (let [states (core/init-game
-                 {:gameid 1
-                  :players [{:side "Corp"
-                             :deck {:identity (load-card (:identity corp))
-                                    :cards (:deck corp)}}
-                            {:side "Runner"
-                             :deck {:identity (load-card (:identity runner))
-                                    :cards (:deck runner)}}]})
-        state (second (last states))]
-    (core/resolve-prompt state :corp {:choice "Keep"})
-    (core/resolve-prompt state :runner {:choice "Keep"})
-    (core/start-turn state :corp nil)
-    state))
+  ([corp runner] (new-game corp runner nil))
+  ([corp runner {:keys [mulligan] :as args}]
+    (let [states (core/init-game
+                   {:gameid 1
+                    :players [{:side "Corp"
+                               :deck {:identity (load-card (:identity corp))
+                                      :cards (:deck corp)}}
+                              {:side "Runner"
+                               :deck {:identity (load-card (:identity runner))
+                                      :cards (:deck runner)}}]})
+          state (second (last states))]
+      (if (#{:both :corp} mulligan)
+        (core/mulligan state :corp nil)
+        (core/resolve-prompt state :corp {:choice "Keep"}))
+      (if (#{:both :runner} mulligan)
+        (core/mulligan state :runner nil)
+        (core/resolve-prompt state :runner {:choice "Keep"}))
+      (core/start-turn state :corp nil)
+      state)))
 
 
 ;;; Card related functions


### PR DESCRIPTION
Addressing concerns in #1313 and my own observations.

1. Clean up identity implementations so that things which are permanent (link strength, draft identity agenda points, Andy starting hand) are moved out of the identity's `:effect`, which then only contains effects that actively affect the game state (Chaos Theory memory, Cerebral Imaging hand size, etc.).
2. Add `:leave-play` effects to identities that kept a `:effect` flag, to disable whatever effect they have on the game when Cerebral Static / Employee Strike is played.
3. Add `:leave-play` to more complicated cards like Haarpsichord and Replicating Perfection to disable the effect of their flag registers.
4. Tweak Cerebral Static / Employee Strike to call `:leave-play`on the opponent's identity when played, and call `:effect` on the ID when the current is trashed.
5. Fix a few identity flags to take into account whether the ID has been disabled. Blue Sun/Tennin/MaxX won't cause Step 1.2, Gagarin won't force slow remote access.