### PR TITLE
Fix Puppet Master; implement Dedicated Neural Net; add "card-title" prompts for Targeted Marketing, Salem's Hospitality

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -468,11 +468,13 @@
 
    "Puppet Master"
    {:events {:successful-run
-             {:effect (req (show-wait-prompt state :runner "Corp to use Puppet Master")
+             {:delayed-completion true
+              :effect (req (show-wait-prompt state :runner "Corp to use Puppet Master")
                            (continue-ability
                              state :corp
                              {:prompt "Choose a card to place 1 advancement token on with Puppet Master" :player :corp
                               :choices {:req can-be-advanced?}
+                              :cancel-effect (final-effect (clear-wait-prompt :runner))
                               :msg (msg "place 1 advancement token on " (card-str state target))
                               :effect (final-effect (add-prop :corp target :advance-counter 1 {:placed true})
                                                     (clear-wait-prompt :runner))} card nil))}}}

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -132,6 +132,38 @@
      :events {:runner-turn-begins e
               :corp-turn-begins   e}})
 
+   "Dedicated Neural Net"
+     (letfn [(access-hq [cards]
+               {:prompt "Select a card to access."
+                :player :runner
+                :choices [(str "Card from HQ")]
+                :effect (req (system-msg state side (str "accesses " (:title (first cards))))
+                             (when-completed
+                               (handle-access state side [(first cards)])
+                               (do (if (< 1 (count cards))
+                                     (continue-ability state side (access-hq (next cards)) card nil)
+                                     (effect-completed state side eid card)))))})]
+       (let [psi-effect
+             {:delayed-completion true
+              :mandatory true
+              :effect (req (if (not-empty (:hand corp))
+                             (do (show-wait-prompt state :runner "Corp to select cards in HQ to be accessed")
+                                 (continue-ability
+                                   state :corp
+                                   {:prompt (msg "Select " (access-count state side :hq-access) " cards in HQ for the Runner to access")
+                                    :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
+                                              :max (req (access-count state side :hq-access))}
+                                    :effect (effect (clear-wait-prompt :runner)
+                                                    (continue-ability :runner (access-hq (shuffle targets)) card nil))}
+                                   card nil))
+                             (effect-completed state side eid card)))}]
+         {:events {:successful-run {:req (req (= target :hq))
+                                    :once :per-turn
+                                    :psi {:not-equal {:effect (req (when-not (:replace-access (get-in @state [:run :run-effect]))
+                                                                     (swap! state update-in [:run :run-effect]
+                                                                            #(assoc % :replace-access psi-effect)))
+                                                                   (effect-completed state side eid))}}}}}))
+
    "Director Haas Pet Project"
    (let [dhelper (fn dpp [n] {:prompt "Select a card to install"
                               :show-discard true

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -407,7 +407,7 @@
    (letfn [(access-pile [cards pile]
              {:prompt "Select a card to access. You must access all cards."
               :choices [(str "Card from pile " pile)]
-              :effect (req (system-msg state side "accesses " (:title (first cards)))
+              :effect (req (system-msg state side (str "accesses " (:title (first cards))))
                            (when-completed
                              (handle-access state side [(first cards)])
                              (do (if (< 1 (count cards))

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -114,8 +114,7 @@
   "Checks if there is an optional ability to resolve"
   [state side {:keys [eid] :as ability} card targets]
   (when-let [optional (:optional ability)]
-    (if (and (not (get-in @state [(:once optional) (or (:once-key optional) (:cid card))]))
-               (check-req state side card targets optional))
+    (if (can-trigger? state side optional card targets)
       (optional-ability state (or (:player optional) side) eid card (:prompt optional) optional targets)
       (effect-completed state side eid card))))
 
@@ -123,7 +122,7 @@
   "Checks if a psi-game is to be resolved"
   [state side {:keys [eid] :as ability} card targets]
   (when-let [psi (:psi ability)]
-    (if (check-req state side card targets psi)
+    (if (can-trigger? state side psi card targets)
       (psi-game state side eid card psi)
       (effect-completed state side eid card))))
 
@@ -131,7 +130,7 @@
   "Checks if there is a trace to resolve"
   [state side {:keys [eid] :as ability} card targets]
   (when-let [trace (:trace ability)]
-    (if (check-req state side card targets trace)
+    (if (can-trigger? state side trace card targets)
       (corp-trace-prompt state card (assoc trace :eid (:eid ability)))
       (effect-completed state side eid card))))
 

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -161,6 +161,12 @@
        (:number choices)
        (let [n ((:number choices) state side eid card targets)]
          (prompt! state s card prompt {:number n} ab args))
+       (:card-title choices)
+       (prompt!
+         state s card prompt
+         (assoc choices :autocomplete
+                        (sort (map :title (filter #((:card-title choices) state side (make-eid state) nil [%]) @all-cards))))
+         ab (assoc args :prompt-type :card-title))
        ;; unknown choice
        :else nil)
      ;; Not a map; either :credit, :counter, or a vector of cards or strings.
@@ -293,6 +299,7 @@
                   :end-effect end-effect}]
      (when (or (= prompt-type :waiting)
                (:number choices)
+               (:card-title choices)
                (#{:credit :counter} choices)
                (pos? (count choices)))
        (swap! state update-in [side :prompt]

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -450,6 +450,18 @@
           (core/score state :corp {:card (refresh pb2)})
           (is (= 5 (:agenda-point (get-corp))) "5 advancements: scored for 3 points")))))
 
+(deftest puppet-master
+  "Puppet Master - game progresses if no valid targets. Issue #1661."
+  (do-game
+    (new-game (default-corp [(qty "Puppet Master" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Puppet Master" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (run-empty-server state :archives)
+    (prompt-choice :corp "Done")
+    (is (empty? (:prompt (get-runner))) "Runner's waiting prompt resolved")))
+
 (deftest tgtbt
   "TGTBT - Give the Runner 1 tag when they access"
   (do-game

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -154,6 +154,31 @@
     (score-agenda state :corp (get-content state :remote2 0))
     (is (= 14 (:credit (get-corp))) "Had 7 credits when scoring, gained another 7")))
 
+(deftest dedicated-neural-net
+  "Dedicated Neural Net"
+  (do-game
+    (new-game (default-corp [(qty "Dedicated Neural Net" 2) (qty "Snare!" 1) (qty "Hedge Fund" 3)])
+              (default-runner [(qty "HQ Interface" 1)]))
+    (play-from-hand state :corp "Dedicated Neural Net" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (run-empty-server state :hq)
+    (prompt-choice :runner "0")
+    (prompt-choice :corp "1")
+    (is (-> @state :run :run-effect :replace-access) "Replace-access tiggered")
+    (prompt-select :corp (find-card "Hedge Fund" (:hand (get-corp))))
+    (prompt-choice :runner "Card from HQ")
+    (is (accessing state "Hedge Fund") "Runner accessing Hedge Fund")
+    (prompt-choice :runner "OK")
+    (is (not (:run @state)) "Run completed")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (play-from-hand state :runner "HQ Interface")
+    (run-empty-server state :hq)
+    (prompt-choice :runner "0")
+    (prompt-choice :corp "1")
+    (is (= 2 (-> (get-corp) :selected first :max)) "Corp chooses 2 cards for Runner to access")))
+
 (deftest eden-fragment
   "Test that Eden Fragment ignores the install cost of the first ice"
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -187,4 +187,9 @@
   (doseq [ctitle cards]
     (core/move state side (find-card ctitle (get-in @state [side :deck])) :hand)))
 
+(defn accessing
+  "Checks to see if the runner has a prompt accessing the given card title"
+  [state title]
+  (= title (-> @state :runner :prompt first :card :title)))
+
 (load "core-game")

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -917,9 +917,12 @@
                             (:card-title (:choices prompt))
                             [:div
                              [:div.credit-select
-                              [:input#card-title {:placeholder "Enter a card title"}]]
-                             [:button {:on-click #(send-command "choice"
-                                                                {:choice (-> "#card-title" js/$ .val)})}
+                              [:input#card-title {:placeholder "Enter a card title"
+                                                  :onKeyUp #(when (= 13 (.-keyCode %))
+                                                             (-> "#card-submit" js/$ .click)
+                                                             (.stopPropagation %))}]]
+                             [:button#card-submit {:on-click #(send-command "choice"
+                                                                            {:choice (-> "#card-title" js/$ .val)})}
                               "OK"]
                              (when-let [autocomp (:autocomplete (:choices prompt))]
                                (-> "#card-title" js/$ (.autocomplete (clj->js {"source" autocomp})))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -858,6 +858,8 @@
       (if (= "select" (get-in cursor [side :prompt 0 :prompt-type]))
         (set! (.-cursor (.-style (.-body js/document))) "url('/img/gold_crosshair.png') 12 12, crosshair")
         (set! (.-cursor (.-style (.-body js/document))) "default"))
+      (when (= "card-title" (get-in cursor [side :prompt 0 :prompt-type]))
+        (-> "#card-title" js/$ .focus))
       (doseq [{:keys [msg type options]} (get-in cursor [side :toast])]
         (toast msg type options)))
 
@@ -912,6 +914,16 @@
                                                                 {:choice (-> "#credit" js/$ .val js/parseInt)})}
                               "OK"]]
                             ;; choice of specified counters on card
+                            (:card-title (:choices prompt))
+                            [:div
+                             [:div.credit-select
+                              [:input#card-title {:placeholder "Enter a card title"}]]
+                             [:button {:on-click #(send-command "choice"
+                                                                {:choice (-> "#card-title" js/$ .val)})}
+                              "OK"]
+                             (when-let [autocomp (:autocomplete (:choices prompt))]
+                               (-> "#card-title" js/$ (.autocomplete (clj->js {"source" autocomp})))
+                               nil)]
                             (:counter (:choices prompt))
                             (let [counter-type (keyword (:counter (:choices prompt)))
                                   num-counters (get-in prompt [:card :counter counter-type] 0)]


### PR DESCRIPTION
Fix #1661. Gives selection prompts the ability to define a `:cancel-effect` that runs if Done is clicked with no selected targets.

@JoelCFC25's implementation of Dedicated Neural Net. Required enforcing `:once` keys for psi/trace abilities (not sure how that one was missed).