### PR TITLE
Fetch NRDB API 2.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,9 +11,11 @@ dependencies:
   post:
     - cd data; coffee fetch.coffee
 
+
 test:
   override:
     - lein compile game.main
+    - lein compile test.core
     - lein test test.core
     - lein test test.cards.agendas
     - lein test test.cards.assets

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -816,7 +816,7 @@
     :prompt "Choose an identity to become"
     :choices (req (let [is-swappable (fn [c] (and (= "Identity" (:type c))
                                              (= (-> @state :runner :identity :faction) (:faction c))
-                                             (not (= "Draft" (:setname c)))
+                                             (not (.startsWith (:code c) "00")) ; only draft identities have this
                                              (not (= (:title c) (-> @state :runner :identity :title)))))
                         swappable-ids (filter is-swappable (vals @all-cards))]
                     (cancellable swappable-ids :sorted)))


### PR DESCRIPTION
Update fetch URL to use new NRDB API 2.0.

Map new API keys to old keys so we don't have to change any card logic. For example, we don't need to update cards that target ice to look for "ice" type instead of "ICE".

Update Rebirth logic to look for "00" in a card's code to look for draft IDs, since we no longer have "setname" in the card data.