### PR TITLE
Minor card fixes

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -826,7 +826,8 @@
     0
     {:req (req (pos? (:advance-counter (get-card state card) 0)))
      :effect
-     (req (doseq [ag (filter #(is-type? % "Agenda") (get-in @state [:corp :hand]))]
+     (req (show-wait-prompt state :runner "Corp to choose an agenda to score with Plan B")
+          (doseq [ag (filter #(is-type? % "Agenda") (get-in @state [:corp :hand]))]
             (update-advancement-cost state side ag))
           (resolve-ability state side
             {:prompt "Choose an Agenda in HQ to score"
@@ -835,7 +836,8 @@
                                   (in-hand? %))}
              :msg (msg "score " (:title target))
              :effect (effect (score (assoc target :advance-counter
-                                           (:current-cost target))))}
+                                           (:current-cost target)))
+                             (clear-wait-prompt :runner))}
            card nil))}
     "Score an Agenda from HQ?")
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -684,6 +684,7 @@
    "Şifr"
    {:in-play [:memory 2]
     :abilities [{:once :per-turn
+                 :req (req (rezzed? current-ice))
                  :msg (msg "lower their maximum hand size by 1 and lower the strength of " (:title current-ice) " to 0")
                  :effect (effect (lose :runner :hand-size-modification 1)
                                  (update! (assoc card :sifr-target current-ice :sifr-used true))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -406,11 +406,15 @@
                           :effect (effect (update! (assoc card
                                                           :hosted-programs (remove #(= (:cid target) %) (:hosted-programs card))))
                                           (lose :memory (:memoryunits target)))}}}
-
    "LLDS Energy Regulator"
    {:prevent {:trash [:hardware]}
-    :abilities [{:cost [:credit 3] :msg "prevent a hardware from being trashed"}
-                {:effect (effect (trash card {:cause :ability-cost})) :msg "prevent a hardware from being trashed"}]}
+    :abilities [{:cost [:credit 3]
+                 :msg "prevent a hardware from being trashed"
+                 :effect (effect (trash-prevent :hardware 1))}
+                {:label "[Trash]: Prevent a hardware from being trashed"
+                 :msg "prevent a hardware from being trashed"
+                 :effect (effect (trash-prevent :hardware 1)
+                                 (trash card {:cause :ability-cost}))}]}
 
    "Magnum Opus"
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -542,7 +542,8 @@
    {:abilities [{:msg "access all cards in Archives"
                  :effect (req (trash state side card {:cause :ability-cost})
                               (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
-                              (swap! state update-in [:run :cards-accessed] (fnil #(+ % (count (:discard corp))) 0))
+                              (when (:run @state)
+                                (swap! state update-in [:run :cards-accessed] (fnil #(+ % (count (:discard corp))) 0)))
                               (resolve-ability state :runner (choose-access (get-in @state [:corp :discard]) '(:archives)) card nil))}]
     :install-cost-bonus (req (if (and run (= (:server run) [:archives]) (= 0 (:position run)))
                                [:credit -7 :click -1] nil))


### PR DESCRIPTION
* Fix #2363: Don't let Sifr be used on unrezzed ICE
* Fix #2330: Only update the number of cards accessed during a run if a run is underway
* Add a second wait prompt in Plan B after the Corp opts to use it but before they've selected the agenda (had a report that a Runner trashing it before an agenda is chosen screws things up)
* Fix LLDS Energy Regulator--both abilities were missing `trash-prevent` calls, so all it was doing was printing log messages.