### PR TITLE
Fixes and improves Femme Icon

### DIFF
--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -189,4 +189,4 @@
   (or (#{:hq :rd :archives} zone) :remote))
 
 (defn private-card [card]
-  (select-keys card [:zone :cid :side :new :host :counter :advance-counter :hosted]))
+  (select-keys card [:zone :cid :side :new :host :counter :advance-counter :hosted :icon]))

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1268,7 +1268,7 @@ nav ul
     line-height: 24px
     font-size: 12px
     top: 3px
-    right: 3px
+    left: 3px
     height: 24px
     width: 24px
 


### PR DESCRIPTION
The icon on unrezzed ice was a collateral victim of the privacy rework.

Also moved the icon to not clash with the virus counter on parasite.

Images:
<img width="118" alt="screen shot 2016-09-01 at 20 03 17" src="https://cloud.githubusercontent.com/assets/13198563/18178791/0e5fd624-7080-11e6-8be5-3346ecd3b118.png">
<img width="109" alt="screen shot 2016-09-01 at 20 03 46" src="https://cloud.githubusercontent.com/assets/13198563/18178796/112ba6c6-7080-11e6-819b-85d20461162e.png">

Fixes #1870 and #1630