### PR TITLE
Implement Full Immersion RecStudio; improvements to corp hosting overall

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -350,6 +350,20 @@
                       :msg "add it to their score area and gain 1 agenda point"
                       :effect (effect (as-agenda :corp card 1))}}}
 
+   "Full Immersion RecStudio"
+   {:can-host (req (and (or (is-type? target "Asset") (is-type? target "Agenda"))
+                        (> 2 (count (:hosted card)))))
+    :trash-cost-bonus (req (* 3 (count (:hosted card))))
+    :abilities [{:label "Install an asset or agenda on Full Immersion RecStudio"
+                 :req (req (< (count (:hosted card)) 2))
+                 :cost [:click 1]
+                 :prompt "Choose an asset or agenda to install"
+                 :choices {:req #(and (or (is-type? % "Asset") (is-type? % "Agenda"))
+                                      (in-hand? %)
+                                      (= (:side %) "Corp"))}
+                 :msg (msg "install and host " (:title target))
+                 :effect (req (corp-install state side target card))}]}
+
    "Genetics Pavilion"
    {:msg "prevent the Runner from drawing more than 2 cards during their turn"
     :effect (req (max-draw state :runner 2)
@@ -1049,11 +1063,8 @@
                                       (in-hand? %)
                                       (= (:side %) "Corp"))}
                  :msg (msg "host " (:title target))
-                 :effect (req (trigger-event state side :corp-install target)
-                              (host state side card target)
-                              (rez-cost-bonus state side -2) (rez state side (last (:hosted (get-card state card))))
-                              (when (:rezzed (last (:hosted (get-card state card))))
-                                (update! state side (dissoc (get-card state (last (:hosted card))) :facedown))))}]}
+                 :effect (req (corp-install state side target card) ;; install target onto card
+                              (rez-cost-bonus state side -2) (rez state side (last (:hosted (get-card state card)))))}]}
 
    "Zaibatsu Loyalty"
    {:prevent {:expose [:all]}

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -189,9 +189,10 @@
                                            :effect (effect (gain :runner :credit 5))}} card))}
 
    "Drive By"
