### PR TITLE
Fix #1981.

### DIFF
--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -280,22 +280,26 @@
     (when (and (can-score? state side card)
                (empty? (filter #(= (:cid card) (:cid %)) (get-in @state [:corp :register :cannot-score])))
                (>= (:advance-counter card 0) (or (:current-cost card) (:advancementcost card))))
+
       ;; do not card-init necessarily. if card-def has :effect, wrap a fake event
       (let [moved-card (move state :corp card :scored)
             c (card-init state :corp moved-card false)
             points (get-agenda-points state :corp c)]
-        (when-completed (trigger-event-simult state :corp :agenda-scored
-                                              {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
-                                                              (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
-                                                              (trash state side current)))}
-                                              (card-as-handler c) c)
-                        (let [c (get-card state c)
-                              points (or (get-agenda-points state :corp c) points)]
-                          (set-prop state :corp (get-card state moved-card) :advance-counter 0)
-                          (system-msg state :corp (str "scores " (:title c) " and gains " points
-                                                       " agenda point" (when (> points 1) "s")))
-                          (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
-                          (gain-agenda-point state :corp points)))))))
+        (trigger-event-simult
+          state :corp (make-eid state) :agenda-scored
+          {:first-ability {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
+                                          (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
+                                          (trash state side current)))}
+           :card-ability (card-as-handler c)
+           :after-active-player {:effect (req (let [c (get-card state c)
+                                                    points (or (get-agenda-points state :corp c) points)]
+                                                (set-prop state :corp (get-card state moved-card) :advance-counter 0)
+
+                                                (system-msg state :corp (str "scores " (:title c) " and gains " points
+                                                                             " agenda point" (when (> points 1) "s")))
+                                                (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
+                                                (gain-agenda-point state :corp points)))}}
+          c)))))
 
 (defn no-action
   "The corp indicates they have no more actions for the encounter."

--- a/src/clj/game/core-events.clj
+++ b/src/clj/game/core-events.clj
@@ -148,8 +148,9 @@
                  interaction with New Angeles Sol and Employee Strike
   card-ability:  a card's ability that triggers at the same time as the event trigger, but is coded as a card ability
                  and not an event handler. (For example, :stolen on agendas happens in the same window as :agenda-stolen
+  after-active-player: an ability to resolve after the active player's triggers resolve, before the opponent's get to act
   targets:       a varargs list of targets to the event, as usual"
-  ([state side eid event first-ability card-ability & targets]
+  ([state side eid event {:keys [first-ability card-ability after-active-player] :as options} & targets]
    (let [get-side #(-> % :card :side game.utils/to-keyword)
          get-ability-side #(-> % :ability :side)
          active-player (:active-player @state)
@@ -178,7 +179,9 @@
                              {:priority -1})
            (when-completed
              (trigger-event-simult-player state side event active-player-events targets)
-             (do (clear-wait-prompt state opponent)
+             (do (when after-active-player
+                   (resolve-ability state side after-active-player nil nil))
+                 (clear-wait-prompt state opponent)
                  (show-wait-prompt state active-player
                                    (str (side-str opponent) " to resolve " (event-title event) " triggers")
                                    {:priority -1})

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -273,7 +273,7 @@
                    (when (has-subtype? c "Icebreaker")
                      (update-breaker-strength state side c))
                    (trigger-event-simult state side eid :runner-install
-                                         nil nil
+                                         nil
                                          installed-card))
                  (effect-completed state side eid))
                (effect-completed state side eid)))


### PR DESCRIPTION
Grant points to the corp after they have finished their triggers, before the runner resolves theirs. This is not 1000% perfect but is needed because of the current implementation of Project Beale.