### PR TITLE
Make Snitch confirm when the runner has decided not to jack out

### DIFF
--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -705,7 +705,7 @@
                                                 {:optional {:prompt "Jack out?"
                                                             :yes-ability {:msg "jack out"
                                                                           :effect (effect (jack-out nil))}
-                                                            :no-ability {:msg "continue"}}}
+                                                            :no-ability {:msg "continue the run"}}}
                                                 card nil)))}]}
 
    "Surfer"

--- a/src/clj/game/cards-programs.clj
+++ b/src/clj/game/cards-programs.clj
@@ -704,7 +704,8 @@
                                                 state side
                                                 {:optional {:prompt "Jack out?"
                                                             :yes-ability {:msg "jack out"
-                                                                          :effect (effect (jack-out nil))}}}
+                                                                          :effect (effect (jack-out nil))}
+                                                            :no-ability {:msg "continue"}}}
                                                 card nil)))}]}
 
    "Surfer"


### PR DESCRIPTION
Adds the following message when "No" is selected at the "Jack Out?" prompt:

> username uses Snitch to continue.