### PR TITLE
implement Mumbad Virtual Tour (seeking review)

### DIFF
--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -235,6 +235,23 @@
                                  (system-msg state side (str "uses Mumbad City Grid to swap " (card-str state passed-ice)
                                                              " with " (card-str state target)))))}]}
 
+   "Mumbad Virtual Tour"
+   {:access {:req (req installed)
+             :effect (req (let [trash-cost (trash-cost state side card)]
+                            (when (seq (filter #(and (= "Imp" (:title %))
+                                                     (pos? (get-in % [:counter :virus] 0)))
+                                               (all-installed state :runner)))
+                              (toast state :runner (str "You must trash Mumbad Virtual Tour by paying its "
+                                                        "trash cost or using an Imp counter, if able")))
+                            (if (and (can-pay? state :runner nil :credit trash-cost)
+                                     (empty? (filter #(and (= "Imp" (:title %))
+                                                           (pos? (get-in % [:counter :virus] 0)))
+                                                     (all-installed state :runner))))
+                              (swap! state assoc-in [:runner :register :force-trash] true)
+                              (toast state :runner (str "You must use any credit sources (Whizzard, Scrubber, "
+                                                        "Ghost Runner, Net Celebrity) to trash Mumbad Virtual Tour, if able")))))}
+    :trash-effect {:effect (req (swap! state assoc-in [:runner :register :force-trash] false))}}
+
    "NeoTokyo Grid"
    (let [ng {:req (req (= (butlast (:zone target)) (butlast (:zone card)))) :once :per-turn
              :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}]

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -238,9 +238,9 @@
    "Mumbad Virtual Tour"
    {:access {:req (req installed)
              :effect (req (let [trash-cost (trash-cost state side card)]
-                            (when (seq (filter #(and (= "Imp" (:title %))
-                                                     (pos? (get-in % [:counter :virus] 0)))
-                                               (all-installed state :runner)))
+                            (when (some #(and (= "Imp" (:title %))
+                                              (pos? (get-in % [:counter :virus] 0)))
+                                        (all-installed state :runner))
                               (toast state :runner (str "You must trash Mumbad Virtual Tour by paying its "
                                                         "trash cost or using an Imp counter, if able")))
                             (if (and (can-pay? state :runner nil :credit trash-cost)


### PR DESCRIPTION
I think the auto-trashing should be done as cautiously as possible, so I took a three-pronged approach here. 

1. If the Runner has any Imps with counters left on them, give a toast informing them they *must* use one, if possible (the only situation where you couldn't is if all Imps have already been used this turn). 
2. If the Runner has enough credits currently in their credit pool and either no Imps at all or no remaining Imp counters, *only then* perform the automatic forced trash of MVT.  In the case of the Runner having Whizzard/Ghost Runner/Scrubber credits they would have used, they can be taken retroactively.
3. If the Runner has insufficient credits in their pool to trash MVT, give a toast alerting them that they have to use all eligible credit sources and let them see the standard Yes/No "do you want to trash this" prompt. Then they can top up their pool from those sources if they have them and do the trash. 