### PR TITLE
prevent Archangel from targeting Corp cards

### DIFF
--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -193,7 +193,8 @@
                                                      card nil))}
                          :no-ability {:effect (req (system-msg state :corp "declines to force the Runner to encounter Archangel")
                                                    (clear-wait-prompt state :runner))}}} card nil))}
-    :abilities [(trace-ability 6 {:choices {:req installed?}
+    :abilities [(trace-ability 6 {:choices {:req #(and (installed? %)
+                                                       (card-is? % :side :runner))}
                                   :label "Add 1 installed card to the Runner's Grip"
                                   :msg "add 1 installed card to the Runner's Grip"
                                   :effect (effect (move :runner target :hand true)

--- a/src/clj/game/cards-upgrades.clj
+++ b/src/clj/game/cards-upgrades.clj
@@ -270,8 +270,9 @@
                               (toast state :runner (str "You must trash Mumbad Virtual Tour by paying its "
                                                         "trash cost or using an Imp counter, if able")))
                             (if (and (can-pay? state :runner nil :credit trash-cost)
-                                     (empty? (filter #(and (= "Imp" (:title %))
-                                                           (pos? (get-in % [:counter :virus] 0)))
+                                     (empty? (filter #(or (and (= "Imp" (:title %))
+                                                               (pos? (get-in % [:counter :virus] 0)))
+                                                          (= "Salsette Slums" (:title %)))
                                                      (all-installed state :runner))))
                               (swap! state assoc-in [:runner :register :force-trash] true)
                               (toast state :runner (str "You must use any credit sources (Whizzard, Scrubber, "


### PR DESCRIPTION
Discovered in a report on Stimhack Slack. Also added a gross hack to stop Mumbad Virtual Tour's forced auto trash if Salsette Slums is installed. 