### PR TITLE
Rough framework for coding "wait until after this effect resolves" abilities

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -546,10 +546,12 @@
                                                             (<= (:cost %) (:credit corp)) true)) (:deck corp)) :sorted))
                  :msg (msg "reveal " (:title target) " from R&D and "
                            (if (= (:type target) "Operation") "play " "install ") " it")
-                 :effect (req (if (= (:type target) "Operation")
-                                (play-instant state side target)
-                                (corp-install state side target nil))
-                              (shuffle! state side :deck))}]}
+                 :effect (req (when-completed target
+                                              (if (= (:type target) "Operation")
+                                                (play-instant state side target)
+                                                (corp-install state side target nil))
+                                              (do (system-msg state side "shuffles their deck")
+                                                  (shuffle! state side :deck))))}]}
 
    "Mumbad Construction Co."
    {:derezzed-events {:runner-turn-ends corp-rez-toast}

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -67,3 +67,16 @@
   "Returns true if the given event has occurred exactly once this turn."
   [state side ev]
   (= (count (turn-events state side ev)) 1))
+
+;;; Effect completion triggers
+(defn register-effect-completed
+  ([state side card effect] (register-effect-completed state side card effect :ability))
+  ([state side card effect key]
+   (swap! state update-in [:effect-completed (:cid card) key] #(conj % effect))))
+
+(defn effect-completed
+  ([state side card] (effect-completed state side card :ability))
+  ([state side card key]
+   (doseq [handler (get-in @state [:effect-completed (:cid card) key])]
+     (handler state side card [key]))
+   (swap! state update-in [:effect-completed (:cid card)] dissoc key)))

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -161,7 +161,9 @@
                  (when-let [dre (:derezzed-events cdef)]
                    (when-not (:rezzed (get-card state moved-card))
                      (register-events state side dre moved-card))))))
-           (clear-install-cost-bonus state side)))))))
+           (clear-install-cost-bonus state side)
+           (when-not (:delayed-completion cdef)
+             (effect-completed state side card))))))))
 
 
 ;;; Installing a runner card

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -4,11 +4,11 @@
                                 dissoc-in cancellable card-is? side-str
                                 build-spend-msg cost-names remote->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side]]
-            [game.macros :refer [effect req msg]]
+            [game.macros :refer [effect req msg when-completed final-effect]]
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))
 
-(declare get-card resolve-ability say system-msg trigger-event update!)
+(declare get-card get-remote-names register-effect-completed resolve-ability say system-msg trigger-event update!)
 
 (def game-states (atom {}))
 

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -54,3 +54,16 @@
             'target '(first targets)
             'tagged '(or (> (:tagged runner) 0) (> (:tag runner) 0))]
        (str ~@expr))))
