### PR TITLE
A stopgap measure for all cards suddenly being unreleased

### DIFF
--- a/data/fetch.coffee
+++ b/data/fetch.coffee
@@ -25,8 +25,9 @@ capitalize = (s) ->
   return s.charAt(0).toUpperCase() + s.substr(1)
 
 setFields = {
+  "code" : same,
+  "date_release" : same
   "name" : same,
-  "date_release" : rename("available")
 }
 
 mapFactions = {
@@ -44,6 +45,50 @@ mapFactions = {
   "neutral-corp" : "Neutral"
 }
 
+# note - this is a horrible, horrible hack. Do not try at home.
+mapPacks = {
+  "core" : "Core Set",
+  "wla" : "What Lies Ahead",
+  "ta" : "Trace Amount",
+  "ce" : "Cyber Exodus",
+  "asis" : "A Study in Static",
+  "hs" : "Humanity's Shadow",
+  "fp" : "Future Proof",
+  "cac" : "Creation and Control",
+  "om" : "Opening Moves",
+  "st" : "Second Thoughts",
+  "mt" : "Mala Tempora",
+  "tc" : "True Colors",
+  "dt" : "Double Time",
+  "fal" : "Fear and Loathing",
+  "draft" : "Draft",
+  "hap" : "Honor and Profit",
+  "up" : "Upstalk",
+  "tsb" : "The Spaces Between",
+  "fc" : "First Contact",
+  "uao" : "Up and Over",
+  "atr" : "All That Remains",
+  "ts" : "The Source",
+  "oac" : "Order and Chaos",
+  "val" : "The Valley",
+  "bb" : "Breaker Bay",
+  "cc" : "Chrome City",
+  "uw" : "The Underway",
+  "oh" : "Old Hollywood",
+  "uot" : "The Universe of Tomorrow",
+  "dad" : "Data and Destiny",
+  "kg" : "Kala Ghoda",
+  "bf" : "Business First",
+  "dag" : "Democracy and Dogma",
+  "si" : "Salsette Island",
+  "tlm" : "The Liberated Mind",
+  "ftm" : "Fear the Masses",
+  "23s" : "23 Seconds",
+  "bm" : "Blood Money",
+  "es" : "Escalation",
+  "in" : "Intervention",
+  "ml" : "Martial Law"
+}
 
 cardFields = {
   "code" : same,
@@ -60,7 +105,7 @@ cardFields = {
   "faction_code" : (k, t) -> ["faction", mapFactions[t]],
   "faction_cost" : rename("factioncost"), # influence
   "position" : rename("number"),
-  # "setname",   --  deprecated
+  "pack_code" : (k, t) -> ["setname", mapPacks[t]]
   "side_code" : (k, t) -> ["side", capitalize(t)],
   "uniqueness" : same,
   "memory_cost" : rename("memoryunits"),

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -162,12 +162,12 @@
              [:option {:value field} field])]]
 
          (let [cycles (for [[cycle cycle-sets] (rest (group-by :cycle sets))]
-                        {:name (str cycle " cycle") :available (:available (first cycle-sets))})
+                        {:name (str cycle " cycle") :date_release (:date_release (first cycle-sets))})
                cycle-sets (map #(if (:cycle %)
                                   (update-in % [:name] (fn [name] (str "&nbsp;&nbsp;&nbsp;&nbsp;" name)))
                                   %)
                                sets)]
-           (for [filter [["Set" :set-filter (map :name (sort-by :available (concat cycles cycle-sets)))]
+           (for [filter [["Set" :set-filter (map :name (sort-by :date_release (concat cycles cycle-sets)))]
                          ["Side" :side-filter ["Corp" "Runner"]]
                          ["Faction" :faction-filter (factions (:side-filter state))]
                          ["Type" :type-filter (types (:side-filter state))]]]

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -275,7 +275,7 @@
   "Returns false if the card comes from a spoiled set or is out of competitive rotation."
   [{:keys [setname] :as card}]
   (let [date (some #(when (= (:name %) setname)
-                           (:available %))
+                           (:date_release %))
                    (:sets @app-state))]
     (and (not= date "")
          (< date (.toJSON (js/Date.))))))


### PR DESCRIPTION
Currently fixed it by mapping the codes to names as @nealterrell suggested. However, it is not very sustainable for the longterm - see #1931