### PR TITLE
Extend when-completed to tagging runner

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -128,7 +128,8 @@
                             :effect (req (rez-cost-bonus state side (- (get-in card [:counter :agenda] 0))))}}}
 
    "Breaking News"
-   {:effect (effect (tag-runner :runner 2))
+   {:delayed-completion true
+    :effect (effect (tag-runner :runner eid 2))
     :silent (req true)
     :msg "give the Runner 2 tags"
     :end-turn {:effect (effect (lose :runner :tag 2))
@@ -529,7 +530,10 @@
    "Posted Bounty"
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
                :yes-ability {:msg "give the Runner 1 tag and take 1 bad publicity"
-                             :effect (final-effect (gain :bad-publicity 1) (tag-runner :runner 1) (forfeit card))}}}
+                             :delayed-completion true
+                             :effect (effect (gain :bad-publicity 1)
+                                             (tag-runner :runner eid 1)
+                                             (forfeit card))}}}
 
    "Priority Requisition"
    {:interactive (req true)
@@ -675,7 +679,9 @@
 
    "Restructured Datapool"
    {:abilities [{:cost [:click 1]
-                 :trace {:base 2 :msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}]}
+                 :trace {:base 2 :msg "give the Runner 1 tag"
+                         :delayed-completion true
+                         :effect (effect (tag-runner :runner eid 1))}}]}
 
    "Self-Destruct Chips"
    {:silent (req true)
@@ -713,7 +719,9 @@
                                 :effect (effect (ice-strength-bonus 1 target))}}}
 
    "TGTBT"
