### PR TITLE
FAQ 3.1 search changes; fix for facedown hosted cards (again)

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -5,15 +5,15 @@
 (def cards-agendas
 
   {"15 Minutes"
-     {:abilities [{:cost [:click 1] :msg "shuffle 15 Minutes into R&D"
-                   :label "Shuffle 15 Minutes into R&D"
-                   :effect (req (let [corp-agendas (get-in corp [:scored])
-                                      agenda-owner (if (some #(= (:cid %) (:cid card)) corp-agendas) :corp :runner)]
-                                  (gain-agenda-point state agenda-owner (- (:agendapoints card))))
-                                ; refresh agendapoints to 1 before shuffle in case it was modified by e.g. The Board
-                                (move state :corp (dissoc (assoc card :agendapoints 1) :seen :rezzed) :deck {:front true})
-                                (shuffle! state :corp :deck))}]
-      :flags {:has-abilities-when-stolen true}}
+   {:abilities [{:cost [:click 1] :msg "shuffle 15 Minutes into R&D"
+                 :label "Shuffle 15 Minutes into R&D"
+                 :effect (req (let [corp-agendas (get-in corp [:scored])
+                                    agenda-owner (if (some #(= (:cid %) (:cid card)) corp-agendas) :corp :runner)]
+                                (gain-agenda-point state agenda-owner (- (:agendapoints card))))
+                              ; refresh agendapoints to 1 before shuffle in case it was modified by e.g. The Board
+                              (move state :corp (dissoc (assoc card :agendapoints 1) :seen :rezzed) :deck {:front true})
+                              (shuffle! state :corp :deck))}]
+    :flags {:has-abilities-when-stolen true}}
 
    "Accelerated Beta Test"
    (letfn [(abt [n i]
@@ -497,8 +497,9 @@
                  :req (req (< 0 (get-in card [:counter :agenda] 0)))
                  :msg (msg "add " (:title target) " to HQ from R&D")
                  :choices (req (cancellable (:deck corp) :sorted))
-                 :cancel-effect (final-effect (system-msg "cancels the effect of Project Atlas"))
-                 :effect (final-effect (move target :hand) (shuffle! :deck))}]}
+                 :cancel-effect (effect (system-msg "cancels the effect of Project Atlas"))
+                 :effect (effect (shuffle! :deck)
+                                 (move target :hand))}]}
 
    "Project Beale"
    {:agendapoints-runner (req (do 2))
@@ -600,7 +601,8 @@
    "The Future is Now"
    {:prompt "Choose a card to add to HQ" :choices (req (:deck corp))
     :msg (msg "add a card from R&D to HQ and shuffle R&D")
-    :effect (final-effect (move target :hand) (shuffle! :deck))}
+    :effect (effect (shuffle! :deck)
+                    (move target :hand) )}
 
    "The Future Perfect"
    {:steal-req (req installed)

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -337,7 +337,9 @@
                                             :sorted))
                  :cost [:credit 1]
                  :label "Search R&D for an asset"
-                 :effect (effect (trash card) (move target :hand) (shuffle! :deck))}]
+                 :effect (effect (trash card)
+                                 (shuffle! :deck)
+                                 (move target :hand))}]
 
     ; A card rezzed by Executive Bootcamp is ineligible to receive the turn-begins event for this turn.
     :suppress {:corp-turn-begins {:req (req (= (:cid target) (:ebc-rezzed (get-card state card))))}}
@@ -542,7 +544,8 @@
                  :choices (req (cancellable (filter ice? (:deck corp)) :sorted))
                  :label "Search R&D for a piece of ICE"
                  :cost [:click 1 :credit 1]
-                 :effect (effect (move target :hand) (shuffle! :deck))}]}
+                 :effect (effect (shuffle! :deck)
+                                 (move target :hand))}]}
 
    "Lily Lockwell"
    {:effect (effect (draw 3))
@@ -560,7 +563,7 @@
                                   (system-msg state side (str "uses Lily Lockwell to put " (:title c) " on top of R&D")))
                                 (do (shuffle! state :corp :deck)
                                     (system-msg state side (str "uses Lily Lockwell, but did not find an Operation in R&D"))))
-                                (lose state :runner :tag 1))}]}
+                              (lose state :runner :tag 1))}]}
 
    "Mark Yale"
    {:events {:agenda-counter-spent {:effect (effect (gain :credit 1))
@@ -618,13 +621,10 @@
                                                             (<= (:cost %) (:credit corp)) true)) (:deck corp)) :sorted))
                  :msg (msg "reveal " (:title target) " from R&D and "
                            (if (= (:type target) "Operation") "play " "install ") " it")
