### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -957,7 +957,8 @@
     :runner-abilities [(runner-break [:credit 1] 1)]}
 
    "Pup"
-   {:subroutines [(do-net-damage 1)]}
+   {:subroutines [(do-net-damage 1)]
+    :runner-abilities [(runner-break [:credit 1] 1)]}
 
    "Quandary"
    {:subroutines [end-the-run]}
@@ -1109,7 +1110,8 @@
     :advanceable :always
     :abilities [{:label "Gain subroutines"
                  :msg (msg "gain " (:advance-counter card 0) " subroutines")}]
-    :subroutines [trash-program]}
+    :subroutines [trash-program]
+    :runner-abilities [(runner-break [:credit 3] 1)]}
 
    "Swordsman"
    {:subroutines [(do-net-damage 1)

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -187,7 +187,8 @@
                                          {:title "/rez command"} nil))
         "/rez-all"    #(when (= %2 :corp) (command-rezall %1 %2 value))
         "/rfg"        #(resolve-ability %1 %2 {:prompt "Select a card to remove from the game"
-                                               :effect (effect (move target :rfg))
+                                               :effect (req (let [c (deactivate %1 %2 target)]
+                                                              (move %1 %2 c :rfg)))
                                                :choices {:req (fn [t] (card-is? t :side %2))}}
                                         {:title "/rfg command"} nil)
         "/move-bottom"  #(resolve-ability %1 %2 {:prompt "Select a card in hand to put on the bottom of your deck"

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -38,6 +38,7 @@
     (advance state (get-content state :remote1 0) 2)
     (take-credits state :corp)
     (run-empty-server state :remote1)
+    (prompt-choice :runner "No") ; Dismiss prompt from non-exiled Find the Truth directive
     (prompt-choice :corp "Yes")
     (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")
     (is (= 1 (count (:discard (get-corp)))) "1 card in archives")))


### PR DESCRIPTION
* Fixes failing Adam test (non-exiled Find the Truth is prompting to look at the top of R&D)
* Give Runner-activated pay credits abilities to Pup and Swarm
* Deactivate target of the `/rfg` command so an exiled Adam directive will not see its effects persist