-   {:access {:msg "give the Runner 1 tag" :effect (effect (tag-runner :runner 1))}}
+   {:access {:msg "give the Runner 1 tag"
+             :delayed-completion true
+             :effect (effect (tag-runner :runner eid 1))}}
 
    "The Cleaners"
    {:events {:pre-damage {:req (req (= target :meat)) :msg "do 1 additional meat damage"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -7,9 +7,9 @@
                               {:msg (msg "force the Corp to lose " (min 5 (:credit corp))
                                          " [Credits], gain " (* 2 (min 5 (:credit corp)))
                                          " [Credits] and take 2 tags")
-                               :effect (effect (tag-runner 2)
-                                               (gain :runner :credit (* 2 (min 5 (:credit corp))))
-                                               (lose :corp :credit (min 5 (:credit corp))))}} card))}
+                               :effect (req (when-completed (tag-runner state :runner 2)
+                                                            (do (gain state :runner :credit (* 2 (min 5 (:credit corp))))
+                                                                (lose state :corp :credit (min 5 (:credit corp))))))}} card))}
 
    "Amped Up"
    {:msg "gain [Click][Click][Click] and suffer 1 brain damage"
@@ -113,14 +113,15 @@
    "Code Siphon"
    {:effect (effect (run :rd
                          {:replace-access
-                          {:prompt "Choose a program to install"
+                          {:delayed-completion true
+                           :prompt "Choose a program to install"
                            :msg (msg "install " (:title target) " and take 1 tag")
                            :choices (req (filter #(is-type? % "Program") (:deck runner)))
                            :effect (effect (trigger-event :searched-stack nil)
                                            (shuffle! :deck)
                                            (install-cost-bonus [:credit (* -3 (count (get-in corp [:servers :rd :ices])))])
                                            (runner-install target)
-                                           (tag-runner 1) )}} card))}
+                                           (tag-runner eid 1) )}} card))}
 
    "Corporate Scandal"
    {:msg "give the Corp 1 additional bad publicity"
@@ -1234,9 +1235,11 @@
    "Vamp"
    {:effect (effect (run :hq {:req (req (= target :hq))
                               :replace-access
-                              {:prompt "How many [Credits]?" :choices :credit
+                              {:delayed-completion true
+                               :prompt "How many [Credits]?" :choices :credit
                                :msg (msg "take 1 tag and make the Corp lose " target " [Credits]")
-                               :effect (effect (lose :corp :credit target) (tag-runner 1))}} card))}
+                               :effect (effect (lose :corp :credit target)
+                                               (tag-runner eid 1))}} card))}
 
    "Wanton Destruction"
    {:effect (effect (run :hq {:req (req (= target :hq))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -387,6 +387,7 @@
    "Maya"
    {:in-play [:memory 2]
     :abilities [{:once :per-turn
+                 :delayed-completion true
                  :label "Move this accessed card to bottom of R&D"
                  :req (req (when-let [c (:card (first (get-in @state [:runner :prompt])))]
                              (in-deck? c)))
@@ -395,18 +396,18 @@
                                 (when (is-type? c "Agenda") ; trashing before the :access events actually fire; fire them manually
                                   (resolve-steal-events state side c))
                                 (move state :corp c :deck)
-                                (tag-runner state :runner 1)
                                 (close-access-prompt state side)
-                                (effect-completed state side eid card)))}
+                                (tag-runner state :runner eid 1)))}
                 {:once :per-turn
                  :label "Move a previously accessed card to bottom of R&D"
                  :effect (effect (resolve-ability
                                    {; only allow targeting cards that were accessed this turn -- not perfect, but good enough?
+                                    :delayed-completion true
                                     :choices {:req #(some (fn [c] (= (:cid %) (:cid c)))
                                                           (map first (turn-events state side :access)))}
                                     :msg (msg "move " (:title target) " to the bottom of R&D")
                                     :effect (req (move state :corp target :deck)
-                                                 (tag-runner state :runner 1)
+                                                 (tag-runner state :runner eid 1)
                                                  (swap! state update-in [side :prompt] rest)
                                                  (when-let [run (:run @state)]
                                                    (when (and (:ended run) (empty? (get-in @state [:runner :prompt])))
@@ -667,10 +668,11 @@
    "Security Nexus"
    {:in-play [:memory 1 :link 1]
     :abilities [{:req (req (:run @state))
+                 :delayed-completion true
                  :msg "force the Corp to initiate a trace"
                  :label "Trace 5 - Give the Runner 1 tag and end the run"
                  :trace {:once :per-turn :base 5 :msg "give the Runner 1 tag and end the run"
-                         :effect (effect (tag-runner :runner 1) (end-run))
+                         :effect (effect (tag-runner :runner eid 1) (end-run))
                          :unsuccessful {:msg "bypass the current ICE"}}}]}
 
    "Silencer"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -26,7 +26,8 @@
    Mostly used with tag-trace"
   {:label "Give the Runner 1 tag"
    :msg "give the Runner 1 tag"
-   :effect (effect (tag-runner :runner 1))})
+   :delayed-completion true
+   :effect (effect (tag-runner :runner eid 1))})
 
 (def add-power-counter
   "Adds 1 power counter to the card."
@@ -278,7 +279,8 @@
 
    "Bandwidth"
    {:subroutines [{:msg "give the Runner 1 tag"
-                   :effect (effect (tag-runner :runner 1)
+                   :delayed-completion true
+                   :effect (effect (tag-runner :runner eid 1)
                                    (register-events
                                      {:successful-run {:effect (effect (lose :runner :tag 1))
                                                        :msg "make the Runner lose 1 tag"}
@@ -502,8 +504,9 @@
                         :effect (req (end-run state :runner)
                                      (system-msg state :runner "chooses to end the run on encountering Data Raven"))}
                        {:label "Take 1 tag"
-                        :effect (req (tag-runner state :runner 1)
-                                     (system-msg state :runner "chooses to take 1 tag on encountering Data Raven"))}]
+                        :delayed-completion true
+                        :effect (req (system-msg state :runner "chooses to take 1 tag on encountering Data Raven")
+                                     (tag-runner state :runner eid 1))}]
     :subroutines [(trace-ability 3 add-power-counter)]}
 
    "Data Ward"
@@ -511,8 +514,9 @@
                         :effect (req (pay state :runner card :credit 3)
                                      (system-msg state :runner "chooses to pay 3 [Credits] on encountering Data Ward"))}
                        {:label "Take 1 tag"
-                        :effect (req (tag-runner state :runner 1)
-                                     (system-msg state :runner "chooses to take 1 tag on encountering Data Ward"))}]
+                        :delayed-completion true
+                        :effect (req (system-msg state :runner "chooses to take 1 tag on encountering Data Ward")
+                                     (tag-runner state :runner eid 1))}]
     :subroutines [{:label "End the run if the Runner is tagged"
                    :req (req tagged)
                    :msg "end the run"
@@ -532,7 +536,8 @@
     :strength-bonus (req (get-in card [:counter :power] 0))
     :subroutines [(trace-ability 2 {:label "Give the Runner 1 tag and end the run"
                                     :msg "give the Runner 1 tag and end the run"
-                                    :effect (effect (tag-runner :runner 1)
+                                    :delayed-completion true
+                                    :effect (effect (tag-runner :runner eid 1)
                                                     (end-run))})]}
 
    "Eli 1.0"
@@ -763,16 +768,18 @@
    {:subroutines [trash-program
                   (trace-ability 1 {:label "Give the Runner 1 tag and do 1 brain damage"
                                     :msg "give the Runner 1 tag and do 1 brain damage"
-                                    :effect (effect (damage eid :brain 1 {:card card})
-                                                    (tag-runner :runner 1))})]
+                                    :delayed-completion true
+                                    :effect (req (when-completed (damage state :runner :brain 1 {:card card})
+                                                                 (tag-runner state :runner eid 1)))})]
     :runner-abilities [(runner-break [:click 1] 1)]}
 
    "Ichi 2.0"
    {:subroutines [trash-program
                   (trace-ability 3 {:label "Give the Runner 1 tag and do 1 brain damage"
                                     :msg "give the Runner 1 tag and do 1 brain damage"
-                                    :effect (effect (damage eid :brain 1 {:card card})
-                                                    (tag-runner :runner 1))})]
+                                    :delayed-completion true
+                                    :effect (req (when-completed (damage state :runner :brain 1 {:card card})
+                                                                 (tag-runner state :runner eid 1)))})]
     :runner-abilities [(runner-break [:click 2] 2)]}
 
    "Information Overload"
