### PR TITLE
Daily Business Show + Political Dealings upgrades

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -246,18 +246,13 @@
               :effect (req (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
                                                     (all-installed state :corp)))]
                              (draw-bonus state side dbs)))}
-             :corp-draw
-             {:once :per-turn
-              :once-key :daily-business-show-register-draws
-              :effect (req (let [drawn (take-last (get-in @state [:corp :register :drawn-this-turn]) (:hand corp))]
-                             (swap! state assoc-in [:corp :register :dbs-drawn] drawn)))}
              :post-corp-draw
              {:once :per-turn
               :once-key :daily-business-show-put-bottom
               :delayed-completion true
               :effect (req (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
                                                     (all-installed state :corp)))
-                                 drawn (get-in @state [:corp :register :dbs-drawn])]
+                                 drawn (get-in @state [:corp :register :most-recent-drawn])]
                              (continue-ability
                                state side
                                {:prompt (str "Choose " dbs " card" (if (> dbs 1) "s" "") " to add to the bottom of R&D")
@@ -766,10 +761,10 @@
      {:events
       {:corp-draw
        {:delayed-completion true
-        :req (req (let [drawn (take-last target (:hand corp))
+        :req (req (let [drawn (get-in @state [:corp :register :most-recent-drawn])
                         agendas (filter #(is-type? % "Agenda") drawn)]
                     (seq agendas)))
-        :effect (req (let [drawn (take-last target (:hand corp))
+        :effect (req (let [drawn (get-in @state [:corp :register :most-recent-drawn])
                            agendas (filter #(is-type? % "Agenda") drawn)]
                        (continue-ability state side (pdhelper agendas 0) card nil)))}}})
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -238,28 +238,27 @@
    {:in-play [:hand-size-modification 4]}
 
    "Daily Business Show"
-   {:events {:corp-draw
+   {:events {:pre-corp-draw
              {:msg "draw additional cards"
               :once :per-turn
               :once-key :daily-business-show
-              :req (req (first-event state side :corp-draw))
-              :effect (req
-                        (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
-                                                  (all-installed state :corp)))
-                              newcards (take dbs (:deck corp))
-                              drawn (concat newcards (take-last target (:hand corp)))]
-                          (if (not= (count newcards) dbs)
-                            ; couldn't draw from R&D, so corp is decked
-                            (win-decked state)
-                            (do (doseq [c newcards] (move state side c :hand))
-                                (resolve-ability
-                                  state side
-                                  {:prompt (str "Choose " dbs " card" (if (> dbs 1) "s" "") " to add to the bottom of R&D")
-                                   :choices {:max dbs
-                                             :req #(and (in-hand? %)
-                                                        (some (fn [c] (= (:cid c) (:cid %))) drawn))}
-                                   :msg (msg "add " dbs " card" (if (> dbs 1) "s" "") " to bottom of R&D")
-                                   :effect (req (doseq [c targets] (move state side c :deck)))} card targets)))))}}}
+              :req (req (first-event state side :pre-corp-draw))
+              :effect (req (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
+                                                    (all-installed state :corp)))]
+                             (draw-bonus state side dbs)))}
+             :corp-draw
+             {:delayed-completion true
+              :effect (req (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
+                                                    (all-installed state :corp)))
+                                 drawn (take-last (get-in @state [:corp :register :drawn-this-turn]) (:hand corp))]
+                             (continue-ability
+                               state side
+                               {:prompt (str "Choose " dbs " card" (if (> dbs 1) "s" "") " to add to the bottom of R&D")
+                                :msg (msg "add " dbs " card" (if (> dbs 1) "s" "") " to the bottom of R&D")
+                                :choices {:max dbs
+                                          :req #(and (in-hand? %)
+                                                     (some (fn [c] (= (:cid c) (:cid %))) drawn))}
+                                :effect (req (doseq [c targets] (move state side c :deck)))} card targets)))}}}
 
    "Dedicated Response Team"
    {:events {:successful-run-ends {:req (req tagged)
@@ -741,22 +740,25 @@
     "Score an Agenda from HQ?")
 
    "Political Dealings"
-   (let [pd-register [:corp :register :pd-drawn]
-         clear (fn [state side] (swap! state assoc-in pd-register []))]
-     {:events {:corp-draw {:effect (req (toast state :corp (str "Political Dealings "
-                                                                "to reveal and install "
-                                                                "an agenda.") "info")
-                                        (let [drawn (take-last target (:hand corp))]
-                                          (swap! state assoc-in pd-register (vec (filter #(is-type? % "Agenda") drawn)))))}
-               :corp-spent-click {:effect (effect (clear))}
-               :corp-turn-ends {:effect (effect (clear))}}
-      :abilities [{:label "Reveal and install agenda"
-                   :req (req (seq (get-in @state [:corp :register :pd-drawn])))
-                   :prompt "Choose an angenda to reveal and install"
-                   :choices (req (cancellable (get-in @state [:corp :register :pd-drawn]) :sorted))
-                   :msg (msg "reveal " (:title target))
-                   :effect (req (corp-install state side target nil {:install-state (or (:install-state (card-def target)) :rezzed-no-cost)})
-                                (swap! state update-in pd-register (fn [pd] (remove #(= (:cid %) (:cid target)) pd))))}]})
+   {:events
+    {:corp-draw
+     {:delayed-completion true
+      :req (req (let [drawn (take-last target (:hand corp))
+                      agendas (filter #(is-type? % "Agenda") drawn)]
+                  (seq agendas)))
+      :effect (req (let [drawn (take-last target (:hand corp))
+                         agendas (filter #(is-type? % "Agenda") drawn)]
+                     (doseq [c agendas]
+                       (continue-ability
+                         state side
+                         {:optional
+                          {:prompt (msg "Reveal and install " (:title c) "?")
+                           :yes-ability {:msg (msg "reveal " (:title c))
+                                         :effect (req (corp-install state side c nil
+                                                                    {:install-state
+                                                                     (or (:install-state (card-def c))
+                                                                         :rezzed-no-cost)}))
+                                         }}} card nil))))}}}
 
    "Primary Transmission Dish"
    {:recurring 3}
@@ -890,7 +892,7 @@
                                    {:prompt "Choose a card in HQ to add to the bottom of R&D"
                                     :choices {:req #(and (= (:side %) "Corp")
                                                          (in-hand? %))}
-                                    :msg "add a card in HQ to the bottom of R&D"
+                                    :msg "add 1 card from HQ to the bottom of R&D"
                                     :effect (effect (move target :deck))}
                                   card nil))}]}
 

--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -243,20 +243,18 @@
               :once :per-turn
               :once-key :daily-business-show-draw-bonus
               :req (req (first-event state side :pre-corp-draw))
-              :effect (req (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
-                                                    (all-installed state :corp)))]
+              :effect (req (let [dbs (count (filter #(and (= "06086" (:code %)) (rezzed? %)) (all-installed state :corp)))]
                              (draw-bonus state side dbs)))}
              :post-corp-draw
              {:once :per-turn
               :once-key :daily-business-show-put-bottom
               :delayed-completion true
-              :effect (req (let [dbs (count (filter #(and (rezzed? %) (= (:title %) "Daily Business Show"))
-                                                    (all-installed state :corp)))
+              :effect (req (let [dbs (count (filter #(and (= "06086" (:code %)) (rezzed? %)) (all-installed state :corp)))
                                  drawn (get-in @state [:corp :register :most-recent-drawn])]
                              (continue-ability
                                state side
-                               {:prompt (str "Choose " dbs " card" (if (> dbs 1) "s" "") " to add to the bottom of R&D")
-                                :msg (msg "add " dbs " card" (if (> dbs 1) "s" "") " to the bottom of R&D")
+                               {:prompt (str "Choose " dbs " card" (when (> dbs 1) "s") " to add to the bottom of R&D")
+                                :msg (msg "add " dbs " card" (when (> dbs 1) "s") " to the bottom of R&D")
                                 :choices {:max dbs
                                           :req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
                                 :effect (req (doseq [c targets] (move state side c :deck)))} card targets)))}}}
@@ -749,8 +747,8 @@
                                     :effect (req (when-completed
                                                    (corp-install state side (nth agendas n) nil
                                                                  {:install-state
-                                                                  (or (:install-state (card-def (nth agendas n)))
-                                                                      :rezzed-no-cost)})
+                                                                  (:install-state (card-def (nth agendas n))
+                                                                    :rezzed-no-cost)})
                                                    (if (< (inc n) (count agendas))
                                                      (continue-ability state side (pd agendas (inc n)) card nil)
                                                      (effect-completed state side eid))))}

--- a/src/clj/game/cards-resources.clj
+++ b/src/clj/game/cards-resources.clj
@@ -653,7 +653,7 @@
    {:abilities [{:cost [:click 1]
                  :msg (msg "draw 2 cards")
                  :effect (req (draw state side 2)
-                              (let [drawn (take-last 2 (conj (take 2 (:deck runner)) (:hand runner)))]
+                              (let [drawn (get-in @state [:runner :register :most-recent-drawn])]
                                 (resolve-ability
                                   state side
                                   {:prompt (str "Choose 1 card to add to the bottom of the Stack")

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -75,7 +75,7 @@
   ([state side] (draw state side 1 nil))
   ([state side n] (draw state side n nil))
   ([state side n {:keys [suppress-event] :as args}]
-   (swap! state assoc-in [side :register :most-recent-drawn] nil) ;clear the most recent draw in case draw prevented
+   (swap! state update-in [side :register] dissoc :most-recent-drawn) ;clear the most recent draw in case draw prevented
    (trigger-event state side (if (= side :corp) :pre-corp-draw :pre-runner-draw) n)
    (let [active-player (get-in @state [:active-player])
          n (-> n (+ (or (get-in @state [:bonus :draw]) 0)))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -65,30 +65,38 @@
     (let [drawn-this-turn (get-in @state [side :register :drawn-this-turn] 0)]
       (max (- max-draw drawn-this-turn) 0))))
 
+(defn draw-bonus
+  "Registers a bonus of n draws to the next draw (Daily Business Show)"
+  [state side n]
+  (swap! state update-in [:bonus :draw] (fnil #(+ % n) 0)))
+
 (defn draw
   "Draw n cards from :deck to :hand."
   ([state side] (draw state side 1 nil))
   ([state side n] (draw state side n nil))
   ([state side n {:keys [suppress-event] :as args}]
+   (trigger-event state side (if (= side :corp) :pre-corp-draw :pre-runner-draw) n)
    (let [active-player (get-in @state [:active-player])
+         n (-> n (+ (or (get-in @state [:bonus :draw]) 0)))
          draws-wanted n
-         n (if (and (= side active-player) (get-in @state [active-player :register :max-draw]))
-             (min n (remaining-draws state side))
-             n)
+         draws-after-prevent (if (and (= side active-player) (get-in @state [active-player :register :max-draw]))
+                                  (min n (remaining-draws state side))
+                                  n)
          deck-count (count (get-in @state [side :deck]))]
-     (when (and (= side :corp) (> n deck-count))
+     (when (and (= side :corp) (> draws-after-prevent deck-count))
        (win-decked state))
      (when-not (and (= side active-player) (get-in @state [side :register :cannot-draw]))
-       (let [drawn (zone :hand (take n (get-in @state [side :deck])))]
+       (let [drawn (zone :hand (take draws-after-prevent (get-in @state [side :deck])))]
          (swap! state update-in [side :hand] #(concat % drawn))
-         (swap! state update-in [side :deck] (partial drop n))
-         (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % n) 0))
+         (swap! state update-in [side :deck] (partial drop draws-after-prevent))
+         (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % draws-after-prevent) 0))
+         (swap! state update-in [:bonus] dissoc :draw)
          (when (and (not suppress-event) (pos? deck-count))
-           (trigger-event state side (if (= side :corp) :corp-draw :runner-draw) n))
+           (trigger-event state side (if (= side :corp) :corp-draw :runner-draw) draws-after-prevent))
          (when (= 0 (remaining-draws state side))
            (prevent-draw state side))))
-     (when (< n draws-wanted)
-       (let [prevented (- draws-wanted n)]
+     (when (< draws-after-prevent draws-wanted)
+       (let [prevented (- draws-wanted draws-after-prevent)]
          (system-msg state (other-side side) (str "prevents " prevented " card"
                                                   (when (> prevented 1) "s")
                                                   " from being drawn")))))))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -75,6 +75,7 @@
   ([state side] (draw state side 1 nil))
   ([state side n] (draw state side n nil))
   ([state side n {:keys [suppress-event] :as args}]
+   (swap! state assoc-in [side :register :most-recent-drawn] nil) ;clear the most recent draw in case draw prevented
    (trigger-event state side (if (= side :corp) :pre-corp-draw :pre-runner-draw) n)
    (let [active-player (get-in @state [:active-player])
          n (-> n (+ (or (get-in @state [:bonus :draw]) 0)))
@@ -89,6 +90,7 @@
        (let [drawn (zone :hand (take draws-after-prevent (get-in @state [side :deck])))]
          (swap! state update-in [side :hand] #(concat % drawn))
          (swap! state update-in [side :deck] (partial drop draws-after-prevent))
+         (swap! state assoc-in [side :register :most-recent-drawn] drawn)
          (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % draws-after-prevent) 0))
          (swap! state update-in [:bonus] dissoc :draw)
          (when (and (not suppress-event) (pos? deck-count))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -92,7 +92,9 @@
          (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % draws-after-prevent) 0))
          (swap! state update-in [:bonus] dissoc :draw)
          (when (and (not suppress-event) (pos? deck-count))
-           (trigger-event state side (if (= side :corp) :corp-draw :runner-draw) draws-after-prevent))
+           (when-completed
+             (trigger-event-sync state side (if (= side :corp) :corp-draw :runner-draw) draws-after-prevent)
+             (trigger-event state side (if (= side :corp) :post-corp-draw :post-runner-draw) draws-after-prevent)))
          (when (= 0 (remaining-draws state side))
            (prevent-draw state side))))
      (when (< draws-after-prevent draws-wanted)

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -158,7 +158,7 @@
       (is (= 1 (:tag (get-runner))) "Runner took 1 tag"))))
 
 (deftest daily-business-show
-  "Daily Business Show - Full test"
+  ;; Daily Business Show - Full test
   (do-game
     (new-game (default-corp [(qty "Daily Business Show" 3) (qty "Hedge Fund" 1) (qty "Jackson Howard" 1)
                              (qty "Resistor" 1) (qty "Product Placement" 1) (qty "Breaking News" 1)])
@@ -189,7 +189,7 @@
         "Breaking News third last card in deck")))
 
 (deftest daily-business-show-sensie-actors-union
-  "Daily Business Show - Sensie Actors Union interaction"
+  ;; Daily Business Show - Sensie Actors Union interaction
   (do-game
     (new-game (default-corp [(qty "Daily Business Show" 1) (qty "Sensie Actors Union" 2)
                              (qty "Hedge Fund" 1) (qty "Jackson Howard" 1)
@@ -206,7 +206,7 @@
       (core/rez state :corp sensie2)
       (take-credits state :corp)
       (take-credits state :runner)
-      ; Use first Sensie
+      ;; Use first Sensie
       (is (= 1 (count (:hand (get-corp)))))
       (card-ability state :corp sensie1 0)
       (is (= 5 (count (:hand (get-corp)))) "Drew 3 cards with Sensie, +1 with DBS")
@@ -216,11 +216,11 @@
       (is (= "Hedge Fund" (:title (last (:deck (get-corp))))) "Hedge Fund last card in deck")
       (is (= "Resistor" (:title (last (butlast (:deck (get-corp))))))
           "Resistor second last card in deck")
-      ; Try to use first Sensie again
+      ;; Try to use first Sensie again
       (card-ability state :corp sensie1 0)
       (is (empty? (get-in @state [:corp :prompt])) "Sensie didn't activate")
       (is (= 3 (count (:hand (get-corp)))))
-      ; Use second Sensie
+      ;; Use second Sensie
       (starting-hand state :corp ["Hedge Fund" "Jackson Howard"])
       (is (= 2 (count (:hand (get-corp)))))
       (card-ability state :corp sensie2 0)
@@ -742,7 +742,7 @@
     (is (find-card "Braintrust" (:scored (get-corp))) "Braintrust is scored")))
 
 (deftest political-dealings
-  "Political Dealings - Full test"
+  ;; Political Dealings - Full test
   (do-game
     (new-game (default-corp [(qty "Political Dealings" 1) (qty "Medical Breakthrough" 1) (qty "Oaktown Renovation" 1)])
               (default-runner))
@@ -750,13 +750,13 @@
     (core/move state :corp (find-card "Oaktown Renovation" (:hand (get-corp))) :deck)
     (play-from-hand state :corp "Political Dealings" "New remote")
     (core/rez state :corp (get-content state :remote1 0))
-    ; Install Medical Breakthrough
+    ;; Install Medical Breakthrough
     (core/draw state :corp)
     (prompt-choice :corp "Yes")
     (prompt-choice :corp "New remote")
     (is (= "Medical Breakthrough" (:title (get-content state :remote2 0)))
         "Medical Breakthrough installed by Political Dealings")
-    ; Install Oaktown Renovation
+    ;; Install Oaktown Renovation
     (core/draw state :corp)
     (prompt-choice :corp "Yes")
     (prompt-choice :corp "New remote")
@@ -766,8 +766,8 @@
         "Oaktown Renovation installed face up")))
 
 (deftest political-dealings-daily-business-show
-  "Political Dealings - Daily Business Show interaction.
-   Draw 2 agendas, install both of them but return 1 to bottom of R&D"
+  ;; Political Dealings - Daily Business Show interaction.
+  ;; Draw 2 agendas, install both of them but return 1 to bottom of R&D"
   (do-game
     (new-game (default-corp [(qty "Political Dealings" 1) (qty "Daily Business Show" 1) (qty "Turtlebacks" 1)
                              (qty "Breaking News" 1) (qty "Project Beale" 1)])
@@ -785,19 +785,19 @@
     (let [agenda1 (first (:deck (get-corp)))
           agenda2 (second (:deck (get-corp)))]
       (take-credits state :runner)
-      ; Install first agenda
+      ;; Install first agenda
       (is (= 2 (count (:hand (get-corp)))))
       (is (= 0 (:credit (get-corp))))
       (prompt-choice :corp "Yes")
       (prompt-choice :corp "New remote")
       (is (= (:cid agenda1) (:cid (get-content state :remote4 0))))
       (is (= 1 (:credit (get-corp))) "Turtlebacks triggered")
-      ; Install second agenda
+      ;; Install second agenda
       (prompt-choice :corp "Yes")
       (prompt-choice :corp "New remote")
       (is (= (:cid agenda2) (:cid (get-content state :remote5 0))))
       (is (= 2 (:credit (get-corp))) "Turtlebacks triggered")
-      ; DBS - put first agenda at bottom of R&D
+      ;; DBS - put first agenda at bottom of R&D
       (prompt-select :corp (get-content state :remote4 0))
       (is (= 0 (count (:hand (get-corp)))))
       (is (= (:cid agenda1) (:cid (last (:deck (get-corp)))))))))


### PR DESCRIPTION
This is part 2 of my updates to draw cards. See #1923 for part 1.
Fixes #1450, #1695 

Thanks to @nealterrell for some help he gave.

This PR upgrades Daily Business Show to use the draw function instead of take x from top of deck. Political Dealings was also reworked to fix some lingering issues and to more closely follow the rules since apparently you can install two agendas off of the DBS draw, triggering turtlebacks, and then put one on bottom of R&D (see http://ancur.wikia.com/wiki/Democracy_and_Dogma_UFAQ)

Additions to the engine:

- draw-bonus function that registers a bonus of n draws to the next draw attempt.

- :pre-corp-draw and :post-corp-draw event hooks (pre-corp-draw signals an attempt to draw, the draw happens, corp-draw is called, post-corp-draw happens after all listeners on corp-draw are finished)

- [side :register :most-recent-drawn] contains the cards in the most recent draw attempt (will be 1 card most of the time but can be 3 from Sensie or 0 if all draws prevented). This seems better than take n from the rightmost part of your hand as done previously.


Lingering issues:

- Really complex scenarios such as using Sensie, DBS and Political Dealings simultaneously make the prompts go a bit awry (you can see below that Political Dealings doesn't fully resolve before the Sensie prompt comes up again - I was unable to fix this):

test uses Sensie Actors Union to draw 3 cards.
test uses Daily Business Show to draw additional cards.
test uses Political Dealings to reveal Chronos Project.
*test uses Sensie Actors Union to add 1 card from HQ to the bottom of R&D.
test installs Chronos Project in Server 4 (new remote).
test uses Daily Business Show to add 1 card to the bottom of R&D.

- Not even entirely sure this is the best approach but thoughts would be appreciated!