### PR TITLE
Load all cards into the game server on launch

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -83,6 +83,9 @@ getUsername = (socket) ->
 clojure_hostname = process.env['CLOJURE_HOST'] || "127.0.0.1"
 requester = zmq.socket('req')
 requester.connect("tcp://#{clojure_hostname}:1043")
+db.collection("cards").find().sort(_id: 1).toArray (err, data) ->
+  requester.send(JSON.stringify({action: "initialize", cards: data}))
+
 requester.on 'message', (data) ->
   response = JSON.parse(data)
   if response.action isnt "remove"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -11,6 +11,7 @@
 (declare get-card get-remote-names register-effect-completed resolve-ability say system-msg trigger-event update!)
 
 (def game-states (atom {}))
+(def all-cards (atom {}))
 
 (load "core-cards")     ; retrieving and updating cards
 (load "core-events")    ; triggering of events


### PR DESCRIPTION
This adds a variable `all-cards` to the Clojure game server that is available to all game logic. That variable contains a list of all cards in the database, and can be filtered, mapped, etc. according to game needs. The data for the list is actually loaded by the web server when it first starts, and is sent as a ZMQ message to the game logic server once and only once. The game server then stores the list as an atom.

This should help @mharris717's implementation of Rebirth. It should also help with automating Targeted Marketing (but that will require UI work for a general text box prompt). It can also be used to validate decks server-side, by replacing the deck data sent by the client with authentic card data from the game server.