### PR TITLE
fix Wyrm, Alexa Belsky

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -96,7 +96,7 @@
                                   (resolve-ability
                                     state side
                                     {:prompt "Prevent Alexa Belsky from shuffling back in 1 card for every 2 [Credits] spent. How many credits?"
-                                     :choices :credit :player :runner
+                                     :choices :credit :player :runner :priority 2
                                      :msg (msg "shuffle " (- (count (:hand corp)) (quot target 2)) " card"
                                                (when-not (= 1 (- (count (:hand corp)) (quot target 2))) "s")
                                                " in HQ into R&D")

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -95,7 +95,7 @@
                               (do (show-wait-prompt state :corp "Runner to decide whether or not to prevent Alexa Belsky")
                                   (resolve-ability
                                     state side
-                                    {:prompt "How many credits?"
+                                    {:prompt "Prevent Alexa Belsky from shuffling back in 1 card for every 2 [Credits] spent. How many credits?"
                                      :choices :credit :player :runner
                                      :msg (msg "shuffle " (- (count (:hand corp)) (quot target 2)) " card"
                                                (when-not (= 1 (- (count (:hand corp)) (quot target 2))) "s")
@@ -104,7 +104,8 @@
                                                     (do (doseq [c (take (- (count (:hand corp)) (quot target 2))
                                                                         (shuffle (:hand corp)))]
                                                           (move state :corp c :deck))
-                                                        (shuffle! state :corp :deck)
+                                                        (when (pos? (- (count (:hand corp)) (quot target 2)))
+                                                          (shuffle! state :corp :deck))
                                                         (system-msg state :runner
                                                                     (str "pays " target " [Credits] to prevent "
                                                                          (quot target 2) " random card"

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -676,20 +676,21 @@
                     {:abilities [{:cost [:credit 3]
                                   :msg "break 1 subroutine on ICE with 0 or less strength"}
                                  {:cost [:credit 1]
-                                  :label "Give -1 strength to current ice"
-                                  :req (req current-ice)
+                                  :label "Give -1 strength to current ICE"
+                                  :req (req (rezzed? current-ice))
                                   :msg (msg "give -1 strength to " (:title current-ice))
-                                  :effect (effect (update! (update-in card [:wyrm-count] (fnil inc 0)))
-                                                  (update-ice-strength current-ice))}
+                                  :effect (req (update! state side (update-in card [:wyrm-count] (fnil #(+ % 1) 0)))
+                                               (update-ice-strength state side current-ice))}
                                  (strength-pump 1 1)]
                      :events (let [auto-pump (fn [state side eid card targets]
                                                ((:effect breaker-auto-pump) state side eid card targets))
                                    wy {:effect (effect (update! (dissoc card :wyrm-count))
-                                                       (auto-pump eid card targets))}]
+                                                       (auto-pump eid (get-card state card) targets))}]
                                {:pre-ice-strength {:req (req (and (= (:cid target) (:cid current-ice))
                                                                   (:wyrm-count card)))
-                                                   :effect (effect (ice-strength-bonus (- (:wyrm-count (get-card state card))) target)
-                                                                   (auto-pump eid card targets))}
+                                                   :effect (req (let [c (:wyrm-count (get-card state card))]
+                                                                  (ice-strength-bonus state side (- c) target)
+                                                                  (auto-pump state side eid card targets)))}
                                 :pass-ice wy
                                 :run-ends wy})})
 


### PR DESCRIPTION
* Fixes Wyrm ICE strength reduction from being carried over to every piece of ICE, and also stops the strength reduction from working on unrezzed ICE (which would reveal it)
* Fixes #2402: Reshuffle should only happen if at least 1 card got shuffled back into R&D
* Fixes #2400: Prompt to Runner needs increased priority to go to the front of the queue during "Action before access" window usage