### PR TITLE
Mr. Li rework (Genetics Pavilion/Mr. Li interaction)

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -622,13 +622,17 @@
     :abilities [ability]})
 
    "Mr. Li"
-   {:abilities [{:cost [:click 1] :prompt "Card to keep?"
-                 :choices (req (take 2 (:deck runner))) :not-distinct true :msg "choose 1 card to draw"
-                 :effect (req (move state side target :hand)
-                              (if (= target (first (:deck runner)))
-                                (move state side (second (:deck runner)) :deck)
-                                (move state side (first (:deck runner)) :deck))
-                              (trigger-event state side :runner-draw))}]}
+   {:abilities [{:cost [:click 1]
+                 :msg (msg "draw 2 cards")
+                 :effect (req (draw state side 2)
+                              (let [drawn (take-last 2 (conj (take 2 (:deck runner)) (:hand runner)))]
+                                (resolve-ability
+                                  state side
+                                  {:prompt (str "Choose 1 card to add to the bottom of the Stack")
+                                   :msg (msg "add 1 card to the bottom of Stack")
+                                   :choices {:req #(and (in-hand? %)
+                                                        (some (fn [c] (= (:cid c) (:cid %))) drawn))}
+                                   :effect (req (move state side target :deck))} card nil)))}]}
 
    "Muertos Gang Member"
    {:effect (req (resolve-ability

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -629,7 +629,7 @@
                                 (resolve-ability
                                   state side
                                   {:prompt (str "Choose 1 card to add to the bottom of the Stack")
-                                   :msg (msg "add 1 card to the bottom of Stack")
+                                   :msg (msg "add 1 card to the bottom of the Stack")
                                    :choices {:req #(and (in-hand? %)
                                                         (some (fn [c] (= (:cid c) (:cid %))) drawn))}
                                    :effect (req (move state side target :deck))} card nil)))}]}

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -443,6 +443,41 @@
       (is (= 2 (count (:hand (get-runner)))) "Drew only 2 cards because of Genetics Pavilion")
       (is (= 3 (count (:hand (get-corp)))) "Drew all 3 cards"))))
 
+(deftest genetics-pavilion-mr-li
+  "Genetics Pavilion - Mr. Li interaction. #1594"
+  (do-game
+    (new-game (default-corp [(qty "Genetics Pavilion" 1)])
+              (default-runner [(qty "Mr. Li" 1) (qty "Account Siphon" 1) (qty "Faerie" 1)
+                               (qty "Sure Gamble" 1) (qty "John Masanori" 1) (qty "Desperado" 1)]))
+    (starting-hand state :runner ["Mr. Li"])
+    (play-from-hand state :corp "Genetics Pavilion" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Mr. Li")
+    (let [mrli (get-in @state [:runner :rig :resource 0])]
+      (is (= 0 (count (:hand (get-runner)))))
+      ;use Mr. Li with 2 draws allowed
+      (card-ability state :runner mrli 0)
+      (is (= 2 (count (:hand (get-runner)))))
+      (prompt-select :runner (first (:hand (get-runner))))
+      (is (= 1 (count (:hand (get-runner)))))
+      ;use Mr. Li with 0 draws allowed
+      (card-ability state :runner mrli 0)
+      (is (= 1 (count (:hand (get-runner)))))
+      (prompt-select :runner (first (:hand (get-runner)))) ;will fail because not a valid target
+      (prompt-choice :runner "Done") ;cancel out
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (core/draw state :runner)
+      (is (= 2 (count (:hand (get-runner)))))
+      ;use Mr. Li with 1 draw allowed
+      (card-ability state :runner mrli 0)
+      (is (= 3 (count (:hand (get-runner)))))
+      (prompt-select :runner (first (:hand (get-runner)))) ;will fail
+      (prompt-select :runner (second (:hand (get-runner)))) ;will fail
+      (prompt-select :runner (second (rest (:hand (get-runner)))))
+      (is (= 2 (count (:hand (get-runner))))))))
+
 (deftest ghost-branch
   "Ghost Branch - Advanceable; give the Runner tags equal to advancements when accessed"
   (do-game


### PR DESCRIPTION
Fixes #1594 

Mr. Li now uses the draw function so that Genetics Pavilion can track the draws.
Looks like Daily Business Show could use a similar update but that one looks a lot harder. I will have a further look sometime.