### PR TITLE
Require ambush assets to be advanced before effects fire

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -67,7 +67,8 @@
                                       (= (:side %) "Corp"))}}]}
 
    "Aggressive Secretary"
-   (advance-ambush 2 {:effect
+   (advance-ambush 2 {:req (req (< 0 (:advance-counter (get-card state card) 0)))
+                      :effect
                       (req (let [agg (get-card state card)
                                  n (:advance-counter agg 0)
                                  ab (-> trash-program
@@ -124,7 +125,8 @@
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 
    "Cerebral Overwriter"
-   (advance-ambush 3 {:msg (msg "do " (:advance-counter (get-card state card) 0) " brain damage")
+   (advance-ambush 3 {:req (req (< 0 (:advance-counter (get-card state card) 0)))
+                      :msg (msg "do " (:advance-counter (get-card state card) 0) " brain damage")
                       :effect (effect (damage eid :brain (:advance-counter (get-card state card) 0) {:card card}))})
 
    "Chairman Hiro"
@@ -351,7 +353,8 @@
     :leave-play (req (swap! state update-in [:runner :register] dissoc :max-draw :cannot-draw))}
 
    "Ghost Branch"
-   (advance-ambush 0 {:msg (msg "give the Runner " (:advance-counter (get-card state card) 0) " tag"
+   (advance-ambush 0 {:req (req (< 0 (:advance-counter (get-card state card) 0)))
+                      :msg (msg "give the Runner " (:advance-counter (get-card state card) 0) " tag"
                                 (when (> (:advance-counter (get-card state card) 0) 1) "s"))
                       :effect (effect (tag-runner :runner (:advance-counter (get-card state card) 0)))})
 
@@ -673,7 +676,8 @@
    "Plan B"
    (advance-ambush
     0
-    {:effect
+    {:req (req (< 0 (:advance-counter (get-card state card) 0)))
+     :effect
      (effect (resolve-ability
               {:prompt "Choose an Agenda in HQ to score"
                :choices {:req #(and (is-type? % "Agenda")
@@ -715,7 +719,8 @@
                               (when (= (get-in card [:counter :credit]) 0) (trash state :corp card)))}]}
 
    "Project Junebug"
-   (advance-ambush 1 {:msg (msg "do " (* 2 (:advance-counter (get-card state card) 0)) " net damage")
+   (advance-ambush 1 {:req (req (< 0 (:advance-counter (get-card state card) 0)))
+                      :msg (msg "do " (* 2 (:advance-counter (get-card state card) 0)) " net damage")
                       :effect (effect (damage eid :net (* 2 (:advance-counter (get-card state card) 0))
                                               {:card card}))})
 
@@ -851,14 +856,15 @@
 
    "Shattered Remains"
    (advance-ambush 1 {:effect (req (let [shat (get-card state card)]
-                                     (resolve-ability
-                                      state side
-                                      (-> trash-hardware
-                                          (assoc-in [:choices :max] (:advance-counter shat))
-                                          (assoc :prompt (msg "Choose " (:advance-counter shat) " pieces of hardware to trash")
-                                                 :effect (effect (trash-cards targets))
-                                                 :msg (msg "trash " (join ", " (map :title targets)))))
-                                      shat nil)))})
+                                     (when (< 0 (:advance-counter shat 0))
+                                       (resolve-ability
+                                         state side
+                                         (-> trash-hardware
+                                             (assoc-in [:choices :max] (:advance-counter shat))
+                                             (assoc :prompt (msg "Choose " (:advance-counter shat) " pieces of hardware to trash")
+                                                    :effect (effect (trash-cards targets))
+                                                    :msg (msg "trash " (join ", " (map :title targets)))))
+                                        shat nil))))})
 
    "Shi.Kyū"
    {:access

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -27,7 +27,7 @@
     (play-from-hand state :corp "Aggressive Secretary" "New remote")
     (let [as (get-content state :remote1 0)]
       ;; Single advance AggSec
-      (core/advance state :corp as)
+      (core/advance state :corp {:card (refresh as)})
       (take-credits state :corp)
       ;; Run on AggSec with 3 programs
       (play-from-hand state :runner "Cache")
@@ -38,7 +38,6 @@
       (is (= 3 (get-in @state [:corp :credit])))
       ;; Corp can trash one program
       (prompt-select :corp (get-in @state [:runner :rig :program 1]))
-      (prompt-choice :corp "Done")
       ;; There should be two Caches left
       (is (= 3 (get-in @state [:corp :credit])))
       (is (= 2 (count (get-in @state [:runner :rig :program])))))))


### PR DESCRIPTION
Confirmed a report that the Corp can trash a piece of hardware with Shattered Remains even if the Runner hits one that has 0 advancements. Aggressive Secretary has a similar problem and the existing test didn't catch it. 

This updates all advanceable ambush assets to require at least 1 advancement before they'll do anything even if the Corp pays for the effect when they're empty. This will avoid triggering any prevention/avoidance from the Runner if they get 0 tags or are dealt 0 net damage, etc--or bonus effects from Corp cards like Defective Brainchips after an Overwriter deals 0 brain damage. 