### PR TITLE
Batch of fixes

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -786,15 +786,17 @@
     0
     {:req (req (pos? (:advance-counter (get-card state card) 0)))
      :effect
-     (effect (resolve-ability
-              {:prompt "Choose an Agenda in HQ to score"
-               :choices {:req #(and (is-type? % "Agenda")
-                                    (<= (:advancementcost %) (:advance-counter (get-card state card) 0))
-                                    (in-hand? %))}
-               :msg (msg "score " (:title target))
-               :effect (effect (score (assoc target :advance-counter
-                                             (:advancementcost target))))}
-              card nil))}
+     (req (doseq [ag (filter #(is-type? % "Agenda") (get-in @state [:corp :hand]))]
+            (update-advancement-cost state side ag))
+          (resolve-ability state side
+            {:prompt "Choose an Agenda in HQ to score"
+             :choices {:req #(and (is-type? % "Agenda")
+                                  (<= (:current-cost %) (:advance-counter (get-card state card) 0))
+                                  (in-hand? %))}
+             :msg (msg "score " (:title target))
+             :effect (effect (score (assoc target :advance-counter
+                                           (:current-cost target))))}
+           card nil))}
     "Score an Agenda from HQ?")
 
    "Political Dealings"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -993,11 +993,17 @@
                       {:replace-access
                        {:msg "access cards from the bottom of R&D"
                         :delayed-completion true
-                        :effect (req (swap! state assoc-in [:corp :deck]
+                        :effect (req (when-completed (resolve-ability state side
+                                                       {:effect (effect (register-events (:events (card-def card))
+                                                                                         (assoc card :zone '(:discard))))}
+                                                      card nil)
+                                                     (do-access state side eid (:server run))))}} card))
+    :events {:pre-access {:silent (req true)
+                          :effect (req (swap! state assoc-in [:corp :deck]
+                                              (rseq (into [] (get-in @state [:corp :deck])))))}
+             :run-ends {:effect (req (swap! state assoc-in [:corp :deck]
                                             (rseq (into [] (get-in @state [:corp :deck]))))
-                                     (do-access state side eid (:server run))
-                                     (swap! state assoc-in [:corp :deck]
-                                            (rseq (into [] (get-in @state [:corp :deck])))))}} card))}
+                                     (unregister-events state side card))}}}
 
    "Singularity"
    {:prompt "Choose a server" :choices (req (filter #(can-run-server? state %) remotes))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -775,6 +775,7 @@
               :effect (effect (handle-access eid [(nth (:deck corp) (dec (Integer/parseInt target)))]))})]
      {:events {:successful-run
                {:req (req (= target :rd))
+                :interactive (req true)
                 :optional {:prompt "Use Top Hat to choose one of the top 5 cards in R&D to access?"
                            :yes-ability {:effect (req (swap! state assoc-in [:run :run-effect :replace-access]
                                                              (ability (count (:deck corp)))))}}}}})

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -872,6 +872,11 @@
                                      (unregister-events state side hosted)
                                      (update! state side (dissoc hosted :abilities))))}
                      card nil)))
+    :events {:runner-install {:req (req (= (:cid card) (:cid (:host target))))
+                              :effect (req (doseq [c (get-in card [:hosted])]
+                                             (unregister-events state side c)
+                                             (update! state side (dissoc c :abilities)))
+                                           (update-ice-strength state side card))}}
     :subroutines [end-the-run]}
 
    "Mamba"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -591,7 +591,8 @@
              :run-ends {:effect (req (swap! state dissoc-in [:runner :identity :omar-run-activated]))}}}
 
    "Pālanā Foods: Sustainable Growth"
-   {:events {:runner-draw {:msg "gain 1 [Credits]"
+   {:events {:runner-draw {:req (req (pos? target))
+                           :msg "gain 1 [Credits]"
                            :once :per-turn
                            :effect (effect (gain :corp :credit 1))}}}
 

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -851,7 +851,8 @@
 
    "Scarcity of Resources"
    {:msg "increase the install cost of resources by 2"
-    :events {:pre-install {:req (req (is-type? target "Resource"))
+    :events {:pre-install {:req (req (and (is-type? target "Resource")
+                                          (not (second targets)))) ; not facedown
                            :effect (effect (install-cost-bonus [:credit 2]))}}}
 
    "Scorched Earth"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -467,7 +467,7 @@
                              (trigger-event-sync state side :pre-access :hq)
                              (let [from-hq (access-count state side :hq-access)]
                                (continue-ability
-                                 state side
+                                 state :runner
                                  (access-helper-hq
                                    state from-hq
                                    ; access-helper-hq uses a set to keep track of which cards have already

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -193,8 +193,9 @@
                  :msg "draw 3 cards and shuffle 1 card from their Grip back into their Stack"
                  :effect (effect (draw 3)
                                  (resolve-ability
-                                   {:prompt "Choose a card to shuffle back into your Stack"
-                                    :choices (req (:hand runner))
+                                   {:prompt "Choose a card in your Grip to shuffle back into your Stack"
+                                    :choices {:req #(and (in-hand? %)
+                                                         (= (:side %) "Runner"))}
                                     :effect (effect (move target :deck)
                                                     (shuffle! :deck))}
                                   card nil))}]}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -439,7 +439,8 @@
    "Find the Truth"
    {:events {:post-runner-draw {:msg (msg "reveal that they drew: "
                                           (join ", " (map :title (get-in @state [:runner :register :most-recent-drawn]))))}
-             :successful-run {:optional
+             :successful-run {:interactive (req true)
+                              :optional
                               {:delayed-completion true
                                :req (req (first-event state side :successful-run))
                                :prompt "Use Find the Truth to look at the top card of R&D?"

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -498,5 +498,6 @@
                                             (when (> m 1) "s")))))
                               " into R&D")
                     :effect (req (doseq [c targets] (move state side c :deck))
-                                 (shuffle! state side :deck))}
+                                 (shuffle! state side :deck))
+                    :cancel-effect (req (shuffle! state side :deck))}
                    card nil))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -307,7 +307,7 @@
                           :prompt (str "Choose a card to host " (:title card) " on")
                           :effect (effect (runner-install eid card (assoc params :host-card target)))}
                          card nil)
-       (do (trigger-event state side :pre-install card)
+       (do (trigger-event state side :pre-install card facedown)
            (let [cost (runner-get-cost state side card params)]
              (if (runner-can-install? state side card facedown)
                (if-let [cost-str (pay state side card cost)]


### PR DESCRIPTION
* Fix #2168: Switch to use card targeting in Blockade Runner
* Fix #2171: Add a `:cancel-effect` to `rfg-and-shuffle-rd-effect` so you can Jackson back 0 cards and still get a reshuffle of R&D
* Fix #2175: Make Plan B check for altered agenda advancement requirements
* Fix #2177: Overhaul Showing Off to work with current access logic
* Fix #2178: Have Magnet blank all cards that get hosted directly onto it
* Fix #2183: Make Find the Truth and Top Hat `:interactive true` so the Runner can choose the order of their resolution
* Stop Palana Foods from firing if 0 cards are drawn
* Stop Scarcity of Resources from charging additional credits when Apex installs a facedown resource
* Fix incredibly rare bug--a Runner with Gang Sign installed runs and accesses an advanced Plan B that the Corp uses to score an agenda from hand, resulting in the "Card from hand" access prompt generated by Gang Sign getting shown to the Corp