### PR TITLE
Damage statement fix + Argus message improvement

### DIFF
--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -48,11 +48,11 @@
               :choices ["1 tag" "2 meat damage"] :player :runner
               :msg "make the Runner take 1 tag or suffer 2 meat damage"
               :effect (req (if (= target "1 tag")
-                             (do (tag-runner state :runner 1)
-                                 (system-msg state side "takes 1 tag")
+                             (do (system-msg state side "chooses to take 1 tag")
+                                 (tag-runner state :runner 1)
                                  (effect-completed state side eid nil))
-                             (do (damage state :runner eid :meat 2 {:unboostable true :card card})
-                                 (system-msg state side "suffers 2 meat damage"))))}}}
+                             (do (system-msg state side "chooses to suffer 2 meat damage")
+                                 (damage state :runner eid :meat 2 {:unboostable true :card card}))))}}}
 
    "Armand \"Geist\" Walker: Tech Lord"
    {:events {:runner-trash {:req (req (and (= side :runner) (= (second targets) :ability-cost)))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -160,20 +160,21 @@
   (when-completed (trigger-event-sync state side :pre-resolve-damage type card n)
                   (do (if-not (or (get-in @state [:damage :damage-replace]))
                         (let [n (if-let [defer (get-defer-damage state side type args)] defer n)]
-                          (let [hand (get-in @state [:runner :hand])
-                                cards-trashed (take n (shuffle hand))
-                                trashed-msg (join ", " (map :title cards-trashed))]
-                            (when (= type :brain)
-                              (swap! state update-in [:runner :brain-damage] #(+ % n))
-                              (swap! state update-in [:runner :hand-size-modification] #(- % n)))
-                            (system-msg state :runner (str "trashes " trashed-msg " due to damage"))
-                            (if (< (count hand) n)
-                              (do (flatline state)
-                                  (trash-cards state side (make-eid state) cards-trashed
-                                               {:unpreventable true}))
-                              (do (trash-cards state side (make-eid state) cards-trashed
-                                               {:unpreventable true :cause type})
-                                  (trigger-event state side :damage type card))))))
+                          (when (pos? n)
+                            (let [hand (get-in @state [:runner :hand])
+                                  cards-trashed (take n (shuffle hand))
+                                  trashed-msg (join ", " (map :title cards-trashed))]
+                              (when (= type :brain)
+                                (swap! state update-in [:runner :brain-damage] #(+ % n))
+                                (swap! state update-in [:runner :hand-size-modification] #(- % n)))
+                              (system-msg state :runner (str "trashes " trashed-msg " due to damage"))
+                              (if (< (count hand) n)
+                                (do (flatline state)
+                                    (trash-cards state side (make-eid state) cards-trashed
+                                                 {:unpreventable true}))
+                                (do (trash-cards state side (make-eid state) cards-trashed
+                                                 {:unpreventable true :cause type})
+                                    (trigger-event state side :damage type card)))))))
                       (swap! state update-in [:damage :defer-damage] dissoc type)
                       (effect-completed state side eid card))))
 


### PR DESCRIPTION
Only perform card trash / hand size modification / flatline check / "trashes ... due to damage" if the damage count is positive.

Elaborates system message when runner chooses an option from Argus -- adds "chooses to". Also moves this message to be printed directly below the argus message, before any messages due to damage or tag taking.

Fixes #1969.

Screenshots:
<img width="211" alt="screen shot 2016-09-18 at 20 49 13" src="https://cloud.githubusercontent.com/assets/13198563/18618221/80d5fe58-7de2-11e6-8198-de92fd2a6566.png">
<img width="211" alt="screen shot 2016-09-18 at 20 50 52" src="https://cloud.githubusercontent.com/assets/13198563/18618222/812d18d2-7de2-11e6-9ba0-106807ec3d36.png">
(Yes, the empty "trashes due to damage" statement is no longer printed if all damage is prevented, it is not just cropped away :wink:)