### PR TITLE
Frantic coding

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -290,9 +290,7 @@
                                                                 (system-msg (str "reveals and trashes "
                                                                                  (:title topcard))))}}} card nil)
                      (do (trash state side topcard {:unpreventable true})
-                         (system-msg
-                           state side
-                           (str "reveals and trashes " (:title topcard)))))))}
+                         (system-msg state side (str "reveals and trashes " (:title topcard)))))))}
 
    "Exclusive Party"
    {:msg (msg "draw 1 card and gain "

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -380,6 +380,33 @@
     :effect (effect (forfeit target) (gain :corp :bad-publicity 1))
     :msg (msg "forfeit " (:title target) " and give the Corp 1 bad publicity")}
 
+   "Frantic Coding"
+   {:effect (req (let [topten (take 10 (:deck runner))]
+                   (prompt! state :runner card (str "The top 10 cards of the Stack are "
+                                                    (join ", " (map :title topten))) ["OK"] {})
+                   (resolve-ability
+                     state side
+                     {:prompt "Install a program?"
+                      :choices (conj (vec (sort-by :title (filter #(and (is-type? % "Program")
+                                                                        (can-pay? state side nil
+                                                                                  (modified-install-cost
+                                                                                    state side % [:credit -5])))
+                                                                  topten))) "No install")
+                      :effect (req (if (not= target "No install")
+                                     (do (install-cost-bonus state side [:credit -5])
+                                         (runner-install state side target)
+                                         (doseq [c (remove (fn [installed] (= (:cid installed) (:cid target))) topten)]
+                                           (trash state side c {:unpreventable true}))
+                                         (system-msg
+                                           state side
+                                           (str "trashes " (join ", " (map :title (remove (fn [installed]
+                                                                                            (= (:cid installed)
+                                                                                               (:cid target))) topten))))))
+                                     (do (doseq [c topten] (trash state side c {:unpreventable true}))
+                                         (system-msg
+                                           state side
+                                           (str "trashes " (join ", " (map :title topten)))))))} card nil)))}
+
    "\"Freedom Through Equality\""
    {:events {:agenda-stolen {:msg "add it to their score area as an agenda worth 1 agenda point"
                              :effect (effect (as-agenda :runner card 1))}}}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -276,17 +276,23 @@
                                  :effect (effect (resolve-ability (es) card nil))}} card))})
 
    "Eureka!"
