### PR TITLE
Fixes: Hemorrhage, Award Bait, Research Grant

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -70,14 +70,21 @@
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "Award Bait"
-   {:access {:choices ["0", "1", "2"]
-             :prompt "How many advancement tokens?"
-             :effect (req (let [c (Integer/parseInt target)]
-                            (continue-ability
-                             state side
-                             {:choices {:req can-be-advanced?}
-                              :msg (msg "place " c " advancement tokens on " (card-str state target))
-                              :effect (final-effect (add-prop :corp target :advance-counter c {:placed true}))} card nil)))}}
+   {:access {:delayed-completion true
+             :effect (effect (show-wait-prompt :runner "Corp to place advancement tokens with Award Bait")
+                             (continue-ability
+                               {:delayed-completion true
+                                :choices ["0", "1", "2"]
+                                :prompt "How many advancement tokens?"
+                                :effect (req (let [c (Integer/parseInt target)]
+                                               (continue-ability
+                                                 state side
+                                                 {:choices {:req can-be-advanced?}
+                                                  :msg (msg "place " c " advancement tokens on " (card-str state target))
+                                                  :cancel-effect (effect (clear-wait-prompt :runner))
+                                                  :effect (effect (add-prop :corp target :advance-counter c {:placed true})
+                                                                  (clear-wait-prompt :runner))} card nil)))}
+                              card nil))}}
 
    "Bifrost Array"
    {:req (req (not (empty? (filter #(not= (:title %) "Bifrost Array") (:scored corp)))))

--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -605,10 +605,14 @@
 
    "Research Grant"
    {:req (req (not (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp)))))
-    :prompt "Choose another installed copy of Research Grant to score"
-    :choices {:req #(= (:title %) "Research Grant")}
-    :effect (final-effect (score (assoc target :advance-counter (:advancementcost target))))
-    :msg (msg "score another copy of Research Grant")}
+    :delayed-completion true
+    :effect (effect (continue-ability
+                      {:prompt "Choose another installed copy of Research Grant to score"
+                       :choices {:req #(= (:title %) "Research Grant")}
+                       :effect (effect (set-prop target :advance-counter (:advancementcost target))
+                                       (score target))
+                       :msg "score another copy of Research Grant"}
+                     card nil))}
 
    "Restructured Datapool"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -129,10 +129,9 @@
 
    "Cyber Threat"
    {:prompt "Choose a server" :choices (req runnable-servers)
-    :effect (req (let [serv target
-                       runtgt [(last (server->zone state serv))]
-                       ices (get-in @state (concat [:corp :servers] runtgt [:ices]))]
-                   (resolve-ability
+    :delayed-completion true
+    :effect (req (let [serv target]
+                   (continue-ability
                      state :corp
                      {:optional
                       {:prompt (msg "Rez a piece of ICE protecting " serv "?")
@@ -140,12 +139,7 @@
                                      :choices {:req #(and (not (:rezzed %))
                                                           (= (last (:zone %)) :ices))}
                                      :effect (req (rez state :corp target nil))}
-                       :no-ability {:effect (req (swap! state assoc :per-run nil
-                                                        :run {:server runtgt :position (count ices)
-                                                              :access-bonus 0 :run-effect nil})
-                                                 (gain-run-credits state :runner (:bad-publicity corp))
-                                                 (swap! state update-in [:runner :register :made-run] #(conj % (first runtgt)))
-                                                 (trigger-event state :runner :run runtgt))
+                       :no-ability {:effect (effect (game.core/run eid serv nil card))
                                     :msg (msg "make a run on " serv " during which no ICE can be rezzed")}}}
                     card nil)))}
 

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -263,12 +263,15 @@
    {:events {:successful-run {:effect (effect (add-counter card :virus 1))}}
     :abilities [{:counter-cost [:virus 2]
                  :cost [:click 1]
+                 :req (req (> (count (:hand corp)) 0))
                  :msg "force the Corp to trash 1 card from HQ"
-                 :effect (req (resolve-ability
+                 :effect (req (show-wait-prompt state :runner "Corp to trash a card from HQ")
+                              (resolve-ability
                                 state :corp
                                 {:prompt "Choose a card to trash"
                                  :choices (req (filter #(= (:side %) "Corp") (:hand corp)))
-                                 :effect (effect (trash target))}
+                                 :effect (effect (trash target)
+                                                 (clear-wait-prompt :runner))}
                                card nil))}]}
 
    "Hivemind"


### PR DESCRIPTION
* Fix #1898: Show Runner a wait prompt while Corp is trashing from HQ, and add requirement that Corp have cards in hand.
* Fix #1860: Use delayed completion framework and wait prompts with Award Bait
* Fix Research Grant, which currently throws a bug when targeting another installed copy of the agenda
* Purely cosmetic improvement to Cyber Threat