### PR TITLE
Fix for Manhunt and other successful-run cards

### DIFF
--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -153,7 +153,7 @@
    (let [get-side #(-> % :card :side game.utils/to-keyword)
          get-ability-side #(-> % :ability :side)
          active-player (:active-player @state)
-         opponent (other-side (:active-player @state))
+         opponent (other-side active-player)
          is-player (fn [player ability] (or (= player (get-side ability)) (= player (get-ability-side ability))))
 
          ;; prepare the list of the given player's handlers for this event.
@@ -167,7 +167,7 @@
                                      (cons card-ability abis)
                                      abis)]
                           (filter #(and (not (apply trigger-suppress state side event (cons (:card %) targets)))
-                                        (check-req state side (get-card state (:card %))targets %))
+                                        (check-req state side (get-card state (:card %)) targets (:ability %)))
                                   abis)))
          active-player-events (get-handlers active-player)
          opponent-events (get-handlers opponent)]

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -501,6 +501,25 @@
       "Breaking News installed by Lateral Growth")
     (is (= 7 (:credit (get-corp))))))
 
+(deftest manhunt-every-run
+  "Manhunt - only fires once per turn. Unreported issue."
+  (do-game
+    (new-game (default-corp [(qty "Manhunt" 1) (qty "Hedge Fund" 3)])
+              (default-runner))
+    (play-from-hand state :corp "Manhunt")
+    (take-credits state :corp)
+    (run-empty-server state "HQ")
+    (is (:prompt (get-corp)) "Manhunt trace initiated")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 1 (:tag (get-runner))) "Runner took 1 tag")
+    (prompt-choice :runner "OK")
+    (is (not (:run @state)) "Run ended")
+    (run-empty-server state "HQ")
+    (is (empty? (:prompt (get-corp))) "No Manhunt trace on second run")
+    (prompt-choice :runner "OK")
+    (is (not (:run @state)) "Run ended")))
+
 (deftest midseason-replacements
   "Midseason Replacements - Trace to give Runner tags after they steal an agenda"
   (do-game


### PR DESCRIPTION
I thought I fixed this in #1953, but did not write a test to verify the correctness. Bad Neal.