### PR TITLE
Next iteration of "wait for completion" framework

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -56,7 +56,8 @@
                                       (clear-wait-prompt state :runner))} card nil))}}}
 
    "Ancestral Imager"
-   {:events {:jack-out {:msg "do 1 net damage" :effect (effect (damage :net 1))}}}
+   {:events {:jack-out {:msg "do 1 net damage"
+                        :effect (effect (damage :net 1))}}}
 
    "AstroScript Pilot Program"
    {:effect (effect (add-counter card :agenda 1))
@@ -300,7 +301,7 @@
                  :msg "do 1 net damage"
                  :req (req (:run @state))
                  :once :per-run
-                 :effect (effect (damage :net 1 {:card card}))}]}
+                 :effect (effect (damage eid :net 1 {:card card}))}]}
 
    "Improved Protein Source"
      {:msg (msg "make the Runner gain 4 [Credits]")

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -207,7 +207,7 @@
 
    "Fetal AI"
    {:access {:req (req (not= (first (:zone card)) :discard)) :msg "do 2 net damage"
-             :effect (effect (damage :net 2 {:card card}))}
+             :effect (effect (damage eid :net 2 {:card card}))
     :steal-cost-bonus (req [:credit 2])}
 
    "Firmware Updates"
@@ -340,7 +340,7 @@
 
    "Medical Breakthrough"
    {:effect (effect (update-all-advancement-costs))
-    :stolen (effect (update-all-advancement-costs))
+    :stolen {:effect (effect (update-all-advancement-costs))}
     :advancement-cost-bonus (req (- (count (filter #(= (:title %) "Medical Breakthrough")
                                                    (concat (:scored corp) (:scored runner))))))}
 

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -206,8 +206,9 @@
                  :effect (effect (forfeit card) (lose :runner :click 2))}]}
 
    "Fetal AI"
-   {:access {:req (req (not= (first (:zone card)) :discard)) :msg "do 2 net damage"
-             :effect (effect (damage eid :net 2 {:card card}))
+   {:access {:delayed-completion true
+             :req (req (not= (first (:zone card)) :discard)) :msg "do 2 net damage"
+             :effect (effect (damage eid :net 2 {:card card}))}
     :steal-cost-bonus (req [:credit 2])}
 
    "Firmware Updates"
@@ -394,7 +395,7 @@
    "Philotic Entanglement"
    {:req (req (> (count (:scored runner)) 0))
     :msg (msg "do " (count (:scored runner)) " net damage")
-    :effect (effect (damage :net (count (:scored runner)) {:card card}))}
+    :effect (effect (damage eid :net (count (:scored runner)) {:card card}))}
 
    "Posted Bounty"
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
@@ -407,7 +408,7 @@
     :effect (effect (rez target {:ignore-cost :all-costs}))}
 
    "Private Security Force"
-   {:abilities [{:req (req tagged) :cost [:click 1] :effect (effect (damage :meat 1 {:card card}))
+   {:abilities [{:req (req tagged) :cost [:click 1] :effect (effect (damage eid :meat 1 {:card card}))
                  :msg "do 1 meat damage"}]}
 
    "Profiteering"
@@ -512,7 +513,7 @@
 
    "Sentinel Defense Program"
    {:events {:damage {:req (req (= target :brain)) :msg "to do 1 net damage"
-                      :effect (effect (damage :net 1 {:card card})) }}}
+                      :effect (effect (damage eid :net 1 {:card card})) }}}
 
    "Superior Cyberwalls"
    {:msg (msg "gain " (reduce (fn [c server]
@@ -580,6 +581,7 @@
                                                   (add-counter (dissoc card :vmi-count) :agenda (- (:vmi-count card))))}}}
 
    "Vulcan Coverup"
-   {:msg "do 2 meat damage" :effect (effect (damage :meat 2 {:card card}))
+   {:msg "do 2 meat damage"
+    :effect (effect (damage eid :meat 2 {:card card}))
     :stolen {:msg "force the Corp to take 1 bad publicity"
              :effect (effect (gain :corp :bad-publicity 1))}}})

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -717,8 +717,7 @@
 
    "Psychic Field"
    (let [ab {:psi {:req (req installed)
-                   :not-equal {:delayed-completion true
-                               :msg (msg "do " (count (:hand runner)) " net damage")
+                   :not-equal {:msg (msg "do " (count (:hand runner)) " net damage")
                                :effect (req (prn "START PSYCHIC FIELD" eid)
                                             (when-completed (damage state side :net (count (:hand runner)) {:card card})
                                                             (do (prn "FINISH PSYCHIC FIELD")

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -718,10 +718,7 @@
    "Psychic Field"
    (let [ab {:psi {:req (req installed)
                    :not-equal {:msg (msg "do " (count (:hand runner)) " net damage")
-                               :effect (req (prn "START PSYCHIC FIELD" eid)
-                                            (when-completed (damage state side :net (count (:hand runner)) {:card card})
-                                                            (do (prn "FINISH PSYCHIC FIELD")
-                                                                (effect-completed state side eid nil))))}}}]
+                               :effect (effect (damage eid :net (count (:hand runner)) {:card card}))}}}]
      {:expose ab :access ab})
 
    "Public Support"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -717,8 +717,12 @@
 
    "Psychic Field"
    (let [ab {:psi {:req (req installed)
-                   :not-equal {:msg (msg "do " (count (:hand runner)) " net damage")
-                               :effect (effect (damage :net (count (:hand runner)) {:card card}))}}}]
+                   :not-equal {:delayed-completion true
+                               :msg (msg "do " (count (:hand runner)) " net damage")
+                               :effect (req (prn "START PSYCHIC FIELD" eid)
+                                            (when-completed (damage state side :net (count (:hand runner)) {:card card})
+                                                            (do (prn "FINISH PSYCHIC FIELD")
+                                                                (effect-completed state side eid nil))))}}}]
      {:expose ab :access ab})
 
    "Public Support"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -98,7 +98,7 @@
                   :label "Do 1 net damage (start of turn)"
                   :once :per-turn
                   :msg "do 1 net damage"
-                  :effect (effect (damage :net 1 {:card card}))}]
+                  :effect (effect (damage eid :net 1 {:card card}))}]
      {:derezzed-events {:runner-turn-ends corp-rez-toast}
       :events {:corp-turn-begins ability}
       :abilities [ability]})
@@ -122,7 +122,7 @@
 
    "Cerebral Overwriter"
    (advance-ambush 3 {:msg (msg "do " (:advance-counter (get-card state card) 0) " brain damage")
-                      :effect (effect (damage :brain (:advance-counter (get-card state card) 0) {:card card}))})
+                      :effect (effect (damage eid :brain (:advance-counter (get-card state card) 0) {:card card}))})
 
    "Chairman Hiro"
    {:effect (effect (lose :runner :hand-size-modification 2))
@@ -189,7 +189,7 @@
                  :choices {:req #(has-subtype? % "Connection")}
                  :msg (msg "to trash " (:title target)) :effect (effect (trash card) (trash target))}
                 {:cost [:click 1] :req (req (>= (:advance-counter card) 2))
-                 :msg "do 2 meat damage" :effect (effect (trash card) (damage :meat 2 {:card card}))}]}
+                 :msg "do 2 meat damage" :effect (effect (trash card) (damage eid :meat 2 {:card card}))}]}
 
    "Corporate Town"
    {:additional-cost [:forfeit]
@@ -233,7 +233,7 @@
 
    "Dedicated Response Team"
    {:events {:successful-run-ends {:req (req tagged) :msg "do 2 meat damage"
-                                   :effect (effect (damage :meat 2 {:card card}))}}}
+                                   :effect (effect (damage eid :meat 2 {:card card}))}}}
 
    "Dedicated Server"
    {:recurring 2}
@@ -268,7 +268,7 @@
    (letfn [(ice-count [state]
              (count (get-in (:corp @state) [:servers (last (:server (:run @state))) :ices])))]
        (installed-access-trigger 3 {:msg (msg "do " (ice-count state) " brain damage")
-                                    :effect (effect (damage :brain (ice-count state)
+                                    :effect (effect (damage eid :brain (ice-count state)
                                                             {:card card}))}))
 
    "Elizabeth Mills"
@@ -369,7 +369,7 @@
                                            " net damage"))
                             :effect (effect (damage eid :net (count (filter #(card-is? % :side :corp) targets))
                                                     {:card card}))}}
-    :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
+    :abilities [{:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}]}
 
    "Ibrahim Salem"
    (let [trash-ability (fn [type] {:req (req (seq (filter #(is-type? % type) (:hand runner))))
@@ -712,7 +712,7 @@
 
    "Project Junebug"
    (advance-ambush 1 {:msg (msg "do " (* 2 (:advance-counter (get-card state card) 0)) " net damage")
-                      :effect (effect (damage :net (* 2 (:advance-counter (get-card state card) 0))
+                      :effect (effect (damage eid :net (* 2 (:advance-counter (get-card state card) 0))
                                               {:card card}))})
 
    "Psychic Field"
@@ -774,7 +774,7 @@
    "Ronin"
    {:advanceable :always
     :abilities [{:cost [:click 1] :req (req (>= (:advance-counter card) 4))
-                 :msg "do 3 net damage" :effect (effect (trash card) (damage :net 3 {:card card}))}]}
+                 :msg "do 3 net damage" :effect (effect (trash card) (damage eid :net 3 {:card card}))}]}
 
    "Sealed Vault"
    {:abilities [{:label "Store any number of [Credits] on Sealed Vault"
@@ -873,13 +873,13 @@
                                                    (gain-agenda-point state :runner -1)
                                                    (system-msg state side
                                                     (str "adds Shi.Kyū to their score area as -1 agenda point")))
-                                                 (do (damage state :corp :net dmg {:card card})
+                                                 (do (damage state :corp eid :net dmg {:card card})
                                                    (system-msg state :corp
                                                     (str "uses Shi.Kyū to do " dmg " net damage"))))))}
                               card targets))}}}}
 
    "Shock!"
