### PR TITLE
Various fixes

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -160,7 +160,7 @@
                                      (game.core/run state side eid :rd nil card)
                                      (effect-completed state side eid))
                                    (update! state side (dissoc card :run-again)))))
-    :events {:successful-run-ends {:optional {:req (req (= :rd target))
+    :events {:successful-run-ends {:optional {:req (req (= [:rd] (:server target)))
                                               :prompt "Make another run on R&D?"
                                               :yes-ability {:effect (effect (update! (assoc card :run-again true)))}}}}}
 

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -485,6 +485,7 @@
                                                 (concat (:hand corp) (:discard corp))))))
                  :yes-ability {:prompt "Choose a Current to play from HQ or Archives"
                                :show-discard true
+                               :delayed-completion true
                                :choices {:req #(and (has-subtype? % "Current")
                                                     (= (:side %) "Corp")
                                                     (#{[:hand] [:discard]} (:zone %)))}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -153,8 +153,8 @@
                                      (turn-flag? state side card :can-trash-operation)))
                       :effect (effect (trash target))
                       :msg (msg "trash " (:title target))}
-             :successful-run-ends {:req (req (and (= target :archives)
-                                                  (not= (:max-access run) 0)
+             :successful-run-ends {:req (req (and (= (:server target) [:archives])
+                                                  (not= (:max-access target) 0)
                                                   (seq (filter #(is-type? % "Operation") (:discard corp)))))
                                    :effect (effect (register-turn-flag! card :can-trash-operation (constantly false)))}}}
 

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -325,15 +325,19 @@
 
    "Prisec"
    {:access {:req (req (installed? card))
+             :delayed-completion true
              :effect (effect (show-wait-prompt :runner "Corp to use Prisec")
-                             (resolve-ability
+                             (continue-ability
                                {:optional
                                 {:prompt "Pay 2 [Credits] to use Prisec ability?"
                                  :end-effect (effect (clear-wait-prompt :runner))
                                  :yes-ability {:cost [:credit 2]
                                                :msg "do 1 meat damage and give the Runner 1 tag"
-                                               :effect (effect (damage eid :meat 1 {:card card})
-                                                               (tag-runner :runner 1))}}}
+                                               :delayed-completion true
+                                               :effect (req (when-completed (damage state side :meat 1 {:card card})
+                                                                            (do (tag-runner state :runner 1)
+                                                                                ;; TO-DO: extend effect-completed to tag prevention
+                                                                                (effect-completed state side eid))))}}}
                                card nil))}}
 
    "Product Placement"

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -191,7 +191,8 @@
 
    "Hokusai Grid"
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"
-                              :effect (req (damage state side eid :net 1 {:card card}))}}}
+                              :delayed-completion true
+                              :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Keegan Lane"
    {:abilities [{:label "[Trash], remove a tag: Trash a program"
@@ -367,6 +368,7 @@
    "Ryon Knight"
    {:abilities [{:label "[Trash]: Do 1 brain damage"
                  :msg "do 1 brain damage" :req (req (and this-server (zero? (:click runner))))
+                 :delayed-completion true
                  :effect (effect (trash card) (damage eid :brain 1 {:card card}))}]}
 
    "SanSan City Grid"

--- a/src/clj/game/core-abilities.clj
+++ b/src/clj/game/core-abilities.clj
@@ -7,6 +7,11 @@
 ;;;; Functions for implementing card abilities and prompts
 
 ;;; Abilities
+(defn is-ability
+  "Checks to see if a given map represents a card ability. Looks for :effect, :optional, :trace, or :psi."
+  [{:keys [effect optional trace psi] :as abi}]
+  (or effect optional trace psi))
+
 (defn resolve-ability
   "Resolves an ability defined by the given ability map. Checks :req functions; shows prompts, psi games,
   traces, etc. as needed; charges costs; invokes :effect functions. All card effects and most engine effects

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -64,7 +64,8 @@
 (defn card-init
   "Initializes the abilities and events of the given card."
   ([state side card] (card-init state side card true))
-  ([state side card resolve]
+  ([state side card resolve] (card-init state side (make-eid state) card resolve))
+  ([state side eid card resolve]
    (let [cdef (card-def card)
          recurring (:recurring cdef)
          abilities (ability-init cdef)
@@ -85,8 +86,9 @@
      (update! state side c)
      (when-let [events (:events cdef)]
        (register-events state side events c))
-     (when resolve
-       (resolve-ability state side cdef c nil))
+     (if (and resolve (is-ability cdef))
+       (resolve-ability state side eid cdef c nil)
+       (effect-completed state side eid))
      (when-let [in-play (:in-play cdef)]
        (apply gain state side in-play))
      (get-card state c))))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -41,7 +41,7 @@
                        (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
                        (trash state side current)))
                    (let [moved-card (move state side (first (get-in @state [side :play-area])) :current)]
-                     (card-init state side moved-card)))
+                     (card-init state side eid moved-card true)))
                (do (resolve-ability state side (assoc cdef :eid eid) card nil)
                    (when-let [c (some #(when (= (:cid %) (:cid card)) %) (get-in @state [side :play-area]))]
                      (move state side c :discard))

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -142,6 +142,23 @@
         (core/move state :runner (find-card "Battering Ram" (:hosted (refresh dino))) :discard)
         (is (= 4 (:memory (get-runner))) "Battering Ram 2 MU not added to available MU")))))
 
+(deftest doppelganger
+  "Doppelgänger - run again when successful"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Doppelgänger" 1)]))
+    (core/gain state :corp :bad-publicity 1)
+    (take-credits state :corp)
+    (play-from-hand state :runner "Doppelgänger")
+    (run-empty-server state :hq)
+    (prompt-choice :runner "OK")
+    (is (= 0 (:run-credit (get-runner))) "Runner lost BP credits")
+    (prompt-choice :runner "Yes")
+    (prompt-choice :runner "R&D")
+    (is (:run @state) "New run started")
+    (is (= [:rd] (:server (:run @state))) "Running on R&D")
+    (is (= 1 (:run-credit (get-runner))) "Runner has 1 BP credit")))
+
 (deftest feedback-filter
   "Feedback Filter - Prevent net and brain damage"
   (do-game


### PR DESCRIPTION
Fix #1880 by causing Currents to trigger effect-completed events when appropriate.

Fix several run issues when accessing damage-causing cards like Prisec and Shi.Kyu. __Any__ effect that calls `damage` should be marked `:delayed-completion true`.

Fix #1865 by better following the game rules regarding when "successful run ends" event should be triggered. The event should be triggered after the run has closed (BP credits lost, icebreakers reset). This requires slight tweaks to some cards, as `:run` in state will no longer exist when the event is triggered. Instead we send a copy of the `:run` map to the event handlers.