### PR TITLE
implement Personality Profiles

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -367,6 +367,12 @@
                        :effect (req (gain state side :credit
                                           (if (>= (:advance-counter (get-card state card)) 5) 3 2)))}}}
 
+   "Personality Profiles"
+   (let [pp {:msg "force the Runner to trash 1 card from their Grip at random"
+             :effect (effect (trash (first (shuffle (:hand runner)))))}]
+     {:events {:searched-stack pp
+               :runner-install (assoc pp :req (req (some #{:discard} (:previous-zone target))))}})
+
    "Philotic Entanglement"
    {:req (req (> (count (:scored runner)) 0))
     :msg (msg "do " (count (:scored runner)) " net damage")

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -325,7 +325,8 @@
     :events {:agenda-scored
              {:player :runner :prompt "Choose a card" :msg (msg "add 1 card to their Grip from their Stack")
               :choices (req (cancellable (:deck runner)))
-              :effect (effect (move target :hand)
+              :effect (effect (trigger-event :searched-stack nil)
+                              (move target :hand)
                               (shuffle! :deck))}}}
 
    "Maya"
@@ -497,6 +498,7 @@
                          :prompt "Install another Rabbit Hole?" :msg "install another Rabbit Hole"
                          :yes-ability {:effect (req (when-let [c (some #(when (= (:title %) "Rabbit Hole") %)
                                                                       (:deck runner))]
+                                                     (trigger-event state side :searched-stack nil)
                                                      (runner-install state side c)
                                                      (shuffle! state :runner :deck)))}}} card nil))}
 
@@ -534,9 +536,10 @@
              {:optional {:req (req (is-type? target "Hardware"))
                          :prompt "Use Replicator to add a copy?"
                          :yes-ability {:msg (msg "add a copy of " (:title target) " to their Grip")
-                                       :effect (effect (move (some #(when (= (:title %) (:title target)) %)
-                                                                  (:deck runner)) :hand)
-                                                      (shuffle! :deck))}}}}}
+                                       :effect (effect (trigger-event :searched-stack nil)
+                                                       (move (some #(when (= (:title %) (:title target)) %)
+                                                                   (:deck runner)) :hand)
+                                                       (shuffle! :deck))}}}}}
 
    "Security Chip"
    {:abilities [{:label "[Trash]: Add [Link] strength to a non-Cloud icebreaker until the end of the run"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -163,7 +163,7 @@
                  :choices (req (cancellable (filter #(and (is-type? % "Program")
                                                           (has-subtype? % "Virus"))
                                                     (:deck runner)) :sorted))
-                 :cost [:click 1 :credit 1] :effect (effect (move target :hand) (shuffle! :deck))}
+                 :cost [:click 1 :credit 1] :effect (effect (trigger-event :searched-stack nil) (move target :hand) (shuffle! :deck))}
                 {:label "Install a non-Icebreaker program on Djinn"
                  :effect (effect (resolve-ability
                                    {:cost [:click 1]
@@ -611,7 +611,9 @@
                  :priority true
                  :choices (req (cancellable (filter #(is-type? % "Program") (:deck runner)) :sorted))
                  :cost [:credit 2]
-                 :effect (effect (trash card {:cause :ability-cost}) (runner-install target) (shuffle! :deck))}]}
+                 :effect (effect (trigger-event :searched-stack nil)
+                                 (trash card {:cause :ability-cost})
+                                 (runner-install target) (shuffle! :deck))}]}
 
    "Sneakdoor Beta"
    {:abilities [{:cost [:click 1] :msg "make a run on Archives"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -66,7 +66,7 @@
                  :msg (msg "install " (:title target))
                  :cost [:forfeit]
                  :choices (req (cancellable (filter #(not (is-type? % "Event")) (:deck runner)) :sorted))
-                 :effect (effect (runner-install target) (shuffle! :deck))}]}
+                 :effect (effect (trigger-event :searched-stack nil) (runner-install target) (shuffle! :deck))}]}
 
    "Bhagat"
    {:events {:successful-run {:req (req (= target :hq))
@@ -601,7 +601,8 @@
                         :yes-ability {:prompt "How many would you like to trash?"
                                       :choices {:number (req num)}
                                       :msg "shuffle their Stack"
-                                      :effect (req (doseq [c (take (int target) cards)]
+                                      :effect (req (trigger-event state side :searched-stack nil)
+                                                   (doseq [c (take (int target) cards)]
                                                      (trash state side c {:unpreventable true}))
                                                    (shuffle! state :runner :deck)
                                                    (when (> (int target) 0)
@@ -1018,9 +1019,9 @@
     :leave-play (effect (damage :meat 3 {:unboostable true :card card}))}
 
    "Tyson Observatory"
-   {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "adds " (:title target) " to their Grip")
+   {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "add " (:title target) " to their Grip")
                  :choices (req (cancellable (filter #(is-type? % "Hardware") (:deck runner)) :sorted))
-                 :cost [:click 2] :effect (effect (move target :hand) (shuffle! :deck))}]}
+                 :cost [:click 2] :effect (effect (trigger-event :searched-stack nil) (move target :hand) (shuffle! :deck))}]}
 
    "Underworld Contact"
    (let [ability {:label "Gain 1 [Credits] (start of turn)"


### PR DESCRIPTION
After some discussion in Slack, I'm not sure we have a better way of identifying when the Runner searches their Stack other than manually inserting a custom event trigger. Therefore, that's what this patch does to [this list of cards](https://netrunnerdb.com/find/?q=x%3A%22search+your+stack%22&sort=set&view=list&_locale=en). 