### PR TITLE
Fixes: Mushin, Populist Rally, Neutralize All Threats, Sec Testing, Snatch and Grab

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -494,7 +494,8 @@
     :effect (effect (lose :corp :click-per-turn 1)
                     (register-events (:events (card-def card))
                                      (assoc card :zone '(:discard))))
-    :events {:corp-turn-ends {:effect (effect (gain :corp :click-per-turn 1))}}}
+    :events {:corp-turn-ends {:effect (effect (gain :corp :click-per-turn 1)
+                                              (unregister-events card))}}}
 
    "Power Nap"
    {:effect (effect (gain :credit (+ 2 (count (filter #(has-subtype? % "Double")

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -2,7 +2,7 @@
 
 (def cards-hardware
   {"Akamatsu Mem Chip"
-   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))}
+   {:in-play [:memory 1]}
 
    "Archives Interface"
    {:events {:no-action {:effect (req (toast state :runner "Click Archives Interface to remove 1 card in Archives from the game instead of accessing it" "info")
@@ -79,7 +79,7 @@
                                      :hand-size-modification bonus))))))
       :leave-play (req (remove-watch state (keyword (str "brainchip" (:cid card))))
                        (lose state :runner
-                             :memory (runner-points @state) 
+                             :memory (runner-points @state)
                              :hand-size-modification (runner-points @state)))})
 
    "Capstone"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -271,7 +271,6 @@
                  :req (req (not (:biotech-used card)))
                  :label "Flip this identity"
                  :effect (req (let [flip (:biotech-target card)]
-                                (update! state side (assoc card :biotech-used true))
                                 (case flip
                                   "[The Brewery~brewery]"
                                   (do (system-msg state side "uses [The Brewery~brewery] to do 2 net damage")
@@ -289,7 +288,8 @@
                                         state side
                                         {:prompt "Choose a card that can be advanced"
                                          :choices {:req can-be-advanced?}
-                                         :effect (effect (add-prop target :advance-counter 4 {:placed true}))} card nil)))))}]}
+                                         :effect (effect (add-prop target :advance-counter 4 {:placed true}))} card nil)))
+                                (update! state side (assoc (get-card state card) :biotech-used true))))}]}
 
    "Kate \"Mac\" McCaffrey: Digital Tinker"
    {:effect (effect (gain :link 1))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -452,7 +452,9 @@
    "Reclamation Order"
    {:prompt "Choose a card from Archives" :msg (msg "add copies of " (:title target) " to HQ")
     :show-discard true
-    :choices {:req #(and (= (:side %) "Corp") (= (:zone %) [:discard]))}
+    :choices {:req #(and (= (:side %) "Corp")
+                         (not= (:title %) "Reclamation Order")
+                         (= (:zone %) [:discard]))}
     :effect (req (doseq [c (filter #(= (:title target) (:title %)) (:discard corp))]
                    (move state side c :hand)))}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -566,8 +566,8 @@
                                                   {:msg (msg "take 1 tag to prevent " (:title c)
                                                              " from being trashed")
                                                    :effect (effect (tag-runner 1 {:unpreventable true}))}
-                                                  {:effect (trash state side c) :msg (msg "trash " (:title c))})
-                                                card nil))}
+                                                  {:effect (effect (trash c)) :msg (msg "trash " (:title c))})
+                                               card nil))}
                              card nil)))}}
 
    "Sub Boost"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -728,7 +728,8 @@
                                     {:mandatory true
                                      :effect (effect (resolve-ability
                                                        {:msg "gain 2 [Credits] instead of accessing"
-                                                        :effect (effect (gain :credit 2))} st nil))})))}}
+                                                        :effect (effect (gain :credit 2))} st nil))})))}
+             :runner-turn-ends {:effect (effect (update! (dissoc card :testing-target)))}}
     :abilities [ability]})
 
    "Spoilers"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -494,9 +494,13 @@
 
    "Neutralize All Threats"
    {:in-play [:hq-access 1]
-    :events {:access {:effect (req (swap! state assoc-in [:runner :register :force-trash] false))}
+    :events {:pre-access {:req (req (and (= target :archives)
+                                         (seq (filter #(not (nil? (:trash %))) (:discard corp)))))
+                          :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}
+             :access {:effect (req (swap! state assoc-in [:runner :register :force-trash] false))}
              :pre-trash {:req (req (let [cards (map first (turn-events state side :pre-trash))]
                                      (empty? (filter #(not (nil? (:trash %))) cards))))
+                         :once :per-turn
                          :effect (req (swap! state assoc-in [:runner :register :force-trash] true))}}}
 
    "New Angeles City Hall"


### PR DESCRIPTION
* Fix #1375: Snatch and Grab has a malformed `:effect` when the Runner declines to take a tag
* Fix #1369: Confine Security Testing replacement effect to Runner's turn only
* Fix #1368: Unregister events at the end of the Corp turn so they don't keep gaining a click per turn indefinitely. 
* Fix #1366: Fix turn flags on Mushin so only the installed card is prevented from rezzing or being scored and not everything.
* Fix #1359: Use `:per-turn` with NAT and set it to true if the Runner accesses something with a trash cost on an initial run on Archives to "switch off" the forced trash ability. 
* Reclamation Order isn't supposed to be able to target copies of itself
* Jinteki Biotech was able to be flipped more than once per game