### PR TITLE
Change mill definition to use move

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -705,7 +705,6 @@
    {:prompt "Choose a server"
     :choices (req runnable-servers)
     :effect (effect (run eid target nil card))
-    :mill-effect {:effect (effect (register-events (ashes-flag) (assoc card :zone [:discard])))}
     :move-zone (req (if (= [:discard] (:zone card))
                       (register-events state side (ashes-flag) (assoc card :zone [:discard]))
                       (unregister-events state side card)))

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -445,8 +445,6 @@
                                             (:events (card-def card))
                                             (assoc card :zone [:discard]))))]
    {:move-zone heap-event
-    :mill-effect {:effect heap-event}
-    :card-moved heap-event
     :abilities [{:label (str "X [Credits]: +X strength, break X subroutines")
                  :choices :credit
                  :prompt "How many credits?"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -873,7 +873,6 @@
                       (resolve-ability {:once :per-turn :once-key :subliminal-messaging
                                         :msg "gain [Click]"
                                         :effect (effect (gain :corp :click 1))} card nil))
-      :mill-effect {:effect (effect (register-events (subliminal) (assoc card :zone '(:discard))))}
       :move-zone (req (if (= [:discard] (:zone card))
                         (register-events state side (subliminal) (assoc card :zone '(:discard)))
                         (unregister-events state side card)))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -428,14 +428,9 @@
   "Force the discard of n cards from :deck to :discard."
   ([state side] (mill state side 1))
   ([state side n]
-   (let [milltargets (take n (get-in @state [side :deck]))
-         milled (zone :discard milltargets)]
+   (let [milltargets (take n (get-in @state [side :deck]))]
      (doseq [c milltargets]
-       (when-let [mill (:mill-effect (card-def c))]
-         (resolve-ability state side mill c nil)
-         (trigger-event state side :mill-effect c)))
-     (swap! state update-in [side :discard] #(concat % milled)))
-   (swap! state update-in [side :deck] (partial drop n))))
+       (move state side c :discard)))))
 
 ;; Exposing
 (defn expose-prevent


### PR DESCRIPTION
Small PR. :mill-effect was something I introduced for Subliminal Messaging but it's redundant because :move-zone with a check to discard fulfills the same purpose. So if we just change the mill definition to use the move function, we can remove :mill-effect and reduce code duplication.