### PR TITLE
Fix Chronos Project + Blacklist, Paperclip, Chrysalis

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,9 @@ test:
   override:
     - lein compile game.main
     - lein compile test.core
+    - lein compile test.cards.assets
+    - lein compile test.cards.events
+    - lein compile test.cards.resources
     - lein test test.core
     - lein test test.cards.agendas
     - lein test test.cards.assets

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -353,11 +353,22 @@
    "Chrysalis"
    {:abilities [(do-net-damage 2)]
     :access {:req (req (not= (first (:zone card)) :discard))
-             :msg "force the Runner to encounter Chrysalis"
-             :optional {:req (req (not= (first (:zone card)) :discard))
-                        :prompt "Use Chrysalis to do 2 net damage?"
-                        :yes-ability {:effect (effect (damage eid :net 2 {:card card}))
-                        :msg "do 2 net damage"}}}}
+             :effect (effect (show-wait-prompt :runner "Corp to decide to trigger Chrysalis")
+                             (resolve-ability
+                               {:optional
+                                {:req (req (not= (first (:zone card)) :discard))
+                                 :prompt "Force the Runner to encounter Chrysalis?"
+                                 :yes-ability {:effect (req (system-msg state :corp "forces the Runner to encounter Chrysalis")
+                                                            (clear-wait-prompt state :runner)
+                                                            (resolve-ability state :runner
+                                                              {:optional
+                                                               {:player :runner
+                                                                :prompt "Allow Chrysalis subroutine to fire?" :priority 1
+                                                                :yes-ability {:effect (req (play-ability state side {:card card :ability 0}))}}}
+                                                             card nil))}
+                                 :no-ability {:effect (req (system-msg state :corp "declines to force the Runner to encounter Chrysalis")
+                                                           (clear-wait-prompt state :runner))}}}
+                              card nil))}}
 
    "Chum"
    {:abilities [(do-net-damage 3)]}

--- a/src/clj/game/cards-icebreakers.clj
+++ b/src/clj/game/cards-icebreakers.clj
@@ -458,7 +458,7 @@
                  :msg (msg "increase strength by " target " and break " target " barrier subroutine"
                            (when (not= target 1) "s"))}]
     :events {:rez install
-             :pass-ice install
+             :approach-ice install
              :run install}})
 
 

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -126,11 +126,12 @@
 (defn move-zone
   "Moves all cards from one zone to another, as in Chronos Project."
   [state side server to]
-  (let [from-zone (cons side (if (sequential? server) server [server]))
-        to-zone (cons side (if (sequential? to) to [to]))]
-    (swap! state assoc-in to-zone (concat (get-in @state to-zone)
-                                          (zone to (get-in @state from-zone))))
-    (swap! state assoc-in from-zone [])))
+  (when-not (seq (get-in @state [side :locked server]))
+    (let [from-zone (cons side (if (sequential? server) server [server]))
+          to-zone (cons side (if (sequential? to) to [to]))]
+      (swap! state assoc-in to-zone (concat (get-in @state to-zone)
+                                            (zone to (get-in @state from-zone))))
+      (swap! state assoc-in from-zone []))))
 
 (defn add-prop
   "Adds the given value n to the existing value associated with the key in the card.

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -9,7 +9,7 @@
 (defn- dissoc-card
   "Dissoc relevant keys in card"
   [card keep-counter]
-  (let [c (dissoc card :current-strength :abilities :rezzed :special :added-virus-counter)
+  (let [c (dissoc card :current-strength :abilities :rezzed :special :new :added-virus-counter)
         c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter :extra-advance-counter))]
     (if (and (= (:side c) "Runner") (not= (last (:zone c)) :facedown))
       (dissoc c :installed :facedown :counter :rec-counter :pump :server-target) c)))

--- a/src/clj/game/core-runs.clj
+++ b/src/clj/game/core-runs.clj
@@ -463,15 +463,16 @@
   "Starts the access routines for the run's server."
   [state side eid server]
   (trigger-event state side :pre-access (first server))
-  (let [cards (access state side server)]
+  (let [cards (access state side server)
+        n (count cards)]
     ;; Cannot use `zero?` as it does not deal with `nil` nicely (throws exception)
     (when-not (or (= (get-in @state [:run :max-access]) 0)
                   (empty? cards))
       (if (= (first server) :rd)
-        (let [n (count cards)]
-          (system-msg state side (str "accesses " n " card" (when (> n 1) "s")))))
+        (system-msg state side (str "accesses " n " card" (when (> n 1) "s"))))
       (when-completed (resolve-ability state side (choose-access cards server) nil nil)
-                      (effect-completed state side eid nil))))
+                      (effect-completed state side eid nil))
+      (swap! state assoc-in [:run :cards-accessed] n)))
   (handle-end-run state side))
 
 (defn replace-access


### PR DESCRIPTION
* Fix #1940: Paperclip is listening for the wrong event
* Fix #1941: The `move-zone` function needs to check if the source zone is locked, so a rezzed Blacklist can prevent Chronos Project from removing cards from the Heap.
* Fix #1942: Adds compilation to a couple of the biggest files in the test framework to stave off out-of-memory errors for awhile longer. 
* Drop the orange "new" halo from cards that are trashed or returned to your hand by dragging.
* Add wait prompts to Chrysalis and Runner ability to decide if its subroutine should fire if they can't/won't break it.
