### PR TITLE
partial implementation of Raman Rai

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -859,6 +859,36 @@
                              (system-msg state :corp "uses Public Support to add it to their score area as an agenda worth 1 agenda point")
                              (as-agenda state :corp (dissoc card :counter) 1)))} }}
 
+   "Raman Rai"
+   {:abilities [{:once :per-turn
+                 :label "Lose [Click] and swap a card in HQ you just drew for a card in Archives"
+                 :req (req (and (pos? (:click corp))
+                                (not-empty (turn-events state side :corp-draw))))
+                 :effect (req (let [drawn (get-in @state [:corp :register :most-recent-drawn])]
+                                (lose state :corp :click 1)
+                                (resolve-ability state side
+                                  {:prompt "Choose a card in HQ that you just drew to swap for a card of the same type in Archives"
+                                   :choices {:req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
+                                   :effect (req (let [hqcard target
+                                                      t (:type hqcard)]
+                                                  (resolve-ability state side
+                                                    {:show-discard true
+                                                     :prompt (msg "Choose an " t " in Archives to reveal and swap into HQ for " (:title hqcard))
+                                                     :choices {:req #(and (= (:side %) "Corp")
+                                                                          (= (:type %) t)
+                                                                          (= (:zone %) [:discard]))}
+                                                     :msg (msg "lose [Click], reveal " (:title hqcard) " from HQ, and swap it for " (:title target) " from Archives")
+                                                     :effect (req (let [swappedcard (assoc hqcard :zone [:discard])
+                                                                        archndx (ice-index state target)
+                                                                        arch (get-in @state [:corp :discard])
+                                                                        newarch (apply conj (subvec arch 0 archndx) swappedcard (subvec arch archndx))]
+                                                                     (swap! state assoc-in [:corp :discard] newarch)
+                                                                     (swap! state update-in [:corp :hand]
+                                                                            (fn [coll] (remove-once #(not= (:cid %) (:cid hqcard)) coll)))
+                                                                     (move state side target :hand)))}
+                                                   card nil)))}
+                                 card nil)))}]}
+
    "Reality Threedee"
    (let [ability {:effect (req (gain state side :credit (if tagged 2 1)))
                   :label "Gain credits (start of turn)"


### PR DESCRIPTION
This is a "most of the way" treatment of this really bizarre card, stealing techniques from DBS and Midori. 

I think in theory during an instance of multi-draw you'd have to decide after each card whether or not to use Raman Rai, but for this I just took the easy route and did what we do with DBS--allow you to choose any of the cards in the `:most-recent-drawn` stored in the register. I also thought it would be really annoying if this card prompted the user after every single draw, so it's just silent and we leave it up to players to decide when to fire it and not abuse it (hopefully). 

![screen shot 2016-11-23 at 9 43 57 am](https://cloud.githubusercontent.com/assets/10407969/20568231/6c62b53a-b161-11e6-90d8-6c2a0362f988.png)

