### PR TITLE
Identity fixes: Null, Khan, Chronos Protocol

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -101,8 +101,8 @@
 
    "Chronos Protocol: Selective Mind-mapping"
    {:events
-    {:corp-turn-begins {:effect (effect (enable-corp-damage-choice))}
-     :runner-turn-begins {:effect (effect (enable-corp-damage-choice))}
+    {:corp-phase-12 {:effect (effect (enable-corp-damage-choice))}
+     :runner-phase-12 {:effect (effect (enable-corp-damage-choice))}
      :pre-resolve-damage
      {:once :per-turn
       :delayed-completion true

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -382,6 +382,7 @@
    {:events {:pass-ice
              {:once :per-turn
               :effect (req (when (some (fn [c] (has? c :subtype "Icebreaker")) (:hand runner))
+                             (install-cost-bonus state side [:credit -1])
                              (resolve-ability state side
                                {:prompt "Choose an icebreaker to install from your Grip"
                                 :choices {:req #(and (in-hand? %) (has-subtype? % "Icebreaker"))}
@@ -525,7 +526,8 @@
                  :msg (msg "trash " (:title target) " and reduce the strength of " (:title current-ice)
                            " by 2 for the remainder of the run")
                  :effect (effect (update! (assoc card :null-target current-ice))
-                                 (update-ice-strength current-ice))}]
+                                 (update-ice-strength current-ice)
+                                 (trash target {:unpreventable true}))}]
     :events {:pre-ice-strength
              {:req (req (= (:cid target) (get-in card [:null-target :cid])))
               :effect (effect (ice-strength-bonus -2 target))}


### PR DESCRIPTION
* Fix #1873: Was missing icebreaker installation discount
* Fix #1862: Move timing of CP's effect activation
* Fix Null: Whistleblower to actually discard the targeted card.