### PR TITLE
Fix for #1729 (out of the ashes)

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -566,7 +566,15 @@
     :msg "add it to their score area and gain 1 agenda point"}
 
    "Out of the Ashes"
-   (letfn [(ashes-run []
+   (letfn [(ashes-flag []
+             {:runner-phase-12 {:priority -1
+                                :once :per-turn
+                                :once-key :out-of-ashes
+                                :effect (effect (continue-ability
+                                                  (ashes-recur (count (filter #(= "Out of the Ashes" (:title %))
+                                                                              (:discard runner))))
+                                                  card nil))}})
+           (ashes-run []
              {:prompt "Choose a server"
               :choices (req runnable-servers)
               :delayed-completion true
@@ -586,16 +594,9 @@
    {:prompt "Choose a server"
     :choices (req runnable-servers)
     :effect (effect (run eid target nil card))
+    :mill-effect {:effect (effect (register-events (ashes-flag) (assoc card :zone [:discard])))}
     :move-zone (req (if (= [:discard] (:zone card))
-                      (register-events state side
-                        {:runner-phase-12 {:priority -1
-                                           :once :per-turn
-                                           :once-key :out-of-ashes
-                                           :effect (effect (continue-ability
-                                                             (ashes-recur (count (filter #(= "Out of the Ashes" (:title %))
-                                                                                         (:discard runner))))
-                                                             card nil))}}
-                        (assoc card :zone [:discard]))
+                      (register-events state side (ashes-flag) (assoc card :zone [:discard]))
                       (unregister-events state side card)))
     :events {:runner-phase-12 nil}})
 

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -514,6 +514,51 @@
     (is (= 1 (count (:scored (get-runner)))) "Notoriety moved to score area")
     (is (= 1 (:agenda-point (get-runner))) "Notoriety scored for 1 agenda point")))
 
+(deftest out-of-the-ashes
+  "Out of the Ashes - ensure card works when played/trashed/milled"
+  (do-game
+    (new-game (default-corp [(qty "Kala Ghoda Real TV" 1) (qty "Underway Renovation" 1)])
+              (default-runner [(qty "Out of the Ashes" 6)]))
+    (play-from-hand state :corp "Underway Renovation" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Out of the Ashes")
+    (prompt-choice :runner "Archives")
+    (is (:run @state))
+    (run-successful state)
+    (trash-from-hand state :runner "Out of the Ashes")
+    (trash-from-hand state :runner "Out of the Ashes")
+    (trash-from-hand state :runner "Out of the Ashes")
+    (trash-from-hand state :runner "Out of the Ashes")
+    (is (= 0 (count (:hand (get-runner)))))
+    (is (= 5 (count (:discard (get-runner)))))
+    (take-credits state :runner)
+    (let [underway (get-content state :remote1 0)]
+      (core/advance state :corp {:card (refresh underway)}))
+    (is (= 6 (count (:discard (get-runner)))))
+    (take-credits state :corp)
+    ;remove 5 Out of the Ashes from the game
+    (loop [x 5]
+      (when (pos? x)
+        (do (is (not (empty? (get-in @state [:runner :prompt]))))
+            (prompt-choice :runner "Yes")
+            (prompt-choice :runner "Archives")
+            (is (:run @state))
+            (run-successful state)
+            (recur (dec x)))))
+    (prompt-choice :runner "No")
+    (is (= 1 (count (:discard (get-runner)))))
+    (is (= 5 (count (:rfg (get-runner)))))
+    (take-credits state :runner)
+    (take-credits state :corp)
+    ;ensure that if you decline the rfg, game will still ask the next turn
+    (is (not (empty? (get-in @state [:runner :prompt]))))
+    (prompt-choice :runner "Yes")
+    (prompt-choice :runner "Archives")
+    (is (:run @state))
+    (run-successful state)
+    (is (= 0 (count (:discard (get-runner)))))
+    (is (= 6 (count (:rfg (get-runner)))))))
+
 (deftest political-graffiti
   "Political Graffiti - swapping with Turntable works / purging viruses restores points"
   (do-game


### PR DESCRIPTION
As with subliminal messaging, use :mill-effect to register the event when milled. Perhaps a better solution in the future would be to rewrite the mill code to use move. Not entirely sure what the ramifications of that would be though.