### PR TITLE
Archives Interface is not triggered when there's no cards to trash

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -9,7 +9,7 @@
     {:successful-run
      {:silent (req true)
       :delayed-completion true
-      :req (req (= target :archives))
+      :req (req (and (= target :archives) (not-empty (:discard corp))))
       :effect (effect (continue-ability
                         {:optional
                          {:prompt "Use Archives Interface to remove a card from the game instead of accessing it?"


### PR DESCRIPTION
Fixes https://github.com/mtgred/netrunner/issues/2276

Adds a simple check not to open **Archives Interface** prompt if Archives is empty