### PR TITLE
Out of the Ashes; /rfg command

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -537,6 +537,40 @@
     :effect (effect (as-agenda :runner (first (:play-area runner)) 1))
     :msg "add it to their score area and gain 1 agenda point"}
 
+   "Out of the Ashes"
+   (letfn [(ashes-run []
+             {:prompt "Choose a server"
+              :choices (req runnable-servers)
+              :delayed-completion true
+              :effect (effect (run eid target nil card))})
+           (ashes-recur [n]
+             {:prompt "Remove Out of the Ashes from the game to make a run?"
+              :choices ["Yes" "No"]
+              :effect (req (if (= target "Yes")
+                             (let [card (some #(when (= "Out of the Ashes" (:title %)) %) (:discard runner))]
+                               (system-msg state side "removes Out of the Ashes from the game to make a run")
+                               (move state side card :rfg)
+                               (unregister-events state side card)
+                               (when-completed (resolve-ability state side (ashes-run) card nil)
+                                               (if (< 1 n)
+                                                 (continue-ability state side (ashes-recur (dec n)) card nil)
+                                                 (effect-completed state side eid card))))))})]
+   {:prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (run eid target nil card))
+    :move-zone (req (if (= [:discard] (:zone card))
+                      (register-events state side
+                        {:runner-phase-12 {:priority -1
+                                           :once :per-turn
+                                           :once-key :out-of-ashes
+                                           :effect (effect (continue-ability
+                                                             (ashes-recur (count (filter #(= "Out of the Ashes" (:title %))
+                                                                                         (:discard runner))))
+                                                             card nil))}}
+                        (assoc card :zone [:discard]))
+                      (unregister-events state side card)))
+    :events {:runner-phase-12 nil}})
+
    "Paper Tripping"
    {:msg "remove all tags" :effect (effect (lose :tag :all))}
 

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -377,6 +377,48 @@
                                        {:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))})
                                      card nil))}
 
