### PR TITLE
implement Harishchandra Ent. (seeking review)

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -206,6 +206,21 @@
    {:events {:pre-ice-strength {:req (req (and (ice? target) (has-subtype? target "Bioroid")))
                                 :effect (effect (ice-strength-bonus 1 target))}}}
 
+   "Harishchandra Ent.: Where Youre the Star"
+   {:effect (req (when tagged
+                   (reveal-hand state :runner))
+                 (add-watch state :harishchandra
+                            (fn [k ref old new]
+                              (when (and (is-tagged? new) (not (is-tagged? old)))
+                                (system-msg ref side (str "uses Harishchandra Ent.: Where You're the Star to"
+                                                          " make the Runner play with their Grip revealed"))
+                                (reveal-hand state :runner))
+                              (when (and (is-tagged? old) (not (is-tagged? new)))
+                                (conceal-hand state :runner)))))
+    :leave-play (req (when tagged
+                       (conceal-hand state :runner))
+                     (remove-watch state :harishchandra))}
+
    "Harmony Medtech: Biomedical Pioneer"
    {:effect (effect (lose :agenda-point-req 1) (lose :runner :agenda-point-req 1))
     :leave-play (effect (gain :agenda-point-req 1) (gain :runner :agenda-point-req 1))}

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -403,6 +403,16 @@
     (resolve-ability state side ability target nil))
   (trigger-event state side :expose target))
 
+(defn reveal-hand
+  "Reveals a side's hand to opponent and spectators."
+  [state side]
+  (swap! state assoc-in [side :openhand] true))
+
+(defn conceal-hand
+  "Conceals a side's revealed hand from opponent and spectators."
+  [state side]
+  (swap! state update-in [side] dissoc :openhand))
+
 (defn win
   "Records a win reason for statistics."
   [state side reason]

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -542,10 +542,11 @@
        (om/build label (:hand player) {:opts {:name name}})
        (map-indexed (fn [i card]
                       [:div.card-wrapper {:class (if (and (not= "select" (get-in player [:prompt 0 :prompt-type]))
+                                                          (= (:user player) (:user @app-state))
                                                           (not (:selected card)) (playable? card))
                                                    "playable" "")
                                           :style {:left (* (/ 320 (dec size)) i)}}
-                       (if (= (:user player) (:user @app-state))
+                       (if (or (= (:user player) (:user @app-state)) (:openhand player))
                          (om/build card-view (assoc card :remotes remotes))
                          [:img.card {:src (str "/img/" (.toLowerCase side) ".png")}])])
                     (:hand player))]))))


### PR DESCRIPTION
Tip of the cap to @queueseven for getting me over the finish line with the gameboard modifications! 

Harishchandra has a watch state very similar to Rachel Beckman's. I've tested the case of a tagged Runner playing Employee Strike and it all works--the Runner's Grip is immediately concealed and then revealed again if they're still tagged when Employee Strike leaves play and the identity is switched back on. Not sure if `core-rules.clj` is the best place for the reveal/conceal functions, arguably they could go in `core-misc.clj` but it probably doesn't matter _that_ much. 

![harishchandra](https://cloud.githubusercontent.com/assets/10407969/15323055/a8b57244-1c05-11e6-9a30-288d2d62e4c0.png)

A lot of people are clamoring for a player option to reveal their hand only to spectators (and if so, muzzle them so they can't grief the game using chat). Maybe this is a jumping off point for that feature? 