### PR TITLE
Choose Adam directives before the start of the game

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -832,8 +832,8 @@
                   (fn [x] (assoc (server-card (:title target) (get-in @state [:runner :user]))
                             :zone [:identity])))
 
-               ;; enable-identity does not do everything that identity-init does
-               (identity-init state side (get-in @state [:runner :identity]))
+               ;; enable-identity does not do everything that init-identity does
+               (init-identity state side (get-in @state [:runner :identity]))
                (system-msg state side "NOTE: passive abilities (Kate, Gabe, etc) will incorrectly fire
                 if their once per turn condition was met this turn before Rebirth was played.
                 Please adjust your game state manually for the rest of this turn if necessary"))}

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -96,13 +96,6 @@
   [eid result]
   (assoc eid :result result))
 
-;; Appears to be unused???
-(def reset-value
-  {:corp {:credit 5 :bad-publicity 0
-          :hand-size-base 5 :hand-size-modification 0}
-   :runner {:credit 5 :run-credit 0 :link 0 :memory 4
-            :hand-size-base 5 :hand-size-modification 0}})
-
 (defn mulligan
   "Mulligan starting hand."
   [state side args]

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -26,7 +26,7 @@
 (defn new-game
   "Init a new game using given corp and runner. Keep starting hands (no mulligan) and start Corp's turn."
   ([corp runner] (new-game corp runner nil))
-  ([corp runner {:keys [mulligan start-as dont-start] :as args}]
+  ([corp runner {:keys [mulligan start-as dont-start-turn dont-start-game] :as args}]
     (let [states (core/init-game
                    {:gameid 1
                     :players [{:side "Corp"
@@ -36,14 +36,15 @@
                                :deck {:identity (@all-cards (:identity runner))
                                       :cards (:deck runner)}}]})
           state (second (last states))]
-      (if (#{:both :corp} mulligan)
-        (core/resolve-prompt state :corp {:choice "Mulligan"})
-        (core/resolve-prompt state :corp {:choice "Keep"}))
-      (if (#{:both :runner} mulligan)
-        (core/resolve-prompt state :runner {:choice "Mulligan"})
-        (core/resolve-prompt state :runner {:choice "Keep"}))
-      (when (not dont-start) (core/start-turn state :corp nil))
-      (when (= start-as :runner) (take-credits state :corp))
+      (when-not dont-start-game
+        (if (#{:both :corp} mulligan)
+          (core/resolve-prompt state :corp {:choice "Mulligan"})
+          (core/resolve-prompt state :corp {:choice "Keep"}))
+        (if (#{:both :runner} mulligan)
+          (core/resolve-prompt state :runner {:choice "Mulligan"})
+          (core/resolve-prompt state :runner {:choice "Keep"}))
+        (when-not dont-start-turn (core/start-turn state :corp nil))
+        (when (= start-as :runner) (take-credits state :corp)))
       state)))
 
 (defn load-all-cards []


### PR DESCRIPTION
The runner is prompted to choose 3 directives from the temporary zone before either side draws their hand. Any unused directives disappear into the aether.

Note: Due to the limitations for the choices interface, the runner is able to choose fewer than 3 directives, and currently has no way back from that.
