### PR TITLE
fix Parasite and Faerie

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -286,7 +286,7 @@
 
    "Faerie"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [{:msg "break any number of sentry subroutines"
+                    {:abilities [{:msg "break a sentry subroutine"
                                   :effect (effect (trash card))}
                                  (strength-pump 1 1)]})
 

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -485,7 +485,8 @@
                              (trigger-event state side :runner-install card))
                            (trash state side target)
                            (trash-ice-in-run state))
-              :msg (msg "trash " (:title target))}}}
+              :msg (msg "trash " (:title target))}}
+    :trash-effect {:effect (req (update-all-ice state side))}}
 
    "Paricia"
    {:recurring 2}


### PR DESCRIPTION
Fix #1464: Updates all ICE if Parasite is trashed (voluntarily or not) so strengths will show correct values. 

Fix #1460: Cosmetic only, but a more accurate message when using Faerie.