### PR TITLE
implement Hasty Relocation

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -417,6 +417,34 @@
             :label "Give the Runner 4 tags"
             :effect (effect (tag-runner :runner 4))}}
 
+   "Hasty Relocation"
+   (letfn [(hr-final [chosen original]
+             {:prompt (str "The top cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
+              :choices ["Done" "Start over"]
+              :delayed-completion true
+              :effect (req (if (= target "Done")
+                             (do (doseq [c (reverse chosen)] (move state :corp c :deck {:front true}))
+                                 (clear-wait-prompt state :runner)
+                                 (effect-completed state side eid card))
+                             (continue-ability state side (hr-choice original '() 3 original)
+                                               card nil)))})
+           (hr-choice [remaining chosen n original]
+             {:prompt "Choose a card to move next onto R&D"
+              :choices remaining
+              :delayed-completion true
+              :effect (req (let [chosen (cons target chosen)]
+                             (if (< (count chosen) n)
+                               (continue-ability state side (hr-choice (remove-once #(not= target %) remaining)
+                                                                        chosen n original) card nil)
+                               (continue-ability state side (hr-final chosen original) card nil))))})]
+     {:delayed-completion true
+      :msg "trash the top card of R&D, draw 3 cards, and add 3 cards in HQ to the top of R&D"
+      :effect (req (mill state :corp)
+                   (draw state side 3)
+                   (show-wait-prompt state :runner "Corp to add 3 cards in HQ to the top of R&D")
+                   (let [from (get-in @state [:corp :hand])]
+                     (continue-ability state :corp (hr-choice from '() 3 from) card nil)))})
+
    "Hatchet Job"
    {:trace {:base 5
             :choices {:req #(and (installed? %)


### PR DESCRIPTION
Stole from CBI Raid here. Could use some eyeballs--@nealterrell, @Saintis, @zaroth, @erbridge etc. 

This **will not** work correctly in conjunction with Accelerated Diagnostics (which, if correct, would stop the mill). But people are asking about this card a lot and a starting point is better than nothing I guess. 