### PR TITLE
Give Chum ability to give +2 strength to ICE

### DIFF
--- a/src/clj/game/cards-events.clj
+++ b/src/clj/game/cards-events.clj
@@ -848,7 +848,7 @@
 
    "Rigged Results"
    (letfn [(choose-ice []
-             {:prompt "Choose a piece of ice to bypass"
+             {:prompt "Choose a piece of ICE to bypass"
               :choices {:req #(ice? %)}
               :effect (final-effect (system-msg :runner (str "chooses to bypass " (card-str state target)))
                                     (run (second (:zone target))))})
@@ -857,7 +857,7 @@
               :choices ["0" "1" "2"]
               :delayed-completion true
               :effect (req (system-msg state :runner (str "spends " spent "[Credit]. "
-                                       (-> corp :user :username) " guesses " target "[Credit]."))
+                                       (-> corp :user :username) " guesses " target "[Credit]"))
                            (clear-wait-prompt state :runner)
                            (if (not= (str spent) target)
                              (continue-ability state :runner (choose-ice) card nil)

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -372,7 +372,20 @@
                               card nil))}}
 
    "Chum"
-   {:abilities [(do-net-damage 3)]}
+   {:abilities [{:label "Give +2 strength to next ICE Runner encounters"
+                 :req (req this-server)
+                 :prompt "Choose the ICE the Runner is encountering"
+                 :choices {:req #(and (rezzed? %) (ice? %))}
+                 :msg (msg "give " (:title target) " +2 strength")
+                 :effect (req (let [ice (:cid target)]
+                                (register-events state side
+                                  {:pre-ice-strength {:req (req (= (:cid target) ice))
+                                                      :effect (effect (ice-strength-bonus 2 target))}
+                                   :run-ends {:effect (effect (unregister-events card))}}
+                                 card)
+                                (update-all-ice state side)))}
+                (do-net-damage 3)]
+    :events {:pre-ice-strength nil :run-ends nil}}
 
    "Cobra"
    {:abilities [trash-program (do-net-damage 2)]}

--- a/src/clj/game/cards-identities.clj
+++ b/src/clj/game/cards-identities.clj
@@ -394,12 +394,12 @@
    {:events {:pass-ice
              {:once :per-turn
               :effect (req (when (some (fn [c] (has? c :subtype "Icebreaker")) (:hand runner))
-                             (install-cost-bonus state side [:credit -1])
                              (resolve-ability state side
                                               {:prompt "Choose an icebreaker to install from your Grip"
                                                :choices {:req #(and (in-hand? %) (has-subtype? % "Icebreaker"))}
                                                :msg (msg "install " (:title target))
-                                               :effect (effect (runner-install target))}
+                                               :effect (effect (install-cost-bonus [:credit -1])
+                                                               (runner-install target))}
                                               card nil)))}}}
 
    "Laramy Fisk: Savvy Investor"

--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -374,6 +374,7 @@
    "Hatchet Job"
    {:trace {:base 5
             :choices {:req #(and (installed? %)
+                                 (card-is? % :side :runner)
                                  (not (has-subtype? % "Virtual")))}
             :msg "add an installed non-virtual card to the Runner's grip"
             :effect (effect (move :runner target :hand true))}}


### PR DESCRIPTION
Minor usability improvement for Chum. The targeted ICE must be rezzed, so the Corp should hold off on using this ability until it's clear that the Runner isn't bypassing (e.g., Security Nexus or some other shenanigans). 

Also fixes the Rigged Results typo, Khan's misplaced install cost bonus, and stops Hatchet Job from targeting Corp cards. 