### PR TITLE
Resolve Silhouette successful run triggers before access

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -627,7 +627,8 @@
               :delayed-completion true
               :req (req (= target :hq)) :once :per-turn
               :effect (effect (continue-ability {:choices {:req #(and installed? (not (rezzed? %)))}
-                                                 :effect (effect (expose target)) :msg "expose 1 card"}
+                                                 :effect (effect (expose eid target)) :msg "expose 1 card"
+                                                 :delayed-completion true }
                                                 card nil))}}}
 
    "Spark Agency: Worldswide Reach"


### PR DESCRIPTION
Fixes https://github.com/mtgred/netrunner/issues/2173

These changes ensure that the resolution of any subsequent effects triggered by exposing a card (e.g. resolving Psychic Field psi game) are completed before accessing cards, as per the timings of the run.