### PR TITLE
stop Tri-maf/Rolodex effects from triggering when lost to damage or manually discarded

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -193,7 +193,7 @@
    "Chairman Hiro"
    {:effect (effect (lose :runner :hand-size-modification 2))
     :leave-play (effect (gain :runner :hand-size-modification 2))
-    :trash-effect {:when-unrezzed true
+    :trash-effect {:when-inactive true
                    :req (req (:access @state))
                    :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
                    :effect (effect (as-agenda :runner card 2))}}
@@ -329,7 +329,7 @@
 
    "Director Haas"
    {:in-play [:click 1 :click-per-turn 1]
-    :trash-effect {:when-unrezzed true
+    :trash-effect {:when-inactive true
                    :req (req (:access @state))
                    :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
                    :effect (effect (as-agenda :runner card 2))}}
@@ -1092,7 +1092,7 @@
    "The Board"
    {:effect (effect (lose :runner :agenda-point (count (:scored runner))))
     :leave-play (effect (gain :runner :agenda-point (count (:scored runner))))
-    :trash-effect {:when-unrezzed true
+    :trash-effect {:when-inactive true
                    :req (req (:access @state))
                    :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
                    :effect (effect (as-agenda :runner card 2))}
@@ -1153,7 +1153,7 @@
     :leave-play (req (gain state :runner :click-per-turn 1)
                      (when (= (:active-player @state) :runner)
                        (gain state :runner :click 1)))
-    :trash-effect {:when-unrezzed true
+    :trash-effect {:when-inactive true
                    :req (req (:access @state))
                    :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
                    :effect (effect (as-agenda :runner card 2))}}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -432,7 +432,8 @@
 
    "Ive Had Worse"
    {:effect (effect (draw 3))
-    :trash-effect {:req (req (#{:meat :net} target))
+    :trash-effect {:when-inactive true
+                   :req (req (#{:meat :net} target))
                    :effect (effect (draw :runner 3)) :msg "draw 3 cards"}}
 
    "Immolation Script"

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -291,7 +291,10 @@
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
-      (when (and (not disabled) (or (= (:side card) "Runner") (:rezzed card) (:when-unrezzed trash-effect)))
+      (when (and (not disabled) (or (and (= (:side card) "Runner")
+                                         (:installed card))
+                                    (:rezzed card)
+                                    (:when-inactive trash-effect)))
         (resolve-ability state side trash-effect moved-card (cons cause targets))))
     (swap! state update-in [:per-turn] dissoc (:cid moved-card))
     (effect-completed state side eid)))


### PR DESCRIPTION
Fixes #2128. 

Maybe _(pretty please?)_ this will kill off Tri-maf problems, but then again I've said that before. Tri-maf's 3 meat damage and Rolodex's "mill 3" leave play effects were changed to `:trash-effect` to solve a different kind of wrong triggering recently, but now they've been firing if you trash these cards from hand (over hand limit) or they get hit by damage. 

This adds a couple more conditions to `resolve-trash-end` so that a Runner card must be _installed_ for its `:trash-effect` to fire (solves Tri-maf and Rolodex), but also allows a card to use `:when-inactive true` in its trash effect to let it work from a player's hand (this preserves I've Had Worse functionality and the 4 Corp trashable Executives are changed to use this as well). 
