### PR TITLE
Jeeves automation - Actual Pull Request now 

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -584,20 +584,18 @@
           ability {:label "Gain [Click]"
                    :msg "gain [Click]"
                    :once :per-turn
-                   :effect jeeves}]
+                   :effect jeeves}
+          cleanup (effect (update! (dissoc card :seen-this-turn)))]
 
     {:abilities  [ability]
-     :leave-play {:effect (effect (update! (dissoc card :seen-this-turn)))}
-     :trash-effect {:effect (effect (update! (dissoc card :seen-this-turn)))}
+     :leave-play {:effect cleanup}
+     :trash-effect {:effect cleanup}
      :events {
              :corp-spent-click
               {:effect (req (update! state side (update-in card [:seen-this-turn target] (fnil + 0) (second targets)))
                             (when (>= (get-in (get-card state card) [:seen-this-turn target]) 3)
-                                 (resolve-ability state side
-                                                  {:once :per-turn
-                                                   :effect jeeves
-                                                   :msg (msg "gain a [Click]")} card nil)))}
-              :corp-turn-ends {:effect (effect (update! (dissoc card :seen-this-turn)))}}})
+                                 (resolve-ability state side ability card nil)))}
+              :corp-turn-ends {:effect cleanup}}})
 
    "Kala Ghoda Real TV"
    {:flags {:corp-phase-12 (req true)}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -695,8 +695,7 @@
     :events {:corp-turn-begins ability}})
 
    "Melange Mining Corp."