-   {:access {:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}
+   {:access {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}}
 
    "Snare!"
    {:access {:req (req (not= (first (:zone card)) :discard))
@@ -890,7 +890,7 @@
                                  :end-effect (effect (clear-wait-prompt :runner))
                                  :yes-ability {:cost [:credit 4]
                                                :msg "do 3 net damage and give the Runner 1 tag"
-                                               :effect (effect (damage :net 3 {:card card})
+                                               :effect (effect (damage eid :net 3 {:card card})
                                                                (tag-runner :runner 1))}}}
                                card nil))}}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -363,10 +363,11 @@
                  :cost [:click 1] :advance-counter-cost 1 :effect (effect (gain :click 2))}]}
 
    "Hostile Infrastructure"
-   {:events {:runner-trash {:req (req (some #(card-is? % :side :corp) targets))
+   {:events {:runner-trash {:delayed-completion true
+                            :req (req (some #(card-is? % :side :corp) targets))
                             :msg (msg (str "do " (count (filter #(card-is? % :side :corp) targets))
                                            " net damage"))
-                            :effect (effect (damage :net (count (filter #(card-is? % :side :corp) targets))
+                            :effect (effect (damage eid :net (count (filter #(card-is? % :side :corp) targets))
                                                     {:card card}))}}
     :abilities [{:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}]}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -73,7 +73,7 @@
                                         (assoc :prompt (msg "Choose " n " program" (when (> n 1) "s") " to trash")
                                                :effect (effect (trash-cards targets))
                                                :msg (msg "trash " (join ", " (map :title targets)))))]
-                             (resolve-ability state side ab agg nil)))})
+                             (continue-ability state side ab agg nil)))})
 
    "Alix T4LB07"
    {:events {:corp-install {:effect (effect (add-counter card :power 1))}}
@@ -567,12 +567,13 @@
                                                             (<= (:cost %) (:credit corp)) true)) (:deck corp)) :sorted))
                  :msg (msg "reveal " (:title target) " from R&D and "
                            (if (= (:type target) "Operation") "play " "install ") " it")
-                 :effect (req (when-completed target
-                                              (if (= (:type target) "Operation")
-                                                (play-instant state side target)
-                                                (corp-install state side target nil))
-                                              (do (system-msg state side "shuffles their deck")
-                                                  (shuffle! state side :deck))))}]}
+                 :effect (req (if (= (:type target) "Operation")
+                                (when-completed (play-instant state side target)
+                                                (do (system-msg state side "shuffles their deck")
+                                                    (shuffle! state side :deck)))
+                                (when-completed (corp-install state side target nil)
+                                                (do (system-msg state side "shuffles their deck")
+                                                    (shuffle! state side :deck)))))}]}
 
    "Mumbad Construction Co."
    {:derezzed-events {:runner-turn-ends corp-rez-toast}

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -13,7 +13,7 @@
 
    "Amped Up"
    {:msg "gain [Click][Click][Click] and suffer 1 brain damage"
-    :effect (effect (gain :click 3) (damage :brain 1 {:unpreventable true :card card}))}
+    :effect (effect (gain :click 3) (damage eid :brain 1 {:unpreventable true :card card}))}
 
    "Apocalypse"
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
@@ -701,7 +701,7 @@
     :effect (effect (gain-run-credits 9)
                     (run target {:end-run
                                  {:msg " take 1 brain damage"
-                                  :effect (effect (damage :brain 1 {:unpreventable true :card card}))}}
+                                  :effect (effect (damage eid :brain 1 {:unpreventable true :card card}))}}
                       card))}
 
    "Sure Gamble"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -63,7 +63,7 @@
 
    "Brain Cage"
    {:in-play [:hand-size-modification 3]
-    :effect (effect (damage :brain 1 {:card card}))}
+    :effect (effect (damage eid :brain 1 {:card card}))}
 
    "Brain Chip"
    (let [runner-points (fn [s] (max (or (get-in s [:runner :agenda-point]) 0) 0))]
@@ -390,7 +390,7 @@
                           :effect (effect (damage-prevent :meat 1))}}}
 
    "Net-Ready Eyes"
-   {:effect (effect (damage :meat 2 {:unboostable true :card card})) :msg "suffer 2 meat damage"
+   {:effect (effect (damage eid :meat 2 {:unboostable true :card card})) :msg "suffer 2 meat damage"
     :events {:run {:choices {:req #(and (installed? %)
                                         (has-subtype? % "Icebreaker"))}
                    :msg (msg "give " (:title target) " +1 strength")
@@ -578,13 +578,13 @@
    {:recurring 1}
 
    "Skulljack"
-   {:effect (effect (damage :brain 1 {:card card}))
+   {:effect (effect (damage eid :brain 1 {:card card}))
     :events {:pre-trash {:effect (effect (trash-cost-bonus -1))}}}
 
    "Spinal Modem"
    {:in-play [:memory 1]
     :recurring 2
-    :events {:successful-trace {:req (req run) :effect (effect (damage :brain 1 {:card card}))}}}
+    :events {:successful-trace {:req (req run) :effect (effect (damage eid :brain 1 {:card card}))}}}
 
    "Sports Hopper"
    {:in-play [:link 1]

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -298,7 +298,7 @@
                                   :effect (req (swap! state assoc-in [:run :run-effect :end-run]
                                                       {:req (req (:successful run))
                                                        :msg "do 3 meat damage"
-                                                       :effect (effect (damage :meat 3
+                                                       :effect (effect (damage eid :meat 3
                                                                                {:card card}))})
                                                (swap! state assoc-in [:run :run-effect :card]
                                                       card))})]}
@@ -307,7 +307,7 @@
    {:abilities [{:msg "make each player gain 2 [Credits]" :effect (effect (gain :runner :credit 2)
                                                                           (gain :corp :credit 2))}
                 (do-psi {:label "Do 1 net damage for each card in the Runner's grip"
-                         :effect (effect (damage :net (count (get-in @state [:runner :hand])) {:card card}))
+                         :effect (effect (damage eid :net (count (get-in @state [:runner :hand])) {:card card}))
                          :msg (msg (str "do " (count (get-in @state [:runner :hand])) " net damage"))})]}
 
    "Chimera"
@@ -341,7 +341,7 @@
              :msg "force the Runner to encounter Chrysalis"
              :optional {:req (req (not= (first (:zone card)) :discard))
                         :prompt "Use Chrysalis to do 2 net damage?"
-                        :yes-ability {:effect (effect (damage :net 2 {:card card}))
+                        :yes-ability {:effect (effect (damage eid :net 2 {:card card}))
                         :msg "do 2 net damage"}}}}
 
    "Chum"
@@ -353,7 +353,7 @@
    "Cortex Lock"
    {:abilities [{:label "Do 1 net damage for each unused memory unit the Runner has"
                  :msg (msg "do " (:memory runner) " net damage")
-                 :effect (effect (damage :net (:memory runner) {:card card}))}]}
+                 :effect (effect (damage eid :net (:memory runner) {:card card}))}]}
 
    "Crick"
    {:abilities [{:label "install a card from Archives"
@@ -388,7 +388,7 @@
 
    "Data Mine"
    {:abilities [{:msg "do 1 net damage"
-                 :effect (req (damage state :runner :net 1 {:card card})
+                 :effect (req (damage state :runner eid :net 1 {:card card})
                               (when current-ice
                                 (trash-ice-in-run state))
                               (trash state side card))}]}
@@ -462,7 +462,7 @@
                                                     :choices {:req #(is-type? % "Hardware")}
                                                     :effect (effect (trash target {:cause :subroutine}))}
                                                    card nil)
-                                                  (damage :meat 2 {:unpreventable true
+                                                  (damage eid :meat 2 {:unpreventable true
                                                                    :card card})
                                                   (end-run))})]}
 
@@ -528,7 +528,7 @@
 
    "Heimdall 2.0"
    {:abilities [(do-brain-damage 1)
-                {:msg "do 1 brain damage and end the run" :effect (effect (damage :brain 1 {:card card}) (end-run))}
+                {:msg "do 1 brain damage and end the run" :effect (effect (damage eid :brain 1 {:card card}) (end-run))}
                 end-the-run]}
 
    "Hourglass"
@@ -577,14 +577,14 @@
    {:abilities [trash-program
                 (trace-ability 1 {:label "Give the Runner 1 tag and do 1 brain damage"
                                   :msg "give the Runner 1 tag and do 1 brain damage"
-                                  :effect (effect (damage :brain 1 {:card card})
+                                  :effect (effect (damage eid :brain 1 {:card card})
                                                   (tag-runner :runner 1))})]}
 
    "Ichi 2.0"
    {:abilities [trash-program
                 (trace-ability 3 {:label "Give the Runner 1 tag and do 1 brain damage"
                                   :msg "give the Runner 1 tag and do 1 brain damage"
-                                  :effect (effect (damage :brain 1 {:card card})
+                                  :effect (effect (damage eid :brain 1 {:card card})
                                                   (tag-runner :runner 1))})]}
 
    "IQ"
@@ -612,7 +612,7 @@
                  :effect (effect (lose :runner :credit 1))}]}
 
    "Its a Trap!"
