### PR TITLE
Never trust the client (client/server security issues)

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -743,7 +743,7 @@
                                              (= (-> @state :runner :identity :faction) (:faction c))
                                              (not (= "Draft" (:setname c)))
                                              (not (= (:title c) (-> @state :runner :identity :title)))))
-                        swappable-ids (filter is-swappable @all-cards)]
+                        swappable-ids (filter is-swappable (vals @all-cards))]
                         (cancellable swappable-ids :sorted)))
 
      :effect (req

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -165,7 +165,8 @@
        (prompt!
          state s card prompt
          (assoc choices :autocomplete
-                        (sort (map :title (filter #((:card-title choices) state side (make-eid state) nil [%]) @all-cards))))
+                        (sort (map :title (filter #((:card-title choices) state side (make-eid state) nil [%])
+                                                  (vals @all-cards)))))
          ab (assoc args :prompt-type :card-title))
        ;; unknown choice
        :else nil)

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -23,7 +23,9 @@
   [state side {:keys [close] :as args}]
   (swap! state update-in [side :deck] shuffle)
   (if close
-    (system-msg state side "stops looking at their deck and shuffles it")
+    (do
+      (swap! state update-in [side] dissoc :view-deck)
+      (system-msg state side "stops looking at their deck and shuffles it"))
     (system-msg state side "shuffles their deck")))
 
 (defn click-draw
@@ -357,3 +359,15 @@
       (doseq [p (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
         (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
         (update-breaker-strength state side p)))))
+
+(defn view-deck
+  "Allows the player to view their deck by making the cards in the deck public."
+  [state side args]
+  (system-msg state side "looks at their deck")
+  (swap! state assoc-in [side :view-deck] true))
+
+(defn close-deck
+  "Closes the deck view and makes cards in deck private again."
+  [state side args]
+  (system-msg state side "stops looking at their deck")
+  (swap! state update-in [side] dissoc :view-deck))

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -11,11 +11,12 @@
 (defn play
   "Called when the player clicks a card from hand."
   [state side {:keys [card server]}]
-  (case (:type card)
-    ("Event" "Operation") (play-instant state side card {:extra-cost [:click 1]})
-    ("Hardware" "Resource" "Program") (runner-install state side (make-eid state) card {:extra-cost [:click 1]})
-    ("ICE" "Upgrade" "Asset" "Agenda") (corp-install state side card server {:extra-cost [:click 1]}))
-  (trigger-event state side :play card))
+  (let [card (get-card state card)]
+    (case (:type card)
+      ("Event" "Operation") (play-instant state side card {:extra-cost [:click 1]})
+      ("Hardware" "Resource" "Program") (runner-install state side (make-eid state) card {:extra-cost [:click 1]})
+      ("ICE" "Upgrade" "Asset" "Agenda") (corp-install state side card server {:extra-cost [:click 1]}))
+    (trigger-event state side :play card)))
 
 (defn shuffle-deck
   "Shuffle R&D/Stack."
@@ -55,7 +56,7 @@
 (defn move-card
   "Called when the user drags a card from one zone to another."
   [state side {:keys [card server]}]
-  (let [c (update-in card [:zone] #(map to-keyword %))
+  (let [c (get-card state card)
         last-zone (last (:zone c))
         src (name-zone (:side c) (:zone c))
         from-str (when-not (nil? src) (str " from their " src))
@@ -110,7 +111,8 @@
   "Resolves a prompt by invoking its effect funtion with the selected target of the prompt.
   Triggered by a selection of a prompt choice button in the UI."
   [state side {:keys [choice card] :as args}]
-  (let [prompt (first (get-in @state [side :prompt]))
+  (let [card (get-card state card)
+        prompt (first (get-in @state [side :prompt]))
         choice (if (= (:choices prompt) :credit)
                  (min choice (get-in @state [side :credit]))
                  choice)]
@@ -118,7 +120,7 @@
       ;; The user did not choose "cancel"
       (if (:card-title (:choices prompt)) ;; check the card title function to see if it's accepted
         (let [title-fn (:card-title (:choices prompt))
-              found (some #(when (= (lower-case choice) (lower-case (:title %))) %) @all-cards)]
+              found (some #(when (= (lower-case choice) (lower-case (:title %))) %) (vals @all-cards))]
           (if found
             (if (title-fn state side (make-eid state) (:card prompt) [found])
               (do ((:effect prompt) (or choice card))
@@ -138,16 +140,14 @@
             ;; the user chose "cancel" -- trigger the cancel effect.
             (cancel-effect choice)
             (effect-completed state side (:eid prompt) nil))
-          (finish-prompt state side prompt card))
-      ;; trigger end-effect if present
-
-      )))
+          (finish-prompt state side prompt card)))))
 
 (defn select
   "Attempt to select the given card to satisfy the current select prompt. Calls resolve-select
   if the max number of cards has been selected."
   [state side {:keys [card] :as args}]
-  (let [r (get-in @state [side :selected 0 :req])]
+  (let [card (get-card state card)
+        r (get-in @state [side :selected 0 :req])]
     (when (or (not r) (r card))
       (let [c (update-in card [:selected] not)]
         (update! state side c)
@@ -163,7 +163,8 @@
 (defn play-ability
   "Triggers a card's ability using its zero-based index into the card's card-def :abilities vector."
   [state side {:keys [card ability targets] :as args}]
-  (let [cdef (card-def card)
+  (let [card (get-card state card)
+        cdef (card-def card)
         abilities (:abilities cdef)
         ab (if (= ability (count abilities))
              ;; recurring credit abilities are not in the :abilities map and are implicit
@@ -203,64 +204,67 @@
   "Rez a corp card."
   ([state side card] (rez state side card nil))
   ([state side card {:keys [ignore-cost no-warning] :as args}]
-   (if (can-rez? state side card)
-     (do
-       (trigger-event state side :pre-rez card)
-       (when (or (#{"Asset" "ICE" "Upgrade"} (:type card))
-                 (:install-rezzed (card-def card)))
-         (trigger-event state side :pre-rez-cost card)
-         (let [cdef (card-def card)
-               cost (rez-cost state side card)
-               costs (concat (when-not ignore-cost [:credit cost])
-                             (when (not= ignore-cost :all-costs) (:additional-cost cdef)))]
-           (when-let [cost-str (apply pay state side card costs)]
-             ;; Deregister the derezzed-events before rezzing card
-             (when (:derezzed-events cdef)
-               (unregister-events state side card))
-             (card-init state side (assoc card :rezzed true))
-             (doseq [h (:hosted card)]
-               (update! state side (-> h
-                                       (update-in [:zone] #(map to-keyword %))
-                                       (update-in [:host :zone] #(map to-keyword %)))))
-             (system-msg state side (str (build-spend-msg cost-str "rez" "rezzes")
-                                         (:title card) (when ignore-cost " at no cost")))
-             (when (and (not no-warning) (:corp-phase-12 @state))
-               (toast state :corp "You are not allowed to rez cards between Start of Turn and Mandatory Draw.
+   (let [card (get-card state card)]
+     (if (can-rez? state side card)
+       (do
+         (trigger-event state side :pre-rez card)
+         (when (or (#{"Asset" "ICE" "Upgrade"} (:type card))
+                   (:install-rezzed (card-def card)))
+           (trigger-event state side :pre-rez-cost card)
+           (let [cdef (card-def card)
+                 cost (rez-cost state side card)
+                 costs (concat (when-not ignore-cost [:credit cost])
+                               (when (not= ignore-cost :all-costs) (:additional-cost cdef)))]
+             (when-let [cost-str (apply pay state side card costs)]
+               ;; Deregister the derezzed-events before rezzing card
+               (when (:derezzed-events cdef)
+                 (unregister-events state side card))
+               (card-init state side (assoc card :rezzed true))
+               (doseq [h (:hosted card)]
+                 (update! state side (-> h
+                                         (update-in [:zone] #(map to-keyword %))
+                                         (update-in [:host :zone] #(map to-keyword %)))))
+               (system-msg state side (str (build-spend-msg cost-str "rez" "rezzes")
+                                           (:title card) (when ignore-cost " at no cost")))
+               (when (and (not no-warning) (:corp-phase-12 @state))
+                 (toast state :corp "You are not allowed to rez cards between Start of Turn and Mandatory Draw.
                       Please rez prior to clicking Start Turn in the future." "warning"
-                      {:time-out 0 :close-button true}))
-             (when (ice? card)
-               (update-ice-strength state side card))
-             (trigger-event state side :rez card))))
-       (swap! state update-in [:bonus] dissoc :cost)))))
+                        {:time-out 0 :close-button true}))
+               (when (ice? card)
+                 (update-ice-strength state side card))
+               (trigger-event state side :rez card))))
+         (swap! state update-in [:bonus] dissoc :cost))))))
 
 (defn derez
   "Derez a corp card."
   [state side card]
-  (system-msg state side (str "derezzes " (:title card)))
-  (update! state :corp (deactivate state :corp card true))
-  (let [cdef (card-def card)]
-    (when-let [derez-effect (:derez-effect cdef)]
-      (resolve-ability state side derez-effect (get-card state card) nil))
-    (when-let [dre (:derezzed-events cdef)]
-      (register-events state side dre card)))
-  (trigger-event state side :derez card))
+  (let [card (get-card state card)]
+    (system-msg state side (str "derezzes " (:title card)))
+    (update! state :corp (deactivate state :corp card true))
+    (let [cdef (card-def card)]
+      (when-let [derez-effect (:derez-effect cdef)]
+        (resolve-ability state side derez-effect (get-card state card) nil))
+      (when-let [dre (:derezzed-events cdef)]
+        (register-events state side dre card)))
+    (trigger-event state side :derez card)))
 
 (defn advance
   "Advance a corp card that can be advanced."
   [state side {:keys [card]}]
-  (when (can-advance? state side card)
-    (when-let [cost (pay state side card :click 1 :credit 1)]
-      (let [spent   (build-spend-msg cost "advance")
-            card    (card-str state card)
-            message (str spent card)]
-        (system-msg state side message))
-      (update-advancement-cost state side card)
-      (add-prop state side (get-card state card) :advance-counter 1))))
+  (let [card (get-card state card)]
+    (when (can-advance? state side card)
+      (when-let [cost (pay state side card :click 1 :credit 1)]
+        (let [spent   (build-spend-msg cost "advance")
+              card    (card-str state card)
+              message (str spent card)]
+          (system-msg state side message))
+        (update-advancement-cost state side card)
+        (add-prop state side (get-card state card) :advance-counter 1)))))
 
 (defn score
   "Score an agenda."
   [state side args]
-  (let [card (or (:card args) args)]
+  (let [card (get-card state (or (:card args) args))]
     (when (can-score? state side card)
       (when (and (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
                  (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -160,6 +160,11 @@
   [card]
   (= (:zone card) [:hand]))
 
+(defn in-discard?
+  "Checks if the specified card is in the discard pile."
+  [card]
+  (= (:zone card) [:discard]))
+
 (defn is-scored?
   "Checks if the specified card is in the scored area of the specified player."
   [state side card]
@@ -173,7 +178,7 @@
 (defn facedown?
   "Checks if the specified card is facedown."
   [card]
-  (= (:zone card) [:rig :facedown]))
+  (or (= (:zone card) [:rig :facedown]) (:facedown card)))
 
 (defn in-corp-scored?
   "Checks if the specified card is in the Corp score area."
@@ -246,3 +251,20 @@
            (not (rezzed? card)))
       (and (is-type? card "Agenda")
            (installed? card))))
+
+(defn card-is-public? [state side {:keys [zone] :as card}]
+  (if (= side :runner)
+    ;; public runner cards: in hand and :openhand is true;
+    ;; or installed/hosted and not facedown;
+    ;; or scored or current or in heap
+    (or (and (:openhand (:runner @state)) (in-hand? card))
+        (and (or (installed? card) (:host card)) (not (facedown? card)))
+        (#{:scored :discard :current} (last zone)))
+    ;; public corp cards: in hand and :openhand;
+    ;; or installed and rezzed;
+    ;; or in :discard and :seen
+    ;; or scored or current
+    (or (and (:openhand (:corp @state)) (in-hand? card))
+        (and (installed? card) (rezzed? card))
+        (and (in-discard? card) (:seen card))
+        (#{:scored :current} (last zone)))))

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -49,16 +49,17 @@
     @game-states))
 
 (defn create-deck
-  "Creates a shuffled draw deck (R&D/Stack) from the given list of cards."
+  "Creates a shuffled draw deck (R&D/Stack) from the given list of cards.
+  Loads card data from server-side @all-cards map if available."
   [deck]
   (shuffle (mapcat #(map (fn [card]
-                           (let [c (assoc card :cid (make-cid))
+                           (let [c (or (@all-cards (:title card)) card)
+                                 c (assoc c :cid (make-cid))
                                  c (dissoc c :setname :text :_id :influence :number :influencelimit
                                            :factioncost)]
                              (if-let [init (:init (card-def c))] (merge c init) c)))
                          (repeat (:qty %) (:card %)))
                    (:cards deck))))
-
 
 (defn make-rid
   "Returns a progressively-increasing integer to identify a new remote server."

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -59,7 +59,7 @@
                                            :factioncost)]
                              (if-let [init (:init (card-def c))] (merge c init) c)))
                          (repeat (:qty %) (:card %)))
-                   (:cards deck))))
+                   (shuffle (vec (:cards deck))))))
 
 (defn make-rid
   "Returns a progressively-increasing integer to identify a new remote server."

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -79,7 +79,7 @@
   caught), or false if an error string should."
   [{:keys [gameid action command side user args text cards] :as msg} state]
   (try (do (case action
-             "initialize" (swap! all-cards (fn [_] (identity cards)))
+             "initialize" (reset! all-cards (into {} (map (juxt :title identity) cards))) ;; creates a map from card title to card data
              "start" (core/init-game msg)
              "remove" (do (swap! game-states dissoc gameid)
                           (swap! last-states dissoc gameid))

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -63,7 +63,7 @@
       (println "Convert error " e))))
 
 (defn strip [state]
-  (dissoc state :events :turn-events :per-turn :prevent :damage))
+  (dissoc state :events :turn-events :per-turn :prevent :damage :effect-completed))
 
 (defn not-spectator? [state user]
   "Returns true if the specified user in the specified state is not a spectator"

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -3,14 +3,15 @@
   (:require [cheshire.core :refer [parse-string generate-string]]
             [cheshire.generate :refer [add-encoder encode-str]]
             [game.macros :refer [effect]]
-            [game.core :refer [all-cards game-states system-msg pay gain draw end-run toast show-error-toast] :as core]
+            [game.core :refer [all-cards game-states system-msg pay gain draw end-run toast show-error-toast
+                               card-is-public?] :as core]
+            [game.utils :refer [card-is? private-card]]
             [environ.core :refer [env]]
             [differ.core :as differ])
   (:gen-class :main true))
 
 (add-encoder java.lang.Object encode-str)
 
-(def last-states (atom {}))
 (def ctx (ZMQ/context 1))
 
 (def spectator-commands
@@ -73,6 +74,44 @@
     (when-let [cmd (spectator-commands command)]
       (cmd state (keyword side) args))))
 
+(defn- private-card-vector [state side cards]
+  (vec (map (fn [card]
+              (cond
+                (not (card-is-public? state side card)) (private-card card)
+                (:hosted card) (update-in card [:hosted] #(private-card-vector state side %))
+                :else card))
+            cards)))
+
+(defn- make-private-runner [state]
+  (-> (:runner @state)
+      (update-in [:hand] #(private-card-vector state :runner %))
+      (update-in [:discard] #(private-card-vector state :runner %))
+      (update-in [:deck] #(private-card-vector state :runner %))
+      (update-in [:rig :facedown] #(private-card-vector state :runner %))
+      (update-in [:rig :resource] #(private-card-vector state :runner %))))
+
+(defn- make-private-corp [state]
+  (let [zones (concat [[:hand]] [[:discard]] [[:deck]]
+                      (for [server (keys (:servers (:corp @state)))] [:servers server :ices])
+                      (for [server (keys (:servers (:corp @state)))] [:servers server :content]))]
+    (loop [s (:corp @state)
+           z zones]
+      (if (empty? z)
+        s
+        (recur (update-in s (first z) #(private-card-vector state :corp %)) (next z))))))
+
+(defn- private-states [state]
+  ;; corp, runner, spectator
+  (let [corp-private (make-private-corp state)
+        runner-private (make-private-runner state)
+        corp-deck (update-in (:corp @state) [:deck] #(map private-card %))
+        runner-deck (update-in (:runner @state) [:deck] #(map private-card %))]
+    [(assoc @state :runner runner-private
+                   :corp corp-deck)
+     (assoc @state :corp corp-private
+                   :runner runner-deck)
+     (assoc @state :corp corp-private :runner runner-private)]))
+
 (defn- handle-command
   "Apply the given command to the given state. Return true if the state should be sent
   back across the socket (if the command was successful or a resolvable exception was
@@ -81,11 +120,11 @@
   (try (do (case action
              "initialize" (reset! all-cards (into {} (map (juxt :title identity) cards))) ;; creates a map from card title to card data
              "start" (core/init-game msg)
-             "remove" (do (swap! game-states dissoc gameid)
-                          (swap! last-states dissoc gameid))
+             "remove" (swap! game-states dissoc gameid)
              "do" (handle-do user command state side args)
              "notification" (when state
                               (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))
+
            true)
        (catch Exception e
          (do (println "Error " action command (get-in args [:card :title]) e)
@@ -102,20 +141,36 @@
   "Main thread for handling commands from the UI server. Attempts to apply a command,
   then returns the resulting game state, or another message as appropriate."
   (while true
+
     (let [{:keys [gameid action command args] :as msg} (convert (.recv socket))
-          state (@game-states (:gameid msg))]
+          state (@game-states (:gameid msg))
+          old-state (when state @state)
+          [old-corp old-runner old-spect] (when old-state (private-states state))]
       ;; Attempt to handle the command. If true is returned, then generate a successful
       ;; message. Otherwise generate an error message.
       (try (if (handle-command msg state)
              (if (= action "initialize")
                (.send socket (generate-string "ok"))
                (if-let [new-state (@game-states gameid)]
-                 (do (case action
-                       ("start" "reconnect" "notification") (.send socket (generate-string {:action action :state (strip @new-state) :gameid gameid}))
-                       (let [diff (differ/diff (strip (@last-states gameid)) (strip @new-state))]
-                         (.send socket (generate-string {:action action :diff diff :gameid gameid}))))
-                     (swap! last-states assoc gameid (strip @new-state)))
-                 (.send socket (generate-string {:action action :gameid gameid :state (strip @state)}))))
+                 (let [[new-corp new-runner new-spect] (private-states new-state)]
+                   (do
+                     (if (#{"start" "reconnect" "notification"} action)
+                       ;; send the whole state, not a diff
+                       (.send socket (generate-string {:action      action
+                                                       :runnerstate (strip new-runner)
+                                                       :corpstate   (strip new-corp)
+                                                       :spectstate  (strip new-spect)
+                                                       :gameid      gameid}))
+                       ;; send a diff
+                       (let [runner-diff (differ/diff (strip old-runner) (strip new-runner))
+                             corp-diff (differ/diff (strip old-corp) (strip new-corp))
+                             spect-diff (differ/diff (strip old-spect) (strip new-spect))]
+                         (.send socket (generate-string {:action     action
+                                                         :runnerdiff runner-diff
+                                                         :corpdiff   corp-diff
+                                                         :spectdiff  spect-diff
+                                                         :gameid     gameid}))))))
+                 (.send socket (generate-string "error"))))
              (.send socket (generate-string "error")))
            (catch Exception e
              (try (do (println "Inner Error " action command (get-in args [:card :title]) e)

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -188,3 +188,5 @@
 (defn get-server-type [zone]
   (or (#{:hq :rd :archives} zone) :remote))
 
+(defn private-card [card]
+  (select-keys card [:zone :cid :side :new :host]))

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -47,7 +47,7 @@
       state)))
 
 (defn load-all-cards []
-  (swap! game.core/all-cards (fn [x] (map #(assoc % :cid (make-cid)) (load-cards)))))
+  (reset! game.core/all-cards (into {} (map (juxt :title identity) (map #(assoc % :cid (make-cid)) (load-cards))))))
 (load-all-cards)
 
 ;;; Card related functions

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -472,8 +472,7 @@
                   :as cursor}
                  owner {:keys [flipped] :as opts}]
   (om/component
-   (when code
-     (sab/html
+    (sab/html
       [:div.card-frame
        [:div.blue-shade.card {:class (str (when selected "selected") (when new " new"))
                               :draggable (when (not-spectator? game-state app-state) true)
@@ -484,11 +483,11 @@
                               :on-drag-end #(-> % .-target js/$ (.removeClass "dragged"))
                               :on-mouse-enter #(when (or (not (or flipped facedown))
                                                          (= (:side @game-state) (keyword (.toLowerCase side))))
-                                                 (put! zoom-channel cursor))
+                                                (put! zoom-channel cursor))
                               :on-mouse-leave #(put! zoom-channel false)
                               :on-click #(handle-card-click @cursor owner)}
         (when-let [url (image-url cursor)]
-          (if (or flipped facedown)
+          (if (or (not code) flipped facedown)
             [:img.card.bg {:src (str "/img/" (.toLowerCase side) ".png")}]
             [:div
              [:span.cardname title]
@@ -498,12 +497,12 @@
            (map (fn [[type num-counters]]
                   (when (pos? num-counters)
                     (let [selector (str "div.darkbg." (lower-case (name type)) "-counter.counter")]
-                     [(keyword selector) num-counters])))
+                      [(keyword selector) num-counters])))
                 counter))
          (when (pos? rec-counter) [:div.darkbg.recurring-counter.counter rec-counter])
          (when (pos? advance-counter) [:div.darkbg.advance-counter.counter advance-counter])]
         (when (and current-strength (not= strength current-strength))
-              current-strength [:div.darkbg.strength current-strength])
+          current-strength [:div.darkbg.strength current-strength])
         (when-let [{:keys [char color]} icon] [:div.darkbg.icon {:class color} char])
         (when server-target [:div.darkbg.server-target server-target])
         (when (and (= zone ["hand"]) (#{"Agenda" "Asset" "ICE" "Upgrade"} type))
@@ -527,16 +526,16 @@
                     [:div {:on-click #(do (send-command action {:card @cursor}))} (capitalize action)])
                   actions)
              (map-indexed
-              (fn [i ab]
-                (if (:auto-pump ab)
-                  [:div {:on-click #(do (send-command "auto-pump" {:card @cursor}))
-                         :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}]
-                  [:div {:on-click #(do (send-command "ability" {:card @cursor
-                                                                 :ability (if (some (fn [a] (:auto-pump a)) abilities)
-                                                                            (dec i) i)})
-                                        (-> (om/get-node owner "abilities") js/$ .fadeOut))
-                         :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}]))
-              abilities)]))
+               (fn [i ab]
+                 (if (:auto-pump ab)
+                   [:div {:on-click #(do (send-command "auto-pump" {:card @cursor}))
+                          :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}]
+                   [:div {:on-click #(do (send-command "ability" {:card @cursor
+                                                                  :ability (if (some (fn [a] (:auto-pump a)) abilities)
+                                                                             (dec i) i)})
+                                         (-> (om/get-node owner "abilities") js/$ .fadeOut))
+                          :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}]))
+               abilities)]))
         (when (= (first zone) "servers")
           (cond
             (and (= type "Agenda") (>= advance-counter (or current-cost advancementcost)))
@@ -549,7 +548,7 @@
              [:div {:on-click #(send-command "rez" {:card @cursor})} "Rez"]]))]
        (when (pos? (count hosted))
          [:div.hosted
-          (om/build-all card-view hosted {:key :cid})])]))))
+          (om/build-all card-view hosted {:key :cid})])])))
 
 (defn drop-area [side server hmap]
   (merge hmap {:on-drop #(handle-drop % server)


### PR DESCRIPTION
Ready to merge.

Two big changes to secure against cheating players. (Not that we've seen this necessarily, but it's still the proper way to do things.)

1. When a player sends a UI command targeting a card in the game, that command contains the data of the targeted card. Currently we take that card data and override the server copy of the card with the data sent by the client. That allows a JavaScript hacker to send a command like `play {:title "Hedge Fund" :cost 0}` to play a Hedge Fund that gains 9 credits and costs 0 to play. Likewise, when starting a game, a player's deck data is sent from the client to the server, and we make no attempt at verifying the deck data is actually valid. Someone can (easily) hack their client deck data so _only their_ cards have modified play costs, agenda values, etc. Most of this would be easy to spot in-game thanks to the extensive log messages, but there are subtle ways to cheat with these flaws.

    I fixed all UI action functions to discard the card data sent from the client, only using it to load the corresponding server-side data for the targeted card. A Hedge Fund with hacked play cost would simply be used to load the actual server-side card, which would have the correct play cost. You can see this in `core-actions.clj`, where any function that takes a `card` parameter from the client immediately re-binds that variable to the server version of the card by loading it from the state with `get-card`. (The client-side card has enough information -- the `:cid` and `:zone` -- to do this reliably.) Thanks to #1572, we can also validate user decks upon game start by replacing the card data sent by the client with the corresponding card data from the server's copy of all cards.

2. Currently the entire game state is sent to each player's UI, and the UI code is responsible for not revealing private information (facedown cards, opponent's hand, both players' decks, etc.). But anyone can read the JavaScript state and/or the network transmissions to read this information illegally, letting them know what's in their opponent's hand/deck, what's in their draw pile, what's in that server, etc. Bad.

    I fix this by sending three different states from the game server to the UI server after each action. The three states contain all the public information available to the Corp, Runner, and spectators, respectively. Public information consists of a player's hand, all their installed cards, and all faceup cards the opponent has installed or discarded. If a card is not public information, then all its data is stripped from the state sent to a player except for the card's `:cid`, `:zone`, and a few other misc keys; these keys are minimally necessary to maintain targeting and other UI functionality. 

#### TO-DO

1. ~~Restore "look at deck" functionality.~~
2. ~~Randomize decks before assigning `:cid`, so a hacker can't surmise the identity of an unknown card based on its `:cid` and the order it appears in their decklist.~~
3. Assign new `:cid` every time a card is moved to a private zone, so a hacker can't record the `:cid` of a card they played and then shuffled back into their deck, to know where that card now is in the deck.