### PR TITLE
Card fixes

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -981,9 +981,15 @@
                                card nil))}}
 
    "Space Camp"
-   {:access {:msg (msg "place 1 advancement token on " (card-str state target))
-             :choices {:req can-be-advanced?}
-             :effect (effect (add-prop target :advance-counter 1 {:placed true}))}}
+   {:access {:delayed-completion true
+             :effect (effect (show-wait-prompt :runner "Corp to place an advancement with Space Camp")
+                             (continue-ability
+                               {:msg (msg "place 1 advancement token on " (card-str state target))
+                                :choices {:req can-be-advanced?}
+                                :cancel-effect (effect (clear-wait-prompt :runner))
+                                :effect (effect (add-prop target :advance-counter 1 {:placed true})
+                                                (clear-wait-prompt :runner))}
+                              card nil))}}
 
    "Sundew"
    {:events {:runner-spent-click {:once :per-turn

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -937,28 +937,35 @@
 
    "Shi.Kyū"
    {:access
-    {:optional {:req (req (not= (first (:zone card)) :deck))
-                :prompt "Pay [Credits] to use Shi.Kyū?"
-                :yes-ability {:prompt "How many [Credits] for Shi.Kyū?" :choices :credit
-                              :msg (msg "attempt to do " target " net damage")
-                              :delayed-completion true
-                              :effect (effect (continue-ability
-                               {:player :runner
-                                :prompt (str "Take " target " net damage or take Shi.Kyū as -1 agenda point?")
-                                :choices [(str "Take " target " net damage") "Add Shi.Kyū to score area"]
-                                :delayed-completion true
-                                :effect (let [dmg target]
-                                          (req (if (= target "Add Shi.Kyū to score area")
-                                                 (do (or (move state :runner (assoc card :agendapoints -1) :scored) ; if the runner did not trash the card on access, then this will work
-                                                         (move state :runner (assoc card :agendapoints -1 :zone [:discard]) :scored)) ;if the runner did trash it, then this will work
-                                                     (gain-agenda-point state :runner -1)
-                                                     (system-msg state side
-                                                                 (str "adds Shi.Kyū to their score area as -1 agenda point"))
-                                                     (effect-completed state side eid))
-                                                 (do (damage state :corp eid :net dmg {:card card})
-                                                     (system-msg state :corp
-                                                                 (str "uses Shi.Kyū to do " dmg " net damage"))))))}
-                              card targets))}}}}
+    {:delayed-completion true
+     :effect (effect (show-wait-prompt :runner "Corp to use Shi.Kyū")
+                     (continue-ability
+                       {:optional
+                        {:req (req (not= (first (:zone card)) :deck))
+                         :prompt "Pay [Credits] to use Shi.Kyū?"
+                         :yes-ability {:prompt "How many [Credits] for Shi.Kyū?" :choices :credit
+                                       :msg (msg "attempt to do " target " net damage")
+                                       :delayed-completion true
+                                       :effect (effect (clear-wait-prompt :runner)
+                                                       (continue-ability
+                                                         {:player :runner
+                                                          :prompt (str "Take " target " net damage or take Shi.Kyū as -1 agenda point?")
+                                                          :choices [(str "Take " target " net damage") "Add Shi.Kyū to score area"]
+                                                          :delayed-completion true
+                                                          :effect (let [dmg target]
+                                                                    (req (if (= target "Add Shi.Kyū to score area")
+                                                                           (do (or (move state :runner (assoc card :agendapoints -1) :scored) ; if the runner did not trash the card on access, then this will work
+                                                                                   (move state :runner (assoc card :agendapoints -1 :zone [:discard]) :scored)) ;if the runner did trash it, then this will work
+                                                                               (gain-agenda-point state :runner -1)
+                                                                               (system-msg state side
+                                                                                           (str "adds Shi.Kyū to their score area as -1 agenda point"))
+                                                                               (effect-completed state side eid))
+                                                                           (do (damage state :corp eid :net dmg {:card card})
+                                                                               (system-msg state :corp
+                                                                                           (str "uses Shi.Kyū to do " dmg " net damage"))))))}
+                                                        card targets))}
+                         :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
+                      card targets))}}
 
    "Shock!"
    {:access {:msg "do 1 net damage"

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -289,11 +289,12 @@
                                        an (get facs "Anarch" 0)
                                        sh (get facs "Shaper" 0)
                                        cr (get facs "Criminal" 0)]
-                                   (and (> sh an) (> sh cr) (pos? (count (:deck runner))))))
+                                   (and (> sh an) (> sh cr) (pos? (count (:deck runner)))
+                                        (first-event state side :pre-install))))
                        :msg "draw 1 card"
                        :once :per-turn
                        :effect (effect (draw 1))}]
-              {:runner-install jam
+              {:pre-install jam
                :pre-start-game {:effect draft-points-target}})}
 
    "Jesminder Sareen: Girl Behind the Curtain"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -726,7 +726,7 @@
                                   (join ", " (map :title (:hand runner)))
                                   " ) and trash any copies of " target))
                  (doseq [c (filter #(= target (:title %)) (:hand runner))]
-                   (trash state side c)))}
+                   (trash state side c {:unpreventable true})))}
 
    "Scarcity of Resources"
    {:msg "increase the install cost of resources by 2"

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -47,7 +47,7 @@
                                  (add-counter card :credit target))
                  :msg (msg "move " target " [Credit] to Algo Trading")}
                 {:label "Take all credits from Algo Trading"
-                 :cost [:credit 2]
+                 :cost [:click 1]
                  :msg (msg "trash it and gain " (get-in card [:counter :credit] 0) " [Credits]")
                  :effect (effect (gain :credit (get-in card [:counter :credit] 0))
                                  (trash card {:cause :ability-cost}))}]


### PR DESCRIPTION
* Fix #1902. Sorry, just failed to correct Algo Trading's cost after the copy/paste from C.I. Fund.
* Fixes Jamie Micken, whose ability is wrongly firing both on an install done after the first one of the turn, and also when the card being installed is the one that results in more installed Shaper cards than other factions. 
* Fix #1908 by adding the `:delayed-completion` framework and wait prompts to Space Camp
* Cards trashed from Runner's hand by Salem's should not be able to be prevented (e.g., Fall Guy)