### PR TITLE
Many fixes

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -190,22 +190,30 @@
 
    "Archangel"
    {:access
-    {:req (req (not= (first (:zone card)) :discard))
+    {:delayed-completion true
+     :req (req (not= (first (:zone card)) :discard))
      :effect (effect (show-wait-prompt :runner "Corp to decide to trigger Archangel")
-                     (resolve-ability
+                     (continue-ability
                        {:optional
                         {:prompt "Pay 3 [Credits] to force Runner to encounter Archangel?"
                          :yes-ability {:cost [:credit 3]
-                                       :effect (req (system-msg state :corp "pays 3 [Credits] to force the Runner to encounter Archangel")
-                                                    (clear-wait-prompt state :runner)
-                                                    (resolve-ability state :runner
-                                                                     {:optional
-                                                                      {:player :runner
-                                                                       :prompt "Allow Archangel trace to fire?" :priority 1
-                                                                       :yes-ability {:effect (req (play-subroutine state side {:card card :subroutine 0}))}}}
-                                                                     card nil))}
-                         :no-ability {:effect (req (system-msg state :corp "declines to force the Runner to encounter Archangel")
-                                                   (clear-wait-prompt state :runner))}}} card nil))}
+                                       :delayed-completion true
+                                       :effect (effect (system-msg :corp "pays 3 [Credits] to force the Runner to encounter Archangel")
+                                                       (clear-wait-prompt :runner)
+                                                       (continue-ability
+                                                         :runner {:optional
+                                                                  {:delayed-completion true
+                                                                   :player :runner
+                                                                   :prompt "Allow Archangel trace to fire?"
+                                                                   :priority 1
+                                                                   :yes-ability {:delayed-completion true
+                                                                                 :effect (effect (play-subroutine eid {:card card :subroutine 0}))}
+                                                                   :no-ability {:effect (effect (effect-completed eid))}}}
+                                                         card nil))}
+                         :no-ability {:effect (effect (system-msg :corp "declines to force the Runner to encounter Archangel")
+                                                      (clear-wait-prompt :runner)
+                                                      (effect-completed eid))}}}
+                       card nil))}
    :subroutines [(trace-ability 6 {:choices {:req #(and (installed? %)
                                                         (card-is? % :side :runner))}
                                    :label "Add 1 installed card to the Runner's Grip"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -202,8 +202,7 @@
                                                        (clear-wait-prompt :runner)
                                                        (continue-ability
                                                          :runner {:optional
-                                                                  {:delayed-completion true
-                                                                   :player :runner
+                                                                  {:player :runner
                                                                    :prompt "Allow Archangel trace to fire?"
                                                                    :priority 1
                                                                    :yes-ability {:delayed-completion true
@@ -211,16 +210,21 @@
                                                                    :no-ability {:effect (effect (effect-completed eid))}}}
                                                          card nil))}
                          :no-ability {:effect (effect (system-msg :corp "declines to force the Runner to encounter Archangel")
-                                                      (clear-wait-prompt :runner)
-                                                      (effect-completed eid))}}}
+                                                      (clear-wait-prompt :runner))}}}
                        card nil))}
