### PR TITLE
Swap agenda function

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -699,42 +699,26 @@
              {:interactive (req true)
               :req (req (not (empty? (:scored corp))))
               :delayed-completion true
-              :effect (req (let [st target]
-                             (continue-ability
-                               state side
-                               {:optional {:prompt (msg "Swap " (:title st) " for an agenda in the Corp's score area?")
-                                           :yes-ability
-                                                   {:delayed-completion true
-                                                    :effect
-                                                    (req (continue-ability
-                                                           state side
-                                                           {:prompt (str "Choose a scored Corp agenda to swap with " (:title st))
-                                                            :choices {:req #(in-corp-scored? state side %)}
-                                                            :effect (req (let [sw target
-                                                                               stpts-corp (get-agenda-points state :corp st)
-                                                                               swpts-corp (get-agenda-points state :corp sw)
-                                                                               stpts-runner (get-agenda-points state :runner st)
-                                                                               swpts-runner (get-agenda-points state :runner sw)]
-                                                                           (swap! state update-in [:corp :scored]
-                                                                                  (fn [coll] (conj (remove-once #(not= (:cid %) (:cid sw)) coll) st)))
-                                                                           (swap! state update-in [:runner :scored]
-                                                                                  (fn [coll] (conj (remove-once #(not= (:cid %) (:cid st)) coll)
-                                                                                                   (dissoc sw :abilities :events))))
-                                                                           (gain-agenda-point state :runner (- swpts-runner stpts-runner))
-                                                                           (gain-agenda-point state :corp (- stpts-corp swpts-corp))
-                                                                           (let [c (find-cid (:cid st) (get-in @state [:corp :scored]))]
-                                                                             (let [abilities (:abilities (card-def c))
-                                                                                   c (merge c {:abilities abilities})]
-                                                                               (update! state :corp c)
-                                                                               (when-let [events (:events (card-def c))]
-                                                                                 (register-events state side events c))))
-                                                                           (let [r (find-cid (:cid sw) (get-in @state [:runner :scored]))]
-                                                                             (deactivate state :corp r))
-                                                                           (system-msg state side (str "uses Turntable to swap "
-                                                                                                       (:title st) " for " (:title sw)))
-                                                                           (effect-completed state side eid card)))}
-                                                           card targets))}}}
-                               card targets)))}}}
+              :effect (req
+                        (let [stolen target]
+                          (continue-ability
+                            state side
+                            {:optional
+                             {:prompt (msg "Swap " (:title stolen) " for an agenda in the Corp's score area?")
+                              :yes-ability
+                              {:delayed-completion true
+                               :effect (req
+                                         (continue-ability
+                                           state side
+                                           {:prompt (str "Choose a scored Corp agenda to swap with " (:title stolen))
+                                            :choices {:req #(in-corp-scored? state side %)}
+                                            :effect (req (let [scored target]
+                                                           (swap-agendas state side scored stolen)
+                                                           (system-msg state side (str "uses Turntable to swap "
+                                                                                       (:title stolen) " for " (:title scored)))
+                                                           (effect-completed state side eid card)))}
+                                           card targets))}}}
+                            card targets)))}}}
 
    "Unregistered S&W 35"
    {:abilities

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -256,45 +256,25 @@
                    (seq (:scored runner))
                    (seq (:scored corp))))
     :delayed-completion true
-    :effect (req (continue-ability
-                   state side
-                   {:prompt "Choose a stolen agenda in the Runner's score area to swap"
-                    :choices {:req #(in-runner-scored? state side %)}
-                    :delayed-completion true
-                    :effect (req (let [r target]
-                                   (continue-ability
-                                     state side
-                                     {:prompt (msg "Choose a scored agenda to swap for " (:title r))
-                                      :choices {:req #(in-corp-scored? state side %)}
-                                      :effect (req (let [c target
-                                                         rpts-corp (get-agenda-points state :corp r)
-                                                         cpts-corp (get-agenda-points state :corp c)
-                                                         rpts-runner (get-agenda-points state :runner r)
-                                                         cpts-runner (get-agenda-points state :runner c)]
-
-                                                     ; Remove end of turn events for swapped out agenda
-                                                     (swap! state update-in [:corp :register :end-turn]
-                                                       (fn [events] (filter #(not (= (:cid c) (get-in % [:card :cid]))) events)))
-
-                                                     (swap! state update-in [:corp :scored]
-                                                            (fn [coll] (conj (remove-once #(not= (:cid %) (:cid c)) coll) r)))
-                                                     (swap! state update-in [:runner :scored]
-                                                            (fn [coll] (conj (remove-once #(not= (:cid %) (:cid r)) coll)
-                                                                             (dissoc c :abilities :events))))
-                                                     (gain-agenda-point state :runner (- cpts-runner rpts-runner))
-                                                     (gain-agenda-point state :corp (- rpts-corp cpts-corp))
-                                                     (let [newc (find-cid (:cid r) (get-in @state [:corp :scored]))]
-                                                       (let [abilities (:abilities (card-def newc))
-                                                             newc (merge newc {:abilities abilities})]
-                                                         (update! state :corp newc)
-                                                         (when-let [events (:events (card-def newc))]
-                                                          (register-events state side events newc))))
-                                                     (let [newr (find-cid (:cid c) (get-in @state [:runner :scored]))]
-                                                       (deactivate state :corp newr))
-                                                     (system-msg state side (str "uses Exchange of Information to swap "
-                                                                                 (:title c) " for " (:title r)))))}
-                                    card nil)))}
-                  card nil))}
+    :effect (req
+              (continue-ability
+                state side
+                {:prompt "Choose a stolen agenda in the Runner's score area to swap"
+                 :choices {:req #(in-runner-scored? state side %)}
+                 :delayed-completion true
+                 :effect (req
+                           (let [stolen target]
+                             (continue-ability
+                               state side
+                               {:prompt (msg "Choose a scored agenda to swap for " (:title stolen))
+                                :choices {:req #(in-corp-scored? state side %)}
+                                :effect (req (let [scored target]
+                                               (swap-agendas state side scored stolen)
+                                               (system-msg state side (str "uses Exchange of Information to swap "
+                                                                           (:title scored) " for " (:title stolen)))
+                                               (effect-completed state side eid card)))}
+                               card nil)))}
+                card nil))}
 
    "Fast Track"
    {:prompt "Choose an Agenda"


### PR DESCRIPTION
Extracts `swap-agendas` from Turntable and Exchange of Information.

Also removes the weird unused functions in core-misc.