### PR TITLE
Efficiency committee bandaid fix

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -227,8 +227,7 @@
                                      ((constantly true)
                                        (toast state :corp "Cannot advance cards this turn due to Efficiency Committee." "warning")))))
                  :msg "gain [Click][Click]"}]
-    :events {:corp-turn-ends {:effect (effect (clear-persistent-flag! card :cannot-advance)
-                                              (unregister-events card))}}}
+    :events {:corp-turn-ends {:effect (effect (clear-persistent-flag! card :cannot-advance))}}}
 
    "Encrypted Portals"
    {:msg (msg "gain " (reduce (fn [c server]


### PR DESCRIPTION
Fixes #1857 

Only a bandaid fix

@JoelCFC25 I couldn't easily transition from using the persistent flag system to the turn flag system. can-advance doesn't currently handle the turn-flag system and simply adding a check for a turn-flag in that function didn't seem to work.

Won't have time to develop for next couple weeks but I can have a further look in the future.




