### PR TITLE
Fix Paige Piper shuffle interaction with Frantic Coding

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -434,31 +434,37 @@
     :msg (msg "forfeit " (:title target) " and give the Corp 1 bad publicity")}
 
    "Frantic Coding"
-   {:effect (req (let [topten (take 10 (:deck runner))]
-                   (prompt! state :runner card (str "The top 10 cards of the Stack are "
-                                                    (join ", " (map :title topten))) ["OK"] {})
-                   (resolve-ability
-                     state side
-                     {:prompt "Install a program?"
-                      :choices (conj (vec (sort-by :title (filter #(and (is-type? % "Program")
-                                                                        (can-pay? state side nil
-                                                                                  (modified-install-cost
-                                                                                    state side % [:credit -5])))
-                                                                  topten))) "No install")
-                      :effect (req (if (not= target "No install")
-                                     (do (install-cost-bonus state side [:credit -5])
-                                         (runner-install state side target)
-                                         (doseq [c (remove (fn [installed] (= (:cid installed) (:cid target))) topten)]
-                                           (trash state side c {:unpreventable true}))
-                                         (system-msg
-                                           state side
-                                           (str "trashes " (join ", " (map :title (remove (fn [installed]
-                                                                                            (= (:cid installed)
-                                                                                               (:cid target))) topten))))))
-                                     (do (doseq [c topten] (trash state side c {:unpreventable true}))
-                                         (system-msg
-                                           state side
-                                           (str "trashes " (join ", " (map :title topten)))))))} card nil)))}
+   {:delayed-completion true
+    :events {:runner-shuffle-deck nil}
+    :effect
+    (req (let [topten (take 10 (:deck runner))]
+           (prompt! state :runner card (str "The top 10 cards of the Stack are "
+                                            (join ", " (map :title topten))) ["OK"] {})
+           (continue-ability
+             state side
+             {:prompt "Install a program?"
+              :choices (conj (vec (sort-by :title (filter #(and (is-type? % "Program")
+                                                                (can-pay? state side nil
+                                                                          (modified-install-cost state side % [:credit -5])))
+                                                          topten))) "No install")
+              :delayed-completion true
+              :effect (req (if (not= target "No install")
+                             (do (register-events state side
+                                                  {:runner-shuffle-deck
+                                                   {:effect (effect (update! (assoc card :shuffle-occurred true)))}}
+                                                  (assoc card :zone '(:discard)))
+                                 (install-cost-bonus state side [:credit -5])
+                                 (let [to-trash (remove #(= (:cid %) (:cid target)) topten)]
+                                   (when-completed (runner-install state side target nil)
+                                                   (let [card (get-card state (assoc card :zone '(:discard)))]
+                                                     (if (not (:shuffle-occurred card))
+                                                       (do (system-msg state side (str "trashes " (join ", " (map :title to-trash))))
+                                                           (doseq [c to-trash] (trash state side c {:unpreventable true}))
+                                                           (effect-completed state side eid))
+                                                       (do (system-msg state side "does not have to trash cards because the stack was shuffled")
+                                                           (effect-completed state side eid)))))))
+                             (do (doseq [c topten] (trash state side c {:unpreventable true}))
+                                 (system-msg state side (str "trashes " (join ", " (map :title topten)))))))} card nil)))}
 
    "\"Freedom Through Equality\""
    {:events {:agenda-stolen {:msg "add it to their score area as an agenda worth 1 agenda point"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -825,16 +825,17 @@
                       {:optional
                        {:prompt (str "Use Paige Piper to trash copies of " title "?")
                         :yes-ability {:prompt "How many would you like to trash?"
-                                      :choices {:number (req num)}
+                                      :choices (take (inc num) ["0" "1" "2" "3" "4" "5"])
                                       :msg "shuffle their Stack"
-                                      :effect (req (trigger-event state side :searched-stack nil)
-                                                   (shuffle! state :runner :deck)
-                                                   (doseq [c (take (int target) cards)]
-                                                     (trash state side c {:unpreventable true}))
-                                                   (when (> (int target) 0)
-                                                     (system-msg state side (str "trashes " (int target)
-                                                                                 " cop" (if (> (int target) 1) "ies" "y")
-                                                                                 " of " title))))}}}))]
+                                      :effect (req (let [target (Integer/parseInt target)]
+                                                     (trigger-event state side :searched-stack nil)
+                                                     (shuffle! state :runner :deck)
+                                                     (doseq [c (take target cards)]
+                                                       (trash state side c {:unpreventable true}))
+                                                     (when (> (int target) 0)
+                                                       (system-msg state side (str "trashes " target
+                                                                                   " cop" (if (not= target 1) "ies" "y")
+                                                                                   " of " title)))))}}}))]
      {:events {:runner-install {:req (req (first-event state side :runner-install))
                                 :delayed-completion true
                                 :effect (effect (continue-ability

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -11,8 +11,8 @@
 
 (def all-cards (atom {}))
 
-(load "core/cards")     ; retrieving and updating cards
 (load "core/events")    ; triggering of events
+(load "core/cards")     ; retrieving and updating cards
 (load "core/costs")     ; application of costs to play
 (load "core/rules")     ; core game rules
 (load "core/turns")     ; the turn sequence

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -172,7 +172,8 @@
 (defn shuffle!
   "Shuffles the vector in @state [side kw]."
   [state side kw]
-  (swap! state update-in [side kw] shuffle))
+  (when-completed (trigger-event-sync state side (keyword (str (name side) "-shuffle-deck")))
+                  (swap! state update-in [side kw] shuffle)))
 
 (defn shuffle-into-deck
   [state side & args]

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -1,8 +1,8 @@
 (in-ns 'game.core)
 
-(declare can-trigger? clear-wait-prompt effect-completed event-title get-nested-host get-remote-names get-runnable-zones
-         get-zones register-effect-completed register-suppress resolve-ability show-wait-prompt trigger-suppress
-         unregister-suppress)
+(declare can-trigger? card-def clear-wait-prompt effect-completed event-title get-card get-nested-host get-remote-names
+         get-runnable-zones get-zones make-eid register-effect-completed register-suppress resolve-ability show-wait-prompt
+         trigger-suppress unregister-suppress)
 
 ; Functions for registering and dispatching events.
 (defn register-events

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -814,6 +814,34 @@
       (is (= 1 (:agenda-point (get-runner))))
       (is (empty? (get-in @state [:runner :rig :resource])) "NACH trashed by agenda steal"))))
 
+(deftest paige-piper-frantic-coding
+  ;; Paige Piper - interaction with Frantic Coding. Issue #2190.
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Paige Piper" 1) (qty "Frantic Coding" 2) (qty "Sure Gamble" 3)
+                               (qty "Gordian Blade" 2) (qty "Ninja" 1) (qty "Bank Job" 3) (qty "Indexing" 2)]))
+    (take-credits state :corp)
+    (starting-hand state :runner ["Paige Piper" "Frantic Coding" "Frantic Coding"])
+    (play-from-hand state :runner "Paige Piper")
+    (prompt-choice :runner "No")
+    (take-credits state :runner) ; now 8 credits
+    (take-credits state :corp)
+    (play-from-hand state :runner "Frantic Coding")
+    (prompt-choice :runner "OK")
+    (prompt-card :runner (find-card "Gordian Blade" (:deck (get-runner))))
+    (is (= 1 (count (get-program state))) "Installed Gordian Blade")
+    (prompt-choice :runner "Yes")
+    (prompt-choice :runner "0")
+    (is (= 1 (count (:discard (get-runner)))) "Paige Piper intervention stopped Frantic Coding from trashing 9 cards")
+    (is (= 5 (:credit (get-runner))) "No charge to install Gordian")
+    ;; a second Frantic Coding will not trigger Paige (once per turn)
+    (play-from-hand state :runner "Frantic Coding")
+    (prompt-choice :runner "OK")
+    (prompt-card :runner (find-card "Ninja" (:deck (get-runner))))
+    (is (= 2 (count (get-program state))) "Installed Ninja")
+    (is (= 11 (count (:discard (get-runner)))) "11 cards in heap")
+    (is (= 2 (:credit (get-runner))) "No charge to install Ninja")))
+
 (deftest patron
   ;; Patron - Ability
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -86,8 +86,9 @@
 
 (defn get-program
   "Get non-hosted program by position."
-  [state pos]
-  (get-in @state [:runner :rig :program pos]))
+  ([state] (get-in @state [:runner :rig :program]))
+  ([state pos]
+   (get-in @state [:runner :rig :program pos])))
 
 (defn get-hardware
   "Get hardware by position."


### PR DESCRIPTION
Based on the interaction between Accelerated Beta Test and The Foundry (also, Accelerated Diagnostics and any "search R&D" card), installing a card with Frantic Coding while Paige Piper is active should trigger a Piper shuffle of the Stack before Frantic Coding moves to the "trash the rest of the cards" phase. Since we were "looking" at the top cards of the stack and the shuffle means they are no longer there, the rest of Frantic Coding fails. This technique can be applied to ABT and AccDiag too.