### PR TITLE
test for clone chip and dont install programs you cant afford

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -141,7 +141,7 @@
                                                    (lose state side :tag 1)))} card nil))}]}
 
    "Clone Chip"
-   {:abilities [{:prompt "Choose a program to install from your Heap" :msg (msg "install " (:title target))
+   {:abilities [{:prompt "Choose a program to install from your Heap"
                  :priority true :show-discard true
                  :req (req (not (seq (get-in @state [:runner :locked :discard]))))
                  :choices {:req #(and (is-type? % "Program")
@@ -149,6 +149,7 @@
                  :effect (req (when (>= (:credit runner) (:cost target))
                                     (do
                                       (trash state side card {:cause :ability-cost})
+                                      (system-msg state side (str "uses " (:title card) " to install " (:title target)))
                                       (runner-install state side target))))}]}
 
    "Comet"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -146,7 +146,10 @@
                  :req (req (not (seq (get-in @state [:runner :locked :discard]))))
                  :choices {:req #(and (is-type? % "Program")
                                       (= (:zone %) [:discard]))}
-                 :effect (effect (trash card {:cause :ability-cost}) (runner-install target))}]}
+                 :effect (req (when (>= (:credit runner) (:cost target))
+                                    (do
+                                      (trash state side card {:cause :ability-cost})
+                                      (runner-install state side target))))}]}
 
    "Comet"
    {:in-play [:memory 1]

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -114,6 +114,30 @@
         (is (not (nil? ds)))
         (is (= (:title ds) "Datasucker"))))))
 
+(deftest clone-chip-dont-install-choices-runner-cant-afford
+  ;; Test clone chip usage - dont show inavalid choices
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Inti" 1) (qty "Magnum Opus" 1) (qty "Clone Chip" 1)]))
+    (take-credits state :corp)
+    (trash-from-hand state :runner "Inti")
+    (trash-from-hand state :runner "Magnum Opus")
+    (play-from-hand state :runner "Clone Chip")
+    (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left")
+    (let [chip (get-in @state [:runner :rig :hardware 0])]
+      (card-ability state :runner chip 0)
+      (prompt-select :runner (find-card "Magnum Opus" (:discard (get-runner))))
+      (is (nil? (get-in @state [:runner :rig :program 0])) "No program was installed"))
+    (let [chip (get-in @state [:runner :rig :hardware 0])]
+      (is (not (nil? chip)) "Clone Chip is still installed")
+      (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left")
+      (card-ability state :runner chip 0)
+      (prompt-select :runner (find-card "Inti" (:discard (get-runner))))
+      (let [inti (get-in @state [:runner :rig :program 0])]
+        (is (not (nil? inti)) "Program was installed")
+        (is (= (:title inti) "Inti") "Program is Inti")
+        (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left")))))
+
 (deftest comet-event-play
   ;; Comet - Play event without spending a click after first event played
   (do-game


### PR DESCRIPTION
Currently if you try to install a program you can not afford, the prompt says that you did install it and trashed clone chip, but the program is still in the heap. The new behavior is that clone chip is not trashed. I was not able to change the prompt from firing.