### PR TITLE
Fix #2000

### DIFF
--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -63,9 +63,12 @@
                            :facedown facedown
                            :zone '(:onhost) ;; hosted cards should not be in :discard or :hand etc
                            :previous-zone (:zone target))
+           ;; Update any cards hosted by the target, so their :host has the updated zone.
+           c (update-in c [:hosted] #(map (fn [h] (assoc h :host c)) %))
            cdef (card-def card)
            tdef (card-def c)]
        (update! state side (update-in card [:hosted] #(conj % c)))
+
        ;; events should be registered for: runner cards that are installed; corp cards that are Operations, or are installed and rezzed
        (when (or (is-type? target "Operation")
                  (is-type? target "Event")


### PR DESCRIPTION
[In the Bug 2000](https://www.youtube.com/watch?v=nzxq7h_WsAo#t=40s), Off-Campus Apartment's ability to host an installed resource which itself was hosting cards was breaking the nested-hosted cards' reference to their host. The only legal way for this to happen is Off-Campus hosting a Street Peddler which itself was installed off a Street Peddler... so yeah, kind of an obscure issue. Thanks to @JoelCFC25 for hunting it down.