+
+(defmacro when-completed
+  ([action expr]
+   (let [reqmac (macroexpand (list (quote req) expr))]
+     `(do (~'register-effect-completed ~'state ~'side ~'card ~reqmac)
+          ~action)))
+  ([card action expr]
+   (let [reqmac (macroexpand (list (quote req) expr))]
+     `(do (~'register-effect-completed ~'state ~'side ~card ~reqmac)
+          ~action))))
+
+(defmacro final-effect [& expr]
+  (macroexpand (apply list `(effect ~@expr ~(list (quote effect-completed) 'card)))))

--- a/src/clj/test/cards-operations.clj
+++ b/src/clj/test/cards-operations.clj
@@ -1,5 +1,33 @@
 (in-ns 'test.core)
 
+(deftest accelerated-diagnostics
+  "Accelerated Diagnostics - Interaction with prompt effects, like Shipment from SanSan"
+  (do-game
+    (new-game (default-corp [(qty "Accelerated Diagnostics" 1) (qty "Cerebral Overwriter" 1) (qty "Shipment from SanSan" 1)
+                             (qty "Hedge Fund" 1) (qty "Back Channels" 1)])
+              (default-runner))
+    (starting-hand state :corp ["Accelerated Diagnostics" "Cerebral Overwriter"])
+    (play-from-hand state :corp "Cerebral Overwriter" "New remote")
+    (core/gain state :corp :credit 1)
+    (play-from-hand state :corp "Accelerated Diagnostics")
+
+    (let [playarea (get-in @state [:corp :play-area])
+          hf (find-card "Hedge Fund" playarea)
+          ss (find-card "Shipment from SanSan" playarea)
+          bc (find-card "Back Channels" playarea)
+          co (get-content state :remote1 0)]
+      (is (= 3 (count playarea)) "3 cards in play area")
+      (prompt-select :corp ss)
+      (prompt-choice :corp "2")
+      (prompt-select :corp co)
+      (is (= 2 (:advance-counter (refresh co))) "Cerebral Overwriter gained 2 advancements")
+      (prompt-select :corp hf)
+      (is (= 9 (:credit (get-corp))) "Corp gained credits from Hedge Fund")
+      (prompt-select :corp bc)
+      (prompt-select :corp (refresh co))
+      (is (= 15 (:credit (get-corp))) "Corp gained 6 credits for Back Channels"))))
+
+
 (deftest big-brother
   "Big Brother - Give the Runner 2 tags if already tagged"
   (do-game


### PR DESCRIPTION
We have repeatedly recognized a shortcoming in our engine regarding effects that _must wait_ for other effects to resolve before they execute. The most prominent examples include Accelerated Diagnostics (must wait for the first operation to conclude before prompting to start the next) and the recently released Mumbad City Hall (must wait for the chosen Alliance operation to complete before shuffling the deck, as per the UFAQ). We have hacked around other similar situations for features like damage prevention, but have never handled these operations very well.

This is a first iteration to help primarily with the two cards listed above, but hopefully the foundation here can be expanded to other troublesome effects in the future. The idea is simple: add a `:effect-completed` event that cards can listen to if they need to wait for some effect to complete before taking additional actions. Accelerated Diagnostics can then handle this event and know that it's appropriate to let the user select the next operation to play. 

This event is easy to trigger for many operations: as soon as the operation's `:effect` function returns to `play-instant`, we can assume the operation is complete and trigger `:effect-completed`. This is why AccDiag works fine for simple operations like three Hedge Funds; as soon as the HF effect is finished, AccDiag can continue to the next. This breaks down, however, for any effect that shows a prompt requiring user interaction: due to the asynchronous nature of the game engine and the Web front-end, showing a prompt does not actually pause the game engine, and so any operation that shows a prompt just immediately returns back to `play-instant`, thus triggering our hypothetical `:effect-completed` event inappropriately.

So we add some logic to the situation:

0. Any operation that does not use `:choices` will trigger `:effect-completed` automatically in `play-instant`.
1. Any operation that uses `:choices` to show a prompt does __not__ trigger `:effect-completed` automatically. These operations will have to trigger a function `(effect-completed ...)` when their final effect has completed. Shipment for SanSan, for example, will trigger this function after the user has selected 0/1/2 advancement tokens and THEN selected a target for the tokens.
2. Some operations don't use `:choices` but still need to delay the `:effect-completed` event; typically, these operations use `resolve-ability` to show a prompt. They must inform the engine to delay the event by indicating a `:delayed-completion true` key in the card definition, and then must implement an `(effect-completed)` call at an appropriate time.

The `(effect-completed)` function calls are necessary to inform the engine that a card effect is 100% completely done and over with, but the function calls are ugly and will pollute a lot of our beautiful code. So I finally bit the bullet and learned how to write a proper Clojure macro to create the `final-effect` macro:

* `final-effect` is a drop-in replacement for `effect`, which inserts a call to `(effect-completed)` as the __last__ function call in the given ability. For example, Shipment from SanSan uses:

    ```clojure
(final-effect (add-prop :corp target :advance-counter c {:placed true}))
```

    to add `c` advancement counters to the `target` installed card, and THEN call `effect-completed` to alert any listeners that the entire SfSS routine is finally finished. This line used to be simply `(effect ...)`; the `(final-effect` inserts the `effect-completed` call but otherwise has the exact same behavior as `effect`. (`final-effect` just directly expands `effect`'s code and then inserts the function call.)
* If an operation cannot use `effect` (needs to use `if` expressions, or other reasons), then it cannot use `final-effect`. In that case it must manually call `(effect-completed)`.

So how does Accelerated Diagnostics actually listen for these `:effect-completed` events? With a second macro `when-completed`:

* `(when-completed target do-now do-after)` will evaluate the `do-now` expression after first hooking into the `:effect-completed` framework to receive a completion event when the full effect of the `do-now` expression has completed. `target` is the card performing the operation. Once the `do-now` has fully resolved, then `do-after` expression will be executed.

    Example from Mumbad City Hall, which must shuffle after its target operation has fully resolved:

    ```clojure
:effect (req (when-completed target
                                 (if (= (:type target) "Operation")
                                   (play-instant state side target)
                                   (corp-install state side target nil))
                                 (do (system-msg state side "shuffles their deck")
                                     (shuffle! state side :deck))))}]}
````

    which calls either `play-instant` or `corp-install` depending on the selected target, waits for that effect to complete, and then triggers a shuffle. `corp-install` completes immediately, but `play-instant` will complete whenever `effect-completed` is called by the framework (immediately for simple operations, or manually/through `final-effect` for complicated operations).

### TL;DR

Accelerated Diagnostics with complicated prompts fixed (famous last words?). Mumbad City Hall interaction with Heritage Committee fixed. 

When writing code for new operations, use `final-effect` when coding the last set of effects for an operation that uses prompts. Simple operations require no changes.

### References

* See __Casting Call__ for an operation that calls `effect-completed` manually because it cannot use `effect`.
* See __Shipment from SanSan__ for an operation that uses many prompts and concludes with a `final-effect`.
* See __Lateral Growth__ for an operation that uses `:delayed-completion true` because its base ability does not use `:choices`.
* See __Mumbad City Hall__ or __Accelerated Diagnostics__ for how to trigger an effect _after_ another operation has completed.

### Weaknesses

This framework currently only applies to Corp operations, as my focus was on AccDiag and Mumbad City Hall. 