### PR TITLE
Make secondary-pane z index 1

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1436,6 +1436,7 @@ nav ul
 
   .secondary-pane
     width: 186px
+    z-index: 1
     justify-content(space-between)
     display-flex()
     flex-direction(column)


### PR DESCRIPTION
I noticed that when you have a logos trigger with a diverse deck, the prompt to select a card is rendered underneath your hand making some cards not selectable.


This PR is just a CSS change to move the secondary pane to +1 z level so that it will get rendered over top of the players hand. 


Before:
<img width="855" alt="screen shot 2016-11-12 at 6 03 10 pm" src="https://cloud.githubusercontent.com/assets/3835755/20236467/498a5cf2-a90a-11e6-9764-31f4a4aa564b.png">

After:
<img width="389" alt="screen shot 2016-11-12 at 6 51 01 pm" src="https://cloud.githubusercontent.com/assets/3835755/20236468/498e1dce-a90a-11e6-95bf-33fe8a470238.png">




 
 