### PR TITLE
Remove a flex setting to fix layout on Chrome

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1525,7 +1525,6 @@ nav ul
           margin-top: auto
 
       .runner-centrals
-        flex(0)
         padding: 5px 0
         display-flex()
 


### PR DESCRIPTION
Not sure why I put the `flex(0)` in there, but it seems to be fine without it.