### PR TITLE
Four Intervention cards

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -398,6 +398,9 @@
    {:msg (msg "draw " (- (hand-size state :runner) (count (:hand runner))) " cards")
     :effect (effect (draw (- (hand-size state :runner) (count (:hand runner)))))}
 
+   "Government Investigations"
+   {:flags {:psi-prevent-spend (req (prn "GI") 2)}}
+
    "Hacktivist Meeting"
    {:events {:rez {:req (req (and (not (ice? target)) (< 0 (count (:hand corp)))))
                    ;; FIXME the above condition is just a bandaid, proper fix would be preventing the rez altogether

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -399,7 +399,7 @@
     :effect (effect (draw (- (hand-size state :runner) (count (:hand runner)))))}
 
    "Government Investigations"
-   {:flags {:psi-prevent-spend (req (prn "GI") 2)}}
+   {:flags {:psi-prevent-spend (req 2)}}
 
    "Hacktivist Meeting"
    {:events {:rez {:req (req (and (not (ice? target)) (< 0 (count (:hand corp)))))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -763,6 +763,19 @@
                     (damage eid :meat 2 {:card card}))
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-runner))}
 
+   "Top Hat"
+   (letfn [(ability [n]
+             {:delayed-completion true
+              :mandatory true
+              :prompt "Which card from the top of R&D would you like to access? (Card 1 is on top.)"
+              :choices (take n ["1" "2" "3" "4" "5"])
+              :effect (effect (handle-access eid [(nth (:deck corp) (dec (Integer/parseInt target)))]))})]
+     {:events {:successful-run
+               {:req (req (= target :rd))
+                :optional {:prompt "Use Top Hat to choose one of the top 5 cards in R&D to access?"
+                           :yes-ability {:effect (req (swap! state assoc-in [:run :run-effect :replace-access]
+                                                             (ability (count (:deck corp)))))}}}}})
+
    "Turntable"
    {:in-play [:memory 1]
     :events {:agenda-stolen

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -707,6 +707,17 @@
                  :effect (effect (prompt! card (str "The top card of R&D is " (:title (first (:deck corp)))) ["OK"] {})
                                  (trash card {:cause :ability-cost}))}]}
 
+   "The Gauntlet"
+   {:in-play [:memory 2]
+    :events {:successful-run {:req (req (= :hq target))
+                              :silent (req true)
+                              :prompt "How many ice protecting HQ did you break all subroutines on?"
+                              ; HACK ALERT - :number needs an upper limit. we don't track "broke all subroutines"
+                              ; events, so we can't put an accurate upper limit here. The higher the upper limit,
+                              ; the more entries in the UI drop-down list. 10 seems OK.
+                              :choices {:number (req 10)}
+                              :effect (effect (access-bonus target))}}}
+
    "The Personal Touch"
    {:hosting {:req #(and (has-subtype? % "Icebreaker")
                          (installed? %))}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -312,6 +312,19 @@
                                         (move state side card
                                               (conj (server->zone state target) :ices)))})]}
 
+   "Bulwark"
+   {:effect take-bad-pub
+    :abilities [{:msg "gain 2[Credits] if there is an installed AI"
+                 :req (req (some #(has-subtype? % "AI") (all-installed state :runner)))
+                 :effect (effect (gain :credit 2))}]
+    :subroutines [(assoc trash-program :player :runner
+                                       :msg "force the Runner to trash 1 program"
+                                       :label "The runner trashes 1 program")
+                  {:msg "gain 2[Credits] and end the run"
+                   :effect (effect (gain :credit 2)
+                                   (end-run))}]}
+
+
    "Burke Bugs"
    {:subroutines [(trace-ability 0 (assoc trash-program :not-distinct true
                                                         :player :runner

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -59,12 +59,13 @@
 
 (defn all-active
   "Returns a vector of all active cards for the given side. Active cards are either installed, the identity,
-  or the corp's scored area."
+  currents, or the corp's scored area."
   [state side]
   (if (= side :runner)
-    (cons (get-in @state [:runner :identity]) (all-installed state side))
+    (cons (get-in @state [:runner :identity]) (concat (get-in @state [:runner :current]) (all-installed state side)))
     (cons (get-in @state [:corp :identity]) (filter #(not (:disabled %))
                                                     (concat (all-installed state side)
+                                                            (get-in @state [:corp :current])
                                                             (get-in @state [:corp :scored]))))))
 
 (defn installed-byname


### PR DESCRIPTION
Bulwark (nothing notable).

Government Investigation. (Improve `all-active` to return currents. Add a card flag to restrict specific bets on psi games.)

Top Hat. (Was pleasantly surprised that this worked first try. Shows optional prompt on successful R&D run. If yes, replaces access with a mandatory "pick a card, any card" routine. Run does not end until a card is chosen.)

The Gauntlet. (We don't have a way to track "how many ice you broke all subroutines on". It's more complicated than counting the ice protecting HQ, thanks to the Bird breakers, Cutlery, etc.  So we just ask the runner. Unfortunately the `:number` UI for prompts requires an upper limit, so I fixed that at 10. I'm open to better suggestions, noting that the higher the number, the longer and more unwieldy the UI list becomes.)