### PR TITLE
ELP implementation

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -294,13 +294,13 @@
    "Enhanced Login Protocol"
    {:events {:run {:once :per-turn
                    ;; TODO: Find more elegant way of seeing if its a run event
-                   :req (req (not (has-subtype? (get (get (get @state :run) :run-effect) :card) "Run")))
+                   :req (req (nil? (:card (:run-effect (:run @state)))))
                    :effect (effect (update! (assoc card :elp-fire true))
-                             (lose :runner :click 1))
+                                   (lose :runner :click 1))
                    :msg "force the Runner to spend an additional [Click]"}
              :runner-spent-click {:req (req (and (not (:elp-fire card)) (>= 2 (:click runner))))
                                   :effect (effect (prevent-run))}
-             :runner-phase-12 {:effect (effect (update! (assoc card :elp-fire (not true))))}}}
+             :runner-phase-12 {:effect (effect (update! (assoc card :elp-fire false)))}}}
 
    "Exchange of Information"
    {:req (req (and tagged

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -291,6 +291,17 @@
                               :effect (effect (trash target))}
                             card nil)))}}
 
+   "Enhanced Login Protocol"
+   {:events {:run {:once :per-turn
+                   ;; TODO: Find more elegant way of seeing if its a run event
+                   :req (req (not (has-subtype? (get (get (get @state :run) :run-effect) :card) "Run")))
+                   :effect (effect (update! (assoc card :elp-fire true))
+                             (lose :runner :click 1))
+                   :msg "force the Runner to spend an additional [Click]"}
+             :runner-spent-click {:req (req (and (not (:elp-fire card)) (>= 2 (:click runner))))
+                                  :effect (effect (prevent-run))}
+             :runner-phase-12 {:effect (effect (update! (assoc card :elp-fire (not true))))}}}
+
    "Exchange of Information"
    {:req (req (and tagged
                    (seq (:scored runner))

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -315,8 +315,8 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Keyhole")
     (is (= 3 (:click (get-runner))) "Runner has 3 clicks before run")
-    (let [sneak (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner sneak 0)
+    (let [keyhole (get-in @state [:runner :rig :program 0])]
+      (card-ability state :runner keyhole 0)
       (is (= 2 (:click (get-runner))) "Runner has 2 clicks after using sneakdoor"))))
 
 (deftest exchange-of-information

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -300,12 +300,24 @@
     (take-credits state :corp)
     (take-credits state :runner 2)
     (is (= 2 (:click (get-runner))))
-    (is (boolean (core/can-run-server? state "HQ")) "Runner can run - two clicks")
+    (is (core/can-run-server? state "HQ") "Runner can run - two clicks")
     (take-credits state :runner 1)
     (is (= 1 (:click (get-runner))))
     (run-on state :hq)
-    (run-jack-out state)
-    (is (= 1 (:click (get-runner))) "Run not available - not enough clicks")))
+    (is (not (:run @state)) "No run initiated - not enough clicks")))
+
+(deftest enhanced-login-protocol-keyhole
+  ;; Enhanced Login Protocol - tests interaction with runs initiated from programs
+  (do-game
+    (new-game (default-corp [(qty "Enhanced Login Protocol" 1)])
+              (default-runner [(qty "Keyhole" 1)]))
+    (play-from-hand state :corp "Enhanced Login Protocol")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Keyhole")
+    (is (= 3 (:click (get-runner))) "Runner has 3 clicks before run")
+    (let [sneak (get-in @state [:runner :rig :program 0])]
+      (card-ability state :runner sneak 0)
+      (is (= 2 (:click (get-runner))) "Runner has 2 clicks after using sneakdoor"))))
 
 (deftest exchange-of-information
   ;; Exchange of Information - Swapping agendas works correctly

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -273,6 +273,40 @@
     (play-from-hand state :corp "Diversified Portfolio")
     (is (= 7 (:credit (get-corp))) "Ignored remote with ICE but no server contents")))
 
+(deftest enhanced-login-protocol
+  ;; Enhanced Login Protocol - tests interaction with run events, interaction with runs, and inability to run last click
+  (do-game
+    (new-game (default-corp [(qty "Enhanced Login Protocol" 1)])
+              (default-runner [(qty "Dirty Laundry" 1)]))
+    (play-from-hand state :corp "Enhanced Login Protocol")
+    (take-credits state :corp)
+    (is (= 4 (:click (get-runner))) "Runner starts turn with 4 clicks")
+    (play-from-hand state :runner "Dirty Laundry")
+    (prompt-choice :runner "Archives")
+    (run-successful state)
+    (is (= 3 (:click (get-runner))) "Run event only takes 1 click")
+    (run-on state :hq)
+    (run-jack-out state)
+    (is (= 1 (:click (get-runner))) "first non-event run takes 2 clicks")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (run-on state :hq)
+    (run-jack-out state)
+    (is (= 2 (:click (get-runner))) "first run takes 2 clicks")
+    (run-on state :hq)
+    (run-jack-out state)
+    (is (= 1 (:click (get-runner))) "second run takes 1 click")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (take-credits state :runner 2)
+    (is (= 2 (:click (get-runner))))
+    (is (boolean (core/can-run-server? state "HQ")) "Runner can run - two clicks")
+    (take-credits state :runner 1)
+    (is (= 1 (:click (get-runner))))
+    (run-on state :hq)
+    (run-jack-out state)
+    (is (= 1 (:click (get-runner))) "Run not available - not enough clicks")))
+
 (deftest exchange-of-information
   ;; Exchange of Information - Swapping agendas works correctly
   (do-game


### PR DESCRIPTION
I was not completely sure on a more elegant approach to writing 

`:req (req (not (has-subtype? (get (get (get @state :run) :run-effect) :card) "Run")))`

but was unsure as to how to tell is a run is started from an Event or not. It works though.
Also, my test suite for the card was a little funky. I originally (at the very end of the test) had
```
(deftest
...
(is (= 1 (:click (get-runner))))
(is (not (core/can-run-server? state "HQ")) "Runner can't run - needs two clicks")))
```
but I was getting failures even though it worked in practice. The failure said it was `(not (not true))`, which I wanted it to be. But it didn't evaluate all the way to true. I'm still new to clojure, so if anyone knows why this happened, please let me know. My replacement simply runs and jacks out and asserts that the clicks left for the runner is still at 1, meaning the run was impossible to do and didn't happen.