### PR TITLE
Many fixes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,7 @@ dependencies:
 
 test:
   override:
+    - lein compile game.main
     - lein test test.core
     - lein test test.cards.agendas
     - lein test test.cards.assets

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -110,7 +110,7 @@
                                                           (= (last (:zone %)) :ices))}
                                      :effect (req (rez state :corp target nil))}
                        :no-ability {:effect (req (swap! state assoc :per-run nil
-                                                        :run {:server runtgt :position (count ices) :ices ices
+                                                        :run {:server runtgt :position (count ices)
                                                               :access-bonus 0 :run-effect nil})
                                                  (gain-run-credits state :runner (:bad-publicity corp))
                                                  (swap! state update-in [:runner :register :made-run] #(conj % (first runtgt)))
@@ -916,7 +916,7 @@
                     :effect (req (let [runtgt [(last (server->zone state target))]
                                        ices (get-in @state (concat [:corp :servers] runtgt [:ices]))]
                                    (swap! state assoc :per-run nil
-                                                      :run {:server runtgt :position (count ices) :ices ices
+                                                      :run {:server runtgt :position (count ices)
                                                             :access-bonus 0 :run-effect nil})
                                    (gain-run-credits state :runner (:bad-publicity corp))
                                    (swap! state update-in [:runner :register :made-run] #(conj % (first runtgt)))

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -814,9 +814,10 @@
    {:effect (effect (run :rd
                       {:replace-access
                        {:msg "access cards from the bottom of R&D"
+                        :delayed-completion true
                         :effect (req (swap! state assoc-in [:corp :deck]
                                             (rseq (into [] (get-in @state [:corp :deck]))))
-                                     (do-access state side (:server run))
+                                     (do-access state side eid (:server run))
                                      (swap! state assoc-in [:corp :deck]
                                             (rseq (into [] (get-in @state [:corp :deck])))))}} card))}
 

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -140,8 +140,7 @@
   (update! state side (assoc card :subtype
                              (->> (remove #(= old %) (.split (:subtype card) " - "))
                                   vec (concat [new]) distinct (join " - "))))
-  (update-ice-strength state side card)
-  (update-run-ice state side))
+  (update-ice-strength state side card))
 
 (defn morph-effect
   "Creates morph effect for ICE. Morphs from base type to other type"
@@ -279,8 +278,7 @@
                                                #(assoc % :position (count (get-in corp (conj dest :ices)))
                                                        :server (rest dest))))
                                       (move state side card
-                                            (conj (server->zone state target) :ices))
-                                      (update-run-ice state side))})]}
+                                            (conj (server->zone state target) :ices)))})]}
 
    "Burke Bugs"
    {:abilities [(trace-ability 0 (assoc trash-program :not-distinct true
@@ -921,8 +919,7 @@
                  :msg "make the Runner continue the run on Archives"
                  :effect (req (swap! state update-in [:run]
                                      #(assoc % :position (count (get-in corp [:servers :archives :ices]))
-                                               :server [:archives]))
-                              (update-run-ice state side))}]}
+                                               :server [:archives])))}]}
 
    "Swarm"
    {:effect take-bad-pub

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -143,7 +143,7 @@
    "Alpha"
    (auto-icebreaker ["All"]
                     {:abilities [{:cost [:credit 1]
-                                  :req (req (= (:position run) (count (:ices run))))
+                                  :req (req (= (:position run) (count run-ices)))
                                   :msg "break 1 subroutine on the outermost ICE protecting this server"}
                                  (strength-pump 1 1)]})
 

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -509,7 +509,6 @@
                                                              {:effect (effect (update! (assoc ice :subtype stypes))
                                                                               (unregister-events card))}} card)
                                 (update-ice-strength state side ice)
-                                (update-run-ice state side)
                                 (trigger-event state side :ice-subtype-changed)))}]
     :events {:run-ends nil}}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -69,7 +69,7 @@
                                                             (= serv "Archives") [:archives])
                                                         ices (get-in @state (concat [:corp :servers] s [:ices]))]
                                                     (swap! state assoc :per-run nil
-                                                           :run {:server s :position (count ices) :ices ices
+                                                           :run {:server s :position (count ices)
                                                                  :access-bonus 0 :run-effect nil})
                                                     (gain-run-credits state :runner (:bad-publicity corp))
                                                     (swap! state update-in [:runner :register :made-run] #(conj % (first s)))

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -103,7 +103,8 @@
                                  card nil)))}]}
 
    "Crescentus"