-   {:expose {:msg "do 2 net damage" :effect (effect (damage :net 2 {:card card}))}
+   {:expose {:msg "do 2 net damage" :effect (effect (damage eid :net 2 {:card card}))}
     :abilities [(assoc trash-installed :effect (req (trash state side target {:cause :subroutine})
                                                     (when current-ice
                                                       (trash-ice-in-run state))
@@ -737,7 +737,7 @@
    "NEXT Gold"
    {:abilities [{:label "Do 1 net damage for each rezzed NEXT ice"
                  :msg (msg "do " (next-ice-count corp) " net damage")
-                 :effect (effect (damage :net (next-ice-count corp) {:card card}))}
+                 :effect (effect (damage eid :net (next-ice-count corp) {:card card}))}
                 trash-program]}
 
    "NEXT Silver"
@@ -846,7 +846,7 @@
                 (trace-ability 2 (do-net-damage 2))
                 (trace-ability 3 {:label "Do 3 net damage and end the run"
                                   :msg "do 3 net damage and end the run"
-                                  :effect (effect (damage :net 3 {:card card}) (end-run))})]}
+                                  :effect (effect (damage eid :net 3 {:card card}) (end-run))})]}
 
    "Shiro"
    {:abilities [{:label "Rearrange the top 3 cards of R&D"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -40,15 +40,17 @@
   "Do specified amount of net-damage."
   [dmg]
   {:label (str "Do " dmg " net damage")
+   :delayed-completion true
    :msg (str "do " dmg " net damage")
-   :effect (effect (damage :net dmg {:card card}))})
+   :effect (effect (damage eid :net dmg {:card card}))})
 
 (defn do-brain-damage
   "Do specified amount of brain damage."
   [dmg]
   {:label (str "Do " dmg " brain damage")
+   :delayed-completion true
    :msg (str "do " dmg " brain damage")
-   :effect (effect (damage :brain dmg {:card card}))})
+   :effect (effect (damage eid :brain dmg {:card card}))})
 
 (defn gain-credits
   "Gain specified amount of credits"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -109,8 +109,7 @@
                      (do (swap! state update-in [:damage] dissoc :damage-choose-corp)
                          (damage state side :net (get-defer-damage state side :net nil)
                                  {:unpreventable true :card card}))
-                     (do (prn "STARTING CHRONOS" eid)
-                         (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
+                     (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
                          (when-completed
                            (resolve-ability state side
                              {:optional
@@ -122,8 +121,7 @@
                                                                  (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
                                                                    (str " and deal " (- (get-defer-damage state side :net nil) 1)
                                                                         " more net damage")))
-                                                       :effect (req ;(prn "CHRONOS-PROTOCOL " eid)
-                                                                    (clear-wait-prompt state :runner)
+                                                       :effect (req (clear-wait-prompt state :runner)
                                                                     (swap! state update-in [:damage] dissoc :damage-choose-corp)
                                                                     (trash state side target {:cause :net :unpreventable true})
                                                                     (let [more (dec (or (get-defer-damage state side :net nil) 0))]

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -100,6 +100,7 @@
      :runner-turn-begins {:effect (effect (enable-corp-damage-choice))}
      :pre-resolve-damage
      {:once :per-turn
+      :delayed-completion true
       :req (req (and (= target :net)
                      (corp-can-choose-damage? state)
                      (> (last targets) 0)))
@@ -109,24 +110,29 @@
                          (damage state side :net (get-defer-damage state side :net nil)
                                  {:unpreventable true :card card}))
                      (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
-                         (resolve-ability state side
-                           {:optional {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                                    "Grip to select the first card trashed?") :player :corp
-                                       :yes-ability {:prompt (msg "Choose a card to trash")
-                                                     :choices (req (:hand runner)) :not-distinct true
-                                                     :msg (msg "trash " (:title target)
-                                                            (when (> (- (get-defer-damage state side :net nil) 1) 0)
-                                                              (str " and deal " (- (get-defer-damage state side :net nil) 1)
-                                                                   " more net damage")))
-                                                     :effect (req (clear-wait-prompt state :runner)
-                                                                  (trash state side target {:cause :net :unpreventable true})
-                                                                  (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                                  (damage state side :net (- (get-defer-damage state side :net nil) 1)
-                                                                          {:unpreventable true :card card}))}
-                                       :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                                 (clear-wait-prompt state :runner)
-                                                                 (damage state side :net (get-defer-damage state side :net nil)
-                                                                         {:unpreventable true :card card}))}}} card nil))))}}
+                         (when-completed
+                           (resolve-ability state side
+                             {:optional
+                              {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
+                                                      "Grip to select the first card trashed?") :player :corp
+                                         :yes-ability {:prompt (msg "Choose a card to trash")
+                                                       :choices (req (:hand runner)) :not-distinct true
+                                                       :msg (msg "trash " (:title target)
+                                                                 (when (> (- (get-defer-damage state side :net nil) 1) 0)
+                                                                   (str " and deal " (- (get-defer-damage state side :net nil) 1)
+                                                                        " more net damage")))
+                                                       :effect (req (clear-wait-prompt state :runner)
+                                                                    (trash state side target {:cause :net :unpreventable true})
+                                                                    (let [more (dec (get-defer-damage state side :net nil))]
+                                                                      (when (pos? more)
+                                                                        (damage state side eid :net
+                                                                                {:unpreventable true :card card})))
+                                                                    (swap! state update-in [:damage] dissoc :damage-choose-corp))}
+                                         :no-ability {:effect (req (clear-wait-prompt state :runner)
+                                                                   (damage state side eid :net (get-defer-damage state side :net nil)
+                                                                           {:unpreventable true :card card})
+                                                                   (swap! state update-in [:damage] dissoc :damage-choose-corp))}}} card nil)
+                           (effect-completed state side eid card)))))}}
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -50,7 +50,7 @@
               :msg "make the Runner take 1 tag or suffer 2 meat damage"
               :effect (req (if (= target "1 tag")
                              (do (tag-runner state :runner 1) (system-msg state side "takes 1 tag"))
-                             (do (damage state :runner :meat 2 {:unboostable true :card card})
+                             (do (damage state :runner eid :meat 2 {:unboostable true :card card})
                                  (system-msg state side "suffers 2 meat damage"))))}}}
 
    "Armand \"Geist\" Walker: Tech Lord"
@@ -107,28 +107,29 @@
       :effect (req (damage-defer state side :net (last targets))
                    (if (= 0 (count (:hand runner)))
                      (do (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                         (damage state side :net (get-defer-damage state side :net nil)
+                         (damage state side eid :net (get-defer-damage state side :net nil)
                                  {:unpreventable true :card card}))
                      (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
-                         (when-completed
-                           (resolve-ability state side
+                           (continue-ability
+                             state side
                              {:optional
                               {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                                      "Grip to select the first card trashed?") :player :corp
-                                         :yes-ability {:prompt (msg "Choose a card to trash")
-                                                       :choices (req (:hand runner)) :not-distinct true
-                                                       :msg (msg "trash " (:title target)
-                                                                 (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
-                                                                   (str " and deal " (- (get-defer-damage state side :net nil) 1)
-                                                                        " more net damage")))
-                                                       :effect (req (clear-wait-prompt state :runner)
-                                                                    (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                                    (trash state side target {:cause :net :unpreventable true})
-                                                                    (let [more (dec (or (get-defer-damage state side :net nil) 0))]
-                                                                      (damage-defer state side :net more)))}
-                                         :no-ability {:effect (req (clear-wait-prompt state :runner)
-                                                                   (swap! state update-in [:damage] dissoc :damage-choose-corp))}}} card nil)
-                           (effect-completed state side eid card)))))}}
+                                            "Grip to select the first card trashed?")
+                               :player :corp
+                               :yes-ability {:prompt (msg "Choose a card to trash")
+                                             :choices (req (:hand runner)) :not-distinct true
+                                             :msg (msg "trash " (:title target)
+                                                       (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
+                                                         (str " and deal " (- (get-defer-damage state side :net nil) 1)
+                                                              " more net damage")))
+                                             :effect (req (clear-wait-prompt state :runner)
+                                                          (swap! state update-in [:damage] dissoc :damage-choose-corp)
+                                                          (trash state side target {:cause :net :unpreventable true})
+                                                          (let [more (dec (or (get-defer-damage state side :net nil) 0))]
+                                                            (damage-defer state side :net more)))}
+                               :no-ability {:effect (req (clear-wait-prompt state :runner)
+                                                         (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
+                             card nil))))}}
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"
@@ -287,8 +288,8 @@
                        :effect (effect (tag-prevent 1))}}}
 
    "Jinteki: Personal Evolution"
