### PR TITLE
fix #561: dont show card text when img-url present

### DIFF
--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -38,39 +38,45 @@
       (make-span "\\[Trash\\]" "trash")))
 
 (defn card-view [card owner]
-  (om/component
-   (sab/html
-    [:div.card-preview.blue-shade
-     [:h4 (:title card)]
-     (when-let [memory (:memoryunits card)]
-       (if (< memory 3)
-         [:div.anr-icon {:class (str "mu" memory)} ""]
-         [:div.heading (str "Memory: " memory) [:span.anr-icon.mu]]))
-     (when-let [cost (:cost card)]
-       [:div.heading (str "Cost: " cost)])
-     (when-let [trash-cost (:trash card)]
-       [:div.heading (str "Trash cost: " trash-cost)])
-     (when-let [strength (:strength card)]
-       [:div.heading (str "Strength: " strength)])
-     (when-let [requirement (:advancementcost card)]
-       [:div.heading (str "Advancement requirement: " requirement)])
-     (when-let [agenda-point (:agendatpoints card)]
-       [:div.heading (str "Agenda points: " agenda-point)])
-     (when-let [min-deck-size (:minimumdecksize card)]
-       [:div.heading (str "Minimum deck size: " min-deck-size)])
-     (when-let [influence-limit (:influencelimit card)]
-       [:div.heading (str "Influence limit: " influence-limit)])
-     (when-let [influence (:factioncost card)]
-       [:div.heading "Influence "
-        [:span.influence
-         {:dangerouslySetInnerHTML #js {:__html (apply str (for [i (range influence)] "&#8226;"))}
-          :class (-> card :faction .toLowerCase (.replace " " "-"))}]])
-     [:div.text
-      [:p [:span.type (str (:type card))] (if (empty? (:subtype card))
-                                            "" (str ": " (:subtype card)))]
-      [:pre {:dangerouslySetInnerHTML #js {:__html (add-symbols (:text card))}}]]
-     (when-let [url (image-url card)]
-       [:img {:src url :onError #(-> % .-target js/$ .hide) :onLoad #(-> % .-target js/$ .show)}])])))
+      (om/component
+        (sab/html
+          (conj [:div.card-preview.blue-shade]
+                (if-let [url (image-url card)]
+                        [:img {:src url :onError #(-> % .-target js/$ .hide) :onLoad #(-> % .-target js/$ .show)}]
+                        (card-text-view card owner)))
+          )))
+
+(defn card-text-view [card owner]
+      [:h4 (:title card)]
+      (when-let [memory (:memoryunits card)]
+                (if (< memory 3)
+                  [:div.anr-icon {:class (str "mu" memory)} ""]
+                  [:div.heading (str "Memory: " memory) [:span.anr-icon.mu]]))
+      (when-let [cost (:cost card)]
+                [:div.heading (str "Cost: " cost)])
+      (when-let [trash-cost (:trash card)]
+                [:div.heading (str "Trash cost: " trash-cost)])
+      (when-let [strength (:strength card)]
+                [:div.heading (str "Strength: " strength)])
+      (when-let [requirement (:advancementcost card)]
+                [:div.heading (str "Advancement requirement: " requirement)])
+      (when-let [agenda-point (:agendatpoints card)]
+                [:div.heading (str "Agenda points: " agenda-point)])
+      (when-let [min-deck-size (:minimumdecksize card)]
+                [:div.heading (str "Minimum deck size: " min-deck-size)])
+      (when-let [influence-limit (:influencelimit card)]
+                [:div.heading (str "Influence limit: " influence-limit)])
+      (when-let [influence (:factioncost card)]
+                [:div.heading "Influence "
+                 [:span.influence
+                  {:dangerouslySetInnerHTML #js {:__html (apply str (for [i (range influence)] "&#8226;"))}
+                   :class (-> card :faction .toLowerCase (.replace " " "-"))}]])
+      [:div.text
+       [:p [:span.type (str (:type card))] (if (empty? (:subtype card))
+                                             "" (str ": " (:subtype card)))]
+
+       [:pre {:dangerouslySetInnerHTML #js {:__html (add-symbols (:text card))}}]
+       ])
 
 (defn types [side]
   (let [runner-types ["Identity" "Program" "Hardware" "Resource" "Event"]

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -38,45 +38,47 @@
       (make-span "\\[Trash\\]" "trash")))
 
 (defn card-view [card owner]
-      (om/component
-        (sab/html
-          (conj [:div.card-preview.blue-shade]
-                (if-let [url (image-url card)]
-                        [:img {:src url :onError #(-> % .-target js/$ .hide) :onLoad #(-> % .-target js/$ .show)}]
-                        (card-text-view card owner)))
-          )))
-
-(defn card-text-view [card owner]
-      [:h4 (:title card)]
-      (when-let [memory (:memoryunits card)]
-                (if (< memory 3)
-                  [:div.anr-icon {:class (str "mu" memory)} ""]
-                  [:div.heading (str "Memory: " memory) [:span.anr-icon.mu]]))
-      (when-let [cost (:cost card)]
-                [:div.heading (str "Cost: " cost)])
-      (when-let [trash-cost (:trash card)]
-                [:div.heading (str "Trash cost: " trash-cost)])
-      (when-let [strength (:strength card)]
-                [:div.heading (str "Strength: " strength)])
-      (when-let [requirement (:advancementcost card)]
-                [:div.heading (str "Advancement requirement: " requirement)])
-      (when-let [agenda-point (:agendatpoints card)]
-                [:div.heading (str "Agenda points: " agenda-point)])
-      (when-let [min-deck-size (:minimumdecksize card)]
-                [:div.heading (str "Minimum deck size: " min-deck-size)])
-      (when-let [influence-limit (:influencelimit card)]
-                [:div.heading (str "Influence limit: " influence-limit)])
-      (when-let [influence (:factioncost card)]
-                [:div.heading "Influence "
-                 [:span.influence
-                  {:dangerouslySetInnerHTML #js {:__html (apply str (for [i (range influence)] "&#8226;"))}
-                   :class (-> card :faction .toLowerCase (.replace " " "-"))}]])
-      [:div.text
-       [:p [:span.type (str (:type card))] (if (empty? (:subtype card))
-                                             "" (str ": " (:subtype card)))]
-
-       [:pre {:dangerouslySetInnerHTML #js {:__html (add-symbols (:text card))}}]
-       ])
+      (reify
+        om/IInitState
+        (init-state [_] {:showText false})
+        om/IRenderState
+        (render-state [_ state]
+                      (let [ifShowText #(when (:showText state) %)]
+                           (sab/html
+                             [:div.card-preview.blue-shade
+                              (ifShowText [:h4 (:title card)])
+                              (ifShowText (when-let [memory (:memoryunits card)]
+                                                    (if (< memory 3)
+                                                      [:div.anr-icon {:class (str "mu" memory)} ""]
+                                                      [:div.heading (str "Memory: " memory) [:span.anr-icon.mu]])))
+                              (ifShowText (when-let [cost (:cost card)]
+                                                    [:div.heading (str "Cost: " cost)]))
+                              (ifShowText (when-let [trash-cost (:trash card)]
+                                                    [:div.heading (str "Trash cost: " trash-cost)]))
+                              (ifShowText (when-let [strength (:strength card)]
+                                                    [:div.heading (str "Strength: " strength)]))
+                              (ifShowText (when-let [requirement (:advancementcost card)]
+                                                    [:div.heading (str "Advancement requirement: " requirement)]))
+                              (ifShowText (when-let [agenda-point (:agendatpoints card)]
+                                                    [:div.heading (str "Agenda points: " agenda-point)]))
+                              (ifShowText (when-let [min-deck-size (:minimumdecksize card)]
+                                                    [:div.heading (str "Minimum deck size: " min-deck-size)]))
+                              (ifShowText (when-let [influence-limit (:influencelimit card)]
+                                                    [:div.heading (str "Influence limit: " influence-limit)]))
+                              (ifShowText (when-let [influence (:factioncost card)]
+                                                    [:div.heading "Influence "
+                                                     [:span.influence
+                                                      {:dangerouslySetInnerHTML #js {:__html (apply str (for [i (range influence)] "&#8226;"))}
+                                                       :class                   (-> card :faction .toLowerCase (.replace " " "-"))}]]))
+                              (ifShowText [:div.text
+                                           [:p [:span.type (str (:type card))] (if (empty? (:subtype card))
+                                                                                 "" (str ": " (:subtype card)))]
+                                           [:pre {:dangerouslySetInnerHTML #js {:__html (add-symbols (:text card))}}]])
+                              (when-not (:showText state) (when-let [url (image-url card)]
+                                                                    [:img {:src url
+                                                                           :onError #(-> (om/set-state! owner {:showText true}))
+                                                                           :onLoad #(-> % .-target js/$ .show)}]))
+                              ])))))
 
 (defn types [side]
   (let [runner-types ["Identity" "Program" "Hardware" "Resource" "Event"]


### PR DESCRIPTION
fixes #561 

<img width="360" alt="screen shot 2016-11-11 at 11 58 28 pm" src="https://cloud.githubusercontent.com/assets/3835755/20236072/47e2b458-a8fb-11e6-8ed5-98420d7d041b.png">

<img width="308" alt="screen shot 2016-11-12 at 3 55 50 pm" src="https://cloud.githubusercontent.com/assets/3835755/20236068/36ebc23e-a8fb-11e6-93fa-b2eeda872047.png">

Previously we were rendering the card text and then putting the img over the top of this.
When the card text was long this would result in card text being visible at the bottom.
We now only show the card text if we are unable to create the img url for the card.

