### PR TITLE
Prevent install-and-host copies of unique cards in play

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -381,12 +381,13 @@
 
    "NetChip"
    {:abilities [{:label "Install a program on NetChip"
-                 :cost [:click 1]
                  :req (req (empty? (:hosted card)))
                  :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
                                 (resolve-ability state side
                                   {:prompt "Choose a program in your Grip to install on NetChip"
+                                   :cost [:click 1]
                                    :choices {:req #(and (is-type? % "Program")
+                                                        (runner-can-install? state side % false)
                                                         (<= (:memoryunits %) n)
                                                         (in-hand? %))}
                                    :msg (msg "host " (:title target))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -162,16 +162,20 @@
                                                     (:deck runner)) :sorted))
                  :cost [:click 1 :credit 1] :effect (effect (move target :hand) (shuffle! :deck))}
                 {:label "Install a non-Icebreaker program on Djinn"
-                 :cost [:click 1]
-                 :prompt "Choose a non-Icebreaker program in your Grip to install on Djinn"
-                 :choices {:req #(and (is-type? % "Program")
-                                      (not (has-subtype? % "Icebreaker"))
-                                      (in-hand? %))}
-                 :msg (msg "install and host " (:title target))
-                 :effect (effect (gain :memory (:memoryunits target))
-                                 (runner-install target {:host-card card})
-                                 (update! (assoc (get-card state card)
-                                                 :hosted-programs (cons (:cid target) (:hosted-programs card)))))}
+                 :effect (effect (resolve-ability
+                                   {:cost [:click 1]
+                                    :prompt "Choose a non-Icebreaker program in your Grip to install on Djinn"
+                                    :choices {:req #(and (is-type? % "Program")
+                                                         (runner-can-install? state side % false)
+                                                         (not (has-subtype? % "Icebreaker"))
+                                                         (in-hand? %))}
+                                    :msg (msg "install and host " (:title target))
+                                    :effect (effect (gain :memory (:memoryunits target))
+                                                    (runner-install target {:host-card card})
+                                                    (update! (assoc (get-card state card)
+                                                                    :hosted-programs
+                                                                    (cons (:cid target) (:hosted-programs card)))))}
+                                  card nil))}
                 {:label "Host an installed non-Icebreaker program on Djinn"
                  :prompt "Choose an installed non-Icebreaker program to host on Djinn"
                  :choices {:req #(and (is-type? % "Program")
@@ -318,15 +322,19 @@
    "Leprechaun"
    {:abilities [{:label "Install a program on Leprechaun"
                  :req (req (< (count (:hosted card)) 2))
-                 :cost [:click 1]
-                 :prompt "Choose a program in your Grip to install on Leprechaun"
-                 :choices {:req #(and (is-type? % "Program")
-                                      (in-hand? %))}
-                 :msg (msg "host " (:title target))
-                 :effect (effect (gain :memory (:memoryunits target))
-                                 (runner-install target {:host-card card})
-                                 (update! (assoc (get-card state card)
-                                                 :hosted-programs (cons (:cid target) (:hosted-programs card)))))}
+                 :effect (effect (resolve-ability
+                                   {:cost [:click 1]
+                                    :prompt "Choose a program in your Grip to install on Leprechaun"
+                                    :choices {:req #(and (is-type? % "Program")
+                                                         (runner-can-install? state side % false)
+                                                         (in-hand? %))}
+                                    :msg (msg "host " (:title target))
+                                    :effect (effect (gain :memory (:memoryunits target))
+                                                    (runner-install target {:host-card card})
+                                                    (update! (assoc (get-card state card)
+                                                                    :hosted-programs
+                                                                    (cons (:cid target) (:hosted-programs card)))))}
+                                  card nil))}
                 {:label "Host an installed program on Leprechaun"
                  :req (req (< (count (:hosted card)) 2))
                  :prompt "Choose an installed program to host on Leprechaun"
@@ -566,12 +574,15 @@
 
    "Scheherazade"
    {:abilities [{:label "Install and host a program from Grip"
-                 :cost [:click 1]
-                 :prompt "Choose a program to install on Scheherazade from your grip"
-                 :choices {:req #(and (is-type? % "Program")
-                                      (in-hand? %))}
-                 :msg (msg "host " (:title target) " and gain 1 [Credits]")
-                 :effect (effect (runner-install target {:host-card card}) (gain :credit 1))}
+                 :effect (effect (resolve-ability
+                                   {:cost [:click 1]
+                                    :prompt "Choose a program to install on Scheherazade from your grip"
+                                    :choices {:req #(and (is-type? % "Program")
+                                                         (runner-can-install? state side % false)
+                                                         (in-hand? %))}
+                                    :msg (msg "host " (:title target) " and gain 1 [Credits]")
+                                    :effect (effect (runner-install target {:host-card card}) (gain :credit 1))}
+                                  card nil))}
                 {:label "Host an installed program"
                  :prompt "Choose a program to host on Scheherazade"
                  :choices {:req #(and (is-type? % "Program")

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -156,7 +156,7 @@
    "Djinn"
    {:abilities [{:label "Search your Stack for a virus program and add it to your Grip"
                  :prompt "Choose a Virus"
-                 :msg (msg "adds " (:title target) " to their Grip")
+                 :msg (msg "add " (:title target) " to their Grip")
                  :choices (req (cancellable (filter #(and (is-type? % "Program")
                                                           (has-subtype? % "Virus"))
                                                     (:deck runner)) :sorted))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -506,11 +506,15 @@
 
    "Off-Campus Apartment"
    {:abilities [{:label "Install and host a connection on Off-Campus Apartment"
-                 :cost [:click 1] :prompt "Choose a connection in your Grip to install on Off-Campus Apartment"
-                 :choices {:req #(and (has-subtype? % "Connection")
-                                      (in-hand? %))}
-                 :msg (msg "host " (:title target) " and draw 1 card")
-                 :effect (effect (runner-install target {:host-card card}) (draw))}
+                 :effect (effect (resolve-ability
+                                   {:cost [:click 1]
+                                    :prompt "Choose a connection in your Grip to install on Off-Campus Apartment"
+                                    :choices {:req #(and (has-subtype? % "Connection")
+                                                         (runner-can-install? state side % false)
+                                                         (in-hand? %))}
+                                    :msg (msg "host " (:title target) " and draw 1 card")
+                                    :effect (effect (runner-install target {:host-card card}) (draw))}
+                                  card nil))}
                 {:label "Host an installed connection"
                  :prompt "Choose a connection to host on Off-Campus Apartment"
                  :choices {:req #(and (has-subtype? % "Connection")


### PR DESCRIPTION
Fixes #523. 

The existing 6 Runner cards that have the ability to spend a click and host something from the Grip are modified to wrap that ability inside a `resolve-ability` along with the cost. This allows the use of `runner-can-install?` in the targeting that in turn checks uniqueness, and also ensures that the click is not deducted unless an install succeeds. Future Runner cards that can host in this fashion will need to use this method. 

Includes a test (again, this is only failing due to the faulty Hayley test that will be removed soon). 