### PR TITLE
Fix #2331 - news team with blacklist issue

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -48,10 +48,13 @@
 
 (defn as-trashed-agenda
   "Adds the given card to the given side's :scored area as an agenda worth n points after resolving the trash prompt."
-  [state side card n]
+  ([state side card n] (as-trashed-agenda state side card n nil))
+  ([state side card n force]
   (or (move state :runner (assoc (deactivate state side card) :agendapoints n) :scored) ; if the runner did not trash the card on access, then this will work
-      (move state :runner (assoc (deactivate state side card) :agendapoints n :zone [:discard]) :scored)) ; if the runner did trash it, then this will work
-  (gain-agenda-point state side n))
+      (if force
+        (move state :runner (assoc (deactivate state side card) :agendapoints n :zone [:discard]) :scored {:force true}) ; allow force option in case of Blacklist/News Team
+        (move state :runner (assoc (deactivate state side card) :agendapoints n :zone [:discard]) :scored))) ; if the runner did trash it, then this will work
+  (gain-agenda-point state side n)))
 
 ;;; Card definitions
 (declare in-server?)
@@ -766,7 +769,7 @@
                                 :choices ["Take 2 tags" "Add News Team to score area"]
                                 :effect (req (if (= target "Add News Team to score area")
                                                (do (system-msg state :runner (str "adds News Team to their score area as an agenda worth -1 agenda point"))
-                                                   (as-trashed-agenda state :runner card -1)
+                                                   (as-trashed-agenda state :runner card -1 "force")
                                                    (effect-completed state side eid))
                                                (do (system-msg state :runner (str "takes 2 tags from News Team"))
                                                    (tag-runner state :runner eid 2))))}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -49,11 +49,9 @@
 (defn as-trashed-agenda
   "Adds the given card to the given side's :scored area as an agenda worth n points after resolving the trash prompt."
   ([state side card n] (as-trashed-agenda state side card n nil))
-  ([state side card n force]
-  (or (move state :runner (assoc (deactivate state side card) :agendapoints n) :scored) ; if the runner did not trash the card on access, then this will work
-      (if force
-        (move state :runner (assoc (deactivate state side card) :agendapoints n :zone [:discard]) :scored {:force true}) ; allow force option in case of Blacklist/News Team
-        (move state :runner (assoc (deactivate state side card) :agendapoints n :zone [:discard]) :scored))) ; if the runner did trash it, then this will work
+  ([state side card n options]
+  (or (move state :runner (assoc (deactivate state side card) :agendapoints n) :scored options) ; if the runner did not trash the card on access, then this will work
+      (move state :runner (assoc (deactivate state side card) :agendapoints n :zone [:discard]) :scored options)) ; allow force option in case of Blacklist/News Team
   (gain-agenda-point state side n)))
 
 ;;; Card definitions
@@ -769,7 +767,7 @@
                                 :choices ["Take 2 tags" "Add News Team to score area"]
                                 :effect (req (if (= target "Add News Team to score area")
                                                (do (system-msg state :runner (str "adds News Team to their score area as an agenda worth -1 agenda point"))
-                                                   (as-trashed-agenda state :runner card -1 "force")
+                                                   (as-trashed-agenda state :runner card -1 {:force true})
                                                    (effect-completed state side eid))
                                                (do (system-msg state :runner (str "takes 2 tags from News Team"))
                                                    (tag-runner state :runner eid 2))))}

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -735,8 +735,7 @@
     (core/rez state :corp (get-content state :remote1 0))
     (run-empty-server state :archives)
     (prompt-choice :runner "Add News Team to score area")
-    (is (= 2 (count (:scored (get-runner)))) "News Team added to Runner score area with Blacklist rez")
-    ))
+    (is (= 2 (count (:scored (get-runner)))) "News Team added to Runner score area with Blacklist rez")))
 
 (deftest net-police
   ;; Net Police - Recurring credits equal to Runner's link

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -717,6 +717,27 @@
       (take-credits state :runner)
       (is (= 8 (:credit (get-corp))) "Gained 1 credit at start of turn"))))
 
+(deftest news-team
+  ;; News Team - on access take 2 tags or take as agenda worth -1
+  (do-game
+    (new-game (default-corp [(qty "News Team" 3) (qty "Blacklist" 1)])
+              (default-runner))
+    (trash-from-hand state :corp "News Team")
+    (play-from-hand state :corp "Blacklist" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state :archives)
+    (prompt-choice :runner "Take 2 tags")
+    (is (= 2 (:tag (get-runner))) "Runner has 2 tags")
+    (run-empty-server state :archives)
+    (prompt-choice :runner "Add News Team to score area")
+    (is (= 1 (count (:scored (get-runner)))) "News Team added to Runner score area")
+    (trash-from-hand state :corp "News Team")
+    (core/rez state :corp (get-content state :remote1 0))
+    (run-empty-server state :archives)
+    (prompt-choice :runner "Add News Team to score area")
+    (is (= 2 (count (:scored (get-runner)))) "News Team added to Runner score area with Blacklist rez")
+    ))
+
 (deftest net-police
   ;; Net Police - Recurring credits equal to Runner's link
   (do-game


### PR DESCRIPTION
Added a flag to News Team to force move to occur even if Blacklist is rezzed.  This seemed the best way to do this - the move function checks the current side for locked zone which means blacklist stops news team moving from corp discard.

Fix #2331