### PR TITLE
Lets Adam Pull Directives from `@all-cards`

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -10,43 +10,21 @@
    {:events {:pre-start-game
              {:req (req (= side :runner))
               :effect (req (let [is-directive? #(has-subtype? % "Directive")
-                                 one-of-each (fn [cards] (->> cards (group-by :title) (map second) (map first)))
-                                 directives (filter is-directive? (concat (:deck runner) (:hand runner)))
-                                 directives (one-of-each directives)]
-                             (case (count directives)
-                               ;; Have directives in the deck
-                               3
-                               (do (prn directives)
-                                   (doseq [c directives]
-                                     (runner-install state side c {:no-cost true
-                                                                   :custom-message (str "starts with " (:title c) " in play")}))
-                                   (draw state :runner (count (filter in-hand? directives)) {:suppress-event true}))
-                               ;; Missing directives. Add them
-                               0
-                               (let [directives (filter is-directive? (vals @all-cards))
-                                     directives (map make-card directives)
-                                     directives (zone :play-area directives)]
-                                 ;; Add directives to :play-area - should be empty
-                                 (swap! state assoc-in [:runner :play-area] directives)
-                                 ;; If more directives are printed this is probably where the runner gets to choose
-                                 (doseq [c directives]
-                                   (runner-install state side c {:no-cost true
-                                                                 :custom-message (str "starts with " (:title c) " in play")}))
-                                 (when (< 3 (count directives))
-                                   ;; Extra directives have been added, ask player to use /rfg on the directives not used.
-                                   ;; This implementation is just to make this more future proof, if extra directives are
-                                   ;; actually added then a selection would be better
-                                   (toast state :runner
-                                          (str "Please use /rfg to remove any directives other than the 3 you intend to start with."))))
-                               ;; Have other number of directives, toast
-                               :else
+                                 directives (filter is-directive? (vals @all-cards))
+                                 directives (map make-card directives)
+                                 directives (zone :play-area directives)]
+                             ;; Add directives to :play-area - should be empty
+                             (swap! state assoc-in [:runner :play-area] directives)
+                             ;; If more directives are printed this is probably where the runner gets to choose
+                             (doseq [c directives]
+                               (runner-install state side c {:no-cost true
+                                                             :custom-message (str "starts with " (:title c) " in play")}))
+                             (when (< 3 (count directives))
+                               ;; Extra directives have been added, ask player to use /rfg on the directives not used.
+                               ;; This implementation is just to make this more future proof, if extra directives are
+                               ;; actually added then a selection would be better
                                (toast state :runner
-                                      (str "Your deck doesn't contain enough directives for Adam's ability. The deck "
-                                           "needs to contain at least one copy of each directive. They are not counted "
-                                           "against the printed decksize limit, so Adam's minimum decksize on this "
-                                           "site is 48 cards.")
-                                      "warning"
-                                      {:time-out 0 :close-button true}))))}}}
+                                      (str "Please use /rfg to remove any directives other than the 3 you intend to start with.")))))}}}
 
    "Andromeda: Dispossessed Ristie"
    {:events {:pre-start-game {:req (req (= side :runner))
@@ -62,8 +40,8 @@
                                               (in-hand? %))}
                   :req (req (> (count (:hand runner)) 0))
                   :effect (effect (runner-install target {:facedown true}))}]
-   {:events {:runner-turn-begins ability}
-    :abilities [ability]})
+     {:events {:runner-turn-begins ability}
+      :abilities [ability]})
 
    "Argus Security: Protection Guaranteed"
    {:events {:agenda-stolen
@@ -224,11 +202,11 @@
                    ((constantly false)
                      (toast state :runner "Cannot steal due to Haarpsichord Studios." "warning"))
                    true))]