-   {:events {:agenda-scored {:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}
-             :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage :net 1 {:card card}))}}}
+   {:events {:agenda-scored {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}
+             :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinteki: Replicating Perfection"
    {:events
@@ -321,7 +322,7 @@
                                 (case flip
                                   "[The Brewery~brewery]"
                                   (do (system-msg state side "uses [The Brewery~brewery] to do 2 net damage")
-                                      (damage state side :net 2 {:card card})
+                                      (damage eid state side :net 2 {:card card})
                                       (update! state side (assoc card :code "brewery")))
                                   "[The Tank~tank]"
                                   (do (system-msg state side "uses [The Tank~tank] to shuffle Archives into R&D")

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -109,7 +109,8 @@
                      (do (swap! state update-in [:damage] dissoc :damage-choose-corp)
                          (damage state side :net (get-defer-damage state side :net nil)
                                  {:unpreventable true :card card}))
-                     (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
+                     (do (prn "STARTING CHRONOS" eid)
+                         (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
                          (when-completed
                            (resolve-ability state side
                              {:optional
@@ -118,19 +119,16 @@
                                          :yes-ability {:prompt (msg "Choose a card to trash")
                                                        :choices (req (:hand runner)) :not-distinct true
                                                        :msg (msg "trash " (:title target)
-                                                                 (when (> (- (get-defer-damage state side :net nil) 1) 0)
+                                                                 (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
                                                                    (str " and deal " (- (get-defer-damage state side :net nil) 1)
                                                                         " more net damage")))
-                                                       :effect (req (clear-wait-prompt state :runner)
+                                                       :effect (req ;(prn "CHRONOS-PROTOCOL " eid)
+                                                                    (clear-wait-prompt state :runner)
+                                                                    (swap! state update-in [:damage] dissoc :damage-choose-corp)
                                                                     (trash state side target {:cause :net :unpreventable true})
-                                                                    (let [more (dec (get-defer-damage state side :net nil))]
-                                                                      (when (pos? more)
-                                                                        (damage state side eid :net
-                                                                                {:unpreventable true :card card})))
-                                                                    (swap! state update-in [:damage] dissoc :damage-choose-corp))}
+                                                                    (let [more (dec (or (get-defer-damage state side :net nil) 0))]
+                                                                      (damage-defer state side :net more)))}
                                          :no-ability {:effect (req (clear-wait-prompt state :runner)
-                                                                   (damage state side eid :net (get-defer-damage state side :net nil)
-                                                                           {:unpreventable true :card card})
                                                                    (swap! state update-in [:damage] dissoc :damage-choose-corp))}}} card nil)
                            (effect-completed state side eid card)))))}}
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -908,7 +908,7 @@
    {:events {:runner-turn-begins
              {:effect (req (if (>= (get-in card [:counter :power] 0) 2)
                              (do (add-counter state side card :power (- (get-in card [:counter :power] 0)))
-                                 (damage state side :brain 1 {:unpreventable true :card card})
+                                 (damage state side eid :brain 1 {:unpreventable true :card card})
                                  (system-msg state side "takes 1 brain damage from Stim Dealer"))
                              (do (add-counter state side card :power 1)
                                  (gain state side :click 1)
@@ -1079,7 +1079,7 @@
    "Tri-maf Contact"
    {:abilities [{:cost [:click 1] :msg "gain 2 [Credits]" :once :per-turn
                  :effect (effect (gain :credit 2))}]
-    :leave-play (effect (damage :meat 3 {:unboostable true :card card}))}
+    :leave-play (effect (damage eid :meat 3 {:unboostable true :card card}))}
 
    "Tyson Observatory"
    {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "add " (:title target) " to their Grip")

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -165,7 +165,7 @@
 
    "Hokusai Grid"
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"
-                              :effect (req (damage state side :net 1 {:card card}))}}}
+                              :effect (req (damage state side eid :net 1 {:card card}))}}}
 
    "Keegan Lane"
    {:abilities [{:label "[Trash], remove a tag: Trash a program"
@@ -306,7 +306,7 @@
    "Ryon Knight"
    {:abilities [{:label "[Trash]: Do 1 brain damage"
                  :msg "do 1 brain damage" :req (req (and this-server (zero? (:click runner))))
-                 :effect (effect (trash card) (damage :brain 1 {:card card}))}]}
+                 :effect (effect (trash card) (damage eid :brain 1 {:card card}))}]}
 
    "SanSan City Grid"
    {:effect (req (when-let [agenda (some #(when (is-type? % "Agenda") %)
@@ -328,7 +328,7 @@
                                 (resolve-ability
                                   state side
                                   {:trace {:base (req (dec (count cards)))
-                                           :effect (effect (damage :net 3 {:card card}))
+                                           :effect (effect (damage eid :net 3 {:card card}))
                                            :msg "do 3 net damage"}} card nil)))}]}
 
    "Shell Corporation"
@@ -409,10 +409,10 @@
                                                :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
                                                             (clear-wait-prompt state :runner)
                                                             (pay state :corp card :credit 2)
-                                                            (damage state side :brain 1 {:card card}))}
+                                                            (damage state side eid :brain 1 {:card card}))}
                                  :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-replace)
                                                            (clear-wait-prompt state :runner)
-                                                           (damage state side :net (get-defer-damage state side :net nil)
+                                                           (damage state side eid :net (get-defer-damage state side :net nil)
                                                                    {:card card}))}}} card nil))}
      :prevented-damage {:req (req (and this-server (= target :net) (> (last targets) 0)))
                         :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}}}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -50,7 +50,9 @@
    "Bernice Mai"
    {:events {:successful-run {:req (req this-server)
                               :trace {:base 5 :msg "give the Runner 1 tag"
-                                      :effect (effect (tag-runner :runner 1))}}}}
+                                      :effect (effect (tag-runner :runner 1))
+                                      :unsuccessful {:effect (effect (system-msg "trashes Bernice Mai from the unsuccessful trace")
+                                                                     (trash card))}}}}}
 
    "Breaker Bay Grid"
    {:events {:pre-rez-cost {:req (req (and (is-remote? (second (:zone card)))

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -405,8 +405,9 @@
     (system-msg state :runner (str " spends " boost " [Credits] to increase link strength to "
                                    (+ (:link runner) boost)))
     (let [succesful (> strength (+ (:link runner) boost))
-          which-ability (if succesful ability (:unsuccessful ability))]
-      (when-completed (resolve-ability state :corp which-ability card [strength (+ (:link runner) boost)])
+          which-ability (assoc (if succesful ability (:unsuccessful ability)) :eid (make-eid state))]
+      (when-completed (resolve-ability state :corp (:eid which-ability) which-ability
+                                       card [strength (+ (:link runner) boost)])
                       (do (trigger-event state :corp (if succesful :successful-trace :unsuccessful-trace))
                           (when-let [kicker (:kicker ability)]
                             (when (>= strength (:min kicker))

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -111,7 +111,7 @@
         (cancel-effect choice)))
     ;; trigger end-effect if present
     (when-let [end-effect (:end-effect prompt)]
-      (end-effect state side card nil))
+      (end-effect state side (make-eid state) card nil))
 
     ;; remove the prompt from the queue
     (swap! state update-in [side :prompt] (fn [pr] (filter #(not= % prompt) pr)))

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -182,7 +182,7 @@
     (update! state side id)
     (unregister-events state side id)
     (when-let [leave-play (:leave-play (card-def id))]
-      (leave-play state side id nil))))
+      (leave-play state side (make-eid state) id nil))))
 
 (defn enable-identity
   "Enables the side's identity"
@@ -192,6 +192,6 @@
         events (:events cdef)]
     (update! state side id)
     (when-let [eff (:effect cdef)]
-      (eff state side id nil))
+      (eff state side (make-eid state) id nil))
     (when events
       (register-events state side events id))))

--- a/src/clj/game/core-costs.clj
+++ b/src/clj/game/core-costs.clj
@@ -75,7 +75,7 @@
 (defn rez-cost [state side {:keys [cost] :as card}]
   (when-not (nil? cost)
     (-> (if-let [rezfun (:rez-cost-bonus (card-def card))]
-          (+ cost (rezfun state side card nil))
+          (+ cost (rezfun state side (make-eid state) card nil))
           cost)
         (+ (or (get-in @state [:bonus :cost]) 0))
         (max 0))))
@@ -106,7 +106,7 @@
   (vec (map #(if (keyword? %) % (max % 0))
             (-> (concat (get-in @state [:bonus :install-cost]) all-cost
                         (when-let [instfun (:install-cost-bonus (card-def card))]
-                          (instfun state side card nil)))
+                          (instfun state side (make-eid state) card nil)))
                 merge-costs flatten))))
 
 (defn modified-install-cost

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -61,6 +61,7 @@
       (when-completed (apply trigger-event-sync-next state side handlers event targets)
                       (effect-completed state side eid nil)))))
 
+;; INCOMPLETE
 (defn trigger-event-async
   "Triggers the given event asynchronously, triggering effect-completed once
   all registered event handlers have completed."
@@ -81,9 +82,6 @@
                                   (when (empty? awaiting)
                                     (effect-completed state side eid nil))
                                   (prn "awaiting still " @awaiting))))))))))
