### PR TITLE
Fix #1717, Explodapalooza / Turning Wheel. Fix advanceable traps.

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -233,9 +233,15 @@
     :abilities [{:cost [:click 1] :counter-cost [:agenda 1] :msg "draw 5 cards" :effect (effect (draw 5))}]}
 
    "Explode-a-palooza"
-   {:access {:optional {:prompt "Gain 5 [Credits] with Explode-a-palooza ability?"
-                       :yes-ability {:msg "gain 5 [Credits]"
-                                     :effect (final-effect (gain :corp :credit 5))}}}}
+   {:access {:delayed-completion true
+             :effect (effect (show-wait-prompt :runner "Corp to use Explode-a-palooza")
+                             (continue-ability
+                               {:optional {:prompt "Gain 5 [Credits] with Explode-a-palooza ability?"
+                                           :yes-ability {:msg "gain 5 [Credits]"
+                                                         :effect (effect (gain :corp :credit 5)
+                                                                         (clear-wait-prompt :runner))}
+                                           :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
+                               card nil))}}
 
    "False Lead"
    {:abilities [{:req (req (>= (:click runner) 2)) :msg "force the Runner to lose [Click][Click]"

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -14,8 +14,9 @@
      (installed-access-trigger cost ab prompt)))
   ([cost ability prompt]
    {:access {:req (req (and installed (>= (:credit corp) cost)))
+             :delayed-completion true
              :effect (effect (show-wait-prompt :runner (str "Corp to use " (:title card)))
-                             (resolve-ability
+                             (continue-ability
                               {:optional
                                {:prompt prompt
                                 :yes-ability ability
@@ -68,13 +69,15 @@
 
    "Aggressive Secretary"
    (advance-ambush 2 {:req (req (< 0 (:advance-counter (get-card state card) 0)))
+                      :delayed-completion true
                       :effect
                       (req (let [agg (get-card state card)
                                  n (:advance-counter agg 0)
                                  ab (-> trash-program
                                         (assoc-in [:choices :max] n)
                                         (assoc :prompt (msg "Choose " n " program" (when (> n 1) "s") " to trash")
-                                               :effect (effect (trash-cards targets))
+                                               :delayed-completion true
+                                               :effect (effect (trash-cards eid targets nil))
                                                :msg (msg "trash " (join ", " (map :title targets)))))]
                              (continue-ability state side ab agg nil)))})
 
@@ -127,6 +130,7 @@
    "Cerebral Overwriter"
    (advance-ambush 3 {:req (req (< 0 (:advance-counter (get-card state card) 0)))
                       :msg (msg "do " (:advance-counter (get-card state card) 0) " brain damage")
+                      :delayed-completion true
                       :effect (effect (damage eid :brain (:advance-counter (get-card state card) 0) {:card card}))})
 
    "Chairman Hiro"
@@ -721,6 +725,7 @@
    "Project Junebug"
    (advance-ambush 1 {:req (req (< 0 (:advance-counter (get-card state card) 0)))
                       :msg (msg "do " (* 2 (:advance-counter (get-card state card) 0)) " net damage")
+                      :delayed-completion true
                       :effect (effect (damage eid :net (* 2 (:advance-counter (get-card state card) 0))
                                               {:card card}))})
 
@@ -855,9 +860,10 @@
                  :effect (effect (move target :deck) (trash card {:cause :ability-cost}))}]}
 
    "Shattered Remains"
-   (advance-ambush 1 {:effect (req (let [shat (get-card state card)]
+   (advance-ambush 1 {:delayed-completion true
+                      :effect (req (let [shat (get-card state card)]
                                      (when (< 0 (:advance-counter shat 0))
-                                       (resolve-ability
+                                       (continue-ability
                                          state side
                                          (-> trash-hardware
                                              (assoc-in [:choices :max] (:advance-counter shat))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -166,11 +166,9 @@
                             (if (< (count hand) n)
                               (do (flatline state)
                                   (trash-cards state side (make-eid state) (take n (shuffle hand))
-                                               {:unpreventable true} type))
-                                  ;(doseq [c (take n (shuffle hand))]
-;                                    (trash state side (make-eid state) c {:unpreventable true} type)))
+                                               {:unpreventable true}))
                               (do (trash-cards state side (make-eid state) (take n (shuffle hand))
-                                               {:unpreventable true} type)
+                                               {:unpreventable true :cause type})
                                   (trigger-event state side :damage type card))))))
                       (swap! state update-in [:damage :defer-damage] dissoc type)
                       (effect-completed state side eid card))))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -2,7 +2,7 @@
 
 (declare card-init card-str close-access-prompt deactivate effect-completed enforce-msg gain-agenda-point
          get-agenda-points handle-end-run is-type? in-corp-scored? prevent-draw resolve-steal-events show-prompt
-         untrashable-while-rezzed? update-all-ice win win-decked)
+         trash-cards untrashable-while-rezzed? update-all-ice win win-decked)
 
 ;;;; Functions for applying core Netrunner game rules.
 
@@ -165,10 +165,12 @@
                               (swap! state update-in [:runner :hand-size-modification] #(- % n)))
                             (if (< (count hand) n)
                               (do (flatline state)
-                                  (doseq [c (take n (shuffle hand))]
-                                    (trash state side c {:unpreventable true} type)))
-                              (do (doseq [c (take n (shuffle hand))]
-                                    (trash state side c {:unpreventable true :cause type} type))
+                                  (trash-cards state side (make-eid state) (take n (shuffle hand))
+                                               {:unpreventable true} type))
+                                  ;(doseq [c (take n (shuffle hand))]
+;                                    (trash state side (make-eid state) c {:unpreventable true} type)))
+                              (do (trash-cards state side (make-eid state) (take n (shuffle hand))
+                                               {:unpreventable true} type)
                                   (trigger-event state side :damage type card))))))
                       (swap! state update-in [:damage :defer-damage] dissoc type)
                       (effect-completed state side eid card))))
@@ -262,28 +264,33 @@
   (swap! state update-in [:trash :trash-prevent type] (fnil #(+ % n) 0)))
 
 (defn- resolve-trash-end
-  [state side {:keys [zone type] :as card} {:keys [unpreventable cause keep-server-alive suppress-event] :as args} & targets]
+  [state side eid {:keys [zone type] :as card}
+   {:keys [unpreventable cause keep-server-alive suppress-event] :as args} & targets]
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
       (when (or (= (:side card) "Runner") (:rezzed card))
         (resolve-ability state side trash-effect moved-card (cons cause targets))))
-    (swap! state update-in [:per-turn] dissoc (:cid moved-card))))
+    (swap! state update-in [:per-turn] dissoc (:cid moved-card))
+    (effect-completed state side eid)))
 
-(defn resolve-trash
-  [state side {:keys [zone type] :as card} {:keys [unpreventable cause keep-server-alive suppress-event] :as args} & targets]
+(defn- resolve-trash
+  [state side eid {:keys [zone type] :as card}
+   {:keys [unpreventable cause keep-server-alive suppress-event] :as args} & targets]
   (if (and (not suppress-event) (not= (last zone) :current)) ; Trashing a current does not trigger a trash event.
     (when-completed (apply trigger-event-sync state side (keyword (str (name side) "-trash")) card cause targets)
-                    (apply resolve-trash-end state side card args targets))
-    (apply resolve-trash-end state side card args targets)))
+                    (apply resolve-trash-end state side eid card args targets))
+    (apply resolve-trash-end state side eid card args targets)))
 
 (defn trash
   "Attempts to trash the given card, allowing for boosting/prevention effects."
-  ([state side {:keys [zone type] :as card}] (trash state side card nil))
-  ([state side {:keys [zone type] :as card} {:keys [unpreventable cause suppress-event] :as args} & targets]
-   (when (not (some #{:discard} zone))
+  ([state side card] (trash state side (make-eid state) card nil))
+  ([state side card args] (trash state side (make-eid state) card args))
+  ([state side eid {:keys [zone type] :as card} {:keys [unpreventable cause suppress-event] :as args} & targets]
+   (if (not (some #{:discard} zone))
      (if (untrashable-while-rezzed? card)
-       (enforce-msg state card "cannot be trashed while installed")
+       (do (enforce-msg state card "cannot be trashed while installed")
+           (effect-completed state side eid))
        ;; Card is not enforced untrashable
        (let [ktype (keyword (clojure.string/lower-case type))]
          (when (and (not unpreventable) (not= cause :ability-cost))
@@ -294,18 +301,27 @@
              (do (system-msg state :runner "has the option to prevent trash effects")
                  (show-prompt state :runner nil
                               (str "Prevent the trashing of " (:title card) "?") ["Done"]
-                              (fn [choice]
-                                (if-let [prevent (get-in @state [:trash :trash-prevent ktype])]
+                              (fn [_]
+                                (if-let [_ (get-in @state [:trash :trash-prevent ktype])]
                                   (do (system-msg state :runner (str "prevents the trashing of " (:title card)))
-                                      (swap! state update-in [:trash :trash-prevent] dissoc ktype))
+                                      (swap! state update-in [:trash :trash-prevent] dissoc ktype)
+                                      (effect-completed state side eid))
                                   (do (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
-                                      (apply resolve-trash state side card args targets))))
+                                      (apply resolve-trash state side eid card args targets))))
                               {:priority 10}))
              ;; No prevention effects; resolve the trash.
-             (apply resolve-trash state side card args targets))))))))
+             (apply resolve-trash state side eid card args targets)))))
+     (effect-completed state side eid))))
 
