### PR TITLE
Provide a base colour for input fields

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -83,6 +83,7 @@ input, select, textarea
   height: 28px
   background-color: rgba(255, 255, 255, 0.9)
   border: 2px solid rgba(39, 56, 76, 0.8)
+  color: black
   transition(all 0.2s ease-in-out)
   outline: none
 


### PR DESCRIPTION
In Firefox, themes are able to set their own default colours. On a dark theme, this can result in unreadable text inputs.