### PR TITLE
Refactor recursive reordering prompts + extension to other cards

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -88,9 +88,8 @@
               :delayed-completion true
               :effect (req (let [chosen (cons target chosen)]
                              (if (< (count chosen) n)
-                               (continue-ability state side
-                                                 (cbi-choice (remove-once #(not= target %) remaining)
-                                                             chosen n original) card nil)
+                               (continue-ability state side (cbi-choice (remove-once #(not= target %) remaining)
+                                                                        chosen n original) card nil)
                                (continue-ability state side (cbi-final chosen original) card nil))))})]
      {:delayed-completion true
       :effect (effect (run :hq {:replace-access

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -90,8 +90,7 @@
                              (if (< (count chosen) n)
                                (continue-ability state side
                                                  (cbi-choice (remove-once #(not= target %) remaining)
-                                                             chosen n original)
-                                                 card nil)
+                                                             chosen n original) card nil)
                                (continue-ability state side (cbi-final chosen original) card nil))))})]
      {:delayed-completion true
       :effect (effect (run :hq {:replace-access
@@ -450,39 +449,18 @@
       :msg (msg "trash " (count targets) " card" (when (not= 1(count targets)) "s") " and draw " (cards-to-draw targets) " cards")})
 
    "Indexing"
-   (letfn [(index-final [chosen original]
-             {:prompt (str "The top 5 cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
-              :choices ["Done" "Start over"]
-              :delayed-completion true
-              :effect (req (if (= target "Done")
-                             (do (swap! state update-in [:corp :deck] #(vec (concat chosen (drop (count chosen) %))))
-                                 (clear-wait-prompt state :corp)
-                                 (effect-completed state side eid card))
-                             (continue-ability state side (index-choice original '() (count original) original)
-                                               card nil)))})
-           (index-choice [remaining chosen n original]
-             {:prompt "Choose a card to move next onto R&D"
-              :choices remaining
-              :delayed-completion true
-              :effect (req (let [chosen (cons target chosen)]
-                             (if (< (count chosen) n)
-                               (continue-ability state side
-                                                 (index-choice (remove-once #(not= target %) remaining)
-                                                               chosen n original)
-                                                 card nil)
-                               (continue-ability state side (index-final chosen original) card nil))))})]
-     {:delayed-completion true
-      :effect (effect
-                (run :rd
-                     {:replace-access
-                      {:msg "rearrange the top 5 cards of R&D"
-                       :delayed-completion true
-                       :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of R&D")
-                                    (let [from (take 5 (:deck corp))]
-                                      (if (pos? (count from))
-                                        (continue-ability state side (index-choice from '() (count from) from) card nil)
-                                        (do (clear-wait-prompt state :corp)
-                                            (effect-completed state side eid card)))))}} card))})
+   {:delayed-completion true
+    :effect (effect (run :rd
+                         {:replace-access
+                          {:msg "rearrange the top 5 cards of R&D"
+                           :delayed-completion true
+                           :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of R&D")
+                                        (let [from (take 5 (:deck corp))]
+                                          (if (pos? (count from))
+                                            (continue-ability state side (reorder-choice :corp :corp from '()
+                                                                                         (count from) from) card nil)
+                                            (do (clear-wait-prompt state :corp)
+                                                (effect-completed state side eid card)))))}} card))}
 
    "Infiltration"
    {:prompt "Gain 2 [Credits] or expose a card?" :choices ["Gain 2 [Credits]" "Expose a card"]
@@ -626,35 +604,15 @@
     :effect (effect (gain :credit 9))}
 
    "Making an Entrance"
-   (letfn [(entrance-final [chosen original]
-             {:prompt (str "The top cards of your Stack will be " (clojure.string/join  ", " (map :title chosen)) ".")
-              :choices ["Done" "Start over"]
-              :delayed-completion true
-              :effect (req (if (= target "Done")
-                             (do (swap! state update-in [:runner :deck] #(vec (concat chosen (drop (count chosen) %))))
-                                 (clear-wait-prompt state :corp)
-                                 (effect-completed state side eid card))
-                             (continue-ability state side (entrance-choice original '() (count original) original)
-                                               card nil)))})
-           (entrance-choice [remaining chosen n original]
-             {:prompt "Choose a card to move next onto your Stack"
-              :choices remaining
-              :delayed-completion true
-              :effect (req (let [chosen (cons target chosen)]
-                             (if (< (count chosen) n)
-                               (continue-ability state side
-                                                 (entrance-choice (remove-once #(not= target %) remaining)
-                                                                  chosen n original)
-                                                 card nil)
-                               (continue-ability state side (entrance-final chosen original) card nil))))})
-           (entrance-trash [cards]
+   (letfn [(entrance-trash [cards]
              {:prompt "Choose a card to trash"
               :choices (cons "None" cards)
               :delayed-completion true
               :msg (req (when (not= target "None") (str "trash " (:title target))))
               :effect (req (if (= target "None")
                              (if (not-empty cards)
-                               (continue-ability state side (entrance-choice cards '() (count cards) cards) card nil)
+                               (continue-ability state side (reorder-choice :runner :corp cards '()
+                                                                            (count cards) cards) card nil)
                                (do (clear-wait-prompt state :corp)
                                    (effect-completed state side eid card)))
                              (do (trash state side target {:unpreventable true})

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -634,44 +634,23 @@
                  :effect (effect (trash card {:cause :ability-cost}) (draw 3))}]}
 
    "Spy Camera"
-   (letfn [(spy-final [chosen original]
-             {:prompt (str "The top cards of your stack will be " (clojure.string/join  ", " (map :title chosen)) ".")
-              :choices ["Done" "Start over"]
-              :delayed-completion true
-              :effect (req (if (= target "Done")
-                             (do (swap! state update-in [:runner :deck] #(vec (concat chosen (drop (count chosen) %))))
-                                 (clear-wait-prompt state :corp)
-                                 (effect-completed state side eid card))
-                             (continue-ability state side (spy-choice original '() (count original) original)
-                                               card nil)))})
-           (spy-choice [remaining chosen n original]
-             {:prompt "Choose a card to move next onto your stack"
-              :choices remaining
-              :delayed-completion true
-              :effect (req (let [chosen (cons target chosen)]
-                             (if (< (count chosen) n)
-                               (continue-ability state side
-                                                 (spy-choice (remove-once #(not= target %) remaining)
-                                                             chosen n original)
-                                                 card nil)
-                               (continue-ability state side (spy-final chosen original) card nil))))})]
    {:abilities [{:cost [:click 1]
                  :delayed-completion true
                  :label "Look at the top X cards of your Stack"
                  :msg "look at the top X cards of their Stack and rearrange them"
                  :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their stack")
                               (let [n (count (filter #(= (:title %) (:title card))
-                                                      (all-installed state :runner)))
+                                                     (all-installed state :runner)))
                                     from (take n (:deck runner))]
                                 (if (pos? (count from))
-                                  (continue-ability state side (spy-choice from '() (count from) from) card nil)
+                                  (continue-ability state side (reorder-choice :runner :corp from '()
+                                                                               (count from) from) card nil)
                                   (do (clear-wait-prompt state :corp)
                                       (effect-completed state side eid card)))))}
                 {:label "[Trash]: Look at the top card of R&D"
                  :msg "trash it and look at the top card of R&D"
-                 :effect (effect (prompt! card (str "The top card of R&D is "
-                                                    (:title (first (:deck corp)))) ["OK"] {})
-                                 (trash card {:cause :ability-cost}))}]})
+                 :effect (effect (prompt! card (str "The top card of R&D is " (:title (first (:deck corp)))) ["OK"] {})
+                                 (trash card {:cause :ability-cost}))}]}
 
    "The Personal Touch"
    {:hosting {:req #(and (has-subtype? % "Icebreaker")

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -385,37 +385,17 @@
               {:corp-install cw :trash cw :card-moved cw})}
 
    "Data Hound"
-   (letfn [(dh-final [chosen original]
-             {:prompt (str "The top cards of your Stack will be " (clojure.string/join  ", " (map :title chosen)) ".")
-              :choices ["Done" "Start over"]
-              :delayed-completion true
-              :effect (req (if (= target "Done")
-                             (do (swap! state update-in [:runner :deck] #(vec (concat chosen (drop (count chosen) %))))
-                                 (clear-wait-prompt state :runner)
-                                 (effect-completed state side eid card))
-                             (continue-ability state side (dh-choice original '() (count original) original)
-                                               card nil)))})
-           (dh-choice [remaining chosen n original]
-             {:prompt "Choose a card to move next onto the Runner's Stack"
-              :choices remaining
-              :delayed-completion true
-              :effect (req (let [chosen (cons target chosen)]
-                             (if (< (count chosen) n)
-                               (continue-ability state side
-                                                 (dh-choice (remove-once #(not= target %) remaining)
-                                                                  chosen n original)
-                                                 card nil)
-                               (continue-ability state side (dh-final chosen original) card nil))))})
-           (dh-trash [cards]
+   (letfn [(dh-trash [cards]
              {:prompt "Choose a card to trash"
               :choices cards
               :delayed-completion true
               :msg (msg "trash " (:title target))
               :effect (req (do (trash state side target {:unpreventable true})
-                               (continue-ability state side (dh-choice (remove-once #(not= % target) cards)
-                                                                       '() (count (remove-once #(not= % target) cards))
-                                                                       (remove-once #(not= % target) cards)) card nil)))})]
-   {:abilities [(trace-ability 2 {:delayed-completion true
+                               (continue-ability state side (reorder-choice
+                                                              :runner :runner (remove-once #(not= % target) cards)
+                                                              '() (count (remove-once #(not= % target) cards))
+                                                              (remove-once #(not= % target) cards)) card nil)))})]
+     {:abilities [(trace-ability 2 {:delayed-completion true
                                   :label "Look at the top of Stack"
                                   :msg "look at top X cards of Stack"
                                   :effect (req (show-wait-prompt state :runner "Corp to rearrange the top cards of the Runner's Stack")
@@ -933,40 +913,20 @@
                                   :effect (effect (damage eid :net 3 {:card card}) (end-run))})]}
 
    "Shiro"
-   (letfn [(shiro-final [chosen original]
-             {:prompt (str "The top 3 cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
-              :choices ["Done" "Start over"]
-              :delayed-completion true
-              :effect (req (if (= target "Done")
-                             (do (swap! state update-in [:corp :deck] #(vec (concat chosen (drop (count chosen) %))))
-                                 (clear-wait-prompt state :runner)
-                                 (effect-completed state side eid card))
-                             (continue-ability state side (shiro-choice original '() (count original) original)
-                                               card nil)))})
-           (shiro-choice [remaining chosen n original]
-             {:prompt "Choose a card to move next onto R&D"
-              :choices remaining
-              :delayed-completion true
-              :effect (req (let [chosen (cons target chosen)]
-                             (if (< (count chosen) n)
-                               (continue-ability state side
-                                                 (shiro-choice (remove-once #(not= target %) remaining)
-                                                                chosen n original)
-                                                 card nil)
-                               (continue-ability state side (shiro-final chosen original) card nil))))})]
    {:abilities [{:label "Rearrange the top 3 cards of R&D"
                  :msg "rearrange the top 3 cards of R&D"
                  :delayed-completion true
                  :effect (req (show-wait-prompt state :runner "Corp to rearrange the top cards of R&D")
                               (let [from (take 3 (:deck corp))]
                                 (if (pos? (count from))
-                                  (continue-ability state side (shiro-choice from '() (count from) from) card nil)
+                                  (continue-ability state side (reorder-choice :corp :runner from '()
+                                                                               (count from) from) card nil)
                                   (do (clear-wait-prompt state :runner)
                                       (effect-completed state side eid card)))))}
                 {:label "Force the Runner to access the top card of R&D"
                  :effect (req (doseq [c (take (get-in @state [:runner :rd-access]) (:deck corp))]
                                 (system-msg state :runner (str "accesses " (:title c)))
-                                (handle-access state side [c])))}]})
+                                (handle-access state side [c])))}]}
 
    "Snoop"
    {:abilities [{:req (req (= current-ice card))

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -551,35 +551,15 @@
                                     card nil)))}
 
    "Precognition"
-   (letfn [(precog-final [chosen original]
-             {:prompt (str "The top 5 cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
-              :choices ["Done" "Start over"]
-              :delayed-completion true
-              :effect (req (if (= target "Done")
-                             (do (swap! state update-in [:corp :deck] #(vec (concat chosen (drop (count chosen) %))))
-                                 (clear-wait-prompt state :runner)
-                                 (effect-completed state side eid card))
-                             (continue-ability state side (precog-choice original '() (count original) original)
-                                               card nil)))})
-           (precog-choice [remaining chosen n original]
-             {:prompt "Choose a card to move next onto R&D"
-              :choices remaining
-              :delayed-completion true
-              :effect (req (let [chosen (cons target chosen)]
-                             (if (< (count chosen) n)
-                               (continue-ability state side
-                                                 (precog-choice (remove-once #(not= target %) remaining)
-                                                               chosen n original)
-                                                 card nil)
-                               (continue-ability state side (precog-final chosen original) card nil))))})]
-     {:delayed-completion true
-      :msg "rearrange the top 5 cards of R&D"
-      :effect (req (show-wait-prompt state :runner "Corp to rearrange the top cards of R&D")
-                (let [from (take 5 (:deck corp))]
-                  (if (pos? (count from))
-                    (continue-ability state side (precog-choice from '() (count from) from) card nil)
-                    (do (clear-wait-prompt state :runner)
-                        (effect-completed state side eid card)))))})
+   {:delayed-completion true
+    :msg "rearrange the top 5 cards of R&D"
+    :effect (req (show-wait-prompt state :runner "Corp to rearrange the top cards of R&D")
+                 (let [from (take 5 (:deck corp))]
+                   (if (pos? (count from))
+                     (continue-ability state side (reorder-choice :corp :runner from '()
+                                                                  (count from) from) card nil)
+                     (do (clear-wait-prompt state :runner)
+                         (effect-completed state side eid card)))))}
 
    "Predictive Algorithm"
    {:events {:pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 2]))}}}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -79,7 +79,7 @@
                                                         ices (get-in @state (concat [:corp :servers] s [:ices]))]
                                                     (swap! state assoc :per-run nil
                                                            :run {:server s :position (count ices)
-                                                                 :access-bonus 0 :run-effect nil})
+                                                                 :access-bonus 0 :run-effect nil :cannot-jack-out true})
                                                     (gain-run-credits state :runner (:bad-publicity corp))
                                                     (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
                                                     (trigger-event state :runner :run s)))}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -557,7 +557,8 @@
               :delayed-completion true
               :effect (req (if (= target "Done")
                              (do (swap! state update-in [:corp :deck] #(vec (concat chosen (drop (count chosen) %))))
-                                 (effect-completed state side eid))
+                                 (clear-wait-prompt state :runner)
+                                 (effect-completed state side eid card))
                              (continue-ability state side (precog-choice original '() (count original) original)
                                                card nil)))})
            (precog-choice [remaining chosen n original]
@@ -573,8 +574,12 @@
                                (continue-ability state side (precog-final chosen original) card nil))))})]
      {:delayed-completion true
       :msg "rearrange the top 5 cards of R&D"
-      :effect (req (let [from (take 5 (:deck corp))]
-                     (continue-ability state side (precog-choice from '() (count from) from) card nil)))})
+      :effect (req (show-wait-prompt state :runner "Corp to rearrange the top cards of R&D")
+                (let [from (take 5 (:deck corp))]
+                  (if (pos? (count from))
+                    (continue-ability state side (precog-choice from '() (count from) from) card nil)
+                    (do (clear-wait-prompt state :runner)
+                        (effect-completed state side eid card)))))})
 
    "Predictive Algorithm"
    {:events {:pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 2]))}}}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -838,11 +838,36 @@
                  :effect (effect (expose eid target) (trash card {:cause :ability-cost}))}]}
 
    "Rolodex"
-   {:msg "look at the top 5 cards of their Stack"
-    :effect (req (toast state :runner
-                        "Drag cards from the Temporary Zone back onto your Stack." "info")
-                 (doseq [c (take 5 (:deck runner))] (move state side c :play-area)))
-    :leave-play (effect (mill :runner 3))}
+   (letfn [(rolodex-final [chosen original]
+             {:prompt (str "The top cards of your Stack will be " (clojure.string/join  ", " (map :title chosen)) ".")
+              :choices ["Done" "Start over"]
+              :delayed-completion true
+              :effect (req (if (= target "Done")
+                             (do (swap! state update-in [:runner :deck] #(vec (concat chosen (drop (count chosen) %))))
+                                 (clear-wait-prompt state :corp)
+                                 (effect-completed state side eid card))
+                             (continue-ability state side (rolodex-choice original '() (count original) original)
+                                               card nil)))})
+           (rolodex-choice [remaining chosen n original]
+             {:prompt "Choose a card to move next onto your Stack"
+              :choices remaining
+              :delayed-completion true
+              :effect (req (let [chosen (cons target chosen)]
+                             (if (< (count chosen) n)
+                               (continue-ability state side
+                                                 (rolodex-choice (remove-once #(not= target %) remaining)
+                                                                 chosen n original)
+                                                 card nil)
+                               (continue-ability state side (rolodex-final chosen original) card nil))))})]
+     {:delayed-completion true
+      :msg "look at the top 5 cards of their Stack"
+      :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their Stack")
+                   (let [from (take 5 (:deck runner))]
+                     (if (pos? (count from))
+                       (continue-ability state side (rolodex-choice from '() (count from) from) card nil)
+                       (do (clear-wait-prompt state :corp)
+                           (effect-completed state side eid card)))))
+      :leave-play (effect (mill :runner 3))})
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -57,9 +57,9 @@
    :choices ["Done" "Start over"]
    :delayed-completion true
    :effect (req (if (= target "Done")
-                  (do (swap! state update-in [(if (= reorder_side :corp) :corp :runner) :deck]
+                  (do (swap! state update-in [reorder_side :deck]
                              #(vec (concat chosen (drop (count chosen) %))))
-                      (clear-wait-prompt state (if (= wait_side :corp) :corp :runner))
+                      (clear-wait-prompt state wait_side)
                       (effect-completed state side eid card))
                   (continue-ability state side (reorder-choice reorder_side wait_side original '() (count original) original)
                                     card nil)))})

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -167,6 +167,39 @@
       (run-jack-out state)
       (run-on state "Archives"))))
 
+(deftest cbi-raid
+  "CBI Raid - Full test"
+  (do-game
+    (new-game (default-corp [(qty "Caprice Nisei" 1) (qty "Adonis Campaign" 1) (qty "Quandary" 1)
+                             (qty "Jackson Howard" 1) (qty "Global Food Initiative" 1)])
+              (default-runner [(qty "CBI Raid" 1)]))
+    (take-credits state :corp)
+    (is (= 5 (count (:hand (get-corp)))))
+    (play-from-hand state :runner "CBI Raid")
+    (is (= :hq (get-in @state [:run :server 0])))
+    (run-successful state)
+    (prompt-choice :runner "Run ability")
+    (prompt-choice :corp (find-card "Caprice Nisei" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Adonis Campaign" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Quandary" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Jackson Howard" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Global Food Initiative" (:hand (get-corp))))
+    ;try starting over
+    (prompt-choice :corp "Start over")
+    (prompt-choice :corp (find-card "Global Food Initiative" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Jackson Howard" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Quandary" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Adonis Campaign" (:hand (get-corp))))
+    (prompt-choice :corp (find-card "Caprice Nisei" (:hand (get-corp)))) ;this is the top card of R&D
+    (prompt-choice :corp "Done")
+    (is (= 0 (count (:hand (get-corp)))))
+    (is (= 5 (count (:deck (get-corp)))))
+    (is (= "Caprice Nisei" (:title (first (:deck (get-corp))))))
+    (is (= "Adonis Campaign" (:title (second (:deck (get-corp))))))
+    (is (= "Quandary" (:title (second (rest (:deck (get-corp)))))))
+    (is (= "Jackson Howard" (:title (second (rest (rest (:deck (get-corp))))))))
+    (is (= "Global Food Initiative" (:title (second (rest (rest (rest (:deck (get-corp)))))))))))
+
 (deftest corporate-scandal
   "Corporate Scandal - Corp has 1 additional bad pub even with 0"
   (do-game
@@ -376,6 +409,41 @@
       (prompt-choice :runner "Done")
       (is (= 4 (count (:hand (get-runner)))) "Trashing 2 cards draws 2 card"))))
 
+(deftest indexing
+  "Indexing - Full test"
+  (do-game
+    (new-game (default-corp [(qty "Caprice Nisei" 1) (qty "Adonis Campaign" 1) (qty "Quandary" 1)
+                            (qty "Jackson Howard" 1) (qty "Global Food Initiative" 1)])
+            (default-runner [(qty "Indexing" 1)]))
+    (loop [x 5]
+    (when (pos? x)
+      (do (core/move state :corp (first (:hand (get-corp))) :deck)
+          (recur (dec x)))))
+    (take-credits state :corp)
+    (is (= 0 (count (:hand (get-corp)))))
+    (is (= 5 (count (:deck (get-corp)))))
+    (play-from-hand state :runner "Indexing")
+    (is (= :rd (get-in @state [:run :server 0])))
+    (run-successful state)
+    (prompt-choice :runner "Run ability")
+    (prompt-choice :runner (find-card "Caprice Nisei" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Adonis Campaign" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Quandary" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Jackson Howard" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Global Food Initiative" (:deck (get-corp))))
+    ;try starting over
+    (prompt-choice :runner "Start over")
+    (prompt-choice :runner (find-card "Global Food Initiative" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Jackson Howard" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Quandary" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Adonis Campaign" (:deck (get-corp))))
+    (prompt-choice :runner (find-card "Caprice Nisei" (:deck (get-corp)))) ;this is the top card of R&D
+    (prompt-choice :runner "Done")
+    (is (= "Caprice Nisei" (:title (first (:deck (get-corp))))))
+    (is (= "Adonis Campaign" (:title (second (:deck (get-corp))))))
+    (is (= "Quandary" (:title (second (rest (:deck (get-corp)))))))
+    (is (= "Jackson Howard" (:title (second (rest (rest (:deck (get-corp))))))))
+    (is (= "Global Food Initiative" (:title (second (rest (rest (rest (:deck (get-corp)))))))))))
 
 (deftest information-sifting
   "Information Sifting - complicated interactions with damage prevention"
@@ -505,6 +573,44 @@
     (is (= 3 (count (:hand (get-runner)))) "Drew 3 cards")
     (is (= 2 (:click (get-runner))) "Spent 2 clicks")
     (is (= 1 (:tag (get-runner))) "Lost 2 tags")))
+
+(deftest making-an-entrance
+  "Making an Entrance - Full test"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Making an Entrance" 2) (qty "Sure Gamble" 1) (qty "Desperado" 1)
+                               (qty "Diesel" 1) (qty "Corroder" 1) (qty "Patron" 1)]))
+    (starting-hand state :runner ["Making an Entrance"])
+    (is (= 1 (count (:hand (get-runner)))))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Making an Entrance")
+    ;trash cards
+    (is (= 1 (count (:discard (get-runner)))))
+    (prompt-choice :runner (find-card "Desperado" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Diesel" (:deck (get-runner))))
+    (is (= 3 (count (:discard (get-runner)))))
+    (prompt-choice :runner "None")
+    ;start arranging
+    (prompt-choice :runner (find-card "Making an Entrance" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Sure Gamble" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Corroder" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Patron" (:deck (get-runner))))
+    ;try starting over
+    (prompt-choice :runner "Start over")
+    (prompt-choice :runner (find-card "Patron" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Corroder" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Sure Gamble" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Making an Entrance" (:deck (get-runner)))) ;this is the top card on stack
+    (prompt-choice :runner "Done")
+    (is (= "Making an Entrance" (:title (first (:deck (get-runner))))))
+    (is (= "Sure Gamble" (:title (second (:deck (get-runner))))))
+    (is (= "Corroder" (:title (second (rest (:deck (get-runner)))))))
+    (is (= "Patron" (:title (second (rest (rest (:deck (get-runner))))))))
+    (core/draw state :runner)
+    (is (= "Making an Entrance" (:title (first (:hand (get-runner))))))
+    (is (= 1 (count (:hand (get-runner)))))
+    (play-from-hand state :runner "Making an Entrance")
+    (is (= 1 (count (:hand (get-runner)))) "Can only play on first click")))
 
 (deftest modded
   "Modded - Install a program or piece of hardware at a 3 credit discount"

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -348,6 +348,52 @@
       (is (= 1 (count (:discard (get-runner)))))
       (is (= 4 (core/hand-size state :runner)) "Reduced hand size"))))
 
+(deftest spy-camera
+  "Spy Camera - Full test"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Spy Camera" 6) (qty "Sure Gamble" 1) (qty "Desperado" 1)
+                               (qty "Diesel" 1) (qty "Corroder" 1) (qty "Patron" 1) (qty "Kati Jones" 1)]))
+    (starting-hand state :runner ["Spy Camera" "Spy Camera" "Spy Camera"
+                                  "Spy Camera" "Spy Camera" "Spy Camera"])
+    (is (= 6 (count (:hand (get-runner)))))
+    (core/move state :corp (find-card "Hedge Fund" (:hand (get-corp))) :deck)
+    (take-credits state :corp)
+    (core/gain state :runner :click 3)
+    (loop [x 6]
+      (when (pos? x)
+        (do (play-from-hand state :runner "Spy Camera")
+            (recur (dec x)))))
+    (let [spy (get-hardware state 5)]
+      ;look at top 6 cards
+      (card-ability state :runner spy 0)
+      (prompt-choice :runner (find-card "Sure Gamble" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Desperado" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Diesel" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Corroder" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Patron" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Kati Jones" (:deck (get-runner))))
+      ;try starting over
+      (prompt-choice :runner "Start over")
+      (prompt-choice :runner (find-card "Kati Jones" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Patron" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Corroder" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Diesel" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Desperado" (:deck (get-runner))))
+      (prompt-choice :runner (find-card "Sure Gamble" (:deck (get-runner)))) ;this is the top card on stack
+      (prompt-choice :runner "Done")
+      (is (= "Sure Gamble" (:title (first (:deck (get-runner))))))
+      (is (= "Desperado" (:title (second (:deck (get-runner))))))
+      (is (= "Diesel" (:title (second (rest (:deck (get-runner)))))))
+      (is (= "Corroder" (:title (second (rest (rest (:deck (get-runner))))))))
+      (is (= "Patron" (:title (second (rest (rest (rest (:deck (get-runner)))))))))
+      (is (= "Kati Jones" (:title (second (rest (rest (rest (rest (:deck (get-runner))))))))))
+      ;look at top card of R&D
+      (card-ability state :runner spy 1)
+      (let [topcard (get-in (first (get-in @state [:runner :prompt])) [:msg])]
+        (is (= "The top card of R&D is Hedge Fund" topcard)))
+      (is (= 1 (count (:discard (get-runner))))))))
+
 (deftest the-personal-touch
   "The Personal Touch - Give +1 strength to an icebreaker"
   (do-game

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -521,6 +521,33 @@
     (prompt-select :runner (get-in @state [:runner :rig :program 0]))
     (is (= 1 (count (:discard (get-runner)))) "Cache trashed")))
 
+(deftest precognition
+  "Precognition - Full test"
+  (do-game
+    (new-game (default-corp [(qty "Precognition" 1) (qty "Caprice Nisei" 1) (qty "Adonis Campaign" 1)
+                             (qty "Quandary" 1) (qty "Jackson Howard" 1) (qty "Global Food Initiative" 1)])
+              (default-runner))
+    (starting-hand state :corp ["Precognition"])
+    (play-from-hand state :corp "Precognition")
+    (prompt-choice :corp (find-card "Caprice Nisei" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Adonis Campaign" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Quandary" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Jackson Howard" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Global Food Initiative" (:deck (get-corp))))
+    ;try starting over
+    (prompt-choice :corp "Start over")
+    (prompt-choice :corp (find-card "Global Food Initiative" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Jackson Howard" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Quandary" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Adonis Campaign" (:deck (get-corp))))
+    (prompt-choice :corp (find-card "Caprice Nisei" (:deck (get-corp)))) ;this is the top card of R&D
+    (prompt-choice :corp "Done")
+    (is (= "Caprice Nisei" (:title (first (:deck (get-corp))))))
+    (is (= "Adonis Campaign" (:title (second (:deck (get-corp))))))
+    (is (= "Quandary" (:title (second (rest (:deck (get-corp)))))))
+    (is (= "Jackson Howard" (:title (second (rest (rest (:deck (get-corp))))))))
+    (is (= "Global Food Initiative" (:title (second (rest (rest (rest (:deck (get-corp)))))))))))
+
 (deftest psychographics
   "Psychographics - Place advancements up to the number of Runner tags on a card"
   (do-game

--- a/src/clj/test/cards/programs.clj
+++ b/src/clj/test/cards/programs.clj
@@ -421,6 +421,38 @@
         (is (= 4 (get-counters (refresh psite) :virus)) "Parasite has 4 counters")
         (is (= -1 (:current-strength (refresh arch))) "Architect at -1 strength")))))
 
+(deftest parasite-builder-moved
+  "Parasite - Should stay on hosted card moved by Builder"
+  (do-game
+    (new-game (default-corp [(qty "Builder" 3) (qty "Ice Wall" 1)])
+              (default-runner [(qty "Parasite" 3)]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Builder" "Archives")
+    (let [builder (get-ice state :archives 0)
+          _ (core/rez state :corp builder)
+          _ (take-credits state :corp)
+          _ (play-from-hand state :runner "Parasite")
+          _ (prompt-select :runner builder)
+          psite (first (:hosted (refresh builder)))
+          _ (take-credits state :runner)
+          _ (take-credits state :corp)
+          _ (is (= 3 (:current-strength (refresh builder))) "Builder reduced to 3 strength")
+          _ (is (= 1 (get-counters (refresh psite) :virus)) "Parasite has 1 counter")
+          _ (take-credits state :runner)
+          orig-builder (refresh builder)
+          _ (card-ability state :corp builder 0)
+          _ (prompt-choice :corp "HQ")
+          moved-builder (get-ice state :hq 1)
+          _ (is (= (:current-strength orig-builder) (:current-strength moved-builder)) "Builder's state is maintained")
+          orig-psite (dissoc (first (:hosted orig-builder)) :host)
+          moved-psite (dissoc (first (:hosted moved-builder)) :host)
+          _ (is (= orig-psite moved-psite) "Hosted Parasite is maintained")
+          _ (take-credits state :corp)
+          updated-builder (refresh moved-builder)
+          updated-psite (first (:hosted updated-builder))
+          _ (is (= 2 (:current-strength updated-builder)) "Builder strength still reduced")
+          _ (is (= 2 (get-counters (refresh updated-psite) :virus)) "Parasite counters still incremented")])))
+
 (deftest parasite-gain-counter
   "Parasite - Gain 1 counter every Runner turn"
   (do-game
@@ -483,40 +515,6 @@
         (take-credits state :corp)
         (is (= 1 (count (:discard (get-corp)))) "Enigma trashed")
         (is (= 1 (count (:discard (get-runner)))) "Parasite trashed when Enigma was trashed")))))
-
-
-(deftest-pending parasite-builder-moved
-  "Parasite - Should stay on hosted card moved by Builder"
-  (do-game
-    (new-game (default-corp [(qty "Builder" 3) (qty "Ice Wall" 1)])
-              (default-runner [(qty "Parasite" 3)]))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Builder" "Archives")
-    (let [builder (get-ice state :archives 0)
-          _ (core/rez state :corp builder)
-          _ (take-credits state :corp)
-          _ (play-from-hand state :runner "Parasite")
-          _ (prompt-select :runner builder)
-          psite (first (:hosted (refresh builder)))
-          _ (take-credits state :runner)
-          _ (take-credits state :corp)
-          _ (is (= 3 (:current-strength (refresh builder))) "Builder reduced to 3 strength")
-          _ (is (= 1 (:counter (refresh psite))) "Parasite has 1 counter")
-          _ (take-credits state :runner)
-          orig-builder (refresh builder)
-          _ (card-ability state :corp builder 0)
-          _ (prompt-choice :corp "HQ")
-          moved-builder (get-ice state :hq 1)
-          _ (is (= (:current-strength orig-builder) (:current-strength moved-builder)) "Builder's state is maintained")
-          orig-psite (dissoc (first (:hosted orig-builder)) :host)
-          moved-psite (dissoc (first (:hosted moved-builder)) :host)
-          _ (is (= orig-psite moved-psite) "Hosted Parasite is maintained")
-          _ (take-credits state :corp)
-          updated-builder (refresh moved-builder)
-          updated-psite (first (:hosted updated-builder))
-          _ (is (= 2 (:current-strength updated-builder)) "Builder strength still reduced")
-          _ (is (= 2 (:counter updated-psite)) "Parasite counters still incremented")]
-        )))
 
 (deftest progenitor-host-hivemind
   "Progenitor - Hosting Hivemind, using Virus Breeding Ground. Issue #738"

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -755,6 +755,38 @@
       (is (= 2 (:credit (get-runner))) "Gained 1 credit")
       (is (= 6 (count (:hand (get-runner)))) "Drew 1 card"))))
 
+(deftest rolodex
+  "Rolodex - Full test"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Rolodex" 1) (qty "Sure Gamble" 1) (qty "Desperado" 1)
+                               (qty "Diesel" 1) (qty "Corroder" 1) (qty "Patron" 1)]))
+    (starting-hand state :runner ["Rolodex"])
+    (is (= 1 (count (:hand (get-runner)))))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Rolodex")
+    (prompt-choice :runner (find-card "Sure Gamble" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Desperado" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Diesel" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Corroder" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Patron" (:deck (get-runner))))
+    ;try starting over
+    (prompt-choice :runner "Start over")
+    (prompt-choice :runner (find-card "Patron" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Corroder" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Diesel" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Desperado" (:deck (get-runner))))
+    (prompt-choice :runner (find-card "Sure Gamble" (:deck (get-runner)))) ;this is the top card on stack
+    (prompt-choice :runner "Done")
+    (is (= "Sure Gamble" (:title (first (:deck (get-runner))))))
+    (is (= "Desperado" (:title (second (:deck (get-runner))))))
+    (is (= "Diesel" (:title (second (rest (:deck (get-runner)))))))
+    (is (= "Corroder" (:title (second (rest (rest (:deck (get-runner))))))))
+    (is (= "Patron" (:title (second (rest (rest (rest (:deck (get-runner)))))))))
+    (core/trash state :runner (get-resource state 0))
+    (is (= 4 (count (:discard (get-runner)))) "Rolodex mills 3 cards when trashed")
+    (is (= "Corroder" (:title (first (:deck (get-runner))))))))
+
 (deftest sacrificial-construct
   "Sacrificial Construct - Trash to prevent trash of installed program or hardware"
   (do-game


### PR DESCRIPTION
Refactors the new recursive prompt code that are used for Indexing, Making an Entrance, etc. I like them a lot over dragging from play area so I aimed to make it more consistent all around.

Changes:
1. Refactor the recursive prompt code into 2 functions in cards.clj
2. Extends the system to a lot of cards that still use drag from play area (Rolodex, Data Hound, Shiro, Spy Camera). Also reworked CBI Raid along the same lines but it is slightly different so doesn't use the refactored functions.
3. Fix bugs for the already reworked cards (Indexing, etc.) where rearranging 0 cards (empty R&D or stack) will freeze the game.
4. Tests for all of the above 

also...
5. Fix that long standing pending parasite/builder test
6. An addition to my previous PR for jack-out prevention, now prevents jacking out on 'An offer you can't refuse' runs