### PR TITLE
Implement manta grid

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -220,6 +220,14 @@
                               (trash state side card {:cause :ability-cost})
                               (lose state :runner :tag 1))}]}
 
+   "Manta Grid"
+   {:events {
+     :successful-run
+     {:msg (msg " gain a [Click] next turn")
+      :req    (req (and this-server
+                        (or (< (:credit runner) 6) (zero? (:click runner)))))
+      :effect (req (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}}}
+
    "Marcus Batty"
    {:abilities [{:req (req this-server)
                  :label "[Trash]: Start a Psi game"

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -158,7 +158,8 @@
   "End phase 1.2 and trigger appropriate events for the player."
   [state side args]
   (turn-message state side true)
-  (gain state side :click (get-in @state [side :click-per-turn]))
+  (gain state side :click (+ (get-in @state [side :click-per-turn]) (or (get-in @state [side :extra-click-temp]) 0)))
+  (swap! state dissoc-in [side :extra-click-temp])
   (when-completed (trigger-event-sync state side (if (= side :corp) :corp-turn-begins :runner-turn-begins))
                   (do (when (= side :corp)
                         (draw state side))

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -354,6 +354,32 @@
       (is (= 1 (count (:discard (get-corp)))) "Keegan trashed")
       (is (= 1 (count (:discard (get-runner)))) "Corroder trashed"))))
 
+(deftest manta-grid
+  ;; If the Runner has fewer than 6 or no unspent clicks on successful run, corp gains a click next turn.
+  (do-game
+    (new-game (default-corp [(qty "Manta Grid" 1)])
+              (default-runner))
+    (starting-hand state :runner [])
+    (is (= 3 (:click (get-corp))) "Corp has 3 clicks")
+    (play-from-hand state :corp "Manta Grid" "HQ")
+    (core/rez state :corp (get-content state :hq 0))
+    (take-credits state :corp)
+    (core/click-draw state :runner nil)
+    (core/click-draw state :runner nil)
+    (run-empty-server state "HQ")
+    (is (= 1 (:click (get-runner))) "Running last click")
+    (run-empty-server state "HQ")
+    (take-credits state :runner)
+    (is (= 5 (:click (get-corp))) "Corp gained 2 clicks due to < 6 runner credits and run last click")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (is (= 3 (:click (get-corp))) "Corp back to 3 clicks")
+    (take-credits state :corp)
+    (take-credits state :runner 3)
+    (run-empty-server state "HQ")
+    (take-credits state :runner)
+    (is (= 4 (:click (get-corp))) "Corp gained a click due to running last click")))
+
 (deftest marcus-batty-security-nexus
   ;; Marcus Batty - Simultaneous Interaction with Security Nexus
   (do-game


### PR DESCRIPTION
Implementation of this card.  When it fires I update game state - because the click(s) you gained still happen even if the card is trashed, derezzed, exploded etc - so did not tie the start of turn gain to the card itself.