### PR TITLE
More Blood Money cards

### DIFF
--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -279,8 +279,10 @@
    "Feedback Filter"
    {:prevent {:damage [:net :brain]}
     :abilities [{:cost [:credit 3] :msg "prevent 1 net damage" :effect (effect (damage-prevent :net 1))}
-                {:msg "prevent 2 brain damage" :effect (effect (trash card {:cause :ability-cost})
-                                                               (damage-prevent :brain 2)) }]}
+                {:label "[Trash]: Prevent up to 2 brain damage"
+                 :msg "prevent up to 2 brain damage"
+                 :effect (effect (trash card {:cause :ability-cost})
+                                 (damage-prevent :brain 2))}]}
 
    "Forger"
    {:prevent {:tag [:all]}

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -169,7 +169,13 @@
 
 ;;;; Card definitions
 (def cards-ice
-  {"Archangel"
+  {"Aiki"
+   {:abilities [(do-psi {:label "Runner draws 2 cards"
+                         :msg "make the Runner draw 2 cards"
+                         :effect (effect (draw :runner 2))})
+                (do-net-damage 1)]}
+
+   "Archangel"
    {:access
     {:req (req (not= (first (:zone card)) :discard))
      :effect (effect (show-wait-prompt :runner "Corp to decide to trigger Archangel")
@@ -477,6 +483,18 @@
                                 (do (pay state side card :credit 1)
                                     (system-msg state side "pays 1 [Credits]"))
                                 (resolve-ability state :runner trash-installed card nil)))}]}
+
+   "Fairchild 2.0"
+   {:abilities [{:label "Force the Runner to pay 2 [Credits] or trash an installed card"
+                 :msg "force the Runner to pay 2 [Credits] or trash an installed card"
+                 :player :runner
+                 :prompt "Choose one"
+                 :choices ["Pay 2 [Credits]" "Trash an installed card"]
+                 :effect (req (if (= target "Pay 2 [Credits]")
+                                (do (pay state side card :credit 2)
+                                    (system-msg state side "pays 2 [Credits]"))
+                                (resolve-ability state :runner trash-installed card nil)))}
+                (do-brain-damage 1)]}
 
    "Fenris"
    {:effect take-bad-pub

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -346,6 +346,17 @@
                     {:abilities [(break-sub 1 1 "sentry")
                                  (strength-pump 1 1)]})
 
+   "Golden"
+   (auto-icebreaker ["Sentry"]
+                    {:abilities [(break-sub 2 2 "sentry")
+                                 (strength-pump 2 4)
+                                 {:label "Derez a sentry and return Golden to your Grip"
+                                  :cost [:credit 2]
+                                  :req (req (and (rezzed? current-ice) (has-subtype? current-ice "Sentry")))
+                                  :msg (msg "derez " (:title current-ice) " and return Golden to their Grip")
+                                  :effect (effect (derez current-ice)
+                                                  (move card :hand))}]})
+
    "Gordian Blade"
    (auto-icebreaker ["Code Gate"]
                     {:abilities [(break-sub 1 1 "code gate")
@@ -406,6 +417,14 @@
    (auto-icebreaker ["Sentry"]
                     {:abilities [(break-sub 1 2 "sentry")
                                  (strength-pump 2 2)]})
+
+   "Nfr"
+   {:abilities [{:label "Place 1 power counter on Nfr"
+                 :msg "place 1 power counter on it"
+                 :effect (effect (add-counter card :power 1)
+                                 (update-breaker-strength card))}
+                (break-sub 1 1 "barrier")]
+    :strength-bonus (req (get-in card [:counter :power] 0))}
 
    "Ninja"
    (auto-icebreaker ["Sentry"]

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -310,9 +310,9 @@
              :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinteki: Potential Unleashed"
-   {:events {:damage {:req (req (= target :net))
-                      :msg "trash the top card of the Runner's Stack"
-                      :effect (effect (mill :runner))}}}
+   {:events {:pre-resolve-damage {:req (req (and (= target :net) (> (last targets) 0)))
+                                  :msg "trash the top card of the Runner's Stack"
+                                  :effect (effect (mill :runner))}}}
 
    "Jinteki: Replicating Perfection"
    {:events

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -760,6 +760,17 @@
                                                 card nil))}
                              card nil)))}}
 
+   "Special Report"
+   {:prompt "Choose any number of cards in HQ to shuffle into R&D"
+    :choices {:max (req (count (:hand corp))) :req #(and (:side % "Corp")
+                                                         (in-hand? %))}
+    :msg (msg "shuffle " (count targets) " cards in HQ into R&D and draw " (count targets) " cards")
+    :effect (req (doseq [c targets]
+                   (move state side c :deck))
+                 (shuffle! state side :deck)
+                 (draw state side (count targets))
+                 (effect-completed state side eid card))}
+
    "Stock Buy-Back"
    {:msg (msg "gain " (* 3 (count (:scored runner))) " [Credits]")
     :effect (effect (gain :credit (* 3 (count (:scored runner)))))}

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -257,6 +257,19 @@
     :effect (effect (trash-cards (get-in @state [:corp :hand]))
                     (draw 5))}
 
+   "Enforcing Loyalty"
+   {:trace {:base 3
+            :label "Trash a card not matching the faction of the Runner's identity"
+            :delayed-completion true
+            :effect (req (let [f (:faction (:identity runner))]
+                           (continue-ability
+                             state side
+                             {:prompt "Choose an installed card not matching the faction of the Runner's identity"
+                              :choices {:req #(and (installed? %) (not= f (:faction %)) (card-is? % :side :runner))}
+                              :msg (msg "trash " (:title target))
+                              :effect (effect (trash target))}
+                            card nil)))}}
+
    "Exchange of Information"
    {:req (req (and tagged
                    (seq (:scored runner))

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -38,6 +38,23 @@
     :effect (effect (gain :corp :click-per-turn 1))
     :leave-play (effect (lose :corp :click-per-turn 1))}
 
+   "Algo Trading"
+   {:flags {:runner-phase-12 (req (> (:credit runner) 0))}
+    :abilities [{:label "Move up to 3 [Credit] from credit pool to Algo Trading"
+                 :prompt "Choose how many [Credit] to move" :once :per-turn
+                 :choices {:number (req (min (:credit runner) 3))}
+                 :effect (effect (lose :credit target)
+                                 (add-counter card :credit target))
+                 :msg (msg "move " target " [Credit] to Algo Trading")}
+                {:label "Take all credits from Algo Trading"
+                 :cost [:credit 2]
+                 :msg (msg "trash it and gain " (get-in card [:counter :credit] 0) " [Credits]")
+                 :effect (effect (gain :credit (get-in card [:counter :credit] 0))
+                                 (trash card {:cause :ability-cost}))}]
+    :events {:runner-turn-begins {:req (req (>= (get-in card [:counter :credit] 0) 6))
+                                  :effect (effect (add-counter card :credit 2)
+                                                  (system-msg (str "adds 2 [Credit] to Algo Trading")))}}}
+
    "Always Be Running"
    {:abilities [{:once :per-turn
                  :cost [:click 2]


### PR DESCRIPTION
Fixes the event listener on Jinteki: Potential Unleashed so no mill occurs if damage is prevented. 

Implements Algo Trading, Golden, Nfr, Special Report, Enforcing Loyalty, Aiki, and Fairchild 2.0 from the upcoming pack. 