### PR TITLE
Voting Machine Initiative

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -522,6 +522,18 @@
    {:msg "lose 2 bad publicity"
     :effect (effect (lose :bad-publicity 2))}
 
+   "Voting Machine Initiative"
+   {:effect (effect (add-prop card :counter 3))
+    :abilities [{:optional {:req (req (> (:counter card) (:vmi-count card 0)))
+                            :prompt "Cause the Runner to lose [Click] at the start of their next turn?"
+                            :yes-ability {:effect (effect (toast (str "The Runner will lose " (inc (:vmi-count card 0))
+                                                                      " [Click] at the start of their next turn") "info")
+                                                    (update! (update-in card [:vmi-count] #(inc (or % 0)))))}}}]
+    :events {:runner-turn-begins {:req (req (pos? (:vmi-count card 0)))
+                                  :msg (msg "to force the Runner to lose " (:vmi-count card) " [Click]")
+                                  :effect (effect (lose :runner :click (:vmi-count card))
+                                                  (add-prop (dissoc card :vmi-count) :counter (- (:vmi-count card))))}}}
+
    "Vulcan Coverup"
    {:msg "do 2 meat damage" :effect (effect (damage :meat 2 {:card card}))
     :stolen {:msg "force the Corp to take 1 bad publicity"


### PR DESCRIPTION
I believe this is the first card with an optional ability that triggers at opponent's start of turn. Rather than incorporate a UI window for this, I just give VMI an optional ability that will wait to trigger until `:runner-turn-begins`. The Corp can click VMI at any point during his turn to cause a delayed ability that causes the click loss only once the runner turn begins, without giving away the corp's intention.