### PR TITLE
Improved message when installing a card in/protecting a new remote server

### DIFF
--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -113,9 +113,12 @@
                           (= :face-up install-state)
                           (:rezzed card))
                     (:title card)
-                    (if (ice? card) "ICE" "a card"))]
+                    (if (ice? card) "ICE" "a card"))
+        server-name (if (= server "New remote")
+                      (str (remote-num->name (get-in @state [:rid])) " (new remote)")
+                      server)]
     (system-msg state side (str (build-spend-msg cost-str "install") card-name
-                                (if (ice? card) " protecting " " in ") server))))
+                                (if (ice? card) " protecting " " in ") server-name))))
 
 (defn corp-install
   ([state side card server] (corp-install state side (make-eid state) card server nil))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1,8 +1,8 @@
 (ns game.core
   (:require [game.utils :refer [remove-once has? merge-costs zone make-cid make-label to-keyword capitalize
                                 costs-to-symbol vdissoc distinct-by abs string->num safe-split
-                                dissoc-in cancellable card-is? side-str
-                                build-spend-msg cost-names remote->name central->name zone->name central->zone
+                                dissoc-in cancellable card-is? side-str build-spend-msg cost-names
+                                remote->name remote-num->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case]]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -122,13 +122,16 @@
   (if (= side :corp) "Corp" "Runner"))
 
 ; Functions for working with zones.
+(defn remote-num->name [num]
+  (str "Server " num))
+
 (defn remote->name [zone]
   "Converts a remote zone to a string"
   (let [kw (if (keyword? zone) zone (last zone))
         s (str kw)]
     (if (.startsWith s ":remote")
       (let [num (last (split s #":remote"))]
-        (str "Server " num)))))
+        (remote-num->name num)))))
 
 (defn central->name [zone]
   "Converts a central zone keyword to a string."


### PR DESCRIPTION
Implementation of #1347 - creating a new remote server results in a message including both the new server's name and the fact it's new, e.g. "User spends [click] to install a card in Server 17 (new remote)."