### PR TITLE
implement Tori Hanzō and Titanium Ribs (seeking review)

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -598,7 +598,32 @@
     :recurring 2}
 
    "Titanium Ribs"
-   {:effect (effect (damage :meat 2 {:card card}))}
+   {:events
+    {:pre-resolve-damage
+     {:req (req (and (> (last targets) 0)
+                     (not (and (= (:active-player @state) :corp) (get-in @state [:damage] :damage-choose)))
+                     (not (get-in @state [:damage :damage-replace]))))
+      :effect (req (let [dtype target
+                         dmg (last targets)]
+                     (when (> dmg (count (:hand runner)))
+                       (flatline state))
+                     (when (= dtype :brain)
+                       (swap! state update-in [:runner :brain-damage] #(+ % dmg))
+                       (swap! state update-in [:runner :hand-size-modification] #(- % dmg)))
+                     (swap! state assoc-in [:damage :damage-choose] true)
+                     (show-wait-prompt state :corp "Runner to use Titanium Ribs to choose cards to be trashed")
+                     (resolve-ability state side
+                       {:prompt (msg "Choose " dmg " cards to trash for the " (name dtype) " damage") :player :runner
+                        :choices {:max dmg :req #(and (in-hand? %) (= (:side %) "Runner"))}
+                        :msg (msg "trash " (join ", " (map :title targets)))
+                        :effect (req (swap! state update-in [:damage] dissoc :damage-choose)
+                                     (clear-wait-prompt state :corp)
+                                     (doseq [c targets]
+                                       (trash state side c {:cause dtype :unpreventable true})))}
+                      card nil)
+                      (trigger-event state side :damage dtype nil)))}}
+    :effect (effect (system-msg (str "suffers 2 meat damage from installing Titanium Ribs"))
+                    (damage :meat 2 {:card card}))}
 
    "Turntable"
    {:in-play [:memory 1]

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -86,26 +86,31 @@
    {:events
     {:pre-resolve-damage
      {:once :per-turn
-      :req (req (and (= target :net) (> (last targets) 0)))
-      :effect (effect (damage-defer :net (last targets))
-                      (show-wait-prompt :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
-                      (resolve-ability
-                        {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                                 "grip to select the first card trashed?") :player :corp
-                                    :yes-ability {:prompt (msg "Choose a card to trash")
-                                                  :choices (req (:hand runner)) :not-distinct true
-                                                  :msg (msg "trash " (:title target)
-                                                         (when (> (- (get-defer-damage state side :net nil) 1) 0)
-                                                           (str " and deal "
-                                                                (- (get-defer-damage state side :net nil) 1)
-                                                                " more net damage")))
-                                                  :effect (effect (clear-wait-prompt :runner)
-                                                                  (trash target {:cause :net :unpreventable true})
-                                                                  (damage :net (- (get-defer-damage state side :net nil) 1)
-                                                                          {:unpreventable true :card card}))}
-                                    :no-ability {:effect (effect (clear-wait-prompt :runner)
-                                                                 (damage :net (get-defer-damage state side :net nil)
-                                                                         {:unpreventable true :card card}))}}} card nil))}}}
+      :req (req (and (= target :net)
+                     (not (and (= (:active-player @state) :runner) (get-in @state [:damage] :damage-choose)))
+                     (> (last targets) 0)))
+      :effect (req (swap! state assoc-in [:damage :damage-choose] true)
+                   (damage-defer state side :net (last targets))
+                   (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
+                   (resolve-ability state side
+                     {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
+                                              "Grip to select the first card trashed?") :player :corp
+                                 :yes-ability {:prompt (msg "Choose a card to trash")
+                                               :choices (req (:hand runner)) :not-distinct true
+                                               :msg (msg "trash " (:title target)
+                                                      (when (> (- (get-defer-damage state side :net nil) 1) 0)
+                                                        (str " and deal "
+                                                             (- (get-defer-damage state side :net nil) 1)
+                                                             " more net damage")))
+                                               :effect (req (swap! state update-in [:damage] dissoc :damage-choose)
+                                                            (clear-wait-prompt state :runner)
+                                                            (trash state side target {:cause :net :unpreventable true})
+                                                            (damage state side :net (- (get-defer-damage state side :net nil) 1)
+                                                                    {:unpreventable true :card card}))}
+                                 :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-choose)
+                                                           (clear-wait-prompt state :runner)
+                                                           (damage state side :net (get-defer-damage state side :net nil)
+                                                                   {:unpreventable true :card card}))}}} card nil))}}}
 
    "Cybernetics Division: Humanity Upgraded"
    {:effect (effect (lose :hand-size-modification 1)

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -365,6 +365,29 @@
                                    :msg (msg "trash a copy of " (:title target) " from HQ and force the Runner to encounter it again")}
                                  card nil)))}]}
 
