### PR TITLE
Expose prevention

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -1,5 +1,7 @@
 (in-ns 'game.core)
 
+(declare expose-prevent)
+
 ;;; Asset-specific helpers
 (defn installed-access-trigger
   "Effect for triggering ambush on access.
@@ -1013,6 +1015,27 @@
                               (rez-cost-bonus state side -2) (rez state side (last (:hosted (get-card state card))))
                               (when (:rezzed (last (:hosted (get-card state card))))
                                 (update! state side (dissoc (get-card state (last (:hosted card))) :facedown))))}]}
+
+   "Zaibatsu Loyalty"
+   {:prevent {:expose [:all]}
+    :derezzed-events
+    {:pre-expose
+     {:delayed-completion true
+      :effect (req (let [etarget target]
+                     (continue-ability state side
+                       {:optional {:req (req (not (rezzed? card)))
+                                   :player :corp
+                                   :prompt (msg "The Runner is about to expose " (:title etarget) ". Rez Zaibatsu Loyalty?")
+                                   :yes-ability {:effect (effect (rez card))}}}
+                       card nil)))}}
+    :abilities [{:msg "prevent 1 card from being exposed"
+                 :cost [:credit 1]
+                 :effect (effect (expose-prevent 1))}
+                {:msg "prevent 1 card from being exposed"
+                 :label "[Trash]: Prevent 1 card from being exposed"
+                 :effect (effect (trash card {:cause :ability-cost})
+                                 (expose-prevent 1))}]}
+
    "Zealous Judge"
    {:rez-req (req tagged)
     :abilities [{:label "Give the Runner 1 tag"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -304,7 +304,7 @@
 
    "Lemuria Codecracker"
    {:abilities [{:cost [:click 1 :credit 1] :req (req (some #{:hq} (:successful-run runner-reg)))
-                 :choices {:req installed?} :effect (effect (expose target))
+                 :choices {:req installed?} :effect (effect (expose eid target))
                  :msg "expose 1 card"}]}
 
    "LLDS Processor"

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -623,7 +623,9 @@
                  :effect (effect (lose :runner :credit 1))}]}
 
    "Its a Trap!"
-   {:expose {:msg "do 2 net damage" :effect (effect (damage eid :net 2 {:card card}))}
+   {:expose {:msg "do 2 net damage"
+             :delayed-completion true
+             :effect (effect (damage eid :net 2 {:card card}))}
     :abilities [(assoc trash-installed :effect (req (trash state side target {:cause :subroutine})
                                                     (when current-ice
                                                       (trash-ice-in-run state))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -647,12 +647,14 @@
 
    "Snitch"
    {:abilities [{:once :per-run :req (req (and (ice? current-ice) (not (rezzed? current-ice))))
-                 :msg (msg "expose " (:title current-ice))
-                 :effect (effect (expose current-ice)
-                                 (resolve-ability {:optional {:prompt "Jack out?"
-                                                              :yes-ability {:msg "jack out"
-                                                                            :effect (effect (jack-out nil))}}}
-                                                  card nil))}]}
+                 :delayed-completion true
+                 :effect (req (when-completed (expose state side current-ice)
+                                              (continue-ability
+                                                state side
+                                                {:optional {:prompt "Jack out?"
+                                                            :yes-ability {:msg "jack out"
+                                                                          :effect (effect (jack-out nil))}}}
+                                                card nil)))}]}
 
    "Surfer"
    (letfn [(surf [state cice]

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -787,11 +787,10 @@
                                                  (resolve-ability state :runner (choose-access c '(:hq)) card nil)))}
                                  card nil)))))
     :leave-play (req (remove-watch state :raymond-flint))
-    :abilities [{:label "Expose 1 card"
-                 :effect (effect (resolve-ability
-                                   {:choices {:req installed?}
-                                    :effect (effect (expose target) (trash card {:cause :ability-cost}))
-                                    :msg (msg "expose " (:title target))} card nil))}]}
+    :abilities [{:msg "expose 1 card"
+                 :choices {:req installed?}
+                 :delayed-completion true
+                 :effect (effect (expose eid target) (trash card {:cause :ability-cost}))}]}
 
    "Rolodex"
    {:msg "look at the top 5 cards of their Stack"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -1,4 +1,5 @@
 (in-ns 'game.core)
+(declare expose-prevent)
 
 (def cards-upgrades
   {"Akitaro Watanabe"
@@ -424,6 +425,11 @@
                                 (has-subtype? current-ice "Bioroid")))
                  :effect (effect (trash card))
                  :msg (msg "prevent a subroutine on " (:title current-ice) " from being broken")}]}
+
+   "Underway Grid"
+   {:events {:pre-expose {:req (req (= (take 2 (:zone target)) (take 2 (:zone card))))
+                          :msg "prevent 1 card from being exposed"
+                          :effect (effect (expose-prevent 1))}}}
 
    "Valley Grid"
    {:abilities [{:req (req this-server)

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -215,11 +215,11 @@
 ;;; Effect completion triggers
 (defn register-effect-completed
   [state side eid card effect]
-  (swap! state update-in [:effect-completed eid] #(conj % {:card card :effect effect})))
+  (swap! state update-in [:effect-completed (:eid eid)] #(conj % {:card card :effect effect})))
 
 (defn effect-completed
   ([state side eid] (effect-completed state side eid nil))
   ([state side eid card]
-   (doseq [handler (get-in @state [:effect-completed eid])]
+   (doseq [handler (get-in @state [:effect-completed (:eid eid)])]
      ((:effect handler) state side eid (:card card) nil))
-   (swap! state update-in [:effect-completed] dissoc eid)))
+   (swap! state update-in [:effect-completed] dissoc (:eid eid))))

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -69,6 +69,10 @@
   [state]
   {:eid (:eid (swap! state update-in [:eid] inc))})
 
+(defn make-result
+  [eid result]
+  (assoc eid :result result))
+
 ;; Appears to be unused???
 (def reset-value
   {:corp {:credit 5 :bad-publicity 0

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -8,7 +8,7 @@
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))
 
-(declare get-card get-remote-names make-eid register-effect-completed resolve-ability say system-msg trigger-event update!)
+(declare get-card get-remote-names make-eid make-result register-effect-completed resolve-ability say system-msg trigger-event update!)
 
 (def game-states (atom {}))
 (def all-cards (atom {}))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -57,7 +57,9 @@
 
 (defmacro when-completed
   ([action expr]
-   (let [reqmac `(fn [~'state1 ~'side1 ~'eid1 ~'card1 ~'targets1] ~expr)
+   (let [reqmac `(fn [~'state1 ~'side1 ~'eid1 ~'card1 ~'target1]
+                   (let [~'async-result (:result ~'eid1)]
+                     ~expr))
    ;; this creates a five-argument function to be resolved later,
    ;; without overriding any local variables name state, card, etc.
          totake (if (= 'apply (first action)) 4 3)

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -686,6 +686,21 @@
       (is (= 2 (count (:discard (get-runner)))) "1 brain damage suffered")
       (is (= 1 (:brain-damage (get-runner)))))))
 
+(deftest underway-grid
+  "Underway Grid - prevent expose of cards in server"
+  (do-game
+    (new-game (default-corp [(qty "Eve Campaign" 1)
+                             (qty "Underway Grid" 1)])
+              (default-runner [(qty "Drive By" 1)]))
+    (play-from-hand state :corp "Underway Grid" "New remote")
+    (play-from-hand state :corp "Eve Campaign" "Server 1")
+    (take-credits state :corp)
+    (core/rez state :corp (get-content state :remote1 0))
+    (let [eve1 (get-content state :remote1 1)]
+      (play-from-hand state :runner "Drive By")
+      (prompt-select :runner eve1)
+      (is (empty? (:discard (get-corp))) "Expose and trash prevented"))))
+
 (deftest valley-grid-trash
   "Valley Grid - Reduce Runner max hand size and restore it even if trashed"
   (do-game
@@ -704,3 +719,4 @@
       (prompt-choice :runner "Yes") ; pay to trash
       (take-credits state :runner 3)
       (is (= 5 (core/hand-size state :runner)) "Runner max hand size increased by 2 at start of Corp turn"))))
+


### PR DESCRIPTION
1. Introduce `:pre-expose` event and `expose-prevent` function for reacting to an attempt to expose.
2. Zaibatsu Loyalty: an `:unrezzed-event` to handle pre-expose and show a prompt to rez Loyalty before the expose goes through.
3. Underway Grid: automatically prevents exposing cards in/protecting server.
4. All expose cards have been reworked to only reveal the target exposed if the expose effect resolves.

A lot of work for 2 unused cards! However, this system did require a useful upgrade to the `when-completed` framework which allows async effects to __return__ values when they indicate that they have finished. This is necessary for Drive By, which must know whether the expose completed before triggering the trash. The await handler of a `when-completed` block now has access to a variable `async-result`, which can be optionally provided by a function when it triggers `effect-completed` by associating `:result _____` onto the effect's eid.