### PR TITLE
Adds server target icons to Patron and Security Testing. 

### DIFF
--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -251,9 +251,10 @@
    "Cyber-Cypher"
    (auto-icebreaker ["Code Gate"]
                     {:prompt "Choose a server where this copy of Cyber-Cypher can be used:"
+                     :msg (msg "target " target)
                      :choices (req servers)
-                     :effect (effect (update! (assoc card :named-target target)))
-                     :leave-play (effect (update! (dissoc card :named-target)))
+                     :effect (effect (update! (assoc card :server-target target)))
+                     :leave-play (effect (update! (dissoc card :server-target)))
                      :abilities [(break-sub 1 1 "code gate")
                                  (strength-pump 1 1)]})
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -682,7 +682,6 @@
    (let [ability {:prompt "Choose a server for Patron" :choices (req (conj servers "No server"))
                   :req (req (not= "No server" target))
                   :msg (msg "target " target)
-                  :once :per-turn
                   :effect (effect (update! (assoc card :server-target target)))}]
      {:events {:runner-turn-begins ability
                :successful-run

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -692,7 +692,9 @@
                                       {:mandatory true
                                        :effect (effect (resolve-ability
                                                          {:msg "draw 2 cards instead of accessing"
-                                                          :effect (effect (draw 2))} st nil))})))}
+                                                          :effect (effect (draw 2)
+                                                                          (update! (dissoc st :server-target)))}
+                                                         st nil))})))}
                :runner-turn-ends {:effect (effect (update! (dissoc card :server-target)))}}
       :abilities [ability]})
 
