### PR TITLE
Deckbuilder improvements

### DIFF
--- a/data/fetch.coffee
+++ b/data/fetch.coffee
@@ -30,6 +30,13 @@ setFields = {
   "cycle_code" : (k, t) -> ["cycle", capitalize(t.replace(/-/g, " "))]
 }
 
+mwlFields = {
+  "name" : same
+  "code" : same
+  "active" : same
+  "cards" : same
+}
+
 mapFactions = {
   "haas-bioroid" : "Haas-Bioroid",
   "jinteki" : "Jinteki",
@@ -121,4 +128,15 @@ fetchCards = (callback) ->
           console.log("#{cards.length} cards fetched")
         callback(null, cards.length)
 
-async.series [fetchSets, fetchCards, () -> db.close()]
+fetchMWL = (callback) ->
+  request.get baseurl + "mwl", (error, response, body) ->
+    if !error and response.statusCode is 200
+      data = JSON.parse(body).data
+      mwl = selectFields(mwlFields, data)
+      db.collection("mwl").remove ->
+      db.collection("mwl").insert mwl, (err, result) ->
+        fs.writeFile "andb-mwl.json", JSON.stringify(mwl), ->
+          console.log("#{mwl.length} MWL lists fetched")
+        callback(null, mwl.length)
+
+async.series [fetchSets, fetchCards, fetchMWL, () -> db.close()]

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -8,7 +8,10 @@
 
 (def cards-channel (chan))
 
-(go (swap! app-state assoc :sets (:json (<! (GET "/data/sets")))))
+;; Load in sets and mwl lists
+(go (let [sets (:json (<! (GET "/data/sets")))
+          mwl (:json (<! (GET "/data/mwl")))]
+      (swap! app-state assoc :sets sets :mwl mwl)))
 
 (go (let [cards (sort-by :code (:json (<! (GET "/data/cards"))))]
       (swap! app-state assoc :cards cards)

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -379,6 +379,10 @@
   [num]
   (make-dots mwl-dot num))
 
+(defn alliance-dots
+  [num]
+  (make-dots alliance-dot num))
+
 (defn- dots-html
   "Make a hiccup-ready vector for the specified dot and cost-map (influence or mwl)"
   [dot cost-map]
@@ -640,6 +644,7 @@
                          (let [card (:card line)
                                infaction (noinfcost? identity card)
                                wanted (mostwanted? card)
+                               allied (is-alliance-free? cards line)
                                valid (and (allowed? card identity)
                                           (legal-num-copies? line))
                                released (released? sets card)]
@@ -652,11 +657,18 @@
                                     :on-mouse-leave #(put! zoom-channel false)} name]
                             (when (or wanted (not infaction))
                               (let [influence (* (:factioncost card) (:qty line))]
-                                (list " " [:span.influence
-                                 {:class (faction-label card)
-                                  :dangerouslySetInnerHTML
-                                  #js {:__html (str (if-not infaction (influence-dots influence))
-                                                    (if wanted (restricted-dots (:qty line))))}}])))])
+                                (list " "
+                                      [:span.influence
+                                       {:class (faction-label card)
+                                        :dangerouslySetInnerHTML
+                                        #js {:__html
+                                             (str
+                                               ;; normal influence
+                                               (when (and (not infaction) (not allied)) (influence-dots influence))
+                                               ;; satisfies alliance criterion
+                                               (when allied (alliance-dots influence))
+                                               ;; on mwl
+                                               (when wanted (restricted-dots (:qty line))))}}])))])
                          (:card line))])])]]))]
 
           [:div.deckedit

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -486,21 +486,6 @@
          [:div {:class (if rotation "legal" "invalid")}
           [:span.tick (if rotation "✔" "✘")] "Only released cards"]])])))
 
