### PR TITLE
User-determined resolution of simultaneous triggers on agenda-score/agenda-steal events

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -906,19 +906,15 @@
                                                  (gain state :corp :credit 2)))}}}
 
    "Team Sponsorship"
-   {:events {:agenda-scored {:effect (req (toast state :corp (str "Click Team Sponsorship "
-                                                                  "to install a card from "
-                                                                  "Archives or HQ.") "info")
-                                          (update! state side (assoc card :ts-active true)))}}
-    :abilities [{:label "Install a card from Archives or HQ"
-                 :req (req (:ts-active card))
-                 :prompt "Choose a card from Archives or HQ to install"
-                 :show-discard true
-                 :choices {:req #(and (not (is-type? % "Operation"))
-                                      (#{[:hand] [:discard]} (:zone %)))}
-                 :msg (msg (corp-install-msg target))
-                 :effect (effect (corp-install target nil {:no-install-cost true})
-                                 (update! (dissoc (get-card state card) :ts-active)))}]}
+   {:events {:agenda-scored {:label "Install a card from Archives or HQ"
+                             :prompt "Choose a card from Archives or HQ to install"
+                             :show-discard true
+                             :interactive (req true)
+                             :delayed-completion true
+                             :choices {:req #(and (not (is-type? % "Operation"))
+                                                  (#{[:hand] [:discard]} (:zone %)))}
+                             :msg (msg (corp-install-msg target))
+                             :effect (effect (corp-install eid target nil {:no-install-cost true}))}}}
 
    "Tech Startup"
    {:derezzed-events {:runner-turn-ends corp-rez-toast}

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -537,6 +537,40 @@
     :effect (effect (as-agenda :runner (first (:play-area runner)) 1))
     :msg "add it to their score area and gain 1 agenda point"}
 
+   "Out of the Ashes"
+   (letfn [(ashes-run []
+             {:prompt "Choose a server"
+              :choices (req runnable-servers)
+              :delayed-completion true
+              :effect (effect (run eid target nil card))})
+           (ashes-recur [n]
+             {:prompt "Remove Out of the Ashes from the game to make a run?"
+              :choices ["Yes" "No"]
+              :effect (req (if (= target "Yes")
+                             (let [card (some #(when (= "Out of the Ashes" (:title %)) %) (:discard runner))]
+                               (system-msg state side "removes Out of the Ashes from the game to make a run")
+                               (move state side card :rfg)
+                               (unregister-events state side card)
+                               (when-completed (resolve-ability state side (ashes-run) card nil)
+                                               (if (< 1 n)
+                                                 (continue-ability state side (ashes-recur (dec n)) card nil)
+                                                 (effect-completed state side eid card))))))})]
+   {:prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (run eid target nil card))
+    :move-zone (req (if (= [:discard] (:zone card))
+                      (register-events state side
+                        {:runner-phase-12 {:priority -1
+                                           :once :per-turn
+                                           :once-key :out-of-ashes
+                                           :effect (effect (continue-ability
+                                                             (ashes-recur (count (filter #(= "Out of the Ashes" (:title %))
+                                                                                         (:discard runner))))
+                                                             card nil))}}
+                        (assoc card :zone [:discard]))
+                      (unregister-events state side card)))
+    :events {:runner-phase-12 nil}})
+
    "Paper Tripping"
    {:msg "remove all tags" :effect (effect (lose :tag :all))}
 

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -377,6 +377,48 @@
                                        {:msg "gain 2 [Credits]" :effect (effect (gain :credit 2))})
                                      card nil))}
 
+   "Information Sifting"
+   (letfn [(access-pile [cards pile]
+             {:prompt "Select a card to access. You must access all cards."
+              :choices [(str "Card from pile " pile)]
+              :effect (req (system-msg state side "accesses " (:title (first cards)))
+                           (when-completed
+                             (handle-access state side [(first cards)])
+                             (do (if (< 1 (count cards))
+                                   (continue-ability state side (access-pile (next cards) pile) card nil)
+                                   (effect-completed state side eid card)))))})
+           (which-pile [p1 p2]
+             {:prompt "Choose a pile to access"
+              :choices [(str "Pile 1 (" (count p1) " cards)") (str "Pile 2 (" (count p2) " cards)")]
+              :effect (req (let [choice (if (.startsWith target "Pile 1") 1 2)]
+                             (clear-wait-prompt state :corp)
+                             (continue-ability state side
+                                (access-pile (if (= 1 choice) p1 p2) choice)
+                                card nil)))})]
+     (let [access-effect
+           {:delayed-completion true
+            :mandatory true
+            :effect (req (if (< 1 (count (:hand corp)))
+                           (do (show-wait-prompt state :runner "Corp to create two piles")
+                               (continue-ability
+                                 state :corp
+                                 {:prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
+                                  :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
+                                            :max (req (dec (count (:hand corp))))}
+                                  :effect (effect (clear-wait-prompt :runner)
+                                                  (show-wait-prompt :corp "Runner to choose a pile")
+                                                  (continue-ability
+                                                    :runner
+                                                    (which-pile (shuffle targets)
+                                                                (shuffle (vec (clojure.set/difference
+                                                                                (set (:hand corp)) (set targets)))))
+                                                    card nil))
+                                  } card nil))
+                           (effect-completed state side eid card)))}]
+       {:effect (effect (run :hq {:req (req (= target :hq))
+                                  :replace-access access-effect}
+                             card))}))
+
    "Inject"
    {:effect (req (doseq [c (take 4 (get-in @state [:runner :deck]))]
                    (if (is-type? c "Program")

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -110,26 +110,28 @@
                          (damage state side eid :net (get-defer-damage state side :net nil)
                                  {:unpreventable true :card card}))
                      (do (show-wait-prompt state :runner "Corp to use Chronos Protocol: Selective Mind-mapping")
-                           (continue-ability
-                             state side
-                             {:optional
-                              {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
-                                            "Grip to select the first card trashed?")
-                               :player :corp
-                               :yes-ability {:prompt (msg "Choose a card to trash")
-                                             :choices (req (:hand runner)) :not-distinct true
-                                             :msg (msg "trash " (:title target)
-                                                       (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
-                                                         (str " and deal " (- (get-defer-damage state side :net nil) 1)
-                                                              " more net damage")))
-                                             :effect (req (clear-wait-prompt state :runner)
-                                                          (swap! state update-in [:damage] dissoc :damage-choose-corp)
-                                                          (trash state side target {:cause :net :unpreventable true})
-                                                          (let [more (dec (or (get-defer-damage state side :net nil) 0))]
-                                                            (damage-defer state side :net more)))}
-                               :no-ability {:effect (req (clear-wait-prompt state :runner)
-                                                         (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
-                             card nil))))}}
+                         (continue-ability
+                           state side
+                           {:optional
+                            {:prompt (str "Use Chronos Protocol: Selective Mind-mapping to reveal the Runner's "
+                                          "Grip to select the first card trashed?")
+                             :priority 10
+                             :player :corp
+                             :yes-ability {:prompt (msg "Choose a card to trash")
+                                           :choices (req (:hand runner)) :not-distinct true
+                                           :priority 10
+                                           :msg (msg "trash " (:title target)
+                                                     (when (pos? (dec (or (get-defer-damage state side :net nil) 0)))
+                                                       (str " and deal " (- (get-defer-damage state side :net nil) 1)
+                                                            " more net damage")))
+                                           :effect (req (clear-wait-prompt state :runner)
+                                                        (swap! state update-in [:damage] dissoc :damage-choose-corp)
+                                                        (trash state side target {:cause :net :unpreventable true})
+                                                        (let [more (dec (or (get-defer-damage state side :net nil) 0))]
+                                                          (damage-defer state side :net more)))}
+                             :no-ability {:effect (req (clear-wait-prompt state :runner)
+                                                       (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
+                           card nil))))}}
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -295,8 +295,7 @@
    {:events {:agenda-scored {:interactive (req true)
                              :delayed-completion true
                              :msg "do 1 net damage"
-                             :effect (effect ((fn [_ _] (prn "JPE " eid)))
-                                             (damage eid :net 1 {:card card}))}
+                             :effect (effect (damage eid :net 1 {:card card}))}
              :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinteki: Replicating Perfection"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -49,7 +49,9 @@
               :choices ["1 tag" "2 meat damage"] :player :runner
               :msg "make the Runner take 1 tag or suffer 2 meat damage"
               :effect (req (if (= target "1 tag")
-                             (do (tag-runner state :runner 1) (system-msg state side "takes 1 tag"))
+                             (do (tag-runner state :runner 1)
+                                 (system-msg state side "takes 1 tag")
+                                 (effect-completed state side eid nil))
                              (do (damage state :runner eid :meat 2 {:unboostable true :card card})
                                  (system-msg state side "suffers 2 meat damage"))))}}}
 
@@ -290,7 +292,11 @@
                        :effect (effect (tag-prevent 1))}}}
 
    "Jinteki: Personal Evolution"