-   :subroutines [(trace-ability 6 {:choices {:req #(and (installed? %)
-                                                        (card-is? % :side :runner))}
-                                   :label "Add 1 installed card to the Runner's Grip"
-                                   :msg "add 1 installed card to the Runner's Grip"
-                                   :effect (effect (move :runner target :hand true)
-                                                   (system-msg (str "adds " (:title target)
-                                                                    " to the Runner's Grip")))})]}
+   :subroutines [(trace-ability 6 {:delayed-completion true
+                                   :effect (effect (show-wait-prompt :runner "Corp to select Archangel target")
+                                                   (continue-ability {:choices {:req #(and (installed? %)
+                                                                                           (card-is? % :side :runner))}
+                                                                      :label "Add 1 installed card to the Runner's Grip"
+                                                                      :msg "add 1 installed card to the Runner's Grip"
+                                                                      :effect (effect (clear-wait-prompt :runner)
+                                                                                      (move :runner target :hand true)
+                                                                                      (system-msg (str "adds " (:title target)
+                                                                                                       " to the Runner's Grip")))
+                                                                      :cancel-effect (effect (clear-wait-prompt :runner)
+                                                                                             (effect-completed eid))}
+                                                                     card nil))})]}
 
    "Archer"
    {:additional-cost [:forfeit]
@@ -373,22 +377,27 @@
 
    "Chrysalis"
    {:subroutines [(do-net-damage 2)]
-    :access {:req (req (not= (first (:zone card)) :discard))
+    :access {:delayed-completion true
+             :req (req (not= (first (:zone card)) :discard))
              :effect (effect (show-wait-prompt :runner "Corp to decide to trigger Chrysalis")
-                             (resolve-ability
+                             (continue-ability
                                {:optional
                                 {:req (req (not= (first (:zone card)) :discard))
                                  :prompt "Force the Runner to encounter Chrysalis?"
-                                 :yes-ability {:effect (req (system-msg state :corp "forces the Runner to encounter Chrysalis")
-                                                            (clear-wait-prompt state :runner)
-                                                            (resolve-ability state :runner
-                                                              {:optional
-                                                               {:player :runner
-                                                                :prompt "Allow Chrysalis subroutine to fire?" :priority 1
-                                                                :yes-ability {:effect (req (play-subroutine state side {:card card :subroutine 0}))}}}
-                                                             card nil))}
-                                 :no-ability {:effect (req (system-msg state :corp "declines to force the Runner to encounter Chrysalis")
-                                                           (clear-wait-prompt state :runner))}}}
+                                 :yes-ability {:delayed-completion true
+                                               :effect (effect (system-msg :corp "forces the Runner to encounter Chrysalis")
+                                                               (clear-wait-prompt :runner)
+                                                               (continue-ability
+                                                                 :runner {:optional
+                                                                          {:player :runner
+                                                                           :prompt "Allow Chrysalis subroutine to fire?"
+                                                                           :priority 1
+                                                                           :yes-ability {:delayed-completion true
+                                                                                         :effect (effect (play-subroutine eid {:card card :subroutine 0}))}
+                                                                           :no-ability {:effect (effect (effect-completed eid))}}}
+                                                                 card nil))}
+                                 :no-ability {:effect (effect (system-msg :corp "declines to force the Runner to encounter Chrysalis")
+                                                              (clear-wait-prompt :runner))}}}
                               card nil))}}
 
    "Chum"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -382,9 +382,9 @@
     :install-cost-bonus (req (if (and run (= (:server run) [:rd]) (zero? (:position run)))
                                [:credit -7 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:rd]) (zero? (:position run)))
-                   (register-successful-run state side (:server run))
-                   (swap! state update-in [:runner :prompt] rest)
-                   (handle-end-run state side)))}
+                   (when-completed (register-successful-run state side (:server run))
+                                   (do (swap! state update-in [:runner :prompt] rest)
+                                       (handle-end-run state side)))))}
 
    "Emptied Mind"
    (let [ability {:req (req (= 0 (count (:hand runner))))
@@ -528,9 +528,9 @@
     :install-cost-bonus (req (if (and run (= (:server run) [:archives]) (= 0 (:position run)))
                                [:credit -7 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:archives]) (= 0 (:position run)))
-                   (register-successful-run state side (:server run))
-                   (swap! state update-in [:runner :prompt] rest)
-                   (handle-end-run state side)))}
+                   (when-completed (register-successful-run state side (:server run))
+                                   (do (swap! state update-in [:runner :prompt] rest)
+                                       (handle-end-run state side)))))}
 
    "Hard at Work"
    (let [ability {:msg "gain 2 [Credits] and lose [Click]"
@@ -1308,9 +1308,9 @@
     :install-cost-bonus (req (if (and run (= (:server run) [:hq]) (zero? (:position run)))
                                [:credit -7 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:hq]) (zero? (:position run)))
-                   (register-successful-run state side (:server run))
-                   (swap! state update-in [:runner :prompt] rest)
-                   (handle-end-run state side)))}
+                   (when-completed (register-successful-run state side (:server run))
+                                   (do (swap! state update-in [:runner :prompt] rest)
+                                       (handle-end-run state side)))))}
 
    "Virus Breeding Ground"
    {:events {:runner-turn-begins {:effect (effect (add-counter card :virus 1))}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -458,8 +458,16 @@
                              :interactive (req true)
                              :msg (msg "access " (get-in @state [:runner :hq-access]) " card"
                                        (when (< 1 (get-in @state [:runner :hq-access])) "s") " from HQ")
-                             :effect (req (let [c (take (get-in @state [:runner :hq-access]) (shuffle (:hand corp)))]
-                                            (continue-ability state :runner (choose-access c '(:hq)) card nil)))}}}
+                             :effect (req (let [from-hq (access-count state side :hq-access)]
+                                            (continue-ability
+                                              state side
+                                              (access-helper-hq
+                                                state from-hq
+                                                ; access-helper-hq uses a set to keep track of which cards have already
+                                                ; been accessed. by adding HQ root's contents to this set, we make the runner
+                                                ; unable to access those cards, as Gang Sign intends.
+                                                (set (get-in @state [:corp :servers :hq :content])))
+                                              card nil)))}}}
 
    "Gene Conditioning Shoppe"
    {:msg "make Genetics trigger a second time each turn"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -200,14 +200,15 @@
 
 (defn play-subroutine
   "Triggers a card's subroutine using its zero-based index into the card's card-def :subroutines vector."
-  [state side {:keys [card subroutine targets] :as args}]
-  (let [cdef (card-def card)
-        sub (get-in cdef [:subroutines subroutine])
-        cost (:cost sub)]
-    (when (or (nil? cost)
-              (apply can-pay? state side (:title card) cost))
-      (when-let [activatemsg (:activatemsg sub)] (system-msg state side activatemsg))
-      (resolve-ability state side sub card targets))))
+  ([state side args] (play-subroutine state side (make-eid state) args))
+  ([state side eid {:keys [card subroutine targets] :as args}]
+   (let [cdef (card-def card)
+         sub (get-in cdef [:subroutines subroutine])
+         cost (:cost sub)]
+     (when (or (nil? cost)
+               (apply can-pay? state side (:title card) cost))
+       (when-let [activatemsg (:activatemsg sub)] (system-msg state side activatemsg))
+       (resolve-ability state side eid sub card targets)))))
 
 ;;; Corp actions
 (defn trash-resource

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -143,6 +143,11 @@
                                             (rez state side c {:ignore-cost :all-costs :force true}))))}}}
     {:title "/rez-all command"} nil))
 