+   "Information Sifting"
+   (letfn [(access-pile [cards pile]
+             {:prompt "Select a card to access. You must access all cards."
+              :choices [(str "Card from pile " pile)]
+              :effect (req (system-msg state side "accesses " (:title (first cards)))
+                           (when-completed
+                             (handle-access state side [(first cards)])
+                             (do (if (< 1 (count cards))
+                                   (continue-ability state side (access-pile (next cards) pile) card nil)
+                                   (effect-completed state side eid card)))))})
+           (which-pile [p1 p2]
+             {:prompt "Choose a pile to access"
+              :choices [(str "Pile 1 (" (count p1) " cards)") (str "Pile 2 (" (count p2) " cards)")]
+              :effect (req (let [choice (if (.startsWith target "Pile 1") 1 2)]
+                             (clear-wait-prompt state :corp)
+                             (continue-ability state side
+                                (access-pile (if (= 1 choice) p1 p2) choice)
+                                card nil)))})]
+     (let [access-effect
+           {:delayed-completion true
+            :mandatory true
+            :effect (req (if (< 1 (count (:hand corp)))
+                           (do (show-wait-prompt state :runner "Corp to create two piles")
+                               (continue-ability
+                                 state :corp
+                                 {:prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
+                                  :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
+                                            :max (req (dec (count (:hand corp))))}
+                                  :effect (effect (clear-wait-prompt :runner)
+                                                  (show-wait-prompt :corp "Runner to choose a pile")
+                                                  (continue-ability
+                                                    :runner
+                                                    (which-pile (shuffle targets)
+                                                                (shuffle (vec (clojure.set/difference
+                                                                                (set (:hand corp)) (set targets)))))
+                                                    card nil))
+                                  } card nil))
+                           (effect-completed state side eid card)))}]
+       {:effect (effect (run :hq {:req (req (= target :hq))
+                                  :replace-access access-effect}
+                             card))}))
+
    "Inject"
    {:effect (req (doseq [c (take 4 (get-in @state [:runner :deck]))]
                    (if (is-type? c "Program")

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -110,26 +110,28 @@
                          (damage state side eid :net (get-defer-damage state side :net nil)
                                  {:unpreventable true :card card}))
                      (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
-                           (continue-ability
-                             state side
-                             {:optional
-                              {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                            "Grip to select the first card trashed?")
-                               :player :corp
-                               :yes-ability {:prompt (msg "Choose a card to trash")
-                                             :choices (req (:hand runner)) :not-distinct true
-                                             :msg (msg "trash " (:title target)
-                                                       (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
-                                                         (str " and deal " (- (get-defer-damage state side :net nil) 1)
-                                                              " more net damage")))
-                                             :effect (req (clear-wait-prompt state :runner)
-                                                          (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                          (trash state side target {:cause :net :unpreventable true})
-                                                          (let [more (dec (or (get-defer-damage state side :net nil) 0))]
-                                                            (damage-defer state side :net more)))}
-                               :no-ability {:effect (req (clear-wait-prompt state :runner)
-                                                         (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
-                             card nil))))}}
+                         (continue-ability
+                           state side
+                           {:optional
+                            {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
+                                          "Grip to select the first card trashed?")
+                             :priority 10
+                             :player :corp
+                             :yes-ability {:prompt (msg "Choose a card to trash")
+                                           :choices (req (:hand runner)) :not-distinct true
+                                           :priority 10
+                                           :msg (msg "trash " (:title target)
+                                                     (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
+                                                       (str " and deal " (- (get-defer-damage state side :net nil) 1)
+                                                            " more net damage")))
+                                           :effect (req (clear-wait-prompt state :runner)
+                                                        (swap! state update-in [:damage] dissoc :damage-choose-corp)
+                                                        (trash state side target {:cause :net :unpreventable true})
+                                                        (let [more (dec (or (get-defer-damage state side :net nil) 0))]
+                                                          (damage-defer state side :net more)))}
+                             :no-ability {:effect (req (clear-wait-prompt state :runner)
+                                                       (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
+                           card nil))))}}
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -359,10 +359,9 @@
 
    "Surat City Grid"
    {:events
-    {:rez {:req (req (and (= (card->server state target) (card->server state card))
-                          (not (and (is-central? (card->server state card))
-                                    (= (card->server state target) (card->server state card))
-                                    (is-type? target "Upgrade")))
+    {:rez {:req (req (and (= (second (:zone target)) (second (:zone card)))
+                          (not (and (is-type? target "Upgrade")
+                                    (is-central? (second (:zone target)))))
                           (not= (:cid target) (:cid card))
                           (seq (filter #(and (not (rezzed? %))
                                              (not (is-type? % "Agenda"))) (all-installed state :corp)))))

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -97,6 +97,8 @@
                (when (= (last (:server run)) (last z))
                  (handle-end-run state side)))
              (swap! state dissoc-in z)))
+         (when-let [card-moved (:move-zone (card-def c))]
+           (card-moved state side (make-eid state) moved-card card))
          (trigger-event state side :card-moved card moved-card)
          (when-let [icon-card (get-in moved-card [:icon :card])]
            ;; remove icon if card moved to :discard or :hand

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -125,7 +125,6 @@
 
 (defn effect-completed
   [state side eid card]
-  ;(prn "EFFECT-COMPLETED" eid)
   (doseq [handler (get-in @state [:effect-completed eid])]
     ((:effect handler) state side eid (:card card) nil))
   (swap! state update-in [:effect-completed] dissoc eid))

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -147,6 +147,10 @@
                                                 :choices {:req (fn [t] (card-is? t :side %2))}}
                                          {:title "/rez command"} nil))
         "/rez-all"    #(when (= %2 :corp) (command-rezall %1 %2 value))
+        "/rfg"        #(resolve-ability %1 %2 {:prompt "Select a card to remove from the game"
+                                               :effect (effect (move target :rfg))
+                                               :choices {:req (fn [t] (card-is? t :side %2))}}
+                                        {:title "/rfg command"} nil)
         nil))))
 
 (defn corp-install-msg

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -101,20 +101,21 @@
   (when (not= (:zone c) [:discard]) ; if not accessing in Archives
     (if-let [trash-cost (trash-cost state side c)]
       ;; The card has a trash cost (Asset, Upgrade)
-      (let [card (assoc c :seen true)]
+      (let [card (assoc c :seen true)
+            name (:title card)]
         (if (and (get-in @state [:runner :register :force-trash])
                  (can-pay? state :runner name :credit trash-cost))
           ;; If the runner is forced to trash this card (Neutralize All Threats)
           (resolve-ability state :runner {:cost [:credit trash-cost]
                                           :effect (effect (trash card)
                                                           (system-msg (str "is forced to pay " trash-cost
-                                                                           " [Credits] to trash " (:title card))))} card nil)
+                                                                           " [Credits] to trash " name)))} card nil)
           ;; Otherwise, show the option to pay to trash the card.
           (optional-ability state :runner card (str "Pay " trash-cost "[Credits] to trash " name "?")
                             {:yes-ability {:cost [:credit trash-cost]
                                            :effect (effect (trash card)
-                                                           (system-msg (str "pays " trash-cost " [Credits] to trash "
-                                                                            (:title card))))}} nil)))
+                                                           (system-msg (str "pays " trash-cost
+                                                                            " [Credits] to trash " name)))}} nil)))
       ;; The card does not have a trash cost
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {}))))
 

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -58,6 +58,7 @@
                         [:li [:code "/take-brain n"] " - Take n brain damage (Runner only)"]
                         [:li [:code "/discard #n"] " - Discard card number n from your hand"]
                         [:li [:code "/deck #n"] " - Put card number n from your hand on top of your deck"]
+                        [:li [:code "/rfg"] " - Select a card to remove from the game"]
                         [:li [:code "/end-run"] " - End the run (Corp only)"]
                         [:li [:code "/jack-out"] " - Jack out (Runner only)"]
                         [:li [:code "/trace n"] " - Start a trace with base strength n (Corp only)"]


### PR DESCRIPTION
Implements Out of the Ashes and a `/rfg` console command (fixes #1590). Requires #1588.

Out of the Ashes registers a `:runner-phase-12` event when it ends up in the Heap for any reason. To do this, I added a `:move-zone` effect for card-defs that will fire when the card moves zones. (@kevkcc may find this helpful for Subliminal Messaging). If Ashes sees that it's now in `:discard`, it will hook an event to prompt at runner's turn start to invoke the removal effect. If the runner answers yes, an instance of Ashes will be moved to `:rfg`, and a run will be invoked. _Once that run ends_, another prompt will be shown if there are additional Ashes in the heap. The whole process ends once there are no Ashes or the runner says no.

The Ashes prompt has a `:priority` of -1 so that it will be hidden by any other prompts that activate because the runner clicked a card during Runner Step 1.2.

This prompt will show every turn while there is at least one Ashes in the heap. We don't have a way of clicking a card in the heap to activate an ability, so this will have to do.

I extended the `when-completed` framework to include `run`, so now a card can wait for a run to complete before triggering a followup effect... in this case, showing the next Ashes prompt.