### PR TITLE
Fix Crisium Grid

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -116,7 +116,7 @@
                                     :req (req this-server)
                                     :effect (req (swap! state update-in [:run :run-effect] dissoc :replace-access)
                                                  (swap! state update-in [:run] dissoc :successful)
-                                                 (swap! state update-in [:runner :register :successful-run] #(rest %)))}}})
+                                                 (swap! state update-in [:runner :register :successful-run] #(next %)))}}})
 
    "Cyberdex Virus Suite"
    {:access {:delayed-completion true

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -199,7 +199,8 @@
     (play-from-hand state :runner "Temüjin Contract")
     (prompt-choice :runner "HQ")
     (run-empty-server state "HQ")
-    (is (= 2 (:credit (get-runner))) "No Desperado or Temujin credits")))
+    (is (= 2 (:credit (get-runner))) "No Desperado or Temujin credits")
+    (is (not (:successful-run (:register (get-runner)))) "No successful run in register")))
 
 (deftest cyberdex-virus-suite-purge
   ;; Cyberdex Virus Suite - Purge ability


### PR DESCRIPTION
Was recording an empty list for `:successful-run runner-reg`, which is a truthy value. Fixes #2272 and probably tons of other unreported bugs, as SEA Source and many other cards use the same req as En Passant.