### PR TITLE
Announcements

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -554,9 +554,15 @@ app.get '/data/:collection/:field/:value', (req, res) ->
     res.send {message: 'Unauthorized'}, 401
 
 app.get '/announce', (req, res) ->
-  if req.user.isadmin
-    requester.send(JSON.stringify({action: "alert", command: req.query.text}))
-    res.send {text: req.query.text, result: "ok"}, 200
+  if req.user and req.user.isadmin
+    res.render('announce.jade', {user : req.user})
+  else
+    res.send {message: 'Unauthorized'}, 401
+
+app.post '/announce', (req, res) ->
+  if req.user and req.user.isadmin
+    requester.send(JSON.stringify({action: "alert", command: req.body.message}))
+    res.send {text: req.body.message, result: "ok"}, 200
   else
     res.send {message: 'Unauthorized'}, 401
 

--- a/server.coffee
+++ b/server.coffee
@@ -326,7 +326,7 @@ passport.serializeUser (user, done) ->
 passport.deserializeUser (id, done) ->
   db.collection('users').findById id, (err, user) ->
     console.log err if err
-    done(err, {username: user.username, emailhash: user.emailhash, _id: user._id, special: user.special})
+    done(err, {username: user.username, emailhash: user.emailhash, _id: user._id, special: user.special, isadmin: user.isadmin})
 
 # Routes
 app.options('*', cors())
@@ -550,6 +550,13 @@ app.get '/data/:collection/:field/:value', (req, res) ->
       console.error(err) if err
       delete d._id for d in data
       res.json(200, data)
+  else
+    res.send {message: 'Unauthorized'}, 401
+
+app.get '/announce', (req, res) ->
+  if req.user.isadmin
+    requester.send(JSON.stringify({action: "alert", command: req.query.text}))
+    res.send {text: req.query.text, result: "ok"}, 200
   else
     res.send {message: 'Unauthorized'}, 401
 

