### PR TITLE
fix Tri-maf/Rolodex damage when returning card to hand

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -953,7 +953,7 @@
                                                                   (count from) from) card nil)
                      (do (clear-wait-prompt state :corp)
                          (effect-completed state side eid card)))))
-    :leave-play (effect (mill :runner 3))}
+    :trash-effect {:effect (effect (mill :runner 3))}}
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}
@@ -1273,7 +1273,7 @@
    "Tri-maf Contact"
    {:abilities [{:cost [:click 1] :msg "gain 2 [Credits]" :once :per-turn
                  :effect (effect (gain :credit 2))}]
-    :leave-play (effect (damage eid :meat 3 {:unboostable true :card card}))}
+    :trash-effect {:effect (effect (damage eid :meat 3 {:unboostable true :card card}))}}
 
    "Tyson Observatory"
    {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "add " (:title target) " to their Grip")

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -1480,7 +1480,7 @@
   ;; Tri-maf Contact - Click for 2c once per turn; take 3 meat dmg when trashed
   (do-game
     (new-game (default-corp)
-              (default-runner [(qty "Tri-maf Contact" 2) (qty "Cache" 3)]))
+              (default-runner [(qty "Tri-maf Contact" 1) (qty "Cache" 3) (qty "Shiv" 1)]))
     (take-credits state :corp)
     (play-from-hand state :runner "Tri-maf Contact")
     (let [tmc (get-resource state 0)]
@@ -1489,8 +1489,13 @@
       (is (= 2 (:click (get-runner))) "Spent 1 click")
       (card-ability state :runner tmc 0)
       (is (= 5 (:credit (get-runner))) "No credits gained; already used this turn")
+      (core/move state :runner tmc :hand)
+      (is (= 5 (count (:hand (get-runner)))) "No meat damage")
+      (play-from-hand state :runner "Tri-maf Contact")
+      (core/gain state :runner :tag 1)
       (take-credits state :runner)
-      (core/trash state :runner tmc)
+      (core/trash-resource state :corp nil)
+      (prompt-select :corp (get-resource state 0))
       (is (= 4 (count (:discard (get-runner)))) "Took 3 meat damage"))))
 
 (deftest virus-breeding-ground-gain


### PR DESCRIPTION
Fixes #2031. 

Tri-maf and Rolodex are returned to the way they worked ages ago, using a `:trash-effect`. Updated the Tri-maf test to ensure the meat damage doesn't hit when dragging the card back to your Grip (e.g., unintentional install or a takeback), but does fire when trashed by the Corp.