### PR TITLE
fix Old Hollywood Grid, Hunting Grounds

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1096,7 +1096,8 @@
    "Sapper"
    {:subroutines [trash-program]
     :access {:delayed-completion true
-             :req (req (not= (first (:zone card)) :discard))
+             :req (req (and (not= (first (:zone card)) :discard)
+                            (some #(is-type? % "Program") (all-installed state :runner))))
              :effect (effect (show-wait-prompt :corp "Runner to decide to break Sapper subroutine")
                              (continue-ability
                                :runner {:optional

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -68,23 +68,16 @@
    {:delayed-completion false
     :prompt "Choose a server" :choices ["Archives" "R&D" "HQ"]
     :effect (req (let [serv target]
+                   (show-wait-prompt state :corp (str "Runner to decide on running " target))
                    (continue-ability
                      state side
                      {:optional
                       {:prompt (msg "Make a run on " serv "?") :player :runner
                        :yes-ability {:msg (msg "let the Runner make a run on " serv)
-                                     :effect (req (let [s (cond
-                                                            (= serv "HQ") [:hq]
-                                                            (= serv "R&D") [:rd]
-                                                            (= serv "Archives") [:archives])
-                                                        ices (get-in @state (concat [:corp :servers] s [:ices]))]
-                                                    (swap! state assoc :per-run nil
-                                                           :run {:server s :position (count ices)
-                                                                 :access-bonus 0 :run-effect nil :cannot-jack-out true})
-                                                    (gain-run-credits state :runner (:bad-publicity corp))
-                                                    (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
-                                                    (trigger-event state :runner :run s)))}
-                       :no-ability {:effect (effect (as-agenda :corp (last (:discard corp)) 1))
+                                     :effect (effect (clear-wait-prompt :corp)
+                                                     (game.core/run eid serv nil card))}
+                       :no-ability {:effect (effect (clear-wait-prompt :corp)
+                                                    (as-agenda :corp (last (:discard corp)) 1))
                                     :msg "add it to their score area as an agenda worth 1 agenda point"}}}
                     card nil)))}
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -564,8 +564,8 @@
                  {:label "[Trash]: Install the top 3 cards of your Stack facedown"
                   :msg "install the top 3 cards of their Stack facedown"
                   :effect (req (trash state side card {:cause :ability-cost})
-                               (doseq [c (take 3 (:deck runner))]
-                                  (runner-install state side c {:facedown true})))}]}
+                               (doseq [c (take 3 (get-in @state [:runner :deck]))]
+                                 (runner-install state side c {:facedown true})))}]}
 
    "Ice Analyzer"
    {:implementation "Credit use restriction is not enforced"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -372,7 +372,7 @@
                                                  :run-ends {:effect (effect (unregister-events card))}}
                                                 (assoc card :zone '(:discard))))}
       :events {:pre-steal-cost ohg
-               :post-access-card {:effect (effect (clear-persistent-flag! card :can-steal))}}})
+               :post-access-card {:effect (effect (clear-persistent-flag! target :can-steal))}}})
 
    "Panic Button"
    {:init {:root "HQ"} :abilities [{:cost [:credit 1] :label "Draw 1 card" :effect (effect (draw))

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -494,14 +494,14 @@
       (prompt-select :runner hok)
       ;; prompt shows "You cannot steal"
       (prompt-choice :runner "OK")
-      (is (= 0 (count (:scored (get-runner)))) "No scored agendas")
+      (is (= 0 (count (:scored (get-runner)))) "No stolen agendas")
       (prompt-select :runner ohg)
       (prompt-choice :runner "No")
       (core/steal state :runner (find-card "House of Knives" (:hand (get-corp))))
       (run-empty-server state "Server 1")
       (prompt-select :runner hok)
       (prompt-choice :runner "Yes")
-      (is (= 2 (count (:scored (get-runner)))) "2 scored agendas"))))
+      (is (= 2 (count (:scored (get-runner)))) "2 stolen agendas"))))
 
 (deftest old-hollywood-grid-central
   ;; Old Hollywood Grid - Central server
@@ -518,7 +518,13 @@
       (prompt-choice :runner "Card from hand")
       ;; prompt shows "You cannot steal"
       (prompt-choice :runner "OK")
-      (is (= 0 (count (:scored (get-runner)))) "No scored agendas"))))
+      (is (= 0 (count (:scored (get-runner)))) "No stolen agendas")
+      (prompt-choice :runner "Old Hollywood Grid")
+      ;; trash OHG
+      (prompt-choice :runner "Yes")
+      (run-empty-server state "HQ")
+      (prompt-choice :runner "Steal")
+      (is (= 1 (count (:scored (get-runner)))) "1 stolen agenda"))))
 
 (deftest old-hollywood-grid-gang-sign
   ;; Old Hollywood Grid - Gang Sign interaction. Prevent the steal outside of a run. #2169
@@ -536,7 +542,7 @@
     (prompt-choice :runner "Card from hand")
     ;; prompt shows "You cannot steal"
     (prompt-choice :runner "OK")
-    (is (= 0 (count (:scored (get-runner)))) "No scored agendas")))
+    (is (= 0 (count (:scored (get-runner)))) "No stolen agendas")))
 
 (deftest port-anson-grid
   ;; Port Anson Grid - Prevent the Runner from jacking out until they trash a program


### PR DESCRIPTION
* Fix #2262: Minor change needed to correctly drop OHG's persistent flag when trashed, updated test.
* Fix #2253: Fix Hunting Grounds to work with Reaver(s)
* Don't prompt Runner when accessing a Sapper if they have no programs installed
* Add wait prompts and do some code prettifying to An Offer You Can't Refuse