### PR TITLE
Improvements to Immolation Script, Bank Job

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -84,19 +84,35 @@
 
    "Bank Job"
    {:data {:counter {:credit 8}}
-    :events {:no-action {:effect (req (toast state :runner "Click Bank Job to take credits from it instead of accessing" "info"))
-                         :req (req (and (is-remote? (:server run)) (not current-ice)))}}
-    :abilities [{:req (req (and (:run @state) (= (:position run) 0)))
-                 :label "Take any number of [Credits] on Bank Job"
-                 :prompt "How many [Credits]?"
-                 :choices {:counter :credit}
-                 :msg (msg "gain " target " [Credits]")
-                 :effect (req (gain state side :credit target)
-                              (register-successful-run state side (:server run))
-                              (swap! state update-in [:runner :prompt] rest)
-                              (handle-end-run state side)
-                              (when (= target (get-in card [:counter :credit]))
-                                (trash state :runner card {:unpreventable true})))}]}
+    :events {:successful-run
+             {:req (req (is-remote? (:server run)))
+              :effect (req (let [bj card]
+                             (when-not (:replace-access (get-in @state [:run :run-effect]))
+                               (swap! state assoc-in [:run :run-effect :replace-access]
+                                      {:effect (req (if (> (count (filter #(= (:title %) "Bank Job") (all-installed state :runner))) 1)
+                                                      (resolve-ability state side
+                                                        {:prompt "Choose a copy of Bank Job to use"
+                                                         :choices {:req #(and installed? (= (:title %) "Bank Job"))}
+                                                         :effect (req (let [c target
+                                                                            creds (get-in c [:counter :credit])]
+                                                                        (resolve-ability state side
+                                                                          {:prompt "How many Bank Job credits?"
+                                                                           :choices {:number (req (get-in c [:counter :credit]))}
+                                                                           :msg (msg "gain " target " [Credits]")
+                                                                           :effect (req (gain state side :credit target)
+                                                                                        (set-prop state side c :counter {:credit (- creds target)})
+                                                                                        (when (= target creds)
+                                                                                          (trash state side c {:unpreventable true})))}
+                                                                         card nil)))}
+                                                       bj nil)
+                                                      (resolve-ability state side
+                                                        {:prompt "How many Bank Job credits?"
+                                                         :choices {:counter :credit}
+                                                         :msg (msg "gain " target " [Credits]")
+                                                         :effect (req (gain state side :credit target)
+                                                                      (when (= target (get-in card [:counter :credit]))
+                                                                        (trash state side card {:unpreventable true})))}
+                                                       bj nil)))}))))}}}
 
    "Bazaar"
    {:events


### PR DESCRIPTION
* Fix #1699: Update Immolation Script to work with new delayed completion framework. 
* Fix #1704, fix #1751: Bank Job is flawed in multiple ways right now. The existing code was a series of hacks to get it to _mostly_ trigger at the correct time, but predates all the delayed completion stuff. Now the card triggers on `:successful-run` and swaps a replacement effect into `[:run]`--but only if no mandatory replacement effect already exists, e.g. Security Testing or Patron. If only one Bank Job is installed the effect happens as usual. If 2 or more Bank Jobs are in play, the Runner is prompted to choose one (wasn't possible before). This code is now sprawling and ghastly and probably begging for a refactor, but let's just get it working for now. *Note:* this still won't combo correctly in the _extremely_ unlikely event that someone plays Exploratory Romp or Singularity with Bank Job(s) out--we still don't have a way of letting a Runner choose from multiple replacement effects, AFAIK. Includes tests for interactions with Manhunt, Security Testing, and multiple Bank Jobs.

Aside:  in the medium term, I think it would be good to change the prompt text from "Run ability" to "Replacement effect", as that's really the more correct game terminology, and also covers the case of Bank Job and Record Reconstructor and any other non-Run event that supplies an access replacement effect. 