-   {:abilities [{:req (req (rezzed? current-ice)) :msg (msg "derez " (:title current-ice))
+   {:abilities [{:req (req (rezzed? current-ice))
+                 :msg (msg "derez " (:title current-ice))
                  :effect (effect (trash card {:cause :ability-cost}) (derez current-ice))}]}
 
    "D4v1d"
@@ -208,16 +209,15 @@
                                            (join ", " (map :title (:hand corp))))}} card))}]}
 
    "False Echo"
-   {:abilities [{:req (req (and (:run @state)
-                                (< (:position run) (count (:ices run)))
-                                (not (:rezzed (nth (get-in @state
-                                                     (vec (concat [:corp :servers] (:server run) [:ices]))) (:position run))))))
+   {:abilities [{:req (req (and run
+                                (< (:position run) (count run-ices))
+                                (not (rezzed? current-ice))))
                  :msg "make the Corp rez the passed ICE or add it to HQ"
                  :effect (req (let [s (:server run)
                                     ice (nth (get-in @state (vec (concat [:corp :servers] s [:ices]))) (:position run))
                                     icename (:title ice)
                                     icecost (rez-cost state side ice)]
-                                (resolve-ability
+                                (continue-ability
                                   state side
                                   {:prompt (msg "Rez " icename " or add it to HQ?") :player :corp
                                    :choices (req (if (< (:credit corp) icecost)
@@ -653,7 +653,6 @@
                                                   ; access don't use Sneakdoor's req. (Security Testing, Ash 2X).
                                                   (swap! state dissoc-in [:run :run-effect :req])
                                                   (trigger-event state :corp :no-action)
-                                                  (update-run-ice state side)
                                                   (system-msg state side
                                                               (str "uses Sneakdoor Beta to make a successful run on HQ")))}}
                                   card))}]}
@@ -685,7 +684,6 @@
                                     #(assoc % cidx target))
                              (swap! state update-in [:run] #(assoc % :position (inc tgtndx)))
                              (update-all-ice state side)
-                             (update-run-ice state side)
                              (trigger-event state side :approach-ice current-ice)))})]
      {:abilities [{:cost [:credit 2]
                    :req (req (and (:run @state)

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -224,7 +224,7 @@
                              card :can-rez
                              (fn [state side card]
                                (if (and (ice? card)
-                                        (= (count (get-in @state (concat [:corp :servers] (:server (:run @state)))))
+                                        (= (count (get-in @state (concat [:corp :servers] (:server (:run @state)) [:ices])))
                                            (inc (ice-index state card))))
                                  ((constantly false) (toast state :corp "Cannot rez any outermost ICE due to DDoS." "warning"))
                                  true)))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -224,7 +224,8 @@
                              card :can-rez
                              (fn [state side card]
                                (if (and (ice? card)
-                                        (= (count (get-in @state [:run :ices])) (get-in @state [:run :position])))
+                                        (= (count (get-in @state (concat [:corp :servers] (:server (:run @state)))))
+                                           (inc (ice-index state card))))
                                  ((constantly false) (toast state :corp "Cannot rez any outermost ICE due to DDoS." "warning"))
                                  true)))
                            (trash card {:cause :ability-cost}))}]}

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -210,8 +210,7 @@
                                        (swap! state update-in [:corp :hand]
                                               (fn [coll] (remove-once #(not= (:cid %) (:cid hqice)) coll)))
                                        (trigger-event state side :corp-install newice)
-                                       (move state side c :hand)
-                                       (update-run-ice state side)))} card nil)))}]}
+                                       (move state side c :hand)))} card nil)))}]}
 
    "Mumbad City Grid"
    {:abilities [{:req (req this-server)
@@ -398,7 +397,7 @@
    "The Twins"
    {:abilities [{:label "Reveal and trash a copy of the ICE just passed from HQ"
                  :req (req (and this-server
-                                (> (count (:ices run)) (:position run))
+                                (> (count (get-run-ices state)) (:position run))
                                 (:rezzed (get-in (:ices (card->server state card)) [(:position run)]))))
                  :effect (req (let [icename (:title (get-in (:ices (card->server state card)) [(:position run)]))]
                                 (resolve-ability

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -3,7 +3,7 @@
 ;; These functions are called by main.clj in response to commands sent by users.
 
 (declare card-str can-rez? can-advance? corp-install effect-as-handler enforce-msg gain-agenda-point get-remote-names
-         jack-out move name-zone play-instant purge resolve-select run has-subtype?
+         get-run-ices jack-out move name-zone play-instant purge resolve-select run has-subtype?
          runner-install trash update-breaker-strength update-ice-in-server update-run-ice win
          can-run-server? can-score?)
 
@@ -225,8 +225,7 @@
                       Please rez prior to clicking Start Turn in the future." "warning"
                       {:time-out 0 :close-button true}))
              (when (ice? card)
-               (update-ice-strength state side card)
-               (update-run-ice state side))
+               (update-ice-strength state side card))
              (trigger-event state side :rez card))))
        (swap! state update-in [:bonus] dissoc :cost)))))
 
