### PR TITLE
Stop Paperclip install prompt when one is already installed

### DIFF
--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -144,7 +144,8 @@
   [title type abilities]
   (let [install-prompt {:req (req (and (= (:zone card) [:discard])
                                        (rezzed? current-ice)
-                                       (has-subtype? current-ice type)))
+                                       (has-subtype? current-ice type)
+                                       (not (some #(= title (:title %)) (all-installed state :runner)))))
                         :optional {:player :runner
                                    :prompt (str "Install " title "?")
                                    :yes-ability {:effect (effect (unregister-events card)
@@ -152,12 +153,14 @@
         heap-event (req (when (= (:zone card) [:discard])
                           (unregister-events state side card)
                           (register-events state side
-                                           (:events (card-def card))
+                                           {:rez install-prompt
+                                            :approach-ice install-prompt
+                                            :run install-prompt}
                                            (assoc card :zone [:discard]))))]
     {:move-zone heap-event
-     :events {:rez install-prompt
-              :approach-ice install-prompt
-              :run install-prompt}
+     :events {:rez nil
+              :approach-ice nil
+              :run nil}
      :abilities abilities}))
 
 (defn- central-breaker

--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -297,6 +297,24 @@
     (let [ov (get-in @state [:runner :rig :program 0])]
       (is (= 5 (get-counters (refresh ov) :power)) "Overmind has 5 counters"))))
 
+(deftest paperclip
+  ;; Paperclip - prompt to install on encounter, but not if another is installed
+  (do-game
+    (new-game (default-corp [(qty "Vanilla" 1)])
+              (default-runner [(qty "Paperclip" 2)]))
+    (play-from-hand state :corp "Vanilla" "Archives")
+    (take-credits state :corp)
+    (trash-from-hand state :runner "Paperclip")
+    (run-on state "Archives")
+    (core/rez state :corp (get-ice state :archives 0))
+    (prompt-choice :runner "Yes") ; install paperclip
+    (run-continue state)
+    (run-successful state)
+    (is (not (:run @state)) "Run ended")
+    (trash-from-hand state :runner "Paperclip")
+    (run-on state "Archives")
+    (is (empty? (:prompt (get-runner))) "No prompt to install second Paperclip")))
+
 (deftest shiv
   ;; Shiv - Gain 1 strength for each installed breaker; no MU cost when 2+ link
   (do-game


### PR DESCRIPTION
Likewise for the other conspiracy breakers.