### PR TITLE
Card fixes: Political assets, NeoTokyo Grid, PAD Factory, Housekeeping, Cell Portal

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -91,7 +91,7 @@
                                                 (lose :runner :credit 1))}}}
 
    "Bio-Ethics Association"
-   (let [ability {:req (req (no-ice? state (second (:zone card))))
+   (let [ability {:req (req unprotected)
                   :label "Do 1 net damage (start of turn)"
                   :once :per-turn
                   :msg "do 1 net damage"
@@ -137,7 +137,7 @@
    "Clone Suffrage Movement"
    {:derezzed-events {:runner-turn-ends corp-rez-toast}
     :flags {:corp-phase-12 (req (and (some #(is-type? % "Operation") (:discard corp))
-                                     (no-ice? state (second (:zone card)))))}
+                                     unprotected))}
     :abilities [{:label "Add 1 operation from Archives to HQ"
                  :prompt "Choose an operation in Archives to add to HQ" :show-discard true
                  :choices {:req #(and (is-type? % "Operation")
@@ -146,7 +146,7 @@
                  :msg (msg "add " (card-str state target) " to HQ")}]}
 
    "Commercial Bankers Group"
-   (let [ability {:req (req (no-ice? state (second (:zone card))))
+   (let [ability {:req (req unprotected)
                   :label "Gain 3 [Credits] (start of turn)"
                   :once :per-turn
                   :msg "gain 3 [Credits]"
@@ -752,7 +752,7 @@
 
    "Sensie Actors Union"
    {:derezzed-events {:runner-turn-ends corp-rez-toast}
-    :flags {:corp-phase-12 (req (no-ice? state (second (:zone card))))}
+    :flags {:corp-phase-12 (req unprotected)}
     :abilities [{:label "Draw 3 cards and add 1 card in HQ to the bottom of R&D"
                  :once :per-turn
                  :msg "draw 3 cards"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -602,13 +602,15 @@
                  :label "Place 1 advancement token on a card"
                  :choices {:req #(and (:side % "Corp") (installed? %))}
                  :msg (msg "place 1 advancement token on " (card-str state target))
-                 :effect (effect (add-prop target :advance-counter 1 {:placed true})
-                                 (register-turn-flag!
-                                   target :can-score
-                                   (fn [state side card]
-                                     (if (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card)))
-                                       ((constantly false) (toast state :corp "Cannot score due to PAD Factory." "warning"))
-                                       true))))}]}
+                 :effect (req (add-prop state :corp target :advance-counter 1 {:placed true})
+                              (let [tgtcid (:cid target)]
+                                (register-turn-flag! state side
+                                  target :can-score
+                                  (fn [state side card]
+                                    (if (and (= (:cid card) tgtcid)
+                                             (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))
+                                      ((constantly false) (toast state :corp "Cannot score due to PAD Factory." "warning"))
+                                      true)))))}]}
 
    "Pālanā Agroplex"
    (let [ability {:msg "make each player draw 1 card"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -908,9 +908,13 @@
     :abilities [end-the-run]}
 
    "Universal Connectivity Fee"
-   {:abilities [{:msg (msg "force the Runner to lose " (if (pos? (:tag runner)) "all credits" "1 [Credits]"))
-                 :effect (req (if (pos? (get-in @state [:runner :tag]))
-                                (do (lose state :runner :credit :all) (trash state side card))
+   {:abilities [{:label "Force the Runner to lose credits"
+                 :msg (msg "force the Runner to lose " (if tagged "all credits" "1 [Credits]"))
+                 :effect (req (if tagged
+                                (do (lose state :runner :credit :all)
+                                    (when current-ice
+                                      (trash-ice-in-run state))
+                                    (trash state side card))
                                 (lose state :runner :credit 1)))}]}
 
    "Uroboros"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -277,7 +277,10 @@
 
    "Cell Portal"
    {:abilities [{:msg "make the Runner approach the outermost ICE"
-                 :effect (req (swap! state assoc-in [:run :position] 0) (derez state side card))}]}
+                 :effect (req (let [srv (first (:server run))
+                                    n (count (get-in @state [:corp :servers srv :ices]))]
+                                (swap! state assoc-in [:run :position] n)
+                                (derez state side card)))}]}
 
    "Changeling"
    (morph-ice "Barrier" "Sentry" end-the-run)

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -204,7 +204,7 @@
                          true)))))}
 
    "Defective Brainchips"
-   {:events {:pre-damage {:req (req (= target :brain)) :msg "to do 1 additional brain damage"
+   {:events {:pre-damage {:req (req (= target :brain)) :msg "do 1 additional brain damage"
                           :once :per-turn :effect (effect (damage-bonus :brain 1))}}}
 
    "Diversified Portfolio"
@@ -268,9 +268,9 @@
    {:events {:runner-install {:req (req (= side :runner))
                               :choices {:req #(and (in-hand? %)
                                                    (= (:side %) "Runner"))}
-                              :prompt "Choose a card from your grip to trash for Housekeeping" :once :per-turn
-                              :msg (msg "to force the Runner to trash " (:title target) " from Grip")
-                              :effect (effect (trash target))}}}
+                              :prompt "Choose a card from your Grip to trash for Housekeeping" :once :per-turn
+                              :msg (msg "force the Runner to trash " (:title target) " from their Grip")
+                              :effect (effect (trash target {:unpreventable true}))}}}
 
    "Interns"
    {:prompt "Choose a card to install from Archives or HQ"
@@ -498,13 +498,19 @@
     :effect (effect (lose :bad-publicity 2) (trash target))}
 
    "Restructure"
-   {:effect (effect (gain :credit 15))}
+   {:msg "gain 15 [Credits]"
+    :effect (effect (gain :credit 15))}
 
    "Reuse"
-   {:choices {:max 100 :req #(and (:side % "Corp")
-                                  (in-hand? %))}
-    :msg (msg "trash " (count targets) " card" (if (not= 1 (count targets)) "s") " and gain " (* 2 (count targets)) " [Credits]")
-    :effect (effect (trash-cards targets) (gain :credit (* 2 (count targets))))}
+   {:effect (req (let [n (count (:hand corp))]
+                   (resolve-ability state side
+                     {:prompt (msg "Choose up to " n " cards in HQ to trash with Reuse")
+                      :choices {:max n :req #(and (:side % "Corp")
+                                                  (in-hand? %))}
+                      :msg (msg "trash " (count targets) " card" (if (not= 1 (count targets)) "s")
+                                " and gain " (* 2 (count targets)) " [Credits]")
+                      :effect (effect (trash-cards targets)
+                                      (gain :credit (* 2 (count targets))))} card nil)))}
 
    "Rework"
    {:prompt "Choose a card from HQ to shuffle into R&D"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -233,8 +233,9 @@
                                                              " with " (card-str state target)))))}]}
 
    "NeoTokyo Grid"