-   {:events {:agenda-scored {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}
+   {:events {:agenda-scored {:interactive (req true)
+                             :delayed-completion true
+                             :msg "do 1 net damage"
+                             :effect (effect ((fn [_ _] (prn "JPE " eid)))
+                                             (damage eid :net 1 {:card card}))}
              :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinteki: Replicating Perfection"
@@ -375,21 +381,14 @@
                  :effect (req (draw state :corp) (swap! state assoc-in [:per-turn (:cid card)] true))}]}
 
    "Leela Patel: Trained Pragmatist"
+   (let [leela {:interactive (req true)
+                :prompt  "Select an unrezzed card to return to HQ"
+                :choices {:req #(and (not (:rezzed %)) (card-is? % :side :corp))}
+                :msg     (msg "add " (card-str state target) " to HQ")
+                :effect  (final-effect (move :corp target :hand))}]
    {:flags {:slow-hq-access (req true)}
-    :events {:agenda-scored
-             {:effect (req (toast state :runner
-                                  (str "Click Leela Patel: Trained Pragmatist to add 1 unrezzed card to HQ.") "info")
-                           (update! state :runner (update-in card [:bounce-hq] #(inc (or % 0)))))}
-             :agenda-stolen
-             {:effect (req (toast state :runner
-                                  (str "Click Leela Patel: Trained Pragmatist to add 1 unrezzed card to HQ.") "info")
-                           (update! state :runner (update-in card [:bounce-hq] #(inc (or % 0)))))}}
-    :abilities [{:req (req (pos? (:bounce-hq card 0)))
-                 :choices {:req #(and (not (:rezzed %)) (= (:side %) "Corp"))} :player :runner
-                 :priority true
-                 :msg (msg "add " (card-str state target) " to HQ")
-                 :effect (effect (move :corp target :hand)
-                                 (update! (update-in (get-card state card) [:bounce-hq] dec)))}]}
+    :events {:agenda-scored leela
+             :agenda-stolen leela}})
 
    "MaxX: Maximum Punk Rock"
    (let [ability {:msg "trash the top 2 cards from Stack and draw 1 card"
@@ -449,7 +448,7 @@
                                                     (= (:side %) "Corp")
                                                     (#{[:hand] [:discard]} (:zone %)))}
                                :msg (msg "play a current from " (name-zone "Corp" (:zone target)))
-                               :effect (effect (play-instant target))}}}]
+                               :effect (effect (play-instant eid target))}}}]
      {:events {:agenda-scored nasol :agenda-stolen nasol}})
 
    "NEXT Design: Guarding the Net"
@@ -616,7 +615,7 @@
 
    "Titan Transnational: Investing In Your Future"
    {:events {:agenda-scored {:msg (msg "add 1 agenda counter to " (:title target))
-                             :effect (effect (add-counter target :agenda 1))}}}
+                             :effect (effect (add-counter (get-card state target) :agenda 1))}}}
 
    "Valencia Estevez: The Angel of Cayambe"
    {:events {:pre-start-game

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -329,14 +329,12 @@
                                   " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]}
 
    "Gang Sign"
-   {:events {:agenda-scored {:effect (req (toast state :runner "Click on Gang Sign to access 1 card from HQ" "info")
-                                          (update! state side (assoc card :access-hq true)))}}
-    :abilities [{:req (req (:access-hq card))
-                 :msg (msg "access " (get-in @state [:runner :hq-access]) " card"
-                           (when (< 1 (get-in @state [:runner :hq-access])) "s") " from HQ")
-                 :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
-                                (resolve-ability state :runner (choose-access c '(:hq)) card nil)
-                                (update! state side (dissoc (get-card state card) :access-hq))))}]}
+   {:events {:agenda-scored {:delayed-completion true
+                             :interactive (req true)
+                             :msg (msg "access " (get-in @state [:runner :hq-access]) " card"
+                                       (when (< 1 (get-in @state [:runner :hq-access])) "s") " from HQ")
+                             :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
+                                            (continue-ability state :runner (choose-access c '(:hq)) card nil)))}}}
 
    "Gene Conditioning Shoppe"
    {:msg "make Genetics trigger a second time each turn"
@@ -897,7 +895,8 @@
     :abilities [ability]})
 
    "Spoilers"
-   {:events {:agenda-scored {:msg "trash the top card of R&D" :effect (effect (mill :corp))}}}
+   {:events {:agenda-scored {:interactive (req true)
+                             :msg "trash the top card of R&D" :effect (effect (mill :corp))}}}
 
    "Starlight Crusade Funding"
    {:msg "ignore additional costs on Double events"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -359,10 +359,9 @@
 
    "Surat City Grid"
    {:events
-    {:rez {:req (req (and (= (card->server state target) (card->server state card))
-                          (not (and (is-central? (card->server state card))
-                                    (= (card->server state target) (card->server state card))
-                                    (is-type? target "Upgrade")))
+    {:rez {:req (req (and (= (second (:zone target)) (second (:zone card)))
+                          (not (and (is-type? target "Upgrade")
+                                    (is-central? (second (:zone target)))))
                           (not= (:cid target) (:cid card))
                           (seq (filter #(and (not (rezzed? %))
                                              (not (is-type? % "Agenda"))) (all-installed state :corp)))))

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -249,7 +249,7 @@
         ;; do not card-init necessarily. if card-def has :effect, wrap a fake event
         (let [moved-card (move state :corp card :scored)
               c (card-init state :corp moved-card false)]
-          (when-completed (trigger-event-async state :corp :agenda-scored (card-as-handler c) c)
+          (when-completed (trigger-event-simult state :corp :agenda-scored (card-as-handler c) c)
                           (let [c (get-card state c)
                                 points (get-agenda-points state :corp c)]
                             (set-prop state :corp (get-card state moved-card) :advance-counter 0)

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -97,6 +97,8 @@
                (when (= (last (:server run)) (last z))
                  (handle-end-run state side)))
              (swap! state dissoc-in z)))
+         (when-let [card-moved (:move-zone (card-def c))]
+           (card-moved state side (make-eid state) moved-card card))
          (trigger-event state side :card-moved card moved-card)
          (when-let [icon-card (get-in moved-card [:icon :card])]
            ;; remove icon if card moved to :discard or :hand

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -125,7 +125,6 @@
 
 (defn effect-completed
   [state side eid card]
-  ;(prn "EFFECT-COMPLETED" eid)
   (doseq [handler (get-in @state [:effect-completed eid])]
     ((:effect handler) state side eid (:card card) nil))
   (swap! state update-in [:effect-completed] dissoc eid))

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -1,6 +1,7 @@
 (in-ns 'game.core)
 
-(declare effect-completed forfeit prompt! register-suppress trigger-suppress unregister-suppress)
+(declare clear-wait-prompt effect-completed event-title forfeit prompt! register-suppress
+         show-wait-prompt trigger-suppress unregister-suppress)
 
 ; Functions for registering and dispatching events.
 (defn register-events
@@ -62,26 +63,86 @@
                       (effect-completed state side eid nil)))))
 
 ;; INCOMPLETE
-(defn trigger-event-async
+(defn- trigger-event-simult-player
+  [state side eid event handlers targets]
+  (if (pos? (count handlers))
+    (letfn [(choose-handler [handlers]
+              (let [cards (map :card handlers)
+                    titles (map :title cards)
+                    interactive (filter #(let [interactive-fn (:interactive (:ability %))]
+                                          (and interactive-fn (interactive-fn state side (make-eid state) (:card %) nil)))
+                                        handlers)]
+                (if (or (= 1 (count handlers)) (empty? interactive))
+                  (let [to-resolve (first handlers)]
+                    {:delayed-completion true
+                     :effect (req (when-completed (resolve-ability state side (:ability to-resolve)
+                                                                   (:card to-resolve) targets)
+                                                  (if (< 1 (count handlers))
+                                                    (continue-ability state side
+                                                                      (choose-handler (next handlers)) nil targets)
+                                                    (effect-completed state side eid nil))))})
+                  {:prompt  "Select a trigger to resolve"
+                   :choices titles
+                   :delayed-completion true
+                   :effect  (req (let [to-resolve (some #(when (= target (:title (:card %))) %) handlers)]
+                                   (when-completed (resolve-ability state side (:ability to-resolve)
+                                                                    (:card to-resolve) targets)
+                                                   (if (< 1 (count handlers))
+                                                     (continue-ability state side
+                                                                       (choose-handler (remove-once #(not= target (:title (:card %))) handlers))
+                                                                       nil targets)
+                                                     (effect-completed state side eid nil)))))})))]
+
+      (continue-ability state side (choose-handler handlers) nil targets))
+    (effect-completed state side eid nil)))
+
+(defn ability-as-handler
+  [card ability]
+  {:card card :ability ability})
+
+(defn card-as-handler
+  [card]
+  (let [{:keys [effect prompt choices psi optional trace] :as cdef} (card-def card)]
+    (when (or effect prompt choices psi optional trace)
+      (ability-as-handler card cdef))))
+
+(defn effect-as-handler
+  [card effect]
+  (ability-as-handler card {:effect effect}))
+
+(defn trigger-event-simult
   "Triggers the given event asynchronously, triggering effect-completed once
   all registered event handlers have completed."
-  [state side eid event & targets]
-  (let [awaiting (atom #{})]
-    (let [get-side #(-> % :card :side game.utils/to-keyword)
-          is-active-player #(= (:active-player @state) (get-side %))
-          handlers (map #([% (make-eid state)]) (sort-by (complement is-active-player) (get-in @state [:events event])))]
-      (doseq [h handlers]
-        (let [e (first h)
-              eid (second h)
-              ability (:ability e)]
-          (when-let [card (get-card state (:card e))]
-            (when (and (not (apply trigger-suppress state side event (cons card targets)))
-                       (or (not (:req ability)) ((:req ability) state side (make-eid state) card targets)))
-              (when-completed (resolve-ability state side ability card targets)
-                              (do (swap! awaiting disj eid)
-                                  (when (empty? awaiting)
-                                    (effect-completed state side eid nil))
-                                  (prn "awaiting still " @awaiting))))))))))
+  ([state side eid event card-ability & targets]
+   (let [awaiting (atom #{})]
+     (let [get-side #(-> % :card :side game.utils/to-keyword)
+           get-ability-side #(-> % :ability :side)
+           active-player (:active-player @state)
+           opponent (other-side (:active-player @state))
+           is-active-player #(or (= active-player (get-side %)) (= active-player (get-ability-side %)))
+           active-player-events (filter is-active-player (get-in @state [:events event]))
+           active-player-events (if (= (:active-player @state) (get-side card-ability))
+                                  (cons card-ability active-player-events)
+                                  active-player-events)
+           opponent-events (filter (complement is-active-player) (get-in @state [:events event]))
+           opponent-events (if (= opponent (get-side card-ability))
+                                  (cons card-ability opponent-events)
+                                  opponent-events)
+           handlers (map #([% (make-eid state)]) (sort-by (complement is-active-player) (get-in @state [:events event])))]
+
+       ; let active player activate their events first
+       (show-wait-prompt state opponent (str (side-str active-player) " to resolve " (event-title event) " triggers")
+                         {:priority -1})
+       (when-completed (trigger-event-simult-player state side event active-player-events targets)
+                       (do (clear-wait-prompt state opponent)
+                           (show-wait-prompt state active-player
+                                             (str (side-str opponent) " to resolve " (event-title event) " triggers")
+                                             {:priority -1})
+                           (when-completed (trigger-event-simult-player state opponent event opponent-events targets)
+                                           (do (swap! state update-in [:turn-events] #(cons [event targets] %))
+                                               (clear-wait-prompt state active-player)
+                                               (effect-completed state side eid nil)))))))))
+
 
 ; Functions for registering trigger suppression events.
 (defn register-suppress

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -64,7 +64,7 @@
 
 ;; INCOMPLETE
 (defn- trigger-event-simult-player
-  [state side eid event handlers targets]
+  [state side eid event handlers event-targets]
   (if (pos? (count handlers))
     (letfn [(choose-handler [handlers]
               (let [cards (map :card handlers)
@@ -76,24 +76,24 @@
                   (let [to-resolve (first handlers)]
                     {:delayed-completion true
                      :effect (req (when-completed (resolve-ability state side (:ability to-resolve)
-                                                                   (:card to-resolve) targets)
+                                                                   (:card to-resolve) event-targets)
                                                   (if (< 1 (count handlers))
                                                     (continue-ability state side
-                                                                      (choose-handler (next handlers)) nil targets)
+                                                                      (choose-handler (next handlers)) nil event-targets)
                                                     (effect-completed state side eid nil))))})
                   {:prompt  "Select a trigger to resolve"
                    :choices titles
                    :delayed-completion true
                    :effect  (req (let [to-resolve (some #(when (= target (:title (:card %))) %) handlers)]
                                    (when-completed (resolve-ability state side (:ability to-resolve)
-                                                                    (:card to-resolve) targets)
+                                                                    (:card to-resolve) event-targets)
                                                    (if (< 1 (count handlers))
                                                      (continue-ability state side
                                                                        (choose-handler (remove-once #(not= target (:title (:card %))) handlers))
-                                                                       nil targets)
+                                                                       nil event-targets)
                                                      (effect-completed state side eid nil)))))})))]
 
-      (continue-ability state side (choose-handler handlers) nil targets))
+      (continue-ability state side (choose-handler handlers) nil event-targets))
     (effect-completed state side eid nil)))
 
 (defn ability-as-handler

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -118,54 +118,58 @@
                                 (if (ice? card) " protecting " " in ") server))))
 
 (defn corp-install
-  ([state side card server] (corp-install state side card server nil))
-  ([state side card server {:keys [extra-cost no-install-cost install-state eid] :as args}]
-   (let [eid (if-not eid (make-eid state) eid)]
-     (if-not server
-       (prompt! state side card (str "Choose a server to install " (:title card))
-                (server-list state card) {:effect (effect (corp-install card target (assoc args :eid eid)))})
-       (do
-         (let [cdef (card-def card)
-               c (-> card
-                     (assoc :advanceable (:advanceable cdef))
-                     (dissoc :seen))
-               slot (conj (server->zone state server) (if (ice? c) :ices :content))
-               dest-zone (get-in @state (cons :corp slot))]
-           ;; trigger :pre-corp-install before computing install costs so that
-           ;; event handlers may adjust the cost.
-           (trigger-event state side :pre-corp-install card {:server server :dest-zone dest-zone})
-           (let [ice-cost (if (and (ice? c)
-                                   (not no-install-cost)
-                                   (not (ignore-install-cost? state side)))
-                            (count dest-zone) 0)
-                 all-cost (concat extra-cost [:credit ice-cost])
-                 end-cost (install-cost state side card all-cost)
-                 install-state (or install-state (:install-state cdef))]
-             (when (corp-can-install? card dest-zone)
-               (when-let [cost-str (pay state side card end-cost)]
-                 (when (= server "New remote")
-                   (trigger-event state side :server-created card))
-                 (corp-install-asset-agenda state side c dest-zone)
-                 (corp-install-message state side c server install-state cost-str)
-                 (let [moved-card (move state side (assoc c :new true) slot)]
-                   (trigger-event state side :corp-install moved-card)
-                   (when (is-type? c "Agenda")
-                     (update-advancement-cost state side moved-card))
-                   (when (= install-state :rezzed-no-cost)
-                     (rez state side moved-card {:ignore-cost :all-costs}))
-                   (when (= install-state :rezzed)
-                     (rez state side moved-card))
-                   (when (= install-state :face-up)
-                     (if (:install-state cdef)
-                       (card-init state side
-                                  (assoc (get-card state moved-card) :rezzed true :seen true) false)
-                       (update! state side (assoc (get-card state moved-card) :rezzed true :seen true))))
-                   (when-let [dre (:derezzed-events cdef)]
-                     (when-not (:rezzed (get-card state moved-card))
-                       (register-events state side dre moved-card))))))
-             (clear-install-cost-bonus state side)
-             (when-not (:delayed-completion cdef)
-               (effect-completed state side eid card)))))))))
+  ([state side card server] (corp-install state side (make-eid state) card server nil))
+  ([state side card server args] (corp-install state side (make-eid state) card server args))
+  ([state side eid card server {:keys [extra-cost no-install-cost install-state] :as args}]
+   (if-not server
+     (continue-ability state side
+                       {:prompt (str "Choose a server to install " (:title card))
+                        :choices (server-list state card)
+                        :delayed-completion true
+                        :effect (effect (corp-install eid card target args))}
+                       card nil)
+     (do
+       (let [cdef (card-def card)
+             c (-> card
+                   (assoc :advanceable (:advanceable cdef))
+                   (dissoc :seen))
+             slot (conj (server->zone state server) (if (ice? c) :ices :content))
+             dest-zone (get-in @state (cons :corp slot))]
+         ;; trigger :pre-corp-install before computing install costs so that
+         ;; event handlers may adjust the cost.
+         (trigger-event state side :pre-corp-install card {:server server :dest-zone dest-zone})
+         (let [ice-cost (if (and (ice? c)
+                                 (not no-install-cost)
+                                 (not (ignore-install-cost? state side)))
+                          (count dest-zone) 0)
+               all-cost (concat extra-cost [:credit ice-cost])
+               end-cost (install-cost state side card all-cost)
+               install-state (or install-state (:install-state cdef))]
+           (when (corp-can-install? card dest-zone)
+             (when-let [cost-str (pay state side card end-cost)]
+               (when (= server "New remote")
+                 (trigger-event state side :server-created card))
+               (corp-install-asset-agenda state side c dest-zone)
+               (corp-install-message state side c server install-state cost-str)
+               (let [moved-card (move state side (assoc c :new true) slot)]
+                 (trigger-event state side :corp-install moved-card)
+                 (when (is-type? c "Agenda")
+                   (update-advancement-cost state side moved-card))
+                 (when (= install-state :rezzed-no-cost)
+                   (rez state side moved-card {:ignore-cost :all-costs}))
+                 (when (= install-state :rezzed)
+                   (rez state side moved-card))
+                 (when (= install-state :face-up)
+                   (if (:install-state cdef)
+                     (card-init state side
+                                (assoc (get-card state moved-card) :rezzed true :seen true) false)
+                     (update! state side (assoc (get-card state moved-card) :rezzed true :seen true))))
+                 (when-let [dre (:derezzed-events cdef)]
+                   (when-not (:rezzed (get-card state moved-card))
+                     (register-events state side dre moved-card))))))
+           (clear-install-cost-bonus state side)
+           (when-not (:delayed-completion cdef)
+             (effect-completed state side eid card))))))))
 
 
 ;;; Installing a runner card

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -167,3 +167,11 @@
         credits (get-in @state [side :credit])
         text (str pre " their turn " (:turn @state) " with " credits " [Credit] and " cards " cards in " hand)]
     (system-msg state side text {:hr (not start-of-turn)})))
+
+(defn event-title
+  "Gets a string describing the internal engine event keyword"
+  [event]
+  (case event
+    :agenda-scored "agenda-scored"
+    :agenda-stolen "agenda-stolen"
+    (str event)))

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -147,6 +147,10 @@
                                                 :choices {:req (fn [t] (card-is? t :side %2))}}
                                          {:title "/rez command"} nil))
         "/rez-all"    #(when (= %2 :corp) (command-rezall %1 %2 value))
+        "/rfg"        #(resolve-ability %1 %2 {:prompt "Select a card to remove from the game"
+                                               :effect (effect (move target :rfg))
+                                               :choices {:req (fn [t] (card-is? t :side %2))}}
+                                        {:title "/rfg command"} nil)
         nil))))
 
 (defn corp-install-msg

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -185,10 +185,10 @@
      (let [prevent (get-in @state [:prevent :damage type])]
        (if (and (not unpreventable) prevent (pos? (count prevent)))
          ;; runner can prevent the damage.
-         (do (system-msg state :runner "has the option to prevent damage")
+         (do (show-wait-prompt state :corp "Runner to prevent damage" {:priority 10})
              (show-prompt
                state :runner nil (str "Prevent any of the " n " " (name type) " damage?") ["Done"]
-               (fn [choice]
+               (fn [_]
                  (let [prevent (get-in @state [:damage :damage-prevent type])]
                    (when prevent
                      (trigger-event state side :prevented-damage type prevent))
@@ -197,6 +197,7 @@
                                  (str "prevents " (if (= prevent Integer/MAX_VALUE) "all" prevent)
                                           " " (name type) " damage")
                                  "will not prevent damage"))
+                   (clear-wait-prompt state :corp)
                    (resolve-damage state side eid type (max 0 (- n (or prevent 0))) args)))
                {:priority 10}))
          (resolve-damage state side eid type n args))))))
@@ -257,16 +258,6 @@
 
 (defn trash-prevent [state side type n]
   (swap! state update-in [:trash :trash-prevent type] (fnil #(+ % n) 0)))
-
-;;(when (and (not suppress-event) (not= (last zone) :current)) ; Trashing a current does not trigger a trash event.
-;; the use of apply here is incompatible with the when-completed macro, so we have to expand the macro by hand.
-;;(let [eid (make-eid state)
-     ;; when-done (fn [state1 side1 eid1 card1 targets1]
-    ;;              ())]
-  ;;(register-effect-completed
- ;;   state side eid nil
-;;    )
-;;  (apply trigger-event-async state side eid (keyword (str (name side) "-trash")) card cause targets)))
 
 (defn- resolve-trash-end
   [state side {:keys [zone type] :as card} {:keys [unpreventable cause keep-server-alive suppress-event] :as args} & targets]

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -142,9 +142,8 @@
       (if-not (empty? cost)
         ;; Ask if the runner will pay the additional cost to steal.
         (optional-ability
-          state :runner c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
-          {:eid eid
-           :yes-ability
+          state :runner eid c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
+          {:yes-ability
                 {:delayed-completion true
                  :effect (req (if (can-pay? state side name cost)
                                 (do (pay state side nil cost)

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -101,20 +101,21 @@
   (when (not= (:zone c) [:discard]) ; if not accessing in Archives
     (if-let [trash-cost (trash-cost state side c)]
       ;; The card has a trash cost (Asset, Upgrade)
-      (let [card (assoc c :seen true)]
+      (let [card (assoc c :seen true)
+            name (:title card)]
         (if (and (get-in @state [:runner :register :force-trash])
                  (can-pay? state :runner name :credit trash-cost))
           ;; If the runner is forced to trash this card (Neutralize All Threats)
           (resolve-ability state :runner {:cost [:credit trash-cost]
                                           :effect (effect (trash card)
                                                           (system-msg (str "is forced to pay " trash-cost
-                                                                           " [Credits] to trash " (:title card))))} card nil)
+                                                                           " [Credits] to trash " name)))} card nil)
           ;; Otherwise, show the option to pay to trash the card.
           (optional-ability state :runner card (str "Pay " trash-cost "[Credits] to trash " name "?")
                             {:yes-ability {:cost [:credit trash-cost]
                                            :effect (effect (trash card)
-                                                           (system-msg (str "pays " trash-cost " [Credits] to trash "
-                                                                            (:title card))))}} nil)))
+                                                           (system-msg (str "pays " trash-cost
+                                                                            " [Credits] to trash " name)))}} nil)))
       ;; The card does not have a trash cost
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {}))))
 

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -421,8 +421,8 @@
     (play-from-hand state :corp "Profiteering" "New remote")
     (let [prof (get-content state :remote1 0)]
       (score-agenda state :corp prof)
-      (is (= 1 (:agenda-point (get-corp))))
       (prompt-choice :corp "3")
+      (is (= 1 (:agenda-point (get-corp))))
       (is (= 3 (:bad-publicity (get-corp))) "Took 3 bad publicity")
       (is (= 20 (:credit (get-corp))) "Gained 15 credits"))))
 

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -511,9 +511,8 @@
     (play-from-hand state :runner "Turntable")
     (run-empty-server state "HQ")
     (prompt-choice :runner "Steal")
-    (is (= 1 (:agenda-point (get-runner))) "Chronos Project stolen")
     (let [tt (get-in @state [:runner :rig :hardware 0])]
-      (card-ability state :runner tt 0)
+      (prompt-choice :runner "Yes")
       (prompt-select :runner (find-card "Breaking News" (:scored (get-corp))))
       (is (= 1 (:agenda-point (get-corp))))
       (is (= 0 (:agenda-point (get-runner))))

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -368,9 +368,8 @@
         (run-empty-server state "HQ")
         (prompt-choice :runner "Steal")
         (is (= 0 (:agenda-point (get-runner))) "Stole Domestic Sleepers")
-        (is (= true (:swap (core/get-card state tt)))) ; Turntable ability enabled by steal
-        (card-ability state :runner tt 0)
         ;; Turntable prompt should be active
+        (prompt-choice :runner "Yes")
         (is (= (:cid tt) (-> @state :runner :prompt first :card :cid)))
         (prompt-select :runner (find-card "Project Vitruvius" (:scored (get-corp))))
         (is (= 2 (:agenda-point (get-runner))) "Took Project Vitruvius from Corp")
@@ -391,8 +390,7 @@
       (let [tt (get-in @state [:runner :rig :hardware 0])]
         (run-empty-server state "HQ")
         (prompt-choice :runner "Steal")
-        (is (= 2 (:agenda-point (get-runner))) "Stole Project Vitruvius")
-        (card-ability state :runner tt 0)
+        (prompt-choice :runner "Yes") ;; Turntable optional prompt
         (prompt-select :runner (find-card "Mandatory Upgrades" (:scored (get-corp))))
         (is (= 3 (:click-per-turn (get-corp))) "Back down to 3 clicks per turn")
         (is (nil? (:swap (core/get-card state tt))) "Turntable ability disabled")))))

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -359,6 +359,7 @@
         (take-credits state :corp)
         (take-credits state :runner)
         (core/score state :corp (refresh prof))
+        (prompt-choice :corp "0")
         (is (= 1 (:agenda-point (get-corp))) "Profiteering was able to be scored")))))
 
 (deftest neural-emp

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -556,7 +556,8 @@
     (take-credits state :runner)
     (play-from-hand state :corp "Subcontract")
     (prompt-select :corp (find-card "Scorched Earth" (:hand (get-corp))))
-    (is (empty? (:prompt (get-corp))) "Corp does not have prompt until damage prevention completes")
+    (is (and (= 1 (count (:prompt (get-corp)))) (= :waiting (-> (get-corp) :prompt first :prompt-type)))
+        "Corp does not have Subcontract prompt until damage prevention completes")
     (prompt-choice :runner "Done")
     (is (not-empty (:prompt (get-corp))) "Corp can now play second Subcontract operation")))
 

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -58,6 +58,7 @@
                         [:li [:code "/take-brain n"] " - Take n brain damage (Runner only)"]
                         [:li [:code "/discard #n"] " - Discard card number n from your hand"]
                         [:li [:code "/deck #n"] " - Put card number n from your hand on top of your deck"]
+                        [:li [:code "/rfg"] " - Select a card to remove from the game"]
                         [:li [:code "/end-run"] " - End the run (Corp only)"]
                         [:li [:code "/jack-out"] " - Jack out (Runner only)"]
                         [:li [:code "/trace n"] " - Start a trace with base strength n (Corp only)"]


### PR DESCRIPTION
As before, this needs #1591.

This is my prototype for allowing the player to choose the order of resolving simultaneous triggers. ~~I don't think this should be merged for another day or two to give some others time to test the changes.~~ I think this is pretty good now and am up for merging it, thanks to some testing with Joel.

### Simultaneous event resolution

I introduce a replacement for `trigger-event` called `trigger-event-simult`. Using the `when-completed` code and some lessons learned from my recent card implementations, `trigger-event-simult` will gather all listeners for a given event and break them into two groups based on the player who owns the card receiving the trigger. We then:

1. Resolve all triggers for the active player.
  0. Inform the opponent that the active player is resolving triggers.
  1. Present a menu to the user listing each card that is listening for the trigger.
  2. Upon menu selection, trigger the given card and wait for its ability's full resolution.
  3. Repeat until all listeners are resolved.
2. Resolve all triggers for the opponent following the same steps.
3. The event has now been resolved, and we can return to the code that triggered the event.
4. This is all recursive: if the resolution of a listener triggers another event, and that event is hooked to `trigger-event-simult`, then all listeners for that trigger must be resolved before going back to any remaining listeners for the original trigger. ("Cascading triggers" on ANCUR.)

A few techniques make this less tedious for players:

1. If there is only one unresolved listener (left) for the event, that listener is resolved immediately. Example: if I am Leela and have Logos installed, on agenda score I can choose (from a menu) to resolve Leela first. Once that ability is resolved, Logos will immediately fire without another click.
2. If there are many unresolved listeners left and none of them require user interaction, they will be automatically resolved. In this case, "user interaction" is indicated by an ability flag `:interactive` which is a function returning either true or false. If all listeners lack this flag or their flag returns false, then none of them care about the order in which they are resolved. Example: if I have three Fan Sites installed, does it matter in which order they are added to my scored area?
3. The two rules above apply recursively. If I am Leela and have three Fan Sites installed, I will get a menu to choose between 4 different listeners on agenda score because Leela is `:interactive`. If I resolve Leela first, I now have 3 non-interactive abilities that resolve immediately.

### User interface

Currently, the menu for selecting a trigger to resolve only displays the receiving card's name:

![image](https://cloud.githubusercontent.com/assets/10083341/15882091/8b2dd1b6-2cf0-11e6-80dd-b4794fc29ace.png)

This could be changed, by giving abilities a `:label` describing what they do (in the image above, "Remove heap from game" and "Do 1 net damage"). Or maybe someone has a prettier solution in mind.

### Applications
I have implemented and tested simultaneous event resolution __only__ for agenda score/stolen triggers. These have historically been the most important interactions requiring manual ordering, so I started here. Highlights:

1. Jinteki: PE can deal net damage before resolving a scored Chronos Project, so the card trashed from the net damage is removed from the agenda score. Likewise, can deal 1 net damage before resolving Philotic Entanglement, increasing the % chance for a kill past I've Had Worse.
2. Team Sponsorship, Leela Patel, and Gang Sign have been cleaned up considerably now that the user can select their order of execution.
  3. In particular, on agenda score, Leela with Logos and 2x Gang Sign can trigger Logos first to retrieve a card, then trigger Leela to bounce a card, then Gang Sign to access, with the bounced card valid for access. If that results in a steal, then a nested agenda-stolen trigger must be resolved (requiring a Leela bounce) before the second Gang Sign can be activated. If THAT second Gang Sign results in a steal, then yet another Leela bounce must happen before the original `:agenda-scored` event is "finished", and the code in `core/score` can continue.

### Future

It won't be too much work to expand simultaneous resolution to other events, but it will take some testing and reworking of some abilities. We'll identify the most pressing issues and leave the rest until an important new card effect mandates the extension of the system. I do believe that this system will lead us to __100% rule enforcement__, as we now (for the first time) have the ability to enforce manual resolution of simultaneous triggers, as well as "cascading triggers" rules.