### PR TITLE
Fix Mumbad Virtual Tour and Turning Wheel message

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -1103,7 +1103,7 @@
              :run-ends {:req (req (and (not (:agenda-stolen card))
                                        (#{:hq :rd} target)))
                         :effect (effect (add-counter card :power 1)
-                                        (system-msg (str "adds a power counter to " (:title card))))
+                                        (system-msg :runner (str "places a power counter on " (:title card))))
                         :silent (req true)}}
     :abilities [{:counter-cost [:power 2]
                  :req (req (:run @state))

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -249,7 +249,8 @@
                               (swap! state assoc-in [:runner :register :force-trash] true)
                               (toast state :runner (str "You must use any credit sources (Whizzard, Scrubber, "
                                                         "Ghost Runner, Net Celebrity) to trash Mumbad Virtual Tour, if able")))))}
-    :trash-effect {:effect (req (swap! state assoc-in [:runner :register :force-trash] false))}}
+    :trash-effect {:when-unrezzed true
+                   :effect (req (swap! state assoc-in [:runner :register :force-trash] false))}}
 
    "NeoTokyo Grid"
    (let [ng {:req (req (and (= (second (:zone target)) (second (:zone card)))


### PR DESCRIPTION
The forced trash effect of MVT is wrongly persisting when the Runner hits an installed, unrezzed copy and the forced trash occurs. 

Turning Wheel message now references the Runner if the Corp fires an ETR subroutine. 