### PR TITLE
Implements 3 Blood Money cards

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -676,6 +676,12 @@
    "Weyland Consortium: Because We Built It"
    {:recurring 1}
 
+   "Weyland Consortium: Builder of Nations"
+   {:abilities [{:label "Do 1 meat damage"
+                 :delayed-completion true
+                 :msg "do 1 meat damage"
+                 :effect} (effect (damage eid :meat 1 {:card card}))]}
+
    "Weyland Consortium: Building a Better World"
    {:events {:play-operation {:msg "gain 1 [Credits]"
                               :effect (effect (gain :credit 1))

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -680,7 +680,7 @@
    {:abilities [{:label "Do 1 meat damage"
                  :delayed-completion true
                  :msg "do 1 meat damage"
-                 :effect} (effect (damage eid :meat 1 {:card card}))]}
+                 :effect (effect (damage eid :meat 1 {:card card}))}]}
 
    "Weyland Consortium: Building a Better World"
    {:events {:play-operation {:msg "gain 1 [Credits]"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -305,19 +305,19 @@
    {:msg "gain 3 [Credits] and draw 1 card"
     :effect (effect (gain :credit 3) (draw))}
 
-   "Hatchet Job"
-   {:trace {:base 5
-            :choices {:req #(and (installed? %)
-                                 (not (has-subtype? % "Virtual")))}
-            :msg "add an installed non-virtual card to the Runner's grip"
-            :effect (effect (move :runner target :hand true))}}
-
    "Hard-Hitting News"
    {:req (req (:made-run runner-reg))
     :trace {:base 4
             :msg "give the Runner 4 tags"
             :label "Give the Runner 4 tags"
             :effect (effect (tag-runner :runner 4))}}
+
+   "Hatchet Job"
+   {:trace {:base 5
+            :choices {:req #(and (installed? %)
+                                 (not (has-subtype? % "Virtual")))}
+            :msg "add an installed non-virtual card to the Runner's grip"
+            :effect (effect (move :runner target :hand true))}}
 
    "Hedge Fund"
    {:msg "gain 9 [Credits]" :effect (effect (gain :credit 9))}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -305,6 +305,13 @@
    {:msg "gain 3 [Credits] and draw 1 card"
     :effect (effect (gain :credit 3) (draw))}
 
+   "Hatchet Job"
+   {:trace {:base 5
+            :choices {:req #(and (installed? %)
+                                 (not (has-subtype? % "Virtual")))}
+            :msg "add an installed non-virtual card to the Runner's grip"
+            :effect (effect (move :runner target :hand true))}}
+
    "Hard-Hitting News"
    {:req (req (:made-run runner-reg))
     :trace {:base 4

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -299,6 +299,19 @@
              :runner-trash {:req (req (and this-server (is-type? target "Program")))
                             :effect (req (swap! state update-in [:run] dissoc :cannot-jack-out))}}}
 
+   "Prisec"
+   {:access {:req (req (installed? card))
+             :effect (effect (show-wait-prompt :runner "Corp to use Prisec")
+                             (resolve-ability
+                               {:optional
+                                {:prompt "Pay 2 [Credits] to use Prisec ability?"
+                                 :end-effect (effect (clear-wait-prompt :runner))
+                                 :yes-ability {:cost [:credit 2]
+                                               :msg "do 1 meat damage and give the Runner 1 tag"
+                                               :effect (effect (damage eid :meat 1 {:card card})
+                                                               (tag-runner :runner 1))}}}
+                               card nil))}}
+
    "Product Placement"
    {:access {:req (req (not= (first (:zone card)) :discard))
              :msg "gain 2 [Credits]" :effect (effect (gain :corp :credit 2))}}

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -453,6 +453,24 @@
       (run-on state "Server 1")
       (is (:cannot-jack-out (get-in @state [:run])) "Prevents jack out when upgrade is rezzed prior to run"))))
 
+(deftest prisec
+  "Prisec - Pay 2 credits to give runner 1 tag and do 1 meat damage, only when installed"
+  (do-game
+    (new-game (default-corp [(qty "Prisec" 2)])
+              (default-runner))
+    (play-from-hand state :corp "Prisec" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state "Server 1")
+    (let [pre-creds (:credit (get-corp))]
+      (prompt-choice :corp "Yes")
+      (is (= (- pre-creds 2) (:credit (get-corp))) "Pay 2 [Credits] to pay for Prisec"))
+    (is (= 1 (:tag (get-runner))) "Give runner 1 tag")
+    (is (= 1 (count (:discard (get-runner)))) "Prisec does 1 damage")
+    ;; Runner trashes Prisec
+    (prompt-choice :runner "Yes")
+    (run-empty-server state "HQ")
+    (is (not (:prompt @state)) "Prisec does not trigger from HQ")))
+
 (deftest product-placement
   "Product Placement - Gain 2 credits when Runner accesses it"
   (do-game

--- a/src/clj/test/utils.clj
+++ b/src/clj/test/utils.clj
@@ -22,10 +22,13 @@
     ret))
 
 (defn qty [card amt]
-  {:card (if (string? card) (@all-cards card) card) :qty amt})
+  (let [loaded-card (if (string? card) (@all-cards card) card)]
+    (when-not loaded-card
+      (throw (Exception. (str card " not found in @all-cards"))))
+    {:card loaded-card :qty amt}))
 
 (defn make-deck [identity deck]
-  {:identity identity 
+  {:identity identity
    :deck (map #(if (string? %) (qty % 1) %) deck)})
 
 (defn default-corp


### PR DESCRIPTION
Implements Prisec and Hatchet Job. Also soft-implements Builder of Nations (damage just as an ability).

Also makes `qty` (in the test ns) throw an Exception if the wanted card is missing from `@all-cards`.

Adds test for Prisec.