### PR TITLE
fix Blacklist interaction with Deja Vu, Trope, Ark Lockdown

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -110,7 +110,7 @@
     :choices (req (cancellable (:discard runner) :sorted))
     :msg (msg "remove all copies of " (:title target) " in the Heap from the game")
     :effect (req (doseq [c (filter #(= (:title target) (:title %)) (:discard runner))]
-                   (move state side c :rfg))
+                   (move state :runner c :rfg))
                  (effect-completed state side eid card))}
 
    "Back Channels"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -89,10 +89,10 @@
         (do (trash state s c {:unpreventable true})
             (system-msg state side (str "trashes " label from-str)))
         ("Grip" "HQ")
-        (do (move state s (dissoc c :seen :rezzed) :hand)
+        (do (move state s (dissoc c :seen :rezzed) :hand {:force true})
             (system-msg state side (str "moves " label from-str " to " server)))
         ("Stack" "R&D")
-        (do (move state s (dissoc c :seen :rezzed) :deck {:front true})
+        (do (move state s (dissoc c :seen :rezzed) :deck {:front true :force true})
             (system-msg state side (str "moves " label from-str " to the top of " server)))
         nil))))
 

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -58,7 +58,7 @@
 (defn move
   "Moves the given card to the given new zone."
   ([state side card to] (move state side card to nil))
-  ([state side {:keys [zone cid host installed] :as card} to {:keys [front keep-server-alive] :as options}]
+  ([state side {:keys [zone cid host installed] :as card} to {:keys [front keep-server-alive force] :as options}]
    (let [zone (if host (map to-keyword (:zone host)) zone)
          src-zone (first zone)
          target-zone (if (vector? to) (first to) to)
@@ -66,7 +66,8 @@
      (when (and card (or host
                          (some #(when (= cid (:cid %)) %) (get-in @state (cons :runner (vec zone))))
                          (some #(when (= cid (:cid %)) %) (get-in @state (cons :corp (vec zone)))))
-                (not (seq (get-in @state [side :locked zone]))))
+                (or (empty? (get-in @state [side :locked (-> card :zone first)]))
+                    force))
        (let [dest (if (sequential? to) (vec to) [to])
              trash-hosted (fn [h]
                              (trash state side
@@ -233,4 +234,3 @@
       (update! state side c)
       (when (active? card)
         (card-init state side c false)))))
-


### PR DESCRIPTION
Fixes #1946. 

The locked zone check in `move` doesn't seem to be working at all, so I stole the one that does work from `runner-install`. Then we add a "force" option to `move` so that you can still perform drag and drop manually. 