-
-;;      (swap! state update-in [:turn-events] #(cons [event targets] %))))
- ;; ))
 
 ; Functions for registering trigger suppression events.
 (defn register-suppress

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -130,6 +130,7 @@
 
 (defn effect-completed
   [state side eid card]
+  ;(prn "EFFECT-COMPLETED" eid)
   (doseq [handler (get-in @state [:effect-completed eid])]
     ((:effect handler) state side eid (:card card) nil))
   (swap! state update-in [:effect-completed] dissoc eid))

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -31,9 +31,31 @@
     (doseq [{:keys [ability] :as e} (sort-by (complement is-active-player) (get-in @state [:events event]))]
       (when-let [card (get-card state (:card e))]
         (when (and (not (apply trigger-suppress state side event (cons card targets)))
-                   (or (not (:req ability)) ((:req ability) state side card targets)))
+                   (or (not (:req ability)) ((:req ability) state side (make-eid state) card targets)))
           (resolve-ability state side ability card targets))))
     (swap! state update-in [:turn-events] #(cons [event targets] %))))
+
+(defn trigger-event-async
+  "Triggers the given event asynchronously, triggering effect-completed once
+  all registered event handlers have completed."
+  [state side event & targets]
+  (let [awaiting (atom #{})]
+    (let [get-side #(-> % :card :side game.utils/to-keyword)
+          is-active-player #(= (:active-player @state) (get-side %))
+          handlers (map #([% (make-eid state)]) (sort-by (complement is-active-player) (get-in @state [:events event])))]
+      (doseq [h handlers]
+        (let [e (first h)
+              eid (second h)
+              ability (:ability e)]
+          (when-let [card (get-card state (:card e))]
+            (when (and (not (apply trigger-suppress state side event (cons card targets)))
+                       (or (not (:req ability)) ((:req ability) state side (make-eid state) card targets)))
+              (when-completed (resolve-ability state side ability card targets)
+                              (do (swap! awaiting disj eid)
+                                  (prn "awaiting still " @awaiting))))))))))
+
+;;      (swap! state update-in [:turn-events] #(cons [event targets] %))))
+ ;; ))
 
 ; Functions for registering trigger suppression events.
 (defn register-suppress
@@ -52,7 +74,7 @@
   "Returns true if the given event on the given targets should be suppressed, by triggering
   each suppression handler and returning true if any suppression handler returns true."
   [state side event & targets]
-  (reduce #(or %1 ((:req (:ability %2)) state side (:card %2) targets))
+  (reduce #(or %1 ((:req (:ability %2)) state side (make-eid state) (:card %2) targets))
           false (get-in @state [:suppress event])))
 
 (defn turn-events
@@ -72,13 +94,11 @@
 
 ;;; Effect completion triggers
 (defn register-effect-completed
-  ([state side card effect] (register-effect-completed state side card effect :ability))
-  ([state side card effect key]
-   (swap! state update-in [:effect-completed (:cid card) key] #(conj % effect))))
+  [state side eid card effect]
+  (swap! state update-in [:effect-completed eid] #(conj % {:card card :effect effect})))
 
 (defn effect-completed
-  ([state side card] (effect-completed state side card :ability))
-  ([state side card key]
-   (doseq [handler (get-in @state [:effect-completed (:cid card) key])]
-     (handler state side card [key]))
-   (swap! state update-in [:effect-completed (:cid card)] dissoc key)))
+  [state side eid card]
+  (doseq [handler (get-in @state [:effect-completed eid])]
+    ((:effect handler) state side eid (:card card) nil))
+  (swap! state update-in [:effect-completed] dissoc eid))

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -37,7 +37,6 @@
 
 (defn- trigger-event-sync-next
   [state side eid handlers event & targets]
-  (prn "TRIGGER-EVENT-SYNC-NEXT" eid)
   (let [e (first handlers)
         ability (:ability e)]
     (if e
@@ -45,24 +44,22 @@
         (if (and (not (apply trigger-suppress state side event (cons card targets)))
                  (or (not (:req ability)) ((:req ability) state side (make-eid state) card targets)))
           (when-completed (resolve-ability state side ability card targets)
-                          (do (prn "ONE SYNCNEXT DONE" eid) (apply trigger-event-sync-next state side eid (next handlers) event targets)))
+                          (apply trigger-event-sync-next state side eid (next handlers) event targets))
           (apply trigger-event-sync-next state side eid (next handlers) event targets))
         (apply trigger-event-sync-next state side eid (next handlers) event targets))
-      (do (prn "FINISHED SYNC" eid)
-          (swap! state update-in [:turn-events] #(cons [event targets] %))
+      (do (swap! state update-in [:turn-events] #(cons [event targets] %))
           (effect-completed state side eid nil)))))
 
 (defn trigger-event-sync
   "Triggers the given event synchronously, requiring each handler to complete before alerting the next handler."
   [state side eid event & targets]
-  (prn "TRIGGER-EVENT-SYNC" eid)
   (let [get-side #(-> % :card :side game.utils/to-keyword)
         is-active-player #(= (:active-player @state) (get-side %))]
 
     (let [handlers (sort-by (complement is-active-player) (get-in @state [:events event]))
           card nil]
       (when-completed (apply trigger-event-sync-next state side handlers event targets)
-                      (do (prn "TRIGGER-EVENT-SYNC DONE" eid)(effect-completed state side eid nil))))))
+                      (effect-completed state side eid nil)))))
 
 (defn trigger-event-async
   "Triggers the given event asynchronously, triggering effect-completed once

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -15,7 +15,7 @@
   [state side card flag-key value]
   (let [cdef (card-def card)
         func (get-in cdef [:flags flag-key])]
-    (and func (= (func state side card nil) value))))
+    (and func (= (func state side (make-eid state) card nil) value))))
 
 (defn is-tagged?
   "Returns true if the runner is tagged."

--- a/src/clj/game/core-ice.clj
+++ b/src/clj/game/core-ice.clj
@@ -14,7 +14,7 @@
   "Gets the modified strength of the given ice."
   [state side {:keys [strength] :as card}]
   (+ (if-let [strfun (:strength-bonus (card-def card))]
-       (+ strength (strfun state side card nil))
+       (+ strength (strfun state side (make-eid state) card nil))
        strength)
      (or (get-in @state [:bonus :ice-strength]) 0)))
 
@@ -71,7 +71,7 @@
     ;; the effects of per-encounter and per-run strength pumps,
     ;; and miscellaneous increases registered by third parties (Dinosaurus, others).
     (+ (if-let [strfun (:strength-bonus (card-def card))]
-         (+ strength (strfun state side card nil))
+         (+ strength (strfun state side (make-eid state) card nil))
          strength)
        (get-in card [:pump :encounter] 0)
        (get-in card [:pump :all-run] 0)

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -157,12 +157,10 @@
   "Resolves the attempt to do n damage, now that both sides have acted to boost or
   prevent damage."
   [state side eid type n {:keys [unpreventable unboostable card] :as args}]
-  (prn "RESOLVE-DAMAGE" n eid)
   (swap! state update-in [:damage :defer-damage] dissoc type)
   (damage-choice-priority state)
   (when-completed (trigger-event-sync state side :pre-resolve-damage type card n)
-                  (do (prn "LET'S GO " eid)
-                      (if-not (or (get-in @state [:damage :damage-replace]))
+                  (do (if-not (or (get-in @state [:damage :damage-replace]))
                         (let [n (if-let [defer (get-defer-damage state side type args)] defer n)]
                           (let [hand (get-in @state [:runner :hand])]
                             (when (< (count hand) n)
@@ -170,12 +168,9 @@
                             (when (= type :brain)
                               (swap! state update-in [:runner :brain-damage] #(+ % n))
                               (swap! state update-in [:runner :hand-size-modification] #(- % n)))
-                            (prn "TAKING " n " FROM HAND" eid)
                             (doseq [c (take n (shuffle hand))]
                               (trash state side c {:unpreventable true :cause type} type))
-                            (trigger-event state side :damage type card)))
-                        (prn "DAMAGE BEING CHOSEN" eid)
-                        )
+                            (trigger-event state side :damage type card))))
                       (swap! state update-in [:damage :defer-damage] dissoc type)
                       (effect-completed state side eid card))))
 
@@ -185,7 +180,6 @@
   ([state side type n] (damage state side (make-eid state) type n nil))
   ([state side type n args] (damage state side (make-eid state) type n args))
   ([state side eid type n {:keys [unpreventable unboostable card] :as args}]
-   (prn "TOLD TO DO " n " DAMAGE FROM " (:title card) eid)
    (swap! state update-in [:damage :damage-bonus] dissoc type)
    (swap! state update-in [:damage :damage-prevent] dissoc type)
    ;; alert listeners that damage is about to be calculated.
@@ -287,7 +281,6 @@
 
 (defn resolve-trash
   [state side {:keys [zone type] :as card} {:keys [unpreventable cause keep-server-alive suppress-event] :as args} & targets]
-  (prn "TOLD TO TRASH " (:title card) (:cid card))
   (if (and (not suppress-event) (not= (last zone) :current)) ; Trashing a current does not trigger a trash event.
     (when-completed (apply trigger-event-sync state side (keyword (str (name side) "-trash")) card cause targets)
                     (apply resolve-trash-end state side card args targets))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -150,9 +150,6 @@
         (swap! state update-in [:damage] dissoc :damage-choose-runner)
         (swap! state update-in [:damage] dissoc :damage-choose-corp)))))
 
-(defn apply-damage
-  [state side eid type n {:keys [unpreventable unboostable card] :as args}])
-
 (defn resolve-damage
   "Resolves the attempt to do n damage, now that both sides have acted to boost or
   prevent damage."

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -9,23 +9,27 @@
 ;;; Playing cards.
 (defn play-instant
   "Plays an Event or Operation."
-  ([state side card] (play-instant state side card nil))
-  ([state side {:keys [title] :as card} {:keys [targets extra-cost no-additional-cost]}]
+  ([state side card] (play-instant state side (make-eid state) card nil))
+  ([state side eid? card?] (if (:eid eid?)
+                             (play-instant state side eid? card? nil)
+                             (play-instant state side (make-eid state) eid? card?)))
+  ([state side eid {:keys [title] :as card} {:keys [targets extra-cost no-additional-cost]}]
    (when-not (seq (get-in @state [side :locked (-> card :zone first)]))
      (let [cdef (card-def card)
            additional-cost (if (and (has-subtype? card "Double")
                                     (not (get-in @state [side :register :double-ignore-additional])))
                              (concat (:additional-cost cdef) [:click 1])
-                             (:additional-cost cdef))]
+                             (:additional-cost cdef))
+           eid (if-not eid (make-eid state) eid)]
        ;; ensure the instant can be played
        (if (and (if-let [req (:req cdef)]
-                    (req state side card targets) true) ; req is satisfied
-                  (not (and (has-subtype? card "Current")
-                            (get-in @state [side :register :cannot-play-current])))
-                  (not (and (has-subtype? card "Run")
-                            (get-in @state [side :register :cannot-run])))
-                  (not (and (has-subtype? card "Priority")
-                            (get-in @state [side :register :spent-click])))) ; if priority, have not spent a click
+                  (req state side eid card targets) true) ; req is satisfied
+                (not (and (has-subtype? card "Current")
+                          (get-in @state [side :register :cannot-play-current])))
+                (not (and (has-subtype? card "Run")
+                          (get-in @state [side :register :cannot-run])))
+                (not (and (has-subtype? card "Priority")
+                          (get-in @state [side :register :spent-click])))) ; if priority, have not spent a click
          (if-let [cost-str (pay state side card :credit (:cost card) extra-cost
                                   (when-not no-additional-cost additional-cost))] ; play cost can be paid
            (let [c (move state side (assoc card :seen true) :play-area)]
@@ -38,17 +42,15 @@
                        (trash state side current)))
                    (let [moved-card (move state side (first (get-in @state [side :play-area])) :current)]
                      (card-init state side moved-card)))
-               (do (resolve-ability state side cdef card nil)
+               (do (resolve-ability state side (assoc cdef :eid eid) card nil)
                    (when-let [c (some #(when (= (:cid %) (:cid card)) %) (get-in @state [side :play-area]))]
                      (move state side c :discard))
-                   (when (or (false? (:delayed-completion cdef)) (not (:choices cdef)))
-                     (effect-completed state side card))
                    (when (has-subtype? card "Terminal")
                      (lose state side :click (-> @state side :click))))))
            ;; could not pay the card's price; mark the effect as being over.
-           (effect-completed state side card))
+           (effect-completed state side eid card))
          ;; card's req was not satisfied; mark the effect as being over.
-         (effect-completed state side card))))))
+         (effect-completed state side eid card))))))
 
 (defn max-draw
   "Put an upper limit on the number of cards that can be drawn in this turn."
@@ -151,7 +153,7 @@
 (defn resolve-damage
   "Resolves the attempt to do n damage, now that both sides have acted to boost or
   prevent damage."
-  [state side type n {:keys [unpreventable unboostable card] :as args}]
+  [state side eid type n {:keys [unpreventable unboostable card] :as args}]
   (swap! state update-in [:damage :defer-damage] dissoc type)
   (damage-choice-priority state)
   (trigger-event state side :pre-resolve-damage type card n)
@@ -167,13 +169,15 @@
           (swap! state update-in [:runner :hand-size-modification] #(- % n)))
         (doseq [c (take n (shuffle hand))]
           (trash state side c {:unpreventable true :cause type} type))
-        (trigger-event state side :damage type card)))))
+        (trigger-event state side :damage type card))))
+  (effect-completed state side eid card))
 
 (defn damage
   "Attempts to deal n damage of the given type to the runner. Starts the
   prevention/boosting process and eventually resolves the damage."
-  ([state side type n] (damage state side type n nil))
-  ([state side type n {:keys [unpreventable unboostable card] :as args}]
+  ([state side type n] (damage state side (make-eid state) type n nil))
+  ([state side type n args] (damage state side (make-eid state) type n args))
+  ([state side eid type n {:keys [unpreventable unboostable card] :as args}]
    (swap! state update-in [:damage :damage-bonus] dissoc type)
    (swap! state update-in [:damage :damage-prevent] dissoc type)
    ;; alert listeners that damage is about to be calculated.
@@ -194,9 +198,9 @@
                                  (str "prevents " (if (= prevent Integer/MAX_VALUE) "all" prevent)
                                           " " (name type) " damage")
                                  "will not prevent damage"))
-                   (resolve-damage state side type (max 0 (- n (or prevent 0))) args)))
+                   (resolve-damage state side eid type (max 0 (- n (or prevent 0))) args)))
                {:priority 10}))
