### PR TITLE
correct ICE removal in front of Caprice Nisei

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -414,7 +414,8 @@
    {:abilities [{:msg "do 1 net damage"
                  :effect (req (damage state :runner eid :net 1 {:card card})
                               (when current-ice
-                                (trash-ice-in-run state))
+                                (no-action state side nil)
+                                (continue state side nil))
                               (trash state side card))}]}
 
    "Datapike"
@@ -652,7 +653,8 @@
              :effect (effect (damage eid :net 2 {:card card}))}
     :abilities [(assoc trash-installed :effect (req (trash state side target {:cause :subroutine})
                                                     (when current-ice
-                                                      (trash-ice-in-run state))
+                                                      (no-action state side nil)
+                                                      (continue state side nil))
                                                     (trash state side card)))]}
 
    "Janus 1.0"
@@ -676,7 +678,8 @@
                                       :msg (msg "force the Runner to trash " (:title target))
                                       :effect (req (trash state side target)
                                                    (when current-ice
-                                                     (trash-ice-in-run state))
+                                                     (no-action state side nil)
+                                                     (continue state side nil))
                                                    (trash state side card)))]}
 
    "Lancelot"
@@ -949,7 +952,8 @@
    {:abilities [{:label "Gain 5 [Credits] and trash Special Offer"
                  :effect (req (gain state :corp :credit 5)
                               (when current-ice
-                                (trash-ice-in-run state))
+                                (no-action state side nil)
+                                (continue state side nil))
                               (trash state side card)
                               (system-msg state side (str "gains 5 [Credits] and trashes Special Offer")))}]}
 
@@ -1038,7 +1042,8 @@
                  :effect (req (if tagged
                                 (do (lose state :runner :credit :all)
                                     (when current-ice
-                                      (trash-ice-in-run state))
+                                      (no-action state side nil)
+                                      (continue state side nil))
                                     (trash state side card))
                                 (lose state :runner :credit 1)))}]}
 
@@ -1110,7 +1115,8 @@
                                                            (:content (card->server state card)))) 1))
                                 (prevent-jack-out state side))
                               (when current-ice
-                                (trash-ice-in-run state))
+                                (no-action state side nil)
+                                (continue state side nil))
                               (trash state side card))}]}
 
    "Woodcutter"

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -164,7 +164,7 @@
                                   :msg (msg "add " (:title current-ice) " to HQ after breaking all its subroutines")
                                   :effect (req (let [c current-ice]
                                                  (move state :corp c :hand nil)
-                                                 (trash-ice-in-run state)))}]})
+                                                 (continue state side nil)))}]})
 
    "Atman"
    {:prompt "How many power counters?"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -504,7 +504,7 @@
                              (update! state side (update-in card [:special] dissoc :installing))
                              (trigger-event state side :runner-install card))
                            (trash state side target)
-                           (trash-ice-in-run state))
+                           (continue state side nil))
               :msg (msg "trash " (:title target))}}}
 
    "Paricia"

--- a/src/clj/game/core-ice.clj
+++ b/src/clj/game/core-ice.clj
@@ -39,13 +39,6 @@
   (doseq [server (get-in @state [:corp :servers])]
     (update-ice-in-server state side (second server))))
 
-(defn trash-ice-in-run
-  "Decreases the position of each ice in the run. For when an ice is trashed mid-run."
-  [state]
-  (when-let [run (:run @state)]
-    (swap! state update-in [:run :position] dec)
-    (trigger-event state :runner :pass-ice nil)))
-
 
 ;;; Icebreaker functions.
 (defn breaker-strength-bonus


### PR DESCRIPTION
This PR removes the obsolete `trash-ice-in-run` function, which was only ever a workaround. As I was alerted on Stimhack Slack, the current behavior of ICE destruction when it occurs immediately in front of a rezzed Caprice Nisei is wrong. Both instant destruction via Parasite and self-trashing ICE (Special Offer, Data Mine, etc) are using `trash-ice-in-run` to update the run position, but this wrongly sends the Runner directly to the successful run prompt, skipping the place where Caprice should fire. 

Now we just call `no-action` followed by `continue` in the ICE (and simply `continue` in Parasite) to accomplish the same goal (automatically update the run position) without barreling past the Caprice trigger point. 