### PR TITLE
Add correct Offer You Can't Refuse card to Corp score area

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -77,7 +77,7 @@
                                      :effect (effect (clear-wait-prompt :corp)
                                                      (game.core/run eid serv nil card))}
                        :no-ability {:effect (effect (clear-wait-prompt :corp)
-                                                    (as-agenda :corp (last (:discard corp)) 1))
+                                                    (as-agenda :corp (some #(when (= (:cid card) (:cid %)) %) (:discard corp)) 1))
                                     :msg "add it to their score area as an agenda worth 1 agenda point"}}}
                     card nil)))}
 

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -107,6 +107,22 @@
       (prompt-select :corp (refresh co))
       (is (= 15 (:credit (get-corp))) "Corp gained 6 credits for Back Channels"))))
 
+(deftest an-offer-you-cant-refuse
+  ;; An Offer You Can't Refuse - exact card added to score area, not the last discarded one
+  (do-game
+    (new-game (default-corp [(qty "Celebrity Gift" 1) (qty "An Offer You Can't Refuse" 1)])
+              (default-runner))
+    (play-from-hand state :corp "An Offer You Can't Refuse")
+    (prompt-choice :corp "R&D")
+    (core/move state :corp (find-card "Celebrity Gift" (:hand (get-corp))) :discard)
+    (is (= 2 (count (:discard (get-corp)))))
+    (prompt-choice :runner "No")
+    (is (= 1 (:agenda-point (get-corp))) "An Offer the Runner refused")
+    (is (= 1 (count (:scored (get-corp)))))
+    (is (find-card "An Offer You Can't Refuse" (:scored (get-corp))))
+    (is (= 1 (count (:discard (get-corp)))))
+    (is (find-card "Celebrity Gift" (:discard (get-corp))))))
+
 (deftest big-brother
   ;; Big Brother - Give the Runner 2 tags if already tagged
   (do-game


### PR DESCRIPTION
Solves https://github.com/mtgred/netrunner/issues/2245

There's some instances the Runner takes a little while to decide. In the
meanwhile, if some other cards go into Archives, the last card discarded
would be the one added to the Corp score area.

This change ensures the actual card that is played to trigger the Runner
decision is the one added to the Corp score area if he/she decides not
to run.