### PR TITLE
issue #2204: increase run menu z level

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1459,7 +1459,7 @@ nav ul
 
       .right-inner-leftpane
         width: 186px
-        z-index: 1
+        z-index: 11
         justify-content(space-between)
         display-flex()
         flex-direction(column)


### PR DESCRIPTION
This fixes a regression where adding a z-level to the right-inner-leftpane caused a stacking context to be formed, which resulted in the run menu appearing below counters on cards (with z-level 10).

This turns z-level up to 11 to stop this from happening.

