### PR TITLE
Implement Cold Read

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -122,6 +122,23 @@
                                            (runner-install target)
                                            (tag-runner 1) )}} card))}
 
+   "Cold Read"
+   (let [end-effect {:prompt "Choose a program that was used during the run to trash "
+                     :choices {:req #(card-is? % :type "Program")}
+                     :msg (msg "trash" (:title target))
+                     :effect (effect (trash target {:unpreventable true}))}]
+     {:delayed-completion true
+      :prompt "Choose a server"
+      :recurring 4
+      :choices (req runnable-servers)
+      :effect (req (let [c (move state side (assoc card :zone '(:discard)) :play-area)]
+                     (card-init state side c false)
+                     (game.core/run state side (make-eid state) target
+                                    {:end-run {:delayed-completion true
+                                               :effect (effect (trash c)
+                                                               (continue-ability end-effect card nil))}}
+                                    c)))})
+
    "Corporate Scandal"
    {:msg "give the Corp 1 additional bad publicity"
     :effect (req (swap! state update-in [:corp :has-bad-pub] inc))


### PR DESCRIPTION
Thanks to @JoelCFC25's memory of how Demolition Run is coded. Cold Read will go into the play area with 4 credits on it, and the runner can click the card to take the credits. Trashes at end of run.