### PR TITLE
Break up R&D access messages

### DIFF
--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -73,11 +73,10 @@
          [:discard] (if (= side "Runner") "Heap" "Archives")
          [:deck] (if (= side "Runner") "Stack" "R&D")
          [:rig _] "Rig"
-         [:servers :hq _] "HQ Server"
-         [:servers :rd _] "R&D Server"
-         [:servers :archives _] "Archives Server"
-         [:servers :remote id _] (str "Remote Server " id)
-         :else nil))
+         [:servers :hq _] "the root of HQ"
+         [:servers :rd _] "the root of R&D"
+         [:servers :archives _] "the root of Archives"
+         :else (zone->name (second zone))))
 
 
 ;;; In-game chat commands

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -108,27 +108,26 @@
     (if-let [trash-cost (trash-cost state side c)]
       ;; The card has a trash cost (Asset, Upgrade)
       (let [card (assoc c :seen true)
-            name (:title card)]
+            name (:title card)
+            trash-msg (str trash-cost " [Credits] to trash " name " from " (name-zone :corp (:zone card)))]
         (if (and (get-in @state [:runner :register :force-trash])
                  (can-pay? state :runner name :credit trash-cost))
           ;; If the runner is forced to trash this card (Neutralize All Threats)
           (continue-ability state :runner
-                           {:cost [:credit trash-cost]
-                            :delayed-completion true
-                            :effect (effect (trash eid card nil)
-                                            (system-msg (str "is forced to pay " trash-cost
-                                                             " [Credits] to trash " name)))} card nil)
+                            {:cost [:credit trash-cost]
+                             :delayed-completion true
+                             :effect (effect (trash eid card nil)
+                                             (system-msg (str "is forced to pay " trash-msg)))}
+                            card nil)
           ;; Otherwise, show the option to pay to trash the card.
-          (continue-ability
-            state :runner
-            {:optional
-             {:prompt (str "Pay " trash-cost "[Credits] to trash " name "?")
-              :yes-ability {:cost [:credit trash-cost]
-                            :delayed-completion true
-                            :effect (effect (trash eid card nil)
-                                            (system-msg (str "pays " trash-cost
-                                                             " [Credits] to trash " name)))}}}
-            card nil)))
+          (continue-ability state :runner
+                            {:optional
+                             {:prompt (str "Pay " trash-cost " [Credits] to trash " name "?")
+                              :yes-ability {:cost [:credit trash-cost]
+                                            :delayed-completion true
+                                            :effect (effect (trash eid card nil)
+                                                            (system-msg (str "pays " trash-msg)))}}}
+                            card nil)))
       ;; The card does not have a trash cost
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid}))
     (effect-completed state side eid)))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -309,7 +309,7 @@
                       (effect-completed state side eid nil))
                     ;; accessing a rezzed upgrade
                     (let [accessed (some #(when (= (:title %) target) %) (get-root-content state))]
-                      (when-completed (msg-handle-access state side (make-eid state) [] (:title accessed))
+                      (when-completed (msg-handle-access state side [accessed])
                                       (if (or (pos? from-hq) (< 1 (count (get-root-content state))))
                                         (continue-ability
                                           state side

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -213,7 +213,10 @@
   ([state side eid cards]
    (msg-handle-access state side eid cards (:title (first cards))))
   ([state side eid cards title]
-   (system-msg state side (str "accesses " title))
+   (system-msg state side
+               (str "accesses " title
+                    (when (pos? (count cards))
+                      (str " from " (->> cards first :zone (name-zone side))))))
    (handle-access state side eid cards)))
 
 (defn max-access


### PR DESCRIPTION
This way, R&D behaves in the same way as HQ, except the card identity is not revealed to all sides. This allows the corp to know where in the accessed cards the agenda or assets were trashed from, but also which cards force the runner to think, just as they would in a physical game.