### PR TITLE
fix Immolation Script + Archives Interface(s)

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -547,28 +547,29 @@
    "Immolation Script"
    {:effect (effect (run :archives nil card)
                     (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
-    :events {:successful-run
-             {:silent (req true)
-              :req (req (= target :archives))
-              :effect (req (when-completed
-                             (resolve-ability state side
-                               {:delayed-completion true
-                                :prompt "Choose a piece of ICE in Archives"
-                                :choices (req (filter ice? (:discard corp)))
-                                :effect (req (let [icename (:title target)]
-                                               (continue-ability
-                                                 state side
-                                                 {:delayed-completion true
-                                                  :prompt (msg "Choose a rezzed copy of " icename " to trash")
-                                                  :choices {:req #(and (ice? %)
-                                                                       (rezzed? %)
-                                                                       (= (:title %) icename))}
-                                                  :msg (msg "trash " (card-str state target))
-                                                  :effect (req (trash state :corp target)
-                                                               (unregister-events state side card)
-                                                               (effect-completed state side eid card))} card nil)))}
-                              card nil)
-                             (do-access state side eid (:server run))))}}}
+    :events {:pre-access
+             {:delayed-completion true
+              :req (req (and (= target :archives)
+                             ;; don't prompt unless there's at least 1 rezzed ICE matching one in Archives
+                             (not-empty (clojure.set/intersection
+                                          (into #{} (map :title (filter #(ice? %) (:discard corp))))
+                                          (into #{} (map :title (filter #(rezzed? %) (all-installed state :corp))))))))
+              :effect (req (continue-ability state side
+                             {:delayed-completion true
+                              :prompt "Choose a piece of ICE in Archives"
+                              :choices (req (filter ice? (:discard corp)))
+                              :effect (req (let [icename (:title target)]
+                                             (continue-ability state side
+                                               {:delayed-completion true
+                                                :prompt (msg "Choose a rezzed copy of " icename " to trash")
+                                                :choices {:req #(and (ice? %)
+                                                                     (rezzed? %)
+                                                                     (= (:title %) icename))}
+                                                :msg (msg "trash " (card-str state target))
+                                                :effect (req (trash state :corp target)
+                                                             (unregister-events state side card)
+                                                             (effect-completed state side eid))} card nil)))}
+                            card nil))}}}
 
    "Independent Thinking"
    (let [cards-to-draw (fn [ts] (* (count ts) (if (some #(and (not (facedown? %)) (has-subtype? % "Directive")) ts) 2 1)))]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1280,6 +1280,7 @@
 
    "Uninstall"
    {:choices {:req #(and (installed? %)
+                         (not (facedown? %))
                          (#{"Program" "Hardware"} (:type %)))}
     :msg (msg "move " (:title target) " to their Grip")
     :effect (effect (move target :hand))}

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -7,21 +7,22 @@
    "Archives Interface"
    {:events
     {:successful-run
-     {:silent (req true)
-      :delayed-completion true
-      :req (req (and (= target :archives) (not-empty (:discard corp))))
+     {:delayed-completion true
+      :req (req (and (= target :archives)
+                     (not-empty (:discard corp))))
       :effect (effect (continue-ability
                         {:optional
-                         {:prompt "Use Archives Interface to remove a card from the game instead of accessing it?"
+                         {:delayed-completion true
+                          :prompt "Use Archives Interface to remove a card from the game instead of accessing it?"
                           :yes-ability
                           {:delayed-completion true
                            :effect (req (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
-                                        (continue-ability
-                                          state side
+                                        (continue-ability state side
                                           {:prompt "Choose a card in Archives to remove from the game instead of accessing"
                                            :choices (req (:discard corp))
                                            :msg (msg "remove " (:title target) " from the game")
-                                           :effect (effect (move :corp target :rfg))} card nil))}}} card nil))}}}
+                                           :effect (effect (move :corp target :rfg))} card nil))}
+                          :no-ability {:effect (req (effect-completed state side eid))}}} card nil))}}}
 
    "Astrolabe"
    {:in-play [:memory 1]


### PR DESCRIPTION
Fixes #2281.

Technically the Runner is supposed to be able to choose the order of resolution of these effects, but since the number of cards to be accessed is frozen earlier during the run sequence, Archives Interface is not able to target a piece of ICE that would be trashed by Immolation Script during the same access phase. 

So we're just electing to make Archives Interface(s) always occur first to avoid complications. Immolation Script will not prompt for its effect unless there is at least 1 piece of rezzed ICE with a match in Archives. 

Also threw in a tiny fix for Uninstall, since someone in chat reported they were able to use it on a facedown Harbinger (facedown cards have no type). 