### PR TITLE
fix Lib Chela agenda forfeit

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -609,29 +609,42 @@
                                 (trash state :runner card {:unpreventable true})))}]}
 
    "Liberated Chela"
-   {:abilities [{:cost [:click 5 :forfeit]
-                 :msg "add it to their score area"
-                 :effect (req (if (not (empty? (:scored corp)))
-                                (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent Liberated Chela")
+   {:abilities [{:cost [:click 5]
+                 :effect (req (if (empty? (get-in @state [:runner :scored]))
+                                (do (toast state :runner "Unable to forfeit agenda for Liberated Chela")
                                     (resolve-ability
                                       state side
-                                      {:prompt (msg "Forfeit an agenda to prevent Liberated Chela from being added to Runner's score area?")
-                                       :choices ["Yes" "No"] :player :corp
-                                       :effect (final-effect (resolve-ability
-                                                               (if (= target "Yes")
-                                                                 {:prompt "Choose an agenda to forfeit" :player :corp
-                                                                  :choices {:req #(in-corp-scored? state side %)}
-                                                                  :effect (effect (forfeit target)
-                                                                                  (move :runner card :rfg)
-                                                                                  (clear-wait-prompt :runner))}
-                                                                 {:effect (effect (as-agenda :runner card 2)
-                                                                                  (clear-wait-prompt :runner))
-                                                                  :msg "add it to their score area as an agenda worth 2 points"})
-                                                              card nil))} card nil))
-                                (resolve-ability
-                                  state side
-                                  {:effect (effect (as-agenda :runner card 2))
-                                   :msg "add it to their score area as an agenda worth 2 points"} card nil)))}]}
+                                      {:effect (effect (gain :click 5))} card nil))
+                                (do (if (not (empty? (get-in @state [:corp :scored])))
+                                      (do (system-msg state :runner (str "spends [Click][Click][Click][Click][Click] to use Liberated Chela to add it to their score area"))
+                                          (show-wait-prompt state :runner "Corp to decide whether or not to prevent Liberated Chela")
+                                          (resolve-ability
+                                            state side
+                                            {:prompt (msg "Forfeit an agenda to prevent Liberated Chela from being added to Runner's score area?")
+                                             :choices ["Yes" "No"] :player :corp
+                                             :effect (final-effect (resolve-ability
+                                                                     (if (= target "Yes")
+                                                                       {:prompt "Choose an agenda to forfeit" :player :corp
+                                                                        :choices {:req #(in-corp-scored? state side %)}
+                                                                        :effect (effect (forfeit target)
+                                                                                        (move :runner card :rfg)
+                                                                                        (clear-wait-prompt :runner))}
+                                                                       {:effect (effect (clear-wait-prompt :runner)
+                                                                                        (resolve-ability
+                                                                                          {:prompt "Choose an agenda to forfeit"
+                                                                                           :choices {:req #(in-runner-scored? state side %)} :player :runner
+                                                                                           :effect (effect (forfeit target)
+                                                                                                           (as-agenda :runner card 2))
+                                                                                           :msg "add it to their score area as an agenda worth 2 points"} card nil))})
+                                                                     card nil))} card nil))
+                                      (do (system-msg state :runner (str "spends [Click][Click][Click][Click][Click] to use Liberated Chela to add it to their score area"))
+                                          (resolve-ability
+                                            state side
+                                            {:prompt "Choose an agenda to forfeit" :player :runner
+                                             :choices {:req #(in-runner-scored? state side %)}
+                                             :effect (effect (forfeit target)
+                                                             (as-agenda :runner card 2))
+                                             :msg "add it to their score area as an agenda worth 2 points"} card nil))))))}]}
 
    "London Library"
    {:abilities [{:label "Install a non-virus program on London Library"


### PR DESCRIPTION
Fixes #2055 :Removed :forfeit from cost and manually checked that :forfeit is able to be paid. Allowed for forfeiting of agenda prior to Lib Chela being added to score area.

Test failure from space camp.