### PR TITLE
Fix #2324 - add log output showing trashed card names

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -771,14 +771,6 @@
                        :effect (effect (mill :runner
                                              (if (>= (:advance-counter (get-card state card)) 4) 2 1)))}}}
 
-;   "Underway Renovation"
-;   {:install-state :face-up
-;    :events {:advance {:req (req (= (:cid card) (:cid target)))
-;                       :msg (msg "trash the top " (if (>= (:advance-counter (get-card state card)) 4) "2 cards" "card")
-;                                 " of the Runner's Stack")
-;                       :effect (effect (mill :runner
-;                                             (if (>= (:advance-counter (get-card state card)) 4) 2 1)))}}}
-
    "Unorthodox Predictions"
    {:implementation "Prevention of subroutine breaking is not enforced"
     :delayed-completion false

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -763,11 +763,13 @@
    {:install-state :face-up
     :events {:advance {:req (req (= (:cid card) (:cid target))) 
                        :msg (msg (let [deck (:deck runner)] 
-                         (if (> (count deck) 0) 
-                           (if (>= (:advance-counter (get-card state card)) 4) 
-                             (str "trash the top 2 cards of the Runner's stack:  " (join ", " (map :title (take 2 deck)))) 
-                             (str "trash the top card of the Runner's stack:  " (:title (first deck)))) 
-                         "trash from the Runner's stack but it is empty")))
+                         (cond
+                           (and (> (count deck) 0)  (>= (:advance-counter (get-card state card)) 4) )
+                             (str "trash the top 2 cards of the Runner's stack:  " (join ", " (map :title (take 2 deck))))
+                           (and (> (count deck) 0)  (< (:advance-counter (get-card state card)) 4) )
+                             (str "trash the top card of the Runner's stack:  " (:title (first deck)))
+                           (= (count deck) 0)  
+                             "trash from the Runner's stack but it is empty")))
                        :effect (effect (mill :runner
                                              (if (>= (:advance-counter (get-card state card)) 4) 2 1)))}}}
 

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -515,11 +515,12 @@
 
    "Personality Profiles"
    (let [pp {:req (req (pos? (count (:hand runner))))
-             :msg "force the Runner to trash 1 card from their Grip at random"
-             :effect (effect (trash (first (shuffle (:hand runner)))))}]
+             :effect (effect (trash (first (shuffle (:hand runner)))))
+             :msg (msg "force the Runner to trash 1 card from their Grip at random. Trashes: "
+                       (:title (first (:discard runner))))}]
      {:events {:searched-stack pp
                :runner-install (assoc pp :req (req (and (some #{:discard} (:previous-zone target))
-                                                        (pos? (count (:hand runner))))))}})
+                                                     (pos? (count (:hand runner))))))}})
 
    "Philotic Entanglement"
    {:interactive (req true)
@@ -760,11 +761,23 @@
 
    "Underway Renovation"
    {:install-state :face-up
-    :events {:advance {:req (req (= (:cid card) (:cid target)))
-                       :msg (msg "trash the top " (if (>= (:advance-counter (get-card state card)) 4) "2 cards" "card")
-                                 " of the Runner's Stack")
+    :events {:advance {:req (req (= (:cid card) (:cid target))) 
+                       :msg (msg (let [deck (:deck runner)] 
+                         (if (> (count deck) 0) 
+                           (if (>= (:advance-counter (get-card state card)) 4) 
+                             (str "trash the top 2 cards of the Runner's stack:  " (join ", " (map :title (take 2 deck)))) 
+                             (str "trash the top card of the Runner's stack:  " (:title (first deck)))) 
+                         "trash from the Runner's stack but it is empty")))
                        :effect (effect (mill :runner
                                              (if (>= (:advance-counter (get-card state card)) 4) 2 1)))}}}
+
+;   "Underway Renovation"
+;   {:install-state :face-up
+;    :events {:advance {:req (req (= (:cid card) (:cid target)))
+;                       :msg (msg "trash the top " (if (>= (:advance-counter (get-card state card)) 4) "2 cards" "card")
+;                                 " of the Runner's Stack")
+;                       :effect (effect (mill :runner
+;                                             (if (>= (:advance-counter (get-card state card)) 4) 2 1)))}}}
 
    "Unorthodox Predictions"
    {:implementation "Prevention of subroutine breaking is not enforced"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -761,16 +761,21 @@
    "Underway Renovation"
    {:install-state :face-up
     :events {:advance {:req (req (= (:cid card) (:cid target))) 
-                       :msg (msg (let [deck (:deck runner)] 
+                       :msg (msg (let [deck (:deck runner)
+                                       anydeck? (pos? (count deck)) 
+                                       adv4? (>= (:advance-counter (get-card state card)))] 
                          (cond
-                           (and (pos? (count deck))  (>= (:advance-counter (get-card state card)) 4) )
-                             (str "trash " (join ", " (map :title (take 2 deck))) " from the Runner's stack")
-                           (and (pos? (count deck))  (< (:advance-counter (get-card state card)) 4) )
-                             (str "trash " (:title (first deck)) " from the Runner's stack")
-                           (zero? (count deck))  
-                             "trash from the Runner's stack but it is empty")))
+                           (and anydeck? adv4?)
+                           (str "trash " (join ", " (map :title (take 2 deck))) " from the Runner's stack")
+
+                           (and anydeck? (not adv4?) )
+                           (str "trash " (:title (first deck)) " from the Runner's stack")
+
+                           (false? anydeck?)  
+                           "trash from the Runner's stack but it is empty")))
+
                        :effect (effect (mill :runner
-                                             (if (>= (:advance-counter (get-card state card)) 4) 2 1)))}}}
+                                             (if (>= (:advance-counter (get-card state card)) 4)  2 1)))}}}
 
    "Unorthodox Predictions"
    {:implementation "Prevention of subroutine breaking is not enforced"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -516,11 +516,10 @@
    "Personality Profiles"
    (let [pp {:req (req (pos? (count (:hand runner))))
              :effect (effect (trash (first (shuffle (:hand runner)))))
-             :msg (msg "force the Runner to trash 1 card from their Grip at random. Trashes: "
-                       (:title (first (:discard runner))))}]
+             :msg (msg "force the Runner to trash " (:title (first (:discard runner))) " from their Grip at random")}]
      {:events {:searched-stack pp
                :runner-install (assoc pp :req (req (and (some #{:discard} (:previous-zone target))
-                                                     (pos? (count (:hand runner))))))}})
+                                                        (pos? (count (:hand runner))))))}})
 
    "Philotic Entanglement"
    {:interactive (req true)
@@ -764,11 +763,11 @@
     :events {:advance {:req (req (= (:cid card) (:cid target))) 
                        :msg (msg (let [deck (:deck runner)] 
                          (cond
-                           (and (> (count deck) 0)  (>= (:advance-counter (get-card state card)) 4) )
-                             (str "trash the top 2 cards of the Runner's stack:  " (join ", " (map :title (take 2 deck))))
-                           (and (> (count deck) 0)  (< (:advance-counter (get-card state card)) 4) )
-                             (str "trash the top card of the Runner's stack:  " (:title (first deck)))
-                           (= (count deck) 0)  
+                           (and (pos? (count deck))  (>= (:advance-counter (get-card state card)) 4) )
+                             (str "trash " (join ", " (map :title (take 2 deck))) " from the Runner's stack")
+                           (and (pos? (count deck))  (< (:advance-counter (get-card state card)) 4) )
+                             (str "trash " (:title (first deck)) " from the Runner's stack")
+                           (zero? (count deck))  
                              "trash from the Runner's stack but it is empty")))
                        :effect (effect (mill :runner
                                              (if (>= (:advance-counter (get-card state card)) 4) 2 1)))}}}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -577,7 +577,8 @@
                   :effect (effect (prompt! card (str "The top card of the Runner's Stack is "
                                                      (:title (first (:deck runner)))) ["OK"] {}))}
                 {:label "[Trash]: Trash the top card of the Runner's Stack"
-                 :msg "trash the top card of the Runner's Stack"
+                 :msg (msg (str "trash the top card of the Runner's Stack: "
+                           (:title (first (:deck runner)))))
                  :effect (effect (mill :runner)
                                  (trash card {:cause :ability-cost}))}]}
 

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -577,8 +577,7 @@
                   :effect (effect (prompt! card (str "The top card of the Runner's Stack is "
                                                      (:title (first (:deck runner)))) ["OK"] {}))}
                 {:label "[Trash]: Trash the top card of the Runner's Stack"
-                 :msg (msg "trash the top card of the Runner's Stack: "
-                           (:title (first (:deck runner))))
+                 :msg (msg "trash " (:title (first (:deck runner))) " from the Runner's Stack")
                  :effect (effect (mill :runner)
                                  (trash card {:cause :ability-cost}))}]}
 

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -577,8 +577,8 @@
                   :effect (effect (prompt! card (str "The top card of the Runner's Stack is "
                                                      (:title (first (:deck runner)))) ["OK"] {}))}
                 {:label "[Trash]: Trash the top card of the Runner's Stack"
-                 :msg (msg (str "trash the top card of the Runner's Stack: "
-                           (:title (first (:deck runner)))))
+                 :msg (msg "trash the top card of the Runner's Stack: "
+                           (:title (first (:deck runner))))
                  :effect (effect (mill :runner)
                                  (trash card {:cause :ability-cost}))}]}
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -611,7 +611,8 @@
                                   {:prompt "Choose how much damage to prevent"
                                    :priority 50
                                    :choices {:number (req (min n (count (:deck runner))))}
-                                   :msg (msg "trash " target " cards from their Stack and prevent " target " damage")
+                                   :msg (msg "trash " target " cards from their Stack and prevent " target " damage.  Trashes: "
+                                             (join ", " (map :title (take target (:deck runner)))))
                                    :effect (effect (damage-prevent :net target)
                                                    (damage-prevent :brain target)
                                                    (mill :runner target)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -611,8 +611,8 @@
                                   {:prompt "Choose how much damage to prevent"
                                    :priority 50
                                    :choices {:number (req (min n (count (:deck runner))))}
-                                   :msg (msg "trash " target " cards from their Stack and prevent " target " damage.  Trashes: "
-                                             (join ", " (map :title (take target (:deck runner)))))
+                                   :msg (msg "trash " (join ", " (map :title (take target (:deck runner))))
+                                             " from their Stack and prevent " target " damage")
                                    :effect (effect (damage-prevent :net target)
                                                    (damage-prevent :brain target)
                                                    (mill :runner target)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -390,6 +390,7 @@
    "Chiyashi"
    {:abilities [{:label "Trash the top 2 cards of the Runner's Stack"
                  :req (req (some #(has-subtype? % "AI") (all-installed state :runner)))
+                 :msg (msg (str "trash " (join ", " (map :title (take 2 (:deck runner)))) " from the Runner's Stack"))
                  :effect (effect (mill :runner 2))}]
     :subroutines [(do-net-damage 2)
                   end-the-run]}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -450,7 +450,11 @@
                :agenda-stolen leela}})
 
    "MaxX: Maximum Punk Rock"
-   (let [ability {:msg "trash the top 2 cards from Stack and draw 1 card"
+   (let [ability {:msg (msg (let [deck (:deck runner)]
+                              (if (> (count deck) 0)
+                                (str "trash the top 2 cards from Stack and draw 1 card.  Trashes "
+                                  (join ", " (map :title (take 2 deck))))
+                                "trash the top 2 cards from Stack and draw 1 card - but their Stack is empty")))
                   :once :per-turn
                   :effect (effect (mill 2) (draw))}]
      {:flags {:runner-turn-draw true

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -451,10 +451,9 @@
 
    "MaxX: Maximum Punk Rock"
    (let [ability {:msg (msg (let [deck (:deck runner)]
-                              (if (> (count deck) 0)
-                                (str "trash the top 2 cards from Stack and draw 1 card.  Trashes "
-                                  (join ", " (map :title (take 2 deck))))
-                                "trash the top 2 cards from Stack and draw 1 card - but their Stack is empty")))
+                              (if (pos? (count deck))
+                                (str "trash " (join ", " (map :title (take 2 deck))) " from their Stack and draw 1 card")
+                                "trash the top 2 cards from their Stack and draw 1 card - but their Stack is empty")))
                   :once :per-turn
                   :effect (effect (mill 2) (draw))}]
      {:flags {:runner-turn-draw true

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -997,20 +997,6 @@
                           (join ", " (map :title (take 3 (:deck runner)))))
                    :effect (effect (mill :runner 3))}}
 
-;   "Rolodex"
-;   {:delayed-completion true
-;    :msg "look at the top 5 cards of their Stack"
-;    :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their Stack")
-;                 (let [from (take 5 (:deck runner))]
-;                   (if (pos? (count from))
-;                     (continue-ability state side (reorder-choice :runner :corp from '()
-;                                                                  (count from) from) card nil)
-;                     (do (clear-wait-prompt state :corp)
-;                         (effect-completed state side eid card)))))
-;    :trash-effect {:msg (msg "trash cards from their Stack as Rolodex was trashed "
-;                             (join ", " (map :title (take 3 (:deck runner)))))
-;                   :effect (effect (mill :runner 3))}}
-
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}
     :abilities [{:effect (req (doseq [c (concat (get-in runner [:rig :hardware])

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -993,9 +993,10 @@
                                                                   (count from) from) card nil)
                      (do (clear-wait-prompt state :corp)
                          (effect-completed state side eid card)))))
-    :trash-effect {:msg (msg "trash " (join ", " (map :title (take 3 (:deck runner))))
-                             " from their Stack as Rolodex was trashed ")
-                   :effect (effect (mill :runner 3))}}
+    :trash-effect {:effect (effect (system-msg :runner (str "trashes "
+                                               (join ", " (map :title (take 3 (:deck runner))))
+                                               " from their Stack due to Rolodex being trashed"))
+                                       (mill :runner 3))}}
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -993,7 +993,23 @@
                                                                   (count from) from) card nil)
                      (do (clear-wait-prompt state :corp)
                          (effect-completed state side eid card)))))
