### PR TITLE
Removes action and ability panels from disabled cards.

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -381,7 +381,9 @@
                                 (is-type? (:card (first (get-in @state [side :prompt]))) "Agenda")))
                  :label "Host an agenda being accessed"
                  :effect (req (when-let [agenda (:card (first (get-in @state [side :prompt])))]
-                                (host state side card (move state side agenda :play-area))
+                                (let [agenda (move state side agenda :play-area)
+                                      agenda (host state side card agenda)]
+                                  (disable-card state side agenda))
                                 (close-access-prompt state side)
                                 (effect-completed state side eid nil)
                                 (when-not (:run @state)
@@ -390,6 +392,7 @@
                 {:cost [:click 2] :label "Add hosted agenda to your score area"
                  :req (req (not (empty? (:hosted card))))
                  :effect (req (let [c (move state :runner (first (:hosted card)) :scored)]
+                                (enable-card state side c)
                                 (gain-agenda-point state :runner (get-agenda-points state :runner c))))
                  :msg (msg (let [c (first (:hosted card))]
                              (str "add " (:title c) " to their score area and gain " (get-agenda-points state :runner c)

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -278,17 +278,18 @@
   (let [card (get-card state (or (:card args) args))]
     (when (can-score? state side card)
       (when (and (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
-                 (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))
-
+                 (>= (:advance-counter card 0) (or (:current-cost card) (:advancementcost card))))
         ;; do not card-init necessarily. if card-def has :effect, wrap a fake event
         (let [moved-card (move state :corp card :scored)
               c (card-init state :corp moved-card false)
               points (get-agenda-points state :corp c)]
-          (when-completed (trigger-event-simult state :corp :agenda-scored
-                                                {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
-                                                                (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
-                                                                (trash state side current)))}
-                                                (card-as-handler c) c)
+          (when-completed
+            (trigger-event-simult state :corp :agenda-scored
+                                  {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
+                                                  (say state side {:user "__system__"
+                                                                   :text (str (:title current) " is trashed.")})
+                                                  (trash state side current)))}
+                                  (card-as-handler c) c)
                           (let [c (get-card state c)
                                 points (or (get-agenda-points state :corp c) points)]
                             (set-prop state :corp (get-card state moved-card) :advance-counter 0)


### PR DESCRIPTION
Also disables agendas hosted on Film Critic in order to fix #1715. Also adds default advancement count to the `score` function to prevent error when trying to score an unadvanced agenda.

Might require rewrite of Rumor Mill depending on how that was implemented (could incorrectly prevent disabled cards form being rezzed, pagind @nealterrell).