+   "Tori Hanzō"
+   {:events
+    {:pre-resolve-damage
+     {:once :per-run
+      :req (req (and this-server (= target :net) (> (last targets) 0)))
+      :effect (req (swap! state assoc-in [:damage :damage-replace] true)
+                   (damage-defer state side :net (last targets))
+                   (show-wait-prompt state :runner "Corp to use Tori Hanzō")
+                   (resolve-ability state side
+                     {:optional {:req (req (can-pay? state :corp nil [:credit 2]))
+                                 :prompt (str "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?") :player :corp
+                                 :yes-ability {:msg "do 1 brain damage instead of net damage"
+                                               :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
+                                                            (clear-wait-prompt state :runner)
+                                                            (pay state :corp card :credit 2)
+                                                            (damage state side :brain 1 {:card card}))}
+                                 :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-replace)
+                                                           (clear-wait-prompt state :runner)
+                                                           (damage state side :net (get-defer-damage state side :net nil)
+                                                                   {:card card}))}}} card nil))}
+     :prevented-damage {:req (req (and this-server (= target :net) (> (last targets) 0)))
+                        :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}}}
+
    "Tyrs Hand"
    {:abilities [{:label "[Trash]: Prevent a subroutine on a Bioroid from being broken"
                  :req (req (and (= (butlast (:zone current-ice)) (butlast (:zone card)))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -110,7 +110,7 @@
   [state side type n {:keys [unpreventable unboostable card] :as args}]
   (swap! state update-in [:damage :defer-damage] dissoc type)
   (trigger-event state side :pre-resolve-damage type card n)
-  (when-not (get-in @state [:damage :damage-replace])
+  (when-not (or (get-in @state [:damage :damage-replace]) (get-in @state [:damage :damage-choose]))
     (let [n (if (get-defer-damage state side type args) 0 n)]
       (let [hand (get-in @state [:runner :hand])]
         (when (< (count hand) n)

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -147,8 +147,8 @@
                                      (trigger-event state side :prevented-damage type prevent))
                                  "will not prevent damage"))
                    (resolve-damage state side type (max 0 (- n (or prevent 0))) args)))
-                 {:priority 10}))
-           (resolve-damage state side type n args))))))
+               {:priority 10}))
+         (resolve-damage state side type n args))))))
 
 
 ;;; Tagging

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -99,7 +99,7 @@
 (defn damage-defer
   "Registers n damage of the given type to be deferred until later. (Chronos Protocol.)"
   [state side dtype n]
-  (swap! state assoc-in [:damage :defer-damage dtype] n ))
+  (swap! state assoc-in [:damage :defer-damage dtype] n))
 
 (defn get-defer-damage [state side dtype {:keys [unpreventable] :as args}]
   (when-not unpreventable (get-in @state [:damage :defer-damage dtype])))
@@ -110,16 +110,17 @@
   [state side type n {:keys [unpreventable unboostable card] :as args}]
   (swap! state update-in [:damage :defer-damage] dissoc type)
   (trigger-event state side :pre-resolve-damage type card n)
