### PR TITLE
added overflow-x to trigger horizontal scrolling when necessary

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1130,6 +1130,7 @@ nav ul
   display: none
 
 .gameboard
+  overflow-x: auto;
   position: absolute
   top: 31px
   bottom: 0


### PR DESCRIPTION
I've had this implemented for a few weeks in [jankteki](https://github.com/SimonS/jankteki), and it seems to work nicely in managing horizontal asset spam decks. On the occasions when you don't want this effect (ie, you're hovering a card on the left that you want to see on the right), the old zoom fix still works.