### PR TITLE
implement Jeeves Model Bioroids

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -428,6 +428,12 @@
                                          (shuffle! state side :deck))}
                            card nil))}]}
 
+   "Jeeves Model Bioroids"
+   {:abilities [{:label "Gain [Click]"
+                 :req (req (< 2 (- (:click-per-turn corp) (:click corp))))
+                 :msg "gain [Click]" :once :per-turn
+                 :effect (effect (gain :click 1))}]}
+
    "Kala Ghoda Real TV"
    {:flags {:corp-phase-12 (req true)}
     :abilities [{:msg "look at the top card of the Runner's Stack"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -430,7 +430,6 @@
 
    "Jeeves Model Bioroids"
    {:abilities [{:label "Gain [Click]"
-                 :req (req (< 2 (- (:click-per-turn corp) (:click corp))))
                  :msg "gain [Click]" :once :per-turn
                  :effect (effect (gain :click 1))}]}
 


### PR DESCRIPTION
This has to be manually activated for the time being since tracking how clicks were spent is way too hairy. At least we can ensure that the Corp has spent at least 3 clicks before it can be used. 