### PR TITLE
Fix server response when saving a new deck.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -551,7 +551,7 @@ app.post '/data/decks', (req, res) ->
     else
       db.collection('decks').insert deck, (err, data) ->
         console.log(err) if err
-        res.status(200).json(data[0])
+        res.status(200).send(data.ops[0])
   else
     res.status(401).send({message: 'Unauthorized'})
 


### PR DESCRIPTION
Don't know why, but the database data returned from insert is now in `data.ops`, not just `data`.