-   {:events {:agenda-stolen
-             {:effect (effect (register-turn-flag! card :can-steal haarp))}}
-    :effect (req (when-not (first-event state side :agenda-stolen)
-                   (register-turn-flag! state side card :can-steal haarp)))
-    :leave-play (effect (clear-turn-flag! card :can-steal))})
+     {:events {:agenda-stolen
+               {:effect (effect (register-turn-flag! card :can-steal haarp))}}
+      :effect (req (when-not (first-event state side :agenda-stolen)
+                     (register-turn-flag! state side card :can-steal haarp)))
+      :leave-play (effect (clear-turn-flag! card :can-steal))})
 
    "Haas-Bioroid: Engineering the Future"
    {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"
@@ -271,12 +249,12 @@
                      (continue-ability
                        state side
                        {:optional {:prompt (msg "Install another " type " from your Grip?")
-                                  :yes-ability
-                                  {:prompt (msg "Choose another " type " to install from your grip")
-                                   :choices {:req #(and (is-type? % type)
-                                                        (in-hand? %))}
-                                   :msg (msg "install " (:title target))
-                                   :effect (effect (runner-install eid target nil))}}}
+                                   :yes-ability
+                                   {:prompt (msg "Choose another " type " to install from your grip")
+                                    :choices {:req #(and (is-type? % type)
+                                                         (in-hand? %))}
+                                    :msg (msg "install " (:title target))
+                                    :effect (effect (runner-install eid target nil))}}}
                        card nil)))}}}
 
    "Iain Stirling: Retired Spook"
@@ -284,11 +262,11 @@
                   :once :per-turn
                   :msg "gain 2 [Credits]"
                   :effect (effect (gain :credit 2))}]
-   {:flags {:drip-economy true}
-    :events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}
-             :runner-turn-begins ability}
-    :abilities [ability]})
+     {:flags {:drip-economy true}
+      :events {:pre-start-game {:req (req (= side :runner))
+                                :effect (effect (gain :link 1))}
+               :runner-turn-begins ability}
+      :abilities [ability]})
 
    "Industrial Genomics: Growing Solutions"
    {:events {:pre-trash {:effect (effect (trash-cost-bonus
@@ -407,11 +385,11 @@
               :effect (req (when (some (fn [c] (has? c :subtype "Icebreaker")) (:hand runner))
                              (install-cost-bonus state side [:credit -1])
                              (resolve-ability state side
-                               {:prompt "Choose an icebreaker to install from your Grip"
-                                :choices {:req #(and (in-hand? %) (has-subtype? % "Icebreaker"))}
-                                :msg (msg "install " (:title target))
-                                :effect (effect (runner-install target))}
-                              card nil)))}}}
+                                              {:prompt "Choose an icebreaker to install from your Grip"
+                                               :choices {:req #(and (in-hand? %) (has-subtype? % "Icebreaker"))}
+                                               :msg (msg "install " (:title target))
+                                               :effect (effect (runner-install target))}
+                                              card nil)))}}}
 
    "Laramy Fisk: Savvy Investor"
    {:events {:successful-run {:delayed-completion true
@@ -426,23 +404,23 @@
 
    "Leela Patel: Trained Pragmatist"
    (let [leela {:interactive (req true)
-                :prompt  "Select an unrezzed card to return to HQ"
+                :prompt "Select an unrezzed card to return to HQ"
                 :choices {:req #(and (not (:rezzed %)) (card-is? % :side :corp))}
-                :msg     (msg "add " (card-str state target) " to HQ")
-                :effect  (final-effect (move :corp target :hand))}]
-   {:flags {:slow-hq-access (req true)}
-    :events {:agenda-scored leela
-             :agenda-stolen leela}})
+                :msg (msg "add " (card-str state target) " to HQ")
+                :effect (final-effect (move :corp target :hand))}]
+     {:flags {:slow-hq-access (req true)}
+      :events {:agenda-scored leela
+               :agenda-stolen leela}})
 
    "MaxX: Maximum Punk Rock"
    (let [ability {:msg "trash the top 2 cards from Stack and draw 1 card"
                   :once :per-turn
                   :effect (effect (mill 2) (draw))}]
-   {:flags {:runner-turn-draw true
-            :runner-phase-12 (req (and (not (:disabled card))
-                                       (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner))))}
-    :events {:runner-turn-begins ability}
-    :abilities [ability]})
+     {:flags {:runner-turn-draw true
+              :runner-phase-12 (req (and (not (:disabled card))
+                                         (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner))))}
+      :events {:runner-turn-begins ability}
+      :abilities [ability]})
 
    "Nasir Meidan: Cyber Explorer"
    {:events {:pre-start-game {:req (req (= side :runner))
@@ -481,7 +459,7 @@
                                                                      (clear-wait-prompt :runner))
                                                      :unsuccessful {:effect (effect (clear-wait-prompt :runner))}}}
                                :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
-                            card nil))}}}
+                             card nil))}}}
 
    "NBN: Making News"
    {:recurring 2}
@@ -572,7 +550,7 @@
              :pre-rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
                        :effect (effect (rez-cost-bonus 1))}
              :rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
