### PR TITLE
Fix the saving of game stats.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -121,7 +121,7 @@ requester.on 'message', (data) ->
       corpAgenda: response.state.corp["agenda-point"]
     }
     db.collection('gamestats').update {gameid: response.gameid}, {$set: g}, (err) ->
-      throw err if er
+      throw err if err
   else
     if (games[response.gameid])
       sendGameResponse(games[response.gameid], response)

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -192,7 +192,7 @@
                                                            :corpdiff   corp-diff
                                                            :spectdiff  spect-diff
                                                            :gameid     gameid}))))))
-                   (.send socket (generate-string "error"))))
+                   (.send socket (generate-string {:action action :state old-state :gameid gameid}))))
                (.send socket (generate-string "error"))))
            (catch Exception e
              (try (do (println "Inner Error " action command (get-in args [:card :title]) e)


### PR DESCRIPTION
My bad. Game server needs to send the string `remove` with the last game state back to the Node server for stats to be saved. We send the "old state" back from the game server, because applying the "remove" command removes the game state from the server (since the game was closed).