### PR TITLE
implement Credit Crash and Hellion Beta Test

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -127,6 +127,38 @@
     :effect (req (swap! state update-in [:corp :has-bad-pub] inc))
     :leave-play (req (swap! state update-in [:corp :has-bad-pub] dec))}
 
+   "Credit Crash"
+   {:prompt "Choose a server" :choices (req runnable-servers)
+    :effect (effect (run target nil card)
+                    (register-events (:events (card-def card))
+                                     (assoc card :zone '(:discard))))
+    :events {:pre-access-card
+             {:once :per-run
+              :delayed-completion true
+              :req (req (not= (:type target) "Agenda"))
+              :effect (req (let [c target
+                                 cost (:cost c)
+                                 title (:title c)]
+                             (if (can-pay? state :corp nil :credit cost)
+                               (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent the trash")
+                                   (continue-ability state :corp
+                                     {:optional
+                                      {:delayed-completion true
+                                       :prompt (msg "Spend " cost " [Credits] to prevent the trash of " title "?")
+                                       :player :corp
+                                       :yes-ability {:effect (req (lose state :corp :credit cost)
+                                                                  (system-msg state :corp (str "spends " cost " [Credits] to prevent "
+                                                                                               title " from being trashed at no cost"))
+                                                                  (clear-wait-prompt state :runner))}
+                                       :no-ability {:msg (msg "trash " title " at no cost")
+                                                    :effect (effect (clear-wait-prompt :runner)
+                                                                    (resolve-trash-no-cost c))}}}
+                                    card nil))
+                               (do (resolve-trash-no-cost state side c)
+                                   (system-msg state side (str "uses Credit Crash to trash " title " at no cost"))
+                                   (effect-completed state side eid)))))}
+             :run-ends {:effect (effect (unregister-events card))}}}
+
    "Cyber Threat"
    {:prompt "Choose a server" :choices (req runnable-servers)
     :delayed-completion true

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -169,7 +169,8 @@
    {:events {:access {:once :per-turn
                       :req (req (and (is-type? target "Operation")
                                      (turn-flag? state side card :can-trash-operation)))
-                      :effect (effect (trash target))
+                      :effect (req (trash state side target)
+                                   (swap! state assoc-in [:runner :register :trashed-card] true))
                       :msg (msg "trash " (:title target))}
              :successful-run-ends {:req (req (and (= (:server target) [:archives])
                                                   (nil? (:replace-access (:run-effect target)))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -466,6 +466,20 @@
             :unsuccessful {:msg "take 1 bad publicity"
                            :effect (effect (gain :corp :bad-publicity 1))}}}
 
+   "Hellion Beta Test"
+   {:req (req (:trashed-card runner-reg))
+    :trace {:base 2
+            :label "Trash 2 installed non-program cards"
+            :choices {:max 2
+                      :req #(and (installed? %)
+                                 (= (:side %) "Runner")
+                                 (not (is-type? % "Program")))}
+            :msg (msg "trash " (join ", " (map :title targets)))
+            :effect (req (doseq [c targets]
+                           (trash state side c)))
+            :unsuccessful {:msg "take 1 bad publicity"
+                           :effect (effect (gain :corp :bad-publicity 1))}}}
+
    "Heritage Committee"
    {:delayed-completion true
     :effect (effect (draw 3)

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -353,6 +353,7 @@
 (defn- resolve-trash-no-cost
   [state side card]
   (trash state side (assoc card :seen true))
+  (swap! state assoc-in [:runner :register :trashed-card] true)
   (close-access-prompt state side))
 
 (defn trash-no-cost

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -352,7 +352,7 @@
 
 (defn- resolve-trash-no-cost
   [state side card]
-  (trash state side card)
+  (trash state side (assoc card :seen true))
   (close-access-prompt state side))
 
 (defn trash-no-cost

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -178,36 +178,41 @@
      (swap! state update-in [:bonus] dissoc :trash)
      (swap! state update-in [:bonus] dissoc :steal-cost)
      (swap! state update-in [:bonus] dissoc :access-cost)
-     (trigger-event state side :pre-access-card c)
-     (let [acost (access-cost state side c)
-           ;; hack to prevent toasts when playing against Gagarin and accessing on 0 credits
-           anon-card (dissoc c :title)]
-       (if (or (empty? acost) (pay state side anon-card acost))
-         ;; Either there were no access costs, or the runner could pay them.
-         (let [cdef (card-def c)
-               c (assoc c :seen true)
-               access-effect (:access cdef)]
-           (when-let [name (:title c)]
-             (if (is-type? c "Agenda")
-               ;; Accessing an agenda
-               (if (and access-effect
-                        (can-trigger? state side access-effect c nil))
-                 ;; deal with access effects first. This is where Film Critic can be used to prevent these
-                 (continue-ability state :runner
-                                   {:delayed-completion true
-                                    :prompt (str "You must access " name)
-                                    :choices ["Access"]
-                                    :effect (req (when-completed
-                                                   (resolve-ability state (to-keyword (:side c)) access-effect c nil)
-                                                   (access-agenda state side eid c)))} c nil)
-                 (access-agenda state side eid c))
-               ;; Accessing a non-agenda
-               (if access-effect
-                 (when-completed (resolve-ability state (to-keyword (:side c)) access-effect c nil)
-                                 (access-non-agenda state side eid c))
-                 (access-non-agenda state side eid c)))))
-         ;; The runner cannot afford the cost to access the card
-         (prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {}))))))
+     (when-completed (trigger-event-sync state side :pre-access-card c)
+                     (do (let [acost (access-cost state side c)
+                               ;; hack to prevent toasts when playing against Gagarin and accessing on 0 credits
+                               anon-card (dissoc c :title)]
+                           (if (or (empty? acost) (pay state side anon-card acost))
+                             ;; Either there were no access costs, or the runner could pay them.
+                             (let [cdef (card-def c)
+                                   c (assoc c :seen true)
+                                   access-effect (:access cdef)]
+                               (when-let [name (:title c)]
+                                 (if (is-type? c "Agenda")
+                                   ;; Accessing an agenda
+                                   (if (and access-effect
+                                            (can-trigger? state side access-effect c nil))
+                                     ;; deal with access effects first. This is where Film Critic can be used to prevent these
+                                     (continue-ability state :runner
+                                                       {:delayed-completion true
+                                                        :prompt (str "You must access " name)
+                                                        :choices ["Access"]
+                                                        :effect (req (when-completed
+                                                                       (resolve-ability state (to-keyword (:side c)) access-effect c nil)
+                                                                       (access-agenda state side eid c)))} c nil)
+                                     (access-agenda state side eid c))
+                                   ;; Accessing a non-agenda
+                                   (if (and access-effect
+                                            (= (:zone c) (:zone (get-card state c))))
+                                     ;; if card wasn't moved by a pre-access effect
+                                     (when-completed (resolve-ability state (to-keyword (:side c)) access-effect c nil)
+                                                     (do (if (= (:zone c) (:zone (get-card state c)))
+                                                           ;; if the card wasn't moved by the access effect
+                                                           (access-non-agenda state side eid c)
+                                                           (effect-completed state side eid))))
+                                     (access-non-agenda state side eid c)))))
+                             ;; The runner cannot afford the cost to access the card
+                             (prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {}))))))))
 
 (defn msg-handle-access
   ([state side cards]

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -128,8 +128,9 @@
                                {:prompt (str "Pay " trash-cost " [Credits] to trash " name "?")
                                 :yes-ability {:cost [:credit trash-cost]
                                               :delayed-completion true
-                                              :effect (effect (trash eid card nil)
-                                                              (system-msg (str "pays " trash-msg)))}}}
+                                              :effect (req (trash state side eid card nil)
+                                                           (swap! state assoc-in [:runner :register :trashed-card] true)
+                                                           (system-msg state side (str "pays " trash-msg)))}}}
                               card nil))))
       ;; The card does not have a trash cost
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid}))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -116,8 +116,9 @@
           (continue-ability state :runner
                             {:cost [:credit trash-cost]
                              :delayed-completion true
-                             :effect (effect (trash eid card nil)
-                                             (system-msg (str "is forced to pay " trash-msg)))}
+                             :effect (req (trash state side eid card nil)
+                                          (swap! state assoc-in [:runner :register :trashed-card] true)
+                                          (system-msg state side (str "is forced to pay " trash-msg)))}
                             card nil)
           ;; Otherwise, show the option to pay to trash the card.
           (if-not (and (is-type? card "Operation")

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -1295,7 +1295,6 @@
 
     (run-empty-server state :remote2)
     (prompt-choice :runner "Add News Team to score area")
-    (prompt-choice :runner "Yes")
     (is (= 3 (count (:scored (get-runner)))) "News Team added to Runner score area")
     (is (= -3 (:agenda-point (get-runner))) "Runner has -3 agenda points")
 


### PR DESCRIPTION
Bear with me on this one...it's the result of several crucial clarifications from rules guru @jakodrako on Stimslack, since there still are no released UFAQs for anything after the 23 Seconds pack. 

He says Credit Crash was ruled to act like a "when you access" trigger, despite not being worded that way _(!!)_. As such, it needs to resolve prior to a Corp card's "when the Runner accesses" effects--and can even make them fizzle entirely, as we'll get to in a moment. The other quirk of this card is that if the Corp opts to pay the credits to prevent "this trash", that only applies to the no-cost trash--the Runner _still_ subsequently gets a chance to pay credits to trash conventionally (assuming the card has a trash cost, of course). 

How this might play out in an actual scenario...the Runner plays Credit Crash and runs R&D. They hit an Archangel, which has a "when accessed" effect. With the `when-completed` framework applied to the `:pre-access-card` event, Credit Crash can fully resolve first. The Corp is asked if they want to pay Archangel's 4 credit rez cost to prevent it being trashed by the Runner. They decline. Archangel is then instantly trashed at no cost and its "when accessed" effect never happens.

This PR also fixes #1089. Just as we have to check "is this card still in the same place?" after resolving any `:pre-access` effect like Credit Crash, we have to check again after any "when accessed" effect resolves, so that a News Team or Shi.Kyu the Runner elects to take as -1 point will no longer ask the Runner to trash them.

EDIT: Also added in Hellion Beta Test. 