### PR TITLE
Allow Sec Test/Patron to be re-targetted Issue #2320

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -861,9 +861,12 @@
    "Patron"
    (let [ability {:prompt "Choose a server for Patron" :choices (req (conj servers "No server"))
                   :req (req (not (:server-target card)))
+                  ;:req (req (or (not (click-spent? :runner state)) (not (:server-target card)) false))
                   :msg (msg "target " target)
                   :effect (req (when (not= target "No server")
                                  (update! state side (assoc card :server-target target))))}]
+                  ;:effect (req (when-not (used-this-turn? (:cid card) state)
+                  ;  (update! state side (assoc card :server-target target))))}]
      {:events {:runner-turn-begins ability
                :successful-run
                {:req (req (= (zone->name (get-in @state [:run :server])) (:server-target (get-card state card))))
@@ -1086,6 +1089,7 @@
    (let [ability {:prompt "Choose a server for Security Testing" :choices (req servers)
                   :msg (msg "target " target)
                   :req (req (not (:server-target card)))
+                  ;:req (req (or (not (click-spent? :runner state)) (not (:server-target card)) false))
                   :effect (effect (update! (assoc card :server-target target)))}]
      {:events {:runner-turn-begins ability
                :successful-run

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -4,7 +4,7 @@
                                 dissoc-in cancellable card-is? side-str build-cost-str build-spend-msg cost-names
                                 zones->sorted-names remote->name remote-num->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side same-card? same-side?
-                                combine-subtypes remove-subtypes]]
+                                combine-subtypes remove-subtypes click-spent? used-this-turn?]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -94,6 +94,18 @@
   [ability]
   (or (:label ability) (and (string? (:msg ability)) (capitalize (:msg ability))) ""))
 
+(defn click-spent?
+  "Returns true if player has spent at least one click"
+  [side state]
+  (case side
+    :runner (contains? (into {} (get @state :turn-events)) :runner-spent-click)
+    :corp   (contains? (into {} (get @state :turn-events)) :corp-spent-click)))
+
+(defn used-this-turn?
+  "Returns true if a card has been used this turn"
+  [cid state]
+  (contains? (get-in @state [:per-turn]) cid))
+
 (defn cancellable
   "Wraps a vector of prompt choices with a final 'Cancel' option. Optionally sorts the vector alphabetically,
   with Cancel always last."


### PR DESCRIPTION
This updates Sec Testing & Patron as follows:

Allow their target to be changed (in case of misclick), unless they have been used this turn, or you've already spent a click.  Also works for #1744 - except we assume the only reason someone would set Patron/SecTest manually in Step 1.2 would be if they are actually using it.

Added a couple of utility functions which I could not see existing code for to enable this.