### PR TITLE
Fix The Board

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -1042,14 +1042,12 @@
                  :msg (msg "derez " (:advance-counter card)) :effect (effect (trash card))}]}
 
    "The Board"
-   {:effect (effect (lose :runner :agenda-point
-                          (count (filter #(> (get-agenda-points state :runner %) 0) (:scored runner)))))
-    :leave-play (effect (gain :runner :agenda-point
-                              (count (filter #(> (get-agenda-points state :runner %) 0) (:scored runner)))))
+   {:effect (effect (lose :runner :agenda-point (count (:scored runner))))
+    :leave-play (effect (gain :runner :agenda-point (count (:scored runner))))
     :trash-effect {:when-unrezzed true
-                   :req (req (:access @state)) :effect (effect (as-agenda :runner card 2))}
-    :events {:agenda-stolen {:req (req (> (get-agenda-points state :runner target) 0))
-                             :effect (effect (lose :runner :agenda-point 1))}}}
+                   :req (req (:access @state))
+                   :effect (effect (as-agenda :runner card 2))}
+    :events {:agenda-stolen {:effect (effect (lose :runner :agenda-point 1))}}}
 
    "The News Now Hour"
    {:events {:runner-turn-begins {:effect (req (prevent-current state side))}}

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -1042,15 +1042,17 @@
                  :msg (msg "derez " (:advance-counter card)) :effect (effect (trash card))}]}
 
    "The Board"
-   (let [lose-agenda-point (effect (lose :runner :agenda-point 1))]
-     {:effect (effect (lose :runner :agenda-point (count (:scored runner))))
-      :leave-play (effect (gain :runner :agenda-point (count (:scored runner))))
-      :trash-effect {:when-unrezzed true
-                     :req (req (:access @state))
-                     :effect (effect (as-agenda :runner card 2))}
-      :events {:agenda-stolen {:effect lose-agenda-point}
-               :card-moved {:req (req (some #{(:cid target)} (map :cid (:scored runner))))
-                            :effect lose-agenda-point}}})
+   {:effect (effect (lose :runner :agenda-point (count (:scored runner))))
+    :leave-play (effect (gain :runner :agenda-point (count (:scored runner))))
+    :trash-effect {:when-unrezzed true
+                   :req (req (:access @state))
+                   :effect (effect (as-agenda :runner card 2))}
+    :events {:agenda-stolen {:effect (effect (lose :runner :agenda-point 1))}
+             :card-moved {:req (req (or (some #{:scored} (:zone (first targets)))
+                                        (some #{:scored} (:zone (second targets)))))
+                          :effect (req (if (some #{:scored} (:zone (first targets)))
+                                           (gain state :runner :agenda-point 1)
+                                           (lose state :runner :agenda-point 1)))}}}
 
    "The News Now Hour"
    {:events {:runner-turn-begins {:effect (req (prevent-current state side))}}

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -1042,12 +1042,15 @@
                  :msg (msg "derez " (:advance-counter card)) :effect (effect (trash card))}]}
 
    "The Board"
-   {:effect (effect (lose :runner :agenda-point (count (:scored runner))))
-    :leave-play (effect (gain :runner :agenda-point (count (:scored runner))))
-    :trash-effect {:when-unrezzed true
-                   :req (req (:access @state))
-                   :effect (effect (as-agenda :runner card 2))}
-    :events {:agenda-stolen {:effect (effect (lose :runner :agenda-point 1))}}}
+   (let [lose-agenda-point (effect (lose :runner :agenda-point 1))]
+     {:effect (effect (lose :runner :agenda-point (count (:scored runner))))
+      :leave-play (effect (gain :runner :agenda-point (count (:scored runner))))
+      :trash-effect {:when-unrezzed true
+                     :req (req (:access @state))
+                     :effect (effect (as-agenda :runner card 2))}
+      :events {:agenda-stolen {:effect lose-agenda-point}
+               :card-moved {:req (req (some #{(:cid target)} (map :cid (:scored runner))))
+                            :effect lose-agenda-point}}})
 
    "The News Now Hour"
    {:events {:runner-turn-begins {:effect (req (prevent-current state side))}}

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -1162,12 +1162,9 @@
     (is (= 3 (count (:scored (get-runner)))) "News Team added to Runner score area")
     (is (= -3 (:agenda-point (get-runner))) "Runner has -3 agenda points")
 
-    ; (is (= (:title (get-resource state 0)) "Artist Colony"))
     ; (card-ability state :runner (get-resource state 0) 0)
-    ; (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
-    ;       prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
-    ;   (prompt-choice :runner (first (prompt-names))))
-    ; (prompt-choice :runner "Fan Site")
+    ; (prompt-choice :runner (->> @state :runner :prompt first :choices first))
+    ; (prompt-choice :runner (first (:scored (get-runner))))
     ; (is (= 2 (count (:scored (get-runner)))) "Fan Site removed from Runner score area")
     ; (is (= -2 (:agenda-point (get-runner))) "Runner has -2 agenda points")
 

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -1124,6 +1124,59 @@
     (prompt-choice :corp "Done")
     (is (= 7 (:agenda-point (get-corp))) "Scored 5 points in one turn")))
 
+(deftest the-board
+  "The Board - Modifies everything in the score area"
+  (do-game
+    (new-game (default-corp [(qty "The Board" 1)
+                             (qty "News Team" 1)
+                             (qty "Firmware Updates" 2)])
+              (default-runner [(qty "Artist Colony" 3)
+                               (qty "Fan Site" 3)]))
+    (play-from-hand state :corp "The Board" "New remote")
+    (play-from-hand state :corp "News Team" "New remote")
+    (play-from-hand state :corp "Firmware Updates" "New remote")
+    (take-credits state :corp)
+
+    (play-from-hand state :runner "Artist Colony")
+    (play-from-hand state :runner "Fan Site")
+    (take-credits state :runner)
+
+    (play-from-hand state :corp "Firmware Updates" "New remote")
+    (score-agenda state :corp (get-content state :remote4 0))
+    (is (= 1 (count (:scored (get-runner)))) "Fan Site added to Runner score area")
+    (is (= 0 (:agenda-point (get-runner))) "Runner has 0 agenda points")
+
+    (take-credits state :corp)
+
+    (run-empty-server state :remote3)
+    (prompt-choice :runner "Steal")
+    (is (= 2 (count (:scored (get-runner)))) "Firmware Updates stolen")
+    (is (= 1 (:agenda-point (get-runner))) "Runner has 1 agenda point")
+
+    (core/rez state :corp (get-content state :remote1 0))
+    (is (= -1 (:agenda-point (get-runner))) "Runner has -1 agenda points")
+
+    (run-empty-server state :remote2)
+    (prompt-choice :runner "Add News Team to score area")
+    (prompt-choice :runner "Yes")
+    (is (= 3 (count (:scored (get-runner)))) "News Team added to Runner score area")
+    (is (= -3 (:agenda-point (get-runner))) "Runner has -3 agenda points")
+
+    ; (is (= (:title (get-resource state 0)) "Artist Colony"))
+    ; (card-ability state :runner (get-resource state 0) 0)
+    ; (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
+    ;       prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
+    ;   (prompt-choice :runner (first (prompt-names))))
+    ; (prompt-choice :runner "Fan Site")
+    ; (is (= 2 (count (:scored (get-runner)))) "Fan Site removed from Runner score area")
+    ; (is (= -2 (:agenda-point (get-runner))) "Runner has -2 agenda points")
+
+    (run-empty-server state :remote1)
+    (prompt-choice :runner "Yes")
+    ; (is (= 3 (count (:scored (get-runner)))) "The Board added to Runner score area")
+    (is (= 4 (count (:scored (get-runner)))) "The Board added to Runner score area")
+    (is (= 2 (:agenda-point (get-runner))) "Runner has 2 agenda points")))
+
 (deftest the-root
   "The Root - recurring credits refill at Step 1.2"
   (do-game

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -1125,7 +1125,7 @@
     (is (= 7 (:agenda-point (get-corp))) "Scored 5 points in one turn")))
 
 (deftest the-board
-  "The Board - Modifies everything in the score area"
+  "The Board - Modify everything in the score area (regression test for #1938)"
   (do-game
     (new-game (default-corp [(qty "The Board" 1)
                              (qty "News Team" 1)
@@ -1162,16 +1162,15 @@
     (is (= 3 (count (:scored (get-runner)))) "News Team added to Runner score area")
     (is (= -3 (:agenda-point (get-runner))) "Runner has -3 agenda points")
 
-    ; (card-ability state :runner (get-resource state 0) 0)
-    ; (prompt-choice :runner (->> @state :runner :prompt first :choices first))
-    ; (prompt-choice :runner (first (:scored (get-runner))))
-    ; (is (= 2 (count (:scored (get-runner)))) "Fan Site removed from Runner score area")
-    ; (is (= -2 (:agenda-point (get-runner))) "Runner has -2 agenda points")
+    (card-ability state :runner (get-resource state 0) 0)
+    (prompt-choice :runner (->> @state :runner :prompt first :choices first))
+    (prompt-choice :runner (first (:scored (get-runner))))
+    (is (= 2 (count (:scored (get-runner)))) "Fan Site removed from Runner score area")
+    (is (= -2 (:agenda-point (get-runner))) "Runner has -2 agenda points")
 
     (run-empty-server state :remote1)
     (prompt-choice :runner "Yes")
-    ; (is (= 3 (count (:scored (get-runner)))) "The Board added to Runner score area")
-    (is (= 4 (count (:scored (get-runner)))) "The Board added to Runner score area")
+    (is (= 3 (count (:scored (get-runner)))) "The Board added to Runner score area")
     (is (= 2 (:agenda-point (get-runner))) "Runner has 2 agenda points")))
 
 (deftest the-root


### PR DESCRIPTION
This resolves most of #1938. Removing agendas from the runner score area still requires manual intervention though (e.g. through forfeiting or Exchange of Information). EDIT: Now implements agenda removal.

Also, the commented out section of the test throws an exception, and I'm not sure why. Although I would expect it to fail at this point.