-    :trash-effect {:effect (effect (mill :runner 3))}}
+    :trash-effect {:msg (msg "trash cards from their Stack as Rolodex was trashed "
+                          (join ", " (map :title (take 3 (:deck runner)))))
+                   :effect (effect (mill :runner 3))}}
+
+;   "Rolodex"
+;   {:delayed-completion true
+;    :msg "look at the top 5 cards of their Stack"
+;    :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their Stack")
+;                 (let [from (take 5 (:deck runner))]
+;                   (if (pos? (count from))
+;                     (continue-ability state side (reorder-choice :runner :corp from '()
+;                                                                  (count from) from) card nil)
+;                     (do (clear-wait-prompt state :corp)
+;                         (effect-completed state side eid card)))))
+;    :trash-effect {:msg (msg "trash cards from their Stack as Rolodex was trashed "
+;                             (join ", " (map :title (take 3 (:deck runner)))))
+;                   :effect (effect (mill :runner 3))}}
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -993,8 +993,8 @@
                                                                   (count from) from) card nil)
                      (do (clear-wait-prompt state :corp)
                          (effect-completed state side eid card)))))
-    :trash-effect {:msg (msg "trash cards from their Stack as Rolodex was trashed "
-                          (join ", " (map :title (take 3 (:deck runner)))))
+    :trash-effect {:msg (msg "trash " (join ", " (map :title (take 3 (:deck runner))))
+                             " from their Stack as Rolodex was trashed ")
                    :effect (effect (mill :runner 3))}}
 
    "Sacrificial Clone"

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -579,7 +579,6 @@
           "Personality Profiles trashed card name is in log")
       (is (= 3 (count (:discard (get-runner))))))))
 
