### PR TITLE
fix HB: Architects of Tomorrow

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -850,7 +850,7 @@
    "Mausolus"
    {:advanceable :always
     :subroutines [{:label "Gain 1 [Credits] (Gain 3 [Credits])"
-                   :msg (msg "gain " (if (> 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0))) 1 2) " [Credits]")
+                   :msg (msg "gain " (if (> 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0))) 1 3) " [Credits]")
                    :effect (effect (gain :credit (if (> 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0))) 1 3)))}
                   {:label "Do 1 net damage (Do 3 net damage)"
                    :delayed-completion true

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -334,7 +334,7 @@
 
    "Jinteki: Potential Unleashed"
    {:events {:pre-resolve-damage
-             {:req (req (and (= target :net) (> (last targets) 0)))
+             {:req (req (and (= target :net) (pos? (last targets))))
               :effect (req (let [c (first (get-in @state [:runner :deck]))]
                              (system-msg state :corp (str "uses Jinteki: Potential Unleashed to trash " (:title c)
                                                           " from the top of the Runner's Stack"))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -238,7 +238,7 @@
                                                                     (rez target)
                                                                     (clear-wait-prompt :runner))}
                                                    card nil))
-                             (effect-completed state side)))}}}
+                             (effect-completed state side eid)))}}}
 
    "Haas-Bioroid: Engineering the Future"
    {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -333,9 +333,12 @@
              :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinteki: Potential Unleashed"
-   {:events {:pre-resolve-damage {:req (req (and (= target :net) (> (last targets) 0)))
-                                  :msg "trash the top card of the Runner's Stack"
-                                  :effect (effect (mill :runner))}}}
+   {:events {:pre-resolve-damage
+             {:req (req (and (= target :net) (> (last targets) 0)))
+              :effect (req (let [c (first (get-in @state [:runner :deck]))]
+                             (system-msg state :corp (str "uses Jinteki: Potential Unleashed to trash " (:title c)
+                                                          " from the top of the Runner's Stack"))
+                             (mill state :runner)))}}}
 
    "Jinteki: Replicating Perfection"
    {:events


### PR DESCRIPTION
* Fixes #2049: Missing function argument causing an error when Runner passes a bioroid and there are no unrezzed bioroids.
* Fixes #2035: Reveal the card milled by Jinteki: Potential Unleashed
* Fix wrong message for Mausolus credit gain subroutine

Ignore failing test, getting fixed at #2048. 