### PR TITLE
Genetics Pavilion fixes

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -336,9 +336,9 @@
    "Genetics Pavilion"
    {:msg "prevent the Runner from drawing more than 2 cards during their turn"
     :effect (req (max-draw state :runner 2)
-                 (when (= 0 (remaining-draws state side))
-                   (prevent-draw state side)))
-    :events {:runner-turn-begins {:effect (effect (max-draw 2))}}
+                 (when (= 0 (remaining-draws state :runner))
+                   (prevent-draw state :runner)))
+    :events {:runner-turn-begins {:effect (effect (max-draw :runner 2))}}
     :leave-play (req (swap! state update-in [:runner :register] dissoc :max-draw))}
 
    "Ghost Branch"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -339,7 +339,7 @@
                  (when (= 0 (remaining-draws state :runner))
                    (prevent-draw state :runner)))
     :events {:runner-turn-begins {:effect (effect (max-draw :runner 2))}}
-    :leave-play (req (swap! state update-in [:runner :register] dissoc :max-draw))}
+    :leave-play (req (swap! state update-in [:runner :register] dissoc :max-draw :cannot-draw))}
 
    "Ghost Branch"
    (advance-ambush 0 {:msg (msg "give the Runner " (:advance-counter card) " tag"

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -47,10 +47,9 @@
 (defn remaining-draws
   "Calculate remaining number of cards that can be drawn this turn if a maximum exists"
   [state side]
-  (let [active-player (get-in @state [:active-player])]
-    (when-let [max-draw (get-in @state [active-player :register :max-draw])]
-      (let [drawn-this-turn (get-in @state [active-player :register :drawn-this-turn] 0)]
-        (max (- max-draw drawn-this-turn) 0)))))
+  (when-let [max-draw (get-in @state [side :register :max-draw])]
+    (let [drawn-this-turn (get-in @state [side :register :drawn-this-turn] 0)]
+      (max (- max-draw drawn-this-turn) 0))))
 
 (defn draw
   "Draw n cards from :deck to :hand."
@@ -58,17 +57,17 @@
   ([state side n] (draw state side n nil))
   ([state side n {:keys [suppress-event] :as args}]
    (let [active-player (get-in @state [:active-player])
-         n (if (get-in @state [active-player :register :max-draw])
+         n (if (and (= side active-player) (get-in @state [active-player :register :max-draw]))
              (min n (remaining-draws state side))
              n)
          deck-count (count (get-in @state [side :deck]))]
      (when (and (= side :corp) (> n deck-count))
        (win-decked state))
-     (when-not (get-in @state [active-player :register :cannot-draw])
+     (when-not (and (= side active-player) (get-in @state [side :register :cannot-draw]))
        (let [drawn (zone :hand (take n (get-in @state [side :deck])))]
          (swap! state update-in [side :hand] #(concat % drawn))
          (swap! state update-in [side :deck] (partial drop n))
-         (swap! state update-in [active-player :register :drawn-this-turn] (fnil #(+ % n) 0))
+         (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % n) 0))
          (when (and (not suppress-event) (pos? deck-count))
            (trigger-event state side (if (= side :corp) :corp-draw :runner-draw) n))
          (when (= 0 (remaining-draws state side))

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -160,5 +160,7 @@
           (when (has-subtype? card "Virus")
             (set-prop state :runner card :added-virus-counter false))))
       (swap! state assoc :end-turn true)
+      (swap! state update-in [side :register] dissoc :cannot-draw)
+      (swap! state update-in [side :register] dissoc :drawn-this-turn)
       (clear-turn-register! state)
       (swap! state dissoc :turn-events))))


### PR DESCRIPTION
Fixes #1374. Again, only failing CircleCI until the Hayley test is removed. 

Genetics Pavilion gets a little more precision and some core function support to cover all the bases. In particular we need to reset :drawn-per-turn and :cannot-draw in the player's register at the end of their turn to allow additional draws during the opponent's turn. The included tests demonstrate Genetics Pavilion compatibility with the following scenarios:

* Limit Runner's draws to 2 during the Runner's turn
* Allow unlimited Runner drawing during the Corp's turn (e.g., Sports Hopper, multiple trashes using Geist)
* Don't restrict the Corp's drawing (the Fisk Investment Seminar case)
* Lift the Runner draw restrictions immediately if GP is trashed or gets derezzed