### PR TITLE
Resizable log pane

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "~2.0.3",
+    "jqueryui": "~1.11.4",
     "react": "0.14.3",
     "bootstrap": "~3.1.1",
     "moment": "~2.6.0",

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -282,6 +282,11 @@
                   (< (- height scrolltop (.height (js/$ ".gameboard .log"))) 500))
           (aset div "scrollTop" height))))
 
+
+    om/IDidMount
+    (did-mount [this]
+      (-> ".log" js/$ (.resizable #js {:handles "w"})))
+
     om/IRenderState
     (render-state [this state]
       (sab/html

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -8,10 +8,12 @@ html
     link(rel='stylesheet', href='/css/carousel.css')
     link(rel='stylesheet', href='/css/netrunner.css')
     link(rel='stylesheet', href='/lib/toastr/toastr.min.css')
+    link(rel='stylesheet', href='/lib/jqueryui/themes/base/jquery-ui.min.css')
   body
     block content
 
     script(src='/lib/jquery/jquery.min.js')
+    script(src='/lib/jqueryui/jquery-ui.min.js')
     script(src='/lib/bootstrap/dist/js/bootstrap.js')
     script(src='/lib/moment/min/moment.min.js')
     script(src='/lib/marked/marked.min.js')


### PR DESCRIPTION
fixes #583

you can make the log pane bigger and smaller (but it's not a solution to
the asset spam problem)