-         (resolve-damage state side type n args))))))
+         (resolve-damage state side eid type n args))))))
 
 
 ;;; Tagging
@@ -316,9 +320,9 @@
         runner-fn (:agendapoints-runner (card-def card))
         corp-fn (:agendapoints-corp (card-def card))]
     (if (and (= side :runner) (not (nil? runner-fn)))
-      (runner-fn state side card nil)
+      (runner-fn state side (make-eid state) card nil)
       (if (and (= side :corp) (not  (nil? corp-fn)))
-        (corp-fn state side card nil)
+        (corp-fn state side (make-eid state) card nil)
         base-points))))
 
 (defn advancement-cost-bonus
@@ -331,7 +335,7 @@
   (if (nil? advancementcost)
     nil
     (-> (if-let [costfun (:advancement-cost-bonus (card-def card))]
-          (+ advancementcost (costfun state side card nil))
+          (+ advancementcost (costfun state side (make-eid state) card nil))
           advancementcost)
         (+ (or (get-in @state [:bonus :advancement-cost]) 0))
         (max 0))))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -48,8 +48,7 @@
   "Trigger events from accessing an agenda, which were delayed to account for Film Critic."
   ([state side card] (resolve-steal-events state side (make-eid state) card))
   ([state side eid card]
-   (let [cdef (card-def card)
-         my-eid eid]
+   (let [cdef (card-def card)]
      (if-let [access-effect (:access cdef)]
        (when-completed (resolve-ability state (to-keyword (:side card)) access-effect card nil)
                        (do (trigger-event state side :access card)

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -162,11 +162,9 @@
                                          {:prompt (str "You access " name) :choices ["Steal"]
                                           :effect (req (resolve-steal state :runner c))} c nil)))))
               ;; Accessing a non-agenda
-              (do (prn "ACCESSING NON AGENDA")
-                  (if-let [access-effect (:access cdef)]
+              (do (if-let [access-effect (:access cdef)]
                     (when-completed (resolve-ability state (to-keyword (:side c)) access-effect c nil)
-                                    (do (prn "ACCESS EFFECT FINISHED")
-                                    (access-non-agenda state side c)))
+                                    (access-non-agenda state side c))
                     (access-non-agenda state side c))))))
         ;; The runner cannot afford the cost to access the card
         (prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {})))))

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -15,7 +15,7 @@
         runner-identity (assoc (or (get-in runner [:deck :identity]) {:side "Runner" :type "Identity"}) :cid (make-cid))
         state (atom
                 {:gameid gameid :log [] :active-player :runner :end-turn true
-                 :rid 0 :turn 0
+                 :rid 0 :turn 0 :eid 0
                  :corp {:user (:user corp) :identity corp-identity
                         :deck (zone :deck (drop 5 corp-deck))
                         :hand (zone :hand (take 5 corp-deck))
@@ -65,6 +65,10 @@
   [state]
   (get-in (swap! state update-in [:rid] inc) [:rid]))
 
+(defn make-eid
+  [state]
+  {:eid (:eid (swap! state update-in [:eid] inc))})
+
 ;; Appears to be unused???
 (def reset-value
   {:corp {:credit 5 :bad-publicity 0
@@ -80,7 +84,7 @@
   (let [card (get-in @state [side :identity])]
     (when-let [cdef (card-def card)]
       (when-let [mul (:mulligan cdef)]
-        (mul state side card nil))))
+        (mul state side (make-eid state) card nil))))
   (swap! state assoc-in [side :keep] true)
   (system-msg state side "takes a mulligan")
   (trigger-event state side :pre-first-turn)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -4,11 +4,11 @@
                                 dissoc-in cancellable card-is? side-str
                                 build-spend-msg cost-names remote->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side]]
-            [game.macros :refer [effect req msg when-completed final-effect]]
+            [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))
 
