### PR TITLE
apply Checkpoint damage at correct timing

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -349,13 +349,14 @@
    {:effect take-bad-pub
     :subroutines [(trace-ability 5 {:label "Do 3 meat damage when this run is successful"
                                     :msg "do 3 meat damage when this run is successful"
-                                    :effect (req (swap! state assoc-in [:run :run-effect :end-run]
-                                                        {:req (req (:successful run))
-                                                         :msg "do 3 meat damage"
-                                                         :effect (effect (damage eid :meat 3
-                                                                                 {:card card}))})
-                                                 (swap! state assoc-in [:run :run-effect :card]
-                                                        card))})]}
+                                    :effect (effect (register-events
+                                                      {:successful-run
+                                                       {:delayed-completion true
+                                                        :msg "do 3 meat damage"
+                                                        :effect (effect (damage eid :meat 3 {:card card}))}
+                                                       :run-ends {:effect (effect (unregister-events card))}}
+                                                     card))})]
+    :events {:successful-run nil :run-ends nil}}
 
    "Chetana"
    {:subroutines [{:msg "make each player gain 2 [Credits]" :effect (effect (gain :runner :credit 2)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -933,7 +933,7 @@
              :effect ab}]
      {:effect ab
       :subroutines [end-the-run]
-      :events {:rez mg :trash mg :derez mg}})
+      :events {:rez mg :card-moved mg :derez mg}})
 
    "Muckraker"
    {:effect take-bad-pub

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -311,12 +311,11 @@
            (remove-effect [state side card]
              (click-run-cost-bonus state side [:click -1])
              (update! state side (dissoc card :elp-activated)))]
-     {:msg (msg (when (and (= :runner (:active-player @state))
-                           (not (:made-click-run runner-reg)))
-                  "add an additional cost of [Click] to make the first run not through a card ability this turn"))
-      :effect (req (when (and (= :runner (:active-player @state))
+     {:effect (req (when (and (= :runner (:active-player @state))
                               (not (:made-click-run runner-reg)))
-                     (add-effect state side card)))
+                     (add-effect state side card)
+                     (system-msg state side (str "uses Enhanced Login Protocol to add an additional cost of [Click]"
+                                                 " to make the first run not through a card ability this turn"))))
       :events {:runner-turn-begins {:msg "add an additional cost of [Click] to make the first run not through a card ability this turn"
                                     :effect (effect (add-effect card))}
                :runner-turn-ends {:req (req (:elp-activated card))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -402,9 +402,10 @@
 
    "Fall Guy"
    {:prevent {:trash [:resource]}
-    :abilities [{:label "Prevent a resource from being trashed"
+    :abilities [{:label "[Trash]: Prevent another installed resource from being trashed"
                  :effect (effect (trash-prevent :resource 1) (trash card {:unpreventable true :cause :ability-cost}))}
-                {:effect (effect (trash card {:cause :ability-cost}) (gain :credit 2)) :msg "gain 2 [Credits]"}]}
+                {:label "[Trash]: Gain 2 [Credits]"
+                 :effect (effect (trash card {:cause :ability-cost}) (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 
    "Fan Site"
    {:events {:agenda-scored {:msg "add it to their score area as an agenda worth 0 agenda points"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -358,7 +358,7 @@
   [state side args]
   (let [remove-cost (max 0 (- 2 (or (get-in @state [:runner :tag-remove-bonus]) 0)))]
     (when-let [cost-str (pay state side nil :click 1 :credit remove-cost :tag 1)]
-      (system-msg state side (build-spend-msg cost-str "remove 1 Tag")))))
+      (system-msg state side (build-spend-msg cost-str "remove 1 tag")))))
 
 (defn auto-pump
   "Use the 'match strength with ice' function of icebreakers."


### PR DESCRIPTION
* Fixes #2165: Checkpoint should use event registration instead of swapping things into `[:run]`. This will also solve the broken interaction of a successful Checkpoint trace on a Dirty Laundry run. 
* Fixes #2129: Use `system-msg` to prevent a truncated message when ELP is played.
* Removes subtypes (if necessary) from Mother Goddess when other ICE gets trashed