### PR TITLE
more Escalation cards

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -532,7 +532,8 @@
                    :effect (req (if (= target "Pay 1 [Credits]")
                                   (do (pay state side card :credit 1)
                                       (system-msg state side "pays 1 [Credits]"))
-                                  (resolve-ability state :runner trash-installed card nil)))}]}
+                                  (resolve-ability state :runner trash-installed card nil)))}]
+    :runner-abilities [(runner-break [:click 1] 1)]}
 
    "Fairchild 2.0"
    {:subroutines [{:label "Force the Runner to pay 2 [Credits] or trash an installed card"
@@ -544,7 +545,8 @@
                                   (do (pay state side card :credit 2)
                                       (system-msg state side "pays 2 [Credits]"))
                                   (resolve-ability state :runner trash-installed card nil)))}
-                  (do-brain-damage 1)]}
+                  (do-brain-damage 1)]
+    :runner-abilities [(runner-break [:click 2] 2)]}
 
    "Fairchild 3.0"
    {:subroutines [{:label "Force the Runner to pay 3 [Credits] or trash an installed card"
@@ -562,7 +564,8 @@
                    :msg (msg (lower-case target))
                    :effect (req (if (= target "Do 1 brain damage")
                                   (damage state side eid :brain 1 {:card card})
-                                  (end-run state side)))}]}
+                                  (end-run state side)))}]
+    :runner-abilities [(runner-break [:click 3] 3)]}
 
    "Fenris"
    {:effect take-bad-pub

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -546,6 +546,24 @@
                                   (resolve-ability state :runner trash-installed card nil)))}
                   (do-brain-damage 1)]}
 
+   "Fairchild 3.0"
+   {:subroutines [{:label "Force the Runner to pay 3 [Credits] or trash an installed card"
+                   :msg "force the Runner to pay 3 [Credits] or trash an installed card"
+                   :player :runner
+                   :prompt "Choose one"
+                   :choices ["Pay 3 [Credits]" "Trash an installed card"]
+                   :effect (req (if (= target "Pay 3 [Credits]")
+                                  (do (pay state side card :credit 3)
+                                      (system-msg state side "pays 3 [Credits]"))
+                                  (resolve-ability state :runner trash-installed card nil)))}
+                  {:label "Do 1 brain damage or end the run"
+                   :prompt "Choose one"
+                   :choices ["Do 1 brain damage" "End the run"]
+                   :msg (msg (lower-case target))
+                   :effect (req (if (= target "Do 1 brain damage")
+                                  (damage state side eid :brain 1 {:card card})
+                                  (end-run state side)))}]}
+
    "Fenris"
    {:effect take-bad-pub
     :subroutines [(do-brain-damage 1)

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -195,6 +195,27 @@
                  :msg "add 2 strength (using at least 1 stealth [Credits])"
                  :effect (effect (pump card 2)) :pump 2}]}
 
+   "Black Orchestra"
+   (let [install {:req (req (and (= (:zone card) [:discard])
+                                 (rezzed? current-ice)
+                                 (has-subtype? current-ice "Code Gate")))
+                  :optional {:player :runner
+                             :prompt "Install Black Orchestra?"
+                             :yes-ability {:effect (effect (unregister-events card)
+                                                           (runner-install :runner card))}}}
+         heap-event (req (when (= (:zone card) [:discard])
+                           (unregister-events state side card)
+                           (register-events state side
+                                            (:events (card-def card))
+                                            (assoc card :zone [:discard]))))]
+   {:move-zone heap-event
+    :abilities [{:cost [:credit 3]
+                 :effect (effect (pump card 2)) :pump 2
+                 :msg "add 2 strength and break up to 2 subroutines"}]
+    :events {:rez install
+             :approach-ice install
+             :run install}})
+
    "Blackstone"
    {:abilities [(break-sub 1 1 "barrier")
                 {:cost [:credit 3]
@@ -382,6 +403,12 @@
    "GS Striker M1"
    (global-sec-breaker "Code Gate")
 
+   "Houdini"
+   {:abilities [(break-sub 1 1 "code gate")
+                {:cost [:credit 2]
+                 :msg "add 4 strength (using at least 1 stealth [Credits])"
+                 :effect (effect (pump card 4 :all-run)) :pump 4}]}
+
    "Inti"
    (auto-icebreaker ["Barrier"]
                     {:abilities [(break-sub 1 1 "barrier")
@@ -486,6 +513,17 @@
    (auto-icebreaker ["Code Gate"]
                     {:abilities [(break-sub 2 1 "code gate")
                                  (strength-pump 2 3)]})
+
+   "Peregrine"
+   (auto-icebreaker ["Code Gate"]
+                    {:abilities [(break-sub 1 1 "code gate")
+                                 (strength-pump 3 3)
+                                 {:label "Derez a code gate and return Peregrine to your Grip"
+                                  :cost [:credit 2]
+                                  :req (req (and (rezzed? current-ice) (has-subtype? current-ice "Code Gate")))
+                                  :msg (msg "derez " (:title current-ice) " and return Peregrine to their Grip")
+                                  :effect (effect (derez current-ice)
+                                                  (move card :hand))}]})
 
    "Pipeline"
    (auto-icebreaker ["Sentry"]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -429,6 +429,12 @@
                              (str "add " (:title c) " to their score area and gain " (get-agenda-points state :runner c)
                                   " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]}
 
+   "First Responders"
+   {:abilities [{:cost [:credit 2]
+                 :req (req (not-empty (turn-events state side :damage)))
+                 :msg "draw 1 card"
+                 :effect (effect (draw))}]}   
+
    "Gang Sign"
    {:events {:agenda-scored {:delayed-completion true
                              :interactive (req true)


### PR DESCRIPTION
Adds Black Orchestra, Peregrine, Houdini, Fairchild 3.0, plus a partial for First Responders (for now it only checks for damage this turn, not that the source was a Corp card). This will fail tests only because of the Adam test that is getting fixed in #2042. 