### PR TITLE
Fail if unable to connect to mongodb

### DIFF
--- a/data/fetch.coffee
+++ b/data/fetch.coffee
@@ -13,7 +13,7 @@ mongoHost = process.env.OPENSHIFT_MONGODB_DB_HOST || '127.0.0.1'
 mongoPort = process.env.OPENSHIFT_MONGODB_DB_PORT || '27017'
 appName = process.env.OPENSHIFT_APP_NAME || 'netrunner'
 
-db = mongoskin.db("mongodb://#{login}#{mongoHost}:#{mongoPort}/#{appName}")
+db = mongoskin.db("mongodb://#{login}#{mongoHost}:#{mongoPort}/#{appName}").open( (err, _) -> throw err if err )
 
 same = (key, t) ->
   return [key, t]


### PR DESCRIPTION
Currently, if unable to connect to mongo, the script will run
"successfully" but silently fail to write to the database. Silent
failures like this are bad, and make it hard to debug often trivial
issues.

If for some reason there's a need to enable the fetch without database-connectivity, I could add a flag to enable that behaviour (i.e. ignore db connection exceptions), but as far as I'm concerned that's not necessary.