+(defn command-close-prompt [state side]
+  (when-let [fprompt (-> @state side :prompt first)]
+    (swap! state update-in [side :prompt] rest)
+    (effect-completed state side (:eid fprompt))))
+
 (defn parse-command [text]
   (let [[command & args] (split text #" ");"
         value (if-let [n (string->num (first args))] n 1)
@@ -179,7 +184,7 @@
         "/end-run"    #(when (= %2 :corp) (end-run %1 %2))
         "/discard"    #(move %1 %2 (nth (get-in @%1 [%2 :hand]) num nil) :discard)
         "/deck"       #(move %1 %2 (nth (get-in @%1 [%2 :hand]) num nil) :deck {:front true})
-        "/close-prompt" #(swap! %1 update-in [%2 :prompt] rest)
+        "/close-prompt" #(command-close-prompt %1 %2)
         "/rez"        #(when (= %2 :corp)
                         (resolve-ability %1 %2 {:effect (effect (rez target {:ignore-cost :all-costs :force true}))
                                                 :choices {:req (fn [t] (card-is? t :side %2))}}

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -463,7 +463,7 @@
   (system-msg state side (str "exposes " (card-str state target {:visible true})))
   (if-let [ability (:expose (card-def target))]
     (when-completed (resolve-ability state side ability target nil)
-                    (trigger-event-sync state side eid :expose target))
+                    (trigger-event-sync state side (make-result eid true) :expose target))
     (trigger-event-sync state side (make-result eid true) :expose target)))
 
 (defn expose

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -401,6 +401,19 @@
       (is (= 1 (count (get-in @state [:corp :servers :remote3 :content])))
           "Project Atlas not trashed from Server 3"))))
 
+(deftest drive-by-psychic-field
+  ;; Drive By - Psychic Field trashed after psi game. Issue #2127.
+  (do-game
+    (new-game (default-corp [(qty "Psychic Field" 1)])
+              (default-runner [(qty "Drive By" 3)]))
+    (play-from-hand state :corp "Psychic Field" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Drive By")
+    (prompt-select :runner (get-content state :remote1 0))
+    (prompt-choice :corp "0 [Credits]")
+    (prompt-choice :runner "1 [Credits]")
+    (is (empty? (get-content state :remote1)) "Psychic Field trashed")))
+
 (deftest employee-strike-blue-sun
   ;; Employee Strike - vs Blue Sun, suppress Step 1.2
   (do-game

--- a/src/clj/test/cards/ice.clj
+++ b/src/clj/test/cards/ice.clj
@@ -22,6 +22,23 @@
       (is (not (:run @state)) "Run is ended")
       (is (get-in @state [:runner :register :unsuccessful-run]) "Run was unsuccessful"))))
 
+(deftest archangel
+  ;; Archangel - accessing from R&D does not cause run to hang.
+  (do-game
+    (new-game (default-corp [(qty "Archangel" 1) (qty "Hedge Fund" 1)])
+              (default-runner [(qty "Bank Job" 1)]))
+    (starting-hand state :corp ["Hedge Fund"])
+    (take-credits state :corp)
+    (play-from-hand state :runner "Bank Job")
+    (run-empty-server state :rd)
+    (prompt-choice :corp "Yes")
+    (prompt-choice :runner "Yes")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (prompt-select :corp (get-resource state 0))
+    (prompt-choice :runner "OK")
+    (is (not (:run @state)) "Run ended")))
+
 (deftest architect-untrashable
   ;; Architect is untrashable while installed and rezzed, but trashable if derezzed or from HQ
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -430,6 +430,25 @@
     (prompt-choice :corp "1 [Credits]")
     (is (not (:run @state)) "Run ended")))
 