@@ -912,10 +919,11 @@
                    :msg (msg "do " (if (> 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0))) 1 3) " net damage")
                    :effect (effect (damage eid :net (if (> 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0))) 1 3) {:card card}))}
                   {:label "Give the Runner 1 tag (and end the run)"
+                   :delayed-completion true
                    :msg (msg "give the Runner 1 tag"
-                          (when (<= 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0))) " and end the run"))
-                   :effect (req (tag-runner state :runner 1)
-                             (when (<= 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0)))
+                             (when (<= 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0))) " and end the run"))
+                   :effect (req (tag-runner state :runner eid 1)
+                                (when (<= 3 (+ (:advance-counter card 0) (:extra-advance-counter card 0)))
                                   (end-run state side)))}]}
 
    "Merlin"
@@ -1105,7 +1113,9 @@
    {:advanceable :always
     ;; Could replace this with (tag-trace advance-counters).
     :subroutines [{:label "Trace X - Give the Runner 1 tag"
-                   :trace {:base advance-counters :effect (effect (tag-runner :runner 1))
+                   :trace {:base advance-counters
+                           :delayed-completion true
+                           :effect (effect (tag-runner :runner eid 1))
                            :msg "give the Runner 1 tag"}}]}
 
    "Sensei"
@@ -1136,7 +1146,8 @@
                            :effect  (effect (move :runner target :deck))}}
                   {:label  "Give the Runner 1 tag"
                    :msg    "give the Runner 1 tag"
-                   :effect (effect (tag-runner :runner 1))}]
+                   :delayed-completion true
+                   :effect (effect (tag-runner :runner eid 1))}]
     :runner-abilities [(runner-break [:click 2] 2)]}
 
    "Shinobi"
