### PR TITLE
fix Drive By, Project Beale, trashable executives

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -481,8 +481,8 @@
 
    "Project Beale"
    {:agendapoints-runner (req (do 2))
-    :effect (effect (add-counter card :agenda (quot (- (:advance-counter card) 3) 2))
-                    (set-prop card :agendapoints (+ 2 (quot (- (:advance-counter card) 3) 2))))}
+    :effect (req (let [n (quot (- (:advance-counter card) 3) 2)]
+                    (set-prop state side card :counter {:agenda n} :agendapoints (+ 2 n))))}
 
    "Project Vitruvius"
    {:effect (effect (add-counter card :agenda (- (:advance-counter card) 3)))

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -132,7 +132,8 @@
    "Chairman Hiro"
    {:effect (effect (lose :runner :hand-size-modification 2))
     :leave-play (effect (gain :runner :hand-size-modification 2))
-    :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
+    :trash-effect {:when-unrezzed true
+                   :req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
 
    "City Surveillance"
    {:events {:runner-turn-begins
@@ -245,7 +246,8 @@
 
    "Director Haas"
    {:in-play [:click 1 :click-per-turn 1]
-    :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
+    :trash-effect {:when-unrezzed true
+                   :req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
 
    "Docklands Crackdown"
    {:abilities [{:cost [:click 2]
@@ -954,7 +956,8 @@
                           (count (filter #(> (get-agenda-points state :runner %) 0) (:scored runner)))))
     :leave-play (effect (gain :runner :agenda-point
                               (count (filter #(> (get-agenda-points state :runner %) 0) (:scored runner)))))
-    :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}
+    :trash-effect {:when-unrezzed true
+                   :req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}
     :events {:agenda-stolen {:req (req (> (get-agenda-points state :runner target) 0))
                              :effect (effect (lose :runner :agenda-point 1))}}}
 
@@ -1005,7 +1008,8 @@
 
    "Victoria Jenkins"
    {:effect (effect (lose :runner :click-per-turn 1)) :leave-play (effect (gain :runner :click-per-turn 1))
-    :trash-effect {:req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
+    :trash-effect {:when-unrezzed true
+                   :req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
 
    "Worlds Plaza"
    {:abilities [{:label "Install an asset on Worlds Plaza"

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -164,7 +164,7 @@
     :effect (req (when-completed (expose state side target) ;; would be nice if this could return a value on completion
                                  (if async-result ;; expose was successful
                                    (if (#{"Asset" "Upgrade"} (:type target))
-                                     (do (system-msg state :runner (str "trash " (:title target)))
+                                     (do (system-msg state :runner (str "uses Drive By to trash " (:title target)))
                                          (trash state side (assoc target :seen true))
                                          (effect-completed state side eid))
                                      (effect-completed state side eid))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -266,7 +266,7 @@
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
-      (when (or (= (:side card) "Runner") (:rezzed card))
+      (when (or (= (:side card) "Runner") (:rezzed card) (:when-unrezzed trash-effect))
         (resolve-ability state side trash-effect moved-card (cons cause targets))))
     (swap! state update-in [:per-turn] dissoc (:cid moved-card))))
 


### PR DESCRIPTION
Getting some quick fixes in before a deployment! This includes a band-aid for the "add as an agenda" trashable executives (fixes #1716). A more elegant solution would be better in the long run.