### PR TITLE
HB: Architects of Tomorrow, MVT, Mother Goddess tweaks

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -920,17 +920,19 @@
                    :effect (req (corp-install state side target (zone->name (first (:server run))) {:no-install-cost true}))}]}
 
    "Mother Goddess"
-   (let [ab {:req (req (ice? target))
-             :effect (effect (update! (let [subtype (->> (mapcat :ices (flatten (seq (:servers corp))))
-                                                         (filter #(and (:rezzed %) (not= (:cid card) (:cid %))))
-                                                         (mapcat #(split (:subtype %) #" - "))
-                                                         (cons "Mythic")
-                                                         distinct
-                                                         (join " - "))]
-                                        (assoc card :subtype-target (remove-subtypes subtype "Mythic")
-                                                    :subtype subtype))))}]
-     {:subroutines [end-the-run]
-      :events {:rez ab :trash ab :derez ab}})
+   (let [ab (effect (update! (let [subtype (->> (mapcat :ices (flatten (seq (:servers corp))))
+                                                (filter #(and (rezzed? %) (not= (:cid card) (:cid %))))
+                                                (mapcat #(split (:subtype %) #" - "))
+                                                (cons "Mythic")
+                                                distinct
+                                                (join " - "))]
+                               (assoc card :subtype-target (remove-subtypes subtype "Mythic")
+                                           :subtype subtype))))
+         mg {:req (req (ice? target))
+             :effect ab}]
+     {:effect ab
+      :subroutines [end-the-run]
+      :events {:rez mg :trash mg :derez mg}})
 
    "Muckraker"
    {:effect take-bad-pub

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -437,7 +437,7 @@
    "Leela Patel: Trained Pragmatist"
    (let [leela {:interactive (req true)
                 :prompt "Select an unrezzed card to return to HQ"
-                :choices {:req #(and (not (:rezzed %)) (card-is? % :side :corp))}
+                :choices {:req #(and (not (rezzed? %)) (installed? %) (card-is? % :side :corp))}
                 :msg (msg "add " (card-str state target) " to HQ")
                 :effect (final-effect (move :corp target :hand))}]
      {:flags {:slow-hq-access (req true)}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -230,18 +230,16 @@
               :delayed-completion true
               :req (req (and (rezzed? target)
                              (has-subtype? target "Bioroid")))
-              :effect (req (if (some #(and (has-subtype? % "Bioroid") (not (rezzed? %))) (all-installed state :corp))
-                             (do (show-wait-prompt state :runner "Corp to use Haas-Bioroid: Architects of Tomorrow")
-                                 (continue-ability state side
-                                                   {:prompt "Choose a bioroid to rez" :player :corp
-                                                    :choices {:req #(and (has-subtype? % "Bioroid") (not (rezzed? %)))}
-                                                    :msg (msg "rez " (:title target))
-                                                    :cancel-effect (final-effect (clear-wait-prompt :runner))
-                                                    :effect (effect (rez-cost-bonus -4)
-                                                                    (rez target)
-                                                                    (clear-wait-prompt :runner))}
-                                                   card nil))
-                             (effect-completed state side eid)))}}}
+              :effect (effect (show-wait-prompt :runner "Corp to use Haas-Bioroid: Architects of Tomorrow")
+                              (continue-ability
+                                {:prompt "Choose a bioroid to rez" :player :corp
+                                 :choices {:req #(and (has-subtype? % "Bioroid") (not (rezzed? %)))}
+                                 :msg (msg "rez " (:title target))
+                                 :cancel-effect (final-effect (clear-wait-prompt :runner))
+                                 :effect (effect (rez-cost-bonus -4)
+                                                 (rez target)
+                                                 (clear-wait-prompt :runner))}
+                               card nil))}}}
 
    "Haas-Bioroid: Engineering the Future"
    {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -282,7 +282,7 @@
                               (toast state :runner
                                      (str "You must trash Mumbad Virtual Tour, if able, using any available means "
                                           "(Whizzard, Imp, Ghost Runner, Net Celebrity...)")))))}
-    :trash-effect {:when-unrezzed true
+    :trash-effect {:when-inactive true
                    :effect (req (swap! state assoc-in [:runner :register :force-trash] false))}}
 
    "NeoTokyo Grid"


### PR DESCRIPTION
* Fixes #2133: Mother Goddess needs to gain subtypes immediately upon rez so Paperclip and Black Orchestra will prompt the Runner for install from the heap.
* Fixes #2140: AoT isn't firing if no unrezzed Bioroids exist, which is giving the Runner a small clue they shouldn't have. 
* Fixes #2162: Mumbad Virtual Tour is using an outdated key for its trash effect to work even when unrezzed.
* Fixes #2163: Leela Patel should not be able to target the Corp identity card with her ability