### PR TITLE
Minor identity handling refactor

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -820,21 +820,16 @@
                (move state side (last (:discard runner)) :rfg)
                (disable-identity state side)
 
-               ;; Manually change the runner's link
-               (swap! state update-in [side :link]
-                 (fn [old-link]
-                   (let [old-id-link (-> @state :runner :identity :baselink)
-                         new-id-link (:baselink target)
-                         link-change (- new-id-link old-id-link)]
-                      (+ old-link link-change))))
+               ;; Manually reduce the runner's link by old link
+               (lose state :runner :link (get-in @state [:runner :identity :baselink]))
 
                ;; Move the selected ID to [:runner :identity] and set the zone
                (swap! state update-in [side :identity]
                   (fn [x] (assoc (server-card (:title target) (get-in @state [:runner :user]))
                             :zone [:identity])))
 
-               ;; enable-identity does not do everything that card-init does
-               (card-init state side (get-in @state [:runner :identity]))
+               ;; enable-identity does not do everything that identity-init does
+               (identity-init state side (get-in @state [:runner :identity]))
                (system-msg state side "NOTE: passive abilities (Kate, Gabe, etc) will incorrectly fire
                 if their once per turn condition was met this turn before Rebirth was played.
                 Please adjust your game state manually for the rest of this turn if necessary"))}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -28,8 +28,7 @@
 
    "Andromeda: Dispossessed Ristie"
    {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1)
-                                              (draw 4 {:suppress-event true}))}}
+                              :effect (effect (draw 4 {:suppress-event true}))}}
     :mulligan (effect (draw 4 {:suppress-event true}))}
 
    "Apex: Invasive Predator"
@@ -56,9 +55,7 @@
                                  (system-msg state side "suffers 2 meat damage"))))}}}
 
    "Armand \"Geist\" Walker: Tech Lord"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}
-             :runner-trash {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
+   {:events {:runner-trash {:req (req (and (= side :runner) (= (second targets) :ability-cost)))
                             :msg "draw a card"
                             :effect (effect (draw 1))}}}
 
@@ -146,9 +143,7 @@
                         (gain :runner :hand-size-modification 1))}
 
    "Edward Kim: Humanitys Hammer"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}
-             :access {:once :per-turn
+   {:events {:access {:once :per-turn
                       :req (req (and (is-type? target "Operation")
                                      (turn-flag? state side card :can-trash-operation)))
                       :effect (effect (trash target))
@@ -162,9 +157,7 @@
    {:recurring 1}
 
    "Exile: Streethawk"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}
-             :runner-install {:req (req (and (is-type? target "Program")
+   {:events {:runner-install {:req (req (and (is-type? target "Program")
                                              (some #{:discard} (:previous-zone target))))
                               :msg (msg "draw a card")
                               :effect (effect (draw 1))}}}
@@ -267,9 +260,7 @@
                   :msg "gain 2 [Credits]"
                   :effect (effect (gain :credit 2))}]
      {:flags {:drip-economy true}
-      :events {:pre-start-game {:req (req (= side :runner))
-                                :effect (effect (gain :link 1))}
-               :runner-turn-begins ability}
+      :events {:runner-turn-begins ability}
       :abilities [ability]})
 
    "Industrial Genomics: Growing Solutions"
@@ -368,9 +359,7 @@
                                 (update! state side (assoc (get-card state card) :biotech-used true))))}]}
 
    "Kate \"Mac\" McCaffrey: Digital Tinker"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}