-(declare get-card get-remote-names register-effect-completed resolve-ability say system-msg trigger-event update!)
+(declare get-card get-remote-names make-eid register-effect-completed resolve-ability say system-msg trigger-event update!)
 
 (def game-states (atom {}))
 (def all-cards (atom {}))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -64,7 +64,7 @@
          th (nth action totake)]
      `(let [~'use-eid (and (map? ~th) (:eid ~th))
             ~'new-eid (if ~'use-eid ~th (game.core/make-eid ~'state))]
-        (~'register-effect-completed ~'state ~'side ~'new-eid ~'card ~reqmac)
+        (~'register-effect-completed ~'state ~'side ~'new-eid ~(if (resolve 'card) ~'card nil) ~reqmac)
         (if ~'use-eid
           ~(concat (take totake action) (list 'new-eid) (drop (inc totake) action))
           ~(concat (take totake action) (list 'new-eid) (drop totake action)))))))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -60,14 +60,13 @@
    (let [reqmac `(fn [~'state1 ~'side1 ~'eid1 ~'card1 ~'targets1] ~expr)
    ;; this creates a five-argument function to be resolved later,
    ;; without overriding any local variables name state, card, etc.
-         th (nth action 3)
-         use-eid (and (map? th) (:eid th))]
-     `(let [~'new-eid (game.core/make-eid ~'state)]
+         th (nth action 3)]
+     `(let [~'use-eid (and (map? ~th) (:eid ~th))
+            ~'new-eid (if ~'use-eid ~th (game.core/make-eid ~'state))]
         (~'register-effect-completed ~'state ~'side ~'new-eid ~'card ~reqmac)
-        ~(let [action (concat (take 3 action)
-                              (list (if use-eid th 'new-eid))
-                              (drop (if use-eid 4 3) action))]
-           action)))))
+        (if ~'use-eid
+          ~(concat (take 3 action) (list 'new-eid) (drop 4 action))
+          ~(concat (take 3 action) (list 'new-eid) (drop 3 action)))))))
 
 (defmacro final-effect [& expr]
   (macroexpand (apply list `(effect ~@expr ~(list (quote effect-completed) 'eid 'card)))))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -60,13 +60,14 @@
    (let [reqmac `(fn [~'state1 ~'side1 ~'eid1 ~'card1 ~'targets1] ~expr)
    ;; this creates a five-argument function to be resolved later,
    ;; without overriding any local variables name state, card, etc.
-         th (nth action 3)]
+         totake (if (= 'apply (first action)) 4 3)
+         th (nth action totake)]
      `(let [~'use-eid (and (map? ~th) (:eid ~th))
             ~'new-eid (if ~'use-eid ~th (game.core/make-eid ~'state))]
         (~'register-effect-completed ~'state ~'side ~'new-eid ~'card ~reqmac)
         (if ~'use-eid
-          ~(concat (take 3 action) (list 'new-eid) (drop 4 action))
-          ~(concat (take 3 action) (list 'new-eid) (drop 3 action)))))))
+          ~(concat (take totake action) (list 'new-eid) (drop (inc totake) action))
+          ~(concat (take totake action) (list 'new-eid) (drop totake action)))))))
 
 (defmacro final-effect [& expr]
   (macroexpand (apply list `(effect ~@expr ~(list (quote effect-completed) 'eid 'card)))))

--- a/src/clj/test/all.clj
+++ b/src/clj/test/all.clj
@@ -11,8 +11,10 @@
             test.cards.operations
             test.cards.programs
             test.cards.resources
-            test.cards.upgrades))
+            test.cards.upgrades
+            test.games.scenarios))
 
 (deftest all-tests
   (run-tests 'test.core)
-  (run-all-tests #"test.cards.*"))
+  (run-all-tests #"test.cards.*")
+  (run-all-tests #"test.games.*"))

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -589,7 +589,6 @@
     (prompt-choice :corp "0 [Credits]")
     (prompt-choice :runner "1 [Credits]")
     (is (not (get-content state :remote1)) "Psychic Field trashed by Neutralize All Threats")
-    (prn (:log @state))
     (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
 
 (deftest public-support

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -575,6 +575,23 @@
       (prompt-choice :runner "0 [Credits]")
       (is (= 6 (count (:discard (get-runner)))) "Suffered 3 net damage on access and psi loss"))))
 
+(deftest psychic-field-neutralize-all-threats
+  "Psychic Field - Interaction with Neutralize All Threats and Hostile Infrastructure, #1208"
+  (do-game
+    (new-game (default-corp [(qty "Psychic Field" 3) (qty "Hostile Infrastructure" 3)])
+              (default-runner [(qty "Neutralize All Threats" 1) (qty "Sure Gamble" 3)]))
+    (play-from-hand state :corp "Psychic Field" "New remote")
+    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+    (core/rez state :corp (get-content state :remote2 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Neutralize All Threats")
+    (run-empty-server state :remote1)
+    (prompt-choice :corp "0 [Credits]")
+    (prompt-choice :runner "1 [Credits]")
+    (is (not (get-content state :remote1)) "Psychic Field trashed by Neutralize All Threats")
+    (prn (:log @state))
+    (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
+
 (deftest public-support
   "Public support scoring and trashing"
   ;; TODO could also test for NOT triggering "when scored" events

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -332,7 +332,6 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Fall Guy")
     (play-from-hand state :runner "Titanium Ribs")
-    (prn (:prompt (get-runner)))
     (prompt-select :runner (find-card "Titanium Ribs" (:hand (get-runner))))
     (prompt-select :runner (find-card "Kati Jones" (:hand (get-runner))))
     (is (empty? (:prompt (get-runner))) "Fall Guy didn't try to prevent trashing of Kati")

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -332,9 +332,11 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Fall Guy")
     (play-from-hand state :runner "Titanium Ribs")
+    (prn (:prompt (get-runner)))
     (prompt-select :runner (find-card "Titanium Ribs" (:hand (get-runner))))
     (prompt-select :runner (find-card "Kati Jones" (:hand (get-runner))))
     (is (empty? (:prompt (get-runner))) "Fall Guy didn't try to prevent trashing of Kati")
+
     (is (= 2 (count (:discard (get-runner)))) "2 cards trashed for Ribs installation meat damage")
     (run-on state "HQ")
     (let [pup (get-ice state :hq 0)]

--- a/src/clj/test/cards/ice.clj
+++ b/src/clj/test/cards/ice.clj
@@ -280,6 +280,25 @@
       (prompt-choice :runner 5) ; match trace
       (is (= 3 (count (:discard (get-runner)))) "Did only 1 net damage for having trace strength 5 or more"))))
 
+(deftest gemini-chronos-protocol
+  "Gemini - Interaction with Chronos Protocol and kicker"
+  (do-game
+    (new-game (make-deck "Chronos Protocol: Selective Mind-mapping" [(qty "Gemini" 1) (qty "Hedge Fund" 2)])
+              (default-runner [(qty "Sure Gamble" 1) (qty "Dirty Laundry" 2)]))
+    (play-from-hand state :corp "Gemini" "HQ")
+    (play-from-hand state :corp "Hedge Fund")
+    (play-from-hand state :corp "Hedge Fund")
+    (take-credits state :corp)
+    (let [gem (get-ice state :hq 0)]
+      (run-on state "HQ")
+      (core/rez state :corp gem)
+      (card-ability state :corp gem 0)
+      (prompt-choice :corp 3) ; boost to trace strength 5
+      (prompt-choice :runner 0)
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp (find-card "Sure Gamble" (:hand (get-runner))))
+      (is (= 2 (count (:discard (get-runner)))) "Did 2 net damage"))))
+
 (deftest iq
   "IQ - Rez cost and strength equal to cards in HQ"
   (do-game

--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -115,7 +115,6 @@
     (let [dx (get-program state 0)]
       (card-ability state :runner dx 1)
       (prompt-choice :runner "Done")
-      (prn (:log @state))
       (is (= 2 (count (:hand (get-runner)))) "Deus X prevented one Hostile net damage"))))
 
 (deftest deus-x-fetal-jinteki-pe

--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -94,6 +94,24 @@
      (is (= 1 (:credit (get-runner))) "No credits spent to break")
      (is (= 3 (get-counters (refresh rex) :power)) "One counter used to break"))))
 
+(deftest deus-x-multiple-damage
+  "Multiple sources of net damage vs. Deus X"
+  (do-game
+    (new-game
+      (make-deck "Jinteki: Personal Evolution" [(qty "Fetal AI" 1)])
+      (default-runner [(qty "Deus X" 3) (qty "Sure Gamble" 2)]))
+    (play-from-hand state :corp "Fetal AI" "New remote")
+    (take-credits state :corp)
+    (core/gain state :runner :credit 10)
+    (play-from-hand state :runner "Deus X")
+    (run-empty-server state "Server 1")
+    (prompt-choice :runner "Yes")
+    (let [dx (get-program state 0)]
+      (card-ability state :runner dx 1)
+      (prompt-choice :runner "Done")
+      (is (= 3 (count (:hand (get-runner)))) "Deus X prevented net damage from accessing Fetal AI, but not from Personal Evolution")
+      (is (= 1 (count (:scored (get-runner)))) "Fetal AI stolen"))))
+
 (deftest faust-pump
   "Faust - Pump by discarding"
   (do-game

--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -94,7 +94,31 @@
      (is (= 1 (:credit (get-runner))) "No credits spent to break")
      (is (= 3 (get-counters (refresh rex) :power)) "One counter used to break"))))
 
-(deftest deus-x-multiple-damage
+(deftest deus-x-multiple-hostile-infrastructure
+  "Multiple Hostile Infrastructure vs. Deus X"
+  (do-game
+    (new-game
+      (default-corp [(qty "Hostile Infrastructure" 3)])
+      (default-runner [(qty "Deus X" 3) (qty "Sure Gamble" 2)]))
+    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+    (core/gain state :corp :credit 10)
+    (core/rez state :corp (get-content state :remote1 0))
+    (core/rez state :corp (get-content state :remote2 0))
+    (core/rez state :corp (get-content state :remote3 0))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 10)
+    (play-from-hand state :runner "Deus X")
+    (run-empty-server state "Server 1")
+    (prompt-choice :runner "Yes")
+    (let [dx (get-program state 0)]
+      (card-ability state :runner dx 1)
+      (prompt-choice :runner "Done")
+      (prn (:log @state))
+      (is (= 2 (count (:hand (get-runner)))) "Deus X prevented one Hostile net damage"))))
+
+(deftest deus-x-fetal-jinteki-pe
   "Multiple sources of net damage vs. Deus X"
   (do-game
     (new-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -321,6 +321,18 @@
     (core/jack-out state :runner nil)
     (is (= 1 (:tag (get-runner))) "Jesminder did not avoid John Masanori tag")))
 
+(deftest jinteki-personal-evolution
+  "Personal Evolution - Prevent runner from running on remotes unless they first run on a central"
+  (do-game
+    (new-game
+      (make-deck "Jinteki: Personal Evolution" [(qty "Braintrust" 1)])
+      (default-runner [(qty "Sure Gamble" 3)]))
+    (play-from-hand state :corp "Braintrust" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state "Server 1")
+    (prompt-choice :runner "Steal")
+    (is (= 2 (count (:hand (get-runner)))) "Runner took 1 net damage from steal")))
+
 (deftest jinteki-replicating-perfection
   "Replicating Perfection - Prevent runner from running on remotes unless they first run on a central"
   (do-game

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -544,6 +544,21 @@
     (is (= :corp (:winner @state)) "Corp wins")
     (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
 
+(deftest subcontract-scorched
+  "Subcontract - Don't allow second operation until damage prevention completes"
+  (do-game
+    (new-game (default-corp [(qty "Scorched Earth" 2) (qty "Subcontract" 1)])
+              (default-runner [(qty "Plascrete Carapace" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :tag 1)
+    (play-from-hand state :runner "Plascrete Carapace")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Subcontract")
+    (prompt-select :corp (find-card "Scorched Earth" (:hand (get-corp))))
+    (is (empty? (:prompt (get-corp))) "Corp does not have prompt until damage prevention completes")
+    (prompt-choice :runner "Done")
+    (is (not-empty (:prompt (get-corp))) "Corp can now play second Subcontract operation")))
+
 (deftest shipment-from-sansan
   "Shipment from SanSan - placing advancements"
   (do-game

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -22,6 +22,54 @@
         (is (get-in (refresh spid) [:rezzed]) "Spiderweb rezzed")
         (is (= 1 (:credit (get-corp))) "Paid only 1 credit to rez")))))
 
+(deftest bernice-mai
+  "Bernice Mai - successful and unsuccessful"
+  (do-game
+    (new-game (default-corp [(qty "Bernice Mai" 3) (qty "Hedge Fund" 3) (qty "Wall of Static" 3)])
+              (default-runner))
+    (starting-hand state :corp ["Bernice Mai" "Bernice Mai" "Bernice Mai"])
+    (play-from-hand state :corp "Bernice Mai" "New remote")
+    (play-from-hand state :corp "Bernice Mai" "New remote")
+    (play-from-hand state :corp "Bernice Mai" "R&D")
+    (core/rez state :corp (get-content state :remote1 0))
+    (core/rez state :corp (get-content state :remote2 0))
+    (core/rez state :corp (get-content state :rd 0))
+    (take-credits state :corp)
+    (run-empty-server state :remote1)
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (prompt-choice :runner "Yes")
+    (is (= 1 (:tag (get-runner))))
+    (is (= 2 (:credit (get-runner))) "Runner paid 3cr to trash Bernice")
+    (core/gain state :runner :credit 20)
+    (run-empty-server state :remote2)
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 10)
+    (is (not (get-content state :remote2 0)) "Bernice auto-trashed from unsuccessful trace")
+    (is (not (:run @state)) "Run ended when Bernice was trashed from server")
+    (run-empty-server state :rd)
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 10)
+    (is (:card (first (:prompt (get-runner)))) "Accessing a card from R&D; not showing Bernice Mai as possible access")))
+
+(deftest bernice-mai-drt
+  "Bernice Mai - interaction with Dedicated Response Team"
+  (do-game
+    (new-game (default-corp [(qty "Bernice Mai" 3) (qty "Dedicated Response Team" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Bernice Mai" "New remote")
+    (play-from-hand state :corp "Dedicated Response Team" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (core/rez state :corp (get-content state :remote2 0))
+    (take-credits state :corp)
+    (run-empty-server state :remote1)
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (prompt-choice :runner "Yes")
+    (is (= 1 (:tag (get-runner))))
+    (is (= 2 (:credit (get-runner))) "Runner paid 3cr to trash Bernice")
+    (is (= 2 (count (:discard (get-runner)))) "Runner took 1 meat damage")))
+
 (deftest breaker-bay-grid
   "Breaker Bay Grid - Reduce rez cost of other cards in this server by 5 credits"
   (do-game


### PR DESCRIPTION
See #1494 for the first part of this discussion.

This PR makes a number of large leaps allowing certain general effects in the game engine to "wait" for other effects to complete before proceeding with their remaining logic. Normally this just happens naturally with function calls, but when functions require user input to complete (via prompts) they return immediately before the prompt is actually dealt with. #1494 solved this problem for a few select Corp Operations; this PR improves the framework and extends it to many other effects, notably damage routines, traces, psi games, and a few run events.

There are a lot of changes, and I'm not 100% confident that there are no breaking changes here. All the tests pass, but we have imperfect coverage. 

Fixes #1092, fixes #1533, fixes #1453, fixes #1429, fixes #1208, fixes #1153.

### eids

If we want the ability to wait for an effect to complete before resuming other code, then we need to identify every effect that occurs in the engine. So we assign integer identifiers ("`eid`s") to every ability that gets invoked via `resolve-ability`, plus a few other core functions. When these effects complete, they signal their completion to any "listeners", where a listener is a closure over a function body that wants to resume once the subscribed effect is completed.

Technically an `eid` is a map with a single key `:eid` mapped to a unique integer. The state assigns new `eid`s via `make-eid`.

The `effect`/`req` macros of implementing card abilities have been expanded to take a fifth parameter (it is in the third position, after `state side`) called `eid`, representing the eid assigned to the resolution of the ability. __Some__ core engine abilities also now take an `eid` parameter; in general, these functions are the ones I have upgraded to support this framework.

### Waiting for an effect to complete

If you want to wait for an effect to complete, you generally use the `when-completed` macro. `when-completed` takes two arguments: a single function to execute "asynchronously" (let's call this "the async") and a single function to execute once the first has completed (let's call this "the await"). The async function __must__ be a function that takes `state side eid` as its first three arguments. `when-completed` will generate an `eid` (unless the async already has a third parameter that is an eid), register a closure around the await function that will listen for the completion of the async's eid, then return. 

If you have programmed in C# or F#, you may recognize this pattern as what Microsoft calls "async/await".

Examples:

Suppose `ability` is some card ability we want to resolve, and once that ability is fully completed we want to print a system message.

```clojure
(when-completed 
  (resolve-ability state side ability card targets)
  (system-msg state side "Ability completed"))
```

`resolve-ability` has been upgraded to take an `eid` parameter, so this works. Once the selected ability has resolved, we will execute the `system-msg`. (Example: Accelerated Diagnostics will wait for its first operation to fully resolve before giving a prompt to choose the next.)

Suppose we want to invoke the `:successful-run` event, wait for all handlers to complete, and then proceed with the run/access code.

```clojure
(when-completed 
  (trigger-event-sync state side :successful-run server)
  (do-access state side server))
```

`trigger-event-sync` will trigger an event, but wait for each handler ability to complete before invoking the next, and the whole event will only complete once the last handler completes. Thus, we will only move to `do-access` once all event handlers for `:successful-run` have finished. (Example: Bernice Mai's trace will fully resolve before moving to the access phase.)

These cover the two most common uses: waiting for a single ability, and waiting for all event listeners. There are a few other functions that can be awaited, but they are mostly just to implement certain other end-results.

* `play-instant` (when the card's effect is complete)
* `corp-install` (when the install-effect of the card is complete [currently no such effects?])
* `damage` (when the entire damage/prevention sequence completes)
* `register-successful-run` (when the event handlers for `:successful-run` have completed)

### When is an effect "completed"?

An effect is completed when its `eid` is passed to `(effect-completed)`. When this happens depends a little on context:

* `resolve-ability` will immediately call `effect-completed` after invoking the `:effect` of the ability, UNLESS the ability is marked with `:delayed-completion true`, OR the ability is a psi, trace, optional, or prompt (choices) ability AND is not marked with `:delayed-completion false`. Thus, simple abilities do not need to change anything about how they work: Hedge Fund will "complete" after granting its credits.
  * psi abilities will complete when credits are spent and the equal/notequal effect completes
  * traces will complete when credits are spent and the successful/unsuccessful effect completes
  * optionals will complete when the yes/no effect completes
  * prompts will complete when the prompt's ability resolves
* if an ability uses `:delayed-completion true`, it is responsible for invoking `effect-completed` itself at an appropriate time. There are two shortcuts: `continue-ability` (see below) can resolve a sub-ability using the same eid, and if that sub-ability immediately resolves as above, that will in effect complete the main ability. Or you can use `final-effect` instead of `effect` to automatically insert the `effect-completed` call.
* `damage` will complete once the damage is applied (post-prevention effects)

### Current uses

I am currently using the framework for these fixes/effects:

1. Damage: each instance of damage will fully resolve before moving onto the next, including prevention opportunities. This cleans up issues with Deus X preventing multiple sources of damage. It also helps Subcontract or AccDiag into double Scorched Earth, by not allowing the selection of the second Scorched until the first fully resolves.

    This also cleans up Chronos Protocol, by allowing its damage-replacement effect to fully resolve before moving on to any other sources of damage.
2. On-access effects: if a Corp card has an `:access` effect, that effect will be resolved before the runner is allowed to trash/steal/continue accessing other cards. Thus, Fetal AI will do its damage routine before Personal Evolution will apply its damage from the steal. Also, the psi game and damage from Psychic Field will complete before PF is trashed and damage from Hostile Infrastructure might be applied.
3. Successful-run effects: the runner will not move to the access phase until all `:successful-run` triggers have resolved, so Bernice Mai's trace will complete prior to access, and if the trace fails she will be trashed and not a valid access target.


### Other details

1. `when-completed` will assign an `eid` to the async target automatically, but you can assign one yourself by giving an `eid` as the third parameter to the async function. This can be useful when you want to be specific about what eid the async gets, because you know someone in particular is waiting for that eid.
2. `when-completed` will also work with `apply`.
3. `continue-ability` is a new macro that works exactly the same as `resolve-ability`, except it passes the current `eid` of whoever called `continue-ability` as the eid of the ability to be resolved. This is useful when a card's effect calls `resolve-ability` to "finish" the effect; by using `continue-ability` instead, the resolved sub-ability keeps the same `eid` as the "main" ability, and so the sub-ability's completion signifies the completion of the main ability.