@@ -1226,8 +1237,9 @@
    {:implementation "Encounter effect is manual"
     :abilities [give-tag]
     :runner-abilities [{:label "Take 1 tag"
-                        :effect (req (tag-runner state :runner 1)
-                                     (system-msg state :runner "takes 1 tag on encountering Thoth"))}]
+                        :delayed-completion true
+                        :effect (req (system-msg state :runner "takes 1 tag on encountering Thoth")
+                                     (tag-runner state :runner eid 1))}]
     :subroutines [(trace-ability 4 {:label "Do 1 net damage for each Runner tag"
                                     :delayed-completion true
                                     :msg (msg "do " (:tag runner) " net damage")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -72,12 +72,12 @@
    "Argus Security: Protection Guaranteed"
    {:events {:agenda-stolen
              {:prompt "Take 1 tag or suffer 2 meat damage?"
+              :delayed-completion true
               :choices ["1 tag" "2 meat damage"] :player :runner
               :msg "make the Runner take 1 tag or suffer 2 meat damage"
               :effect (req (if (= target "1 tag")
                              (do (system-msg state side "chooses to take 1 tag")
-                                 (tag-runner state :runner 1)
-                                 (effect-completed state side eid nil))
+                                 (tag-runner state :runner eid 1))
                              (do (system-msg state side "chooses to suffer 2 meat damage")
                                  (damage state :runner eid :meat 2 {:unboostable true :card card}))))}}}
 
@@ -311,7 +311,8 @@
    {:events (let [inf {:req (req (and (not (:disabled card))
                                       (has-most-faction? state :corp "NBN")))
                        :msg "give the Runner 1 tag"
-                       :effect (effect (tag-runner :runner 1))}]
+                       :delayed-completion true
+                       :effect (effect (tag-runner :runner eid 1))}]
               {:pre-start-game {:effect draft-points-target}
                :agenda-scored inf :agenda-stolen inf})}
 
