### PR TITLE
fix New Construction, Freelance Coding Contract, Cerebral Imaging, Qianju PT

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -403,10 +403,10 @@
                              :msg (msg "install a card from HQ" (when (>= (:advance-counter (get-card state card)) 5)
                                        " and rez it, ignoring all costs"))
                              :effect (req (if (>= (:advance-counter (get-card state card)) 5)
-                                            (do (corp-install state side eid target "New remote"
+                                            (do (corp-install state side target "New remote"
                                                               {:install-state :rezzed-no-cost})
                                                 (trigger-event state side :rez target))
-                                            (corp-install state side eid target "New remote")))}}}}}
+                                            (corp-install state side target "New remote")))}}}}}
 
    "Nisei MK II"
    {:effect (effect (add-counter card :agenda 1))

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -490,14 +490,15 @@
     :abilities [{:label "Lose [Click], avoid 1 tag (start of turn)"
                  :once :per-turn
                  :req (req (:runner-phase-12 @state))
-                 :effect (effect (lose :click 1)
-                                 (update! (assoc card :qianju-active true)))
-                 :msg "avoid the first tag received until their next turn"}]
-    :events {:corp-turn-ends {:effect (effect (update! (dissoc card :qianju-active)))}}
+                 :effect (effect (update! (assoc card :qianju-active true)))
+                 :msg "lose [Click] and avoid the first tag received until their next turn"}]
+    :events {:corp-turn-ends {:effect (effect (update! (dissoc card :qianju-active)))}
+             :runner-turn-begins {:req (req (:qianju-active card))
+                                  :effect (effect (lose :click 1))}
              :pre-tag {:req (req (:qianju-active card))
-                       :msg "to avoid the first tag received"
+                       :msg "avoid the first tag received"
                        :effect (effect (tag-prevent 1)
-                                       (update! (dissoc card :qianju-active)))}}
+                                       (update! (dissoc card :qianju-active)))}}}
 
    "R&D Interface"
    {:in-play [:rd-access 1]}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -85,12 +85,15 @@
                :pre-start-game {:effect draft-points-target}})}
 
    "Cerebral Imaging: Infinite Frontiers"
-   {:effect (req (add-watch state :cerebral-imaging
+   {:effect (req (when (> (:turn @state) 1)
+                   (swap! state assoc-in [:corp :hand-size-base] (:credit corp)))
+                 (add-watch state :cerebral-imaging
                             (fn [k ref old new]
                               (let [credit (get-in new [:corp :credit])]
                                 (when (not= (get-in old [:corp :credit]) credit)
                                   (swap! ref assoc-in [:corp :hand-size-base] credit))))))
-    :leave-play (effect (remove-watch state :cerebral-imaging))}
+    :leave-play (req (remove-watch state :cerebral-imaging)
+                     (swap! state assoc-in [:corp :hand-size-base] 5))}
 
    "Chaos Theory: Wünderkind"
    {:effect (effect (gain :memory 1))


### PR DESCRIPTION
* Fix #1681: Drop the `eid` parameter to `corp-install` so New Construction can successfully install something when advanced.
* Fix #1682: Make FCC trash all selected programs sequentially with the `:unpreventable true` parameter. 
* Fix #1410: Qianju PT had a misplaced closing brace that was keeping it from preventing a tag, and also wasn't losing the click if used.
* Fix watch state removal error when Employee Strike disables Cerebral Imaging, and also corrects base hand size adjustments when CI is disabled and later re-enabled.