### PR TITLE
Fix large quantities of influence dots overflowing the display

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -363,12 +363,18 @@
 (defn influence-dots
   "Returns a string with UTF-8 full circles representing influence."
   [num]
-  (join (conj (repeat num "&#9679;&#8203;") ""))) ; &#8203; is a zero-width space to allow wrapping
+  (let [dot "&#9679;&#8203;"] ; &#8203; is a zero-width space to allow wrapping
+    (if (<= 20 num)
+      (str num dot)
+      (join (conj (repeat num dot) "")))))
 
 (defn restricted-dots
   "Returns a string with UTF-8 empty circles representing MWL restricted cards."
   [num]
-  (join (conj (repeat num "&#9675;&#8203;") "")))
+  (let [dot "&#9675;&#8203;"]
+    (if (<= 20 num)
+      (str num dot)
+      (join (conj (repeat num dot) "")))))
 
 (defn influence-html
   "Returns hiccup-ready vector with dots colored appropriately to deck's influence."


### PR DESCRIPTION
Thought I would tackle issue #1341 for my first attempt at contributing.

![image](https://cloud.githubusercontent.com/assets/620163/15378954/7f08620a-1d3e-11e6-9079-459582af58e7.png)
