### PR TITLE
Omni-drive fix

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -515,8 +515,8 @@
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
                  :msg (msg "host " (:title target))
-                 :effect (effect (host card target))
-                         (effect (gain :memory (:memoryunits target)))}]}
+                 :effect (effect (host card target)
+                         (gain :memory (:memoryunits target)))}]}
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -516,7 +516,7 @@
                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target)
-                         (gain :memory (:memoryunits target)))}]}
+                                 (gain :memory (:memoryunits target)))}]}
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -513,6 +513,7 @@
                 {:label "Host an installed program of 1[Memory Unit] or less on Omni-drive"
                  :prompt "Choose an installed program of 1[Memory Unit] or less to host on Omni-drive"
                  :choices {:req #(and (is-type? % "Program")
+                                      (<= (:memoryunits %) 1)
                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -515,7 +515,8 @@
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
                  :msg (msg "host " (:title target))
-                 :effect (effect (host card target))}]}
+                 :effect (effect (host card target))
+                 :effect (effect (gain :memory (:memoryunits target))}]}
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -516,7 +516,7 @@
                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target))
-                 :effect (effect (gain :memory (:memoryunits target))}]}
+                 :effect (effect (gain :memory (:memoryunits target)))}]}
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -516,7 +516,7 @@
                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target))
-                 :effect (effect (gain :memory (:memoryunits target)))}]}
+                         (effect (gain :memory (:memoryunits target)))}]}
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -522,7 +522,7 @@
                                  (update! (assoc (get-card state card) :Omnidrive-prog (:cid target))))}]
    :events {:card-moved {:req (req (= (:cid target) (:Omnidrive-prog (get-card state card))))
                           :effect (effect (update! (dissoc card :Omnidrive-prog))
-                                          (lose :memory (:memoryunits target)))}}
+                                          (lose :memory (:memoryunits target)))}}}
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -509,7 +509,8 @@
                                       (in-hand? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (gain :memory (:memoryunits target))
-                                 (runner-install target {:host-card card}))}
+                                 (runner-install target {:host-card card})
+                                 (update! (assoc (get-card state card) :Omnidrive-prog (:cid target))))}
                 {:label "Host an installed program of 1[Memory Unit] or less on Omni-drive"
                  :prompt "Choose an installed program of 1[Memory Unit] or less to host on Omni-drive"
                  :choices {:req #(and (is-type? % "Program")
@@ -517,7 +518,11 @@
                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target)
-                                 (gain :memory (:memoryunits target)))}]}
+                                 (gain :memory (:memoryunits target))
+                                 (update! (assoc (get-card state card) :Omnidrive-prog (:cid target))))}]
+   :events {:card-moved {:req (req (= (:cid target) (:Omnidrive-prog (get-card state card))))
+                          :effect (effect (update! (dissoc card :Omnidrive-prog))
+                                          (lose :memory (:memoryunits target)))}}
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]


### PR DESCRIPTION
Omni-drive is missing an effect to remove the hosted card's memory from the Runner's memory when you host a card that is already in play. I've tried to make a quick fix but the code test keeps denying my changes. The most recent error is saying that the map literal contains an even number of forms. What exactly does this mean and how can I fix it.(Fixed).