### PR TITLE
Fix Space Camp and other run-ending-too-soon issues

### DIFF
--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -226,6 +226,7 @@
 (defn access-helper-remote [cards]
   {:prompt "Click a card to access it. You must access all cards in this server."
    :choices {:req #(some (fn [c] (= (:cid %) (:cid c))) cards)}
+   :delayed-completion true
    :effect (req (when-completed (handle-access state side [target])
                                 (if (< 1 (count cards))
                                   (continue-ability state side (access-helper-remote (filter #(not= (:cid %) (:cid target)) cards))
@@ -266,6 +267,7 @@
                         state side
                         {:prompt "Choose an upgrade in HQ to access."
                          :choices {:req #(= (second (:zone %)) :hq)}
+                         :delayed-completion true
                          :effect (req (system-msg state side (str "accesses " (:title target)))
                                       (when-completed (handle-access state side [target])
                                                       (continue-ability
@@ -337,6 +339,7 @@
                       (continue-ability
                         state side
                         {:prompt "Choose an upgrade in R&D to access."
+                         :delayed-completion true
                          :choices {:req #(= (second (:zone %)) :rd)}
                          :effect (req (system-msg state side (str "accesses " (:title target)))
                                       (when-completed (handle-access state side [target])
@@ -394,6 +397,7 @@
                         state side
                         {:prompt "Choose an upgrade in Archives to access."
                          :choices {:req #(= (second (:zone %)) :archives)}
+                         :delayed-completion true
                          :effect (req  (system-msg state side (str "accesses " (:title target)))
                                        (when-completed (handle-access state side [target])
                                                        (continue-ability
@@ -413,7 +417,8 @@
                                         (effect-completed state side eid nil))))))})
 
 (defmethod choose-access :archives [cards server]
-  {:effect (req (let [; only include agendas and cards with an :access ability whose :req is true
+  {:delayed-completion true
+   :effect (req (let [; only include agendas and cards with an :access ability whose :req is true
                       ; (or don't have a :req, or have an :optional with no :req, or :optional with a true :req.)
                       cards (filter #(let [cdef (card-def %)]
                                       (or (is-type? % "Agenda")

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -917,6 +917,24 @@
       (prompt-choice :runner "Yes")
       (is (= 5 (count (:discard (get-runner)))) "Runner took 5 damage"))))
 
+(deftest space-camp-archives
+  "Space Camp - bugged interaction from Archives. Issue #1929."
+  (do-game
+    (new-game (default-corp [(qty "Space Camp" 1) (qty "News Team" 1) (qty "Breaking News" 1)])
+              (default-runner))
+    (trash-from-hand state :corp "Space Camp")
+    (trash-from-hand state :corp "News Team")
+    (play-from-hand state :corp "Breaking News" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state :archives)
+    (prompt-choice :runner "News Team")
+    (prompt-choice :runner "Take 2 tags")
+    (prompt-choice :runner "Space Camp")
+    (prompt-select :corp (get-content state :remote1 0))
+    (is (= 1 (:advance-counter (get-content state :remote1 0))) "Agenda advanced once from Space Camp")
+    (is (= 2 (:tag (get-runner))) "Runner has 2 tags")
+    (is (not (:run @state)) "Run completed")))
+
 (deftest sundew
   "Sundew"
   (do-game

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -494,6 +494,31 @@
     (run-empty-server state "HQ")
     (is (not (:prompt @state)) "Prisec does not trigger from HQ")))
 
+(deftest prisec-dedicated-response-team
+  "Multiple unrezzed upgrades in Archives interaction with DRT."
+  (do-game
+    (new-game (default-corp [(qty "Prisec" 2) (qty "Dedicated Response Team" 1)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Diesel" 3)]))
+    (play-from-hand state :corp "Dedicated Response Team" "New remote")
+    (play-from-hand state :corp "Prisec" "Archives")
+    (play-from-hand state :corp "Prisec" "Archives")
+    (core/gain state :corp :click 1 :credit 14)
+    (core/rez state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+
+    (run-empty-server state :archives)
+    (is (:run @state) "Run still active")
+    (prompt-choice :runner "Unrezzed upgrade in Archives")
+    (prompt-select :runner (get-content state :archives 0))
+    (prompt-choice :corp "Yes") ; corp pay for PriSec
+    (prompt-choice :runner "No") ; runner don't pay to trash
+    (is (:run @state) "Run still active")
+    (prompt-choice :runner "Unrezzed upgrade in Archives")
+    (prompt-choice :corp "Yes") ; corp pay for PriSec
+    (prompt-choice :runner "No") ; runner don't pay to trash
+    (is (not (:run @state)) "Run ended")
+    (is (= 4 (count (:discard (get-runner)))) "Runner took 4 meat damage")))
+
 (deftest product-placement
   "Product Placement - Gain 2 credits when Runner accesses it"
   (do-game


### PR DESCRIPTION
Fix #1929. It's not actually a problem with Space Camp... I overlooked archives access when fixing some of the run routines to not end runs too early. While doing this, I discovered potential issues when accessing multiple unrezzed upgrades in a server, so I fixed that too. Tests for each scenario. Thanks to @kevkcc for the reproduction steps.