### PR TITLE
Adds "Gain subroutines" abilities to relevant pieces of ICE.

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -211,7 +211,9 @@
                  :msg (msg (corp-install-msg target))}]}
 
    "Ashigaru"
-   {:abilities [end-the-run]}
+   {:abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (count (:hand corp)) " subroutines")}
+                end-the-run]}
 
    "Assassin"
    {:abilities [(trace-ability 5 (do-net-damage 3))
@@ -238,7 +240,9 @@
    {:abilities [end-the-run]}
 
    "Brainstorm"
-   {:abilities [(do-brain-damage 1)]}
+   {:abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (count (:hand runner)) " subroutines")}
+                (do-brain-damage 1)]}
 
    "Builder"
    {:abilities [{:label "Move Builder to the outermost position of any server"
@@ -585,11 +589,16 @@
     :leave-play (req (remove-watch state (keyword (str "iq" (:cid card)))))}
 
    "Information Overload"
-   {:abilities [(tag-trace 1)
+   {:abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (:tag runner 0) " subroutines")}
+                (tag-trace 1)
                 trash-installed]}
 
    "Ireress"
-   {:abilities [{:msg "make the Runner lose 1 [Credits]" :effect (effect (lose :runner :credit 1))}]}
+   {:abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (:bad-publicity corp 0) " subroutines")}
+                {:msg "make the Runner lose 1 [Credits]"
+                 :effect (effect (lose :runner :credit 1))}]}
 
    "Its a Trap!"
    {:expose {:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}
@@ -609,7 +618,9 @@
                  :effect (effect (handle-access targets) (trash card))}]}
 
    "Komainu"
-   {:abilities [(do-net-damage 1)]}
+   {:abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (count (:hand runner)) " subroutines")}
+                (do-net-damage 1)]}
 
    "Lab Dog"
    {:abilities [(assoc trash-hardware :label "Force the Runner to trash an installed piece of hardware"
@@ -719,7 +730,12 @@
                 trash-program]}
 
    "NEXT Silver"
-   {:abilities [end-the-run]}
+   {:abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (count (filter #(and (is-type? % "ICE")
+                                                           (has-subtype? % "NEXT")
+                                                           (rezzed? %))
+                                                     (all-installed state :corp))) " subroutines")}
+                end-the-run]}
 
    "Orion"
    ;; TODO: wormhole subroutine
@@ -774,7 +790,9 @@
 
    "Salvage"
    {:advanceable :while-rezzed
-    :abilities [(tag-trace 2)]}
+    :abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                (tag-trace 2)]}
 
    "Searchlight"
    {:advanceable :always
@@ -858,7 +876,9 @@
    "Swarm"
    {:effect take-bad-pub
     :advanceable :always
-    :abilities [trash-program]}
+    :abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                trash-program]}
 
    "Swordsman"
    {:abilities [(do-net-damage 1)
@@ -885,7 +905,10 @@
                 end-the-run]}
 
    "Tour Guide"
-   {:abilities [end-the-run]}
+   {:abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (count (filter #(and (is-type? % "Asset") (rezzed? %))
+                                                     (all-installed state :corp))) " subroutines")}
+                end-the-run]}
 
    "Troll"
    {:abilities [(trace-ability 2 {:label "Force the Runner to lose [Click] or end the run"
@@ -915,7 +938,9 @@
 
    "Tyrant"
    {:advanceable :while-rezzed
-    :abilities [end-the-run]}
+    :abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                end-the-run]}
 
    "Universal Connectivity Fee"
    {:abilities [{:label "Force the Runner to lose credits"
@@ -994,7 +1019,9 @@
 
    "Woodcutter"
    {:advanceable :while-rezzed
-    :abilities [(do-net-damage 1)]}
+    :abilities [{:label "Gain subroutines"
+                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                (do-net-damage 1)]}
 
    "Wormhole"
    ;; TODO: create an ability for wormhole

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -212,7 +212,7 @@
 
    "Ashigaru"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (count (:hand corp)) " subroutines")}
+                 :msg (msg "gain " (count (:hand corp)) " subroutines")}
                 end-the-run]}
 
    "Assassin"
@@ -241,7 +241,7 @@
 
    "Brainstorm"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (count (:hand runner)) " subroutines")}
+                 :msg (msg "gain " (count (:hand runner)) " subroutines")}
                 (do-brain-damage 1)]}
 
    "Builder"
@@ -590,13 +590,13 @@
 
    "Information Overload"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (:tag runner 0) " subroutines")}
+                 :msg (msg "gain " (:tag runner 0) " subroutines")}
                 (tag-trace 1)
                 trash-installed]}
 
    "Ireress"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (:bad-publicity corp 0) " subroutines")}
+                 :msg (msg "gain " (:bad-publicity corp 0) " subroutines")}
                 {:msg "make the Runner lose 1 [Credits]"
                  :effect (effect (lose :runner :credit 1))}]}
 
@@ -619,7 +619,7 @@
 
    "Komainu"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (count (:hand runner)) " subroutines")}
+                 :msg (msg "gain " (count (:hand runner)) " subroutines")}
                 (do-net-damage 1)]}
 
    "Lab Dog"
@@ -731,7 +731,7 @@
 
    "NEXT Silver"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (count (filter #(and (is-type? % "ICE")
+                 :msg (msg "gain " (count (filter #(and (is-type? % "ICE")
                                                            (has-subtype? % "NEXT")
                                                            (rezzed? %))
                                                      (all-installed state :corp))) " subroutines")}
@@ -791,7 +791,7 @@
    "Salvage"
    {:advanceable :while-rezzed
     :abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                 :msg (msg "gain " (:advance-counter card 0) " subroutines")}
                 (tag-trace 2)]}
 
    "Searchlight"
@@ -877,7 +877,7 @@
    {:effect take-bad-pub
     :advanceable :always
     :abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                 :msg (msg "gain " (:advance-counter card 0) " subroutines")}
                 trash-program]}
 
    "Swordsman"
@@ -906,7 +906,7 @@
 
    "Tour Guide"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (count (filter #(and (is-type? % "Asset") (rezzed? %))
+                 :msg (msg "gain " (count (filter #(and (is-type? % "Asset") (rezzed? %))
                                                      (all-installed state :corp))) " subroutines")}
                 end-the-run]}
 
@@ -939,7 +939,7 @@
    "Tyrant"
    {:advanceable :while-rezzed
     :abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                 :msg (msg "gain " (:advance-counter card 0) " subroutines")}
                 end-the-run]}
 
    "Universal Connectivity Fee"
@@ -1020,7 +1020,7 @@
    "Woodcutter"
    {:advanceable :while-rezzed
     :abilities [{:label "Gain subroutines"
-                 :msg (msg "to gain " (:advance-counter card 0) " subroutines")}
+                 :msg (msg "gain " (:advance-counter card 0) " subroutines")}
                 (do-net-damage 1)]}
 
    "Wormhole"


### PR DESCRIPTION
Allows for players to announce number of subroutines on ICE that have variable number of subroutines, like Komainu, Tour Guide and Ashigaru.

Also works with the advanceable only while rezzed ICE.

Does not account for 1 subroutine not being plural, so if that would irritate anyone they are more than welcome to fix it. I felt it was too much of a hassle.

Note that this is only a cosmetic change, no game state is changed, the number is just printed to chat.

Screenshot:
<img width="231" alt="screen shot 2016-05-10 at 23 18 00" src="https://cloud.githubusercontent.com/assets/13198563/15164643/191fece2-1708-11e6-9263-c5247b3e5739.png">
