### PR TITLE
disable SYNC when Employee Strike is played

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -529,7 +529,11 @@
                               :effect (effect (gain :link 2))}}}
 
    "SYNC: Everything, Everywhere"
-   {:events {:pre-first-turn {:req (req (= side :corp))
+   {:effect (req (when (> (:turn @state) 1)
+                   (if (:sync-front card)
+                     (tag-remove-bonus state side -1)
+                     (trash-resource-bonus state side 2))))
+    :events {:pre-first-turn {:req (req (= side :corp))
                               :effect (effect (update! (assoc card :sync-front true)) (tag-remove-bonus -1))}}
     :abilities [{:cost [:click 1]
                  :effect (req (if (:sync-front card)
@@ -539,7 +543,10 @@
                            (do (tag-remove-bonus state side -1)
                                (trash-resource-bonus state side -2)
                                (update! state side (-> card (assoc :sync-front true)(assoc :code "09001"))))))
-                 :msg (msg "flip their ID")}]}
+                 :msg (msg "flip their ID")}]
+    :leave-play (req (if (:sync-front card)
+                       (tag-remove-bonus state side 1)
+                       (trash-resource-bonus state side -2)))}
 
    "Synthetic Systems: The World Re-imagined"
    {:events {:pre-start-game {:effect draft-points-target}}


### PR DESCRIPTION
Fixes #1513. 

The ID's side has to be checked to see which effect to reverse, then a corresponding `:effect` is added to allow the ID to be re-enabled (has a turn check so it won't activate at game start). 