### PR TITLE
Only do trash effect of a Corp card if it's rezzed

### DIFF
--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -264,7 +264,8 @@
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
-      (resolve-ability state side trash-effect moved-card (cons cause targets)))
+      (when (or (= (:side card) "Runner") (:rezzed card))
+        (resolve-ability state side trash-effect moved-card (cons cause targets))))
     (swap! state update-in [:per-turn] dissoc (:cid moved-card))))
 
 (defn resolve-trash

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -506,10 +506,10 @@
     (play-from-hand state :corp "Red Herrings" "New remote")
     (play-from-hand state :corp "House of Knives" "Server 1")
     (take-credits state :corp 1)
-
     (core/gain state :runner :credit 1)
     (let [rh (get-content state :remote1 0)
           hok (get-content state :remote1 1)]
+      (core/rez state :corp rh)
       (run-empty-server state "Server 1")
       ;; runner now chooses which to access.
       (prompt-select :runner rh)
@@ -719,4 +719,3 @@
       (prompt-choice :runner "Yes") ; pay to trash
       (take-credits state :runner 3)
       (is (= 5 (core/hand-size state :runner)) "Runner max hand size increased by 2 at start of Corp turn"))))
-


### PR DESCRIPTION
Fixes #1485. 

I uncovered an error in an existing test (Red Herrings) while fixing this--it was giving the Red Herrings steal penalty without the card even being rezzed. Before resolving a trash effect ability, check that it's either a Runner card or a _rezzed_ Corp card. Without this, a Runner trashing an unrezzed Red Herrings or Strongbox before accessing an agenda was wrongly seeing the effect of those cards when trying to do a steal. 