+(deftest laramy-fisk-shards
+  ;; Laramy Fisk - installing a Shard should still give option to force Corp draw.
+  (do-game
+    (new-game
+      (default-corp [(qty "Hedge Fund" 3) (qty "Eli 1.0" 3)])
+      (make-deck "Laramy Fisk: Savvy Investor" [(qty "Eden Shard" 1)]))
+    (starting-hand state :corp ["Hedge Fund" "Hedge Fund" "Hedge Fund" "Eli 1.0" "Eli 1.0"])
+    (take-credits state :corp)
+    (run-on state "R&D")
+    (core/no-action state :corp nil)
+    ;; at Successful Run stage -- click Eden Shard to install
+    (play-from-hand state :runner "Eden Shard")
+    (is (= 5 (:credit (get-runner))) "Eden Shard install was free")
+    (is (= "Eden Shard" (:title (get-resource state 0))) "Eden Shard installed")
+    (is (= "Identity" (-> (get-runner) :prompt first :card :type)) "Fisk prompt showing")
+    (prompt-choice :runner "Yes")
+    (is (not (:run @state)) "Run ended")
+    (is (= 6 (count (:hand (get-corp)))) "Corp forced to draw")))
+
 (deftest leela-gang-sign-complicated
   ;; Leela Patel - complicated interaction with mutiple Gang Sign
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -208,6 +208,7 @@
     (take-credits state :runner)
     (play-from-hand state :corp "15 Minutes" "New remote")
     (score-agenda state :corp (get-content state :remote1 0))
+    (prompt-choice :runner "Card from hand")
     (prompt-choice :runner "Steal")
     (is (= 2 (:agenda-point (get-runner))) "Steal prevention didn't carry over to Corp turn")))
 


### PR DESCRIPTION
Fix #2127 by correctly setting the async result after exposing a card with an on-expose effect.

Fix #2113 by tricking the access helper into thinking all the cards in HQ root were already accessed.

Fix #2046 by making `close-prompt` trigger the closed prompt as "effect completed".

Fix #2070 by reworking Archangel's `:access` effect to use delayed completion.

Fix an issue reported in chat involving installing Shards as Laramy Fisk leading to an infinite loop.