### PR TITLE
Consistent sorting of corp server list in dialogs and menus

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -334,8 +334,8 @@
    "High-Stakes Job"
    {:prompt "Choose a server"
     :choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
-                        ok-servs (filter unrezzed-ice (get-in @state [:corp :servers]))]
-                    (filter #(can-run-server? state %) (map (comp zone->name first) ok-servs))))
+                        bad-zones (keys (filter (complement unrezzed-ice) (get-in @state [:corp :servers])))]
+                    (zones->sorted-names (remove (set bad-zones) (get-runnable-zones @state)))))
     :effect (effect (run target {:end-run {:req (req (:successful run)) :msg " gain 12 [Credits]"
                                            :effect (effect (gain :runner :credit 12))}} card))}
 

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -56,7 +56,7 @@
 
    "An Offer You Cant Refuse"
    {:delayed-completion false
-    :prompt "Choose a server" :choices ["HQ" "R&D" "Archives"]
+    :prompt "Choose a server" :choices ["Archives" "R&D" "HQ"]
     :effect (req (let [serv target]
                    (continue-ability
                      state side

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -56,10 +56,11 @@
   (zones->sorted-names (get-remote-zones state)))
 
 (defn server-list [state card]
-  (cons "New remote"
+  (concat
     (if (#{"Asset" "Agenda"} (:type card))
       (get-remote-names @state)
-      (zones->sorted-names (get-zones @state)))))
+      (zones->sorted-names (get-zones @state)))
+    ["New remote"]))
 
 (defn server->zone [state server]
   (if (sequential? server)

--- a/src/clj/game/core-misc.clj
+++ b/src/clj/game/core-misc.clj
@@ -39,18 +39,27 @@
           leave-effect (:leave-play source-def)]
       (when-not (nil? leave-effect) (leave-effect state side card nil)))))
 