@@ -897,7 +899,9 @@
                                       {:mandatory true
                                        :effect (effect (resolve-ability
                                                          {:msg "gain 2 [Credits] instead of accessing"
-                                                          :effect (effect (gain :credit 2))} st nil))})))}
+                                                          :effect (effect (gain :credit 2)
+                                                                          (update! (dissoc st :server-target)))}
+                                                         st nil))})))}
                :runner-turn-ends {:effect (effect (update! (dissoc card :server-target)))}}
       :abilities [ability]})
 

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -682,6 +682,7 @@
    (let [ability {:prompt "Choose a server for Patron" :choices (req (conj servers "No server"))
                   :req (req (not= "No server" target))
                   :msg (msg "target " target)
+                  :once :per-turn
                   :effect (effect (update! (assoc card :server-target target)))}]
      {:events {:runner-turn-begins ability
                :successful-run

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -682,19 +682,19 @@
    (let [ability {:prompt "Choose a server for Patron" :choices (req (conj servers "No server"))
                   :req (req (not= "No server" target))
                   :msg (msg "target " target)
-                  :effect (effect (update! (assoc card :patron-target (vec (next (server->zone state target))))))}]
-   {:events {:runner-turn-begins ability
-             :successful-run
-             {:req (req (= (get-in @state [:run :server]) (:patron-target (get-card state card))))
-              :once :per-turn
-              :effect (req (let [st card]
-                             (swap! state assoc-in [:run :run-effect :replace-access]
-                                    {:mandatory true
-                                     :effect (effect (resolve-ability
-                                                       {:msg "draw 2 cards instead of accessing"
-                                                        :effect (effect (draw 2))} st nil))})))}
-             :runner-turn-ends {:effect (effect (update! (dissoc card :patron-target)))}}
-    :abilities [ability]})
+                  :effect (effect (update! (assoc card :server-target target)))}]
+     {:events {:runner-turn-begins ability
+               :successful-run
+               {:req (req (= (zone->name (get-in @state [:run :server])) (:server-target (get-card state card))))
+                :once :per-turn
+                :effect (req (let [st card]
+                               (swap! state assoc-in [:run :run-effect :replace-access]
+                                      {:mandatory true
+                                       :effect (effect (resolve-ability
+                                                         {:msg "draw 2 cards instead of accessing"
+                                                          :effect (effect (draw 2))} st nil))})))}
+               :runner-turn-ends {:effect (effect (update! (dissoc card :server-target)))}}
+      :abilities [ability]})
 
    "Paparazzi"
    {:effect (req (swap! state update-in [:runner :tagged] inc))
@@ -887,19 +887,19 @@
    "Security Testing"
    (let [ability {:prompt "Choose a server for Security Testing" :choices (req servers)
                   :msg (msg "target " target)
-                  :effect (effect (update! (assoc card :testing-target (vec (next (server->zone state target))))))}]
-   {:events {:runner-turn-begins ability
-             :successful-run
-             {:req (req (= (get-in @state [:run :server]) (:testing-target (get-card state card))))
-              :once :per-turn
-              :effect (req (let [st card]
-                             (swap! state assoc-in [:run :run-effect :replace-access]
-                                    {:mandatory true
-                                     :effect (effect (resolve-ability
-                                                       {:msg "gain 2 [Credits] instead of accessing"
-                                                        :effect (effect (gain :credit 2))} st nil))})))}
-             :runner-turn-ends {:effect (effect (update! (dissoc card :testing-target)))}}
-    :abilities [ability]})
+                  :effect (effect (update! (assoc card :server-target target)))}]
+     {:events {:runner-turn-begins ability
+               :successful-run
+               {:req (req (= (zone->name (get-in @state [:run :server])) (:server-target (get-card state card))))
+                :once :per-turn
+                :effect (req (let [st card]
+                               (swap! state assoc-in [:run :run-effect :replace-access]
+                                      {:mandatory true
+                                       :effect (effect (resolve-ability
+                                                         {:msg "gain 2 [Credits] instead of accessing"
+                                                          :effect (effect (gain :credit 2))} st nil))})))}
+               :runner-turn-ends {:effect (effect (update! (dissoc card :server-target)))}}
+      :abilities [ability]})
 
    "Spoilers"
    {:events {:agenda-scored {:interactive (req true)

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -462,7 +462,7 @@
 
 (defn card-view [{:keys [zone code type abilities counter advance-counter advancementcost current-cost subtype
                          advanceable rezzed strength current-strength title remotes selected hosted
-                         side rec-counter facedown named-target icon new]
+                         side rec-counter facedown server-target icon new]
                   :as cursor}
                  owner {:keys [flipped] :as opts}]
   (om/component
@@ -499,7 +499,7 @@
         (when (and current-strength (not= strength current-strength))
               current-strength [:div.darkbg.strength current-strength])
         (when-let [{:keys [char color]} icon] [:div.darkbg.icon {:class color} char])
-        (when named-target [:div.darkbg.named-target named-target])
+        (when server-target [:div.darkbg.server-target server-target])
         (when (and (= zone ["hand"]) (#{"Agenda" "Asset" "ICE" "Upgrade"} type))
           (let [centrals ["Archives" "R&D" "HQ"]
                 remotes (concat (remote-list remotes) ["New remote"])

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1277,7 +1277,7 @@ nav ul
     &.red
       background-color: red
 
-  .named-target
+  .server-target
     position: absolute
     z-index: 10
     padding: 0

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1287,6 +1287,8 @@ nav ul
     font-size: 10px
     top: 3px
     right: 3px
+    padding-left: 3px
+    padding-right: 3px
     height: 16px
     width: auto
 


### PR DESCRIPTION
Unifies how Patron, SecTest and CyCy handle server targeting. Also adds a message to CyCy when target is chosen.

Icons are removed once ability triggers (or turn ends).

Screenshot
<img width="240" alt="screen shot 2016-07-08 at 22 33 08" src="https://cloud.githubusercontent.com/assets/13198563/16701352/7b7cb0e8-455f-11e6-88e5-70f8c43280e4.png">


Note - made icons slightly wider. Also z-layer of icons conflicts with the run selection menu:
<img width="200" alt="screen shot 2016-07-08 at 22 55 52" src="https://cloud.githubusercontent.com/assets/13198563/16701370/93f8361a-455f-11e6-9116-07a2dddc6b73.png">

Maybe someone with CSS skillz could have a quick look?