### PR TITLE
Fix Film Critic, Maya

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -342,10 +342,8 @@
                                   (resolve-steal-events state side c))
                                 (move state :corp c :deck)
                                 (tag-runner state :runner 1)
-                                (swap! state update-in [side :prompt] rest)
-                                (when-let [run (:run @state)]
-                                  (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
-                                    (handle-end-run state :runner)))))}
+                                (close-access-prompt state side)
+                                (effect-completed state side eid card)))}
                 {:once :per-turn
                  :label "Move a previously accessed card to bottom of R&D"
                  :effect (effect (resolve-ability

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -1,5 +1,7 @@
 (in-ns 'game.core)
 
+(declare close-access-prompt)
+
 (def cards-resources
   {"Access to Globalsec"
    {:in-play [:link 1]}
@@ -314,11 +316,10 @@
                  :label "Host an agenda being accessed"
                  :effect (req (when-let [agenda (:card (first (get-in @state [side :prompt])))]
                                 (host state side card (move state side agenda :play-area))
-                                (swap! state update-in [side :prompt] rest)
-                                (when-let [run (:run @state)]
-                                  (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
-                                    (handle-end-run state :runner)
-                                    (swap! state dissoc :access)))))
+                                (close-access-prompt state side)
+                                (effect-completed state side eid nil)
+                                (when-not (:run @state)
+                                  (swap! state dissoc :access))))
                  :msg (msg "host " (:title (:card (first (get-in @state [side :prompt])))) " instead of accessing it")}
                 {:cost [:click 2] :label "Add hosted agenda to your score area"
                  :req (req (not (empty? (:hosted card))))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -1,8 +1,8 @@
 (in-ns 'game.core)
 
-(declare card-init card-str deactivate effect-completed enforce-msg gain-agenda-point get-agenda-points
-         handle-end-run is-type? resolve-steal-events show-prompt untrashable-while-rezzed?
-         in-corp-scored? update-all-ice win win-decked prevent-draw)
+(declare card-init card-str close-access-prompt deactivate effect-completed enforce-msg gain-agenda-point
+         get-agenda-points handle-end-run is-type? in-corp-scored? prevent-draw resolve-steal-events show-prompt
+         untrashable-while-rezzed? update-all-ice win win-decked)
 
 ;;;; Functions for applying core Netrunner game rules.
 
@@ -305,13 +305,9 @@
   (doseq [c cards] (trash state side c)))
 
 (defn- resolve-trash-no-cost
-  [state side eid card]
+  [state side card]
   (trash state side card)
-  (swap! state update-in [side :prompt] rest)
-  (effect-completed state side eid nil)
-  (when-let [run (:run @state)]
-    (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
-      (handle-end-run state :runner))))
+  (close-access-prompt state side))
 
 (defn trash-no-cost
   "Trashes a card at no cost while it is being accessed. (Imp.)"
@@ -322,8 +318,8 @@
     (when card
       (if (is-type? card "Agenda") ; trashing before the :access events actually fire; fire them manually
         (when-completed (resolve-steal-events state side card)
-                        (resolve-trash-no-cost state side eid card))
-        (resolve-trash-no-cost state side eid card)))))
+                        (resolve-trash-no-cost state side card))
+        (resolve-trash-no-cost state side card)))))
 
 
 ;;; Agendas

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -581,3 +581,14 @@
   (if-not (empty? (get-in @state [:runner :prompt]))
     (swap! state assoc-in [:run :ended] true)
     (run-cleanup state side)))
+
+(defn close-access-prompt
+  "Closes a 'You accessed _' prompt through a non-standard card effect like Imp."
+  [state side]
+  (let [prompt (-> @state side :prompt first)
+        eid (:eid prompt)]
+    (swap! state update-in [side :prompt] rest)
+    (effect-completed state side eid nil)
+    (when-let [run (:run @state)]
+      (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
+        (handle-end-run state :runner)))))

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -241,6 +241,26 @@
         (is (not (:run @state)) "Run is ended")
         (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")))))
 
+(deftest maya-multi-access
+  "Maya - Does not interrupt multi-access."
+  (do-game
+    (new-game (default-corp [(qty "Hedge Fund" 2) (qty "Scorched Earth" 2) (qty "Snare!" 2)])
+              (default-runner [(qty "Maya" 1) (qty "Sure Gamble" 3) (qty "R&D Interface" 1)]))
+    (core/move state :corp (find-card "Scorched Earth" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Snare!" (:hand (get-corp))) :deck)
+    (take-credits state :corp)
+    (core/gain state :runner :credit 10)
+    (play-from-hand state :runner "Maya")
+    (play-from-hand state :runner "R&D Interface")
+    (let [maya (get-in @state [:runner :rig :hardware 0])
+          accessed (first (:deck (get-corp)))]
+      (run-empty-server state :rd)
+      (prompt-choice :runner "Card from deck")
+      (is (= (:cid accessed) (:cid (:card (first (:prompt (get-runner)))))) "Accessing the top card of R&D")
+      (card-ability state :runner maya 0)
+      (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")
+      (is (:prompt (get-runner)) "Runner has next access prompt"))))
+
 (deftest plascrete
   "Plascrete Carapace - Prevent meat damage"
   (do-game


### PR DESCRIPTION
Refactored the code that closes access prompts with non-standard effects (Imp, Film Critic, Maya). Now correctly triggers that the access is over.