### PR TITLE
Fix for Fan Site, Posted Bounty

### DIFF
--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -248,14 +248,15 @@
 
         ;; do not card-init necessarily. if card-def has :effect, wrap a fake event
         (let [moved-card (move state :corp card :scored)
-              c (card-init state :corp moved-card false)]
+              c (card-init state :corp moved-card false)
+              points (get-agenda-points state :corp c)]
           (when-completed (trigger-event-simult state :corp :agenda-scored
                                                 {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
                                                                 (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
                                                                 (trash state side current)))}
                                                 (card-as-handler c) c)
                           (let [c (get-card state c)
-                                points (get-agenda-points state :corp c)]
+                                points (or (get-agenda-points state :corp c) points)]
                             (set-prop state :corp (get-card state moved-card) :advance-counter 0)
                             (system-msg state :corp (str "scores " (:title c) " and gains " points
                                                          " agenda point" (when (> points 1) "s")))

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -74,13 +74,16 @@
                                         handlers)]
                 (if (or (= 1 (count handlers)) (empty? interactive))
                   (let [to-resolve (first handlers)]
-                    {:delayed-completion true
-                     :effect (req (when-completed (resolve-ability state side (:ability to-resolve)
-                                                                   (:card to-resolve) event-targets)
-                                                  (if (< 1 (count handlers))
-                                                    (continue-ability state side
-                                                                      (choose-handler (next handlers)) nil event-targets)
-                                                    (effect-completed state side eid nil))))})
+                    (if-let [the-card (get-card state (:card to-resolve))]
+                      {:delayed-completion true
+                       :effect (req (when-completed (resolve-ability state side (:ability to-resolve)
+                                                                     the-card event-targets)
+                                                    (if (< 1 (count handlers))
+                                                      (continue-ability state side
+                                                                        (choose-handler (next handlers)) nil event-targets)
+                                                      (effect-completed state side eid nil))))}
+                      {:delayed-completion true
+                       :effect (effect (continue-ability (choose-handler (next handlers)) nil event-targets))}))
                   {:prompt  "Select a trigger to resolve"
                    :choices titles
                    :delayed-completion true

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -370,7 +370,7 @@
 (defn as-agenda
   "Adds the given card to the given side's :scored area as an agenda worth n points."
   [state side card n]
-  (move state side (assoc card :agendapoints n) :scored)
+  (move state side (assoc (deactivate state side card) :agendapoints n) :scored)
   (gain-agenda-point state side n))
 
 (defn forfeit


### PR DESCRIPTION
Make sure a card still exists before dispatching an event to it. Make sure the agenda is still there (hasn't been forfeited) when granting agenda points.