-   {:events {:advance {:req (req (= (butlast (:zone target)) (butlast (:zone card)))) :once :per-turn
-                       :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
+   (let [ng {:req (req (= (butlast (:zone target)) (butlast (:zone card)))) :once :per-turn
+             :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}]
+     {:events {:advance ng :advancement-placed ng}})
 
    "Oaktown Grid"
    {:events {:pre-trash {:req (req (= (:zone card) (:zone target)))

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -359,12 +359,9 @@
                               {:prompt (msg "Rez another card with Surat City Grid?")
                                :yes-ability {:prompt "Choose a card to rez"
                                              :choices {:req #(not (rezzed? %))}
-                                             :msg (msg "rez " (:title target)
-                                                       (when (= (card->server state target) (card->server state card))
-                                                         ", lowering the rez cost by 2 [Credits]"))
-                                             :effect (req (when (= (card->server state target) (card->server state card))
-                                                            (rez-cost-bonus state side -2))
-                                                          (rez state side target))}}}
+                                             :msg (msg "rez " (:title target) ", lowering the rez cost by 2 [Credits]")
+                                             :effect (effect (rez-cost-bonus -2)
+                                                             (rez target))}}}
                             card nil))}}}
 
    "The Twins"

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -148,12 +148,6 @@
 (defn release-zone [state side cid tside tzone]
   (swap! state update-in [tside :locked tzone] #(remove #{cid} %)))
 
-;;; Small utilities for server properties.
-(defn no-ice?
-  "Checks if the specified server is unprotected by ICE.
-  For the Political assets in Democracy and Dogma."
-  [state server]
-  (empty? (get-in @state [:corp :servers server :ices])))
 
 ;;; Small utilities for card properties.
 (defn in-server?

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -27,6 +27,9 @@
             'installed '(#{:rig :servers} (first (:zone card)))
             'remotes '(get-remote-names @state)
             'servers '(concat ["HQ" "R&D" "Archives"] remotes)
+            'unprotected '(let [server (second (:zone (if (:host card)
+                                                        (get-card state (:host card)) card)))]
+                            (empty? (get-in @state [:corp :servers server :ices])))
             'runnable-servers '(let [servers (map zone->name
                                                   (keys (get-in @state [:corp :servers])))
                                      restricted (map zone->name


### PR DESCRIPTION
* Tidy up the Political assets using a new macro instead of a `no-ice?` function. Much cleaner, and now accounts for these assets being hosted on Worlds Plaza or the upcoming Full Immersion RecStudio.
* Fix NeoTokyo Grid to listen for advancements being placed by Shipment from SanSan/Kaguya, Tennin, etc
* Fix #1437: Surat City Grid discount should apply everywhere
* Fix #1432: Add precision to PAD Factory's turn flag, as was done to Dedication Ceremony previously.
* Fix Housekeeping case of a Runner trashing a resource from hand when they have Fall Guy installed (don't want Fall Guy triggering for prevention).
* Fix Cell Portal, which is currently teleporting the Runner to position 0 of the run instead of to the outermost position.
* Fix Universal Connectivity Fee to update the run position if it trashes itself, and also fire the second way when the Runner is tagged from Paparazzi
* A few other small card message tweaks