### PR TITLE
Fix for Dedicated Neural Net, Salsette Slums.

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -157,9 +157,9 @@
                                                     (continue-ability :runner (access-hq (shuffle targets)) card nil))}
                                    card nil))
                              (effect-completed state side eid card)))}]
-         {:events {:successful-run {:req (req (= target :hq))
-                                    :once :per-turn
-                                    :psi {:not-equal {:effect (req (when-not (:replace-access (get-in @state [:run :run-effect]))
+         {:events {:successful-run {:psi {:req (req (= target :hq))
+                                          :once :per-turn
+                                          :not-equal {:effect (req (when-not (:replace-access (get-in @state [:run :run-effect]))
                                                                      (swap! state update-in [:run :run-effect]
                                                                             #(assoc % :replace-access psi-effect)))
                                                                    (effect-completed state side eid))}}}}}))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -854,10 +854,7 @@
                                 (move state :corp c :rfg)
                                 (pay state :runner card :credit (trash-cost state side c))
                                 (update! state side (dissoc card :slums-active))
-                                (swap! state update-in [side :prompt] rest)
-                                 (when-let [run (:run @state)]
-                                   (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
-                                     (handle-end-run state :runner)))))}
+                                (close-access-prompt state side)))}
                 {:label "Remove a card trashed this turn from the game"
                  :req (req (if (:slums-active card)
                              true
@@ -869,11 +866,8 @@
                                     :msg (msg "remove " (:title target) " from the game")
                                     :effect (req (deactivate state side target)
                                                  (move state :corp target :rfg)
-                                                 (update! state side (dissoc card :slums-active))
-                                                 (swap! state update-in [side :prompt] rest)
-                                                 (when-let [run (:run @state)]
-                                                   (when (and (:ended run) (empty? (get-in @state [:runner :prompt])))
-                                                     (handle-end-run state :runner))))} card nil))}]}
+                                                 (update! state side (dissoc card :slums-active)))}
+                                   card nil))}]}
 
    "Same Old Thing"
    {:abilities [{:cost [:click 2]

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -371,6 +371,7 @@
   ([state side card psi] (psi-game state side (make-eid state) card psi))
   ([state side eid card psi]
    (swap! state assoc :psi {})
+   (register-once state psi card)
    (doseq [s [:corp :runner]]
      (show-prompt state s card (str "Choose an amount to spend for " (:title card))
                   (map #(str % " [Credits]") (range (min 3 (inc (get-in @state [s :credit])))))

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -157,7 +157,7 @@
 (deftest dedicated-neural-net
   "Dedicated Neural Net"
   (do-game
-    (new-game (default-corp [(qty "Dedicated Neural Net" 2) (qty "Snare!" 1) (qty "Hedge Fund" 3)])
+    (new-game (default-corp [(qty "Dedicated Neural Net" 1) (qty "Scorched Earth" 3) (qty "Hedge Fund" 1)])
               (default-runner [(qty "HQ Interface" 1)]))
     (play-from-hand state :corp "Dedicated Neural Net" "New remote")
     (score-agenda state :corp (get-content state :remote1 0))
@@ -171,6 +171,9 @@
     (is (accessing state "Hedge Fund") "Runner accessing Hedge Fund")
     (prompt-choice :runner "OK")
     (is (not (:run @state)) "Run completed")
+    (run-empty-server state :hq)
+    (prn (:prompt (get-runner)))
+
     (take-credits state :runner)
     (take-credits state :corp)
     (play-from-hand state :runner "HQ Interface")

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -172,8 +172,7 @@
     (prompt-choice :runner "OK")
     (is (not (:run @state)) "Run completed")
     (run-empty-server state :hq)
-    (prn (:prompt (get-runner)))
-
+    (prompt-choice :runner "OK")
     (take-credits state :runner)
     (take-credits state :corp)
     (play-from-hand state :runner "HQ Interface")


### PR DESCRIPTION
The req on psi games goes inside `:psi`, not the main ability, but psi games also weren't respecting `:once` keys.