-   {:effect
-    (req (let [topcard (first (:deck runner))
-               caninst (some #(= % (:type topcard)) '("Hardware" "Resource" "Program"))
-               cost (min 10 (:cost topcard))]
-           (when caninst
-             (do (gain state side :credit cost)
-                 (runner-install state side topcard)))
-           (when (get-card state topcard) ; only true if card was not installed
-             (do (system-msg state side (str "reveals and trashes " (:title topcard)))
-                 (trash state side topcard)
-                 (when caninst (lose state side :credit cost))))))}
+   {:effect (req (let [topcard (first (:deck runner))
+                       caninst (or (is-type? topcard "Hardware")
+                                   (is-type? topcard "Program")
+                                   (is-type? topcard "Resource"))]
+                   (if caninst
+                     (resolve-ability
+                       state side
+                       {:optional {:prompt (msg "Install " (:title topcard) "?")
+                                   :yes-ability {:effect (effect (install-cost-bonus [:credit -10])
+                                                                 (runner-install topcard))}
+                                   :no-ability {:effect (effect (trash topcard {:unpreventable true})
+                                                                (system-msg (str "reveals and trashes "
+                                                                                 (:title topcard))))}}} card nil)
+                     (do (trash state side topcard {:unpreventable true})
+                         (system-msg
+                           state side
+                           (str "reveals and trashes " (:title topcard)))))))}
 
    "Exclusive Party"
    {:msg (msg "draw 1 card and gain "

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -426,6 +426,46 @@
     (take-credits state :runner)
     (is (not (:corp-phase-12 @state)) "Employee Strike suppressed Blue Sun step 1.2")))
 
+(deftest frantic-coding-install
+  ;; Frantic Coding - Install 1 program, other 9 cards are trashed
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Frantic Coding" 1) (qty "Torch" 1) (qty "Corroder" 1)
+                               (qty "Magnum Opus" 1) (qty "Daily Casts" 2) (qty "Sure Gamble" 2)
+                               (qty "John Masanori" 1) (qty "Amped Up" 1) (qty "Wanton Destruction" 1)]))
+    (starting-hand state :runner ["Frantic Coding"])
+    (take-credits state :corp)
+    (play-from-hand state :runner "Frantic Coding")
+    (prompt-choice :runner "OK")
+    (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
+          prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
+      (is (= (list "Corroder" "Magnum Opus" nil) (prompt-names)) "No Torch in list because can't afford")
+      (is (= 2 (:credit (get-runner))))
+      (is (= 1 (count (:discard (get-runner)))))
+      (prompt-choice :runner (find-card "Magnum Opus" (:deck (get-runner))))
+      (is (= 1 (count (get-in @state [:runner :rig :program]))))
+      (is (= 2 (:credit (get-runner))) "Magnum Opus installed for free")
+      (is (= 10 (count (:discard (get-runner))))))))
+
+(deftest frantic-coding-noinstall
+  ;; Frantic Coding - Don't install anything, all 10 cards are trashed
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Frantic Coding" 1) (qty "Torch" 1) (qty "Corroder" 1)
+                               (qty "Magnum Opus" 1) (qty "Daily Casts" 2) (qty "Sure Gamble" 2)
+                               (qty "John Masanori" 1) (qty "Amped Up" 1) (qty "Wanton Destruction" 1)]))
+    (starting-hand state :runner ["Frantic Coding"])
+    (take-credits state :corp)
+    (play-from-hand state :runner "Frantic Coding")
+    (prompt-choice :runner "OK")
+    (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
+          prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
+      (is (= (list "Corroder" "Magnum Opus" nil) (prompt-names)) "No Torch in list because can't afford")
+      (is (= 1 (count (:discard (get-runner)))))
+      (prompt-choice :runner "No install")
+      (is (= 0 (count (get-in @state [:runner :rig :program]))))
+      (is (= 11 (count (:discard (get-runner))))))))
+
 (deftest freelance-coding-contract
   ;; Freelance Coding Contract - Gain 2 credits per program trashed from Grip
   (do-game

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -426,6 +426,23 @@
     (take-credits state :runner)
     (is (not (:corp-phase-12 @state)) "Employee Strike suppressed Blue Sun step 1.2")))
 
+(deftest eureka!
+  ;; Eureka! - Install the program but trash the event
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Eureka!" 2) (qty "Torch" 1) (qty "Sure Gamble" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 1)
+    (core/move state :runner (find-card "Torch" (:hand (get-runner))) :deck)
+    (play-from-hand state :runner "Eureka!")
+    (prompt-choice :runner "Yes")
+    (is (= 3 (:credit (get-runner))))
+    (is (= 1 (count (get-in @state [:runner :rig :program]))))
+    (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
+    (play-from-hand state :runner "Eureka!")
+    (is (= 0 (:credit (get-runner))))
+    (is (= 3 (count (:discard (get-runner)))))))
+
 (deftest frantic-coding-install
   ;; Frantic Coding - Install 1 program, other 9 cards are trashed
   (do-game


### PR DESCRIPTION
So I guess there's the possibility that if the runner had recurring credits and didn't take them before playing frantic coding, something they could possibly install wouldn't be on the list since i populate the list of installable targets at the time the card is played but it's not a huge deal and I'm not sure how best to deal with it. This situation is gonna come up a lot more with Net Mercur.

Also updated Eureka which is a similar card.