-                              :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
+                   :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
 
    "Rielle \"Kit\" Peddler: Transhuman"
    {:abilities [{:req (req (and (:run @state)
@@ -597,8 +575,8 @@
              {:delayed-completion true
               :req (req (= target :hq)) :once :per-turn
               :effect (effect (continue-ability {:choices {:req #(and installed? (not (rezzed? %)))}
-                                                :effect (effect (expose target)) :msg "expose 1 card"}
-                                               card nil))}}}
+                                                 :effect (effect (expose target)) :msg "expose 1 card"}
+                                                card nil))}}}
 
    "Spark Agency: Worldswide Reach"
    {:events
@@ -638,12 +616,12 @@
                               :effect (effect (update! (assoc card :sync-front true)) (tag-remove-bonus -1))}}
     :abilities [{:cost [:click 1]
                  :effect (req (if (:sync-front card)
-                           (do (tag-remove-bonus state side 1)
-                               (trash-resource-bonus state side 2)
-                               (update! state side (-> card (assoc :sync-front false) (assoc :code "sync"))))
-                           (do (tag-remove-bonus state side -1)
-                               (trash-resource-bonus state side -2)
-                               (update! state side (-> card (assoc :sync-front true)(assoc :code "09001"))))))
+                                (do (tag-remove-bonus state side 1)
+                                    (trash-resource-bonus state side 2)
+                                    (update! state side (-> card (assoc :sync-front false) (assoc :code "sync"))))
+                                (do (tag-remove-bonus state side -1)
+                                    (trash-resource-bonus state side -2)
+                                    (update! state side (-> card (assoc :sync-front true) (assoc :code "09001"))))))
                  :msg (msg "flip their ID")}]
     :leave-play (req (if (:sync-front card)
                        (tag-remove-bonus state side 1)

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -50,10 +50,17 @@
     @game-states))
 
 (defn server-card
-  ([title] (server-card title))
+  ([title] (@all-cards title))
   ([title user]
    (let [c (@all-cards title)]
      (or (when (:special user) (@all-cards-alt title)) c))))
+
+(defn make-card
+  "Makes a proper card from an @all-cards card"
+  [card]
+  (-> card
+      (assoc :cid (make-cid))
+      (dissoc :setname :text :_id :influence :number :influencelimit :factioncost)))
 
 (defn create-deck
   "Creates a shuffled draw deck (R&D/Stack) from the given list of cards.
@@ -61,10 +68,8 @@
   ([deck] (create-deck deck nil))
   ([deck user]
    (shuffle (mapcat #(map (fn [card]
-                            (let [c (or (server-card (:title card) user) card)
-                                  c (assoc c :cid (make-cid))
-                                  c (dissoc c :setname :text :_id :influence :number :influencelimit
-                                            :factioncost)]
+                            (let [card (or (server-card (:title card) user) card)
+                                  c (make-card card)]
                               (if-let [init (:init (card-def c))] (merge c init) c)))
                           (repeat (:qty %) (:card %)))
                     (shuffle (vec (:cards deck)))))))

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -33,7 +33,10 @@
       (and (keyword? value) (string? cv)) (= value (keyword (.toLowerCase cv)))
       :else (= value cv))))
 
-(defn zone [zone coll]
+(defn zone
+  "Associate the specified zone to each item in the collection.
+  Zone can be a singleton or a sequential collection"
+  [zone coll]
   (let [dest (if (sequential? zone) (vec zone) [zone])]
     (map #(assoc % :zone dest) coll)))
 

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -20,6 +20,18 @@
       (is (and nat sf abr) "3 directives installed")
       (is (= 3 (count (get-in @state [:runner :rig :resource]))) "Only the directives were installed"))))
 
+(deftest adam-no-directives
+  ;; Test generate directives from @all-cards
+  (do-game
+    (new-game
+      (default-corp)
+      (make-deck "Adam: Compulsive Hacker" [(qty "Bank Job" 3)]))
+    (let [nat (find-card "Neutralize All Threats" (get-in @state [:runner :rig :resource]))
+          sf (find-card "Safety First" (get-in @state [:runner :rig :resource]))
+          abr (find-card "Always Be Running" (get-in @state [:runner :rig :resource]))]
+      (is (and nat sf abr) "3 directives installed")
+      (is (= 3 (count (get-in @state [:runner :rig :resource]))) "Only the directives were installed"))))
+
 (deftest adam-palana
   "Adam - Directives should not grant Pālanā credits."
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -5,21 +5,6 @@
             [test.macros :refer :all]
             [clojure.test :refer :all]))
 
