### PR TITLE
Add a Beginner room.

### DIFF
--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -244,7 +244,8 @@
                             roomname " (" (count-games room) ")"])]
             [:div.rooms
              (room-tab "competitive" "Competitive")
-             (room-tab "casual" "Casual")])]
+             (room-tab "casual" "Casual")
+             (room-tab "beginner" "Beginner")])]
          (game-list cursor owner)]
 
         [:div.game-panel


### PR DESCRIPTION
Reasons to support a beginner room:

* Beginners often play much more slowly than experienced players, and it's irritating for experienced players.
* Beginners don't learn by getting creamed by experienced players.
* Experienced players don't learn by creaming beginners.
* Beginners should/may want to limit to Core for simplicity's sake and this won't be fun for experienced players.