### PR TITLE
Fixes for Turning Wheel, Ramujan-Reliant, Liberated Chela, Bio-Ethics Association; rework /counter command

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -95,6 +95,7 @@
 
    "Bio-Ethics Association"
    (let [ability {:req (req unprotected)
+                  :delayed-completion true
                   :label "Do 1 net damage (start of turn)"
                   :once :per-turn
                   :msg "do 1 net damage"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -506,9 +506,11 @@
 
    "Ramujan-reliant 550 BMI"
    {:prevent {:damage [:net :brain]}
-    :abilities [{:effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
+    :abilities [{:req (req (not-empty (:deck runner)))
+                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
                                 (resolve-ability state side
-                                  {:prompt "Choose how much damage to prevent" :priority 50
+                                  {:prompt "Choose how much damage to prevent"
+                                   :priority 50
                                    :choices {:number (req (min n (count (:deck runner))))}
                                    :msg (msg "trash " target " cards from their Stack and prevent " target " damage")
                                    :effect (effect (damage-prevent :net target)

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -732,11 +732,32 @@
       :effect (effect (continue-ability (sc 1 card) card nil))})
 
    "Subliminal Messaging"
-   {:msg "gain 1 [Credits]"
-    :effect (effect (gain :credit 1)
-                    (resolve-ability {:once :per-turn :once-key :subliminal-messaging
-                                      :msg "gain [Click]"
-                                      :effect (effect (gain :corp :click 1))} card nil))}
+   (letfn [(subliminal []
+             {:corp-phase-12
+              {:effect
+               (req (if (not (:made-run runner-reg))
+                      (do (resolve-ability state side
+                                           {:optional
+                                            {:prompt "Add Subliminal Messaging to HQ?"
+                                             :yes-ability {:effect (req (move state side card :hand)
+                                                                        (system-msg state side "adds Subliminal Messaging to HQ"))}
+                                             :no-ability {:effect (effect (register-events (subliminal) (assoc card :zone '(:discard))))}}}
+                                           card nil)
+                          (unregister-events state side card))
+                      (do (unregister-events state side card)
+                          (resolve-ability state side
+                                           {:effect (effect (register-events (subliminal) (assoc card :zone '(:discard))))}
+                                           card nil))))}})]
+     {:msg "gain 1 [Credits]"
+      :effect (effect (gain :credit 1)
+                      (resolve-ability {:once :per-turn :once-key :subliminal-messaging
+                                        :msg "gain [Click]"
+                                        :effect (effect (gain :corp :click 1))} card nil))
+      :mill-effect {:effect (effect (register-events (subliminal) (assoc card :zone '(:discard))))}
+      :move-zone (req (if (= [:discard] (:zone card))
+                        (register-events state side (subliminal) (assoc card :zone '(:discard)))
+                        (unregister-events state side card)))
+      :events {:corp-phase-12 nil}})
 
    "Successful Demonstration"
    {:req (req (:unsuccessful-run runner-reg))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -1051,23 +1051,21 @@
              :pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 3]))}}}
 
    "The Turning Wheel"
-   {:events {:run {:req (req (#{:hq :rd} target))
-                   :effect (effect (register-run-flag! card :no-agenda-stolen (constantly true)))}
-             :agenda-stolen {:req (req (#{[:hq] [:rd]} (:server run)))
-                             :effect (effect (clear-run-flag! card :no-agenda-stolen)
-                                             (register-run-flag! card :no-agenda-stolen (constantly false)))}
-             :run-ends {:req (req (and (run-flag? state side card :no-agenda-stolen)
+   {:events {:run {:effect (effect (update! (dissoc card :agenda-stolen :counters-spent)))}
+             :agenda-stolen {:effect (effect (update! (assoc card :agenda-stolen true)))
+                             :silent true}
+             :successful-run {:req (req (and (:counters-spent card) (#{:hq :rd} target)))
+                              :effect (effect (access-bonus (:counters-spent card 0)))
+                              :silent true}
+             :run-ends {:req (req (and (not (:agenda-stolen card))
                                        (#{:hq :rd} target)))
                         :effect (effect (add-counter card :power 1)
-                                        (unregister-events card)
-                                        (register-events (:events (card-def card)) card))}
-             :successful-run nil}
+                                        (system-msg (str "adds a power counter to " (:title card))))
+                        :silent true}}
     :abilities [{:counter-cost [:power 2]
                  :req (req (:run @state))
                  :msg "access 1 additional card from HQ or R&D for the remainder of the run"
-                 :effect (effect (register-events
-                                   {:successful-run {:req (req (#{:hq :rd} target))
-                                                     :effect (effect (access-bonus 1))}} card))}]}
+                 :effect (effect (update! (update-in card [:counters-spent] #(inc (or % 0)))))}]}
 
    "Theophilius Bagbiter"
    {:effect (req (lose state :runner :credit :all)

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -504,7 +504,7 @@
    {:abilities [{:cost [:click 5 :forfeit]
                  :msg "add it to their score area"
                  :effect (req (if (not (empty? (:scored corp)))
-                                (do (show-wait-prompt :runner "Corp to decide whether or not to prevent Liberated Chela")
+                                (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent Liberated Chela")
                                     (resolve-ability
                                       state side
                                       {:prompt (msg "Forfeit an agenda to prevent Liberated Chela from being added to Runner's score area?")

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -267,7 +267,7 @@
   ([state side card msg choices ability] (prompt! state side card msg choices ability nil))
   ([state side card msg choices ability args]
    (letfn [(wrap-function [args kw]
-             (let [f (kw args)] (if f (assoc args kw #(f state side (:eid ability) card [%])) kw)))]
+             (let [f (kw args)] (if f (assoc args kw #(f state side (:eid ability) card [%])) args)))]
        (show-prompt state side (:eid ability) card msg choices #(resolve-ability state side ability card [%])
                     (-> args
                         (wrap-function :cancel-effect)

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -71,7 +71,7 @@
   [state side eid event handlers event-targets]
   (if (pos? (count handlers))
     (letfn [(choose-handler [handlers]
-              (let [cards (map :card handlers)
+              (let [cards (map :card (filter #(not (:silent (:ability %))) handlers))
                     titles (map :title cards)
                     interactive (filter #(let [interactive-fn (:interactive (:ability %))]
                                           (and interactive-fn (interactive-fn state side (make-eid state) (:card %) nil)))

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -139,35 +139,34 @@
                  and not an event handler. (For example, :stolen on agendas happens in the same window as :agenda-stolen
   targets:       a varargs list of targets to the event, as usual"
   ([state side eid event first-ability card-ability & targets]
-   (let [awaiting (atom #{})]
-     (let [get-side #(-> % :card :side game.utils/to-keyword)
-           get-ability-side #(-> % :ability :side)
-           active-player (:active-player @state)
-           opponent (other-side (:active-player @state))
-           is-active-player #(or (= active-player (get-side %)) (= active-player (get-ability-side %)))
-           active-player-events (filter is-active-player (get-in @state [:events event]))
-           active-player-events (if (= (:active-player @state) (get-side card-ability))
-                                  (cons card-ability active-player-events)
-                                  active-player-events)
-           opponent-events (filter (complement is-active-player) (get-in @state [:events event]))
-           opponent-events (if (= opponent (get-side card-ability))
-                             (cons card-ability opponent-events)
-                             opponent-events)]
-       ; let active player activate their events first
-       (when-completed
-         (resolve-ability state side first-ability nil nil)
-         (do (show-wait-prompt state opponent (str (side-str active-player) " to resolve " (event-title event) " triggers")
-                               {:priority -1})
-             (when-completed
-               (trigger-event-simult-player state side event active-player-events targets)
-               (do (clear-wait-prompt state opponent)
-                   (show-wait-prompt state active-player
-                                     (str (side-str opponent) " to resolve " (event-title event) " triggers")
-                                     {:priority -1})
-                   (when-completed (trigger-event-simult-player state opponent event opponent-events targets)
-                                   (do (swap! state update-in [:turn-events] #(cons [event targets] %))
-                                       (clear-wait-prompt state active-player)
-                                       (effect-completed state side eid nil)))))))))))
+   (let [get-side #(-> % :card :side game.utils/to-keyword)
+         get-ability-side #(-> % :ability :side)
+         active-player (:active-player @state)
+         opponent (other-side (:active-player @state))
+         is-active-player #(or (= active-player (get-side %)) (= active-player (get-ability-side %)))
+         active-player-events (filter is-active-player (get-in @state [:events event]))
+         active-player-events (if (= (:active-player @state) (get-side card-ability))
+                                (cons card-ability active-player-events)
+                                active-player-events)
+         opponent-events (filter (complement is-active-player) (get-in @state [:events event]))
+         opponent-events (if (= opponent (get-side card-ability))
+                           (cons card-ability opponent-events)
+                           opponent-events)]
+     ; let active player activate their events first
+     (when-completed
+       (resolve-ability state side first-ability nil nil)
+       (do (show-wait-prompt state opponent (str (side-str active-player) " to resolve " (event-title event) " triggers")
+                             {:priority -1})
+           (when-completed
+             (trigger-event-simult-player state side event active-player-events targets)
+             (do (clear-wait-prompt state opponent)
+                 (show-wait-prompt state active-player
+                                   (str (side-str opponent) " to resolve " (event-title event) " triggers")
+                                   {:priority -1})
+                 (when-completed (trigger-event-simult-player state opponent event opponent-events targets)
+                                 (do (swap! state update-in [:turn-events] #(cons [event targets] %))
+                                     (clear-wait-prompt state active-player)
+                                     (effect-completed state side eid nil))))))))))
 
 
 ; Functions for registering trigger suppression events.

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -100,7 +100,8 @@
                     (cond advance (do (set-prop state side target :advance-counter value)
                                       (system-msg state side (str "sets advancement counters to " value " on "
                                                                   (card-str state target))))
-                          (not c-type) (toast state side "You need to specify a counter type for that card." "error")
+                          (not c-type) (toast state side "You need to specify a counter type for that card." "error"
+                                              {:time-out 0 :close-button true})
                           :else (do (set-prop state side target :counter (merge (:counter target) {c-type value}))
                                     (system-msg state side (str "sets " (name c-type) " counters to " value " on "
                                                                 (card-str state target)))))))

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -87,13 +87,47 @@
                     :choices {:req (fn [t] (card-is? t :side side))}}
                    {:title "/adv-counter command"} nil))
 
-;; This command will no longer work as specified with rewrite, need to allow for type specifying
-#_(defn command-counter [state side type value]
-  (resolve-ability state side
-                   {:effect (effect (set-prop target :counter {type value})
-                                    (system-msg (str "sets " (name type) " counters to " value " on " (card-str state target))))
-                    :choices {:req (fn [t] (card-is? t :side side))}}
-                   {:title "/counter command"} nil))
+(defn command-counter-smart [state side args]
+  (resolve-ability
+    state side
+    {:effect (req (let [existing (:counter target)
+                        value (if-let [n (string->num (first args))] n 0)
+                        c-type (cond (= 1 (count existing)) (first (keys existing))
+                                     (can-be-advanced? target) :advance-counter
+                                     (and (is-type? target "Agenda") (is-scored? state target)) :agenda
+                                     (and (card-is? target :side :runner) (has-subtype? target "Virus")) :virus)
+                        advance (= :advance-counter c-type)]
+                    (cond advance (do (set-prop state side target :advance-counter value)
+                                      (system-msg state side (str "sets advancement counters to " value " on "
+                                                                  (card-str state target))))
+                          (not c-type) (toast state side "You need to specify a counter type for that card." "error")
+                          :else (do (set-prop state side target :counter (merge (:counter target) {c-type value}))
+                                    (system-msg state side (str "sets " (name c-type) " counters to " value " on "
+                                                                (card-str state target)))))))
+     :choices {:req (fn [t] (card-is? t :side side))}}
+    {:title "/counter command"} nil))
+
+(defn command-counter [state side args]
+  (if (= 1 (count args))
+    (command-counter-smart state side args)
+    (let [typestr (.toLowerCase (first args))
+          value (if-let [n (string->num (second args))] n 0)
+          one-letter (if (<= 1 (.length typestr)) (.substring typestr 0 1) "")
+          two-letter (if (<= 2 (.length typestr)) (.substring typestr 0 2) one-letter)
+          c-type (cond (= "v" one-letter) :virus
+                       (= "p" one-letter) :power
+                       (= "c" one-letter) :credit
+                       (= "ag" two-letter) :agenda
+                       :else :advance-counter)
+          advance (= :advance-counter c-type)]
+      (if advance
+        (command-adv-counter state side value)
+        (resolve-ability state side
+                       {:effect (effect (set-prop target :counter (merge (:counter target) {c-type value}))
+                                        (system-msg (str "sets " (name c-type) " counters to " value " on "
+                                                         (card-str state target))))
+                        :choices {:req (fn [t] (card-is? t :side side))}}
+                       {:title "/counter command"} nil)))))
 
 (defn command-rezall [state side value]
   (resolve-ability state side
@@ -109,7 +143,7 @@
   (let [[command & args] (split text #" ");"
         value (if-let [n (string->num (first args))] n 1)
         num   (if-let [n (-> args first (safe-split #"#") second string->num)] (dec n) 0)]
-    (when (<= (count args) 1)
+    (when (<= (count args) 2)
       (case command
         "/draw"       #(draw %1 %2 (max 0 value))
         "/credit"     #(swap! %1 assoc-in [%2 :credit] (max 0 value))
@@ -135,7 +169,7 @@
                                                                                 (card-str state target) ": " (get-card state target))))
                                                :choices {:req (fn [t] (card-is? t :side %2))}}
                                         {:title "/card-info command"} nil)
-        ;; "/counter"    #(command-counter %1 %2 type num)
+        "/counter"    #(command-counter %1 %2 args)
         "/adv-counter" #(command-adv-counter %1 %2 value)
         "/jack-out"   #(when (= %2 :runner) (jack-out %1 %2 nil))
         "/end-run"    #(when (= %2 :corp) (end-run %1 %2))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -409,7 +409,12 @@
   "Force the discard of n cards from :deck to :discard."
   ([state side] (mill state side 1))
   ([state side n]
-   (let [milled (zone :discard (take n (get-in @state [side :deck])))]
+   (let [milltargets (take n (get-in @state [side :deck]))
+         milled (zone :discard milltargets)]
+     (doseq [c milltargets]
+       (when-let [mill (:mill-effect (card-def c))]
+         (resolve-ability state side mill c nil)
+         (trigger-event state side :mill-effect c)))
      (swap! state update-in [side :discard] #(concat % milled)))
    (swap! state update-in [side :deck] (partial drop n))))
 

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -111,12 +111,12 @@
   [state side args]
   (turn-message state side true)
   (gain state side :click (get-in @state [side :click-per-turn]))
-  (trigger-event state side (if (= side :corp) :corp-turn-begins :runner-turn-begins))
-  (when (= side :corp)
-    (draw state side))
-  (swap! state dissoc (if (= side :corp) :corp-phase-12 :runner-phase-12))
-  (when (= side :corp)
-    (update-all-advancement-costs state side)))
+  (when-completed (trigger-event-sync state side (if (= side :corp) :corp-turn-begins :runner-turn-begins))
+                  (do (when (= side :corp)
+                        (draw state side))
+                      (swap! state dissoc (if (= side :corp) :corp-phase-12 :runner-phase-12))
+                      (when (= side :corp)
+                        (update-all-advancement-costs state side)))))
 
 (defn start-turn
   "Start turn."

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -60,6 +60,28 @@
       (card-ability state :corp alix 0)
       (is (= 8 (get-in @state [:corp :credit]))))) "Gain 4 credits from Alix")
 
+(deftest bio-ethics-multiple
+  "Bio-Ethics Association: preventing damage from multiple copies"
+  (do-game
+    (new-game
+      (default-corp [(qty "Bio-Ethics Association" 2)])
+      (default-runner [(qty "Feedback Filter" 1) (qty "Sure Gamble" 3)]))
+    (play-from-hand state :corp "Bio-Ethics Association" "New remote")
+    (play-from-hand state :corp "Bio-Ethics Association" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (core/rez state :corp (get-content state :remote2 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Feedback Filter")
+    (take-credits state :runner)
+    (let [filter (get-hardware state 0)]
+      (is (= 1 (count (:prompt (get-runner)))) "Runner has a single damage prevention prompt")
+      (card-ability state :runner filter 0)
+      (prompt-choice :runner "Done")
+      (is (= 0 (count (:discard (get-runner)))) "Runner prevented damage")
+      (is (= 1 (count (:prompt (get-runner)))) "Runner has a next damage prevention prompt")
+      (prompt-choice :runner "Done")
+      (is (= 1 (count (:discard (get-runner)))) "Runner took 1 net damage"))))
+
 (deftest brain-taping-warehouse
   "Brain-Taping Warehouse - Lower rez cost of bioroid ICE by 1 for each unspent Runner click"
   (do-game

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -574,6 +574,132 @@
       (is (= 5 (:credit (get-corp))))
       (is (= 2 (:advance-counter (refresh iwall)))))))
 
+(deftest subliminal-messaging
+  "Subliminal Messaging - Playing/trashing/milling will all prompt returning to hand"
+  (do-game
+    (new-game (default-corp [(qty "Subliminal Messaging" 3)])
+              (make-deck "Noise: Hacker Extraordinaire" [(qty "Cache" 3) (qty "Utopia Shard" 1)]))
+    (play-from-hand state :corp "Subliminal Messaging")
+    (is (= 6 (:credit (get-corp))))
+    (is (= 3 (:click (get-corp))) "First Subliminal Messaging gains 1 click")
+    (play-from-hand state :corp "Subliminal Messaging")
+    (is (= 7 (:credit (get-corp))))
+    (is (= 2 (:click (get-corp))) "Second Subliminal Messaging does not gain 1 click")
+    (trash-from-hand state :corp "Subliminal Messaging")
+    (is (= 0 (count (:hand (get-corp)))))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (prompt-choice :corp "Yes")
+    (prompt-choice :corp "Yes")
+    (prompt-choice :corp "Yes")
+    (is (= 3 (count (:hand (get-corp)))) "All 3 Subliminals returned to HQ")
+    (core/move state :corp (find-card "Subliminal Messaging" (:hand (get-corp))) :deck)
+    (take-credits state :corp)
+    (play-from-hand state :runner "Cache")
+    (play-from-hand state :runner "Utopia Shard")
+    (let [utopia (get-in @state [:runner :rig :resource 0])]
+      (card-ability state :runner utopia 0))
+    (take-credits state :runner)
+    (prompt-choice :corp "Yes")
+    (prompt-choice :corp "Yes")
+    (prompt-choice :corp "Yes")
+    (is (= 3 (count (:hand (get-corp)))) "All 3 Subliminals returned to HQ")
+    (play-from-hand state :corp "Subliminal Messaging")
+    (take-credits state :corp)
+    (run-on state "R&D")
+    (run-jack-out state)
+    (take-credits state :runner)
+    (is (empty? (get-in @state [:corp :prompt])) "No prompt here because runner made a run last turn")
+    (take-credits state :corp)
+    (is (= 2 (count (:hand (get-corp)))))
+    (is (= 1 (count (:discard (get-corp)))) "1 Subliminal not returned because runner made a run last turn")))
+
+(deftest subliminal-messaging-archived
+  "Subliminal Messaging - Scenario involving Subliminal being added to HQ with Archived Memories"
+  (do-game
+    (new-game (default-corp [(qty "Subliminal Messaging" 2) (qty "Archived Memories" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Archived Memories")
+    (prompt-select :corp (find-card "Subliminal Messaging" (:discard (get-corp))))
+    (is (= 2 (count (:discard (get-corp)))))
+    (is (= 1 (count (:hand (get-corp)))))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (prompt-choice :corp "No")
+    (is (empty? (get-in @state [:corp :prompt])) "Only 1 Subliminal prompt")
+    (play-from-hand state :corp "Subliminal Messaging")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (prompt-choice :corp "Yes")
+    (prompt-choice :corp "Yes")
+    (is (empty? (get-in @state [:corp :prompt]))
+        "Only 2 Subliminal prompts - there will be a third if flag not cleared")))
+
+(deftest subliminal-messaging-jackson
+  "Subliminal Messaging - Scenario involving Subliminal being reshuffled into R&D with Jackson"
+  (do-game
+    (new-game (default-corp [(qty "Subliminal Messaging" 1) (qty "Jackson Howard" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Jackson Howard" "New remote")
+    (take-credits state :corp)
+    (let [jhow (get-content state :remote1 0)]
+      (core/rez state :corp jhow)
+      (card-ability state :corp jhow 1)
+      (prompt-select :corp (find-card "Subliminal Messaging" (:discard (get-corp))))
+      (prompt-choice :corp "Done")
+      (is (= 0 (count (:discard (get-corp)))))
+      (is (= 1 (count (:rfg (get-corp))))))
+    (take-credits state :runner)
+    (play-from-hand state :corp "Subliminal Messaging")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (prompt-choice :corp "Yes")
+    (is (= 1 (count (:hand (get-corp)))) "Subliminal returned to HQ")
+    (is (empty? (get-in @state [:corp :prompt]))
+        "Subliminal prompt cleared - there will be a second prompt if flag not cleared")))
+
+(deftest subliminal-messaging-made-run
+  "Subliminal Messaging - Runner made run, ensure game asks again next turn"
+  (do-game
+    (new-game (default-corp [(qty "Subliminal Messaging" 2)])
+              (default-runner))
+  (play-from-hand state :corp "Subliminal Messaging")
+  (trash-from-hand state :corp "Subliminal Messaging")
+  (take-credits state :corp)
+  (run-on state "R&D")
+  (run-jack-out state)
+  (take-credits state :runner)
+  (is (empty? (get-in @state [:corp :prompt])) "No prompt here because runner made a run last turn")
+  (take-credits state :corp)
+  (take-credits state :runner)
+  (prompt-choice :corp "Yes")
+  (prompt-choice :corp "Yes")
+  (is (= 2 (count (:hand (get-corp)))) "Both Subliminals returned to HQ")
+  (is (= 0 (count (:discard (get-corp)))) "No Subliminals in Archives")))
+
+(deftest subliminal-messaging-no
+  "Subliminal Messaging - User declines to return to hand, ensure game asks again next turn"
+  (do-game
+    (new-game (default-corp [(qty "Subliminal Messaging" 2)])
+              (default-runner))
+    (play-from-hand state :corp "Subliminal Messaging")
+    (trash-from-hand state :corp "Subliminal Messaging")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (prompt-choice :corp "No")
+    (prompt-choice :corp "No")
+    (is (= 0 (count (:hand (get-corp)))) "Neither Subliminal returned to HQ")
+    (is (= 2 (count (:discard (get-corp)))) "Both Subliminals in Archives")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (prompt-choice :corp "Yes")
+    (prompt-choice :corp "Yes")
+    (is (= 2 (count (:hand (get-corp)))) "Both Subliminals returned to HQ")
+    (is (= 0 (count (:discard (get-corp)))) "No Subliminals in Archives")))
+
 (deftest successful-demonstration
   "Successful Demonstration - Play if only Runner made unsuccessful run last turn; gain 7 credits"
   (do-game

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -64,8 +64,11 @@
                         [:li [:code "/trace n"] " - Start a trace with base strength n (Corp only)"]
                         [:li [:code "/psi"] " - Start a Psi game (Corp only)"]
                         [:li [:code "/close-prompt"] " - close an active prompt and show the next waiting prompt, or the core click actions"]
-                        [:li [:code "/counter n"] " - set counters on a card to n (player's own cards only)"]
-                        [:li [:code "/adv-counter n"] " - set advancement counters on a card to n (player's own cards only)"]
+                        [:li [:code "/counter n"] " - set counters on a card to n (player's own cards only). Attempts to infer the type of counter to place. If the inference fails, you must use the next command to specify the counter type."]
+                        [:li [:code "/counter type n"] " - set the specified counter type on a card to n (player's own cards only). Type must be " [:code "agenda"] ", "
+                         [:code "advance"] ", " [:code "credit"] ", " [:code "power"] ", or " [:code "virus"] ". Can be abbreviated as " [:code "ag"] ", "  [:code "ad"]
+                         ", "  [:code "c"] ", "  [:code "p"] ", or " [:code "v"] " respectively."]
+                        [:li [:code "/adv-counter n"] " - set advancement counters on a card to n (player's own cards only). Deprecated in favor of " [:code "/counter ad n"]]
                         [:li [:code "/card-info"] " - display debug info about a card (player's own cards only)"]]]}
             {:id "documentation"
              :title "Is there more documentation on how to use Jinteki.net?"


### PR DESCRIPTION
`/counter n`: attempts to infer the type of counter to place on target card. If the card already has counters, use that type. If it is an advanceable card, add advancement counters. If it is a scored agenda, use agenda counters. If it is a virus subtype, use virus counters. Otherwise, player must use:

`/counter type n`: specify the type of counter to add, as `agenda`, `advancement`, `credit`, `power`, or `virus`. Can abbreviate the type by specifying enough letters to distinguish it from the other types, e.g., `ag`, `ad`, `c`, `p`, `v`. Really, anything that starts with `ag` will be an agenda counter, so you could live life on the edge and type `/counter aggrivated-assault 10` to ad 10 agenda counters.

Adds a new ability handler key `:silent true` which will hide an event handler from a simultaneous-trigger ordering prompt. Use when a card needs to handle an event for which simultaneous-triggers have been implemented (right now, only agenda steal/score), but the event handler isn't actually part of the card's printed text, but only used for internal logic reasons. (Example: The Turning Wheel uses `:agenda-stolen` so it can know that an agenda was stolen this run. This is not an ability that the player needs to interact with because it is not an ability actually printed on the card.)

Video on fixing multiple Bio-Ethics Association damages being prevented: https://www.livecoding.tv/nealpro/videos/z8o6Y-jintekinet-resolution-of-simultaneous-triggers