### PR TITLE
Rebirth Implementation

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -596,7 +596,7 @@
                                              (not (= "Draft" (:setname c)))
                                              (not (= (:title c) (-> @state :runner :identity :title)))))
                         swappable-ids (filter is-swappable @all-cards)]
-                        (cancellable swappable-ids)))
+                        (cancellable swappable-ids :sorted)))
 
      :effect (req
                (move state side (last (:discard runner)) :rfg)

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -588,6 +588,38 @@
     :choices {:req installed?} :msg (msg "access " (:title target))
     :effect (effect (handle-access targets))}
 
+   "Rebirth"
+   {:msg "change identities"
+    :prompt "Choose an identity to become"
+    :choices (req (let [is-swappable (fn [c] (and (= "Identity" (:type c)) 
+                                             (= (-> @state :runner :identity :faction) (:faction c))
+                                             (not (= "Draft" (:setname c)))
+                                             (not (= (:title c) (-> @state :runner :identity :title)))))
+                        swappable-ids (filter is-swappable @all-cards)]
+                        (cancellable swappable-ids)))
+
+     :effect (req
+               (move state side (last (:discard runner)) :rfg)
+               (disable-identity state side)
+
+               ;; Manually change the runner's link
+               (swap! state update-in [side :link] 
+                 (fn [old-link] 
+                   (let [old-id-link (-> @state :runner :identity :baselink)
+                         new-id-link (:baselink target)
+                         link-change (- new-id-link old-id-link)]
+                      (+ old-link link-change))))
+
+               ;; Move the selected ID to [:runner :identity] and set the zone
+               (swap! state update-in [side :identity] 
+                  (fn [x] (assoc target :zone [:identity])))
+
+               ;; enable-identity does not do everything that card-init does
+               (card-init state side (get-in @state [:runner :identity]))
+               (system-msg state side "NOTE: passive abilities (Kate, Gabe, etc) will incorrectly fire 
+                if their once per turn condition was met this turn before Rebirth was played. 
+                Please adjust your game state manually for the rest of this turn if necessary"))}
+
    "Recon"
    {:prompt "Choose a server" :choices (req runnable-servers) :effect (effect (run target nil card))}
 

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -497,6 +497,7 @@
       kit "Rielle \"Kit\" Peddler: Transhuman"
       professor "The Professor: Keeper of Knowledge"
       jamie "Jamie \"Bzzz\" Micken: Techno Savant"
+      chaos "Chaos Theory: Wünderkind"
       whizzard "Whizzard: Master Gamer"
       reina "Reina Roja: Freedom Fighter"]
 
@@ -506,6 +507,7 @@
       (new-game (default-corp) (default-runner ["Magnum Opus" "Rebirth"]) {:start-as :runner})
 
       (play-from-hand state :runner "Rebirth")
+      (is (= (first (prompt-titles :runner)) chaos) "List is sorted")
       (is (every?   #(some #{%} (prompt-titles :runner))
                     [kate kit]))
       (is (not-any? #(some #{%} (prompt-titles :runner))
@@ -516,7 +518,7 @@
       (is (= kate (-> (get-runner) :identity :title)))
       (is (= 1 (:link (get-runner))) "1 link")
 
-      (is (= 0 (count (:discard (get-runner)))))
+      (is (empty? (:discard (get-runner))))
       (is (= "Rebirth" (-> (get-runner) :rfg first :title)))
 
       (is (changes-credits (get-runner) -4

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -617,6 +617,21 @@
         (is (= 0 (get-counters (refresh scored) :agenda)) "No agenda counter used by Mark Yale")
         (is (= 10 (get-counters (refresh scored) :credit)) "Credits not used by Mark Yale")))))
 
+(deftest whizzard
+  "Whizzard - Recurring credits"
+  (do-game
+    (new-game (default-corp) (make-deck "Whizzard: Master Gamer" ["Sure Gamble"]))
+
+    (let [click-whizzard (fn [n] (dotimes [i n] (card-ability state :runner (:identity (get-runner)) 0)))]
+      (is (changes-credits (get-runner) 1 (click-whizzard 1)))
+      (is (changes-credits (get-runner) 2 (click-whizzard 5)) "Can't take more than 3 Whizzard credits")
+
+      (take-credits state :corp)
+      (is (changes-credits (get-runner) 3 (click-whizzard 3)) "Credits reset at start of Runner's turn")
+
+      (take-credits state :runner)
+      (is (changes-credits (get-runner) 0 (click-whizzard 1)) "Credits don't reset at start of Corp's turn"))))
+
 (deftest wyvern-chemically-enhanced
   "Wyvern: Chemically Enhanced - Ability"
   (do-game

--- a/src/clj/test/utils.clj
+++ b/src/clj/test/utils.clj
@@ -10,11 +10,21 @@
     (mg/disconnect conn)
     ret))
 
-(defn make-deck [identity deck]
-  {:identity identity :deck deck})
+(defn load-cards []
+  (let [conn (mg/connect {:host "127.0.0.1" :port 27017})
+        db (mg/get-db conn "netrunner")
+        cards (mc/find-maps db "cards")
+        ret (take 99999 cards)]
+    (count ret)
+    (mg/disconnect conn)
+    ret))
 
 (defn qty [card amt]
   {:card (if (string? card) (load-card card) card) :qty amt})
+
+(defn make-deck [identity deck]
+  {:identity identity 
+   :deck (map #(if (string? %) (qty % 1) %) deck)})
 
 (defn default-corp
   ([] (default-corp [(qty "Hedge Fund" 3)]))

--- a/src/clj/test/utils.clj
+++ b/src/clj/test/utils.clj
@@ -15,6 +15,7 @@
         db (mg/get-db conn "netrunner")
         cards (mc/find-maps db "cards")
         ret (take 99999 cards)]
+    ;; Doing this to materialize the list. I'm sure there's a better way. The take above might be useless.
     (count ret)
     (mg/disconnect conn)
     ret))


### PR DESCRIPTION
I send all rebirth-able identities as part of the JSON payload for a deck in server.coffee. Opinions on whether this is a good idea or not are welcome. 

## Major Issues
- Passive once per turn abilities (Kate, Gabe, etc) will fire if their condition is met after a Rebirth, even if the condition was met with a different action before the Rebirth. I added a message when Rebirth is played to notify players of this. 

- Recurring credit display is a bit wonky. If you go Whizzard -> Someone Else, his ability no longer works but the 3 recurring credits visually appear at the start of turn.

## Minor Issues
- The message when Rebirth is played doesn't say what ID was picked. This isn't an actual issue to me, since you can obviously see the new ID.

- Not positive, but I think how I removed the card from the game was a bit hacky. Levy works by moving the card from play-area to rfg, but I have to move the last card in the discard pile. Pretty sure this has to do with how I used final-effect instead of a different macro, but I don't really understand what's happening, since I was just cargo culting when I chose final-effect

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtgred/netrunner/1559)
<!-- Reviewable:end -->
