### PR TITLE
Admin paths for version string and for refreshing all-cards

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -332,7 +332,18 @@ app.use express.static(__dirname + '/resources/public')
 
 # load version info from database
 db.collection('config').findOne (err, config) ->
-  app.locals.version = config && config.version || process.env['APP_VERSION'] || "0.1.0"
+  if err || config == null
+      console.log('Creating config information in database')
+      db.createCollection('config')
+      db.collection('config').insert {version: process.env['APP_VERSION'] || "0.1.0"}, (err) ->
+        if err
+          console.log('Could not create config in database')
+        else
+          app.locals.version = config && config.version || process.env['APP_VERSION'] || "0.1.0"
+          console.log('App version ' + app.locals.version)
+  else
+    app.locals.version = config && config.version || process.env['APP_VERSION'] || "0.1.0"
+    console.log('App version ' + app.locals.version)
 
 # Auth
 passport.use new LocalStrategy (username, password, done) ->

--- a/views/version.jade
+++ b/views/version.jade
@@ -1,0 +1,14 @@
+doctype html
+html
+  head
+    meta(charset="utf-8")
+    title Jinteki
+    link(rel='stylesheet', href='/css/netrunner.css')
+  body
+    div.reset-bg
+    form.panel.blue-shade.reset-form(method='POST')
+      h3 App Version
+      p
+        input(type='text', name='version', value='#{version}')
+      p
+        button.btn.btn-primary(type='submit') Submit


### PR DESCRIPTION
Moves app version information into the database, instead of an environment variable. 

Adds a URL path `/admin/version` for updating this version string. The string is used when referencing `app.js` in the HTML; a new string forces browsers to retrieve a new copy of the file. Updating the string while the site is live will cause all future connections to pull the new game script without having to reboot Node.

Adds a URL path `/admin/init`, which resends the "initialize" data sent to the game server upon initial web server connection. This data includes the list of all cards in the game, used for Adam's directives, Targeted Marketing, Rebirth, etc. If the initial connection fails, or if the card data sent to the server is incomplete, this URL will force the latest data from the database to be sent to the game server, without having to reboot Node.

Moves `/announce` to `/admin/announce` for consistency.