### PR TITLE
Fix CVS on Archives; fix Replicator + Bazaar interaction

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -250,7 +250,8 @@
     :events {:pre-install {:req (req (and (not (zero? (get-in  card [:counter :power])))
                                           (not (get-in @state [:per-turn (:cid card)]))))
                            :effect (effect (install-cost-bonus [:credit (get-in card [:counter :power])]))}
-             :runner-install {:req (req (and (not (zero? (get-in card [:counter :power])))
+             :runner-install {:silent (req true)
+                              :req (req (and (not (zero? (get-in card [:counter :power])))
                                              (not (get-in @state [:per-turn (:cid card)]))))
                               :msg (msg "increase the install cost of " (:title target) " by " (get-in card [:counter :power]) " [Credits]")
                               :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -25,7 +25,8 @@
                               :effect (effect (draw :runner))}}}
 
    "Autoscripter"
-   {:events {:runner-install {:req (req (and (is-type? target "Program")
+   {:events {:runner-install {:silent (req true)
+                              :req (req (and (is-type? target "Program")
                                              (= (:active-player @state) :runner)
                                              ;; only trigger when played a programm from grip
                                              (some #{:hand} (:previous-zone target))
@@ -208,6 +209,7 @@
    {:in-play [:memory 1]
     :events {:runner-install
              {:req (req (= card target))
+              :silent (req true)
               :effect (effect (update! (assoc card :dopp-active true)))}
              :runner-turn-begins
              {:effect (effect (update! (assoc card :dopp-active true)))}
@@ -282,7 +284,8 @@
 
    "Grimoire"
    {:in-play [:memory 2]
-    :events {:runner-install {:req (req (has-subtype? target "Virus"))
+    :events {:runner-install {:silent (req true)
+                              :req (req (has-subtype? target "Virus"))
                               :effect (effect (add-counter target :virus 1))}}}
 
    "Heartbeat"
@@ -312,7 +315,8 @@
                                 (update-breaker-strength state side
                                                          (find-cid (:cid c) (all-installed state :runner))))))}]
        {:runner-turn-ends llds :corp-turn-ends llds
-        :runner-install {:req (req (has-subtype? target "Icebreaker"))
+        :runner-install {:silent (req true)
+                         :req (req (has-subtype? target "Icebreaker"))
                          :effect (effect (update! (update-in card [:llds-target] #(conj % target)))
                                          (update-breaker-strength target))}
         :pre-breaker-strength {:req (req (some #(= (:cid target) (:cid %)) (:llds-target card)))
@@ -535,8 +539,12 @@
 
    "Replicator"
    {:events {:runner-install
-             {:optional {:req (req (is-type? target "Hardware"))
-                         :prompt "Use Replicator to add a copy?"
+             {:interactive (req (and (is-type? target "Hardware")
+                                     (some #(= (:title %) (:title target)) (:deck runner))))
+              :silent (req (not (and (is-type? target "Hardware")
+                                     (some #(= (:title %) (:title target)) (:deck runner)))))
+              :optional {:prompt "Use Replicator to add a copy?"
+                         :req (req (and (is-type? target "Hardware") (some #(= (:title %) (:title target)) (:deck runner))))
                          :yes-ability {:msg (msg "add a copy of " (:title target) " to their Grip")
                                        :effect (effect (trigger-event :searched-stack nil)
                                                        (move (some #(when (= (:title %) (:title target)) %)

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -1073,7 +1073,8 @@
    {:abilities [end-the-run]
     :strength-bonus (req (if (some #(has-subtype? % "Fracter") (all-installed state :runner))
                            0 7))
-    :events (let [wr {:req (req (and (not= (:cid target) (:cid card))
+    :events (let [wr {:silent (req true)
+                      :req (req (and (not= (:cid target) (:cid card))
                                      (has-subtype? target "Fracter")))
                       :effect (effect (update-ice-strength card))}]
               {:runner-install wr :trash wr :card-moved wr})}

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -98,7 +98,8 @@
   [type]
   (cloud-icebreaker {:abilities [{:msg (str "break up to 3 " (lower-case type) " subroutines")
                                   :effect (effect (trash card {:cause :ability-cost}))}]
-                      :events (let [cloud {:req (req (has-subtype? target "Icebreaker"))
+                      :events (let [cloud {:silent (req true)
+                                           :req (req (has-subtype? target "Icebreaker"))
                                            :effect (effect (update-breaker-strength card))}]
                                 {:runner-install cloud :trash cloud :card-moved cloud})
                       :strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -348,7 +348,7 @@
                       card nil))}
 
    "Housekeeping"
-   {:events {:runner-install {:req (req (= side :runner))
+   {:events {:runner-install {:player :runner
                               :choices {:req #(and (in-hand? %)
                                                    (= (:side %) "Runner"))}
                               :prompt "Choose a card from your Grip to trash for Housekeeping" :once :per-turn

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -13,7 +13,7 @@
   [state side {:keys [card server]}]
   (case (:type card)
     ("Event" "Operation") (play-instant state side card {:extra-cost [:click 1]})
-    ("Hardware" "Resource" "Program") (runner-install state side card {:extra-cost [:click 1]})
+    ("Hardware" "Resource" "Program") (runner-install state side (make-eid state) card {:extra-cost [:click 1]})
     ("ICE" "Upgrade" "Asset" "Agenda") (corp-install state side card server {:extra-cost [:click 1]}))
   (trigger-event state side :play card))
 

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -209,4 +209,5 @@
   (case event
     :agenda-scored "agenda-scored"
     :agenda-stolen "agenda-stolen"
+    :runner-install "runner-install"
     (str event)))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -106,7 +106,7 @@
   [state side eid c]
   (trigger-event state side :access c)
   (trigger-event state side :pre-trash c)
-  (when (not= (:zone c) [:discard]) ; if not accessing in Archives
+  (if (not= (:zone c) [:discard]) ; if not accessing in Archives
     (if-let [trash-cost (trash-cost state side c)]
       ;; The card has a trash cost (Asset, Upgrade)
       (let [card (assoc c :seen true)
@@ -130,7 +130,8 @@
                                                              " [Credits] to trash " name)))}}}
             card nil)))
       ;; The card does not have a trash cost
-      (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid}))))
+      (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid}))
+    (effect-completed state side eid)))
 
 (defn- access-agenda
   [state side eid c]
@@ -311,6 +312,7 @@
 
 (defn access-helper-rd [cards]
   {:prompt "Select a card to access."
+   :delayed-completion true
    :choices (concat (when (some #(= (first (:zone %)) :deck) cards) ["Card from deck"])
                     (map #(if (rezzed? %) (:title %) "Unrezzed upgrade in R&D")
                          (filter #(= (last (:zone %)) :content) cards)))
@@ -365,6 +367,7 @@
 
 (defn access-helper-archives [cards]
   {:prompt "Select a card to access. You must access all cards."
+   :delayed-completion true
    :choices (map #(if (= (last (:zone %)) :content)
                    (if (rezzed? %) (:title %) "Unrezzed upgrade in Archives")
                    (:title %)) cards)
@@ -401,7 +404,7 @@
                       (when-completed (handle-access state side [(some #(when (= (:title %) target) %) cards)])
                                       (if (< 1 (count cards))
                                         (continue-ability state side (access-helper-archives
-                                                                      (remove-once #(not= (:title %) target) cards))
+                                                                       (remove-once #(not= (:title %) target) cards))
                                                          card nil)
                                         (effect-completed state side eid nil))))))})
 

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -299,6 +299,37 @@
     (is (= 2 (:click (get-runner))) "Clickless installs of extra 2 copies")
     (is (= 3 (:credit (get-runner))) "Paid 2c for each of 3 copies")))
 
+(deftest replicator-bazaar
+  "Replicator - interaction with Bazaar. Issue #1511."
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Replicator" 1) (qty "Bazaar" 1) (qty "Spy Camera" 6)]))
+    (letfn [(count-spy [n] (= n (count (filter #(= "Spy Camera" (:title %)) (-> (get-runner) :rig :hardware)))))]
+      (take-credits state :corp)
+      (starting-hand state :runner ["Replicator" "Bazaar" "Spy Camera"])
+      (play-from-hand state :runner "Replicator")
+      (play-from-hand state :runner "Bazaar")
+      (play-from-hand state :runner "Spy Camera") ;; 1 installed
+      (is (count-spy 1) "1 Spy Cameras installed")
+      (prompt-choice :runner "Yes") ;; for now, choosing Replicator then shows its optional Yes/No
+      (prompt-choice :runner "Yes") ;; Bazaar triggers, 2 installed
+      (is (count-spy 2) "2 Spy Cameras installed")
+      (prompt-choice :runner "Yes")
+      (prompt-choice :runner "Yes")  ;; 3 installed
+      (is (count-spy 3) "3 Spy Cameras installed")
+
+      (prompt-choice :runner "Yes")
+      (prompt-choice :runner "Yes")  ;; 4 installed
+      (is (count-spy 4) "4 Spy Cameras installed")
+
+      (prompt-choice :runner "Yes")
+      (prompt-choice :runner "Yes")  ;; 5 installed
+      (is (count-spy 5) "5 Spy Cameras installed")
+
+      (prompt-choice :runner "Yes")
+      (prompt-choice :runner "Yes")  ;; 6 installed
+      (is (count-spy 6) "6 Spy Cameras installed"))))
+
 (deftest spinal-modem
   "Spinal Modem - +1 MU, 2 recurring credits, take 1 brain damage on successful trace during run"
   (do-game

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -237,6 +237,27 @@
       (is (zero? (virus-counters (find-card "Medium" (get-in @state [:runner :rig :program]))))
           "Medium has no counters"))))
 
+(deftest cyberdex-virus-suite-archives-access
+  "Cyberdex Virus Suite - Don't interrupt archives access. Issue #1647."
+  (do-game
+    (new-game (default-corp [(qty "Cyberdex Virus Suite" 1) (qty "Braintrust" 1)])
+              (default-runner [(qty "Cache" 1)]))
+    (trash-from-hand state :corp "Cyberdex Virus Suite")
+    (trash-from-hand state :corp "Braintrust")
+    (take-credits state :corp)
+    ;; runner's turn
+    ;; install cache
+    (play-from-hand state :runner "Cache")
+    (let [cache (get-program state 0)]
+      (is (= 3 (get-counters (refresh cache) :virus)))
+      (run-empty-server state "Archives")
+      (prompt-choice :runner "Cyberdex Virus Suite")
+      (prompt-choice :corp "Yes")
+      (is (pos? (count (:prompt (get-runner)))) "CVS purge did not interrupt archives access")
+      ;; purged counters
+      (is (zero? (get-counters (refresh cache) :virus))
+          "Cache has no counters"))))
+
 (deftest ghost-branch-dedicated-response-team
   "Ghost Branch - with Dedicated Response Team"
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -83,8 +83,9 @@
 
 (defn get-hardware
   "Get hardware by position."
-  [state pos]
-  (get-in @state [:runner :rig :hardware pos]))
+  ([state] (get-in @state [:runner :rig :hardware]))
+  ([state pos]
+   (get-in @state [:runner :rig :hardware pos])))
 
 (defn get-resource
   "Get non-hosted resource by position."


### PR DESCRIPTION
Extended the simultaneous trigger resolution to the runner-install event, to allow manual ordering for interactions like Replicator + Bazaar. Slightly reworked Haley to work better with this system. Tweaked many cards so they don't show up in the manual resolution prompt (like Kate). 

Fixed CVS on Archives breaking further accesses.