-   {:choices {:req #(and (is-remote? (second (:zone %)))
-                         (= (last (:zone %)) :content)
-                         (not (:rezzed %)))}
+   {:choices {:req #(let [topmost (get-nested-host %)]
+                     (and (is-remote? (second (:zone topmost)))
+                          (= (last (:zone topmost)) :content)
+                          (not (:rezzed %))))}
     :delayed-completion true
     :effect (req (when-completed (expose state side target) ;; would be nice if this could return a value on completion
                                  (if async-result ;; expose was successful

--- a/src/clj/game/core-costs.clj
+++ b/src/clj/game/core-costs.clj
@@ -86,7 +86,9 @@
 
 (defn trash-cost [state side {:keys [trash] :as card}]
   (when-not (nil? trash)
-    (-> trash
+    (-> (if-let [trashfun (:trash-cost-bonus (card-def card))]
+          (+ trash (trashfun state side (make-eid state) card nil))
+          trash)
         (+ (or (get-in @state [:bonus :trash]) 0))
         (max 0))))
 

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -267,6 +267,7 @@
     ;; or scored or current
     (or (card-is? card :side :runner)
         (and (:openhand (:corp @state)) (in-hand? card))
-        (and (installed? card) (rezzed? card))
+        (and (or (installed? card) (:host card))
+             (or (is-type? card "Operation") (rezzed? card)))
         (and (in-discard? card) (:seen card))
         (#{:scored :current} (last zone)))))

--- a/src/clj/game/core-hosting.clj
+++ b/src/clj/game/core-hosting.clj
@@ -2,8 +2,8 @@
 
 (defn get-nested-host
   "Recursively searches upward to find the 'root' card of a hosting chain."
-  [state card]
-  (if (:host card) (recur state (:host card)) card))
+  [card]
+  (if (:host card) (recur (:host card)) card))
 
 (defn update-hosted!
   "Updates a card that is hosted on another, by recursively updating the host card's
@@ -24,7 +24,7 @@
 (defn get-card-hosted
   "Finds the current version of the given card by finding its host."
   [state {:keys [cid zone side host] :as card}]
-  (let [root-host (get-card state (get-nested-host state card))
+  (let [root-host (get-card state (get-nested-host card))
         helper (fn search [card target]
                  (when-not (nil? card)
                    (if-let [c (some #(when (= (:cid %) (:cid target)) %) (:hosted card))]

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -120,59 +120,81 @@
     (system-msg state side (str (build-spend-msg cost-str "install") card-name
                                 (if (ice? card) " protecting " " in ") server-name))))
 
+(defn corp-install-list
+  "Returns a list of targets for where a given card can be installed."
+  [state card]
+  (let [hosts (filter #(when-let [can-host (:can-host (card-def %))]
+                        (and (rezzed? %)
+                             (can-host state :corp (make-eid state) % [card])))
+                      (all-installed state :corp))]
+    (concat hosts (server-list state card))))
+
 (defn corp-install
   ([state side card server] (corp-install state side (make-eid state) card server nil))
   ([state side card server args] (corp-install state side (make-eid state) card server args))
-  ([state side eid card server {:keys [extra-cost no-install-cost install-state] :as args}]
-   (if-not server
+  ([state side eid card server {:keys [extra-cost no-install-cost install-state host-card] :as args}]
+   (cond
+     ;; No server selected; show prompt to select an install site (Interns, Lateral Growth, etc.)
+     (not server)
      (continue-ability state side
-                       {:prompt (str "Choose a server to install " (:title card))
-                        :choices (server-list state card)
+                       {:prompt (str "Choose a location to install " (:title card))
+                        :choices (corp-install-list state card)
                         :delayed-completion true
                         :effect (effect (corp-install eid card target args))}
                        card nil)
-     (do
-       (let [cdef (card-def card)
-             c (-> card
-                   (assoc :advanceable (:advanceable cdef))
-                   (dissoc :seen))
-             slot (conj (server->zone state server) (if (ice? c) :ices :content))
-             dest-zone (get-in @state (cons :corp slot))]
-         ;; trigger :pre-corp-install before computing install costs so that
-         ;; event handlers may adjust the cost.
-         (trigger-event state side :pre-corp-install card {:server server :dest-zone dest-zone})
-         (let [ice-cost (if (and (ice? c)
-                                 (not no-install-cost)
-                                 (not (ignore-install-cost? state side)))
-                          (count dest-zone) 0)
-               all-cost (concat extra-cost [:credit ice-cost])
-               end-cost (install-cost state side card all-cost)
-               install-state (or install-state (:install-state cdef))]
-           (when (corp-can-install? card dest-zone)
-             (when-let [cost-str (pay state side card end-cost)]
-               (when (= server "New remote")
-                 (trigger-event state side :server-created card))
-               (corp-install-asset-agenda state side c dest-zone)
-               (corp-install-message state side c server install-state cost-str)
-               (let [moved-card (move state side (assoc c :new true) slot)]
-                 (trigger-event state side :corp-install moved-card)
-                 (when (is-type? c "Agenda")
-                   (update-advancement-cost state side moved-card))
-                 (when (= install-state :rezzed-no-cost)
-                   (rez state side moved-card {:ignore-cost :all-costs}))
-                 (when (= install-state :rezzed)
-                   (rez state side moved-card))
-                 (when (= install-state :face-up)
-                   (if (:install-state cdef)
-                     (card-init state side
-                                (assoc (get-card state moved-card) :rezzed true :seen true) false)
-                     (update! state side (assoc (get-card state moved-card) :rezzed true :seen true))))
-                 (when-let [dre (:derezzed-events cdef)]
-                   (when-not (:rezzed (get-card state moved-card))
-                     (register-events state side dre moved-card))))))
-           (clear-install-cost-bonus state side)
-           (when-not (:delayed-completion cdef)
-             (effect-completed state side eid card))))))))
+     ;; A card was selected as the server; recurse, with the :host-card parameter set.
+     (and (map? server) (not host-card))
+     (corp-install state side eid card server (assoc args :host-card server))
+     ;; A server was selected
+     :else
+     (let [cdef (card-def card)
+           slot (if host-card
+                  (:zone host-card)
+                  (conj (server->zone state server) (if (ice? card) :ices :content)))
+           dest-zone (get-in @state (cons :corp slot))]
+       ;; trigger :pre-corp-install before computing install costs so that
+       ;; event handlers may adjust the cost.
+       (trigger-event state side :pre-corp-install card {:server server :dest-zone dest-zone})
+       (let [ice-cost (if (and (ice? card)
+                               (not no-install-cost)
+                               (not (ignore-install-cost? state side)))
+                        (count dest-zone) 0)
+             all-cost (concat extra-cost [:credit ice-cost])
+             end-cost (install-cost state side card all-cost)
+             install-state (or install-state (:install-state cdef))]
+
+         (if (corp-can-install? card dest-zone)
+           (if-let [cost-str (pay state side card end-cost)]
+             (do (let [c (-> card
+                             (assoc :advanceable (:advanceable cdef) :new true)
+                             (dissoc :seen))]
+                   (when (= server "New remote")
+                     (trigger-event state side :server-created card))
+                   (when (not host-card)
+                     (corp-install-asset-agenda state side c dest-zone)
+                     (corp-install-message state side c server install-state cost-str))
+
+                   (let [moved-card (if host-card
+                                      (host state side host-card (assoc c :installed true))
+                                      (move state side c slot))]
+                     (trigger-event state side :corp-install moved-card)
+                     (when (is-type? c "Agenda")
+                       (update-advancement-cost state side moved-card))
+                     (when (= install-state :rezzed-no-cost)
+                       (rez state side moved-card {:ignore-cost :all-costs}))
+                     (when (= install-state :rezzed)
+                       (rez state side moved-card))
+                     (when (= install-state :face-up)
+                       (if (:install-state cdef)
+                         (card-init state side
+                                    (assoc (get-card state moved-card) :rezzed true :seen true) false)
+                         (update! state side (assoc (get-card state moved-card) :rezzed true :seen true))))
+                     (when-let [dre (:derezzed-events cdef)]
+                       (when-not (:rezzed (get-card state moved-card))
+                         (register-events state side dre moved-card))))))))
+         (clear-install-cost-bonus state side)
+         (when-not (:delayed-completion cdef)
+           (effect-completed state side eid card)))))))
 
 
 ;;; Installing a runner card

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -117,7 +117,8 @@
           ;; If the runner is forced to trash this card (Neutralize All Threats)
           (continue-ability state :runner
                            {:cost [:credit trash-cost]
-                            :effect (effect (trash card)
+                            :delayed-completion true
+                            :effect (effect (trash eid card nil)
                                             (system-msg (str "is forced to pay " trash-cost
                                                              " [Credits] to trash " name)))} card nil)
           ;; Otherwise, show the option to pay to trash the card.
@@ -126,7 +127,8 @@
             {:optional
              {:prompt (str "Pay " trash-cost "[Credits] to trash " name "?")
               :yes-ability {:cost [:credit trash-cost]
-                            :effect (effect (trash card)
+                            :delayed-completion true
+                            :effect (effect (trash eid card nil)
                                             (system-msg (str "pays " trash-cost
                                                              " [Credits] to trash " name)))}}}
             card nil)))

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -339,6 +339,32 @@
     (is (find-card "Franchise City" (:scored (get-corp))) "Franchise City in corp scored area")
     (is (= 1 (:agenda-point (get-corp))) "Corp has 1 point")))
 
+(deftest full-immersion-recstudio
+  "Full Immmersion RecStudio - install directly, and via Interns"
+  (do-game
+    (new-game
+      (default-corp [(qty "Full Immersion RecStudio" 1)
+                     (qty "Interns" 2)
+                     (qty "Launch Campaign" 3)])
+      (default-runner))
+    (play-from-hand state :corp "Full Immersion RecStudio" "New remote")
+    (let [fir (get-content state :remote1 0)]
+      (core/rez state :corp fir)
+      (card-ability state :corp fir 0)
+      (prompt-select :corp (find-card "Launch Campaign" (:hand (get-corp))))
+      (let [lc (first (:hosted (refresh fir)))]
+        (is lc "Launch Campaign hosted on Full Immersion RecStudio")
+        (core/rez state :corp lc)
+        (is (and (:installed (refresh lc)) (:rezzed (refresh lc))) "Rezzed Launch Campaign")
+        (take-credits state :corp)
+        (take-credits state :runner)
+        (is (= 5 (:credit (get-corp))) "Gained 2cr from Launch Campaign")
+        (is (= 4 (get-counters (refresh lc) :credit)) "4cr left on Launch Campaign")
+        (play-from-hand state :corp "Interns")
+        (prompt-select :corp (find-card "Launch Campaign" (:hand (get-corp))))
+        (prompt-choice :corp (refresh fir))
+        (is (= 2 (count (:hosted (refresh fir)))) "Interns installed onto FIR")))))
+
 (deftest genetics-pavilion
   "Genetics Pavilion - Limit Runner to 2 draws per turn, but only during Runner's turn"
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -537,6 +537,25 @@
     (prompt-choice :runner "Yes")
     (is (empty? (:prompt (get-corp))) "No trace chance on 2nd trashed card of turn")))
 
+
+(deftest nbn-controlling-the-message-drt
+  "NBN: Controlling the Message - Interaction with Dedicated Response Team"
+  (do-game
+    (new-game
+      (make-deck "NBN: Controlling the Message" [(qty "Launch Campaign" 1) (qty "Dedicated Response Team" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Launch Campaign" "New remote")
+    (play-from-hand state :corp "Dedicated Response Team" "New remote")
+    (core/rez state :corp (get-content state :remote2 0))
+    (take-credits state :corp)
+    (run-empty-server state "Server 1")
+    (prompt-choice :runner "Yes")
+    (prompt-choice :corp "Yes")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 1 (:tag (get-runner))) "Runner took 1 unpreventable tag")
+    (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage from DRT")))
+
 (deftest new-angeles-sol-on-steal
   "New Angeles Sol - interaction with runner stealing agendas"
   (do-game


### PR DESCRIPTION
Implements Full Immersion RecStudio. Gives FIR a "Click: Install an asset or agenda" ability to target a card in hand. Also allows FIR to be the target of an install triggered by another ability, like Interns or Lateral Growth, by expanding the "no server specified" path of `corp-install` to include rezzed cards with positive `:can-host` functions. (See FIR implementation.) When showing a list of servers the corp can install to, this menu will include Full Immersion RecStudio if there are not already 2 cards hosted. 

FIR does not have the equivalent of Dinosaurus' "move an installed card onto Dinosaurus" ability. That ability is for interactions with Clone Chip etc. We don't want that for Corp cards, because the equivalent operation (installing to a new remove server, then "moving" onto FIR) would trigger Turtlebacks and Astrolabe from the new server creation. 

In the future I would like to apply the same treatment to runner cards, so that if Dinosaurus is in play and you use Clone Chip, the target program won't go directly into your rig, instead you will get a menu to choose to install onto Dinosaurus or onto the rig. 

Fixes a few other issues involving hosted corp cards. Fix #1644, Fix #1799, Fix #1752.

NOTE: the UI isn't acceptable IMO, but I don't know how to fix it. Paging @mtgred and @domtancredi:

![image](https://cloud.githubusercontent.com/assets/10083341/17042854/4511cb90-4f66-11e6-8017-f3fe975ef8a6.png)

There are two cards hosted on this FIR, but the offset is maybe 10 pixels between the two?