### PR TITLE
Fix several successful-run issues

### DIFF
--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -1393,6 +1393,20 @@
     (is (= :corp (:winner @state)) "Corp wins")
     (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
 
+(deftest temujin-contract
+  "Temüjin Contract - Multiple times in one turn. Issue #1952."
+  (do-game
+    (new-game (default-corp)
+              (make-deck "Silhouette: Stealth Operative" [(qty "Temüjin Contract" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Temüjin Contract")
+    (prompt-choice :runner "Archives")
+    (run-empty-server state "Archives")
+    (is (= 5 (:credit (get-runner))) "Gained 4cr")
+    (run-empty-server state "Archives")
+    (is (= 9 (:credit (get-runner))) "Gained 4cr")
+    (is (= 12 (get-counters (get-resource state 0) :credit)) "Temjin has 12 credits remaining")))
+
 (deftest tri-maf-contact
   "Tri-maf Contact - Click for 2c once per turn; take 3 meat dmg when trashed"
   (do-game
@@ -1409,6 +1423,7 @@
       (take-credits state :runner)
       (core/trash state :runner tmc)
       (is (= 4 (count (:discard (get-runner)))) "Took 3 meat damage"))))
+
 
 (deftest virus-breeding-ground-gain
   "Virus Breeding Ground - Gain counters"

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -185,6 +185,22 @@
       (is (= 0 (:current-strength (refresh q1)))
           "Inner Quandary back to default 0 strength after turn ends"))))
 
+(deftest crisium-grid
+  "Crisium Grid - various interactions"
+  (do-game
+    (new-game (default-corp [(qty "Crisium Grid" 2)])
+              (default-runner [(qty "Desperado" 1) (qty "Temüjin Contract" 1)]))
+    (play-from-hand state :corp "Crisium Grid" "HQ")
+    (core/rez state :corp (get-content state :hq 0))
+    (take-credits state :corp)
+    (is (= 4 (:credit (get-corp))) "Corp has 4 credits")
+    (core/gain state :runner :credit 4)
+    (play-from-hand state :runner "Desperado")
+    (play-from-hand state :runner "Temüjin Contract")
+    (prompt-choice :runner "HQ")
+    (run-empty-server state "HQ")
+    (is (= 2 (:credit (get-runner))) "No Desperado or Temujin credits")))
+
 (deftest cyberdex-virus-suite-purge
   "Cyberdex Virus Suite - Purge ability"
   (do-game


### PR DESCRIPTION
Fix #1949, fix #1951, fix #1952.

Cleans up `trigger-event-simult`. Ignores handlers that are suppressed (Crisium Grid) or whose `:req` is false. (Not sure why I didn't do this before. Maybe it'll come to me in a dream.)