### PR TITLE
Fix various "first time each turn" issues

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -62,7 +62,7 @@
    "Advanced Concept Hopper"
    {:events
     {:run
-     {:req (req (first-event state side :run))
+     {:req (req (first-event? state side :run))
       :effect (effect (show-wait-prompt :runner "Corp to use Advanced Concept Hopper")
                       (continue-ability
                         {:player :corp

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -313,7 +313,7 @@
              {:msg "draw additional cards"
               :once :per-turn
               :once-key :daily-business-show-draw-bonus
-              :req (req (first-event state side :pre-corp-draw))
+              :req (req (first-event? state side :pre-corp-draw))
               :effect (req (let [dbs (count (filter #(and (= "06086" (:code %)) (rezzed? %)) (all-installed state :corp)))]
                              (draw-bonus state side dbs)))}
              :post-corp-draw

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1180,7 +1180,7 @@
     :effect (req (add-counter state :runner target :virus 2))}
 
    "System Outage"
-   {:events {:corp-draw {:req (req (not (first-event state side :corp-draw)))
+   {:events {:corp-draw {:req (req (not (first-event? state side :corp-draw)))
                          :msg "force the Corp to lose 1 [Credits]"
                          :effect (effect (lose :corp :credit 1))}}}
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -150,7 +150,7 @@
 
    "Comet"
    {:in-play [:memory 1]
-    :events {:play-event {:req (req (first-event state side :play-event))
+    :events {:play-event {:req (req (first-event? state side :play-event))
                           :effect (req (system-msg state :runner
                                                    (str "can play another event without spending a [Click] by clicking on Comet"))
                                        (update! state side (assoc card :comet-event true)))}}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -124,11 +124,11 @@
     {:corp-phase-12 {:effect (effect (enable-corp-damage-choice))}
      :runner-phase-12 {:effect (effect (enable-corp-damage-choice))}
      :pre-resolve-damage
-     {:once :per-turn
-      :delayed-completion true
+     {:delayed-completion true
       :req (req (and (= target :net)
                      (corp-can-choose-damage? state)
-                     (> (last targets) 0)))
+                     (> (last targets) 0)
+                     (empty? (filter #(= :net (first %)) (turn-events state :runner :damage)))))
       :effect (req (damage-defer state side :net (last targets))
                    (if (= 0 (count (:hand runner)))
                      (do (swap! state update-in [:damage] dissoc :damage-choose-corp)
@@ -157,6 +157,8 @@
                              :no-ability {:effect (req (clear-wait-prompt state :runner)
                                                        (swap! state update-in [:damage] dissoc :damage-choose-corp))}}}
                            card nil))))}}
+    :req (req (empty? (filter #(= :net (first %)) (turn-events state :runner :damage))))
+    :effect (effect (enable-corp-damage-choice))
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))}
 
    "Cybernetics Division: Humanity Upgraded"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -246,7 +246,8 @@
                                card nil))}}}
 
    "Haas-Bioroid: Engineering the Future"
-   {:events {:corp-install {:once :per-turn :msg "gain 1 [Credits]"
+   {:events {:corp-install {:req (req (first-event state corp :corp-install))
+                            :msg "gain 1 [Credits]"
                             :effect (effect (gain :credit 1))}}}
 
    "Haas-Bioroid: Stronger Together"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -226,7 +226,7 @@
                    true))]
      {:events {:agenda-stolen
                {:effect (effect (register-turn-flag! card :can-steal haarp))}}
-      :effect (req (when-not (first-event state side :agenda-stolen)
+      :effect (req (when-not (first-event? state side :agenda-stolen)
                      (register-turn-flag! state side card :can-steal haarp)))
       :leave-play (effect (clear-turn-flag! card :can-steal))})
 
@@ -235,7 +235,7 @@
              {:delayed-completion true
               :req (req (and (rezzed? target)
                              (has-subtype? target "Bioroid")
-                             (first-event state :corp :pass-ice)))
+                             (first-event? state :corp :pass-ice)))
               :effect (effect (show-wait-prompt :runner "Corp to use Haas-Bioroid: Architects of Tomorrow")
                               (continue-ability
                                 {:prompt "Choose a bioroid to rez" :player :corp
@@ -248,7 +248,7 @@
                                card nil))}}}
 
    "Haas-Bioroid: Engineering the Future"
-   {:events {:corp-install {:req (req (first-event state corp :corp-install))
+   {:events {:corp-install {:req (req (first-event? state corp :corp-install))
                             :msg "gain 1 [Credits]"
                             :effect (effect (gain :credit 1))}}}
 
@@ -277,9 +277,9 @@
 
    "Hayley Kaplan: Universal Scholar"
    {:events {:runner-install
-             {:silent (req (not (and (first-event state side :runner-install)
+             {:silent (req (not (and (first-event? state side :runner-install)
                                      (some #(is-type? % (:type target)) (:hand runner)))))
-              :req (req (and (first-event state side :runner-install)
+              :req (req (and (first-event? state side :runner-install)
                              (some #(is-type? % (:type target)) (:hand runner))))
               :once :per-turn
               :delayed-completion true
@@ -323,7 +323,7 @@
    {:events {:pre-start-game {:effect draft-points-target}
              :pre-install {:req (req (and (has-most-faction? state :runner "Shaper")
                                           (pos? (count (:deck runner)))
-                                          (first-event state side :pre-install)))
+                                          (first-event? state side :pre-install)))
                            :msg "draw 1 card"
                            :once :per-turn
                            :effect (effect (draw 1))}}}
@@ -418,7 +418,7 @@
 
    "Khan: Savvy Skiptracer"
    {:events {:pass-ice
-             {:req (req (first-event state :corp :pass-ice))
+             {:req (req (first-event? state :corp :pass-ice))
               :delayed-completion true
               :effect (req (if (some #(has-subtype? % "Icebreaker") (:hand runner))
                              (continue-ability state side
@@ -513,7 +513,7 @@
     :leave-play (effect (lose :hand-size-modification 1))}
 
    "Near-Earth Hub: Broadcast Center"
-   {:events {:server-created {:req (req (first-event state :corp :server-created))
+   {:events {:server-created {:req (req (first-event? state :corp :server-created))
                               :msg "draw 1 card"
                               :effect (effect (draw 1))}}}
 
@@ -603,7 +603,7 @@
              :run-ends {:effect (req (swap! state dissoc-in [:runner :identity :omar-run-activated]))}}}
 
    "Pālanā Foods: Sustainable Growth"
-   {:events {:runner-draw {:req (req (and (first-event state :corp :runner-draw)
+   {:events {:runner-draw {:req (req (and (first-event? state :corp :runner-draw)
                                           (pos? target)))
                            :msg "gain 1 [Credits]"
                            :effect (effect (gain :corp :credit 1))}}}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -357,6 +357,9 @@
            :req (req (is-central? (:server run)))
            :effect (req (apply enable-run-on-server
                                state card (map first (get-remotes @state))))}}
+    :req (req (empty? (let [successes (turn-events state side :successful-run)]
+                        (filter #(is-central? %) successes))))
+    :effect (req (apply prevent-run-on-server state card (map first (get-remotes @state))))
     :leave-play (req (apply enable-run-on-server state card (map first (get-remotes @state))))}
 
    "Jinteki Biotech: Life Imagined"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -603,7 +603,7 @@
 
    "Manhunt"
    {:events {:successful-run {:interactive (req true)
-                              :req (req (first-event state side :successful-run))
+                              :req (req (first-event? state side :successful-run))
                               :trace {:base 2 :msg "give the Runner 1 tag"
                                       :delayed-completion true
                                       :effect (effect (tag-runner :runner eid 1))}}}}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -595,7 +595,7 @@
                                           (lose :memory (:memoryunits target)))}}}
 
    "Reaver"
-   {:events {:runner-trash {:req (req (and (first-event state :runner :runner-trash) (installed? target)))
+   {:events {:runner-trash {:req (req (and (first-event? state :runner :runner-trash) (installed? target)))
                             :effect (effect (draw :runner 1))
                             :msg "draw 1 card"}}}
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -114,10 +114,10 @@
                                  (runner-install target))}]}
 
    "Bhagat"
-   {:events {:successful-run {:req (req (= target :hq))
+   {:events {:successful-run {:req (req (= target :hq)
+                                        (first-successful-run-on-server? state :hq))
                               :msg "force the Corp to trash the top card of R&D"
-                              :effect (effect (mill :corp))
-                              :once :per-turn}}}
+                              :effect (effect (mill :corp))}}}
 
    "Bank Job"
    {:data {:counter {:credit 8}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -5,9 +5,9 @@
 (defn- genetics-trigger?
   "Returns true if Genetics card should trigger - does not work with Adjusted Chronotype"
   [state side event]
-  (or (first-event state side event)
+  (or (first-event? state side event)
       (and (has-flag? state side :persistent :genetics-trigger-twice)
-           (second-event state side event))))
+           (second-event? state side event))))
 
 ;;; Card definitions
 (def cards-resources
@@ -453,7 +453,7 @@
              :successful-run {:interactive (req true)
                               :optional
                               {:delayed-completion true
-                               :req (req (first-event state side :successful-run))
+                               :req (req (first-event? state side :successful-run))
                                :prompt "Use Find the Truth to look at the top card of R&D?"
                                :yes-ability {:msg "look at the top card of R&D"
                                              :effect (req (prompt! state :runner card (str "The top card of R&D is "
@@ -615,10 +615,10 @@
     :abilities [ability]})
 
    "John Masanori"
-   {:events {:successful-run {:req (req (first-event state side :successful-run))
+   {:events {:successful-run {:req (req (first-event? state side :successful-run))
                               :msg "draw 1 card" :once-key :john-masanori-draw
                               :effect (effect (draw))}
-             :unsuccessful-run {:req (req (first-event state side :unsuccessful-run))
+             :unsuccessful-run {:req (req (first-event? state side :unsuccessful-run))
                                 :delayed-completion true
                                 :msg "take 1 tag" :once-key :john-masanori-tag
                                 :effect (effect (tag-runner :runner eid 1))}}}
@@ -850,7 +850,7 @@
                                                        (system-msg state side (str "trashes " target
                                                                                    " cop" (if (not= target 1) "ies" "y")
                                                                                    " of " title)))))}}}))]
-     {:events {:runner-install {:req (req (first-event state side :runner-install))
+     {:events {:runner-install {:req (req (first-event? state side :runner-install))
                                 :delayed-completion true
                                 :effect (effect (continue-ability
                                                  (pphelper (:title target)
@@ -1357,7 +1357,7 @@
                                 (add-counter state side target :virus 1)))}]}
 
    "Wasteland"
-   {:events {:runner-trash {:req (req (and (first-event state :runner :runner-trash) (:installed target)))
+   {:events {:runner-trash {:req (req (and (first-event? state :runner :runner-trash) (:installed target)))
                      :effect (effect (gain :credit 1))
                      :msg "to gain 1[Credit]"}}}
 

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -212,7 +212,6 @@
   (reduce #(or %1 ((:req (:ability %2)) state side (make-eid state) (:card %2) targets))
           false (get-in @state [:suppress event])))
 
-
 (defn turn-events
   "Returns the targets vectors of each event with the given key that was triggered this turn."
   [state side ev]
@@ -227,6 +226,11 @@
   "Returns true if the given event has occurred exactly once this turn."
   [state side ev]
   (= (count (turn-events state side ev)) 1))
+
+(defn first-successful-run-on-server?
+  "Returns true if the active run is the first succesful run on the given server"
+  [state server]
+  (empty? (filter #(= [server] %) (turn-events state :runner :successful-run))))
 
 ;;; Effect completion triggers
 (defn register-effect-completed

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -217,12 +217,12 @@
   [state side ev]
   (mapcat rest (filter #(= ev (first %)) (:turn-events @state))))
 
-(defn first-event
+(defn first-event?
   "Returns true if the given event has not occurred yet this turn."
   [state side ev]
   (empty? (turn-events state side ev)))
 
-(defn second-event
+(defn second-event?
   "Returns true if the given event has occurred exactly once this turn."
   [state side ev]
   (= (count (turn-events state side ev)) 1))

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -251,16 +251,21 @@
     (prompt-choice :runner "Steal")
     (is (= 2 (:agenda-point (get-runner))) "Third steal prevented")))
 
-(deftest haas-bioroid-stronger-together
-  ;; Stronger Together - +1 strength for Bioroid ice
+(deftest haas-bioroid-architects-of-tomorrow
+  ;; Architects of Tomorrow - prompt to rez after passing bioroid
   (do-game
     (new-game
-      (make-deck "Haas-Bioroid: Stronger Together" [(qty "Eli 1.0" 1)])
+      (make-deck "Haas-Bioroid: Architects of Tomorrow" [(qty "Eli 1.0" 3)])
       (default-runner))
     (play-from-hand state :corp "Eli 1.0" "Archives")
-    (let [eli (get-ice state :archives 0)]
-      (core/rez state :corp eli)
-      (is (= 5 (:current-strength (refresh eli))) "Eli 1.0 at 5 strength"))))
+    (play-from-hand state :corp "Eli 1.0" "HQ")
+    (take-credits state :corp)
+    (run-on state "Archives")
+    (core/rez state :corp (get-ice state :archives 0))
+    (is (= 3 (:credit (get-corp))) "Corp has 3 credits after rezzing Eli 1.0")
+    (run-continue state)
+    (prompt-select :corp (get-ice state :hq 0))
+    (is (= 3 (:credit (get-corp))) "Corp not charged for Architects of Tomorrow rez of Eli 1.0")))
 
 (deftest haas-bioroid-engineering-the-future-employee-strike
   ;; EtF - interaction with Employee Strike
@@ -281,6 +286,17 @@
     (take-credits state :runner)
     (play-from-hand state :corp "Eli 1.0" "New remote")
     (is (= 9 (:credit (get-corp))) "Corp gained 1cr from EtF")))
+
+(deftest haas-bioroid-stronger-together
+  ;; Stronger Together - +1 strength for Bioroid ice
+  (do-game
+    (new-game
+      (make-deck "Haas-Bioroid: Stronger Together" [(qty "Eli 1.0" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Eli 1.0" "Archives")
+    (let [eli (get-ice state :archives 0)]
+      (core/rez state :corp eli)
+      (is (= 5 (:current-strength (refresh eli))) "Eli 1.0 at 5 strength"))))
 
 (deftest iain-stirling-credits
   ;; Iain Stirling - Gain 2 credits when behind
@@ -1022,15 +1038,20 @@
   ;; Spark Agency - Rezzing advertisements
   (do-game
     (new-game
-      (make-deck "Spark Agency: Worldswide Reach" [(qty "Launch Campaign" 2)])
+      (make-deck "Spark Agency: Worldswide Reach" [(qty "Launch Campaign" 3)])
       (default-runner))
     (play-from-hand state :corp "Launch Campaign" "New remote")
     (play-from-hand state :corp "Launch Campaign" "New remote")
+    (play-from-hand state :corp "Launch Campaign" "New remote")
     (let [lc1 (get-content state :remote1 0)
-          lc2 (get-content state :remote2 0)]
+          lc2 (get-content state :remote2 0)
+          lc3 (get-content state :remote3 0)]
       (core/rez state :corp lc1)
       (is (= 4 (:credit (get-runner)))
           "Runner lost 1 credit from rez of advertisement (Corp turn)")
+      (core/rez state :corp lc3)
+      (is (= 4 (:credit (get-runner)))
+          "Runner did not lose credit from second Spark rez")
       (take-credits state :corp)
       (run-on state "Server 1")
       (core/rez state :corp lc2)

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -147,6 +147,30 @@
         (is (empty? (:prompt (get-corp))) "No choice after declining on first damage")
         (is (= 3 (count (:discard (get-runner)))))))))
 
+(deftest chronos-protocol-employee-strike
+  ;; Chronos Protocol - Issue #1958 also affects Chronos Protocol
+  (do-game
+    (new-game
+      (make-deck "Chronos Protocol: Selective Mind-mapping" [(qty "Pup" 1)])
+      (default-runner [(qty "Employee Strike" 1) (qty "Scrubbed" 3) (qty "Sure Gamble" 1)]))
+    (play-from-hand state :corp "Pup" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Employee Strike")
+    (run-on state :hq)
+    (let [pup (get-ice state :hq 0)]
+      (core/rez state :corp pup)
+      (card-subroutine state :corp pup 0)
+      (is (empty? (:prompt (get-corp))) "No choice because of Employee Strike")
+      (card-subroutine state :corp pup 0)
+      (is (= 2 (count (:discard (get-runner)))))
+      (run-jack-out state)
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Scrubbed")
+      (run-on state :hq)
+      (card-subroutine state :corp pup 0)
+      (is (not (empty? (:prompt (get-corp)))) "Employee Strike out of play - Ability turned on correctly"))))
+
 (deftest edward-kim
   ;; Edward Kim - Trash first operation accessed each turn, but not if first one was in Archives
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -262,6 +262,26 @@
       (core/rez state :corp eli)
       (is (= 5 (:current-strength (refresh eli))) "Eli 1.0 at 5 strength"))))
 
+(deftest haas-bioroid-engineering-the-future-employee-strike
+  ;; EtF - interaction with Employee Strike
+  (do-game
+    (new-game
+      (make-deck "Haas-Bioroid: Engineering the Future" [(qty "Eli 1.0" 3) (qty "Paywall Implementation" 1)])
+      (default-runner [(qty "Employee Strike" 1)]))
+    (take-credits state :corp)
+    (is (= 8 (:credit (get-corp))) "Corp has 8 credits at turn end")
+    (play-from-hand state :runner "Employee Strike")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Eli 1.0" "New remote")
+    (is (= 8 (:credit (get-corp))) "Corp did not gain 1cr from EtF")
+    (play-from-hand state :corp "Paywall Implementation")
+    (play-from-hand state :corp "Eli 1.0" "New remote")
+    (is (= 8 (:credit (get-corp))) "Corp did not gain 1cr from EtF")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (play-from-hand state :corp "Eli 1.0" "New remote")
+    (is (= 9 (:credit (get-corp))) "Corp gained 1cr from EtF")))
+
 (deftest iain-stirling-credits
   ;; Iain Stirling - Gain 2 credits when behind
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -405,7 +405,7 @@
     (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")))
 
 (deftest jinteki-replicating-perfection-employee-strike
-  ;; Replicating Perfection - interaction with Employee Strike. Issue #1313.
+  ;; Replicating Perfection - interaction with Employee Strike. Issue #1313 and #1956.
   (do-game
     (new-game
       (make-deck "Jinteki: Replicating Perfection" [(qty "Mental Health Clinic" 3)])
@@ -414,7 +414,9 @@
     (take-credits state :corp)
     (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
     (play-from-hand state :runner "Employee Strike")
-    (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")))
+    (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")
+    (play-from-hand state :runner "Scrubbed")
+    (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")))
 
 (deftest kate-mac-mccaffrey-discount
   ;; Kate 'Mac' McCaffrey - Install discount

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -182,6 +182,22 @@
     (take-credits state :corp)
     (is (= 3 (:click (get-runner))) "Lost 1 click at turn start")))
 
+(deftest bhagat
+  ;; Bhagat - only trigger on first run
+  (do-game
+    (new-game (default-corp [(qty "Hedge Fund" 3) (qty "Eli 1.0" 3) (qty "Architect" 3)])
+              (default-runner [(qty "Bhagat" 1)]))
+    (starting-hand state :corp [])
+    (take-credits state :corp)
+    (run-empty-server state :hq)
+    (play-from-hand state :runner "Bhagat")
+    (run-empty-server state :hq)
+    (is (empty? (:discard (get-corp))) "Bhagat did not trigger on second successful run")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (run-empty-server state :hq)
+    (is (= 1 (count (:discard (get-corp)))) "Bhagat milled one card")))
+
 (deftest chrome-parlor
   ;; Chrome Parlor - Prevent all meat/brain dmg when installing cybernetics
   (do-game


### PR DESCRIPTION
Fix #1838, #2328, and any number of unreported issues with "the first time" triggers, most notably with identities and Cerebral Static / Employee Strike. 

Fix #1956 by giving Jinteki: RP an `:effect` to re-enable the remote lock when the ID comes back into play (Employee Strike trashed).

To be clear to devs, `:once :per-turn` is only sufficient for card abilities that read "once per turn" (Kati Jones, Şifr, etc.)... it is _not_ for abilities that read "the first time ____". You must use `first-event?` or manual filtering with `turn-events` to implement those actions.

Also, I renamed `first-event` to `first-event?` because it is a predicate.

This means Rebirth should work fine with Gabe, Silhouette, and Fisk.