### PR TITLE
Active player indicator

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -372,7 +372,7 @@
       (remote->name zone)))
 
 (defn get-remotes [servers]
- (->> servers 
+ (->> servers
      (filter #(not (#{:hq :rd :archives} (first %))))
      (sort-by #(remote->num (first %)))))
 
@@ -675,11 +675,11 @@
 
 (defmethod stats-view "Runner" [{:keys [user click credit run-credit memory link tag
                                         brain-damage agenda-point tagged hand-size-base
-                                        hand-size-modification]} owner]
+                                        hand-size-modification active]} owner]
   (om/component
    (sab/html
     (let [me? (= (:side @game-state) :runner)]
-      [:div.stats.panel.blue-shade {}
+      [:div.stats.panel.blue-shade {:class (when active "active-player")}
        [:h4.ellipsis (om/build avatar user {:opts {:size 22}}) (:username user)]
        [:div (str click " Click" (if (not= click 1) "s" "")) (when me? (controls :click))]
        [:div (str credit " Credit" (if (not= credit 1) "s" "")
@@ -697,11 +697,11 @@
         (when me? (controls :hand-size-modification))]]))))
 
 (defmethod stats-view "Corp" [{:keys [user click credit agenda-point bad-publicity has-bad-pub
-                                      hand-size-base hand-size-modification]} owner]
+                                      hand-size-base hand-size-modification active]} owner]
   (om/component
    (sab/html
     (let [me? (= (:side @game-state) :corp)]
-      [:div.stats.panel.blue-shade {}
+      [:div.stats.panel.blue-shade {:class (when active "active-player")}
        [:h4.ellipsis (om/build avatar user {:opts {:size 22}}) (:username user)]
        [:div (str click " Click" (if (not= click 1) "s" "")) (when me? (controls :click))]
        [:div (str credit " Credit" (if (not= credit 1) "s" "")) (when me? (controls :credit))]
@@ -793,7 +793,7 @@
     ;; remove restricted servers from all servers to just return allowed servers
     (remove (set restricted-servers) (set servers))))
 
-(defn gameboard [{:keys [side gameid active-player run end-turn runner-phase-12 corp-phase-12] :as cursor} owner]
+(defn gameboard [{:keys [side gameid active-player run end-turn runner-phase-12 corp-phase-12 turn] :as cursor} owner]
   (reify
     om/IWillMount
     (will-mount [this]
@@ -815,8 +815,8 @@
     (render-state [this state]
       (sab/html
        (when side
-         (let [me ((if (= side :runner) :runner :corp) cursor)
-               opponent ((if (= side :runner) :corp :runner) cursor)]
+         (let [me       (assoc ((if (= side :runner) :runner :corp) cursor) :active (and (pos? turn) (= (keyword active-player) side)))
+               opponent (assoc ((if (= side :runner) :corp :runner) cursor) :active (and (pos? turn) (not= (keyword active-player) side)))]
            [:div.gameboard
             [:div.mainpane
              (om/build zones {:player opponent :remotes (get-remotes (get-in cursor [:corp :servers]))})

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -474,6 +474,9 @@ nav ul
   background-color: transparent-blue
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(255, 255, 255, 0.1)
 
+.active-player
+  border: 1px solid #ffa500
+
 // Influence dots
 
 .influence.neutral
@@ -1237,7 +1240,7 @@ nav ul
 
     &.blue
       background-color: blue
-    
+
     &.red
       background-color: red
 


### PR DESCRIPTION
Highlights the stat block of the active player so it's easier to follow the game

![image](https://cloud.githubusercontent.com/assets/3126597/14783899/fd32b666-0af2-11e6-9628-18711217b570.png)

Related to https://trello.com/c/DSlZ7idc/225-give-a-better-indicator-of-whose-turn-it-is-maybe-outline-their-information-box-or-something-might-make-spectating-easier