### PR TITLE
Fixes: Shi.Kyu in R&D, remove halo from stolen agendas

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -938,11 +938,11 @@
    "Shi.Kyū"
    {:access
     {:delayed-completion true
+     :req (req (not= (first (:zone card)) :deck))
      :effect (effect (show-wait-prompt :runner "Corp to use Shi.Kyū")
                      (continue-ability
                        {:optional
-                        {:req (req (not= (first (:zone card)) :deck))
-                         :prompt "Pay [Credits] to use Shi.Kyū?"
+                        {:prompt "Pay [Credits] to use Shi.Kyū?"
                          :yes-ability {:prompt "How many [Credits] for Shi.Kyū?" :choices :credit
                                        :msg (msg "attempt to do " target " net damage")
                                        :delayed-completion true

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -37,7 +37,7 @@
   "Moves a card to the runner's :scored area, triggering events from the completion of the steal."
   ([state side card] (steal state side (make-eid state) card))
   ([state side eid card]
-   (let [c (move state :runner (dissoc card :advance-counter) :scored)
+   (let [c (move state :runner (dissoc card :advance-counter :new) :scored)
          points (get-agenda-points state :runner c)]
      (when-completed
        (trigger-event-simult state :runner :agenda-stolen


### PR DESCRIPTION
* Fix #1937: The `:req` is at the wrong spot, leaving the Runner blocked by a wait prompt even when hitting the card in R&D
* Fix #1935: Dissoc `:new` from agendas when they are stolen so an orange halo around it won't persist. 