@@ -286,7 +285,7 @@
   (system-msg state side "has no further action")
   (trigger-event state side :no-action)
   (when-let [pos (get-in @state [:run :position])]
-    (when-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
+    (when-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-run-ices state) (dec pos))))]
       (when (:rezzed ice)
         (trigger-event state side :encounter-ice ice)
         (update-ice-strength state side ice)))))
@@ -315,7 +314,7 @@
   "Use the 'match strength with ice' function of icebreakers."
   [state side args]
   (let [run (:run @state) card (get-card state (:card args))
-        current-ice (when (and run (> (or (:position run) 0) 0)) (get-card state ((:ices run) (dec (:position run)))))
+        current-ice (when (and run (> (or (:position run) 0) 0)) (get-card state ((get-run-ices state) (dec (:position run)))))
         pumpabi (some #(when (:pump %) %) (:abilities (card-def card)))
         pumpcst (when pumpabi (second (drop-while #(and (not= % :credit) (not= % "credit")) (:cost pumpabi))))
         strdif (when current-ice (max 0 (- (or (:current-strength current-ice) (:strength current-ice))
@@ -331,7 +330,7 @@
   [state side args]
   (when (get-in @state [:run :no-action])
     (when-let [pos (get-in @state [:run :position])]
-      (do (if-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-in @state [:run :ices]) (dec pos))))]
+      (do (if-let [ice (when (and pos (> pos 0)) (get-card state (nth (get-run-ices state) (dec pos))))]
             (trigger-event state side :pass-ice ice)
             (trigger-event state side :pass-ice nil))
           (update-ice-in-server state side (get-in @state (concat [:corp :servers] (get-in @state [:run :server]))))))
@@ -339,10 +338,10 @@
     (swap! state assoc-in [:run :no-action] false)
     (system-msg state side "continues the run")
     (let [pos (get-in @state [:run :position])]
-      (when (> (count (get-in @state [:run :ices])) 0)
-        (update-ice-strength state side (nth (get-in @state [:run :ices]) pos)))
+      (when (not-empty (get-run-ices state))
+        (update-ice-strength state side (nth (get-run-ices state) pos)))
       (when (> pos 0)
-        (let [ice (get-card state (nth (get-in @state [:run :ices]) (dec pos)))]
+        (let [ice (get-card state (nth (get-run-ices state) (dec pos)))]
           (trigger-event state side :approach-ice ice))))
     (doseq [p (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
       (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -214,7 +214,7 @@
    (and (run-flag? state side card :can-rez)
         (turn-flag? state side card :can-rez)
         (if-let [rez-req (:rez-req (card-def card))]
-          (rez-req state side card nil)
+          (rez-req state side (make-eid state) card nil)
           true))))
 
 (defn can-steal?

--- a/src/clj/game/core-ice.clj
+++ b/src/clj/game/core-ice.clj
@@ -37,16 +37,7 @@
   "Updates all installed ice."
   [state side]
   (doseq [server (get-in @state [:corp :servers])]
-    (update-ice-in-server state side (second server)))
-  (update-run-ice state :corp))
-
-(defn update-run-ice
-  "Updates the :run :ices key with an updated copy of all ice in the run's server."
-  [state side]
-  (when (get-in @state [:run])
-    (let [s (get-in @state [:run :server])
-          ices (get-in @state (concat [:corp :servers] s [:ices]))]
-      (swap! state assoc-in [:run :ices] ices))))
+    (update-ice-in-server state side (second server))))
 
 (defn trash-ice-in-run
   "Decreases the position of each ice in the run. For when an ice is trashed mid-run."

--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -94,7 +94,7 @@
                         value (if-let [n (string->num (first args))] n 0)
                         c-type (cond (= 1 (count existing)) (first (keys existing))
                                      (can-be-advanced? target) :advance-counter
-                                     (and (is-type? target "Agenda") (is-scored? state target)) :agenda
+                                     (and (is-type? target "Agenda") (is-scored? target)) :agenda
                                      (and (card-is? target :side :runner) (has-subtype? target "Virus")) :virus)
                         advance (= :advance-counter c-type)]
                     (cond advance (do (set-prop state side target :advance-counter value)

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -420,7 +420,7 @@
                                                    ((get-in cdef [:access :req]) state side (make-eid state) % nil)))
                                           (and (get-in cdef [:access :optional])
                                                (or (not (get-in cdef [:access :optional :req]))
-                                                   ((get-in cdef [:access :optional :req]) state side % nil)))))
+                                                   ((get-in cdef [:access :optional :req]) state side (make-eid state) % nil)))))
                                     cards)]
                   (if (pos? (count cards))
                     (if (= 1 (count cards))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -17,7 +17,7 @@
            ices (get-in @state (concat [:corp :servers] s [:ices]))]
        ;; s is a keyword for the server, like :hq or :remote1
        (swap! state assoc :per-run nil
-              :run {:server s :position (count ices) :ices ices :access-bonus 0
+              :run {:server s :position (count ices) :access-bonus 0
                     :run-effect (assoc run-effect :card card)
                     :eid eid})
        (gain-run-credits state side (+ (get-in @state [:corp :bad-publicity]) (get-in @state [:corp :has-bad-pub])))
@@ -595,3 +595,7 @@
     (when-let [run (:run @state)]
       (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
         (handle-end-run state :runner)))))
