### PR TITLE
implement Net Mercur

### DIFF
--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -444,6 +444,7 @@
                  :msg "gain 1 [Credits]"
                  :req (req (:run @state))
                  :effect (req (gain state side :credit 1)
+                              (trigger-event state side :spent-stealth-credit card)
                               (when (zero? (get-in card [:counter :credit] 0))
                                 (trash state :runner card {:unpreventable true})))}]}
 
@@ -678,6 +679,30 @@
                       card nil))
     :abilities [{:msg "draw 1 card"
                  :effect (effect (trash card {:cause :ability-cost}) (draw))}]}
+
+   "Net Mercur"
+   {:abilities [{:counter-cost [:credit 1]
+                 :msg "gain 1 [Credits]"
+                 :effect (effect (gain :credit 1)
+                                 (trigger-event :spent-stealth-credit card))}]
+    :events {:spent-stealth-credit
+             {:req (req (and (:run @state)
+                             (has-subtype? target "Stealth")))
+              :once :per-run
+              :delayed-completion true
+              :effect (effect (show-wait-prompt :corp "Runner to use Net Mercur")
+                              (continue-ability
+                                {:prompt "Place 1 [Credits] on Net Mercur or draw 1 card?"
+                                 :player :runner
+                                 :choices ["Place 1 [Credits]" "Draw 1 card"]
+                                 :effect (req (if (= target "Draw 1 card")
+                                                (do (draw state side)
+                                                    (clear-wait-prompt state :corp)
+                                                    (system-msg state :runner (str "uses Net Mercur to draw 1 card")))
+                                                (do (add-counter state :runner card :credit 1)
+                                                    (clear-wait-prompt state :corp)
+                                                    (system-msg state :runner (str "places 1 [Credits] on Net Mercur")))))}
+                               card nil))}}}
 
    "Neutralize All Threats"
    {:in-play [:hq-access 1]

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -177,7 +177,10 @@
         ab (if (= ability (count abilities))
              ;; recurring credit abilities are not in the :abilities map and are implicit
              {:msg "take 1 [Recurring Credits]" :req (req (> (:rec-counter card) 0))
-              :effect (effect (add-prop card :rec-counter -1) (gain :credit 1))}
+              :effect (req (add-prop state side card :rec-counter -1)
+                           (gain state side :credit 1)
+                           (when (has-subtype? card "Stealth")
+                             (trigger-event state side :spent-stealth-credit card)))}
              (get-in cdef [:abilities ability]))
         cost (:cost ab)]
     (when (and (not (:disabled card))

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -690,6 +690,34 @@
         (is (:rezzed (refresh toll)) "Tollbooth was rezzed")
         (is (= 0 (:credit (get-corp))) "Corp has 0 credits")))))
 
+(deftest net-mercur
+  "Net Mercur - Gains 1 credit or draw 1 card when a stealth credit is used"
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Net Mercur" 1) (qty "Silencer" 1) (qty "Ghost Runner" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :click 4 :credit 10)
+    (play-from-hand state :runner "Silencer")
+    (play-from-hand state :runner "Net Mercur")
+    (play-from-hand state :runner "Ghost Runner")
+    (let [sil (get-hardware state 0)
+          nm (get-resource state 0)
+          gr (get-resource state 1)]
+      (card-ability state :runner gr 0)
+      (is (empty? (:prompt (get-runner))) "No Net Mercur prompt from stealth spent outside of run")
+      (run-on state :hq)
+      (card-ability state :runner sil 0)
+      (prompt-choice :runner "Place 1 [Credits]")
+      (is (= 1 (get-counters (refresh nm) :credit)) "1 credit placed on Net Mercur")
+      (card-ability state :runner gr 0)
+      (is (empty? (:prompt (get-runner))) "No Net Mercur prompt for 2nd stealth in run")
+      (run-jack-out state)
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (run-on state :hq)
+      (card-ability state :runner nm 0)
+      (is (= "Net Mercur" (:title (:card (first (get-in @state [:runner :prompt]))))) "Net Mercur triggers itself"))))
+
 (deftest new-angeles-city-hall
   "New Angeles City Hall - Avoid tags; trash when agenda is stolen"
   (do-game


### PR DESCRIPTION
This card is bonkers. We simply check for the Stealth subtype on a card when recurring credits are taken and then trigger a new event. Ghost Runner and Net Mercur have to manually trigger this event themselves since they don't use recurring credits. 