### PR TITLE
prevent mid-run ICE trash from throwing JS error

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -851,7 +851,7 @@
       [:div.server
        (let [ices (:ices server)
              run-pos (:position run)
-             current-ice (when (and run (pos? run-pos))
+             current-ice (when (and run (pos? run-pos) (<= run-pos (count ices)))
                            (nth ices (dec run-pos)))
              run-arrow (sab/html [:div.run-arrow [:div]])
              max-hosted (apply max (map #(count (:hosted %)) ices))]


### PR DESCRIPTION
As discussed in Slack yesterday--just making sure the `gameboard.cljs` fix for mid-run ICE trashing gets incorporated into master. 