### PR TITLE
Fix: tests, Archives Interface, TS, Stinson; implement: Mad Dash, Jemison, Los, Clan Vengeance

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1149,6 +1149,7 @@
                              :interactive (req true)
                              :delayed-completion true
                              :choices {:req #(and (not (is-type? % "Operation"))
+                                                  (= (:side %) "Corp")
                                                   (#{[:hand] [:discard]} (:zone %)))}
                              :msg (msg (corp-install-msg target))
                              :effect (effect (corp-install eid target nil {:no-install-cost true}))}}}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -184,16 +184,6 @@
                  :trace {:base 3 :msg "avoid taking a bad publicity"
                          :effect (effect (lose :bad-publicity 1))}}]}
 
-   "Bryan Stinson"
-   {:abilities [{:cost [:click 1]
-                 :req (req (and (< (:credit runner) 6)
-                                (< 0 (count (filter #(is-type? % "Operation") (:discard corp))))))
-                 :label "Play an operation from Archives ignoring all costs and remove it from the game"
-                 :prompt "Choose an operation to play"
-                 :msg (msg "play " (:title target) " from Archives ignoring all costs and remove it from the game")
-                 :choices (req (cancellable (filter #(is-type? % "Operation") (:discard corp)) :sorted))
-                 :effect (effect (play-instant nil target {:ignore-cost true}) (move target :rfg))}]}
-
    "Capital Investors"
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -772,6 +772,23 @@
    {:msg "gain 9 [Credits]"
     :effect (effect (gain :credit 9))}
 
+   "Mad Dash"
+   {:prompt "Choose a server"
+    :choices (req runnable-servers)
+    :delayed-completion true
+    :effect (effect (run target nil card)
+                    (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
+    :events {:agenda-stolen {:silent (req true)
+                             :effect (effect (update! (assoc card :steal true)))}
+             :run-ends {:effect (req (if (:steal card)
+                                       (do (as-agenda state :runner (get-card state card) 1)
+                                           (system-msg state :runner
+                                                       (str "adds Mad Dash to their score area as an agenda worth 1 agenda point")))
+                                       (do (system-msg state :runner
+                                                       (str "suffers 1 meat damage from Mad Dash"))
+                                                       (damage state side eid :meat 1 {:card card})))
+                                     (unregister-events state side card))}}}
+
    "Making an Entrance"
    (letfn [(entrance-trash [cards]
              {:prompt "Choose a card to trash"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -9,6 +9,7 @@
     {:successful-run
      {:delayed-completion true
       :req (req (and (= target :archives)
+                     (not= (:max-access run) 0)
                      (not-empty (:discard corp))))
       :effect (effect (continue-ability
                         {:optional

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -462,6 +462,12 @@
       :events {:agenda-scored leela
                :agenda-stolen leela}})
 
+   "Los: Data Hijacker"
+   {:events {:rez {:once :per-turn
+                   :req (req (ice? target))
+                   :msg "gain 2 [Credits]"
+                   :effect (effect (gain :runner :credit 2))}}}
+
    "MaxX: Maximum Punk Rock"
    (let [ability {:msg (msg (let [deck (:deck runner)]
                               (if (pos? (count deck))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -330,6 +330,19 @@
                            :once :per-turn
                            :effect (effect (draw 1))}}}
 
+   "Jemison Astronautics: Sacrifice. Audacity. Success."
+   {:events {:corp-forfeit-agenda
+             {:delayed-completion true
+              :effect (req (show-wait-prompt state :runner "Corp to place advancement tokens")
+                           (let [p (inc (get-agenda-points state :corp target))]
+                             (continue-ability state side
+                               {:prompt "Choose a card to place advancement tokens on with Jemison Astronautics: Sacrifice. Audacity. Success."
+                                :choices {:req #(and (installed? %) (= (:side %) "Corp"))}
+                                :msg (msg "place " p " advancement tokens on " (card-str state target))
+                                :effect (effect (add-prop :corp target :advance-counter p {:placed true})
+                                                (clear-wait-prompt :runner))}
+                              card nil)))}}}
+
    "Jesminder Sareen: Girl Behind the Curtain"
    {:events {:pre-tag {:once :per-run
                        :req (req (:run @state))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -263,7 +263,8 @@
     :abilities [{:label "[Trash]: Trash 1 random card from HQ for each power counter"
                  :req (req (pos? (get-in card [:counter :power] 0)))
                  :msg (msg "trash " (min (get-in card [:counter :power] 0) (count (:hand corp))) " cards from HQ")
-                 :effect (effect (mill :corp (min (get-in card [:counter :power] 0) (count (:hand corp))))
+                 :effect (effect (trash-cards (take (min (get-in card [:counter :power] 0) (count (:hand corp)))
+                                              (shuffle (:hand corp))))
                                  (trash card {:cause :ability-cost}))}]}
 
    "Compromised Employee"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -256,6 +256,16 @@
               :trace {:base 1 :unsuccessful {:effect (effect (lose :runner :tag 1))
                                              :msg "remove 1 tag"}}}}}
 
+   "Clan Vengeance"
+   {:events {:pre-resolve-damage {:req (req (pos? (last targets)))
+                                  :effect (effect (add-counter card :power 1)
+                                                  (system-msg :runner (str "places 1 power counter on Clan Vengeance")))}}
+    :abilities [{:label "[Trash]: Trash 1 random card from HQ for each power counter"
+                 :req (req (pos? (get-in card [:counter :power] 0)))
+                 :msg (msg "trash " (min (get-in card [:counter :power] 0) (count (:hand corp))) " cards from HQ")
+                 :effect (effect (mill :corp (min (get-in card [:counter :power] 0) (count (:hand corp))))
+                                 (trash card {:cause :ability-cost}))}]}
+
    "Compromised Employee"
    {:recurring 1
     :events {:rez {:req (req (ice? target))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -65,6 +65,18 @@
                                                (= (:zone card) (:zone (get-card state (:host target)))))))
                             :effect (effect (rez-cost-bonus -5))}}}
 
+   "Bryan Stinson"
+   {:abilities [{:cost [:click 1]
+                 :req (req (and (< (:credit runner) 6)
+                                (< 0 (count (filter #(and (is-type? % "Operation")
+                                                          (has-subtype? % "Transaction")) (:discard corp))))))
+                 :label "Play a transaction operation from Archives ignoring all costs and remove it from the game"
+                 :prompt "Choose a transaction operation to play"
+                 :msg (msg "play " (:title target) " from Archives ignoring all costs and remove it from the game")
+                 :choices (req (cancellable (filter #(and (is-type? % "Operation")
+                                                          (has-subtype? % "Transaction")) (:discard corp)) :sorted))
+                 :effect (effect (play-instant nil target {:ignore-cost true}) (move target :rfg))}]}
+
    "Caprice Nisei"
    {:events {:pass-ice {:req (req (and this-server
                                        (= (:position run) 1))) ; trigger when last ice passed

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -427,12 +427,15 @@
 
 (defn forfeit
   "Forfeits the given agenda to the :rfg zone."
-  [state side card]
-  (let [c (if (in-corp-scored? state side card)
-            (deactivate state side card) card)]
-    (system-msg state side (str "forfeits " (:title c)))
-    (gain-agenda-point state side (- (get-agenda-points state side c)))
-    (move state :corp c :rfg)))
+  ([state side card] (forfeit state side (make-eid state) card))
+  ([state side eid card]
+   (let [c (if (in-corp-scored? state side card)
+             (deactivate state side card) card)]
+     (system-msg state side (str "forfeits " (:title c)))
+     (gain-agenda-point state side (- (get-agenda-points state side c)))
+     (move state :corp c :rfg)
+     (when-completed (trigger-event-sync state side (keyword (str (name side) "-forfeit-agenda")) c)
+                     (effect-completed state side eid)))))
 
 (defn gain-agenda-point
   "Gain n agenda points and check for winner."

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -1110,6 +1110,7 @@
                       (let [kate-choice (some #(when (= name (:title %)) %) (:choices (prompt-map :runner)))]
                         (core/resolve-prompt state :runner {:card kate-choice})))
 
+      ayla "Ayla \"Bios\" Rahim: Simulant Specialist"
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"
       kit "Rielle \"Kit\" Peddler: Transhuman"
       professor "The Professor: Keeper of Knowledge"
@@ -1124,7 +1125,7 @@
       (new-game (default-corp) (default-runner ["Magnum Opus" "Rebirth"]) {:start-as :runner})
 
       (play-from-hand state :runner "Rebirth")
-      (is (= (first (prompt-titles :runner)) chaos) "List is sorted")
+      (is (= (first (prompt-titles :runner)) ayla) "List is sorted")
       (is (every?   #(some #{%} (prompt-titles :runner))
                     [kate kit]))
       (is (not-any? #(some #{%} (prompt-titles :runner))

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -850,6 +850,23 @@
     (is (= 2 (:click (get-runner))) "Spent 2 clicks")
     (is (= 1 (:tag (get-runner))) "Lost 2 tags")))
 
+(deftest mad-dash
+  ;; Mad Dash - Make a run. Move to score pile as 1 point if steal agenda.  Take 1 meat if not
+  (do-game
+    (new-game (default-corp [(qty "Project Atlas" 1)])
+              (default-runner [(qty "Mad Dash" 3)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Mad Dash")
+    (prompt-choice :runner "Archives")
+    (run-successful state)
+    (is (= 2 (count (:discard (get-runner)))) "Took a meat damage")
+    (play-from-hand state :runner "Mad Dash")
+    (prompt-choice :runner "HQ")
+    (run-successful state)
+    (prompt-choice :runner "Steal")
+    (is (= 2 (count (:scored (get-runner)))) "Mad Dash moved to score area")
+    (is (= 3 (:agenda-point (get-runner))) "Mad Dash scored for 1 agenda point")))
+
 (deftest making-an-entrance
   ;; Making an Entrance - Full test
   (do-game

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -356,6 +356,32 @@
       (run-empty-server state "Server 1")
       (is (= 8 (core/trash-cost state :runner (refresh pad)))))))
 
+(deftest jemison-astronautics
+  ;; Jemison Astronautics - Place advancements when forfeiting agendas
+  (do-game
+    (new-game
+      (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success." [(qty "Enforcer 1.0" 1) (qty "Hostile Takeover" 1)
+                                                                        (qty "Ice Wall" 1) (qty "Global Food Initiative" 1)])
+      (default-runner [(qty "Data Dealer" 1)]))
+    (play-from-hand state :corp "Enforcer 1.0" "HQ")
+    (play-from-hand state :corp "Ice Wall" "R&D")
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (let [enf (get-ice state :hq 0)
+          iwall (get-ice state :rd 0)]
+      (take-credits state :corp)
+      (play-from-hand state :runner "Data Dealer")
+      (run-empty-server state "Server 1")
+      (prompt-choice :runner "Steal")
+      (let [dd (get-resource state 0)]
+        (card-ability state :runner dd 0)
+        (is (empty? (:prompt (get-corp))) "No Jemison prompt for Runner forfeit")
+        (take-credits state :runner)
+        (play-from-hand state :corp "Global Food Initiative" "New remote")
+        (score-agenda state :corp (get-content state :remote2 0))
+        (core/rez state :corp enf)
+        (prompt-select :corp iwall)
+        (is (= 4 (:advance-counter (refresh iwall))) "Jemison placed 4 advancements")))))
+
 (deftest jesminder-sareen-ability
   ;; Jesminder Sareen - avoid tags only during a run
   (do-game


### PR DESCRIPTION
Gets tests passing again (failing due to new Shaper identity), fixes #2386, fixes #2389. 

Moves Bryan Stinson to upgrades, adds missing restriction that the operation must have the Transaction subtype.

Also implemented: Mad Dash and Jemison Astronautics (with tests) from the current pack; Clan Vengeance and Los: Data Hijacker from Station One.