### PR TITLE
tweak Salsette Slums for the 382nd time

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -982,7 +982,7 @@
                                 (deactivate state side c)
                                 (move state :corp c :rfg)
                                 (pay state :runner card :credit (trash-cost state side c))
-                                (trigger-event state side :runner-trash nil)
+                                (swap! state update-in [:turn-events] #(cons [:runner-trash c] %))
                                 (update! state side (dissoc card :slums-active))
                                 (close-access-prompt state side)
                                 (when-not (:run @state)
@@ -998,7 +998,7 @@
                                     :msg (msg "remove " (:title target) " from the game")
                                     :effect (req (deactivate state side target)
                                                  (move state :corp target :rfg)
-                                                 (trigger-event state side :runner-trash nil)
+                                                 (swap! state update-in [:turn-events] #(cons [:runner-trash target] %))
                                                  (update! state side (dissoc card :slums-active)))}
                                    card nil))}]}
 


### PR DESCRIPTION
Instead of "falsely" triggering the `:runner-trash` event with a target of `nil` to "turn off" NBN: Controlling the Message for the turn (FAQ ruling) while also averting a Hostile Infrastructure response, we manually splice the results into `[:turn-events]`. 

This achieves the following correct outcomes: 

1. A Runner using a Street Peddler (which results in `:runner-trash` on the remaining hosted items) and *later that turn* trashing a Corp card against CtM will see CtM's trace fire
2. A Runner using Salsette Slums to exile a card *will not* see CtM's trace fire on a subsequent trash of a Corp card that same turn.