### PR TITLE
Old Hollywood Grid refresh

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -355,14 +355,22 @@
     :leave-play (req (enable-run-on-server state card (second (:zone card))))}
 
    "Old Hollywood Grid"
-   (let [ohg {:req (req this-server)
-              :effect (effect (register-run-flag!
+   (let [ohg {:req (req (or (= (:zone card) (:zone target)) (= (central->zone (:zone target)) (butlast (:zone card)))))
+              :effect (effect (register-persistent-flag!
                                 card :can-steal
-                                (fn [state side card]
+                                (fn [state _ card]
                                   (if-not (some #(= (:title %) (:title card)) (:scored runner))
                                     ((constantly false) (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
                                     true))))}]
-     (assoc-in ohg [:events :run] ohg))
+     {:trash-effect
+              {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
+               :effect (effect (register-events {:pre-steal-cost (assoc ohg :req (req (or (= (:zone target) (:previous-zone card))
+                                                                                          (= (central->zone (:zone target))
+                                                                                             (butlast (:previous-zone card))))))
+                                                 :run-ends {:effect (effect (unregister-events card))}}
+                                                (assoc card :zone '(:discard))))}
+      :events {:pre-steal-cost ohg
+               :post-access-card {:effect (effect (clear-persistent-flag! card :can-steal))}}})
 
    "Panic Button"
    {:init {:root "HQ"} :abilities [{:cost [:credit 1] :label "Draw 1 card" :effect (effect (draw))

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -322,7 +322,8 @@
 (defn can-steal?
   "Checks if the runner can steal agendas"
   [state side card]
-  (check-flag-types? state side card :can-steal [:current-turn :current-run]))
+  (and (check-flag-types? state side card :can-steal [:current-turn :current-run])
+       (check-flag-types? state side card :can-steal [:current-turn :persistent])))
 
 (defn can-access?
   "Checks if the runner can access the specified card"

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -215,7 +215,8 @@
                                                            (effect-completed state side eid))))
                                      (access-non-agenda state side eid c)))))
                              ;; The runner cannot afford the cost to access the card
-                             (prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {}))))))))
+                             (prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {})))
+                         (trigger-event state side :post-access-card c))))))
 
 (defn msg-handle-access
   ([state side cards]

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -520,6 +520,24 @@
       (prompt-choice :runner "OK")
       (is (= 0 (count (:scored (get-runner)))) "No scored agendas"))))
 
+(deftest old-hollywood-grid-gang-sign
+  ;; Old Hollywood Grid - Gang Sign interaction. Prevent the steal outside of a run. #2169
+  (do-game
+    (new-game (default-corp [(qty "Old Hollywood Grid" 1) (qty "Project Beale" 2)])
+              (default-runner [(qty "Gang Sign" 1)]))
+    (play-from-hand state :corp "Old Hollywood Grid" "HQ")
+    (play-from-hand state :corp "Project Beale" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Gang Sign")
+    (take-credits state :runner)
+    (core/rez state :corp (get-content state :hq 0))
+    (score-agenda state :corp (get-content state :remote1 0))
+    ;; Gang sign fires
+    (prompt-choice :runner "Card from hand")
+    ;; prompt shows "You cannot steal"
+    (prompt-choice :runner "OK")
+    (is (= 0 (count (:scored (get-runner)))) "No scored agendas")))
+
 (deftest port-anson-grid
   ;; Port Anson Grid - Prevent the Runner from jacking out until they trash a program
   (do-game


### PR DESCRIPTION
I think this is the way to go but tbh, this one was sort of tricky and might warrant a review. Copies ideas from Red Herrings. Fixes #2169 

Instead of registering a run-flag as before, we now register a persistent-flag when the :pre-steal-cost event triggers (even though there is no actual additional cost, we avoid unnecessary triggers over using :pre-access-card). The persistent flag is immediately cleared after the access, upon a new event hook, :post-access-card. 