### PR TITLE
Update to installed macro

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -9,7 +9,7 @@
             [clojure.core.match :refer [match]]))
 
 (declare get-card get-zones get-runnable-zones get-remote-names make-eid make-result register-effect-completed
-         resolve-ability say server-card system-msg trigger-event update!)
+         get-nested-host resolve-ability say server-card system-msg trigger-event update!)
 
 (def game-states (atom {}))
 (def all-cards (atom {}))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -33,7 +33,7 @@
             'corp-reg '(get-in @state [:corp :register])
             'runner-reg '(get-in @state [:runner :register])
             'target '(first targets)
-            'installed '(#{:rig :servers} (first (:zone card)))
+            'installed '(#{:rig :servers} (first (:zone (get-nested-host card))))
             'remotes '(get-remote-names @state)
             'servers '(zones->sorted-names (get-zones @state))
             'unprotected '(let [server (second (:zone (if (:host card)


### PR DESCRIPTION
Fixes #1839.

The `installed` macro needs to check not the `card` alone, but rather `(get-nested-host card)` in order to return an accurate result. 