@@ -486,11 +487,11 @@
                            (continue-ability
                              state :corp
                              {:optional
-                              {:delayed-completion true
-                               :prompt "Trace the Runner with NBN: Controlling the Message?"
+                              {:prompt "Trace the Runner with NBN: Controlling the Message?"
                                :yes-ability {:trace {:base 4
                                                      :msg "give the Runner 1 tag"
-                                                     :effect (effect (tag-runner :runner 1 {:unpreventable true})
+                                                     :delayed-completion true
+                                                     :effect (effect (tag-runner :runner eid 1 {:unpreventable true})
                                                                      (clear-wait-prompt :runner))
                                                      :unsuccessful {:effect (effect (clear-wait-prompt :runner))}}}
                                :no-ability {:effect (effect (clear-wait-prompt :runner))}}}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -150,7 +150,8 @@
    "Big Brother"
    {:req (req tagged)
     :msg "give the Runner 2 tags"
-    :effect (effect (tag-runner :runner 2))}
+    :delayed-completion true
+    :effect (effect (tag-runner :runner eid 2))}
 
    "Bioroid Efficiency Research"
    {:implementation "Derez is manual"
@@ -194,7 +195,8 @@
                                                 (system-msg state side (str "hosts Casting Call on " (:title agenda)))))}
                      card nil)))
     :events {:access {:req (req (= (:cid target) (:cid (:host card))))
-                      :effect (effect (tag-runner :runner 2)) :msg "give the Runner 2 tags"}}}
+                      :delayed-completion true
+                      :effect (effect (tag-runner :runner eid 2)) :msg "give the Runner 2 tags"}}}
 
    "Celebrity Gift"
    {:choices {:max 5
@@ -207,8 +209,9 @@
    {:req (req (:successful-run runner-reg))
     :psi {:not-equal {:player :runner :prompt "Take 1 tag or 1 brain damage?"
                       :choices ["1 tag" "1 brain damage"] :msg (msg "give the Runner " target)
+                      :delayed-completion true
                       :effect (req (if (= target "1 tag")
-                                     (tag-runner state side 1)
+                                     (tag-runner state side eid 1)
                                      (damage state side eid :brain 1 {:card card})))}}}
 
    "Cerebral Static"
@@ -281,8 +284,7 @@
                       :delayed-completion true
                       :effect (req (if tagged
                                      (damage state side eid :meat 1 {:card card})
-                                     (do (tag-runner state :runner 1)
-                                         (effect-completed state side eid card))))}}}}
+                                     (tag-runner state :runner eid 1)))}}}}
 
    "Election Day"
    {:req (req (->> (get-in @state [:corp :hand])
@@ -435,9 +437,10 @@
    "Hard-Hitting News"
    {:req (req (:made-run runner-reg))
     :trace {:base 4
+            :delayed-completion true
             :msg "give the Runner 4 tags"
             :label "Give the Runner 4 tags"
-            :effect (effect (tag-runner :runner 4))}}
+            :effect (effect (tag-runner :runner eid 4))}}
 
    "Hasty Relocation"
    (letfn [(hr-final [chosen original]
@@ -607,7 +610,8 @@
    {:events {:successful-run {:interactive (req true)
                               :req (req (first-event state side :successful-run))
                               :trace {:base 2 :msg "give the Runner 1 tag"
-                                      :effect (effect (tag-runner :runner 1))}}}}
+                                      :delayed-completion true
+                                      :effect (effect (tag-runner :runner eid 1))}}}}
 
    "Medical Research Fundraiser"
    {:msg "gain 8 [Credits]. The Runner gains 3 [Credits]"
@@ -618,8 +622,9 @@
     :trace {:base 6
             :msg "give the Runner X tags"
             :label "Give the Runner X tags"
-            :effect (effect (tag-runner :runner (- target (second targets)))
-                            (system-msg (str "gives the Runner " (- target (second targets)) " tags")))}}
+            :delayed-completion true
+            :effect (effect (system-msg (str "gives the Runner " (- target (second targets)) " tags"))
+                            (tag-runner :runner eid (- target (second targets))))}}
 
    "Mushin No Shin"
    {:prompt "Choose a card to install from HQ"
@@ -904,7 +909,8 @@
     :trace {:base 3
             :msg "give the Runner 1 tag"
             :label "Give the Runner 1 tag"
-            :effect (effect (tag-runner :runner 1))}}
+            :delayed-completion true
+            :effect (effect (tag-runner :runner eid 1))}}
 
    "Service Outage"
    (let [add-effect (fn [state side card]
@@ -986,8 +992,11 @@
                                                 (if (= target "Yes")
                                                   {:msg (msg "take 1 tag to prevent " (:title c)
                                                              " from being trashed")
-                                                   :effect (final-effect (tag-runner 1 {:unpreventable true}))}
-                                                  {:effect (final-effect (trash c)) :msg (msg "trash " (:title c))})
+                                                   :delayed-completion true
+                                                   :effect (effect (tag-runner eid 1 {:unpreventable true}))}
+                                                  {:delayed-completion true
+                                                   :effect (effect (trash eid c nil))
+                                                   :msg (msg "trash " (:title c))})
                                                 card nil))}
                              card nil)))}}
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -18,7 +18,8 @@
    {:events
     {:corp-turn-begins {:req (req (= 0 (:tag runner)))
                         :msg "take 1 tag"
-                        :effect (effect (tag-runner :runner 1))}
+                        :delayed-completion true
+                        :effect (effect (tag-runner :runner eid 1))}
      :runner-turn-begins {:req (req (not has-bad-pub))
                           :msg "give the Corp 1 bad publicity"
                           :effect (effect (gain :corp :bad-publicity 1))}}}
