### PR TITLE
Fix The Foundry interaction with Accelerated Beta Test

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -17,26 +17,47 @@
 
    "Accelerated Beta Test"
    (letfn [(abt [n i]
-             {:req (req (pos? i))
-              :prompt "Select a piece of ICE from the Temporary Zone to install"
-              :choices {:req #(and (= (:side %) "Corp")
-                                   (ice? %)
-                                   (= (:zone %) [:play-area]))}
-              :effect (req (corp-install state side target nil
-                                         {:no-install-cost true :install-state :rezzed-no-cost})
-                           (trigger-event state side :rez target)
-                           (if (< n i)
-                             (continue-ability state side (abt (inc n) i) card nil)
-                             (effect-completed state side eid card)))})]
+             (if (pos? i)
+               {:delayed-completion true
+                :prompt "Select a piece of ICE from the Temporary Zone to install"
+                :choices {:req #(and (= (:side %) "Corp")
+                                     (ice? %)
+                                     (= (:zone %) [:play-area]))}
+                :effect (req (when-completed (corp-install state side target nil
+                                                           {:no-install-cost true :install-state :rezzed-no-cost})
+                                             (let [card (get-card state card)]
+                                               (unregister-events state side card)
+                                               (if (not (:shuffle-occurred card))
+                                                 (if (< n i)
+                                                   (continue-ability state side (abt (inc n) i) card nil)
+                                                   (do (doseq [c (get-in @state [:corp :play-area])]
+                                                         (system-msg state side "trashes a card")
+                                                         (trash state side c {:unpreventable true}))
+                                                       (effect-completed state side eid)))
+                                                 (do (doseq [c (get-in @state [:corp :play-area])]
+                                                       (move state side c :deck))
+                                                     (shuffle! state side :deck)
+                                                     (effect-completed state side eid))))))
+                :cancel-effect (req (doseq [c (get-in @state [:corp :play-area])]
+                                      (system-msg state side "trashes a card")
+                                      (trash state side c {:unpreventable true})))}
+               {:prompt "None of the cards are ice. Say goodbye!"
+                :choices ["I have no regrets"]
+                :effect (req (doseq [c (get-in @state [:corp :play-area])]
+                               (system-msg state side "trashes a card")
+                               (trash state side c {:unpreventable true})))}))]
      {:interactive (req true)
       :optional {:prompt "Look at the top 3 cards of R&D?"
-                 :yes-ability {:effect (req (let [n (count (filter ice? (take 3 (:deck corp))))]
-                                              (continue-ability state side
-                                                                {:msg "look at the top 3 cards of R&D"
-                                                                 :effect (req (doseq [c (take 3 (:deck corp))]
-                                                                                (move state side c :play-area))
-                                                                              (resolve-ability state side (abt 1 n) card nil))}
-                                                                card nil)))}}})
+                 :yes-ability {:delayed-completion true
+                               :msg "look at the top 3 cards of R&D"
+                               :effect (req (register-events state side
+                                                             {:corp-shuffle-deck
+                                                              {:effect (effect (update! (assoc card :shuffle-occurred true)))}}
+                                                             card)
+                                            (let [n (count (filter ice? (take 3 (:deck corp))))]
+                                              (doseq [c (take 3 (:deck corp))]
+                                                (move state side c :play-area))
+                                              (continue-ability state side (abt 1 n) card nil)))}}})
 
    "Advanced Concept Hopper"
    {:events

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -812,7 +812,7 @@
                                                    (corp-install state side (nth agendas n) nil
                                                                  {:install-state
                                                                   (:install-state (card-def (nth agendas n))
-                                                                    :rezzed-no-cost)})
+                                                                    :unrezzed)})
                                                    (if (< (inc n) (count agendas))
                                                      (continue-ability state side (pd agendas (inc n)) card nil)
                                                      (effect-completed state side eid))))}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -699,14 +699,15 @@
    "The Foundry: Refining the Process"
    {:events
     {:rez {:req (req (and (ice? target) ;; Did you rez and ice just now
-                          (some #(= (:title %) (:title target)) (:deck corp)) ;; Are there more copies in the dec
+                          ;; Are there more copies in the deck or play area (ABT interaction)?
+                          (some #(= (:title %) (:title target)) (concat (:deck corp) (:play-area corp)))
                           (empty? (let [rezzed-this-turn (map first (turn-events state side :rez))]
                                     (filter ice? rezzed-this-turn))))) ;; Is this the first ice you've rezzed this turn
            :optional
-           {:prompt "Add another copy to HQ?" :priority 1
+           {:prompt "Add another copy to HQ?"
             :yes-ability {:msg (msg "add a copy of " (:title target) " from R&D to HQ")
                           :effect (effect (shuffle! :deck)
-                                          (move (some #(when (= (:title %) (:title target)) %) (:deck corp)) :hand))}}}}}
+                                          (move (some #(when (= (:title %) (:title target)) %) (concat (:deck corp) (:play-area corp))) :hand))}}}}}
 
    "The Masque: Cyber General"
    {:events {:pre-start-game {:effect draft-points-target}}}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -700,14 +700,20 @@
    {:events
     {:rez {:req (req (and (ice? target) ;; Did you rez and ice just now
                           ;; Are there more copies in the deck or play area (ABT interaction)?
-                          (some #(= (:title %) (:title target)) (concat (:deck corp) (:play-area corp)))
+                          ;; (some #(= (:title %) (:title target)) (concat (:deck corp) (:play-area corp)))
+                          ;; Based on ruling re: searching and failing to find, we no longer enforce the requirement
+                          ;; of there being a target ice to bring into HQ.
                           (empty? (let [rezzed-this-turn (map first (turn-events state side :rez))]
                                     (filter ice? rezzed-this-turn))))) ;; Is this the first ice you've rezzed this turn
            :optional
            {:prompt "Add another copy to HQ?"
-            :yes-ability {:msg (msg "add a copy of " (:title target) " from R&D to HQ")
-                          :effect (effect (shuffle! :deck)
-                                          (move (some #(when (= (:title %) (:title target)) %) (concat (:deck corp) (:play-area corp))) :hand))}}}}}
+            :yes-ability {:effect (req (if-let [found-card (some #(when (= (:title %) (:title target)) %) (concat (:deck corp) (:play-area corp)))]
+                                         (do (move state side found-card :hand)
+                                             (system-msg state side (str "uses The Foundry to add a copy of "
+                                                                         (:title found-card) " to HQ, and shuffles their deck"))
+                                             (shuffle! state side :deck))
+                                         (do (system-msg state side (str "fails to find a target for The Foundry, and shuffles their deck"))
+                                             (shuffle! state side :deck))))}}}}}
 
    "The Masque: Cyber General"
    {:events {:pre-start-game {:effect draft-points-target}}}

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -1009,6 +1009,21 @@
       (is (= 0 (count (:prompt (get-corp))))
           "Corp not prompted to trigger Strategic Innovations"))))
 
+(deftest the-foundry-abt
+  ;; The Foundry - interaction with Accelerated Beta Test
+  (do-game
+    (new-game
+      (make-deck "The Foundry: Refining the Process" [(qty "Accelerated Beta Test" 2) (qty "Eli 1.0" 3)])
+      (default-runner))
+    (starting-hand state :corp ["Accelerated Beta Test"])
+    (play-from-hand state :corp "Accelerated Beta Test" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (prompt-choice :corp "Yes")
+    (prompt-select :corp (find-card "Eli 1.0" (:play-area (get-corp))))
+    (prompt-choice :corp "Archives")
+    (prompt-choice :corp "Yes")
+    (is (empty? (:play-area (get-corp))) "Play area shuffled into R&D")))
+
 (deftest titan-agenda-counter
   ;; Titan Transnational - Add a counter to a scored agenda
   (do-game


### PR DESCRIPTION
Not that anyone was holding their breath.

Make the `rez` function work with `when-completed`. Make ABT watch for shuffle effects during ice installs; abort the next prompt if a shuffle is detected. ABT now auto-trashes once all ice are installed, or if there are no ice in top 3. A prompt is shown in the latter case. The wording of the prompt is a little silly; if it's too unprofessional, we can change it. See line 44 in agendas.clj.

Fix #1672.