-                 :effect (req (if (= (:type target) "Operation")
-                                (when-completed (play-instant state side target)
-                                                (do (system-msg state side "shuffles their deck")
-                                                    (shuffle! state side :deck)))
-                                (when-completed (corp-install state side target nil nil)
-                                                (do (system-msg state side "shuffles their deck")
-                                                    (shuffle! state side :deck)))))}]}
+                 :effect (req (shuffle! state side :deck)
+                              (if (= (:type target) "Operation")
+                                (play-instant state side target)
+                                (corp-install state side target nil nil)))}]}
 
    "Mumbad Construction Co."
    {:derezzed-events {:runner-turn-ends corp-rez-toast}
@@ -990,7 +990,9 @@
                  :prompt "Choose an asset to install"
                  :msg (msg "install " (:title target))
                  :choices (req (filter #(is-type? % "Asset") (:deck corp)))
-                 :effect (effect (trash card) (corp-install target nil) (shuffle! :deck))}]}
+                 :effect (effect (trash card)
+                                 (shuffle! :deck)
+                                 (corp-install target nil))}]}
 
    "Tenma Line"
    {:abilities [{:label "Swap 2 pieces of installed ICE"

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -351,8 +351,8 @@
              {:player :runner :prompt "Choose a card" :msg (msg "add 1 card to their Grip from their Stack")
               :choices (req (cancellable (:deck runner)))
               :effect (effect (trigger-event :searched-stack nil)
-                              (move target :hand)
-                              (shuffle! :deck))}}}
+                              (shuffle! :deck)
+                              (move target :hand))}}}
 
    "Maya"
    {:in-play [:memory 2]
@@ -536,8 +536,8 @@
                          :yes-ability {:effect (req (when-let [c (some #(when (= (:title %) "Rabbit Hole") %)
                                                                       (:deck runner))]
                                                      (trigger-event state side :searched-stack nil)
-                                                     (runner-install state side c)
-                                                     (shuffle! state :runner :deck)))}}} card nil))}
+                                                     (shuffle! state :runner :deck)
+                                                     (runner-install state side c)))}}} card nil))}
 
    "Ramujan-reliant 550 BMI"
    {:prevent {:damage [:net :brain]}
@@ -580,9 +580,9 @@
                          :req (req (and (is-type? target "Hardware") (some #(= (:title %) (:title target)) (:deck runner))))
                          :yes-ability {:msg (msg "add a copy of " (:title target) " to their Grip")
                                        :effect (effect (trigger-event :searched-stack nil)
+                                                       (shuffle! :deck)
                                                        (move (some #(when (= (:title %) (:title target)) %)
-                                                                   (:deck runner)) :hand)
-                                                       (shuffle! :deck))}}}}}
+                                                                   (:deck runner)) :hand))}}}}}
 
    "Security Chip"
    {:abilities [{:label "[Trash]: Add [Link] strength to a non-Cloud icebreaker until the end of the run"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -653,8 +653,8 @@
            :optional
            {:prompt "Add another copy to HQ?" :priority 1
             :yes-ability {:msg (msg "add a copy of " (:title target) " from R&D to HQ")
-                          :effect (effect (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand)
-                                          (shuffle! :deck))}}}}}
+                          :effect (effect (shuffle! :deck)
+                                          (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand))}}}}}
 
    "The Masque: Cyber General"
    {:events {:pre-start-game {:effect draft-points-target}}}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -205,9 +205,9 @@
                            (<= (:cost %) (:credit corp)))
                       (:deck corp))
              :sorted))
-    :effect  (final-effect (play-instant target)
-                           (system-msg "shuffles their deck")
-                           (shuffle! :deck))
+    :effect  (effect (shuffle! :deck)
+                     (system-msg "shuffles their deck")
+                     (play-instant target))
     :msg (msg "search R&D for " (:title target) " and play it")}
 
    "Corporate Shuffle"
@@ -279,8 +279,9 @@
    "Fast Track"
    {:prompt "Choose an Agenda"
     :choices (req (cancellable (filter #(is-type? % "Agenda") (:deck corp)) :sorted))
-    :effect (final-effect (system-msg (str "adds " (:title target) " to HQ and shuffle R&D"))
-                          (move target :hand) (shuffle! :deck))}
+    :effect (effect (system-msg (str "adds " (:title target) " to HQ and shuffle R&D"))
+                    (shuffle! :deck)
+                    (move target :hand) )}
 
    "Foxfire"
    {:trace {:base 7
@@ -420,9 +421,9 @@
                     {:prompt "How many copies?"
                      :choices {:number (req (count cs))}
                      :msg (msg "add " target " cop" (if (= target 1) "y" "ies") " of " c " to HQ")
-                     :effect (req (doseq [c (take target cs)]
-                                    (move state side c :hand))
-                                  (shuffle! state :corp :deck))}
+                     :effect (req (shuffle! state :corp :deck)
+                                  (doseq [c (take target cs)]
+                                    (move state side c :hand)))}
                     card nil)))}
 
    "Manhunt"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -169,7 +169,10 @@
                  :choices (req (cancellable (filter #(and (is-type? % "Program")
                                                           (has-subtype? % "Virus"))
                                                     (:deck runner)) :sorted))
