### PR TITLE
Fixes for corp hosting

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -834,7 +834,8 @@
                             (fn [k ref old new]
                               (let [credit (get-in new [:corp :credit])]
                                 (when (not= (get-in old [:corp :credit]) credit)
-                                  (update-all-ice ref side))))))
+                                  (update-all-ice ref side)))))
+                 (update-all-ice state side))
     :events {:pre-ice-strength {:req (req (and (ice? target)
                                                (>= (:credit corp) 10)))
                                 :effect (effect (ice-strength-bonus (quot (:credit corp) 5) target))}}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -504,7 +504,7 @@
    "Patch"
    {:choices {:req #(and (ice? %) (rezzed? %))}
     :msg (msg "give +2 strength to " (card-str state target))
-    :effect (final-effect (host target (assoc card :zone [:discard] :seen true :installed true))
+    :effect (final-effect (host target (assoc card :zone [:discard] :seen true))
                           (update-ice-strength (get-card state target)))
     :events {:pre-ice-strength {:req (req (= (:cid target) (:cid (:host card))))
                                 :effect (effect (ice-strength-bonus 2 target))}}}

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -365,6 +365,29 @@
         (prompt-choice :corp (refresh fir))
         (is (= 2 (count (:hosted (refresh fir)))) "Interns installed onto FIR")))))
 
+(deftest full-immersion-recstudio-sandburg
+  "Full Immmersion RecStudio - hosting an asset with events does not double-register events. Issue #1827."
+  (do-game
+    (new-game
+      (default-corp [(qty "Full Immersion RecStudio" 1) (qty "Sandburg" 1) (qty "Vanilla" 1)
+                     (qty "Oaktown Renovation" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Full Immersion RecStudio" "New remote")
+    (play-from-hand state :corp "Vanilla" "HQ")
+    (let [fir (get-content state :remote1 0)
+          van (get-ice state :hq 0)]
+      (core/rez state :corp fir)
+      (core/rez state :corp van)
+      (card-ability state :corp fir 0)
+      (prompt-select :corp (find-card "Sandburg" (:hand (get-corp))))
+      (core/gain state :corp :credit 7 :click 3)
+      (core/rez state :corp (first (:hosted (refresh fir))))
+      (is (= 2 (:current-strength (refresh van))) "Vanilla at 2 strength")
+      (card-ability state :corp fir 0)
+      (prompt-select :corp (find-card "Oaktown Renovation" (:hand (get-corp))))
+      (core/advance state :corp {:card (last (:hosted (refresh fir)))})
+      (is (= 11 (:credit (get-corp))) "Gained 1cr from advancing Oaktown"))))
+
 (deftest genetics-pavilion
   "Genetics Pavilion - Limit Runner to 2 draws per turn, but only during Runner's turn"
   (do-game

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -466,6 +466,17 @@
       (is (= "Oversight AI" (:title (first (:hosted (refresh archer)))))
           "Archer hosting OAI as a condition"))))
 
+(deftest patch
+  "Patch - +2 current strength"
+  (do-game
+    (new-game (default-corp [(qty "Patch" 1) (qty "Vanilla" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Vanilla" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (play-from-hand state :corp "Patch")
+    (prompt-select :corp (get-ice state :hq 0))
+    (is (= 2 (:current-strength (get-ice state :hq 0))) "Vanilla at 2 strength")))
+
 (deftest paywall-implementation
   "Paywall Implementation - Gain 1 credit for every successful run"
   (do-game


### PR DESCRIPTION
Notably with Full Immersion RecStudio. Fix #1827. Also has a minor fix for Sandburg (immediately update ice strength when rezzed), and more tests for corp hosting (Patch, Sandburg on FIR).