### PR TITLE
Space camp fix

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -989,14 +989,15 @@
 
    "Space Camp"
    {:access {:delayed-completion true
-             :effect (effect (show-wait-prompt :runner "Corp to place an advancement with Space Camp")
+             :effect (effect (show-wait-prompt :runner "Corp to use Space Camp")
                              (continue-ability
-                               {:msg (msg "place 1 advancement token on " (card-str state target))
-                                :choices {:req can-be-advanced?}
-                                :cancel-effect (effect (clear-wait-prompt :runner))
-                                :effect (effect (add-prop target :advance-counter 1 {:placed true})
-                                                (clear-wait-prompt :runner))}
-                              card nil))}}
+                               {:optional
+                                {:prompt "Place 1 advancement token?"
+                                 :end-effect (effect (clear-wait-prompt :runner))
+                                 :yes-ability {:msg (msg "place 1 advancement token on " (card-str state target))
+                                               :choices {:req can-be-advanced?}
+                                               :effect (effect (add-prop target :advance-counter 1 {:placed true}))}}}
+                               card nil))}}
 
    "Sundew"
    {:events {:runner-spent-click {:once :per-turn

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -986,6 +986,7 @@
     (prompt-choice :runner "News Team")
     (prompt-choice :runner "Take 2 tags")
     (prompt-choice :runner "Space Camp")
+    (prompt-choice :corp "Yes")
     (prompt-select :corp (get-content state :remote1 0))
     (is (= 1 (:advance-counter (get-content state :remote1 0))) "Agenda advanced once from Space Camp")
     (is (= 2 (:tag (get-runner))) "Runner has 2 tags")


### PR DESCRIPTION
Small PR but noticed that space camp is (still) not 100% since cancelling the effect kicks you out of an archives run before accessing anything else prematurely. This should be good now.