### PR TITLE
Fixes: Chronos Protocol, Bifrost Array, Howler, Mumbad City Hall, Character Assassination

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -101,7 +101,7 @@
     :choices {:req #(and (installed? %)
                          (is-type? % "Resource"))}
     :msg (msg "trash " (:title target))
-    :effect (effect (trash target))}
+    :effect (effect (trash target {:unpreventable true}))}
 
    "Chronos Project"
    {:msg "remove all cards in the Runner's Heap from the game"

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -78,9 +78,12 @@
    {:req (req (not (empty? (filter #(not= (:title %) "Bifrost Array") (:scored corp)))))
     :optional {:prompt "Trigger the ability of a scored agenda?"
                :yes-ability {:prompt "Choose an agenda to trigger its \"when scored\" ability"
-                             :choices (req (filter #(not= (:title %) "Bifrost Array") (:scored corp)))
+                             :choices {:req #(and (is-type? % "Agenda")
+                                                  (not= (:title %) "Bifrost Array")
+                                                  (= (first (:zone %)) :scored)
+                                                  (:abilities %))}
                              :msg (msg "trigger the \"when scored\" ability of " (:title target))
-                             :effect (effect (card-init target))}}}
+                             :effect (effect (resolve-ability (card-def target) target nil))}}}
 
    "Braintrust"
    {:effect (effect (set-prop card :counter (quot (- (:advance-counter card) 3) 2)))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -529,7 +529,8 @@
                            (if (= (:type target) "Operation") "play " "install ") " it")
                  :effect (req (if (= (:type target) "Operation")
                                 (play-instant state side target)
-                                (corp-install state side target nil)))}]}
+                                (corp-install state side target nil))
+                              (shuffle! state side :deck))}]}
 
    "Mumbad Construction Co."
    {:derezzed-events {:runner-turn-ends corp-rez-toast}

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -528,6 +528,7 @@
                                        (swap! state update-in (cons :corp (:zone target))
                                               (fn [coll] (remove-once #(not= (:cid %) (:cid target)) coll)))
                                        (update! state side (assoc card :howler-target newice))
+                                       (card-init state side newice false)
                                        (trigger-event state side :corp-install newice)))} card nil)))}]
     :events {:run-ends {:req (req (:howler-target card))
                         :effect (effect (trash card {:cause :self-trash})

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -95,13 +95,14 @@
 
    "Chronos Protocol: Selective Mind-mapping"
    {:events
-    {:pre-resolve-damage
+    {:corp-turn-begins {:effect (effect (enable-corp-damage-choice))}
+     :runner-turn-begins {:effect (effect (enable-corp-damage-choice))}
+     :pre-resolve-damage
      {:once :per-turn
       :req (req (and (= target :net)
-                     (not (and (= (:active-player @state) :runner) (get-in @state [:damage] :damage-choose)))
+                     (corp-can-choose-damage? state)
                      (> (last targets) 0)))
-      :effect (req (swap! state assoc-in [:damage :damage-choose] true)
-                   (damage-defer state side :net (last targets))
+      :effect (req (damage-defer state side :net (last targets))
                    (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
                    (resolve-ability state side
                      {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
@@ -113,12 +114,12 @@
                                                         (str " and deal "
                                                              (- (get-defer-damage state side :net nil) 1)
                                                              " more net damage")))
-                                               :effect (req (swap! state update-in [:damage] dissoc :damage-choose)
-                                                            (clear-wait-prompt state :runner)
+                                               :effect (req (clear-wait-prompt state :runner)
                                                             (trash state side target {:cause :net :unpreventable true})
+                                                            (swap! state update-in [:damage] dissoc :damage-choose-corp)
                                                             (damage state side :net (- (get-defer-damage state side :net nil) 1)
                                                                     {:unpreventable true :card card}))}
-                                 :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-choose)
+                                 :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-choose-corp)
                                                            (clear-wait-prompt state :runner)
                                                            (damage state side :net (get-defer-damage state side :net nil)
                                                                    {:unpreventable true :card card}))}}} card nil))}}}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -86,10 +86,12 @@
                     (system-msg (str "adds " (if (:seen target) (:title target) "an unseen card") " to HQ")))}
 
    "Back Channels"
-   {:prompt "Choose an installed card in a server to trash" :choices {:req #(= (last (:zone %)) :content)}
-    :effect (effect (gain :credit (* 3 (:advance-counter target))) (trash target))
+   {:prompt "Choose an installed card in a server to trash"
+    :choices {:req #(and (= (last (:zone %)) :content)
+                         (is-remote? (second (:zone %))))}
+    :effect (effect (gain :credit (* 3 (get target :advance-counter 0))) (trash target))
     :msg (msg "trash " (card-str state target) " and gain "
-              (* 3 (:advance-counter target)) " [Credits]")}
+              (* 3 (get target :advance-counter 0)) " [Credits]")}
 
    "Bad Times"
    {:req (req tagged)

--- a/src/clj/test/cards-hardware.clj
+++ b/src/clj/test/cards-hardware.clj
@@ -240,8 +240,10 @@
       (core/move state :runner (find-card "Sure Gamble" (:discard (get-runner))) :hand)
       (core/move state :runner (find-card "Kati Jones" (:discard (get-runner))) :hand)
       (play-from-hand state :corp "Neural EMP")
-      (prompt-choice :corp "Kati Jones") ; Chronos Protocol takes precedence over Ribs on Corp turn
-      (is (= 2 (count (:discard (get-runner)))) "Card chosen by Corp for first net damage"))))
+      (prompt-choice :corp "Yes")
+      (let [kati (find-card "Kati Jones" (:hand (get-runner)))]
+        (prompt-choice :corp kati) ; Chronos Protocol takes precedence over Ribs on Corp turn
+        (is (= 2 (count (:discard (get-runner)))) "Card chosen by Corp for first net damage")))))
 
 (deftest turntable-swap
   "Turntable - Swap a stolen agenda for a scored agenda"


### PR DESCRIPTION
* Fix #1419: Steal the technique from 24/7 News Cycle to use in Bifrost Array so targeting a scored Corporate Sales Team won't result in doubled event hooks.
* Fix #1416: Restores basic functions of Chronos Protocol when no Runner "choose damage" ability is present. My initial attempt at "choose damage" abilities for Chronos Protocol and Titanium Ribs had to be totally reworked with the help of some extra core functions. Includes an updated Titanium Ribs test and a new test for checking basic functionality of Chronos Protocol. 
* Fix #1403: Do a `card-init` on the ICE installed by Howler so its abilities will work.
* Adds the missing shuffle to Mumbad City Hall (card still needs work to support the Heritage Committee interaction).
* Character Assassination resource trash needs to be unpreventable.
* Back Channels was bugged when targeting an unadvanced card.