### PR TITLE
implement Interdiction

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -648,6 +648,19 @@
     :choices (req runnable-servers)
     :effect (effect (run target nil card))}
 
+   "Interdiction"
+   (let [ab (effect (register-turn-flag!
+                     card :can-rez
+                     (fn [state side card]
+                       (if (and (= (:active-player @state) :runner) (not (ice? card)))
+                         ((constantly false)
+                          (toast state :corp "Cannot rez non-ICE on the Runner's turn due to Interdiction"))
+                         true))))]
+     {:msg "prevent the Corp from rezzing non-ICE cards on the Runner's turn"
+      :effect ab
+      :events {:runner-turn-begins {:effect ab}}
+      :leave-play (req (clear-all-flags-for-card! state side card))})
+
    "Itinerant Protesters"
    {:msg "reduce the Corp's maximum hand size by 1 for each bad publicity"
     :effect (req (lose state :corp :hand-size-modification (:bad-publicity corp))


### PR DESCRIPTION
Thanks to @Saintis great work on refactoring the flags system awhile back, this card is much easier now. Has a `:leave-play` effect in the _exceedingly_ unlikely event that the Corp manages a Plan B score on the Runner's turn. :P 