### PR TITLE
fix Salsette Slums + Controlling the Message interaction

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -442,8 +442,8 @@
    "NBN: Controlling the Message"
    {:events {:runner-trash
              {:delayed-completion true
-              :once :per-turn
-              :req (req (and (card-is? target :side :corp)
+              :req (req (and (first-event state side :runner-trash)
+                             (card-is? target :side :corp)
                              (installed? target)))
               :effect (req (show-wait-prompt state :runner "Corp to use NBN: Controlling the Message")
                            (continue-ability

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -920,6 +920,7 @@
                                 (deactivate state side c)
                                 (move state :corp c :rfg)
                                 (pay state :runner card :credit (trash-cost state side c))
+                                (trigger-event state side :runner-trash nil)
                                 (update! state side (dissoc card :slums-active))
                                 (close-access-prompt state side)))}
                 {:label "Remove a card trashed this turn from the game"
@@ -933,6 +934,7 @@
                                     :msg (msg "remove " (:title target) " from the game")
                                     :effect (req (deactivate state side target)
                                                  (move state :corp target :rfg)
+                                                 (trigger-event state side :runner-trash nil)
                                                  (update! state side (dissoc card :slums-active)))}
                                    card nil))}]}
 


### PR DESCRIPTION
This is a relatively [recent ruling](https://twitter.com/ANR_RulesWiki/status/760495404639068160?s=09). 

Salsette Slums fires a "fake" `:runner-trash` (with a target of `nil` to avoid triggering Hostile Infrastructure) in order to "switch off" NBN: Controlling the Message for the rest of the turn. 