-
 (deftest personality-profiles-empty-hand
   ;; Personality Profiles - Ensure effects still fire with an empty hand, #1840
   (do-game

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -575,7 +575,10 @@
     (let [chip (get-in @state [:runner :rig :hardware 0])]
       (card-ability state :runner chip 0)
       (prompt-select :runner (find-card "Self-modifying Code" (:discard (get-runner))))
+      (is (last-log-contains? state "Patron")
+          "Personality Profiles trashed card name is in log")
       (is (= 3 (count (:discard (get-runner))))))))
+
 
 (deftest personality-profiles-empty-hand
   ;; Personality Profiles - Ensure effects still fire with an empty hand, #1840
@@ -831,6 +834,8 @@
     (play-from-hand state :corp "Underway Renovation" "New remote")
     (let [ur (get-content state :remote1 0)]
       (core/advance state :corp {:card (refresh ur)})
+      (is (last-log-contains? state "Sure Gamble")
+          "Underway Renovation trashed card name is in log")
       (is (= 1 (count (:discard (get-runner)))) "1 card milled from Runner Stack")
       (play-from-hand state :corp "Shipment from SanSan")
       (prompt-choice :corp "2")
@@ -839,6 +844,8 @@
       (is (= 1 (count (:discard (get-runner)))) "No Runner mills; advancements were placed")
       (core/advance state :corp {:card (refresh ur)})
       (is (= 4 (:advance-counter (refresh ur))))
+      (is (last-log-contains? state "Sure Gamble, Sure Gamble")
+          "Underway Renovation trashed card name is in log")
       (is (= 3 (count (:discard (get-runner)))) "2 cards milled from Runner Stack; 4+ advancements"))))
 
 (deftest vulcan-coverup

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -657,6 +657,27 @@
       (is (= 7 (count (:hand (get-corp)))) "Drew 2 cards")
       (is (= 1 (:click (get-corp)))))))
 