+(defn get-zones [state]
+  (keys (get-in state [:corp :servers])))
+
+(defn get-remote-zones [state]
+  (filter is-remote? (get-zones state)))
+
+(defn get-runnable-zones [state]
+  (let [restricted-zones (keys (get-in state [:runner :register :cannot-run-on-server]))]
+    (remove (set restricted-zones) (get-zones state))))
 
 (defn get-remotes [state]
-  (filter #(-> % first is-remote?) (get-in state [:corp :servers])))
+  (select-keys (get-in state [:corp :servers]) (get-remote-zones state)))
 
 (defn get-remote-names [state]
-  (->> state get-remotes (map (comp zone->name first)) sort))
+  (zones->sorted-names (get-remote-zones state)))
 
 (defn server-list [state card]
-  (let [remotes (cons "New remote" (get-remote-names @state))]
+  (cons "New remote"
     (if (#{"Asset" "Agenda"} (:type card))
-      remotes
-      (concat ["HQ" "R&D" "Archives"] remotes))))
+      (get-remote-names @state)
+      (zones->sorted-names (get-zones @state)))))
 
 (defn server->zone [state server]
   (if (sequential? server)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -2,13 +2,13 @@
   (:require [game.utils :refer [remove-once has? merge-costs zone make-cid make-label to-keyword capitalize
                                 costs-to-symbol vdissoc distinct-by abs string->num safe-split
                                 dissoc-in cancellable card-is? side-str build-spend-msg cost-names
-                                remote->name remote-num->name central->name zone->name central->zone
+                                zones->sorted-names remote->name remote-num->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))
 
-(declare get-card get-remote-names make-eid make-result register-effect-completed resolve-ability say system-msg trigger-event update!)
+(declare get-card get-zones get-runnable-zones get-remote-names make-eid make-result register-effect-completed resolve-ability say system-msg trigger-event update!)
 
 (def game-states (atom {}))
 (def all-cards (atom {}))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -35,15 +35,11 @@
             'target '(first targets)
             'installed '(#{:rig :servers} (first (:zone card)))
             'remotes '(get-remote-names @state)
-            'servers '(concat ["HQ" "R&D" "Archives"] remotes)
+            'servers '(zones->sorted-names (get-zones @state))
             'unprotected '(let [server (second (:zone (if (:host card)
                                                         (get-card state (:host card)) card)))]
                             (empty? (get-in @state [:corp :servers server :ices])))
-            'runnable-servers '(let [servers (map zone->name
-                                                  (keys (get-in @state [:corp :servers])))
-                                     restricted (map zone->name
-                                                     (keys (get-in @state [:runner :register :cannot-run-on-server])))]
-                                 (remove (set restricted) (set servers)))
+            'runnable-servers '(zones->sorted-names (get-runnable-zones @state))
             'tagged '(or (> (:tagged runner) 0) (> (:tag runner) 0))
             'has-bad-pub '(or (> (:bad-publicity corp) 0) (> (:has-bad-pub corp) 0))
             'this-server '(let [s (-> card :zone rest butlast)

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -146,6 +146,17 @@
   (or (central->name zone)
       (remote->name zone)))
 
+(defn zone->sort-key [zone]
+  (case (if (keyword? zone) zone (last zone))
+    :hq -3
+    :rd -2
+    :archives -1
+    (string->num
+      (last (safe-split (str zone) #":remote")))))
+
+(defn zones->sorted-names [zones]
+  (->> zones (sort-by zone->sort-key) (map zone->name)))
+
 (defn is-remote? [zone]
   "Returns true if the zone is for a remote server"
   (not (nil? (remote->name zone))))

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -148,9 +148,9 @@
 
 (defn zone->sort-key [zone]
   (case (if (keyword? zone) zone (last zone))
-    :hq -3
+    :archives -3
     :rd -2
-    :archives -1
+    :hq -1
     (string->num
       (last (safe-split (str zone) #":remote")))))
 

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -412,9 +412,9 @@
 
 (defn zone->sort-key [zone]
   (case (if (keyword? zone) zone (last zone))
-    :hq -3
+    :archives -3
     :rd -2
-    :archives -1
+    :hq -1
     (js/parseInt
       (last (clojure.string/split (str zone) #":remote")))))
 
@@ -501,10 +501,10 @@
         (when-let [{:keys [char color]} icon] [:div.darkbg.icon {:class color} char])
         (when named-target [:div.darkbg.named-target named-target])
         (when (and (= zone ["hand"]) (#{"Agenda" "Asset" "ICE" "Upgrade"} type))
-          (let [centrals ["HQ" "R&D" "Archives"]
-                remotes (conj (remote-list remotes) "New remote")
+          (let [centrals ["Archives" "R&D" "HQ"]
+                remotes (concat (remote-list remotes) ["New remote"])
                 servers (case type
-                          ("Upgrade" "ICE") (concat remotes centrals)
+                          ("Upgrade" "ICE") (concat centrals remotes)
                           ("Agenda" "Asset") remotes)]
             [:div.blue-shade.panel.servers-menu {:ref "servers"}
              (map (fn [label]

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -410,13 +410,24 @@
   (or (central->name zone)
       (remote->name zone)))
 
+(defn zone->sort-key [zone]
+  (case (if (keyword? zone) zone (last zone))
+    :hq -3
+    :rd -2
+    :archives -1
+    (js/parseInt
+      (last (clojure.string/split (str zone) #":remote")))))
+
+(defn zones->sorted-names [zones]
+  (->> zones (sort-by zone->sort-key) (map zone->name)))
+
 (defn get-remotes [servers]
- (->> servers
-     (filter #(not (#{:hq :rd :archives} (first %))))
-     (sort-by #(remote->num (first %)))))
+  (->> servers
+       (filter #(not (#{:hq :rd :archives} (first %))))
+       (sort-by #(zone->sort-key (first %)))))
 
 (defn remote-list [remotes]
-  (->> remotes (map #(remote->name (first %))) (sort-by #(remote->num (first %)))))
+  (->> remotes (map first) zones->sorted-names))
 
 (defn card-counter-type [card]
   (let [counter-type (:counter-type card)]
@@ -841,7 +852,7 @@
   (let [servers (keys (get-in @state [:corp :servers]))
         restricted-servers (keys (get-in @state [:runner :register :cannot-run-on-server]))]
     ;; remove restricted servers from all servers to just return allowed servers
-    (remove (set restricted-servers) (set servers))))
+    (remove (set restricted-servers) servers)))
 
 (defn gameboard [{:keys [side gameid active-player run end-turn runner-phase-12 corp-phase-12 turn] :as cursor} owner]
   (reify
@@ -993,7 +1004,7 @@
                                                              js/$
                                                              .fadeOut))}
                                     label])
-                                 (map zone->name (runnable-servers cursor)))]]])
+                                 (zones->sorted-names (runnable-servers cursor)))]]])
                        (when (= side :corp)
                          (cond-button "Purge" (>= (:click me) 3) #(send-command "purge")))
                        (when (= side :corp)


### PR DESCRIPTION
Intended to resolve #1477.

* (server) added consistent sorting for 'Choose a server' dialogs: (New remote < ) HQ < R&D < Archives < remotes in numeric ascending order. Where remote servers were already being sorted lexicographically, changed the sorting to be numeric (so Server 2 < Server 11).
* (client) added sorting of the server popup menus for Runner's 'Run' option (ordered as above), and used new sorting for Corp's install popup menu as well for consistency

I've tried to make sorting only happen on lists of server keywords, i.e. 'zones', because I didn't want to have to do sorting on both zones and the derived server names. This has led to a few more code changes than were strictly necessary. Criticism would be very welcome - I'm still very new to Clojure so I might have approached this issue inefficiently.

<a href="https://cloud.githubusercontent.com/assets/1334553/16546179/6e265fe4-413a-11e6-9eed-f695a1796233.png"><img src="https://cloud.githubusercontent.com/assets/1334553/16546179/6e265fe4-413a-11e6-9eed-f695a1796233.png" align="left" height="64px"></a><a href="https://cloud.githubusercontent.com/assets/1334553/16546182/76478572-413a-11e6-9f14-ae2d6af9c26e.png"><img src="https://cloud.githubusercontent.com/assets/1334553/16546182/76478572-413a-11e6-9f14-ae2d6af9c26e.png" align="left" height="64px"></a><a href="https://cloud.githubusercontent.com/assets/1334553/16546183/77bd4cca-413a-11e6-975c-82e7bd0f2c94.png"><img src="https://cloud.githubusercontent.com/assets/1334553/16546183/77bd4cca-413a-11e6-975c-82e7bd0f2c94.png" align="left" height="64px"></a><a href="https://cloud.githubusercontent.com/assets/1334553/16546184/792281b6-413a-11e6-86ec-db23c93ce7a8.png"><img src="https://cloud.githubusercontent.com/assets/1334553/16546184/792281b6-413a-11e6-86ec-db23c93ce7a8.png" align="left" height="64px"></a>