### PR TITLE
Forces action panel on installed agendas and ice outside runs

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -160,14 +160,19 @@
   (let [actions (action-list card)
         c (+ (count actions) (count abilities))]
     (when-not (and (= side "Runner") facedown)
-      (cond (or (> c 1)
-                (= (first actions) "derez")) (-> (om/get-node owner "abilities") js/$ .toggle)
-            (= c 1) (if (= (count abilities) 1)
-                          (send-command "ability" {:card card :ability 0})
-                          (send-command (first actions) {:card card}))))))
+      (cond
+        ;; Open panel
+        (or (> c 1)
+            (= (first actions) "derez")
+            (= (first actions) "advance"))
+        (-> (om/get-node owner "abilities") js/$ .toggle)
+        ;; Trigger first (and only) ability / action
+        (= c 1)
+        (if (= (count abilities) 1)
+          (send-command "ability" {:card card :ability 0})
+          (send-command (first actions) {:card card}))))))
 
-(defn handle-card-click [{:keys [type zone counter advance-counter advancementcost advanceable
-                                 root] :as card} owner]
+(defn handle-card-click [{:keys [type zone root] :as card} owner]
   (let [side (:side @game-state)]
     (when (not-spectator? game-state app-state)
       (if (= (get-in @game-state [side :prompt 0 :prompt-type]) "select")

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -514,7 +514,8 @@
                   servers)]))
         (let [actions (action-list cursor)]
           (when (or (> (+ (count actions) (count abilities)) 1)
-                    (= (first actions) "derez"))
+                    (= (first actions) "derez")
+                    (= (first actions) "advance"))
             [:div.blue-shade.panel.abilities {:ref "abilities"}
              (map (fn [action]
                     [:div {:on-click #(do (send-command action {:card @cursor}))} (capitalize action)])

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -142,8 +142,6 @@
 
 (defn action-list [{:keys [type zone rezzed advanceable advance-counter advancementcost current-cost] :as card}]
   (-> []
-      (#(if (and (= type "Agenda") (>= advance-counter current-cost))
-          (cons "score" %) %))
       (#(if (or (and (= type "Agenda")
                      (= (first zone) "servers"))
                 (= advanceable "always")
@@ -152,6 +150,8 @@
                 (and (not rezzed)
                      (= advanceable "while-unrezzed")))
           (cons "advance" %) %))
+      (#(if (and (= type "Agenda") (>= advance-counter current-cost))
+         (cons "score" %) %))
       (#(if (#{"Asset" "ICE" "Upgrade"} type)
           (if-not rezzed (cons "rez" %) (cons "derez" %))
           %))))


### PR DESCRIPTION
Forces the rez panel on ice outside of runs, fixing #1673.

Also forces advance panel on installed agendas. This makes them require as many clicks to advance as advanceable traps, since those have options of rez and advance. Maybe I'm just paranoid but I always worry someone will notice I advance slower on traps and faster on agendas.

As an additional bonus this will midly slow down fast advance, forcing small clot windows 😉 