-                 :cost [:click 1 :credit 1] :effect (effect (trigger-event :searched-stack nil) (move target :hand) (shuffle! :deck))}
+                 :cost [:click 1 :credit 1]
+                 :effect (effect (trigger-event :searched-stack nil)
+                                 (shuffle! :deck)
+                                 (move target :hand) )}
                 {:label "Install a non-Icebreaker program on Djinn"
                  :effect (effect (resolve-ability
                                    {:cost [:click 1]
@@ -641,7 +644,8 @@
                  :cost [:credit 2]
                  :effect (effect (trigger-event :searched-stack nil)
                                  (trash card {:cause :ability-cost})
-                                 (runner-install target) (shuffle! :deck))}]}
+                                 (shuffle! :deck)
+                                 (runner-install target))}]}
 
    "Sneakdoor Beta"
    {:abilities [{:cost [:click 1] :msg "make a run on Archives"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -74,7 +74,9 @@
                  :msg (msg "install " (:title target))
                  :cost [:forfeit]
                  :choices (req (cancellable (filter #(not (is-type? % "Event")) (:deck runner)) :sorted))
-                 :effect (effect (trigger-event :searched-stack nil) (runner-install target) (shuffle! :deck))}]}
+                 :effect (effect (trigger-event :searched-stack nil)
+                                 (shuffle! :deck)
+                                 (runner-install target))}]}
 
    "Bhagat"
    {:events {:successful-run {:req (req (= target :hq))
@@ -702,9 +704,9 @@
                                       :choices {:number (req num)}
                                       :msg "shuffle their Stack"
                                       :effect (req (trigger-event state side :searched-stack nil)
+                                                   (shuffle! state :runner :deck)
                                                    (doseq [c (take (int target) cards)]
                                                      (trash state side c {:unpreventable true}))
-                                                   (shuffle! state :runner :deck)
                                                    (when (> (int target) 0)
                                                      (system-msg state side (str "trashes " (int target)
                                                                                  " cop" (if (> (int target) 1) "ies" "y")
@@ -1166,7 +1168,10 @@
    "Tyson Observatory"
    {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "add " (:title target) " to their Grip")
                  :choices (req (cancellable (filter #(is-type? % "Hardware") (:deck runner)) :sorted))
-                 :cost [:click 2] :effect (effect (trigger-event :searched-stack nil) (move target :hand) (shuffle! :deck))}]}
+                 :cost [:click 2]
+                 :effect (effect (trigger-event :searched-stack nil)
+                                 (shuffle! :deck)
+                                 (move target :hand))}]}
 
    "Underworld Contact"
    (let [ability {:label "Gain 1 [Credits] (start of turn)"

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -556,8 +556,7 @@
        (when (pos? (count hosted))
          [:div.hosted
           (for [card hosted]
-            (om/build card-view card {:opts {:flipped (and (not= (:type card) "Operation")
-                                                           (not (:rezzed card)))}}))])])))
+            (om/build card-view card {:opts {:flipped (face-down? card)}}))])])))
 
 (defn drop-area [side server hmap]
   (merge hmap {:on-drop #(handle-drop % server)


### PR DESCRIPTION
Updates all cards that search R&D/Stack so that they shuffle immediately after a card is chosen, before the effect is executed. I was thorough and changed cards that don't really need to be changed (anything that brings the target into the player's hand, like Project Atlas), just in case there is some future card that messes with the draw pile when a card is tutored. This has a functional effect on Hostage (into Street Peddler) and Heritage Committee (via Mumbad City Hall).

Along the way, I noticed that several runner cards with tutor effects were not actually shuffling afterwards. Whoops.

Also fixes (I hope) issues with runner cards being drawn face-down when hosted on other cards. For future reference, there are two reasons why the UI will draw a card face down:

1. The card is missing a `:code` field. `:code` identifies the card and allows its image to be drawn. We don't want this information to be known if the card is private/unknown to the player, so this field is stripped from private states. Any card without a code, regardless of anything else, will be drawn face down.
2. The function `face-down?` in `gameboard.cljs` returns true. This function will return true if:

    1. The card has a `:facedown` key, which is used by Street Peddler and Apex effects.
    2. The card is a corp card that is `(not rezzed)`.
    3. Unless that corp card is an Operation (Oversight AI, Patch). 

The same rules are then applied to any hosted cards. In the past, case 1 was broken, and the private states were stripping out codes for too many cards. This time case 2 was broken, thanks to the upgrades for Full Immersion RecStudio in #1804.