### PR TITLE
implement Ark Lockdown

### DIFF
--- a/src/clj/game/cards-operations.clj
+++ b/src/clj/game/cards-operations.clj
@@ -103,6 +103,16 @@
                                             (system-msg (str "adds " (if (:seen target) (:title target) "an unseen card") " to HQ")))}
                     card nil)))}
 
+   "Ark Lockdown"
+   {:delayed-completion true
+    :req (req (not-empty (:discard runner)))
+    :prompt "Name a card to remove all copies in the Heap from the game"
+    :choices (req (cancellable (:discard runner) :sorted))
+    :msg (msg "remove all copies of " (:title target) " in the Heap from the game")
+    :effect (req (doseq [c (filter #(= (:title target) (:title %)) (:discard runner))]
+                   (move state side c :rfg))
+                 (effect-completed state side eid card))}
+
    "Back Channels"
    {:prompt "Choose an installed card in a server to trash"
     :choices {:req #(and (= (last (:zone %)) :content)


### PR DESCRIPTION
We briefly discussed how the auto-complete text entry boxes on Targeted Marketing and Salem's Hospitality are not the best fit here, since the Corp would never name a card which isn't present in the Heap (would they??). 