### PR TITLE
Jack out prevention implementation + other prevention upgrades

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -352,9 +352,14 @@
                               :effect (effect (init-trace-bonus 1))}}}
 
    "Labyrinthine Servers"
-   {:effect (effect (add-counter card :power 2))
-    :abilities [{:counter-cost [:power 1]
-                 :effect (effect (prevent-jack-out))
+   {:prevent {:jack-out [:all]}
+    :effect (effect (add-counter card :power 2))
+    :abilities [{:req (req (:run @state))
+                 :counter-cost [:power 1]
+                 :effect (req (let [ls (filter #(= "Labyrinthine Servers" (:title %)) (:scored corp))]
+                                (jack-out-prevent state side)
+                                (when (zero? (reduce + (for [c ls] (get-in c [:counter :power]))))
+                                  (swap! state update-in [:prevent] dissoc :jack-out))))
                  :msg "prevent the Runner from jacking out"}]}
 
    "License Acquisition"

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -567,7 +567,7 @@
                   (let [prevent (get-in @state [:prevent :jack-out])]
                     (if (pos? (count prevent))
                       (do (system-msg state :corp "has the option to prevent the Runner from jacking out")
-                          (show-wait-prompt state :runner "Corp to decide to prevent the jack out" {:priority 10})
+                          (show-wait-prompt state :runner "Corp to prevent the jack out" {:priority 10})
                           (show-prompt state :corp nil
                                        (str "Prevent the Runner from jacking out?") ["Done"]
                                        (fn [_]


### PR DESCRIPTION
This is an attempt to do jack out prevention along the lines of expose/damage prevention/etc. Only one card uses this right now (Labyrinthine servers).

I added a :pre-jack-out event hook along the lines of the other prevention mechanisms which is not necessary for Labyrinthine servers but decided to keep it in in case future cards may want it.

Also tries to make the prevention mechanisms already within the game more consistent by adding wait prompts to the opposing side when necessary (i.e. wait prompt for corp while runner is preventing tags).