### PR TITLE
implement Manta Grid

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -218,6 +218,24 @@
                               (trash state side card {:cause :ability-cost})
                               (lose state :runner :tag 1))}]}
 
+   "Manta Grid"
+   {:events
+    {:successful-run
+     {:req (req this-server)
+      :effect (req (register-events state side
+                     {:run-ends {:msg "gain an additional [Click] on their next turn"
+                                 :req (req (and (< (:credit runner) 6)
+                                                (= 0 (:click runner))))
+                                 :effect (req (gain state :corp :click-per-turn 1)
+                                              (update! state side (assoc card :manta-used true)))}
+                      :corp-turn-begins {:req (req (:manta-used card))
+                                         :effect (effect (lose :corp :click-per-turn 1)
+                                                         (update! (dissoc card :manta-used))
+                                                         (unregister-events card))}}
+                    card))}}
+    :leave-play (req (when (:manta-used card)
+                       (lose state :corp :click-per-turn 1)))}
+
    "Marcus Batty"
    {:abilities [{:req (req this-server)
                  :label "[Trash]: Start a Psi game"


### PR DESCRIPTION
There is an extra layer of care in here for what I think would be an _exceedingly rare_ situation in which Manta Grid can trigger but the Runner still manages to trash it before the end of their turn. I think you could in theory have this happen with either a Data Breach or a Doppelganger "free" run that happens after you're out of clicks and you can resurrect an Imp mid-run, allowing you to trash Manta Grid after its effect has occurred. 