-(defn trash-cards [state side cards]
-  (doseq [c cards] (trash state side c)))
+(defn trash-cards
+  ([state side cards] (trash-cards state side (make-eid state) cards nil))
+  ([state side eid cards args & targets]
+   (letfn [(trashrec [cs]
+             (if (not-empty cs)
+               (when-completed (apply trash state side (first cs) args targets)
+                               (trashrec (next cs)))
+               (effect-completed state side eid)))]
+     (trashrec cards))))
 
 (defn- resolve-trash-no-cost
   [state side card]

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -211,6 +211,29 @@
     (prompt-choice :corp "Yes")
     (is (= 12 (:credit (get-corp))) "Gained 5 credits")))
 
+(deftest explode-ttw
+  "Explode-a-palooza - Interaction with The Turning Wheel. Issue #1717."
+  (do-game
+    (new-game (default-corp [(qty "Explode-a-palooza" 3)])
+              (default-runner [(qty "The Turning Wheel" 1)]))
+    (starting-hand state :corp ["Explode-a-palooza" "Explode-a-palooza"])
+    (play-from-hand state :corp "Explode-a-palooza" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "The Turning Wheel")
+    (run-empty-server state :remote1)
+    (prompt-choice :runner "Steal")
+    (prompt-choice :corp "Yes")
+    (let [ttw (get-resource state 0)]
+      (is (= 0 (get-counters (refresh ttw) :power)) "TTW did not gain counters")
+      (is (= 1 (count (:scored (get-runner)))) "Runner stole Explodapalooza")
+      (is (= 12 (:credit (get-corp))) "Gained 5 credits")
+      (run-empty-server state :rd)
+      (prompt-choice :runner "Steal")
+      (prompt-choice :corp "Yes")
+      (is (= 0 (get-counters (refresh ttw) :power)) "TTW did not gain counters")
+      (is (= 2 (count (:scored (get-runner)))) "Runner stole Explodapalooza")
+      (is (= 17 (:credit (get-corp))) "Gained 5 credits"))))
+
 (deftest fetal-ai-damage
   "Fetal AI - damage on access"
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -29,6 +29,21 @@
                                             (qty "Always Be Running" 1) (qty "Bank Job" 3)]))
     (is (= 5 (:credit (get-corp))) "Pālanā does not gain credit from Adam's starting Directives")))
 
