### PR TITLE
Use npm scripts rather than global modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The implementation of the game rules is in progress. About 95% of the cards are 
 * Node.js, Node Package Manager
 * Leiningen (version 2+)
 * MongoDB
-* Coffeescript
 * Zero MQ
 
 
@@ -41,8 +40,7 @@ Launch MongoDB and fetch card data:
 
 ```
 $ mongod
-$ cd data
-$ coffee fetch.coffee
+$ npm run fetch
 ```
 
 Compile and watch client side Clojurescript files:
@@ -66,7 +64,7 @@ $ java -jar target/netrunner-0.1.0-SNAPSHOT-standalone.jar
 Launch the Node server:
 
 ```
-$ coffee server.coffee
+$ npm start
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -26,22 +26,15 @@ The implementation of the game rules is in progress. About 95% of the cards are 
 * Leiningen (version 2+)
 * MongoDB
 * Coffeescript
-* Bower
 * Zero MQ
 
 
 ## Installation
 
-Install Node.js dependencies:
+Install frontend dependencies:
 
 ```
 $ npm install
-```
-
-Install JavaScript dependencies:
-
-```
-$ bower install
 ```
 
 Launch MongoDB and fetch card data:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "url": "https://github.com/mtgred/netrunner.git"
   },
   "scripts": {
-    "postinstall": "bower install"
+    "start": "coffee server.coffee",
+    "postinstall": "bower install",
+    "fetch": "cd data/ && coffee fetch.coffee"
   },
   "devDependencies": {
     "bower": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/mtgred/netrunner.git"
   },
+  "scripts": {
+    "postinstall": "bower install"
+  },
   "devDependencies": {
     "bower": "^1.7.9",
     "coffee-script": "^1.11.0"


### PR DESCRIPTION
This removes the requirement to globally install Coffeescript and Bower (and make sure they're at the correct versions). It also simplifies the installation process.