+
+(defn get-run-ices
+  [state]
+  (get-in @state (concat [:corp :servers] (:server (:run @state)) [:ices])))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -10,8 +10,12 @@
                 'corp '(:corp @state)
                 'corp-reg '(get-in @state [:corp :register])
                 'runner-reg '(get-in @state [:runner :register])
-                'current-ice '(when-let [run (:run @state)]
-                                (when (> (or (:position run) 0) 0) ((:ices run) (dec (:position run)))))
+                'run-server '(when (:run @state)
+                               (get-in @state (concat [:corp :servers] (:server (:run @state)))))
+                'run-ices '(:ices run-server)
+                'current-ice '(when-let [run-pos (:position (:run @state))]
+                                (when (and (pos? run-pos) (<= run-pos (count (:ices run-server))))
+                                  (nth (:ices run-server) (dec run-pos))))
                 'target '(first targets)]
            ~@actions))))
 
@@ -20,7 +24,12 @@
      (let ~['runner '(:runner @state)
             'corp '(:corp @state)
             'run '(:run @state)
-            'current-ice '(when (and run (> (or (:position run) 0) 0)) ((:ices run) (dec (:position run))))
+            'run-server '(when (:run @state)
+                           (get-in @state (concat [:corp :servers] (:server (:run @state)))))
+            'run-ices '(:ices run-server)
+            'current-ice '(when-let [run-pos (:position (:run @state))]
+                            (when (and (pos? run-pos) (<= run-pos (count (:ices run-server))))
+                              (nth (:ices run-server) (dec run-pos))))
             'corp-reg '(get-in @state [:corp :register])
             'runner-reg '(get-in @state [:runner :register])
             'target '(first targets)
@@ -50,7 +59,12 @@
             'corp-reg '(get-in @state [:corp :register])
             'runner-reg '(get-in @state [:runner :register])
             'run '(:run @state)
-            'current-ice '(when (and run (> (or (:position run) 0) 0)) ((:ices run) (dec (:position run))))
+            'run-server '(when (:run @state)
+                           (get-in @state (concat [:corp :servers] (:server (:run @state)))))
+            'run-ices '(:ices run-server)
+            'current-ice '(when-let [run-pos (:position (:run @state))]
+                            (when (and (pos? run-pos) (<= run-pos (count (:ices run-server))))
+                              (nth (:ices run-server) (dec run-pos))))
             'target '(first targets)
             'tagged '(or (> (:tagged runner) 0) (> (:tag runner) 0))]
        (str ~@expr))))

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -102,7 +102,9 @@
                              (.send socket (generate-string {:action action :diff diff :gameid gameid}))))
                          (swap! last-states assoc gameid (strip @new-state)))
                        (.send socket (generate-string {:action action :gameid gameid :state (strip @state)})))))
