### PR TITLE
implement Nihongai Grid, minor upgrade enhancements

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -51,7 +51,8 @@
     :events {:run-ends nil}}
 
    "Bernice Mai"
-   {:events {:successful-run {:req (req this-server)
+   {:events {:successful-run {:interactive (req true)
+                              :req (req this-server)
                               :trace {:base 5 :msg "give the Runner 1 tag"
                                       :effect (effect (tag-runner :runner 1))
                                       :unsuccessful {:effect (effect (system-msg "trashes Bernice Mai from the unsuccessful trace")
@@ -292,6 +293,49 @@
                             (is-remote? (second (:zone card))))) :once :per-turn
              :msg "gain 1 [Credits]" :effect (effect (gain :credit 1))}]
      {:events {:advance ng :advancement-placed ng}})
+
+   "Nihongai Grid"
+   {:events
+    {:successful-run
+     {:interactive (req true)
+      :delayed-completion true
+      :req (req (and this-server
+                     (< (:credit runner) 6)
+                     (< (count (:hand runner)) 2)
+                     (not-empty (:hand corp))))
+      :effect (req (show-wait-prompt state :runner "Corp to use Nihongai Grid")
+                   (let [top5 (take 5 (:deck corp))]
+                     (if (pos? (count top5))
+                       (continue-ability state side
+                         {:optional
+                          {:prompt "Use Nihongai Grid to look at top 5 cards of R&D and swap one with a card from HQ?"
+                           :yes-ability
+                           {:delayed-completion true
+                            :prompt "Choose a card to swap with a card from HQ"
+                            :choices top5
+                            :effect (req (let [rdc target]
+                                           (continue-ability state side
+                                             {:delayed-completion true
+                                              :prompt (msg "Choose a card in HQ to swap for " (:title rdc))
+                                              :choices {:req in-hand?}
+                                              :msg "swap a card from the top 5 of R&D with a card in HQ"
+                                              :effect (req (let [hqc target
+                                                                 newrdc (assoc hqc :zone [:deck])
+                                                                 deck (vec (get-in @state [:corp :deck]))
+                                                                 rdcndx (first (keep-indexed #(when (= (:cid %2) (:cid rdc)) %1) deck))
+                                                                 newdeck (seq (apply conj (subvec deck 0 rdcndx) target (subvec deck rdcndx)))]
+                                                             (swap! state assoc-in [:corp :deck] newdeck)
+                                                             (swap! state update-in [:corp :hand]
+                                                                    (fn [coll] (remove-once #(not= (:cid %) (:cid hqc)) coll)))
+                                                             (move state side rdc :hand)
+                                                             (clear-wait-prompt state :runner)
+                                                             (effect-completed state side eid)))}
+                                            card nil)))}
+                           :no-ability {:effect (req (clear-wait-prompt state :runner)
+                                                     (effect-completed state side eid card))}}}
+                        card nil)
+                       (do (clear-wait-prompt state :runner)
+                           (effect-completed state side eid card)))))}}}
 
    "Oaktown Grid"
    {:events {:pre-trash {:req (req (and (is-remote? (second (:zone card)))
@@ -547,7 +591,25 @@
                                                 (update! (dissoc card :times-used)))}}}
 
    "Will-o-the-Wisp"
-   {:abilities [{:label "[Trash]: Add an icebreaker to the bottom of Stack"
-                 :choices {:req #(has-subtype? % "Icebreaker")}
-                 :msg (msg "add " (:title target) " to the bottom of Stack")
-                 :effect (effect (trash card) (move :runner target :deck))}]}})
+   {:events
+    {:successful-run
+     {:interactive (req true)
+      :delayed-completion true
+      :req (req (and this-server
+                     (some #(has-subtype? % "Icebreaker") (all-installed state :runner))))
+      :effect (req (show-wait-prompt state :runner "Corp to use Will-o'-the-Wisp")
+                   (continue-ability state side
+                     {:optional
+                      {:prompt "Trash Will-o'-the-Wisp?"
+                       :choices {:req #(has-subtype? % "Icebreaker")}
+                       :yes-ability {:delayed-completion true
+                                     :prompt "Choose an icebreaker used to break at least 1 subroutine during this run"
+                                     :choices {:req #(has-subtype? % "Icebreaker")}
+                                     :msg (msg "add " (:title target) " to the bottom of the Runner's Stack")
+                                     :effect (effect (trash card)
+                                                     (move :runner target :deck)
+                                                     (clear-wait-prompt :runner)
+                                                     (effect-completed eid card))}
+                       :no-ability {:effect (effect (clear-wait-prompt :runner)
+                                                    (effect-completed eid card))}}}
+                    card nil))}}}})


### PR DESCRIPTION
Implements Nihongai Grid. The tricksy bit was taking the deck (a sequence) and vectorizing it to reuse all the swapping code elsewhere, then turning it back into a sequence. 

Fully automates Will-o'-the-Wisp and adds interactivity checks to it and Bernice Mai, so you can do this properly like you ought to be able to: 

![screen shot 2016-12-09 at 2 59 03 pm](https://cloud.githubusercontent.com/assets/10407969/21065319/4b9c437c-be25-11e6-974d-d8ea2b89c268.png)
