### PR TITLE
Don't trigger I've Had Worse if Runner flatlines

### DIFF
--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -160,14 +160,16 @@
                   (do (if-not (or (get-in @state [:damage :damage-replace]))
                         (let [n (if-let [defer (get-defer-damage state side type args)] defer n)]
                           (let [hand (get-in @state [:runner :hand])]
-                            (when (< (count hand) n)
-                              (flatline state))
                             (when (= type :brain)
                               (swap! state update-in [:runner :brain-damage] #(+ % n))
                               (swap! state update-in [:runner :hand-size-modification] #(- % n)))
-                            (doseq [c (take n (shuffle hand))]
-                              (trash state side c {:unpreventable true :cause type} type))
-                            (trigger-event state side :damage type card))))
+                            (if (< (count hand) n)
+                              (do (flatline state)
+                                  (doseq [c (take n (shuffle hand))]
+                                    (trash state side c {:unpreventable true} type)))
+                              (do (doseq [c (take n (shuffle hand))]
+                                    (trash state side c {:unpreventable true :cause type} type))
+                                  (trigger-event state side :damage type card))))))
                       (swap! state update-in [:damage :defer-damage] dissoc type)
                       (effect-completed state side eid card))))
 

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -417,6 +417,27 @@
     (is (= 6 (:credit (get-runner)))
         "Paid 1 credit to play Inject, gained 2 credits from trashed programs")))
 
+(deftest ive-had-worse
+  "I've Had Worse - Draw 3 cards when lost to net/meat damage; don't trigger if flatlined"
+  (do-game
+    (new-game (default-corp [(qty "Scorched Earth" 3) (qty "Pup" 3)])
+              (default-runner [(qty "I've Had Worse" 2) (qty "Sure Gamble" 3) (qty "Imp" 2)]))
+    (core/gain state :runner :tag 1)
+    (core/gain state :corp :credit 5)
+    (starting-hand state :runner ["I've Had Worse"])
+    (play-from-hand state :corp "Pup" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (card-ability state :corp (get-ice state :hq 0) 0)
+    (is (= 1 (count (:discard (get-runner)))))
+    (is (= 3 (count (:hand (get-runner)))) "I've Had Worse triggered and drew 3 cards")
+    (starting-hand state :runner ["I've Had Worse" "Imp" "Imp"])
+    (play-from-hand state :corp "Scorched Earth")
+    (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+    (is (= :corp (:winner @state)) "Corp wins")
+    (is (= "Flatline" (:reason @state)) "Win condition reports flatline")
+    (is (= 4 (count (:discard (get-runner)))) "All 3 cards in Grip trashed by Scorched Earth")
+    (is (= 3 (count (:deck (get-runner)))) "No cards drawn from I've Had Worse")))
+
 (deftest lawyer-up
   "Lawyer Up - Lose 2 tags and draw 3 cards"
   (do-game
@@ -558,7 +579,7 @@
 
   (deftest rebirth-kate
     "Rebirth - Kate's discount applies after rebirth"
-    (do-game 
+    (do-game
       (new-game (default-corp) (default-runner ["Magnum Opus" "Rebirth"]) {:start-as :runner})
 
       (play-from-hand state :runner "Rebirth")


### PR DESCRIPTION
Fixes #1050. 

When resolving damage, we check if the amount of damage exceeds the Runner's hand size (e.g, Scorched Earth against a Runner with 3 cards). If so, flatline the Runner and discard all their cards unpreventably, but do nothing more. If the Runner survives, also trash cards unpreventably, but add in the `:cause` parameter, which is what I've Had Worse is looking for so it will draw 3.  