### PR TITLE
Prevent multiple install prompts for conspiracy breakers when user denies first prompt

### DIFF
--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -145,11 +145,15 @@
   (let [install-prompt {:req (req (and (= (:zone card) [:discard])
                                        (rezzed? current-ice)
                                        (has-subtype? current-ice type)
-                                       (not (some #(= title (:title %)) (all-installed state :runner)))))
+                                       (not (some #(= title (:title %)) (all-installed state :runner)))
+                                       (not (get-in @state [:run :register :conspiracy (:cid current-ice)]))))
                         :optional {:player :runner
                                    :prompt (str "Install " title "?")
                                    :yes-ability {:effect (effect (unregister-events card)
-                                                                 (runner-install :runner card))}}}
+                                                                 (runner-install :runner card))}
+                                   :no-ability {:effect (req  ;; Add a register to note that the player was already asked about installing,
+                                                              ;; to prevent multiple copies from prompting multiple times.
+                                                              (swap! state assoc-in [:run :register :conspiracy (:cid current-ice)] true))}}}
         heap-event (req (when (= (:zone card) [:discard])
                           (unregister-events state side card)
                           (register-events state side

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -426,7 +426,7 @@
                           (when cur-ice
                             (update-ice-strength state side cur-ice))
                           (when next-ice
-                            (trigger-event state side :approach-ice next-ice))
+                            (trigger-event-sync state side (make-eid state) :approach-ice next-ice))
                           (doseq [p (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
                             (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
                             (update-breaker-strength state side p)))))))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -24,7 +24,7 @@
        (gain-run-credits state side (+ (get-in @state [:corp :bad-publicity]) (get-in @state [:corp :has-bad-pub])))
        (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
        (update-all-ice state :corp)
-       (trigger-event state :runner :run s)))))
+       (trigger-event-sync state :runner (make-eid state) :run s)))))
 
 (defn gain-run-credits
   "Add temporary credits that will disappear when the run is over."

--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -321,6 +321,32 @@
     (run-on state "Archives")
     (is (empty? (:prompt (get-runner))) "No prompt to install second Paperclip")))
 
+(deftest paperclip-multiple
+  ;; Paperclip - do not show a second install prompt if user said No to first, when multiple are in heap
+  (do-game
+    (new-game (default-corp [(qty "Vanilla" 2)])
+              (default-runner [(qty "Paperclip" 3)]))
+    (play-from-hand state :corp "Vanilla" "Archives")
+    (play-from-hand state :corp "Vanilla" "Archives")
+    (take-credits state :corp)
+    (trash-from-hand state :runner "Paperclip")
+    (trash-from-hand state :runner "Paperclip")
+    (trash-from-hand state :runner "Paperclip")
+    (run-on state "Archives")
+    (core/rez state :corp (get-ice state :archives 1))
+    (prompt-choice :runner "No")
+    (is (empty? (:prompt (get-runner))) "No additional prompts to rez other copies of Paperclip")
+    (run-continue state)
+    ;; we should get the prompt on a second ice even after denying the first.
+    (core/rez state :corp (get-ice state :archives 0))
+    (prompt-choice :runner "No")
+    (is (empty? (:prompt (get-runner))) "No additional prompts to rez other copies of Paperclip")
+    (core/jack-out state :runner)
+    ;; Run again, make sure we get the prompt to install again.
+    (run-on state "Archives")
+    (prompt-choice :runner "No")
+    (is (empty? (:prompt (get-runner))) "No additional prompts to rez other copies of Paperclip")))
+
 (deftest shiv
   ;; Shiv - Gain 1 strength for each installed breaker; no MU cost when 2+ link
   (do-game


### PR DESCRIPTION
Conspiracy breakers already won't ask to install if another copy is already installed. Now they won't ask to install if you just said "no" to another copy for the same piece of ice.

Fix #2360, not 2630 (whoops).