### PR TITLE
Fixes: Executive Retreat, Deep Red, Scavenge

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -228,7 +228,7 @@
                                 :effect (effect (ice-strength-bonus 1 target))}}}
 
    "Executive Retreat"
-   {:effect (effect (add-prop card :counter 1)
+   {:effect (effect (add-counter card :agenda 1)
                     (shuffle-into-deck :hand))
     :abilities [{:cost [:click 1] :counter-cost [:agenda 1] :msg "draw 5 cards" :effect (effect (draw 5))}]}
 

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -783,7 +783,8 @@
                                    (expose state side eid card2))))}
 
    "Scavenge"
-   {:req (req (pos? (count (filter #(is-type? % "Program") (all-installed state :runner)))))
+   {:req (req (and (some #(is-type? % "Program") (all-installed state :runner))
+                   (some #(is-type? % "Program") (concat (:hand runner) (:discard runner)))))
     :prompt "Choose an installed program to trash"
     :choices {:req #(and (is-type? % "Program")
                          (installed? %))}
@@ -791,7 +792,7 @@
                    (trash state side trashed)
                    (resolve-ability
                      state side
-                     {:prompt "Choose a program to install from your grip or heap"
+                     {:prompt "Choose a program to install from your Grip or Heap"
                       :show-discard true
                       :choices {:req #(and (is-type? % "Program")
                                            (#{[:hand] [:discard]} (:zone %))

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -171,11 +171,17 @@
     :events {:runner-install
              {:optional
               {:req (req (has-subtype? target "Caïssa"))
+               :delayed-completion true
                :prompt "Use Deep Red to trigger the [Click] ability of the installed Caïssa?"
-               :yes-ability {:effect (req (let [caissa (first (map last (turn-events state :runner :runner-install)))]
-                                            (system-msg state side (str "uses Deep Red to trigger the [Click] ability of " (:title caissa)))
-                                            (gain state :runner :click 1)
-                                            (play-ability state side {:card (get-card state caissa) :ability 0})))}}}}}
+               :yes-ability {:effect (req (let [cid (:cid (first (map last (turn-events state :runner :pre-install))))
+                                                caissa (find-cid cid (all-installed state :runner))]
+                                            (continue-ability state side
+                                              {:msg (msg "trigger the [Click] ability of " (:title caissa)
+                                                         " without spending [Click]")
+                                               :effect (effect (gain :click 1)
+                                                               (play-ability {:card (get-card state caissa) :ability 0}))}
+                                             card nil)))}
+               :no-ability {:effect (req (effect-completed state side eid card))}}}}}
 
    "Desperado"
    {:in-play [:memory 1]

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -795,7 +795,8 @@
   "Test Run - Make sure program remains installed if Scavenged"
   (do-game
     (new-game (default-corp)
-              (default-runner [(qty "Test Run" 1) (qty "Morning Star" 1) (qty "Scavenge" 1)]))
+              (default-runner [(qty "Test Run" 1) (qty "Morning Star" 1)
+                               (qty "Scavenge" 1) (qty "Inti" 1)]))
     (take-credits state :corp)
     (core/move state :runner (find-card "Morning Star" (:hand (get-runner))) :discard)
     (play-from-hand state :runner "Test Run")

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -190,7 +190,7 @@
   "Trashing a card should remove it from [:per-turn] - Issue #1345"
   (do-game
     (new-game (default-corp [(qty "Hedge Fund" 3)])
-              (default-runner [(qty "Imp" 1) (qty "Scavenge" 1)]))
+              (default-runner [(qty "Imp" 2) (qty "Scavenge" 1)]))
     (take-credits state :corp)
     (core/gain state :runner :click 1)
     (play-from-hand state :runner "Imp")


### PR DESCRIPTION
* Fixes problem with Executive Retreat disappearing when scored.
* Fixes #1677: Update Deep Red to use the `:delayed-completion` framework. 
* Update Scavenge (and tests) to respect the ruling with regard to when it can be played. With the "potential to change game state" stuff in the official FAQ, Scavenge is only playable if you have a program in your Grip or Heap ([some background here](https://www.reddit.com/r/Netrunner/comments/4bis6a/can_we_have_or_is_there_already_an_official/))