### PR TITLE
Indicate whether trashed cards were inside a central or protecting it

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -125,9 +125,11 @@
              {:prompt (str "Pay " trash-cost "[Credits] to trash " name "?")
               :yes-ability {:cost [:credit trash-cost]
                             :delayed-completion true
-                            :effect (effect (trash eid card nil)
-                                            (system-msg (str "pays " trash-cost
-                                                             " [Credits] to trash " name)))}}}
+                            :effect (req (trash state side eid card nil)
+                                         (let [src (name-zone :corp (:zone card))]
+                                           (system-msg state side (str "pays " trash-cost
+                                                                       " [Credits] to trash " name
+                                                                       (when-not (nil? src) (str " from " src))))))}}}
             card nil)))
       ;; The card does not have a trash cost
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid}))


### PR DESCRIPTION
The result is "pays 4 [Credits] to trash PAD Campaign from HQ" vs "pays 1 [Credits] to trash Cyberdex Virus Suite from HQ Server".