--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -810,7 +810,7 @@
     :prompt "Choose an identity to become"
     :choices (req (let [is-swappable (fn [c] (and (= "Identity" (:type c))
                                              (= (-> @state :runner :identity :faction) (:faction c))
-                                             (not (= "Draft" (:setname c)))
+                                             (not (.startsWith (:code c) "00")) ; only draft identities have this
                                              (not (= (:title c) (-> @state :runner :identity :title)))))
                         swappable-ids (filter is-swappable (vals @all-cards))]
                     (cancellable swappable-ids :sorted)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -12,6 +12,7 @@
          resolve-ability say server-card system-msg trigger-event update!)
 
 (def game-states (atom {}))
+(def old-states (atom {}))
 (def all-cards (atom {}))
 (def all-cards-alt (atom {}))
 

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -154,7 +154,10 @@
          (do (println "Error " action command (get-in args [:card :title]) e)
              (try (if state
                     (do (show-error-toast state (keyword side))
-                        (swap! state assoc :last-error (pr-str e))
+                        (swap! state assoc :last-error (str "Error " action " " command " "
+                                                            (or (get-in args [:card :title])
+                                                                (get-in args [:choice]))
+                                                            " " (pr-str e)))
                         true)
                     false)
                   (catch Exception e
@@ -165,48 +168,48 @@
   "Main thread for handling commands from the UI server. Attempts to apply a command,
   then returns the resulting game state, or another message as appropriate."
   (while true
-    (let [{:keys [gameid action command args] :as msg} (convert (.recv socket))]
       ;; Attempt to handle the command. If true is returned, then generate a successful
       ;; message. Otherwise generate an error message.
       (try
-        (if (= action "alert")
-          (do (doseq [state (vals @game-states)]
-                (doseq [side [:runner :corp]]
-                  (toast state side command "warning" {:time-out 0 :close-button true})))
-              (.send socket (generate-string "ok")))
-          (let [state (@game-states (:gameid msg))
-                old-state (when state (@old-states (:gameid msg)))
-                [old-corp old-runner old-spect] (when old-state (private-states (atom old-state)))]
-            (if (handle-command msg state)
-              (if (= action "initialize")
-                (.send socket (generate-string "ok"))
-                (if-let [new-state (@game-states gameid)]
-                  (let [[new-corp new-runner new-spect] (private-states new-state)]
-                    (do
-                      (swap! old-states assoc (:gameid msg) @new-state)
-                      (if (#{"start" "reconnect" "notification"} action)
-                        ;; send the whole state, not a diff
-                        (.send socket (generate-string {:action      action
-                                                        :runnerstate (strip new-runner)
-                                                        :corpstate   (strip new-corp)
-                                                        :spectstate  (strip new-spect)
-                                                        :gameid      gameid}))
-                        ;; send a diff
-                        (let [runner-diff (differ/diff (strip old-runner) (strip new-runner))
-                              corp-diff (differ/diff (strip old-corp) (strip new-corp))
-                              spect-diff (differ/diff (strip old-spect) (strip new-spect))]
-                          (.send socket (generate-string {:action     action
-                                                          :runnerdiff runner-diff
-                                                          :corpdiff   corp-diff
-                                                          :spectdiff  spect-diff
-                                                          :gameid     gameid}))))))
-                  (.send socket (generate-string {:action action :state old-state :gameid gameid}))))
-              (.send socket (generate-string "error")))))
+        (let [{:keys [gameid action command args] :as msg} (convert (.recv socket))]
+          (if (= action "alert")
+            (do (doseq [state (vals @game-states)]
+                  (doseq [side [:runner :corp]]
+                    (toast state side command "warning" {:time-out 0 :close-button true})))
+                (.send socket (generate-string "ok")))
+            (let [state (@game-states (:gameid msg))
+                  old-state (when state (@old-states (:gameid msg)))
+                  [old-corp old-runner old-spect] (when old-state (private-states (atom old-state)))]
+              (if (handle-command msg state)
+                (if (= action "initialize")
+                  (.send socket (generate-string "ok"))
+                  (if-let [new-state (@game-states gameid)]
+                    (let [[new-corp new-runner new-spect] (private-states new-state)]
+                      (do
+                        (swap! old-states assoc (:gameid msg) @new-state)
+                        (if (#{"start" "reconnect" "notification"} action)
+                          ;; send the whole state, not a diff
+                          (.send socket (generate-string {:action      action
+                                                          :runnerstate (strip new-runner)
+                                                          :corpstate   (strip new-corp)
+                                                          :spectstate  (strip new-spect)
+                                                          :gameid      gameid}))
+                          ;; send a diff
+                          (let [runner-diff (differ/diff (strip old-runner) (strip new-runner))
+                                corp-diff (differ/diff (strip old-corp) (strip new-corp))
+                                spect-diff (differ/diff (strip old-spect) (strip new-spect))]
+                            (.send socket (generate-string {:action     action
+                                                            :runnerdiff runner-diff
+                                                            :corpdiff   corp-diff
+                                                            :spectdiff  spect-diff
+                                                            :gameid     gameid}))))))
+                    (.send socket (generate-string {:action action :state old-state :gameid gameid}))))
+                (.send socket (generate-string "error"))))))
         (catch Exception e
-          (try (do (println "Inner Error " action command (get-in args [:card :title]) e)
+          (try (do (println "Inner Error " e)
                    (.send socket (generate-string "error")))
                (catch Exception e
-                 (println "Socket Error " e))))))))
+                 (println "Socket Error " e)))))))
 
 (def zmq-url (str "tcp://" (or (env :zmq-host) "127.0.0.1") ":1043"))
 

--- a/views/announce.jade
+++ b/views/announce.jade
@@ -1,0 +1,14 @@
+doctype html
+html
+  head
+    meta(charset="utf-8")
+    title Jinteki
+    link(rel='stylesheet', href='/css/netrunner.css')
+  body
+    div.reset-bg
+    form.panel.blue-shade.reset-form(method='POST')
+      h3 Announcement
+      p
+        textarea.form-control(rows=5, style='height: 80px; width: 250px', name='message', value='', autofocus=true required)
+      p
+        button.btn.btn-primary(type='submit') Submit


### PR DESCRIPTION
Allows an admin to push announcement toasts to all active games. 

I think this is a "good enough" solution. Upon submitting a message, a toast is shown in all active games. It is not shown in main chat, and it is not shown to any game that starts after the message is submitted. The purpose of this feature is to warn users when @mtgred has to bring the server down for upgrades. A message in main chat is good to warn people who are chatting, but insufficient for those who are playing.

This feature is enabled at the URL `./announce`. Only administrators can see this page. Administrators must be marked in the users database as `isadmin: true`; Minh will know how to do this. I copied the layout of this page from the Reset Password page, so it's a little basic, but it gets the job done:

![image](https://cloud.githubusercontent.com/assets/10083341/18015975/e353cbbc-6b7e-11e6-92eb-a0e54a99f2d2.png)

The message goes to the Node server, which sends it to the game server. The game server inserts a Warning toast into each active game state. This took some minor surgery on `main`.