### PR TITLE
stop Targeted Marketing from paying out if a named Runner Current is played

### DIFF
--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -34,7 +34,6 @@
                                   (when-not no-additional-cost additional-cost))] ; play cost can be paid
            (let [c (move state side (assoc card :seen true) :play-area)]
              (system-msg state side (str (build-spend-msg cost-str "play") title))
-             (trigger-event state side (if (= side :corp) :play-operation :play-event) c)
              (if (has-subtype? c "Current")
                (do (doseq [s [:corp :runner]]
                      (when-let [current (first (get-in @state [s :current]))] ; trash old current
@@ -47,7 +46,8 @@
                      (move state side c :discard))
                    (when (has-subtype? card "Terminal")
                      (lose state side :click (-> @state side :click))
-                     (swap! state assoc-in [:corp :register :terminal] true)))))
+                     (swap! state assoc-in [:corp :register :terminal] true))))
+             (trigger-event state side (if (= side :corp) :play-operation :play-event) c))
            ;; could not pay the card's price; mark the effect as being over.
            (effect-completed state side eid card))
          ;; card's req was not satisfied; mark the effect as being over.


### PR DESCRIPTION
Fixes issue raised in Stimslack:

Targeted Marketing is wrongly paying out 10cr if it names a Runner Current and that Current gets played (see official FAQ page 11). Targeted Marketing is supposed to be trashed immediately before it has a chance to trigger. This just postpones `:play-operation` or `:play-event` until after the Current trash is done.  