### PR TITLE
marginal Blackguard improvement against "additional cost to rez" cards

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -44,8 +44,26 @@
 
    "Blackguard"
    {:in-play [:memory 2]
-    :events {:expose {:msg (msg "attempt to force the rez of " (:title target))
-                      :effect (effect (rez :corp target))}}}
+    :events {:expose
+             {:msg (msg "attempt to force the rez of " (:title target))
+              :delayed-completion true
+              :effect (req (let [c target
+                                 cdef (card-def c)
+                                 cname (:title c)]
+                             (if (:additional-cost cdef)
+                               (do (show-wait-prompt state :runner (str "Corp to decide if they will rez " cname))
+                                   (continue-ability state side
+                                     {:optional
+                                      {:prompt (msg "Pay additional cost to rez " cname "?")
+                                       :player :corp
+                                       :yes-ability {:effect (effect (rez :corp c)
+                                                                     (clear-wait-prompt :runner))}
+                                       :no-ability {:effect (effect (system-msg :corp (str "declines to pay additional costs"
+                                                                                       " and is not forced to rez " cname))
+                                                                    (clear-wait-prompt :runner))}}}
+                                    card nil))
+                               (do (rez :corp target)
+                                   (effect-completed state side eid)))))}}}
 
    "Bookmark"
    {:abilities [{:label "Host up to 3 cards from your Grip facedown"


### PR DESCRIPTION
Related to #1244. Not a total fix, but this will keep the Corp from being forced to forfeit an agenda to rez Archer, Enforcer 1.0, Corporate Town, or Ibrahim Salem when they are exposed with Blackguard in play. As they have additional costs to rez, the Corp is supposed to be able to decline to pay them and thus avoid rezzing the card entirely. 