+(deftest adam-advanceable-traps
+  "Adam - Neutralize All Threats interaction with advanceable traps."
+  (do-game
+    (new-game
+      (default-corp [(qty "Cerebral Overwriter" 3)])
+      (make-deck "Adam: Compulsive Hacker" [(qty "Neutralize All Threats" 1) (qty "Safety First" 1)
+                                            (qty "Always Be Running" 1) (qty "Bank Job" 3)]))
+    (play-from-hand state :corp "Cerebral Overwriter" "New remote")
+    (advance state (get-content state :remote1 0) 2)
+    (take-credits state :corp)
+    (run-empty-server state :remote1)
+    (prompt-choice :corp "Yes")
+    (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")
+    (is (= 1 (count (:discard (get-corp)))) "1 card in archives")))
+
 (deftest andromeda
   "Andromeda - 9 card starting hand, 1 link"
   (do-game

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -372,3 +372,24 @@
     (is (= 4 (:agenda-point (get-corp)))) ; PS2 should get scored
     (is (= (:zone (refresh publics2) :scored)))
     (is (= 12 (:credit (get-corp))) "twice Adonis money and 2xmoney turn, no third Adonis"))))
+
+(deftest run-bad-publicity-credits
+  "Should not lose BP credits until a run is completely over. Issue #1721."
+  (do-game
+    (new-game (default-corp [(qty "PAD Campaign" 3)])
+              (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Sure Gamble" 3)]))
+    (is (= 1 (:bad-publicity (get-corp))) "Corp starts with 1 BP")
+    (starting-hand state :corp ["PAD Campaign" "PAD Campaign"])
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state :remote1)
+    (prompt-choice :runner "Yes")
+    (is (= 2 (:credit (get-runner))) "1 BP credit spent to trash PAD Campaign")
+    (core/gain state :runner :credit 3)
+    (run-empty-server state :hq)
+    (prompt-choice :runner "Yes")
+    (is (= 2 (:credit (get-runner))) "1 BP credit spent to trash PAD Campaign")
+    (core/gain state :runner :credit 3)
+    (run-empty-server state :rd)
+    (prompt-choice :runner "Yes")
+    (is (= 2 (:credit (get-runner))) "1 BP credit spent to trash PAD Campaign")))

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -167,6 +167,13 @@
     (core/score state :corp {:card (core/get-card state card)})
     (is (find-card title (get-in @state [:corp :scored]))))))
 
+(defn advance
+  "Advance the given card."
+  ([state card] (advance state card 1))
+  ([state card n]
+   (dotimes [_ n]
+     (core/advance state :corp {:card (core/get-card state card)}))))
+
 (defn last-log-contains?
   [state content]
   (not (nil?


### PR DESCRIPTION
Old run code needs to be cleaned up, but for now, Exploda shows a waiting prompt to the run doesn't end after the runner elects to steal. (Run can end when closing a prompt while `:run` is active in state.) 

Fixes advanceable traps (fix #1732).