### PR TITLE
Information Sifting; improvements to when-completed

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -377,6 +377,48 @@
                                        {:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))})
                                      card nil))}
 
+   "Information Sifting"
+   (letfn [(access-pile [cards pile]
+             {:prompt "Select a card to access. You must access all cards."
+              :choices [(str "Card from pile " pile)]
+              :effect (req (system-msg state side "accesses " (:title (first cards)))
+                           (when-completed
+                             (handle-access state side [(first cards)])
+                             (do (if (< 1 (count cards))
+                                   (continue-ability state side (access-pile (next cards) pile) card nil)
+                                   (effect-completed state side eid card)))))})
+           (which-pile [p1 p2]
+             {:prompt "Choose a pile to access"
+              :choices [(str "Pile 1 (" (count p1) " cards)") (str "Pile 2 (" (count p2) " cards)")]
+              :effect (req (let [choice (if (.startsWith target "Pile 1") 1 2)]
+                             (clear-wait-prompt state :corp)
+                             (continue-ability state side
+                                (access-pile (if (= 1 choice) p1 p2) choice)
+                                card nil)))})]
+     (let [access-effect
+           {:delayed-completion true
+            :mandatory true
+            :effect (req (if (< 1 (count (:hand corp)))
+                           (do (show-wait-prompt state :runner "Corp to create two piles")
+                               (continue-ability
+                                 state :corp
+                                 {:prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
+                                  :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
+                                            :max (req (dec (count (:hand corp))))}
+                                  :effect (effect (clear-wait-prompt :runner)
+                                                  (show-wait-prompt :corp "Runner to choose a pile")
+                                                  (continue-ability
+                                                    :runner
+                                                    (which-pile (shuffle targets)
+                                                                (shuffle (vec (clojure.set/difference
+                                                                                (set (:hand corp)) (set targets)))))
+                                                    card nil))
+                                  } card nil))
+                           (effect-completed state side eid card)))}]
+       {:effect (effect (run :hq {:req (req (= target :hq))
+                                  :replace-access access-effect}
+                             card))}))
+
    "Inject"
    {:effect (req (doseq [c (take 4 (get-in @state [:runner :deck]))]
                    (if (is-type? c "Program")

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -110,26 +110,28 @@
                          (damage state side eid :net (get-defer-damage state side :net nil)
                                  {:unpreventable true :card card}))
                      (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
-                           (continue-ability
-                             state side
-                             {:optional
-                              {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                            "Grip to select the first card trashed?")
-                               :player :corp
-                               :yes-ability {:prompt (msg "Choose a card to trash")
-                                             :choices (req (:hand runner)) :not-distinct true
-                                             :msg (msg "trash " (:title target)
-                                                       (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
-                                                         (str " and deal " (- (get-defer-damage state side :net nil) 1)
-                                                              " more net damage")))
-                                             :effect (req (clear-wait-prompt state :runner)
-                                                          (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                          (trash state side target {:cause :net :unpreventable true})
-                                                          (let [more (dec (or (get-defer-damage state side :net nil) 0))]
-                                                            (damage-defer state side :net more)))}
-                               :no-ability {:effect (req (clear-wait-prompt state :runner)
-                                                         (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
-                             card nil))))}}
+                         (continue-ability
+                           state side
+                           {:optional
+                            {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
+                                          "Grip to select the first card trashed?")
+                             :priority 10
+                             :player :corp
+                             :yes-ability {:prompt (msg "Choose a card to trash")
+                                           :choices (req (:hand runner)) :not-distinct true
+                                           :priority 10
+                                           :msg (msg "trash " (:title target)
+                                                     (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
+                                                       (str " and deal " (- (get-defer-damage state side :net nil) 1)
+                                                            " more net damage")))
+                                           :effect (req (clear-wait-prompt state :runner)
+                                                        (swap! state update-in [:damage] dissoc :damage-choose-corp)
+                                                        (trash state side target {:cause :net :unpreventable true})
+                                                        (let [more (dec (or (get-defer-damage state side :net nil) 0))]
+                                                          (damage-defer state side :net more)))}
+                             :no-ability {:effect (req (clear-wait-prompt state :runner)
+                                                       (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
+                           card nil))))}}
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -359,10 +359,9 @@
 
    "Surat City Grid"
    {:events
-    {:rez {:req (req (and (= (card->server state target) (card->server state card))
-                          (not (and (is-central? (card->server state card))
-                                    (= (card->server state target) (card->server state card))
-                                    (is-type? target "Upgrade")))
+    {:rez {:req (req (and (= (second (:zone target)) (second (:zone card)))
+                          (not (and (is-type? target "Upgrade")
+                                    (is-central? (second (:zone target)))))
                           (not= (:cid target) (:cid card))
                           (seq (filter #(and (not (rezzed? %))
                                              (not (is-type? % "Agenda"))) (all-installed state :corp)))))

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -125,7 +125,6 @@
 
 (defn effect-completed
   [state side eid card]
-  ;(prn "EFFECT-COMPLETED" eid)
   (doseq [handler (get-in @state [:effect-completed eid])]
     ((:effect handler) state side eid (:card card) nil))
   (swap! state update-in [:effect-completed] dissoc eid))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -101,20 +101,21 @@
   (when (not= (:zone c) [:discard]) ; if not accessing in Archives
     (if-let [trash-cost (trash-cost state side c)]
       ;; The card has a trash cost (Asset, Upgrade)
-      (let [card (assoc c :seen true)]
+      (let [card (assoc c :seen true)
+            name (:title card)]
         (if (and (get-in @state [:runner :register :force-trash])
                  (can-pay? state :runner name :credit trash-cost))
           ;; If the runner is forced to trash this card (Neutralize All Threats)
           (resolve-ability state :runner {:cost [:credit trash-cost]
                                           :effect (effect (trash card)
                                                           (system-msg (str "is forced to pay " trash-cost
-                                                                           " [Credits] to trash " (:title card))))} card nil)
+                                                                           " [Credits] to trash " name)))} card nil)
           ;; Otherwise, show the option to pay to trash the card.
           (optional-ability state :runner card (str "Pay " trash-cost "[Credits] to trash " name "?")
                             {:yes-ability {:cost [:credit trash-cost]
                                            :effect (effect (trash card)
-                                                           (system-msg (str "pays " trash-cost " [Credits] to trash "
-                                                                            (:title card))))}} nil)))
+                                                           (system-msg (str "pays " trash-cost
+                                                                            " [Credits] to trash " name)))}} nil)))
       ;; The card does not have a trash cost
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {}))))
 


### PR DESCRIPTION
Already merged this with Joel's #1584.

Implementation and test for Information Sifting. We ask the corp to select up to (n - 1) cards for the first pile, the implicitly gather the second, and shuffle each. Runner chooses which pile to access, then uses the familiar "Access 1 card from pile" routine until all cards are accessed. Thanks to #1582, each access fully resolves, including damage/access/steal events, before the next access occurs.

Included a few minor improvements to the when-completed framework, particularly for abilities whose `:req` is false and thus don't get resolved... these abilities will immediately trigger `effect-completed`. Noticed this when accessing Psychic Field from hand.

Also adds a priority to Chronos Protocol's prompt so it can't get buried under other prompts.