-(defn octgn-link [owner]
-  (let [deck (om/get-state owner :deck)
-        identity (not-alternate (:identity deck))
-        id "bc0f047c-01b1-427f-a439-d451eda"
-        xml (str
-             "<deck game=\"0f38e453-26df-4c04-9d67-6d43de939c77\"><section name=\"Identity\"><card qty=\"1\" id=\""
-             id (:code identity) "\">" (:title identity) "</card></section>"
-             "<section name=\"R&amp;D / Stack\">"
-             (join (for [c (:cards deck) :when (get-in c [:card :title])]
-                     (str "<card qty=\"" (:qty c) "\" id=\"" id (get-in c [:card :code]) "\">"
-                          (html-escape (get-in c [:card :title])) "</card>")))
-             "</section></deck>")
-        blob (js/Blob. (clj->js [xml]) #js {:type "application/download"})]
-    (.createObjectURL js/URL blob)))
-
 (defn match [identity query]
   (if (empty? query)
     []
@@ -686,10 +671,7 @@
                            [:button {:on-click #(end-delete owner)} "Cancel"]]
                   :else [:div.button-bar
                          [:button {:on-click #(edit-deck owner)} "Edit"]
-                         [:button {:on-click #(delete-deck owner)} "Delete"]
-                         [:a.button {:href (octgn-link owner)
-                                     :download (str (:name deck) ".o8d")}
-                          "OCTGN Export"]])
+                         [:button {:on-click #(delete-deck owner)} "Delete"]])
                 [:h3 (:name deck)]
                 [:div.header
                  [:img {:src (image-url identity)}]

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -260,7 +260,8 @@
       0
       (cond
         ;; The Professor: Keeper of Knowledge - discount influence cost of first copy of each program
-        (= (get-in deck [:identity :code]) "03029")
+        (and (= "03029" (get-in deck [:identity :code]))
+             (= "Program" (get-in line [:card :type])))
         (- base-cost (get-in line [:card :factioncost]))
         ;; Check if the card is Alliance and fulfills its requirement
         (alliance-is-free? (:cards deck) line)

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -30,13 +30,23 @@
   [identity]
   (if (is-draft-id? identity) INFINITY (:influencelimit identity)))
 
+(defn- check-mwl-map
+  "Check if card is in specified mwl map"
+  [mwl-map card]
+  (let [mwl-cards (:cards mwl-map)
+        code (keyword (:code card))]
+    (contains? mwl-cards code)))
+
 (defn mostwanted?
   "Returns true if card is on Most Wanted NAPD list."
-  [card]
-  (let [napdmwl #{"Cerberus \"Lady\" H1" "Clone Chip" "D4v1d" "Desperado" "Faust" "Parasite" "Prepaid VoicePAD"
-                  "Wyldside" "Yog.0"
-                  "Architect" "Breaking News" "Eli 1.0" "Mumba Temple" "NAPD Contract" "SanSan City Grid"}]
-    (napdmwl (:title card))))
+  ([card]
+   (let [mwl-list (:mwl @app-state)
+         active-mwl (first (filter :active mwl-list))]
+     (check-mwl-map active-mwl card)))
+  ([mwl-code card]
+   (let [mwl-list (:mwl @app-state)
+         mwl-map (first (filter #(= mwl-code (:code %)) mwl-list))]
+     (check-mwl-map mwl-map card))))
 
 (defn card-count [cards]
   (reduce #(+ %1 (:qty %2)) 0 cards))

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -135,7 +135,7 @@
       (aset input "value" "")
       (.focus input))))
 
-(defn deckselect-modal [{:keys [gameid games decks user]} owner opts]
+(defn deckselect-modal [{:keys [gameid games decks sets user]} owner opts]
   (om/component
    (sab/html
     [:div.modal.fade#deck-select
@@ -148,7 +148,7 @@
           (for [deck (sort-by :date > (filter #(= (get-in % [:identity :side]) side) decks))]
             [:div.deckline {:on-click #(send {:action "deck" :gameid (:gameid @app-state) :deck deck})}
              [:img {:src (image-url (:identity deck))}]
-             [:div.float-right (deck-status-span deck)]
+             [:div.float-right (deck-status-span sets deck)]
              [:h4 (:name deck)]
              [:div.float-right (-> (:date deck) js/Date. js/moment (.format "MMM Do YYYY"))]
              [:p (get-in deck [:identity :title])]])])]]])))
@@ -258,7 +258,7 @@
        (for [game roomgames]
         (om/build game-view (assoc game :current-game gameid :password-game password-game))))]))
 
-(defn game-lobby [{:keys [games gameid messages user password-gameid] :as cursor} owner]
+(defn game-lobby [{:keys [games gameid messages sets user password-gameid] :as cursor} owner]
   (reify
     om/IInitState
     (init-state [this]
@@ -359,13 +359,13 @@
                     [:div
                      (om/build player-view {:player player})
                      (when-let [deck (:deck player)]
-                       [:span {:class (deck-status-label deck)}
+                       [:span {:class (deck-status-label sets deck)}
                         [:span.label
                          (if (= (:user player) user)
                            (:name deck)
                            "Deck selected")]])
                      (when-let [deck (:deck player)]
-                       [:div.float-right (deck-status-span deck true)])
+                       [:div.float-right (deck-status-span sets deck true)])
                      (when (= (:user player) user)
                        [:span.fake-link.deck-load
                         {:data-target "#deck-select" :data-toggle "modal"} "Select deck"])])]

--- a/src/cljs/netrunner/main.cljs
+++ b/src/cljs/netrunner/main.cljs
@@ -8,7 +8,7 @@
 (def app-state
   (atom {:active-page "/"
          :user (js->clj js/user :keywordize-keys true)
-         :cards [] :sets []
+         :cards [] :sets [] :mwl []
          :decks [] :decks-loaded false
          :games [] :gameid nil :messages []}))
 


### PR DESCRIPTION
Refactors some stuff:
- Alliance helpers
- Dots construction for costs
- Influence mapping function
- Draft identity check
- Deck parsing from the database and text
- Checking for MWL penalty (see below for more details)

Significant Changes:
- Looks up the identity like any other card. Significant change is that now only save the `:title :side :code` keys of the identity back to the database. First change should fix any weird "unreleased cards" issues from the `:setname` of the id. Second change will reduce data stored in the database.
- Now loads in the MWL lists from NRDB. Uses the currently active MWL list to check for penalty influence.
- Removes the OCTGN Export button (and the functionality).

Ideally the id should just be the card code (and all the other cards as well), but in the current implementation cards are looked up by `:title` and the search is filtered by the `:side` of the identity so both those keys are also needed.

MWL changes: fetches MWL lists from NRDB, defaults to using currently active list to check for influence penalty but has functionality to specify the code of the list to use for checking. This could allow people to specify what penalty list they are building for (e.g. MWL 1.0, 1.1 or ANRPC GLC 1.0).

Adds empty dots for free Alliance influence -- fixes #1926 

Makes functions more pure by extracting `sets` variable up to the `deck-builder` function.

Improves Draft identity support. Draft identities are no longer restricted by maximum card counts and can freely add more cards.

Screenshots:
<img width="421" alt="screen shot 2016-09-07 at 20 53 58" src="https://cloud.githubusercontent.com/assets/13198563/18324612/b4c646a8-753d-11e6-93f0-9dbc9cb745fe.png">
<img width="426" alt="screen shot 2016-09-07 at 22 25 03" src="https://cloud.githubusercontent.com/assets/13198563/18327334/5b11b9e6-754a-11e6-8970-12e7b3a9c87e.png">
