### PR TITLE
Added test for Deja Vu, recurring non-virus and virus cards

### DIFF
--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -265,6 +265,55 @@
     (run-jack-out state)
     (is (empty? (:prompt (get-runner))) "No option to run again on unsuccessful run")))
 
+(deftest deja-vu
+  ;; Deja Vu - recur one non-virus or two virus cards
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Déjà Vu" 2)
+                               (qty "Cache" 1)
+                               (qty "Datasucker" 1)
+                               (qty "Dirty Laundry" 1)]))
+    (take-credits state :corp 3) ; pass to runner's turn
+    (trash-from-hand state :runner "Cache")
+    (trash-from-hand state :runner "Datasucker")
+    (trash-from-hand state :runner "Dirty Laundry")
+    (is (= 2 (count (:hand (get-runner)))) "Two cards in hand prior to playing Déjà Vu")
+    (play-from-hand state :runner "Déjà Vu")
+    (prompt-choice :runner (find-card "Dirty Laundry" (:discard (get-runner))))
+    (is (empty? (:prompt (get-runner))) "Recurring a non-virus card stops Déjà Vu prompting further")
+    (is (= 2 (count (:hand (get-runner)))) "Two cards in after playing Déjà Vu")
+    (play-from-hand state :runner "Déjà Vu")
+    (prompt-choice :runner (find-card "Cache" (:discard (get-runner))))
+    (is (not (empty? (:prompt (get-runner)))) "Recurring a virus card causes Déjà Vu to prompt for second virus to recur")
+    (prompt-choice :runner (find-card "Datasucker" (:discard (get-runner))))
+    (is (= 3 (count (:hand (get-runner)))) "Three cards in after playing second Déjà Vu")))
+
+(deftest demolition-run
+  ;; Demolition Run - Trash at no cost
+  (do-game
+    (new-game (default-corp [(qty "False Lead" 1)
+                             (qty "Shell Corporation" 1)
+                             (qty "Hedge Fund" 3)])
+              (default-runner [(qty "Demolition Run" 1)]))
+    (core/move state :corp (find-card "False Lead" (:hand (get-corp))) :deck) ; put False Lead back in R&D
+    (play-from-hand state :corp "Shell Corporation" "R&D") ; install upgrade with a trash cost in root of R&D
+    (take-credits state :corp 2) ; pass to runner's turn by taking credits
+    (play-from-hand state :runner "Demolition Run")
+    (is (= 3 (:credit (get-runner))) "Paid 2 credits for the event")
+    (prompt-choice :runner "R&D")
+    (is (= [:rd] (get-in @state [:run :server])) "Run initiated on R&D")
+    (prompt-choice :runner "OK") ; dismiss instructional prompt for Demolition Run
+    (run-successful state)
+    (let [demo (get-in @state [:runner :play-area 0])] ; Demolition Run "hack" is to put it out in the play area
+      (prompt-choice :runner "Unrezzed upgrade in R&D")
+      (card-ability state :runner demo 0)
+      (is (= 3 (:credit (get-runner))) "Trashed Shell Corporation at no cost")
+      (prompt-choice :runner "Card from deck")
+      (card-ability state :runner demo 0)  ; trash False Lead instead of stealing
+      (is (= 0 (:agenda-point (get-runner))) "Didn't steal False Lead")
+      (is (= 2 (count (:discard (get-corp)))) "2 cards in Archives")
+      (is (empty? (:prompt (get-runner))) "Run concluded"))))
+
 (deftest deuces-wild
   ;; Deuces Wild
   (do-game
@@ -299,32 +348,6 @@
     (is (= 1 (:tag (get-runner))) "Runner has 1 tag")
     (prompt-choice :runner "Remove 1 tag")
     (is (= 0 (:tag (get-runner))))))
-
-(deftest demolition-run
-  ;; Demolition Run - Trash at no cost
-  (do-game
-    (new-game (default-corp [(qty "False Lead" 1)
-                             (qty "Shell Corporation" 1)
-                             (qty "Hedge Fund" 3)])
-              (default-runner [(qty "Demolition Run" 1)]))
-    (core/move state :corp (find-card "False Lead" (:hand (get-corp))) :deck) ; put False Lead back in R&D
-    (play-from-hand state :corp "Shell Corporation" "R&D") ; install upgrade with a trash cost in root of R&D
-    (take-credits state :corp 2) ; pass to runner's turn by taking credits
-    (play-from-hand state :runner "Demolition Run")
-    (is (= 3 (:credit (get-runner))) "Paid 2 credits for the event")
-    (prompt-choice :runner "R&D")
-    (is (= [:rd] (get-in @state [:run :server])) "Run initiated on R&D")
-    (prompt-choice :runner "OK") ; dismiss instructional prompt for Demolition Run
-    (run-successful state)
-    (let [demo (get-in @state [:runner :play-area 0])] ; Demolition Run "hack" is to put it out in the play area
-      (prompt-choice :runner "Unrezzed upgrade in R&D")
-      (card-ability state :runner demo 0)
-      (is (= 3 (:credit (get-runner))) "Trashed Shell Corporation at no cost")
-      (prompt-choice :runner "Card from deck")
-      (card-ability state :runner demo 0)  ; trash False Lead instead of stealing
-      (is (= 0 (:agenda-point (get-runner))) "Didn't steal False Lead")
-      (is (= 2 (count (:discard (get-corp)))) "2 cards in Archives")
-      (is (empty? (:prompt (get-runner))) "Run concluded"))))
 
 (deftest dirty-laundry
   ;; Dirty Laundry - Gain 5 credits at the end of the run if it was successful


### PR DESCRIPTION
Added basic testing for Deja Vu, recurring a non-virus and a virus card and checking behaviour of the UI for both.

Would have added a check for only viruses being presented as options in testing the virus recursion, but still cutting my teeth on how to interrogate which options are returned by the UI for a prompt.

Have ensured that I've pushed all files from local repo this time! ;-)