### PR TITLE
Finish remaining "in this server" fixes

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -692,7 +692,8 @@
                                (has-subtype? % "Clone")
                                (has-subtype? % "Executive")
                                (has-subtype? % "Sysop"))
-                           (or (= (last (:zone %)) :content) (= (last (:zone %)) :onhost)))}
+                           (or (and (= (last (:zone %)) :content) (is-remote? (second (:zone %))))
+                               (= (last (:zone %)) :onhost)))}
       :msg (msg "trash " (:title target)) :effect (effect (trash target))}]}
 
    "Vigil"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -149,8 +149,11 @@
     :effect (effect (update! (assoc card :named-target target)))
     :leave-play (effect (update! (dissoc card :named-target)))
     :events {:purge {:effect (effect (trash card))}
-             :pre-corp-install {:req (req (let [serv (:server (second targets))]
-                                            (= serv (:named-target card))))
+             :pre-corp-install {:req (req (let [c target
+                                                serv (:server (second targets))]
+                                            (and (= serv (:named-target card))
+                                                 (not (and (is-central? serv)
+                                                           (is-type? c "Upgrade"))))))
                                 :effect (effect (install-cost-bonus [:credit 1]))}}}
 
    "Djinn"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -239,7 +239,9 @@
      {:events {:advance ng :advancement-placed ng}})
 
    "Oaktown Grid"
-   {:events {:pre-trash {:req (req (= (:zone card) (:zone target)))
+   {:events {:pre-trash {:req (req (and (is-remote? (second (:zone card)))
+                                           (or (= (:zone card) (:zone target))
+                                               (= (:zone card) (:zone (get-card state (:host target)))))))
                          :effect (effect (trash-cost-bonus 3))}}}
 
    "Off the Grid"
@@ -353,6 +355,9 @@
    "Surat City Grid"
    {:events
     {:rez {:req (req (and (= (card->server state target) (card->server state card))
+                          (not (and (is-central? (card->server state card))
+                                    (= (card->server state target) (card->server state card))
+                                    (is-type? target "Upgrade")))
                           (not= (:cid target) (:cid card))
                           (seq (filter #(and (not (rezzed? %))
                                              (not (is-type? % "Agenda"))) (all-installed state :corp)))))

--- a/src/clj/test/cards/programs.clj
+++ b/src/clj/test/cards/programs.clj
@@ -83,16 +83,16 @@
     (play-from-hand state :corp "Ice Wall" "HQ")
     (is (= 7 (:credit (get-corp))) "Diwan charged 1cr to install ice protecting the named server")
     (play-from-hand state :corp "Crisium Grid" "HQ")
-    (is (= 6 (:credit (get-corp))) "Diwan charged 1cr to install in the named server")
+    (is (= 7 (:credit (get-corp))) "Diwan didn't charge to install another upgrade in root of HQ")
     (take-credits state :corp)
     (take-credits state :runner)
     (play-from-hand state :corp "Ice Wall" "HQ")
-    (is (= 4 (:credit (get-corp))) "Diwan charged 1cr + 1cr to install a second ice protecting the named server")
+    (is (= 5 (:credit (get-corp))) "Diwan charged 1cr + 1cr to install a second ice protecting the named server")
     (core/gain state :corp :click 1)
     (core/purge state :corp)
     (play-from-hand state :corp "Fire Wall" "HQ") ; 2cr cost from normal install cost
     (is (= "Diwan" (-> (get-runner) :discard first :title)) "Diwan was trashed from purge")
-    (is (= 2 (:credit (get-corp))) "No charge for installs after Diwan purged")))
+    (is (= 3 (:credit (get-corp))) "No charge for installs after Diwan purged")))
 
 (deftest djinn-host-chakana
   "Djinn - Hosted Chakana does not disable advancing agendas. Issue #750"


### PR DESCRIPTION
Fixes #1362. 

This caps off the fixes needed to comply with the Business First ruling that upgrades in the root of a central server are not considered to be "in" that server. 