### PR TITLE
Fix On the Lam.

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -811,10 +811,8 @@
     :prompt "Choose a resource to host On the Lam"
     :choices {:req #(and (is-type? % "Resource")
                          (installed? %))}
-    :effect (req (let [c (card-init state side (assoc card :zone [:discard] :seen true))]
-                   (host state side target c)
-                   (system-msg state side (str "hosts On the Lam on " (:title target)))
-                   (swap! state update-in [:runner :prompt] rest)))
+    :effect (effect (host target (assoc card :zone [:discard]))
+                    (system-msg (str "hosts On the Lam on " (:title target))))
     :prevent {:tag [:all] :damage [:meat :net :brain]}
     :abilities [{:label "[Trash]: Avoid 3 tags"
                  :msg "avoid up to 3 tags"

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -62,22 +62,24 @@
            c (assoc target :host (dissoc card :hosted)
                            :facedown facedown
                            :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
-                           :previous-zone (:zone target))]
+                           :previous-zone (:zone target))
+           cdef (card-def card)
+           tdef (card-def c)]
        (update! state side (update-in card [:hosted] #(conj % c)))
-
        ;; events should be registered for: runner cards that are installed; corp cards that are Operations, or are installed and rezzed
-       (when (or (and installed (card-is? target :side :runner))
-                 (or (is-type? target "Operation")
-                     (and installed (card-is? target :side :corp) (:rezzed target))))
-         (when-let [events (:events (card-def target))]
+       (when (or (is-type? target "Operation")
+                 (is-type? target "Event")
+                 (and installed (card-is? target :side :runner))
+                 (and installed (card-is? target :side :corp) (:rezzed target)))
+         (when-let [events (:events tdef)]
            (register-events state side events c))
-         (when (:recurring (card-def c))
+         (when (or (:recurring tdef) (:prevent tdef))
            (card-init state side c false)))
 
-       (when-let [events (:events (card-def target))]
-         (when (and installed (:recurring (card-def c)))
+       (when-let [events (:events tdef)]
+         (when (and installed (:recurring tdef))
            (unregister-events state side target)
            (register-events state side events c)))
-       (when-let [hosted-gained (:hosted-gained (card-def card))]
+       (when-let [hosted-gained (:hosted-gained cdef)]
          (hosted-gained state side (make-eid state) (get-card state card) [c]))
        c))))


### PR DESCRIPTION
This is the first Event card that can be hosted on others, so `host` had to be changed to account for the ability.