### PR TITLE
Refactor main to run on single thread

### DIFF
--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -215,10 +215,11 @@
 
 (defn show-error-toast
   [state side]
-  (toast state side
-         (str "Your last action caused a game error on the server. You can keep playing, but there "
-              "may be errors in the game's current state. Please click the button below to submit a report "
-              "to our GitHub issues page.<br/><br/>Use /error to see this message again.")
-         "exception"
-         {:time-out 0 :close-button true}))
+  (when state
+    (toast state side
+           (str "Your last action caused a game error on the server. You can keep playing, but there "
+                "may be errors in the game's current state. Please click the button below to submit a report "
+                "to our GitHub issues page.<br/><br/>Use /error to see this message again.")
+           "exception"
+           {:time-out 0 :close-button true})))
 

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -73,38 +73,55 @@
     (when-let [cmd (spectator-commands command)]
       (cmd state (keyword side) args))))
 
+(defn- handle-command
+  "Apply the given command to the given state. Return true if the state should be sent
+  back across the socket (if the command was successful or a resolvable exception was
+  caught), or false if an error string should."
+  [{:keys [gameid action command side user args text cards] :as msg} state]
+  (try (do (case action
+             "initialize" (swap! all-cards (fn [_] (identity cards)))
+             "start" (core/init-game msg)
+             "remove" (do (swap! game-states dissoc gameid)
+                          (swap! last-states dissoc gameid))
+             "do" (handle-do user command state side args)
+             "notification" (when state
+                              (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))
+           true)
+       (catch Exception e
+         (do (println "Error " action command (get-in args [:card :title]) e)
+             (try (if state
+                    (do (show-error-toast state (keyword side))
+                        (swap! state assoc :last-error (pr-str e))
+                        true)
+                    false)
+                  (catch Exception e
+                    (do (println "Toast Error " action command (get-in args [:card :title]) e)
+                        false)))))))
+
 (defn run [socket]
+  "Main thread for handling commands from the UI server. Attempts to apply a command,
+  then returns the resulting game state, or another message as appropriate."
   (while true
-    (let [{:keys [gameid action command side user args text cards] :as msg} (convert (.recv socket))
-          state (@game-states gameid)]
-      (try
-        (case action
-          "initialize" (swap! all-cards (fn [_] (identity cards)))
-          "start" (core/init-game msg)
-          "remove" (do (swap! game-states dissoc gameid)
-                       (swap! last-states dissoc gameid))
-          "do" (handle-do user command state side args)
-          "notification" (when state
-                           (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))
-        (catch Exception e
-          (do (println "Error " action command (get-in args [:card :title]) e)
-              (when state
-                (show-error-toast state (keyword side))
-                (swap! state assoc :last-error (pr-str e)))))
-        (finally
-          (try (do (if (= action "initialize")
-                     (.send socket (generate-string "ok"))
-                     (if-let [new-state (@game-states gameid)]
-                       (do
-                         (case action
-                           ("start" "reconnect" "notification") (.send socket (generate-string {:action action :state (strip @new-state) :gameid gameid}))
-                           (let [diff (differ/diff (strip (@last-states gameid)) (strip @new-state))]
-                             (.send socket (generate-string {:action action :diff diff :gameid gameid}))))
-                         (swap! last-states assoc gameid (strip @new-state)))
-                       (.send socket (generate-string {:action action :gameid gameid :state (strip @state)})))))
-               (catch Exception e
-                 (do (println "Inner Error " action command (get-in args [:card :title]) e)
-                     (.send socket (generate-string "error"))))))))))
+    (let [{:keys [gameid action command args] :as msg} (convert (.recv socket))
+          state (@game-states (:gameid msg))]
+      ;; Attempt to handle the command. If true is returned, then generate a successful
+      ;; message. Otherwise generate an error message.
+      (try (if (handle-command msg state)
+             (if (= action "initialize")
+               (.send socket (generate-string "ok"))
+               (if-let [new-state (@game-states gameid)]
+                 (do (case action
+                       ("start" "reconnect" "notification") (.send socket (generate-string {:action action :state (strip @new-state) :gameid gameid}))
+                       (let [diff (differ/diff (strip (@last-states gameid)) (strip @new-state))]
+                         (.send socket (generate-string {:action action :diff diff :gameid gameid}))))
+                     (swap! last-states assoc gameid (strip @new-state)))
+                 (.send socket (generate-string {:action action :gameid gameid :state (strip @state)}))))
+             (.send socket (generate-string "error")))
+           (catch Exception e
+             (try (do (println "Inner Error " action command (get-in args [:card :title]) e)
+                      (.send socket (generate-string "error")))
+                  (catch Exception e
+                    (println "Socket Error " e))))))))
 
 (def zmq-url (str "tcp://" (or (env :zmq-host) "127.0.0.1") ":1043"))
 
@@ -119,12 +136,11 @@
   (let [worker-url "inproc://responders"
         router (doto (.socket ctx ZMQ/ROUTER) (.bind zmq-url))
         dealer (doto (.socket ctx ZMQ/DEALER) (.bind worker-url))]
-    (dotimes [n 2]
-      (.start
-       (Thread.
+    (.start
+      (Thread.
         (fn []
           (let [socket (.socket ctx ZMQ/REP)]
             (.connect socket worker-url)
-            (run socket))))))
+            (run socket)))))
 
     (.start (Thread. #(.run (ZMQQueue. ctx router dealer))))))


### PR DESCRIPTION
As per discussion with @mtgred, refactors `main` to run on a single message-handling thread instead of 2. Expected non-impact on server CPU. With no per-state locking mechanism, a single thread should help weird race conditions like the suspected cause of #468.

Also reworks the message-handling logic to be exception-safe. Should fix the server crashes we've been seeing, in which an exception caused when showing an error report toast wasn't being handled, crashing the server thread.