### PR TITLE
fix Salsette Slums and trashable executives; fix Liquidation

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -460,10 +460,10 @@
                    (continue-ability state side
                      {:prompt "Choose any number of rezzed cards to trash"
                       :choices {:max n :req #(and (rezzed? %) (not (is-type? % "Agenda")))}
-                      :msg (msg "trash " (join ", " (map :title targets)) " and gain " (* n 3) " [Credits]")
+                      :msg (msg "trash " (join ", " (map :title targets)) " and gain " (* (count targets) 3) " [Credits]")
                       :effect (req (doseq [c targets]
                                      (trash state side c))
-                                   (gain state side :credit (* n 3)))}
+                                   (gain state side :credit (* (count targets) 3)))}
                     card nil)))}
 
    "Localized Product Line"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -629,7 +629,7 @@
                                     :effect (effect (runner-install target {:host-card card}) (gain :credit 1))}
                                   card nil))}
                 {:label "Host an installed program"
-                 :prompt "Choose a program to host on Scheherazade"
+                 :prompt "Choose a program to host on Scheherazade" :priority 2
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
                  :msg (msg "host " (:title target) " and gain 1 [Credits]")

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -922,7 +922,9 @@
                                 (pay state :runner card :credit (trash-cost state side c))
                                 (trigger-event state side :runner-trash nil)
                                 (update! state side (dissoc card :slums-active))
-                                (close-access-prompt state side)))}
+                                (close-access-prompt state side)
+                                (when-not (:run @state)
+                                  (swap! state dissoc :access))))}
                 {:label "Remove a card trashed this turn from the game"
                  :req (req (if (:slums-active card)
                              true


### PR DESCRIPTION
* Salsette Slums has the same problem Film Critic used to have (fixed at #1277)--using it during a run would result in `:access true` lingering on in the game state, so a Corp player subsequently doing a voluntary trash from hand of one of the 2-point executives would see the card wrongly teleport to the Runner's area. 
* Liquidation is using the wrong calculation to figure credits paid--it's always doing 3x number of rezzed cards, regardless of how many the Corp actually selects.
* Fix #1886: Bumped up the priority of Scheherazade's "host an installed program" ability to slightly ease the pain of the tortuous Pawn+Deep Red+Scheherazade engine, avoiding duplicated Pawns.

