### PR TITLE
Band-aid fix for #1782.

### DIFF
--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -6,7 +6,8 @@
   "Prints a message to the log as coming from the given username. The special user string
   __system__ shows no user name."
   [state side {:keys [user text]}]
-  (let [author (or user (get-in @state [side :user]))]
+  (let [author (or user (get-in @state [side :user]))
+        text (if (= (.trim text) "null") " null" text)]
     (if-let [command (parse-command text)]
       (when (and (not= side nil) (not= side :spectator))
         (command state side)


### PR DESCRIPTION
Fix #1782 by replacing any message that is just "null" (the only message that seems to be crashing things) with " null", which renders identically but does not seems to trip up the JavaScript UI. My notes in #1782 might be helpful for anyone who seeks to understand exactly why this happening, which I have not determined.