@@ -610,15 +611,17 @@
                               :msg "draw 1 card" :once-key :john-masanori-draw
                               :effect (effect (draw))}
              :unsuccessful-run {:req (req (first-event state side :unsuccessful-run))
+                                :delayed-completion true
                                 :msg "take 1 tag" :once-key :john-masanori-tag
-                                :effect (effect (tag-runner :runner 1))}}}
+                                :effect (effect (tag-runner :runner eid 1))}}}
 
    "Joshua B."
    (let [ability {:msg "gain [Click]"
                   :once :per-turn
                   :label "Gain [Click] (start of turn)"
                   :effect (effect (gain :click 1))
-                  :end-turn {:effect (effect (tag-runner 1))
+                  :end-turn {:delayed-completion true
+                             :effect (effect (tag-runner eid 1))
                              :msg "gain 1 tag"}}]
    {:events {:runner-turn-begins
              {:optional {:prompt "Use Joshua B. to gain [Click]?"
@@ -1153,8 +1156,9 @@
                               {:prompt "Use Tallie Perrault to give the Corp 1 bad publicity and take 1 tag?"
                                :player :runner
                                :yes-ability {:msg "give the Corp 1 bad publicity and take 1 tag"
+                                             :delayed-completion true
                                              :effect (effect (gain :corp :bad-publicity 1)
-                                                             (tag-runner :runner 1)
+                                                             (tag-runner :runner eid 1)
                                                              (clear-wait-prompt :corp))}
                                :no-ability {:effect (effect (clear-wait-prompt :corp))}}}
                             card nil))}}}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -53,7 +53,8 @@
    "Bernice Mai"
    {:events {:successful-run {:req (req this-server)
                               :trace {:base 5 :msg "give the Runner 1 tag"
-                                      :effect (effect (tag-runner :runner 1))
+                                      :delayed-completion true
+                                      :effect (effect (tag-runner :runner eid 1))
                                       :unsuccessful {:effect (effect (system-msg "trashes Bernice Mai from the unsuccessful trace")
                                                                      (trash card))}}}}}
 
@@ -77,7 +78,8 @@
 
    "ChiLo City Grid"
    {:events {:successful-trace {:req (req this-server)
-                                :effect (effect (tag-runner :runner 1))
+                                :delayed-completion true
+                                :effect (effect (tag-runner :runner eid 1))
                                 :msg "give the Runner 1 tag"}}}
 
    "Corporate Troubleshooter"
@@ -346,9 +348,7 @@
                                                :msg "do 1 meat damage and give the Runner 1 tag"
                                                :delayed-completion true
                                                :effect (req (when-completed (damage state side :meat 1 {:card card})
-                                                                            (do (tag-runner state :runner 1)
-                                                                                ;; TO-DO: extend effect-completed to tag prevention
-                                                                                (effect-completed state side eid))))}}}
+                                                                            (tag-runner state :runner eid 1)))}}}
                                card nil))}}
 
    "Product Placement"

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -220,8 +220,8 @@
                            (when-not (:delayed-completion cdef)
                              (effect-completed state side eid)))
 
-                       ;; All other cards. Trigger effect-completed as long as the card itself is not delayed.
-                       (not (:delayed-completion cdef))
+                       ;; All other cards. Trigger effect-completed.
+                       :else
                        (effect-completed state side eid))
 
                      (when-let [dre (:derezzed-events cdef)]

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -814,6 +814,24 @@
       (is (= 1 (:agenda-point (get-runner))))
       (is (empty? (get-in @state [:runner :rig :resource])) "NACH trashed by agenda steal"))))
 
+(deftest new-angeles-city-hall-siphon
+  ;; New Angeles City Hall - don't gain Siphon credits until opportunity to avoid tags has passed
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Account Siphon" 1) (qty "New Angeles City Hall" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "New Angeles City Hall")
+    (play-run-event state (first (:hand (get-runner))) :hq)
+    (prompt-choice :runner "Run ability")
+    (let [nach (get-in @state [:runner :rig :resource 0])]
+      (is (= 4 (:credit (get-runner))) "Have not gained Account Siphon credits until tag avoidance window closes")
+      (card-ability state :runner nach 0)
+      (card-ability state :runner nach 0)
+      (prompt-choice :runner "Done")
+      (is (= 0 (:tag (get-runner))) "Tags avoided")
+      (is (= 10 (:credit (get-runner))) "10 credits siphoned")
+      (is (= 3 (:credit (get-corp))) "Corp lost 5 credits"))))
+
 (deftest paige-piper-frantic-coding
   ;; Paige Piper - interaction with Frantic Coding. Issue #2190.
   (do-game


### PR DESCRIPTION
Fixes #2228 and a few other issues, by enabling `tag-runner` to be awaited with `when-completed`.

Also fixes an interaction with Accelerated Beta Test and Team Sponsorship... I think.

I don't know why there are all these other commits here, oh well.