### PR TITLE
Fixes: Rebirth, invisible Parasite/Pawn/programs hosted on ice, dragging from :play-area. Rework Indexing, Making an Entrance.

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -749,7 +749,7 @@
                                              (not (= "Draft" (:setname c)))
                                              (not (= (:title c) (-> @state :runner :identity :title)))))
                         swappable-ids (filter is-swappable (vals @all-cards))]
-                        (cancellable swappable-ids :sorted)))
+                    (cancellable swappable-ids :sorted)))
 
      :effect (req
                (move state side (last (:discard runner)) :rfg)

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -426,12 +426,37 @@
       :msg (msg "trash " (count targets) " card" (when (not= 1(count targets)) "s") " and draw " (cards-to-draw targets) " cards")})
 
    "Indexing"
-   {:effect (effect (run :rd {:replace-access
-                              {:msg "rearrange the top 5 cards of R&D"
-                               :effect (req (prompt! state side card
-                                                     (str "Drag cards from the Temporary Zone back onto R&D") ["OK"] {})
-                                            (doseq [c (take 5 (:deck corp))]
-                                              (move state side c :play-area)))}} card))}
+   (letfn [(index-final [chosen original]
+             {:prompt (str "The top 5 cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
+              :choices ["Done" "Start over"]
+              :delayed-completion true
+              :effect (req (if (= target "Done")
+                             (do (swap! state update-in [:corp :deck] #(vec (concat chosen (drop (count chosen) %))))
+                                 (clear-wait-prompt state :corp)
+                                 (effect-completed state side eid))
+                             (continue-ability state side (index-choice original '() (count original) original)
+                                               card nil)))})
+           (index-choice [remaining chosen n original]
+             {:prompt "Choose a card to move next onto R&D"
+              :choices remaining
+              :delayed-completion true
+              :effect (req (let [chosen (cons target chosen)]
+                             (if (< (count chosen) n)
+                               (continue-ability state side
+                                                 (index-choice (remove-once #(not= target %) remaining)
+                                                               chosen n original)
+                                                 card nil)
+                               (continue-ability state side (index-final chosen original) card nil))))})]
+     {:delayed-completion true
+      :effect (effect
+                (run :rd
+                     {:replace-access
+                      {:msg "rearrange the top 5 cards of R&D"
+                       :delayed-completion true
+                       :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of R&D")
+                                    (let [from (take 5 (:deck corp))]
+                                      (continue-ability state side (index-choice from '() (count from) from) card nil)))}}
+                     card))})
 
    "Infiltration"
    {:prompt "Gain 2 [Credits] or expose a card?" :choices ["Gain 2 [Credits]" "Expose a card"]
@@ -575,9 +600,43 @@
     :effect (effect (gain :credit 9))}
 
    "Making an Entrance"
-   {:msg "look at and trash or rearrange the top 6 cards of their Stack"
-    :effect (req (toast state :runner "Drag remaining untrashed cards from the Temporary Zone back onto your Stack" "info")
-                 (doseq [c (take 6 (:deck runner))] (move state side c :play-area)))}
+   (letfn [(entrance-final [chosen original]
+             {:prompt (str "The top cards of your stack will be " (clojure.string/join  ", " (map :title chosen)) ".")
+              :choices ["Done" "Start over"]
+              :delayed-completion true
+              :effect (req (if (= target "Done")
+                             (do (swap! state update-in [:runner :deck] #(vec (concat chosen (drop (count chosen) %))))
+                                 (clear-wait-prompt state :corp)
+                                 (effect-completed state side eid))
+                             (continue-ability state side (entrance-choice original '() (count original) original)
+                                               card nil)))})
+           (entrance-choice [remaining chosen n original]
+             {:prompt "Choose a card to move next onto your stack"
+              :choices remaining
+              :delayed-completion true
+              :effect (req (let [chosen (cons target chosen)]
+                             (if (< (count chosen) n)
+                               (continue-ability state side
+                                                 (entrance-choice (remove-once #(not= target %) remaining)
+                                                                  chosen n original)
+                                                 card nil)
+                               (continue-ability state side (entrance-final chosen original) card nil))))})
+           (entrance-trash [cards]
+             {:prompt "Choose a card to trash"
+              :choices (cons "None" cards)
+              :delayed-completion true
+              :effect (req (if (= target "None")
+                             (if (not-empty cards)
+                               (continue-ability state side (entrance-choice cards '() (count cards) cards) card nil)
+                               (effect-completed state side eid))
+                             (do (trash state side target {:unpreventable true})
+                                 (continue-ability state side (entrance-trash (remove-once #(not= % target) cards))
+                                                   card nil))))})]
+     {:msg "look at and trash or rearrange the top 6 cards of their Stack"
+      :delayed-completion true
+      :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their stack")
+                   (let [from (take 6 (:deck runner))]
+                     (continue-ability state side (entrance-trash from) card nil)))})
 
    "Mass Install"
    (let [mhelper (fn mi [n] {:prompt "Select a program to install"

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -59,6 +59,9 @@
   "Called when the user drags a card from one zone to another."
   [state side {:keys [card server]}]
   (let [c (get-card state card)
+        ;; hack: if dragging opponent's card from play-area (Indexing), the previous line will fail
+        ;; to find the card. the next line will search in the other player's play-area.
+        c (or c (get-card state (assoc card :side (other-side (to-keyword (:side card))))))
         last-zone (last (:zone c))
         src (name-zone (:side c) (:zone c))
         from-str (when-not (nil? src) (str " from their " src))

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -113,12 +113,15 @@
   "Resolves a prompt by invoking its effect funtion with the selected target of the prompt.
   Triggered by a selection of a prompt choice button in the UI."
   [state side {:keys [choice card] :as args}]
-  (let [card (get-card state card)
+  (let [servercard (get-card state card)
+        card (if (not= (:title card) (:title servercard))
+               (@all-cards (:title card))
+               servercard)
         prompt (first (get-in @state [side :prompt]))
         choice (if (= (:choices prompt) :credit)
                  (min choice (get-in @state [side :credit]))
                  choice)]
-    (if (not= choice "Cancel")
+    (if (not= choice "Can cel")
       ;; The user did not choose "cancel"
       (if (:card-title (:choices prompt)) ;; check the card title function to see if it's accepted
         (let [title-fn (:card-title (:choices prompt))

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -257,14 +257,16 @@
     ;; public runner cards: in hand and :openhand is true;
     ;; or installed/hosted and not facedown;
     ;; or scored or current or in heap
-    (or (and (:openhand (:runner @state)) (in-hand? card))
+    (or (card-is? card :side :corp)
+        (and (:openhand (:runner @state)) (in-hand? card))
         (and (or (installed? card) (:host card)) (not (facedown? card)))
         (#{:scored :discard :current} (last zone)))
     ;; public corp cards: in hand and :openhand;
     ;; or installed and rezzed;
     ;; or in :discard and :seen
     ;; or scored or current
-    (or (and (:openhand (:corp @state)) (in-hand? card))
+    (or (card-is? card :side :runner)
+        (and (:openhand (:corp @state)) (in-hand? card))
         (and (installed? card) (rezzed? card))
         (and (in-discard? card) (:seen card))
         (#{:scored :current} (last zone)))))

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -189,4 +189,4 @@
   (or (#{:hq :rd :archives} zone) :remote))
 
 (defn private-card [card]
-  (select-keys card [:zone :cid :side :new :host :counter :advance-counter]))
+  (select-keys card [:zone :cid :side :new :host :counter :advance-counter :hosted]))

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -665,7 +665,7 @@
 ;; Rebirth
 (let [choose-runner (fn [name state prompt-map]
                       (let [kate-choice (some #(when (= name (:title %)) %) (:choices (prompt-map :runner)))]
-                        (core/resolve-prompt state :runner {:choice kate-choice})))
+                        (core/resolve-prompt state :runner {:card kate-choice})))
 
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"
       kit "Rielle \"Kit\" Peddler: Transhuman"

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -3,7 +3,7 @@
                                 costs-to-symbol vdissoc distinct-by]]
             [game.macros :refer [effect req msg]]
             [clojure.string :refer [split-lines split join]]
-            [game.core :as core]
+            [game.core :as core :refer [all-cards]]
             [test.utils :refer [load-card load-cards qty default-corp default-runner
                                 make-deck]]
             [test.macros :refer [do-game]]
@@ -30,10 +30,10 @@
     (let [states (core/init-game
                    {:gameid 1
                     :players [{:side "Corp"
-                               :deck {:identity (load-card (:identity corp))
+                               :deck {:identity (@all-cards (:identity corp))
                                       :cards (:deck corp)}}
                               {:side "Runner"
-                               :deck {:identity (load-card (:identity runner))
+                               :deck {:identity (@all-cards (:identity runner))
                                       :cards (:deck runner)}}]})
           state (second (last states))]
       (if (#{:both :corp} mulligan)

--- a/src/clj/test/utils.clj
+++ b/src/clj/test/utils.clj
@@ -1,6 +1,7 @@
 (ns test.utils
   (:require [monger.core :as mg]
-            [monger.collection :as mc]))
+            [monger.collection :as mc]
+            [game.core :refer [all-cards]]))
 
 (defn load-card [title]
   (let [conn (mg/connect {:host "127.0.0.1" :port 27017})
@@ -21,7 +22,7 @@
     ret))
 
 (defn qty [card amt]
-  {:card (if (string? card) (load-card card) card) :qty amt})
+  {:card (if (string? card) (@all-cards card) card) :qty amt})
 
 (defn make-deck [identity deck]
   {:identity identity 


### PR DESCRIPTION
Fix #1769, as a consequence of #1749. 

Fix #1767 by making your cards that are hosted on opponent's cards public to you. Also fixes Parasite.

Fix all outstanding issues with Indexing by reworking the card to use a recursive prompt where you select the cards to place on R&D. Includes a final "This is what R&D will look like, are you sure?" prompt. (Fix #1413, Fix #1127.)

![image](https://cloud.githubusercontent.com/assets/10083341/16887297/08c284b8-4a8e-11e6-918d-6840dc9d224a.png)

Also applied this logic to Making an Entrance.

Also includes a 50-80% speedup in `lein test test.all` runtime by not needing to hit the database for each card's data in each test.
