### PR TITLE
SMC change to allow reaver draw before SMC effect happens - Fix #2288

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -655,19 +655,23 @@
                                 (gain state side :credit 1)))}]}
 
    "Self-modifying Code"
-   {:abilities [{:prompt "Choose a program to install"
-                 :msg (req (if (not= target "No install")
-                             (str "install " (:title target))
-                             (str "shuffle their Stack")))
-                 :priority true
-                 :choices (req (cancellable
-                                 (conj (vec (sort-by :title (filter #(is-type? % "Program") (:deck runner))))
-                                       "No install")))
-                 :cost [:credit 2]
-                 :effect (req (trigger-event state side :searched-stack nil)
-                              (trash state side card {:cause :ability-cost})
-                              (shuffle! state side :deck)
-                              (when (not= target "No install") (runner-install state side target)))}]}
+   {:abilities  [{:effect (req (when-completed (trash state side card {:cause :ability-cost})
+                                               (continue-ability state side
+                                                                  {:prompt "Choose a program to install"
+                                                                   :msg (req (if (not= target "No install")
+                                                                               (str "install " (:title target))
+                                                                               (str "shuffle their Stack")))
+                                                                   :priority true
+                                                                   :choices (req (cancellable
+                                                                                   (conj (vec (sort-by :title (filter #(is-type? % "Program")
+                                                                                                                      (:deck runner))))
+                                                                                         "No install")))
+                                                                   :cost [:credit 2]
+                                                                   :effect (req (trigger-event state side :searched-stack nil)
+                                                                                (trash state side card {:cause :ability-cost})
+                                                                                (shuffle! state side :deck)
+                                                                                (when (not= target "No install")
+                                                                                  (runner-install state side target)))} card nil)))}]}
 
    "Sneakdoor Beta"
    {:abilities [{:cost [:click 1]


### PR DESCRIPTION
Wrapped SMC inside a "when-completed" to allow Reaver to draw on SMC trash + add test cases.

Fix #2288