-  (let [n (if (get-defer-damage state side type args) 0 n)]
-    (let [hand (get-in @state [:runner :hand])]
-      (when (< (count hand) n)
-        (flatline state))
-      (when (= type :brain)
-        (swap! state update-in [:runner :brain-damage] #(+ % n))
-        (swap! state update-in [:runner :hand-size-modification] #(- % n)))
-      (doseq [c (take n (shuffle hand))]
-        (trash state side c {:unpreventable true :cause type} type))
-      (trigger-event state side :damage type card))))
+  (when-not (get-in @state [:damage :damage-replace])
+    (let [n (if (get-defer-damage state side type args) 0 n)]
+      (let [hand (get-in @state [:runner :hand])]
+        (when (< (count hand) n)
+          (flatline state))
+        (when (= type :brain)
+          (swap! state update-in [:runner :brain-damage] #(+ % n))
+          (swap! state update-in [:runner :hand-size-modification] #(- % n)))
+        (doseq [c (take n (shuffle hand))]
+          (trash state side c {:unpreventable true :cause type} type))
+        (trigger-event state side :damage type card)))))
 
 (defn damage
   "Attempts to deal n damage of the given type to the runner. Starts the
@@ -129,7 +130,7 @@
    (swap! state update-in [:damage :damage-bonus] dissoc type)
    (swap! state update-in [:damage :damage-prevent] dissoc type)
    ;; alert listeners that damage is about to be calculated.
-   (trigger-event state side :pre-damage type card)
+   (trigger-event state side :pre-damage type card n)
    (let [n (damage-count state side type n args)]
      (let [prevent (get-in @state [:prevent :damage type])]
        (if (and (not unpreventable) prevent (pos? (count prevent)))
@@ -141,12 +142,13 @@
                  (let [prevent (get-in @state [:damage :damage-prevent type])]
                    (system-msg state :runner
                                (if prevent
-                                 (str "prevents " (if (= prevent Integer/MAX_VALUE) "all" prevent )
-                                      " " (name type) " damage")
+                                 (do (str "prevents " (if (= prevent Integer/MAX_VALUE) "all" prevent)
+                                          " " (name type) " damage")
+                                     (trigger-event state side :prevented-damage type prevent))
                                  "will not prevent damage"))
                    (resolve-damage state side type (max 0 (- n (or prevent 0))) args)))
-               {:priority 10}))
-         (resolve-damage state side type n args))))))
+                 {:priority 10}))
+           (resolve-damage state side type n args))))))
 
 
 ;;; Tagging

--- a/src/clj/test/cards-upgrades.clj
+++ b/src/clj/test/cards-upgrades.clj
@@ -445,6 +445,37 @@
       (is (= 2 (:click (get-runner))) "Runner was charged 1click")
       (is (= 1 (count (:scored (get-runner)))) "1 scored agenda"))))
 
+(deftest tori-hanzo
+  "Tori Hanzō - Pay to do 1 brain damage instead of net damage"
+  (do-game
+    (new-game (default-corp [(qty "Pup" 1) (qty "Tori Hanzō" 1)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Net Shield" 1)]))
+    (core/gain state :corp :credit 10)
+    (play-from-hand state :corp "Pup" "HQ")
+    (play-from-hand state :corp "Tori Hanzō" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Net Shield")
+    (run-on state "HQ")
+    (let [pup (get-ice state :hq 0)
+          tori (get-content state :hq 0)
+          nshld (get-in @state [:runner :rig :program 0])]
+      (core/rez state :corp pup)
+      (core/rez state :corp tori)
+      (card-ability state :corp pup 0)
+      (card-ability state :runner nshld 0)
+      (prompt-choice :runner "Done")
+      (is (empty? (:discard (get-runner))) "1 net damage prevented")
+      (card-ability state :corp pup 0)
+      (prompt-choice :runner "Done") ; decline to prevent
+      (is (= 1 (count (:discard (get-runner)))) "1 net damage; previous prevention stopped Tori ability")
+      (run-jack-out state)
+      (run-on state "HQ")
+      (card-ability state :corp pup 0)
+      (prompt-choice :runner "Done")
+      (prompt-choice :corp "Yes")
+      (is (= 2 (count (:discard (get-runner)))) "1 brain damage suffered")
+      (is (= 1 (:brain-damage (get-runner)))))))
+
 (deftest valley-grid-trash
   "Valley Grid - Reduce Runner max hand size and restore it even if trashed"
   (do-game


### PR DESCRIPTION
An extra set of eyes on this one would be appreciated since it involved surgery to the much-used `damage` function. A check is put into `resolve-damage` to nullify the damage if anything in play can swap in a different kind of damage (Tori) or choose specific cards to take instead of suffering random card losses (Ribs). Tori uses the damage deferral stuff that came with Chronos Protocol to "store" the net damage in case the Corp chooses not to employ the optional ability (or can't pay for it). 

Complies with the [FAQ rulings](http://ancur.wikia.com/wiki/Tori_Hanz%C5%8D) regarding Tori Hanzō and damage prevention using a new `:prevented-damage` event. Includes a test!  

I've now included Titanium Ribs in this PR as well, since I had to make further modifications to `resolve-damage` for it. Includes a test for the correct card taking precedence when going against Chronos Protocol. 