### PR TITLE
undoing overflow, because causes cutting off run menu in runner when …

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1416,7 +1416,6 @@ nav ul
 
     .button-pane
       .panel
-        overflow-y: scroll
         padding: 8px
 
       .run-button


### PR DESCRIPTION
…clicking button

Issue #1493 