### PR TITLE
Fix alt arts.

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -824,7 +824,8 @@
 
                ;; Move the selected ID to [:runner :identity] and set the zone
                (swap! state update-in [side :identity]
-                  (fn [x] (assoc target :zone [:identity])))
+                  (fn [x] (assoc (server-card (:title target) (get-in @state [:runner :user]))
+                            :zone [:identity])))
 
                ;; enable-identity does not do everything that card-init does
                (card-init state side (get-in @state [:runner :identity]))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -8,10 +8,12 @@
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))
 
-(declare get-card get-zones get-runnable-zones get-remote-names make-eid make-result register-effect-completed resolve-ability say system-msg trigger-event update!)
+(declare get-card get-zones get-runnable-zones get-remote-names make-eid make-result register-effect-completed
+         resolve-ability say server-card system-msg trigger-event update!)
 
 (def game-states (atom {}))
 (def all-cards (atom {}))
+(def all-cards-alt (atom {}))
 
 (load "core-cards")     ; retrieving and updating cards
 (load "core-events")    ; triggering of events


### PR DESCRIPTION
Can't have those filthy plebs using our fancy alt-art cards.

Things I learned:

1. Alt-art was being set by the deckbuilder when adding the card to a deck. If you made a deck before you are marked as a donor and never update it, the deck would always use regular art.
2. I broke alt-art by insisting on loading server versions of each card in a player's deck. The server loads all cards from the `cards` table in the database, and then creates a map from card title to card data. Cards with alt art have TWO entries in this table, and depending on the random order they were being retrieved, the alt version of a card was overriding the regular version in this map for some cards. When validating a deck, the server's version of a card is placed into the deck instead of the client's, so everyone was getting the same copy of the (either regular or alt) card.

I fixed it by:

1. Loading `all-cards` with regular cards and `all-cards-alt` with alt-art cards.
2. Adding `server-card` which loads a card from one of these two maps based on the `user` information passed to the function. (Loads alt arts for special users.)

I also made Rebirth load the alt-art version of an ID if appropriate. Groovy.