### PR TITLE
Patent-pending grab bag of card fixes

### DIFF
--- a/src/clj/game/cards-agendas.clj
+++ b/src/clj/game/cards-agendas.clj
@@ -73,6 +73,7 @@
 
    "Award Bait"
    {:access {:delayed-completion true
+             :req (req (not-empty (filter #(can-be-advanced? %) (all-installed state :corp))))
              :effect (effect (show-wait-prompt :runner "Corp to place advancement tokens with Award Bait")
                              (continue-ability
                                {:delayed-completion true

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -1096,7 +1096,12 @@
    {:events {:server-created {:msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}}}
 
    "Victoria Jenkins"
-   {:effect (effect (lose :runner :click-per-turn 1)) :leave-play (effect (gain :runner :click-per-turn 1))
+   {:effect (req (lose state :runner :click-per-turn 1)
+                 (when (= (:active-player @state) :runner)
+                   (lose state :runner :click 1)))
+    :leave-play (req (gain state :runner :click-per-turn 1)
+                     (when (= (:active-player @state) :runner)
+                       (gain state :runner :click 1)))
     :trash-effect {:when-unrezzed true
                    :req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}}
 

--- a/src/clj/game/cards-hardware.clj
+++ b/src/clj/game/cards-hardware.clj
@@ -490,8 +490,8 @@
                                    :req (req (let [successes (rest (turn-events state side :successful-run))]
                                                (and (#{[:rd] [:hq]} (:server target))
                                                     (empty? (filter #(#{'(:rd) '(:hq)} %) successes)))))
-                                   :msg (msg "draw " (:cards-accessed target) " cards")
-                                   :effect (effect (draw (:cards-accessed target)))}}}
+                                   :msg (msg "draw " (:cards-accessed target 0) " cards")
+                                   :effect (effect (draw (:cards-accessed target 0)))}}}
 
    "Omni-drive"
    {:recurring 1

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -149,6 +149,7 @@
                       :effect (effect (trash target))
                       :msg (msg "trash " (:title target))}
              :successful-run-ends {:req (req (and (= (:server target) [:archives])
+                                                  (nil? (:replace-access (:run-effect target)))
                                                   (not= (:max-access target) 0)
                                                   (seq (filter #(is-type? % "Operation") (:discard corp)))))
                                    :effect (effect (register-turn-flag! card :can-trash-operation (constantly false)))}}}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -566,8 +566,7 @@
 
    "Silhouette: Stealth Operative"
    {:events {:successful-run
-             {:interactive (req (and (some #(not (rezzed? %)) (all-installed state :corp))
-                                     (= target :hq)))
+             {:interactive (req (some #(not (rezzed? %)) (all-installed state :corp)))
               :delayed-completion true
               :req (req (= target :hq)) :once :per-turn
               :effect (effect (continue-ability {:choices {:req #(and installed? (not (rezzed? %)))}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -566,7 +566,8 @@
 
    "Silhouette: Stealth Operative"
    {:events {:successful-run
-             {:interactive (req (some #(not (rezzed? %)) (all-installed state :corp)))
+             {:interactive (req (and (some #(not (rezzed? %)) (all-installed state :corp))
+                                     (= target :hq)))
               :delayed-completion true
               :req (req (= target :hq)) :once :per-turn
               :effect (effect (continue-ability {:choices {:req #(and installed? (not (rezzed? %)))}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -440,7 +440,8 @@
    "NBN: Controlling the Message"
    {:events {:runner-trash
              {:delayed-completion true
-              :req (req (and (first-event state side :runner-trash)
+              :req (req (and (let [trashes (flatten (turn-events state side :runner-trash))]
+                               (empty? (filter #(card-is? % :side :corp) trashes)))
                              (card-is? target :side :corp)
                              (installed? target)))
               :effect (req (show-wait-prompt state :runner "Corp to use NBN: Controlling the Message")


### PR DESCRIPTION
* Fix #1962: For NBN: Controlling the Message, scan all the instances of `:runner-trash` for the turn and make sure none are Corp cards. 
* Fix #1947: Solves Edward Kim + Retrieval Run by only switching off his ability for the turn if no access replacement was used on the Archives run.
* Fixes Award Bait issue where the stolen agenda is never placed in the Runner's score area if the Corp has no advanceable cards in play.
* Fixes Obelus interaction with access replacement run events (where `:cards-accessed` would be nil). 
* Runner needs to lose/gain 1 click if Victoria Jenkins is rezzed or trashed during the Runner's turn