### PR TITLE
Tricksy fixes

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -384,18 +384,19 @@
                     (get-card state (nth run-ice (dec pos))))
           next-ice (when (and pos (< 1 pos) (<= (dec pos) (count run-ice)))
                      (get-card state (nth run-ice (- pos 2))))]
-      (trigger-event state side :pass-ice cur-ice)
-      (update-ice-in-server state side (get-in @state (concat [:corp :servers] (get-in @state [:run :server]))))
-      (swap! state update-in [:run :position] dec)
-      (swap! state assoc-in [:run :no-action] false)
-      (system-msg state side "continues the run")
-      (when cur-ice
-        (update-ice-strength state side cur-ice))
-      (when next-ice
-        (trigger-event state side :approach-ice next-ice))
-      (doseq [p (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
-        (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
-        (update-breaker-strength state side p)))))
+      (when-completed (trigger-event-sync state side :pass-ice cur-ice)
+                      (do (update-ice-in-server
+                            state side (get-in @state (concat [:corp :servers] (get-in @state [:run :server]))))
+                          (swap! state update-in [:run :position] dec)
+                          (swap! state assoc-in [:run :no-action] false)
+                          (system-msg state side "continues the run")
+                          (when cur-ice
+                            (update-ice-strength state side cur-ice))
+                          (when next-ice
+                            (trigger-event state side :approach-ice next-ice))
+                          (doseq [p (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
+                            (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
+                            (update-breaker-strength state side p)))))))
 
 (defn view-deck
   "Allows the player to view their deck by making the cards in the deck public."

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -471,6 +471,38 @@
     (prompt-select :runner (get-content state :remote1 0))
     (is (not (:run @state)) "Run is over")))
 
+(deftest leela-upgrades
+  ;; Leela Patel - upgrades returned to hand in the middle of a run do not break the run. Issue #2008.
+  (do-game
+    (new-game (default-corp [(qty "Crisium Grid" 3) (qty "Project Atlas" 3) (qty "Shock!" 1)])
+              (make-deck "Leela Patel: Trained Pragmatist" [(qty "Sure Gamble" 1)]))
+    (starting-hand state :corp ["Crisium Grid" "Crisium Grid" "Crisium Grid" "Project Atlas" "Shock!" "Project Atlas"])
+    (play-from-hand state :corp "Crisium Grid" "HQ")
+    (play-from-hand state :corp "Crisium Grid" "Archives")
+    (play-from-hand state :corp "Crisium Grid" "R&D")
+    (trash-from-hand state :corp "Project Atlas")
+    (trash-from-hand state :corp "Shock!")
+    (take-credits state :corp)
+    (run-empty-server state "HQ")
+    (prompt-choice :runner "Card from hand")
+    (prompt-choice :runner "Steal")
+    (prompt-select :runner (get-content state :hq 0))
+    (is (not (get-content state :hq 0)) "Upgrade returned to hand")
+    (is (not (:run @state)) "Run ended, no more accesses")
+    (run-empty-server state "R&D")
+    (prompt-choice :runner "Card from deck")
+    (prompt-choice :runner "Steal")
+    (prompt-select :runner (get-content state :rd 0))
+    (is (not (get-content state :rd 0)) "Upgrade returned to hand")
+    (is (not (:run @state)) "Run ended, no more accesses")
+    (run-empty-server state "Archives")
+    (prompt-choice :runner "Shock!")
+    (prompt-choice :runner "Project Atlas")
+    (prompt-choice :runner "Steal")
+    (prompt-select :runner (get-content state :archives 0))
+    (is (not (get-content state :archives 0)) "Upgrade returned to hand")
+    (is (not (:run @state)) "Run ended, no more accesses")))
+
 (deftest maxx-wyldside-start-of-turn
   ;; MaxX and Wyldside - using Wyldside during Step 1.2 should lose 1 click
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -403,6 +403,30 @@
     (play-run-event state (first (:hand (get-runner))) :hq)
     (is (= 16 (:credit (get-runner))) "No credit gained for second Run event")))
 
+(deftest khan-vs-caprice
+  ;; Khan - proper order of events when vs. Caprice
+  (do-game
+    (new-game
+      (default-corp [(qty "Eli 1.0" 1) (qty "Caprice Nisei" 1)])
+      (make-deck "Khan: Savvy Skiptracer" [(qty "Corroder" 1)]))
+    (play-from-hand state :corp "Eli 1.0" "Archives")
+    (play-from-hand state :corp "Caprice Nisei" "Archives")
+    (core/rez state :corp (get-content state :archives 0))
+    (take-credits state :corp)
+    (run-on state "Archives")
+    (run-continue state)
+    (is (and (empty? (:prompt (get-corp)))
+             (= 1 (count (:prompt (get-runner))))
+             (= "Khan: Savvy Skiptracer" (-> (get-runner) :prompt first :card :title)))
+        "Only Khan prompt showing")
+    (prompt-select :runner (first (:hand (get-runner))))
+    (is (find-card "Corroder" (-> (get-runner) :rig :program)) "Corroder installed")
+    (is (= 4 (:credit (get-runner))) "1cr discount from Khan")
+    (is (= "Caprice Nisei" (-> (get-runner) :prompt first :card :title)) "Caprice prompt showing")
+    (prompt-choice :runner "0 [Credits]")
+    (prompt-choice :corp "1 [Credits]")
+    (is (not (:run @state)) "Run ended")))
+
 (deftest leela-gang-sign-complicated
   ;; Leela Patel - complicated interaction with mutiple Gang Sign
   (do-game


### PR DESCRIPTION
Fix #1916 by making the `:pass-ice` event synchronous, so Khan's install prompt has to resolve before Caprice is triggered.

Fix #2008 by reworking central-server access so that upgrades which are moved in the middle of the access phase via Leela are do not show up in the remaining "Choose a card to access" prompts.