### PR TITLE
Fix Fan Site and Full Immersion RecStudio

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -381,7 +381,7 @@
                  :choices {:req #(and (or (is-type? % "Asset") (is-type? % "Agenda"))
                                       (in-hand? %)
                                       (= (:side %) "Corp"))}
-                 :msg (msg "install and host " (:title target))
+                 :msg "install and host an asset or agenda"
                  :effect (req (corp-install state side target card))}]}
 
    "Genetics Pavilion"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -351,7 +351,8 @@
                 {:effect (effect (trash card {:cause :ability-cost}) (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 
    "Fan Site"
-   {:events {:agenda-scored {:msg "add it to their score area as an agenda worth 0 agenda points"
+   {:events {:agenda-scored {:req (req installed)
+                             :msg "add it to their score area as an agenda worth 0 agenda points"
                              :effect (effect (as-agenda :runner card 0))}}}
 
    "Fester"


### PR DESCRIPTION
Requires that Fan Site be installed in order to handle the `:agenda-scored` event, and stops revealing the names of cards hosted on Full Immersion RecStudio.