### PR TITLE
Small batch of fixes

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -640,7 +640,8 @@
      :damage-chosen {:effect (effect (enable-runner-damage-choice))}}
     :effect (effect (enable-runner-damage-choice)
                     (system-msg (str "suffers 2 meat damage from installing Titanium Ribs"))
-                    (damage :meat 2 {:card card}))}
+                    (damage :meat 2 {:card card}))
+    :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-runner))}
 
    "Turntable"
    {:in-play [:memory 1]

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -324,8 +324,10 @@
    "Logos"
    {:in-play [:memory 1 :hand-size-modification 1]
     :events {:agenda-scored
-             {:player :runner :prompt "Choose a card" :msg (msg "add 1 card to Grip from Stack")
-              :choices (req (:deck runner)) :effect (effect (move target :hand) (shuffle! :deck))}}}
+             {:player :runner :prompt "Choose a card" :msg (msg "add 1 card to their Grip from their Stack")
+              :choices (req (cancellable (:deck runner)))
+              :effect (effect (move target :hand)
+                              (shuffle! :deck))}}}
 
    "Maya"
    {:in-play [:memory 2]

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -140,13 +140,12 @@
    "Cortez Chip"
    {:abilities [{:prompt "Choose a piece of ICE"
                  :choices {:req #(and (not (rezzed? %)) (ice? %))}
-                 :effect (req (let [ice target
-                                    serv (zone->name (second (:zone ice)))]
+                 :effect (req (let [ice target]
                                 (update! state side (assoc card :cortez-target ice))
                                 (trash state side (get-card state card) {:cause :ability-cost})
                                 (system-msg state side
-                                  (str "increases the cost to rez the ICE at position "
-                                    (ice-index state ice) " of " serv " by 2 [Credits] until the end of the turn"))))}]
+                                  (str "trashes Cortez Chip to increase the rez cost of " (card-str state ice)
+                                       " by 2 [Credits] until the end of the turn"))))}]
     :trash-effect {:effect (effect (register-events {:pre-rez {:req (req (= (:cid target) (:cid (:cortez-target card))))
                                                                :effect (effect (rez-cost-bonus 2))}
                                                      :runner-turn-ends {:effect (effect (unregister-events card))}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -103,26 +103,29 @@
                      (corp-can-choose-damage? state)
                      (> (last targets) 0)))
       :effect (req (damage-defer state side :net (last targets))
-                   (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
-                   (resolve-ability state side
-                     {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                              "Grip to select the first card trashed?") :player :corp
-                                 :yes-ability {:prompt (msg "Choose a card to trash")
-                                               :choices (req (:hand runner)) :not-distinct true
-                                               :msg (msg "trash " (:title target)
-                                                      (when (> (- (get-defer-damage state side :net nil) 1) 0)
-                                                        (str " and deal "
-                                                             (- (get-defer-damage state side :net nil) 1)
-                                                             " more net damage")))
-                                               :effect (req (clear-wait-prompt state :runner)
-                                                            (trash state side target {:cause :net :unpreventable true})
-                                                            (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                            (damage state side :net (- (get-defer-damage state side :net nil) 1)
-                                                                    {:unpreventable true :card card}))}
-                                 :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                           (clear-wait-prompt state :runner)
-                                                           (damage state side :net (get-defer-damage state side :net nil)
-                                                                   {:unpreventable true :card card}))}}} card nil))}}
+                   (if (= 0 (count (:hand runner)))
+                     (do (swap! state update-in [:damage] dissoc :damage-choose-corp)
+                         (damage state side :net (get-defer-damage state side :net nil)
+                                 {:unpreventable true :card card}))
+                     (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
+                         (resolve-ability state side
+                           {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
+                                                    "Grip to select the first card trashed?") :player :corp
+                                       :yes-ability {:prompt (msg "Choose a card to trash")
+                                                     :choices (req (:hand runner)) :not-distinct true
+                                                     :msg (msg "trash " (:title target)
+                                                            (when (> (- (get-defer-damage state side :net nil) 1) 0)
+                                                              (str " and deal " (- (get-defer-damage state side :net nil) 1)
+                                                                   " more net damage")))
+                                                     :effect (req (clear-wait-prompt state :runner)
+                                                                  (trash state side target {:cause :net :unpreventable true})
+                                                                  (swap! state update-in [:damage] dissoc :damage-choose-corp)
+                                                                  (damage state side :net (- (get-defer-damage state side :net nil) 1)
+                                                                          {:unpreventable true :card card}))}
+                                       :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-choose-corp)
+                                                                 (clear-wait-prompt state :runner)
+                                                                 (damage state side :net (get-defer-damage state side :net nil)
+                                                                         {:unpreventable true :card card}))}}} card nil))))}}
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -122,7 +122,8 @@
                                  :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-choose-corp)
                                                            (clear-wait-prompt state :runner)
                                                            (damage state side :net (get-defer-damage state side :net nil)
-                                                                   {:unpreventable true :card card}))}}} card nil))}}}
+                                                                   {:unpreventable true :card card}))}}} card nil))}}
+    :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"
    {:effect (effect (lose :hand-size-modification 1)

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -118,7 +118,8 @@
    {:events {:rez {:req (req (and (#{"Asset" "Upgrade"} (:type target))
                                   (can-pay? state :runner nil [:credit (rez-cost state :corp target)])))
                    :effect (req (toast state :runner (str "Click Councilman to derez " (card-str state target {:visible true})
-                                                          " that was just rezzed") "info"))}}
+                                                          " that was just rezzed") "info")
+                                (toast state :corp (str "Runner has the opportunity to derez with Councilman.") "error"))}}
     :abilities [{:prompt "Choose an asset or upgrade that was just rezzed"
                  :choices {:req #(and (rezzed? %)
                                       (or (is-type? % "Asset") (is-type? % "Upgrade")))}
@@ -130,6 +131,13 @@
                                     {:msg (msg "pay " creds " [Credit] and derez " (:title c) ". Councilman is trashed")
                                      :effect (req (lose state :runner :credit creds)
                                                   (derez state :corp c)
+                                                  (register-turn-flag! state side
+                                                    card :can-rez
+                                                    (fn [state side card]
+                                                      (if (= (:cid card) (:cid c))
+                                                        ((constantly false)
+                                                         (toast state :corp "Cannot rez the rest of this turn due to Councilman"))
+                                                        true)))
                                                   (trash state side card {:unpreventable true}))}
                                    card nil))))}]}
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -694,9 +694,10 @@
 
    "Rolodex"
    {:msg "look at the top 5 cards of their Stack"
-    :effect (req (prompt! state side card
-                          (str "Drag cards from the Temporary Zone  back onto your Stack") ["OK"] {})
-                 (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))}
+    :effect (req (toast state :runner
+                        "Drag cards from the Temporary Zone back onto your Stack." "info")
+                 (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))
+    :leave-play (effect (mill :runner 3))}
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -389,13 +389,12 @@
    {:events
     {:pre-resolve-damage
      {:once :per-run
-      :req (req (and this-server (= target :net) (> (last targets) 0)))
+      :req (req (and this-server (= target :net) (> (last targets) 0) (can-pay? state :corp nil [:credit 2])))
       :effect (req (swap! state assoc-in [:damage :damage-replace] true)
                    (damage-defer state side :net (last targets))
                    (show-wait-prompt state :runner "Corp to use Tori Hanzō")
                    (resolve-ability state side
-                     {:optional {:req (req (can-pay? state :corp nil [:credit 2]))
-                                 :prompt (str "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?") :player :corp
+                     {:optional {:prompt (str "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?") :player :corp
                                  :yes-ability {:msg "do 1 brain damage instead of net damage"
                                                :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
                                                             (clear-wait-prompt state :runner)

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -354,12 +354,14 @@
    {:events
     {:rez {:req (req (and (= (card->server state target) (card->server state card))
                           (not= (:cid target) (:cid card))
-                          (seq (filter #(not (rezzed? %)) (all-installed state :corp)))))
+                          (seq (filter #(and (not (rezzed? %))
+                                             (not (is-type? % "Agenda"))) (all-installed state :corp)))))
            :effect (effect (resolve-ability
                              {:optional
                               {:prompt (msg "Rez another card with Surat City Grid?")
                                :yes-ability {:prompt "Choose a card to rez"
-                                             :choices {:req #(not (rezzed? %))}
+                                             :choices {:req #(and (not (rezzed? %))
+                                                                  (not (is-type? % "Agenda")))}
                                              :msg (msg "rez " (:title target) ", lowering the rez cost by 2 [Credits]")
                                              :effect (effect (rez-cost-bonus -2)
                                                              (rez target))}}}

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -43,7 +43,8 @@
    (unregister-events state side card)
    (when (and (:memoryunits card) (:installed card) (not (:facedown card)))
      (gain state :runner :memory (:memoryunits card)))
-   (when (find-cid (:cid card) (all-installed state side))
+   (when (and (find-cid (:cid card) (all-installed state side))
+              (or (:rezzed card) (:installed card)))
      (when-let [in-play (:in-play (card-def card))]
        (apply lose state side in-play)))
    (dissoc-card card keep-counter)))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -21,6 +21,8 @@
                     (req state side card targets) true)
                   (not (and (has-subtype? card "Current")
                             (get-in @state [side :register :cannot-play-current])))
+                  (not (and (has-subtype? card "Run")
+                            (get-in @state [side :register :cannot-run])))
                   (not (and (has-subtype? card "Priority")
                             (get-in @state [side :register :spent-click]))))
          (when-let [cost-str (pay state side card :credit (:cost card) extra-cost

--- a/src/clj/test/cards-ice.clj
+++ b/src/clj/test/cards-ice.clj
@@ -192,6 +192,26 @@
       (card-ability state :corp enig 0)
       (is (= 2 (:click (get-runner))) "Runner lost 1 click"))))
 
+(deftest excalibur
+  "Excalibur - Prevent Runner from making another run this turn"
+  (do-game
+    (new-game (default-corp [(qty "Excalibur" 1)])
+              (default-runner [(qty "Stimhack" 1)]))
+    (play-from-hand state :corp "Excalibur" "HQ")
+    (take-credits state :corp)
+    (let [excal (get-ice state :hq 0)]
+      (run-on state "HQ")
+      (core/rez state :corp excal)
+      (card-ability state :corp excal 0)
+      (run-jack-out state)
+      (run-on state "R&D")
+      (is (not (:run @state)) "No run initiated")
+      (is (= 3 (:click (get-runner))))
+      (play-from-hand state :runner "Stimhack")
+      (is (not (:run @state)) "No run initiated")
+      (is (= 3 (:click (get-runner))))
+      (is (empty? (:discard (get-runner))) "Card not played from Grip"))))
+
 (deftest fenris
   "Fenris - Illicit ICE give Corp 1 bad publicity when rezzed"
   (do-game


### PR DESCRIPTION
I don't expect this will keep growing into a mega-patch, but you never know! 

* Fix #1446: Only lose `[:in-play]` of a Corp card when `deactivate` is called if the card is rezzed.
* Fix #1445: Don't fire Surat City Grid when only agendas remain, and don't allow targeting an agenda with it
* Entirely prevent the play of Run events when `:cannot-run` is in Runner's register after an Excalibur or Uroboros subroutine successfully fires.
* Turn off Chronos Protocol when Employee Strike is active so that net damage can occur normally. Also, don't do its ability when the Runner has 0 cards in hand (fixes #1459).
* Remove Titanium Ribs effect if it gets trashed
* Add the "can't rez the rest of the turn" restriction to Councilman's target. Also alerts the Corp player with a toast when they rez an asset/upgrade with Councilman in play so they will be less likely to plow ahead with more actions/abilities before the Runner has decided to use Councilman.
* Add missing `:leave-play` to Rolodex for milling the Runner 3 times.
* Move the ability to pay requirement for Tori Hanzō to the outermost level to avoid a state that stops net damage from working