### PR TITLE
Shard(s) replacement access

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1330,9 +1330,13 @@
    {:abilities [{:effect (effect (trash-cards :corp (take 2 (shuffle (:hand corp))))
                                  (trash card {:cause :ability-cost}))
                  :msg "force the Corp to discard 2 cards from HQ at random"}]
-    :install-cost-bonus (req (if (and run (= (:server run) [:hq]) (zero? (:position run)))
+    :install-cost-bonus (req (if (and (and run (= (:server run) [:hq])
+                                           (zero? (:position run)))
+                                      (not (get-in @state [:access])))
                                [:credit -7 :click -1] nil))
-    :effect (req (when (and run (= (:server run) [:hq]) (zero? (:position run)))
+    :effect (req (when (and (and run (= (:server run) [:hq])
+                                 (zero? (:position run)))
+                            (not (get-in @state [:access])))
                    (when-completed (register-successful-run state side (:server run))
                                    (do (swap! state update-in [:runner :prompt] rest)
                                        (handle-end-run state side)))))}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -383,9 +383,13 @@
    "Eden Shard"
    {:abilities [{:effect (effect (trash card {:cause :ability-cost}) (draw :corp 2))
                  :msg "force the Corp to draw 2 cards"}]
-    :install-cost-bonus (req (if (and run (= (:server run) [:rd]) (zero? (:position run)))
+    :install-cost-bonus (req (if (and (and run (= (:server run) [:rd])
+                                           (zero? (:position run)))
+                                      (not (get-in @state [:access])))
                                [:credit -7 :click -1] nil))
-    :effect (req (when (and run (= (:server run) [:rd]) (zero? (:position run)))
+    :effect (req (when (and (and run (= (:server run) [:rd])
+                                 (zero? (:position run)))
+                            (not (get-in @state [:access])))
                    (when-completed (register-successful-run state side (:server run))
                                    (do (swap! state update-in [:runner :prompt] rest)
                                        (handle-end-run state side)))))}
@@ -536,9 +540,13 @@
                               (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                               (swap! state update-in [:run :cards-accessed] (fnil #(+ % (count (:discard corp))) 0))
                               (resolve-ability state :runner (choose-access (get-in @state [:corp :discard]) '(:archives)) card nil))}]
-    :install-cost-bonus (req (if (and run (= (:server run) [:archives]) (= 0 (:position run)))
+    :install-cost-bonus (req (if (and (and run (= (:server run) [:archives])
+                                           (zero? (:position run)))
+                                      (not (get-in @state [:access])))
                                [:credit -7 :click -1] nil))
-    :effect (req (when (and run (= (:server run) [:archives]) (= 0 (:position run)))
+    :effect (req (when (and (and run (= (:server run) [:archives])
+                                 (zero? (:position run)))
+                            (not (get-in @state [:access])))
                    (when-completed (register-successful-run state side (:server run))
                                    (do (swap! state update-in [:runner :prompt] rest)
                                        (handle-end-run state side)))))}


### PR DESCRIPTION
At the moment if user performs a run on any central server and the run is successful, there's some occasions where the user has the opportunity to access cards and while doing it install the related Shard at no cost.

These changes ensure that if the user choose to access, the Shard can no longer be installed as a replacement access condition.

Related to https://github.com/mtgred/netrunner/issues/2016

**NOTE:** These changes do NOT solve the other main issue, which is the Shard(s) effect is a replacement access effect that occur at 4.4 step of a run. Currently it's handled as a trigger ability.