### PR TITLE
Add a /move-bottom console command

### DIFF
--- a/src/clj/game/core-io.clj
+++ b/src/clj/game/core-io.clj
@@ -187,6 +187,10 @@
                                                :effect (effect (move target :rfg))
                                                :choices {:req (fn [t] (card-is? t :side %2))}}
                                         {:title "/rfg command"} nil)
+        "/move-bottom"  #(resolve-ability %1 %2 {:prompt "Select a card in hand to put on the bottom of your deck"
+                                                 :effect (effect (move target :deck))
+                                                 :choices {:req (fn [t] (and (card-is? t :side %2) (in-hand? t)))}}
+                                          {:title "/move-bottom command"} nil)
         "/error"      #(show-error-toast %1 %2)
         nil))))
 


### PR DESCRIPTION
Fixes #1834. 

This is a workaround for the current inability to put what should be eligible cards on the bottom of R&D when using Sensie Actors Union in multi-draw situations. 