### PR TITLE
A few card fixes

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -5,7 +5,8 @@
                     :msg (msg "trash " (:title target))
                     :choices {:req #(and (installed? %)
                                          (is-type? % "Program"))}
-                    :effect (effect (trash target {:cause :subroutine}))})
+                    :effect (effect (trash target {:cause :subroutine})
+                                    (clear-wait-prompt :runner))})
 
 (def trash-hardware {:prompt "Choose a piece of hardware to trash"
                      :label "Trash a piece of hardware"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1095,8 +1095,9 @@
                                         {:player :runner
                                          :prompt "Allow Sapper subroutine to fire?"
                                          :priority 1
-                                         :yes-ability {:effect (effect (clear-wait-prompt :corp)
-                                                                       (play-subroutine :corp eid {:card card :subroutine 0}))}
+                                         :yes-ability {:effect (req (clear-wait-prompt state :corp)
+                                                                    (show-wait-prompt state :runner "Corp to trash a program with Sapper")
+                                                                    (play-subroutine state :corp eid {:card card :subroutine 0}))}
                                          :no-ability {:effect (effect (clear-wait-prompt :corp)
                                                                       (effect-completed eid))}}}
                               card nil))}}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -422,9 +422,11 @@
                                                    (in-discard? %))}
                               :effect (req (when-completed
                                              (corp-install state side target nil nil)
-                                             (if (< n 2)
-                                               (continue-ability state side (fhp (inc n)) card nil)
-                                               (effect-completed state side eid card))))})]
+                                             (do (system-msg state side (str "uses Friends in High Places to "
+                                                                             (corp-install-msg target)))
+                                                 (if (< n 2)
+                                                   (continue-ability state side (fhp (inc n)) card nil)
+                                                   (effect-completed state side eid card)))))})]
      {:delayed-completion true
       :effect (effect (continue-ability (fhelper 1) card nil))})
 

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -328,7 +328,9 @@
                  :msg (msg "to trigger an ability on " (:title target))}]}
 
    "Hyperdriver"
-   {:abilities [{:label "Remove Hyperdriver from the game to gain [Click] [Click] [Click]"
+   {:flags {:runner-phase-12 (req true)}
+    :abilities [{:label "Remove Hyperdriver from the game to gain [Click] [Click] [Click]"
+                 :req (req (:runner-phase-12 @state))
                  :effect (effect (move card :rfg) (gain :memory 3 :click 3))
                  :msg "gain [Click] [Click] [Click]"}]}
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -687,7 +687,8 @@
                  :msg (msg "add " (:title target) " to their Grip")
                  :effect (effect (move target :hand))}]
     :events {:runner-turn-ends {:effect (req (doseq [c (:hosted card)]
-                                               (trash state side c)))}}}
+                                               (when (is-type? c "Program")
+                                                 (trash state side c))))}}}
 
    "Motivation"
    (let [ability {:msg "look at the top card of their Stack"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -696,7 +696,9 @@
                   :req (req (:runner-phase-12 @state))
                   :effect (effect (prompt! card (str "The top card of your Stack is "
                                                      (:title (first (:deck runner)))) ["OK"] {}))}]
-   {:events {:runner-turn-begins ability}
+   {:flags {:runner-turn-draw true
+            :runner-phase-12 (req (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner)))}
+    :events {:runner-turn-begins ability}
     :abilities [ability]})
 
    "Mr. Li"

--- a/src/clj/test/cards/programs.clj
+++ b/src/clj/test/cards/programs.clj
@@ -263,8 +263,10 @@
     (is (= 1 (:memory (get-runner))) "3 MU used")
     (take-credits state :runner)
     (take-credits state :corp)
+    (is (:runner-phase-12 @state) "Runner in Step 1.2")
     (let [hyp (get-in @state [:runner :rig :program 0])]
       (card-ability state :runner hyp 0)
+      (core/end-phase-12 state :runner nil)
       (is (= 7 (:click (get-runner))) "Gained 3 clicks")
       (is (= 1 (count (:rfg (get-runner)))) "Hyperdriver removed from game"))))
 


### PR DESCRIPTION
* Fix #2244: Only trash programs on London Library when turn ends (sparing On the Lam)
* Fix #2222: Have Friends in High Places identify cards installed from Archives that were face up.
* Fix #2220: Motivation needs to be able to be triggered after MaxX if the Runner wishes
* Fix #2212: Prevent a lingering prompt issue by preventing the Runner from seeing "Trash Sapper?"  until after the subroutine has fully resolved
* Use `runner-phase-12` in Hyperdriver so it can be fired before copies of Data Folding trigger.