-             :pre-install {:req (req (and (#{"Hardware" "Program"} (:type target))
+   {:events {:pre-install {:req (req (and (#{"Hardware" "Program"} (:type target))
                                           (not (get-in @state [:per-turn (:cid card)]))))
                            :effect (effect (install-cost-bonus [:credit -1]))}
              :runner-install {:req (req (and (#{"Hardware" "Program"} (:type target))
@@ -432,9 +421,7 @@
       :abilities [ability]})
 
    "Nasir Meidan: Cyber Explorer"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}
-             :rez {:req (req (and (:run @state)
+   {:events {:rez {:req (req (and (:run @state)
                                   ;; check that the rezzed item is the encountered ice
                                   (= (:cid target)
                                      (:cid (get-card state current-ice)))))
@@ -481,9 +468,7 @@
    {:events {:server-created {:msg "draw 1 card" :once :per-turn :effect (effect (draw 1))}}}
 
    "Nero Severn: Information Broker"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}}
-    :abilities [{:req (req (has-subtype? current-ice "Sentry"))
+   {:abilities [{:req (req (has-subtype? current-ice "Sentry"))
                  :once :per-turn
                  :msg "jack out when encountering a sentry"
                  :effect (effect (jack-out nil))}]}
@@ -554,9 +539,7 @@
    {:abilities [{:once :per-turn :msg "break 1 barrier subroutine"}]}
 
    "Reina Roja: Freedom Fighter"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 1))}
-             :pre-rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
+   {:events {:pre-rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
                        :effect (effect (rez-cost-bonus 1))}
              :rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
                    :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}}
@@ -613,9 +596,9 @@
               :effect (effect (move :corp target :deck)
                               (shuffle! :corp :deck))}}}
 
+   ;; No special implementation
    "Sunny Lebeau: Security Specialist"
-   {:events {:pre-start-game {:req (req (= side :runner))
-                              :effect (effect (gain :link 2))}}}
+   {}
 
    "SYNC: Everything, Everywhere"
    {:effect (req (when (> (:turn @state) 1)

--- a/src/clj/game/core-turns.clj
+++ b/src/clj/game/core-turns.clj
@@ -4,6 +4,13 @@
          turn-message)
 
 ;;; Functions for the creation of games and the progression of turns.
+(defn- identity-init
+  "Initialise the identity"
+  [state side identity]
+  (card-init state side identity)
+  (when-let [baselink (:baselink identity)]
+    (gain state side :link baselink)))
+
 (defn init-game
   "Initializes a new game with the given players vector."
   [{:keys [players gameid spectatorhands] :as game}]
@@ -36,8 +43,8 @@
                           :agenda-point 0
                           :hq-access 1 :rd-access 1 :tagged 0
                           :brain-damage 0 :click-per-turn 4 :agenda-point-req 7 :keep false}})]
-    (card-init state :corp corp-identity)
-    (card-init state :runner runner-identity)
+    (identity-init state :corp corp-identity)
+    (identity-init state :runner runner-identity)
     (swap! game-states assoc gameid state)
     (trigger-event state :corp :pre-start-game)
     (trigger-event state :runner :pre-start-game)

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -872,7 +872,33 @@
 
       (is (changes-credits (get-corp) -1
         (core/rez state :corp (get-ice state :rd 0)))
-        "Reina is no longer active"))))
+        "Reina is no longer active")))
+
+  (deftest rebirth-lose-link
+    "Rebirth - Lose link from ID"
+    (do-game
+      (new-game (default-corp)
+                (make-deck kate ["Rebirth" "Access to Globalsec"])
+                {:start-as :runner})
+      (play-from-hand state :runner "Access to Globalsec")
+      (is (= 2 (:link (get-runner))) "2 link before rebirth")
+
+      (play-from-hand state :runner "Rebirth")
+      (choose-runner chaos state prompt-map)
+      (is (= 1 (:link (get-runner))) "1 link after rebirth")))
+
+  (deftest rebirth-gain-link
+    "Rebirth - Gain link from ID"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Rebirth" "Access to Globalsec"])
+                {:start-as :runner})
+      (play-from-hand state :runner "Access to Globalsec")
+      (is (= 1 (:link (get-runner))) "1 link before rebirth")
+
+      (play-from-hand state :runner "Rebirth")
+      (choose-runner kate state prompt-map)
+      (is (= 2 (:link (get-runner))) "2 link after rebirth"))))
 
 (deftest rigged-results
   "Rigged Results - success and failure"


### PR DESCRIPTION
Creates new function `identity-init` that initialises the runner starting link. Removes link gaining from identity carddefs. Updates Rebirth to use new function.

Adds two tests to ensure link is gained/lost properly.

Fixes #1948 