-   {:abilities [{:cost [:click 3] :effect (effect (gain :credit 7))
-                 :msg "gain 7 [Credits]"}]}
+   {:abilities [{:cost [:click 3] :effect (effect (gain :credit 7)) :msg "gain 7 [Credits]"}]}
 
    "Mental Health Clinic"
    (let [ability {:msg "gain 1 [Credits]"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -591,8 +591,9 @@
 
    "Jeeves Model Bioroids"
     (let [ability {:label "Gain [Click]"
-                 :msg "gain [Click]" :once :per-turn
-                 :effect (effect (gain :click 1))}
+                   :msg "gain [Click]" :once :per-turn
+                   :effect (effect (gain :click 1))
+                   }
 
           jeeves  (fn [eventkey]
                     {:effect (req (do (swap! state update-in [:jeeves] conj (first eventkey)))
@@ -604,7 +605,9 @@
 
     {:abilities  [ability]
 
-    :events {:corp-click-credit (jeeves [:corp-click-credit])
+     :leave-play (req(swap! state dissoc :jeeves))
+
+     :events {:corp-click-credit (jeeves [:corp-click-credit])
              :corp-click-draw (jeeves [:corp-click-draw])
              :corp-click-install (jeeves [:corp-click-install])
              :advance (jeeves [:advance])
@@ -615,7 +618,6 @@
                                 :once :per-turn
                                 :msg (msg "gain a [Click]")}
              :corp-turn-begins {:effect (req(swap! state dissoc :jeeves))}
-
              ;add one more for using a card power -eg. PAD factory
              }})
 

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -222,7 +222,7 @@
              (or (not advance-counter-cost)
                  (<= advance-counter-cost (or advance-counter 0))))
     ;; Ensure that any costs can be paid.
-    (when-let [cost-str (apply pay (concat [state side card] cost))]
+    (when-let [cost-str (apply pay (concat [state side card] cost [{:action (:cid card)}]))]
       (let [c (if counter-cost
                 (update-in card [:counter (first counter-cost)]
                            #(- (or % 0) (or (second counter-cost) 0)))

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -15,8 +15,8 @@
     (case (:type card)
       ("Event" "Operation") (play-instant state side card {:extra-cost [:click 1]})
       ("Hardware" "Resource" "Program") (runner-install state side (make-eid state) card {:extra-cost [:click 1]})
-      ("ICE" "Upgrade" "Asset" "Agenda") (corp-install state side card server {:extra-cost [:click 1]})))
-  (trigger-event state side :play card))
+      ("ICE" "Upgrade" "Asset" "Agenda") (corp-install state side card server {:extra-cost [:click 1]}))
+    (trigger-event state side :play card)))
 
 (defn shuffle-deck
   "Shuffle R&D/Stack."

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -15,7 +15,8 @@
     (case (:type card)
       ("Event" "Operation") (play-instant state side card {:extra-cost [:click 1]})
       ("Hardware" "Resource" "Program") (runner-install state side (make-eid state) card {:extra-cost [:click 1]})
-      ("ICE" "Upgrade" "Asset" "Agenda") (corp-install state side card server {:extra-cost [:click 1]}))
+      ("ICE" "Upgrade" "Asset" "Agenda") (do (corp-install state side card server {:extra-cost [:click 1]})
+                                             (trigger-event state side :corp-click-install card)))
     (trigger-event state side :play card)))
 
 (defn shuffle-deck
@@ -256,6 +257,7 @@
                        {:prompt "Choose a resource to trash"
                         :choices {:req #(is-type? % "Resource")}
                         :effect (effect (trash target)
+                                        (trigger-event state side :corp-click-trash nil)
                                         (system-msg (str (build-spend-msg cost-str "trash")
                                                          (:title target))))} nil nil))))
 
@@ -264,6 +266,7 @@
   [state side args]
   (when-let [cost (pay state side nil :click 3)]
     (purge state side)
+    (trigger-event state side :corp-click-purge nil)
     (let [spent (build-spend-msg cost "purge")
           message (str spent "all virus counters")]
       (system-msg state side message))

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -15,8 +15,7 @@
     (case (:type card)
       ("Event" "Operation") (play-instant state side card {:extra-cost [:click 1]})
       ("Hardware" "Resource" "Program") (runner-install state side (make-eid state) card {:extra-cost [:click 1]})
-      ("ICE" "Upgrade" "Asset" "Agenda") (do (corp-install state side card server {:extra-cost [:click 1]})
-                                             (trigger-event state side :corp-spend-click :click-install 1)))
+      ("ICE" "Upgrade" "Asset" "Agenda") (do (corp-install state side card server {:extra-cost [:click 1]})))
     (trigger-event state side :play card)))
 
 (defn shuffle-deck
@@ -32,20 +31,19 @@
 (defn click-draw
   "Click to draw."
   [state side args]
-  (when (and (not (get-in @state [side :register :cannot-draw])) (pay state side nil :click 1))
+  (when (and (not (get-in @state [side :register :cannot-draw]))
+             (pay state side nil :click 1 {:action :corp-click-draw}))
     (system-msg state side "spends [Click] to draw a card")
     (draw state side)
-    (when (= side :corp) (trigger-event state side :corp-spend-click :click-draw 1))
     (trigger-event state side (if (= side :corp) :corp-click-draw :runner-click-draw))
     (play-sfx state side "click-card")))
 
 (defn click-credit
   "Click to gain 1 credit."
   [state side args]
-  (when (pay state side nil :click 1)
+  (when (pay state side nil :click 1 {:action :corp-click-credit})
     (system-msg state side "spends [Click] to gain 1 [Credits]")
     (gain state side :credit 1)
-    (when (= side :corp) (trigger-event state side :corp-spend-click :click-credit 1))
     (trigger-event state side (if (= side :corp) :corp-click-credit :runner-click-credit))
     (play-sfx state side "click-credit")))
 
@@ -254,21 +252,19 @@
   "Click to trash a resource."
   [state side args]
   (let [trash-cost (max 0 (- 2 (or (get-in @state [:corp :trash-cost-bonus]) 0)))]
-    (when-let [cost-str (pay state side nil :click 1 :credit trash-cost)]
+    (when-let [cost-str (pay state side nil :click 1 :credit trash-cost {:action :corp-trash-resource})]
       (resolve-ability state side
                        {:prompt "Choose a resource to trash"
                         :choices {:req #(is-type? % "Resource")}
                         :effect (effect (trash target)
-                                        (trigger-event state side :corp-spend-click :click-trash 1)
                                         (system-msg (str (build-spend-msg cost-str "trash")
                                                          (:title target))))} nil nil))))
 
 (defn do-purge
   "Purge viruses."
   [state side args]
-  (when-let [cost (pay state side nil :click 3)]
+  (when-let [cost (pay state side nil :click 3 {:action :corp-click-purge})]
     (purge state side)
-    (trigger-event state side :corp-spend-click :click-purge 3)
     (let [spent (build-spend-msg cost "purge")
           message (str spent "all virus counters")]
       (system-msg state side message))
@@ -336,14 +332,13 @@
   [state side {:keys [card]}]
   (let [card (get-card state card)]
     (when (can-advance? state side card)
-      (when-let [cost (pay state side card :click 1 :credit 1)]
+      (when-let [cost (pay state side card :click 1 :credit 1 {:action :corp-advance})]
         (let [spent   (build-spend-msg cost "advance")
               card    (card-str state card)
               message (str spent card)]
           (system-msg state side message))
         (update-advancement-cost state side card)
         (add-prop state side (get-card state card) :advance-counter 1)
-        (trigger-event state side :corp-spend-click :click-advance 1)
         (play-sfx state side "click-advance")))))
 
 (defn score

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -15,8 +15,8 @@
     (case (:type card)
       ("Event" "Operation") (play-instant state side card {:extra-cost [:click 1]})
       ("Hardware" "Resource" "Program") (runner-install state side (make-eid state) card {:extra-cost [:click 1]})
-      ("ICE" "Upgrade" "Asset" "Agenda") (do (corp-install state side card server {:extra-cost [:click 1]})))
-    (trigger-event state side :play card)))
+      ("ICE" "Upgrade" "Asset" "Agenda") (corp-install state side card server {:extra-cost [:click 1]})))
+  (trigger-event state side :play card))
 
 (defn shuffle-deck
   "Shuffle R&D/Stack."

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -43,9 +43,9 @@
       (when title (toast state side (str cost-msg " for " title ".")) false))))
 
 (defn pay
-  "Deducts each cost from the player."
-  ; args format  ([:click 1 :credit 0] [:forfeit] {:action :corp-click-credit})
-  ; for Jeeves added a map we can pull action out of
+  "Deducts each cost from the player.
+  args format as follows with each being optional ([:click 1 :credit 0] [:forfeit] {:action :corp-click-credit})
+  The map with :action was added for Jeeves so we can log what each click was used on"
   [state side card & args]
   (when-let [{:keys [costs forfeit-cost scored]} (apply can-pay? state side (:title card) args)]
     (when forfeit-cost

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -184,7 +184,7 @@
              install-state (or install-state (:install-state cdef))]
 
          (if (corp-can-install? card dest-zone)
-           (if-let [cost-str (pay state side card end-cost)]
+           (if-let [cost-str (pay state side card end-cost {:action :corp-click-install})]
              (do (let [c (-> card
                              (assoc :advanceable (:advanceable cdef) :new true)
                              (dissoc :seen :disabled))]

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -60,10 +60,10 @@
              ;; This is for Jeeves to see two events for a double
              (when (and (has-subtype? card "Double")
                       (not (get-in @state [side :register :double-ignore-additional])))
-               (trigger-event state side (if (= side :corp) :pay-double-operation :pay-double-event) c))
+               (trigger-event state side (when (= side :corp) :corp-spent-click :play-op 1)))
              ;; This is for Jeeves to not trigger from Accelerated Diagnostics
              (when-not (or ignore-cost no-additional-cost)
-               (trigger-event state side (if (= side :corp) :pay-click-operation :pay-click-event) c))
+               (trigger-event state side (when (= side :corp) :corp-spent-click :play-op 1)))
              (trigger-event state side (if (= side :corp) :play-operation :play-event) c))
            ;; could not pay the card's price; mark the effect as being over.
            (effect-completed state side eid card))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -36,7 +36,7 @@
                           (get-in @state [side :register :spent-click])))) ; if priority, have not spent a click
          (if-let [cost-str (pay state side card :credit (if ignore-cost 0 (:cost card)) extra-cost
                                 (when-not (or ignore-cost no-additional-cost)
-                                  additional-cost))]
+                                  additional-cost) {:action :play-instant})]
            (let [c (move state side (assoc card :seen true) :play-area)]
              (system-msg state side (str (if ignore-cost
                                            "play "
@@ -57,13 +57,6 @@
                    (when (has-subtype? card "Terminal")
                      (lose state side :click (-> @state side :click))
                      (swap! state assoc-in [:corp :register :terminal] true))))
-             ;; This is for Jeeves to see two events for a double
-             (when (and (has-subtype? card "Double")
-                      (not (get-in @state [side :register :double-ignore-additional])))
-               (trigger-event state side (when (= side :corp) :corp-spent-click :play-op 1)))
-             ;; This is for Jeeves to not trigger from Accelerated Diagnostics
-             (when-not (or ignore-cost no-additional-cost)
-               (trigger-event state side (when (= side :corp) :corp-spent-click :play-op 1)))
              (trigger-event state side (if (= side :corp) :play-operation :play-event) c))
            ;; could not pay the card's price; mark the effect as being over.
            (effect-completed state side eid card))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -57,6 +57,13 @@
                    (when (has-subtype? card "Terminal")
                      (lose state side :click (-> @state side :click))
                      (swap! state assoc-in [:corp :register :terminal] true))))
