### PR TITLE
Fix regex for server messages

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -252,8 +252,11 @@
 (def add-image-codes (memoize add-image-codes-impl))
 
 (defn get-message-parts-impl [text]
-  (let [with-image-codes (add-image-codes (if (nil? text) "" text))]
-    (.split with-image-codes (js/RegExp. (str "(" ci-open "[^" ci-close "]*" ci-close ")") "g"))))
+  (let [with-image-codes (add-image-codes (if (nil? text) "" text))
+        splitted (.split with-image-codes (js/RegExp. (str "(" ci-open "[^" ci-close "]*" ci-close ")") "g"))
+        oldstyle (for [i splitted]
+                   (seq (.split i (js/RegExp. (str "([1-3]\\[mu\\]|\\[[^\\]]*\\])") "g"))))]
+    (flatten oldstyle)))
 
 (def get-message-parts (memoize get-message-parts-impl))
 


### PR DESCRIPTION
also re-enables mu symbols like 1[mu]/2[mu]/3[mu] which didn't work