### PR TITLE
Targeted Marketing fix

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -126,7 +126,7 @@
     (if (not= choice "Cancel")
       (if (:card-title choices) ; check the card has a :card-title function
         (let [title-fn (:card-title choices)
-              found (some #(when (= (lower-case choice) (lower-case (:title %))) %) (vals @all-cards))]
+              found (some #(when (= (lower-case choice) (lower-case (:title % ""))) %) (vals @all-cards))]
           (if found
             (if (title-fn state side (make-eid state) (:card prompt) [found])
               (do ((:effect prompt) (or choice card))


### PR DESCRIPTION
I still believe this is an issue with the database on live, as the only possible NPE on the line reported in #2154 etc. is if the `:title` of one of the entries in `@all-cards` is `nil`. This check will coerce a nil title to the empty string, so `lower-case` won't throw.