+             ;; This is for Jeeves to see two events for a double
+             (when (and (has-subtype? card "Double")
+                      (not (get-in @state [side :register :double-ignore-additional])))
+               (trigger-event state side (if (= side :corp) :pay-double-operation :pay-double-event) c))
+             ;; This is for Jeeves to not trigger from Accelerated Diagnostics
+             (when-not (or ignore-cost no-additional-cost)
+               (trigger-event state side (if (= side :corp) :pay-click-operation :pay-click-event) c))
              (trigger-event state side (if (= side :corp) :play-operation :play-event) c))
            ;; could not pay the card's price; mark the effect as being over.
            (effect-completed state side eid card))

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -709,7 +709,6 @@
       (is (last-log-contains? state "Sure Gamble")
           "Kala Ghoda did log trashed card names")
       )))
->>>>>>> upstream/master
 
 (deftest launch-campaign
   (do-game

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -659,6 +659,36 @@
       (is (= 7 (count (:hand (get-corp)))) "Drew 2 cards")
       (is (= 1 (:click (get-corp)))))))
 
+(deftest jeeves-model-bioroids
+  (do-game
+    (new-game (default-corp [(qty "Jeeves Model Bioroids" 1) (qty "TGTBT" 1)])
+              (default-runner [(qty "Personal Workshop" 3)]))
+    (play-from-hand state :corp "Jeeves Model Bioroids" "New remote")
+    (play-from-hand state :corp "TGTBT" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Personal Workshop")
+    (play-from-hand state :runner "Personal Workshop")
+    (play-from-hand state :runner "Personal Workshop")
+    (take-credits state :runner)
+    ;click for credits
+    (take-credits state :corp 3)
+    (is (= 1 (:click (get-corp))))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    ;click to purge
+    (core/do-purge state :corp 3)
+    (is (= 1 (:click (get-corp))))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    ;click to advance
+    (core/advance state :corp (get-content state :remote2 0))
+    (core/advance state :corp (get-content state :remote2 0))
+    (core/advance state :corp (get-content state :remote2 0))
+    (is (= 1 (:click (get-corp))))
+    ; trash resources - tbc
+    (core/gain state :runner :tag 1)))
+
 (deftest launch-campaign
   (do-game
     (new-game (default-corp [(qty "Launch Campaign" 1)])

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -661,33 +661,58 @@
 
 (deftest jeeves-model-bioroids
   (do-game
-    (new-game (default-corp [(qty "Jeeves Model Bioroids" 1) (qty "TGTBT" 1)])
-              (default-runner [(qty "Personal Workshop" 3)]))
+    (new-game (default-corp [(qty "Jeeves Model Bioroids" 1) (qty "TGTBT" 1)
+                             (qty "Melange Mining Corp." 2)])
+              (default-runner [(qty "Ghost Runner" 3)]))
     (play-from-hand state :corp "Jeeves Model Bioroids" "New remote")
-    (play-from-hand state :corp "TGTBT" "New remote")
     (core/rez state :corp (get-content state :remote1 0))
     (take-credits state :corp)
-    (play-from-hand state :runner "Personal Workshop")
-    (play-from-hand state :runner "Personal Workshop")
-    (play-from-hand state :runner "Personal Workshop")
+    (play-from-hand state :runner "Ghost Runner")
+    (play-from-hand state :runner "Ghost Runner")
+    (play-from-hand state :runner "Ghost Runner")
     (take-credits state :runner)
-    ;click for credits
+    ; install 3 things
+    (play-from-hand state :corp "TGTBT" "New remote")
+    (play-from-hand state :corp "Melange Mining Corp." "New remote")
+    (play-from-hand state :corp "Melange Mining Corp." "New remote")
+    (is (= 1 (:click (get-corp))))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    ;;click for credits
     (take-credits state :corp 3)
     (is (= 1 (:click (get-corp))))
     (take-credits state :corp)
     (take-credits state :runner)
-    ;click to purge
+    ;;click to purge
     (core/do-purge state :corp 3)
     (is (= 1 (:click (get-corp))))
     (take-credits state :corp)
     (take-credits state :runner)
-    ;click to advance
+    ;;click to advance
     (core/advance state :corp (get-content state :remote2 0))
     (core/advance state :corp (get-content state :remote2 0))
     (core/advance state :corp (get-content state :remote2 0))
     (is (= 1 (:click (get-corp))))
-    ; trash resources - tbc
-    (core/gain state :runner :tag 1)))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    ;; use 3 clicks on card ability - Melange
+    (core/rez state :corp (get-content state :remote3 0))
+    (card-ability state :corp (get-content state :remote3 0) 0)
+    (is (= 1 (:click (get-corp))))
+    (take-credits state :corp)
+    (take-credits state :runner)
+    ;; trash 3 resources
+    (core/gain state :runner :tag 1)
+    (core/trash-resource state :corp nil)
+    (prompt-select :corp (get-resource state 0))
+    (is (= 1 (count (:discard (get-runner)))))
+    (core/trash-resource state :corp nil)
+    (prompt-select :corp (get-resource state 0))
+    (is (= 2 (count (:discard (get-runner)))))
+    (core/trash-resource state :corp nil)
+    (prompt-select :corp (get-resource state 0))
+    (is (= 3 (count (:discard (get-runner)))))
+    (is (= 1 (:click (get-corp))))))
 
 (deftest kala-ghoda
   ; Kala Ghoda Real TV
@@ -707,8 +732,7 @@
       (is (= 1 (count (:discard (get-corp)))))
       (is (= 1 (count (:discard (get-runner)))))
       (is (last-log-contains? state "Sure Gamble")
-          "Kala Ghoda did log trashed card names")
-      )))
+          "Kala Ghoda did log trashed card names"))))
 
 (deftest launch-campaign
   (do-game


### PR DESCRIPTION
Hi team,
I added automation for Jeeves to cover everything except Click abilities on cards.  This needed a bit of work.  

Can someone please confirm they are ok with the approach within the game engine as I am clearly still learning it (and Clojure).

1. Added event emitters for several click abilities that did not exist. New events were:

- corp-click-install 
- pay-click-operation
- pay-double-operation
- corp-click-purge
- corp-click-trash 

2. Made Jeeves listen for them
3. Jeeves has its own key in the @state atom which gets cleared each turn.  Here we track what events it has seen each turn
4. Added unit test

What remains if this is not a terrible way to do this...

- Clickable card abilities - via another event emitter
- More test cases

(Edit - added a :leave-play key to clear :jeeves from @state if it is trashed)