### PR TITLE
Fixes Plan B

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -727,7 +727,7 @@
    "Plan B"
    (advance-ambush
     0
-    {:req (req (< 0 (:advance-counter (get-card state card) 0)))
+    {:req (req (pos? (:advance-counter (get-card state card) 0)))
      :effect
      (effect (resolve-ability
               {:prompt "Choose an Agenda in HQ to score"

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -274,29 +274,28 @@
         (add-prop state side (get-card state card) :advance-counter 1)))))
 
 (defn score
-  "Score an agenda."
+  "Score an agenda. It trusts the card data passed to it."
   [state side args]
-  (let [card (get-card state (or (:card args) args))]
-    (when (can-score? state side card)
-      (when (and (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
-                 (>= (:advance-counter card) (or (:current-cost card) (:advancementcost card))))
-
-        ;; do not card-init necessarily. if card-def has :effect, wrap a fake event
-        (let [moved-card (move state :corp card :scored)
-              c (card-init state :corp moved-card false)
-              points (get-agenda-points state :corp c)]
-          (when-completed (trigger-event-simult state :corp :agenda-scored
-                                                {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
-                                                                (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
-                                                                (trash state side current)))}
-                                                (card-as-handler c) c)
-                          (let [c (get-card state c)
-                                points (or (get-agenda-points state :corp c) points)]
-                            (set-prop state :corp (get-card state moved-card) :advance-counter 0)
-                            (system-msg state :corp (str "scores " (:title c) " and gains " points
-                                                         " agenda point" (when (> points 1) "s")))
-                            (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
-                            (gain-agenda-point state :corp points))))))))
+  (let [card (or (:card args) args)]
+    (when (and (can-score? state side card)
+               (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
+               (>= (:advance-counter card 0) (or (:current-cost card) (:advancementcost card))))
+      ;; do not card-init necessarily. if card-def has :effect, wrap a fake event
+      (let [moved-card (move state :corp card :scored)
+            c (card-init state :corp moved-card false)
+            points (get-agenda-points state :corp c)]
+        (when-completed (trigger-event-simult state :corp :agenda-scored
+                                              {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
+                                                              (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
+                                                              (trash state side current)))}
+                                              (card-as-handler c) c)
+                        (let [c (get-card state c)
+                              points (or (get-agenda-points state :corp c) points)]
+                          (set-prop state :corp (get-card state moved-card) :advance-counter 0)
+                          (system-msg state :corp (str "scores " (:title c) " and gains " points
+                                                       " agenda point" (when (> points 1) "s")))
+                          (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
+                          (gain-agenda-point state :corp points)))))))
 
 (defn no-action
   "The corp indicates they have no more actions for the encounter."

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -42,7 +42,7 @@
    "access" core/successful-run
    "jack-out" core/jack-out
    "advance" core/advance
-   "score" core/score
+   "score" #(core/score %1 %2 (game.core/get-card %1 %3))
    "choice" core/resolve-prompt
    "select" core/select
    "shuffle" core/shuffle-deck

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -614,6 +614,27 @@
       (take-credits state :runner)
       (is (= 4 (:rec-counter (refresh netpol))) "4 recurring for Runner's 4 link"))))
 
+(deftest plan-b
+  "Plan B - score agenda with adv cost <= # of adv counters"
+  (do-game
+    (new-game (default-corp [(qty "Plan B" 1)
+                             (qty "Braintrust" 1)
+                             (qty "The Future Perfect" 1)
+                             (qty "Mushin No Shin" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Mushin No Shin")
+    (prompt-select :corp (find-card "Plan B" (:hand (get-corp))))
+    (take-credits state :corp)
+    (run-empty-server state :remote1)
+    ;; prompt for corp to use Plan B
+    (prompt-choice :corp "Yes")
+    ;; Pick TFP, does not score
+    (prompt-select :corp (find-card "The Future Perfect" (:hand (get-corp))))
+    (is (find-card "The Future Perfect" (:hand (get-corp))) "TFP is not scored")
+    ;; Pick Brain Trust, scores
+    (prompt-select :corp (find-card "Braintrust" (:hand (get-corp))))
+    (is (find-card "Braintrust" (:scored (get-corp))) "Braintrust is scored")))
+
 (deftest political-dealings
   (do-game
     (new-game (default-corp [(qty "Political Dealings" 1) (qty "Medical Breakthrough" 1) (qty "Oaktown Renovation" 1)])

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -170,9 +170,8 @@
               (default-runner))
     (play-from-hand state :corp "Ancestral Imager" "New remote")
     (let [ai (get-content state :remote1 0)]
-      ;; Trying to score without any tokens throws NPE
-      (is (thrown? java.lang.NullPointerException
-                   (core/score state :corp {:card (refresh ai)})))
+      ;; Trying to score without any tokens does not do anything
+      (is (not (find-card "Ancestral Imager" (:scored (get-corp)))) "AI not scored")
       (is (not (nil? (get-content state :remote1 0))))
       (core/advance state :corp {:card (refresh ai)})
       (core/score state :corp {:card (refresh ai)})
@@ -323,7 +322,7 @@
     (core/advance state :corp {:card (refresh oaktown)})
     (is (= 8 (:credit (get-corp))) "Corp 5+3 creds from Oaktown")
     (core/end-turn state :corp nil)
-    
+
     ;; Turn 1 Runner
     (core/start-turn state :runner nil)
     (take-credits state :runner 3)
@@ -331,7 +330,7 @@
     (core/end-turn state :runner nil)
     (core/rez state :corp (refresh adonis))
     (core/rez state :corp (refresh publics1))
-    
+
     ;; Turn 2 Corp
     (core/start-turn state :corp nil)
     (core/rez state :corp (refresh publics2))
@@ -340,7 +339,7 @@
     (is (= 9 (get-counters (refresh adonis) :credit)))
     (is (= 2 (get-counters (refresh publics1) :power)))
     (is (= 3 (get-counters (refresh publics2) :power)))
-    
+
     ;; oops, forgot to rez 2nd public support before start of turn,
     ;; let me fix it with a /command
     (core/command-counter state :corp ["power" 2])
@@ -361,7 +360,7 @@
     (core/score state :corp (refresh oaktown)) ; now the score should go through
     (is (= 2 (:agenda-point (get-corp))))
     (take-credits state :corp)
-    
+
     ;; Turn 2 Runner
     ;; cheating with publics1 going too fast. Why? because I can
     (is (= 2 (get-counters (refresh publics1) :power)))
@@ -374,7 +373,7 @@
     (prompt-select :corp (refresh adonis))
     (is (= 3 (get-counters (refresh adonis) :credit)))
     (take-credits state :runner)
-    
+
     ;; Turn 3 Corp
     (is (= 3 (:agenda-point (get-corp)))) ; cheated PS1 should get scored
     (is (= 9 (:credit (get-corp))))
@@ -382,7 +381,7 @@
     (is (= (:zone (refresh publics2)) [:servers :remote3 :content]))
     (is (= (:zone (refresh adonis) :discard)))
     (take-credits state :corp)
-    
+
     ;; Turn 3 Runner
     (take-credits state :runner)
 


### PR DESCRIPTION
Fixes NPE on trying to score with no advancement counters (and updates related test).
Fixes Plan B by moving `get-card` out from the `score` function into the commands map in `main`.
Adds test for Plan B.

Just three changes to `score`:

- Removed `get-card`
- Added default value for `:advancement-counter` to prevent NPE
- Combined the two `when` checks into one `and`

Fixes #1919.