### PR TITLE
Fix trash prompt, Salsette Slums, Surat City Grid

### DIFF
--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -359,10 +359,9 @@
 
    "Surat City Grid"
    {:events
-    {:rez {:req (req (and (= (card->server state target) (card->server state card))
-                          (not (and (is-central? (card->server state card))
-                                    (= (card->server state target) (card->server state card))
-                                    (is-type? target "Upgrade")))
+    {:rez {:req (req (and (= (second (:zone target)) (second (:zone card)))
+                          (not (and (is-type? target "Upgrade")
+                                    (is-central? (second (:zone target)))))
                           (not= (:cid target) (:cid card))
                           (seq (filter #(and (not (rezzed? %))
                                              (not (is-type? % "Agenda"))) (all-installed state :corp)))))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -101,20 +101,21 @@
   (when (not= (:zone c) [:discard]) ; if not accessing in Archives
     (if-let [trash-cost (trash-cost state side c)]
       ;; The card has a trash cost (Asset, Upgrade)
-      (let [card (assoc c :seen true)]
+      (let [card (assoc c :seen true)
+            name (:title card)]
         (if (and (get-in @state [:runner :register :force-trash])
                  (can-pay? state :runner name :credit trash-cost))
           ;; If the runner is forced to trash this card (Neutralize All Threats)
           (resolve-ability state :runner {:cost [:credit trash-cost]
                                           :effect (effect (trash card)
                                                           (system-msg (str "is forced to pay " trash-cost
-                                                                           " [Credits] to trash " (:title card))))} card nil)
+                                                                           " [Credits] to trash " name)))} card nil)
           ;; Otherwise, show the option to pay to trash the card.
           (optional-ability state :runner card (str "Pay " trash-cost "[Credits] to trash " name "?")
                             {:yes-ability {:cost [:credit trash-cost]
                                            :effect (effect (trash card)
-                                                           (system-msg (str "pays " trash-cost " [Credits] to trash "
-                                                                            (:title card))))}} nil)))
+                                                           (system-msg (str "pays " trash-cost
+                                                                            " [Credits] to trash " name)))}} nil)))
       ;; The card does not have a trash cost
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {}))))
 


### PR DESCRIPTION
* Fixes #1553: Any card removed by Salsette Slums needs to be deactivated so its effects don't persist. Also tweaked the toast on this card so it won't toast at all when accessing cards that have no trash costs.
* Fixes #1581: This time Surat City Grid really, _really_ is fixed--and has a test to prove it!
* Tidy up the trashing prompt in `access-non-agenda` so you don't get gibberish by referencing an undeclared variable: 

![image](https://cloud.githubusercontent.com/assets/10407969/15784100/9bd78e08-2976-11e6-8532-006429cb7607.png)
