### PR TITLE
Builder of Nations enhancement Issue #2259 & made once per turn

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -739,9 +739,13 @@
    "Weyland Consortium: Builder of Nations"
    {:implementation "Damage triggered manually"
     :abilities [{:label "Do 1 meat damage"
+                 :once :per-turn
+                 :prompt "Do a meat damage from identity ability?"
+                 :choices (cancellable ["Yes"])
                  :delayed-completion true
-                 :msg "do 1 meat damage"
-                 :effect (effect (damage eid :meat 1 {:card card}))}]}
+                 :effect (req (when (= target "Yes")
+                                (do (damage state :runner eid :meat 1 {:card card})
+                                    (system-msg state side "uses Weyland Consortium: Builder of Nations to do 1 meat damage"))))}]}
 
    "Weyland Consortium: Building a Better World"
    {:events {:play-operation {:msg "gain 1 [Credits]"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -744,8 +744,8 @@
                  :choices (cancellable ["Yes"])
                  :delayed-completion true
                  :effect (req (when (= target "Yes")
-                                (do (damage state :runner eid :meat 1 {:card card})
-                                    (system-msg state side "uses Weyland Consortium: Builder of Nations to do 1 meat damage"))))}]}
+                                (damage state :runner eid :meat 1 {:card card})
+                                (system-msg state side "uses Weyland Consortium: Builder of Nations to do 1 meat damage")))}]}
 
    "Weyland Consortium: Building a Better World"
    {:events {:play-operation {:msg "gain 1 [Credits]"

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -1104,6 +1104,23 @@
         (is (= 0 (get-counters (refresh scored) :agenda)) "No agenda counter used by Mark Yale")
         (is (= 10 (get-counters (refresh scored) :credit)) "Credits not used by Mark Yale")))))
 
+(deftest weyland-builder
+  ;; Builder of Nations - 1 meat damage per turn at most
+  (do-game
+    (new-game
+      (make-deck "Weyland Consortium: Builder of Nations" [(qty "Hedge Fund" 3)])
+      (default-runner))
+      (let [bon (get-in @state [:corp :identity])]
+        (card-ability state :corp bon 0)
+        (prompt-choice :corp "Cancel")
+        (is (= 0 (count (:discard (get-runner)))) "Runner took no meat damage from BoN")
+        (card-ability state :corp bon 0)
+        (prompt-choice :corp "Yes")
+        (is (= 1 (count (:discard (get-runner)))) "Runner took 1 meat damage from BoN")
+        (card-ability state :corp bon 0)
+        (is (= 1 (count (:discard (get-runner)))) "Runner took only 1 meat damage from BoN total")
+        (is (= 0 (count (:prompt (get-corp))))))))
+
 (deftest whizzard
   ;; Whizzard - Recurring credits
   (do-game


### PR DESCRIPTION
Submitted an enhancement for this - so you have to confirm the damage, or can cancel the ability.  Also made it once per turn max.  Also added test cases.