### PR TITLE
More fixes

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -329,7 +329,7 @@
                                 (case flip
                                   "[The Brewery~brewery]"
                                   (do (system-msg state side "uses [The Brewery~brewery] to do 2 net damage")
-                                      (damage eid state side :net 2 {:card card})
+                                      (damage state side eid :net 2 {:card card})
                                       (update! state side (assoc card :code "brewery")))
                                   "[The Tank~tank]"
                                   (do (system-msg state side "uses [The Tank~tank] to shuffle Archives into R&D")

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -393,7 +393,7 @@
   (show-wait-prompt state :corp "Runner to boost Link strength" {:priority 2})
   (trigger-event state side :pre-init-trace card)
   (let [bonus (or (get-in @state [:bonus :trace]) 0)
-        base (if (fn? base) (base state side card nil) base)
+        base (if (fn? base) (base state side  (make-eid state) card nil) base)
         total (+ base boost bonus)]
     (system-msg state :corp (str "uses " (:title card)
                                  " to initiate a trace with strength " total

--- a/src/clj/test/cards/ice.clj
+++ b/src/clj/test/cards/ice.clj
@@ -452,6 +452,25 @@
       (core/remove-tag state :runner 1)
       (is (= 1 (:current-strength (refresh resistor))) "Runner removed 1 tag; down to 1 strength"))))
 
+(deftest searchlight
+  "Searchlight - Trace bace equal to advancement counters"
+  (do-game
+    (new-game (default-corp [(qty "Searchlight" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Searchlight" "HQ")
+    (let [searchlight (get-ice state :hq 0)]
+      (core/rez state :corp searchlight)
+      (card-ability state :corp (refresh searchlight) 0)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (= 0 (:tag (get-runner))) "Trace failed with 0 advancements")
+      (core/advance state :corp {:card (refresh searchlight)})
+      (card-ability state :corp (refresh searchlight) 0)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (= 1 (:tag (get-runner))) "Trace succeeds with 0 advancements"))))
+
+
 (deftest sherlock
   "Sherlock 1.0 - Trace to add an installed program to the top of Runner's Stack"
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -300,6 +300,18 @@
     (core/jack-out state :runner nil)
     (is (= 1 (:tag (get-runner))) "Jesminder did not avoid John Masanori tag")))
 
+(deftest jinteki-biotech-brewery
+  "Jinteki Biotech - Brewery net damage"
+  (do-game
+    (new-game
+      (make-deck "Jinteki Biotech: Life Imagined" [(qty "Braintrust" 1)])
+      (default-runner)
+      {:dont-start true})
+    (prompt-choice :corp "[The Brewery~brewery]")
+    (core/start-turn state :corp nil)
+    (card-ability state :corp (:identity (get-corp)) 1)
+    (is (= 1 (count (:hand (get-runner)))) "Runner took 2 net damage from Brewery flip")))
+
 (deftest jinteki-personal-evolution
   "Personal Evolution - Prevent runner from running on remotes unless they first run on a central"
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -26,7 +26,7 @@
 (defn new-game
   "Init a new game using given corp and runner. Keep starting hands (no mulligan) and start Corp's turn."
   ([corp runner] (new-game corp runner nil))
-  ([corp runner {:keys [mulligan start-as] :as args}]
+  ([corp runner {:keys [mulligan start-as dont-start] :as args}]
     (let [states (core/init-game
                    {:gameid 1
                     :players [{:side "Corp"
@@ -42,8 +42,8 @@
       (if (#{:both :runner} mulligan)
         (core/resolve-prompt state :runner {:choice "Mulligan"})
         (core/resolve-prompt state :runner {:choice "Keep"}))
-      (core/start-turn state :corp nil)
-      (if (= start-as :runner) (take-credits state :corp))
+      (when (not dont-start) (core/start-turn state :corp nil))
+      (when (= start-as :runner) (take-credits state :corp))
       state)))
 
 (defn load-all-cards []


### PR DESCRIPTION
Fix ordering of parameters in The Brewery's net damage.

Add `eid` parameter to `:base` function call for cards that need dynamic trace base strengths. 

Fix infinite recursion in `trigger-event-simult` from Slack.