### PR TITLE
fix z-index issue for archives close hyperlink using opacity. 

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -784,11 +784,10 @@
 
        [:div.panel.blue-shade.popup {:ref "popup" :class (if (= (:side @game-state) :runner) "opponent" "me")}
         [:div
-         [:a
-          {:on-click #(close-popup % owner "popup" nil false false)}
-          (let [total (count discard)
+         [:a {:on-click #(close-popup % owner "popup" nil false false)} "Close"]
+         [:label (let [total (count discard)
                        face-up (count (filter faceup? discard))]
-                   (str "Close - " total " cards, " (- total face-up) " face-down."))]]
+                   (str total " cards, " (- total face-up) " face-down."))]]
         (for [c discard]
           (if (faceup? c)
             (om/build card-view c)

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1553,6 +1553,7 @@ nav ul
           margin-right: 16px
 
     .runner-board.opponent
+      opacity: 0.99
       > div:first-child
         margin-top: 0
 
@@ -1698,6 +1699,7 @@ nav ul
         transform(rotate(-90deg))
 
       .ices
+        opacity: 0.99
         .subtype-target
           transform(rotate(-90deg), translateY(-100%))
 


### PR DESCRIPTION
fix for  #2243

This is a better fix as I have not made the Close hyperlink ugly and much more reliable.  Using CSS opacity for opponent board elements that might encroach on our own popups.