### PR TITLE
Setting width of deck title in deckbuilder to prevent overrunning

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -805,6 +805,7 @@ nav ul
       text-overflow: ellipsis
       white-space: nowrap
       overflow: hidden
+      width: 260px
 
     > img
       float: left


### PR DESCRIPTION
Proposed fix for Issue #1548 