### PR TITLE
allow Archangel trace to be fired during access

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -171,12 +171,23 @@
 ;;;; Card definitions
 (def cards-ice
   {"Archangel"
-   {:access {:optional
-             {:req (req (not= (first (:zone card)) :discard))
-              :prompt "Pay 3 [Credits] to force Runner to encounter Archangel?"
-              :yes-ability {:cost [:credit 3]
-                            :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel"))}
-              :no-ability {:effect (req (system-msg state :corp "declines to force the Runner to encounter Archangel"))}}}
+   {:access
+    {:req (req (not= (first (:zone card)) :discard))
+     :effect (effect (show-wait-prompt :runner "Corp to decide to trigger Archangel")
+                     (resolve-ability
+                       {:optional
+                        {:prompt "Pay 3 [Credits] to force Runner to encounter Archangel?"
+                         :yes-ability {:cost [:credit 3]
+                                       :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel")
+                                                    (clear-wait-prompt state :runner)
+                                                    (resolve-ability state :runner
+                                                      {:optional
+                                                       {:player :runner
+                                                        :prompt "Allow Archangel trace to fire?" :priority 1
+                                                        :yes-ability {:effect (req (play-ability state side {:card card :ability 0}))}}}
+                                                     card nil))}
+                         :no-ability {:effect (req (system-msg state :corp "declines to force the Runner to encounter Archangel")
+                                                   (clear-wait-prompt state :runner))}}} card nil))}
     :abilities [(trace-ability 6 {:choices {:req installed?}
                                   :label "Add 1 installed card to the Runner's Grip"
                                   :msg "add 1 installed card to the Runner's Grip"


### PR DESCRIPTION
This is a semi-frequently requested feature--currently if the Runner hits an Archangel in R&D or HQ, there is no way to fire its trace, forcing players to use the console command to initiate a trace. 

With this addition, the Runner is given a prompt to initiate Archangel's trace after the Corp has chosen to pay to force the encounter. They should respond "No" if they are going to break, and "Yes" if they can't (or won't) break the subroutine. The Runner also sees a wait prompt while the Corp is deciding whether or not to pay the 3 credits.

![screen shot 2016-06-03 at 8 29 07 pm](https://cloud.githubusercontent.com/assets/10407969/15796766/67cccbe2-29ca-11e6-9a33-bf9208d5c285.png)
