### PR TITLE
fix Jak Sinclair interaction with Replicating Perfection

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -308,11 +308,7 @@
 
    "Jinteki: Replicating Perfection"
    {:events
-    {:runner-turn-begins {:req (req (let [runs (turn-events state side :run)]
-                                      (empty? (filter #(is-central? %) runs))))
-                          :effect (req (apply prevent-run-on-server
-                                              state card (map first (get-remotes @state))))}
-     :runner-phase-12 {:effect (req (apply prevent-run-on-server
+    {:runner-phase-12 {:effect (req (apply prevent-run-on-server
                                            state card (map first (get-remotes @state))))}
      :run {:once :per-turn
            :req (req (is-central? (:server run)))

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -308,8 +308,12 @@
 
    "Jinteki: Replicating Perfection"
    {:events
-    {:runner-turn-begins {:effect (req (apply prevent-run-on-server
+    {:runner-turn-begins {:req (req (let [runs (turn-events state side :run)]
+                                      (empty? (filter #(is-central? %) runs))))
+                          :effect (req (apply prevent-run-on-server
                                               state card (map first (get-remotes @state))))}
+     :runner-phase-12 {:effect (req (apply prevent-run-on-server
+                                           state card (map first (get-remotes @state))))}
      :run {:once :per-turn
            :req (req (is-central? (:server run)))
            :effect (req (apply enable-run-on-server

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -454,14 +454,16 @@
 
    "Jak Sinclair"
    (let [ability {:label "Make a run (start of turn)"
-                  :prompt "Choose a server"
+                  :prompt "Choose a server to run with Jak Sinclair"
+                  :once :per-turn
                   :choices (req runnable-servers)
                   :msg (msg "make a run on " target " during which no programs can be used")
                   :effect (effect (run target))}]
-   {:install-cost-bonus (req [:credit (* -1 (:link runner))])
+   {:flags {:runner-phase-12 (req true)}
+    :install-cost-bonus (req [:credit (* -1 (:link runner))])
     :events {:runner-turn-begins
-              {:optional {:prompt "Use Jak Sinclair to make a run?"
-                          :once :per-turn
+              {:optional {:req (req (not (get-in @state [:per-turn (:cid card)])))
+                          :prompt "Use Jak Sinclair to make a run?"
                           :yes-ability ability}}}
     :abilities [ability]})
 


### PR DESCRIPTION
Fixes #1693. 

Extends Jinteki RP to listen for `:runner-phase-12` in the event that the Runner has Jak Sinclair and uses him to make a run before taking clicks. Jak Sinclair is modified to use `:runner-phase-12` so the Runner can trigger him manually before taking clicks, or just let it ask at `:runner-turn-begins` if it hasn't already been used. 