-
-
-(deftest adam-directives
-  "Adam: Compulsive Hacker - install 3 directives"
-  (do-game
-    (new-game
-      (default-corp)
-      (make-deck "Adam: Compulsive Hacker" [(qty "Neutralize All Threats" 3) (qty "Safety First" 3)
-                                                   (qty "Always Be Running" 3) (qty "Bank Job" 3)]))
-    (let [nat (find-card "Neutralize All Threats" (get-in @state [:runner :rig :resource]))
-          sf (find-card "Safety First" (get-in @state [:runner :rig :resource]))
-          abr (find-card "Always Be Running" (get-in @state [:runner :rig :resource]))]
-      (is (and nat sf abr) "3 directives installed")
-      (is (= 3 (count (get-in @state [:runner :rig :resource]))) "Only the directives were installed"))))
-
 (deftest adam-no-directives
   ;; Test generate directives from @all-cards
   (do-game

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -236,9 +236,7 @@
 (defn min-deck-size
   "Contains implementation-specific decksize adjustments, if they need to be different from printed ones."
   [identity]
-  (cond
-    (= "09037" (:code identity)) 48 ;; Adam needs to have his 3 directives in deck
-    :else (:minimumdecksize identity)))
+  (:minimumdecksize identity))
 
 (defn min-agenda-points [deck]
   (let [size (max (card-count (:cards deck)) (min-deck-size (:identity deck)))]
@@ -253,14 +251,6 @@
   [{:keys [qty card] :as line}]
   (<= qty (or (:limited card) 3)))
 
-(defn adam-valid?
-  "Checks for Adam decks specific to current implementation of his identity."
-  [{:keys [identity cards] :as deck}]
-  (or (not= "09037" (:code identity))
-      (and (<= 1 (card-count (filter #(= "09041" (:code (:card %))) cards))) ;; Always Be Running
-           (<= 1 (card-count (filter #(= "09043" (:code (:card %))) cards))) ;; Neutralize All Threats
-           (<= 1 (card-count (filter #(= "09044" (:code (:card %))) cards)))))) ;; Safety First
-
 (defn valid? [{:keys [identity cards] :as deck}]
   (and (>= (card-count cards) (min-deck-size identity))
        (<= (influence-count deck) (id-inf-limit identity))
@@ -268,8 +258,7 @@
                      (legal-num-copies? %)) cards)
        (or (= (:side identity) "Runner")
            (let [min (min-agenda-points deck)]
-             (<= min (agenda-points deck) (inc min))))
-       (adam-valid? deck)))
+             (<= min (agenda-points deck) (inc min))))))
 
 (defn released?
   "Returns false if the card comes from a spoiled set or is out of competitive rotation."
@@ -601,9 +590,7 @@
                        min-count (min-deck-size identity)]
                    [:div count " cards"
                     (when (< count min-count)
-                      [:span.invalid (str " (minimum " min-count ")")])
-                    (when-not (adam-valid? deck)
-                      [:span.invalid " (not enough directives)"])])
+                      [:span.invalid (str " (minimum " min-count ")")])])
                  (let [inf (influence-count deck)
                        limit (deck-inf-limit deck)
                        id-limit (id-inf-limit identity)

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -164,9 +164,9 @@
                        "identity card to trigger the ability."]}
             {:id "adam"
              :title "How do I install Adam's directives?"
-             :content [:p "Adam's directives are installed automatically at the game start. However, every Adam deck needs to "
-                       "put one copy of each directive in the deck in addition to your normal deck. Yes, that means that "
-                       "minimal Adam decksize on Jinteki.net is 48."]}
+             :content [:p "Adam's directives are installed automatically at the game start. The directives are pulled "
+                       "directly from the game-server so do not need to be a part of your deck. The previous workaround "
+                       "of explicitly adding the 3 directives to the deck is no longer necessary."]}
             {:id "napdmwl"
              :title "What is MWL and \"Tournament legal\"? Why is my deck marked as \"Casual play only\"?"
              :content (list


### PR DESCRIPTION
Rewrites the Adam implementation to let the directives be fetched from `@all-cards` if no directives are specified in the deck.

~~The old way of adding 3 directives to the deck still works.~~

Removes the Adam specific stuff in the deckbuilder since this is no longer relevant. Updates the help page.

Adds a test for Adam with no directives.

Fixes #1239 