-               (catch Exception e (.send socket (generate-string "error")))))))))
+               (catch Exception e
+                 (do (println "Inner Error " action command (get-in args [:card :title]) e)
+                     (.send socket (generate-string "error"))))))))))
 
 (def zmq-url (str "tcp://" (or (env :zmq-host) "127.0.0.1") ":1043"))
 

--- a/src/clj/test/cards/programs.clj
+++ b/src/clj/test/cards/programs.clj
@@ -146,6 +146,31 @@
       (is (= 2 (:credit (get-runner))) "1cr to use Djinn ability")
       (is (= 2 (:click (get-runner))) "1click to use Djinn ability"))))
 
+(deftest false-echo
+  "False Echo - choice for Corp"
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 3)])
+              (default-runner [(qty "False Echo" 3)]))
+    (play-from-hand state :corp "Ice Wall" "Archives")
+    (play-from-hand state :corp "Ice Wall" "Archives")
+    (take-credits state :corp)
+    (play-from-hand state :runner "False Echo")
+    (play-from-hand state :runner "False Echo")
+    (run-on state "Archives")
+    (run-continue state)
+    (let [echo1 (get-program state 0)
+          echo2 (get-program state 1)]
+      (card-ability state :runner echo1 0)
+      (prompt-choice :corp "Add to HQ")
+      (is (= 2 (count (:hand (get-corp)))) "Ice Wall added to HQ")
+      (is (= 1 (count (:discard (get-runner)))) "False Echo trashed")
+      (run-continue state)
+      (card-ability state :runner echo2 0)
+      (prompt-choice :corp "Rez")
+      (is (:rezzed (get-ice state :archives 0)) "Ice Wall rezzed")
+      (is (= 2 (count (:discard (get-runner)))) "False Echo trashed"))))
+
+
 (deftest gravedigger
   "Gravedigger - Gain counters when Corp cards are trashed, spend click-counter to mill Corp"
   (do-game
@@ -581,7 +606,7 @@
     (trash-from-hand state :corp "Priority Requisition")
     (take-credits state :corp)
     (play-from-hand state :runner "Sneakdoor Beta")
-    (let [sb (get-in @state [:runner :rig :program 0])
+    (let [sb (get-program state 0)
           cr (get-content state :archives 0)]
       (core/rez state :corp cr)
       (card-ability state :runner sb 0)

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -204,7 +204,7 @@
     (take-credits state :corp)
     (play-from-hand state :runner "DDoS")
     (let [ddos (get-in @state [:runner :rig :resource 0])
-          iwall (get-ice state :hq 0)]
+          iwall (get-ice state :hq 1)]
       (card-ability state :runner ddos 0)
       (is (= (:title ddos) (get-in @state [:runner :discard 0 :title])))
       (run-on state "HQ")


### PR DESCRIPTION
1. Fix arity exception preventing the rez of Zealous Judge, #1675.
2. Fix arity exception in Showing Off, from server error log.
3. Fix arity exception when testing the `:req` of optional on-access effects in Archives, from server log.
4. Fix /counter command with scored agendas.
5. Remove the `[:run :ices]` vector from the state. As far as I can tell this is an artifact of earlier design decisions, and we've had to hack around it for ages, but I believe it can be removed now. Ice data should be pulled directly from a server's `:ices` vector, not from a vector that was being initialized once at the start of the run but not keeping updated to other changes to ice (strength changes, positional changes, etc.). 
6. Add another line of logging to `main.clj`. I don't know what has caused the last few server crashes, and I don't know why they aren't being logged, but this may help.
7. Compile game.* namespaces separately from test.* namespaces to address out-of-memory issue when compiling on Circle CI. @mtgred: you may want to look into excluding the test namespaces from the `lein uberjar` build, since they're unused in live deployment. I briefly looked for a solution but couldn't find one.