+(deftest kala-ghoda
+  ; Kala Ghoda Real TV
+  (do-game
+    (new-game (default-corp [(qty "Kala Ghoda Real TV" 1)])
+              (default-runner) [(qty "Sure Gamble" 3)])
+    (starting-hand state :runner ["Sure Gamble"])
+    (play-from-hand state :corp "Kala Ghoda Real TV" "New remote")
+    (let [tv (get-content state :remote1 0)]
+      (core/rez state :corp tv)
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (:corp-phase-12 @state) "Corp is in Step 1.2")
+      (card-ability state :corp tv 0)
+      (prompt-choice :corp "Done")
+      (card-ability state :corp tv 1)
+      (is (= 1 (count (:discard (get-corp)))))
+      (is (= 1 (count (:discard (get-runner)))))
+      (is (last-log-contains? state "Sure Gamble")
+          "Kala Ghoda did log trashed card names")
+      )))
+
 (deftest launch-campaign
   (do-game
     (new-game (default-corp [(qty "Launch Campaign" 1)])

--- a/src/clj/test/cards/ice.clj
+++ b/src/clj/test/cards/ice.clj
@@ -235,6 +235,19 @@
       (is (= 2 (count (:discard (get-runner)))))
       (is (= "Corroder" (:title (first (:deck (get-runner)))))))))
 
