### PR TITLE
Delay successful run until after Silhouette expose finishes

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -513,8 +513,9 @@
 
    "Silhouette: Stealth Operative"
    {:events {:successful-run
-             {:req (req (= target :hq)) :once :per-turn
-              :effect (effect (resolve-ability {:choices {:req installed?}
+             {:delayed-completion true
+              :req (req (= target :hq)) :once :per-turn
+              :effect (effect (continue-ability {:choices {:req #(and installed? (not (rezzed? %)))}
                                                 :effect (effect (expose target)) :msg "expose 1 card"}
                                                card nil))}}}
 


### PR DESCRIPTION
Fixes #1367, fixes #155. 

Thanks to @nealterrell's heroics, Silhouette's expose ability can take priority and fully complete (including any knock-on effects like hitting a Psychic Field) before the run is successful. 

Silhouette is also updated to target only unrezzed cards with her ability. 