### PR TITLE
Fixes: Controlling the Message, Temujin Contract, C.I. Fund

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -153,7 +153,7 @@
                  :msg (msg "trash it and gain " (get-in card [:counter :credit] 0) " [Credits]")
                  :effect (effect (gain :credit (get-in card [:counter :credit] 0))
                                  (trash card {:cause :ability-cost}))}]
-    :events {:corp-turn-begins {:req (req (>= (get-in card [:counter :credit]) 6))
+    :events {:corp-turn-begins {:req (req (>= (get-in card [:counter :credit] 0) 6))
                                 :effect (effect (add-counter card :credit 2)
                                                 (system-msg (str "adds 2 [Credit] to C.I. Fund")))}}}
 

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -449,7 +449,8 @@
                                :yes-ability {:trace {:base 4
                                                      :msg "give the Runner 1 tag"
                                                      :effect (effect (tag-runner :runner 1 {:unpreventable true})
-                                                                     (clear-wait-prompt :runner))}}
+                                                                     (clear-wait-prompt :runner))
+                                                     :unsuccessful {:effect (effect (clear-wait-prompt :runner))}}}
                                :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
                             card nil))}}}
 

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -152,12 +152,11 @@
    "Diwan"
    {:prompt "Choose the server that this copy of Diwan is targeting:"
     :choices (req servers)
-    :effect (effect (update! (assoc card :named-target target)))
-    :leave-play (effect (update! (dissoc card :named-target)))
+    :effect (effect (update! (assoc card :server-target target)))
     :events {:purge {:effect (effect (trash card))}
              :pre-corp-install {:req (req (let [c target
                                                 serv (:server (second targets))]
-                                            (and (= serv (:named-target card))
+                                            (and (= serv (:server-target card))
                                                  (not (and (is-central? serv)
                                                            (is-type? c "Upgrade"))))))
                                 :effect (effect (install-cost-bonus [:credit 1]))}}}

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -12,7 +12,7 @@
   (let [c (dissoc card :current-strength :abilities :rezzed :special :added-virus-counter)
         c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
     (if (and (= (:side c) "Runner") (not= (last (:zone c)) :facedown))
-      (dissoc c :installed :facedown :counter :rec-counter :pump :named-target) c)))
+      (dissoc c :installed :facedown :counter :rec-counter :pump :server-target) c)))
 
 (defn- trigger-leave-effect
   "Triggers leave effects for specified card if relevant"


### PR DESCRIPTION
* Fix #1819: Change to `dissoc-card` so it will drop `:server-target` from deactivated cards; update Diwan to use this instead of `:named-target`
* Fix #1796: Add an unsuccessful effect to CtM trace so Runner's wait prompt will be cleared. 
* Prevent a Corp turn start bug when C.I. Fund has no credits on it. 