### PR TITLE
24/7 accelerated diagnostics interaction fix

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -2,7 +2,7 @@
 
 (def cards-operations
   {"24/7 News Cycle"
-   {:req (req (> (count (:scored corp)) 0))
+   {:req (req (pos? (count (:scored corp))))
     :delayed-completion true
     :additional-cost [:forfeit]
     :effect (req (continue-ability

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -2,7 +2,7 @@
 
 (def cards-operations
   {"24/7 News Cycle"
-   {:req (req (> (count (:scored corp)) 1))
+   {:req (req (> (count (:scored corp)) 0))
     :delayed-completion true
     :additional-cost [:forfeit]
     :effect (req (continue-ability


### PR DESCRIPTION
Simple fix for #1856, allows 24/7 News Cycle to be played with only 1 agenda scored.