### PR TITLE
update to card-list to be scrollable without position absolute

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -735,9 +735,7 @@ nav ul
       border: 1px solid orange
 
 .card-list
-  position: absolute
-  top: 0
-  bottom: 0
+  max-height: 960px
   overflow: auto
   -webkit-overflow-scrolling: touch
   padding-top: 40px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -735,7 +735,7 @@ nav ul
       border: 1px solid orange
 
 .card-list
-  max-height: 960px
+  max-height: 728px
   overflow: auto
   -webkit-overflow-scrolling: touch
   padding-top: 40px


### PR DESCRIPTION
Fixes #1866, fixes #1815.

If we want this to be a flexible scroll, we may want to set a height to the entire wrapper.