+(deftest data-mine
+  ;; Data Mine - do one net and trash
+  (do-game
+    (new-game (default-corp [(qty "Data Mine" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Data Mine" "Server 1")
+    (take-credits state :corp)
+    (let [dm (get-ice state :remote1 0)]
+      (run-on state "Server 1")
+      (core/rez state :corp dm)
+      (card-subroutine state :corp dm 0)
+      (is (= 1 (count (:discard (get-runner)))) "Runner suffered 1 net damage"))))
+
 (deftest draco
   ;; Dracō - Pay credits when rezzed to increase strength; trace to give 1 tag and end the run
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -544,6 +544,17 @@
     (is (not (get-content state :archives 0)) "Upgrade returned to hand")
     (is (not (:run @state)) "Run ended, no more accesses")))
 
+(deftest maxx
+  (do-game
+    (new-game (default-corp)
+              (make-deck "MaxX: Maximum Punk Rock" [(qty "Wyldside" 3)
+                                                    (qty "Eater" 1)]))
+    (starting-hand state :runner ["Eater"])
+    (take-credits state :corp)
+    (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
+    (is (last-log-contains? state "Wyldside, Wyldside")
+        "Maxx did log trashed card names")))
+
 (deftest maxx-wyldside-start-of-turn
   ;; MaxX and Wyldside - using Wyldside during Step 1.2 should lose 1 click
   (do-game

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -977,6 +977,8 @@
     (is (= "Corroder" (:title (second (rest (rest (:deck (get-runner))))))))
     (is (= "Patron" (:title (second (rest (rest (rest (:deck (get-runner)))))))))
     (core/trash state :runner (get-resource state 0))
+    (is (last-log-contains? state "Sure Gamble, Desperado, Diesel")
+        "Rolodex did log trashed card names")
     (is (= 4 (count (:discard (get-runner)))) "Rolodex mills 3 cards when trashed")
     (is (= "Corroder" (:title (first (:deck (get-runner))))))))
 


### PR DESCRIPTION
Implemented adding trashed card names for the following:

- Khala Goda Real TV 
- MaXX 
- Personality Profiles 
- Underway Renovation 
- Ramujan-reliant 550 BMI 
- Rolodex

Updated tests for existing, and created tests for Data Mine, Khala Goda Real TV, Ramujan-reliant 550 BMI 

Fix #2324