### PR TITLE
Make the central pane overflow

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1510,6 +1510,7 @@ nav ul
     flex(1)
     display-flex()
     flex-direction(column)
+    overflow: auto
 
     .card-wrapper
       margin: 3px 6px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1510,6 +1510,7 @@ nav ul
     flex(1)
     display-flex()
     flex-direction(column)
+    min-width: 90px
     overflow: auto
 
     .card-wrapper


### PR DESCRIPTION
Causes the central pane to scroll independently of the main window, so the left and right panes stay visible and in position.

I looked at adding shadows to indicate the scrollable area's edges using http://lea.verou.me/2012/04/background-attachment-local/, but that solution requires a solid background colour.

Fixes #2261.