### PR TITLE
Grab bag of fixes

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -105,7 +105,8 @@
                                                  state side
                                                  {:choices {:req can-be-advanced?}
                                                   :msg (msg "place " c " advancement tokens on " (card-str state target))
-                                                  :cancel-effect (effect (clear-wait-prompt :runner))
+                                                  :cancel-effect (req (clear-wait-prompt state :runner)
+                                                                      (effect-completed state side eid))
                                                   :effect (effect (add-prop :corp target :advance-counter c {:placed true})
                                                                   (clear-wait-prompt :runner))} card nil)))}
                               card nil))}}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -571,22 +571,20 @@
                  :effect (effect (rfg-and-shuffle-rd-effect card 3))}]}
 
    "Jeeves Model Bioroids"
-    (let [jeeves (effect (gain :click 1))
-          ability {:label "Gain [Click]"
-                   :msg "gain [Click]"
-                   :once :per-turn
-                   :effect jeeves}
-          cleanup (effect (update! (dissoc card :seen-this-turn)))]
-
-    {:abilities  [ability]
-     :leave-play {:effect cleanup}
-     :trash-effect {:effect cleanup}
-     :events {
-             :corp-spent-click
-              {:effect (req (update! state side (update-in card [:seen-this-turn target] (fnil + 0) (second targets)))
-                            (when (>= (get-in (get-card state card) [:seen-this-turn target]) 3)
-                                 (resolve-ability state side ability card nil)))}
-              :corp-turn-ends {:effect cleanup}}})
+   (let [jeeves (effect (gain :click 1))
+         ability {:label "Gain [Click]"
+                  :msg "gain [Click]"
+                  :once :per-turn
+                  :effect jeeves}
+         cleanup (effect (update! (dissoc card :seen-this-turn)))]
+     {:abilities [ability]
+      :leave-play cleanup
+      :trash-effect {:effect cleanup}
+      :events {:corp-spent-click
+               {:effect (req (update! state side (update-in card [:seen-this-turn target] (fnil + 0) (second targets)))
+                             (when (>= (get-in (get-card state card) [:seen-this-turn target]) 3)
+                               (resolve-ability state side ability card nil)))}
+               :corp-turn-ends {:effect cleanup}}})
 
    "Kala Ghoda Real TV"
    {:flags {:corp-phase-12 (req true)}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -20,7 +20,6 @@
    "Another Day, Another Paycheck"
    {:events {:agenda-stolen
              {:trace {:base 0
-                      :msg (msg (str "Runner gains " (+ (:agenda-point runner) (:agenda-point corp)) " [Credits]"))
                       :unsuccessful {:effect (effect (gain :runner :credit
                                                            (+ (:agenda-point runner) (:agenda-point corp))))
                                      :msg (msg (str "gain " (+ (:agenda-point runner) (:agenda-point corp)) " [Credits]"))}}}}}

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -395,10 +395,10 @@
    (let [manual {:optional
                  {:label "Trash a card from HQ"
                   :req (req (not (used-this-turn? (:cid card) state)))
-                  :prompt "Trash a card from HQ?"
-                  :yes-ability {:msg "trash a card from HQ"
+                  :prompt "Use Maw to trash a card from HQ?"
+                  :yes-ability {:msg "force the Corp to trash a random card from HQ"
                                 :once :per-turn
-                                :effect (effect (trash-cards (take 1 (shuffle (:hand corp)))))}}}]
+                                :effect (req (trash state :corp (first (shuffle (:hand corp)))))}}}]
      {:in-play [:memory 2]
       :implementation "Manual - click card to fire the trash"
       :abilities [manual]})
@@ -582,9 +582,10 @@
    {:recurring 1}
 
    "Q-Coherence Chip"
-   {:effect (effect (gain :memory 1)) :leave-play (effect (lose :memory 1))
-    :events (let [e {:msg "trash itself" :req (req (= (last (:zone target)) :program))
-                     :effect (effect (trash card))}]
+   {:in-play [:memory 1]
+    :events (let [e {:req (req (= (last (:zone target)) :program))
+                     :effect (effect (trash card)
+                                     (system-msg (str "trashes Q-Coherence Chip")))}]
               {:runner-trash e :corp-trash e})}
 
    "Qianju PT"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -531,9 +531,9 @@
                    :effect (effect (end-run))}]}
 
    "DNA Tracker"
-   {:abilities [{:msg "do 1 net damage and make the Runner lose 2 [Credits]"
-                 :effect (req (when-completed (damage state side :net 1 {:card card})
-                                              (lose state :runner :credit 2)))}]}
+   {:subroutines [{:msg "do 1 net damage and make the Runner lose 2 [Credits]"
+                   :effect (req (when-completed (damage state side :net 1 {:card card})
+                                                (lose state :runner :credit 2)))}]}
 
    "Dracō"
    {:prompt "How many power counters?"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -810,6 +810,14 @@
                                                                  (tag-runner state :runner eid 1)))})]
     :runner-abilities [(runner-break [:click 2] 2)]}
 
+   "Inazuma"
+   {:abilities [{:msg "prevent the Runner from breaking subroutines on the next piece of ICE they encounter this run"}
+                {:msg "prevent the Runner from jacking out until after the next piece of ICE"
+                 :effect (effect (register-events
+                                   {:pass-ice {:effect (req (swap! state update-in [:run] dissoc :prevent-jack-out)
+                                                            (unregister-events state side card))}} card)
+                                 (prevent-jack-out))}]}
+
    "Information Overload"
    {:implementation "Encounter effect is manual"
     :abilities [{:label "Gain subroutines"
@@ -819,12 +827,12 @@
 
    "IP Block"
    {:abilities [(assoc give-tag :req (req (not-empty (filter #(has-subtype? % "AI") (all-installed state :runner))))
-                                :label "Give the Runner 1 tag if there is an installed AI")
-                (tag-trace 3)
-                {:label "End the run if the Runner is tagged"
-                 :req (req tagged)
-                 :msg "end the run"
-                 :effect (effect (end-run))}]}
+                                :label "Give the Runner 1 tag if there is an installed AI")]
+    :subroutines [(tag-trace 3)
+                  {:label "End the run if the Runner is tagged"
+                   :req (req tagged)
+                   :msg "end the run"
+                   :effect (effect (end-run))}]}
 
    "IQ"
    {:effect (req (add-watch state (keyword (str "iq" (:cid card)))
@@ -1178,7 +1186,7 @@
                            :delayed-completion true
                            :effect (effect (tag-runner :runner eid 1))
                            :msg "give the Runner 1 tag"}}]}
-                           
+
     "Self-Adapting Code Wall"
     {:subroutines [end-the-run]
      :flags {:cannot-lower-strength true}}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -351,6 +351,7 @@
                                {:prompt "Choose a card to place advancement tokens on with Jemison Astronautics: Sacrifice. Audacity. Success."
                                 :choices {:req #(and (installed? %) (= (:side %) "Corp"))}
                                 :msg (msg "place " p " advancement tokens on " (card-str state target))
+                                :cancel-effect (effect (clear-wait-prompt :runner))
                                 :effect (effect (add-prop :corp target :advance-counter p {:placed true})
                                                 (clear-wait-prompt :runner))}
                               card nil)))}}}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -387,8 +387,9 @@
 
    "Oberth Protocol"
    {:additional-cost [:forfeit]
-    :events {:advance {:req (req (empty? (filter #(= (second (:zone %)) (second (:zone card)))
-                                                 (map first (turn-events state side :advance)))))
+    :events {:advance {:req (req (and (= (second (:zone target)) (second (:zone card)))
+                                      (empty? (filter #(= (second (:zone %)) (second (:zone card)))
+                                                      (map first (turn-events state side :advance))))))
                        :msg (msg "place an additional advancement token on " (card-str state target))
                        :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}}}
 

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -254,12 +254,11 @@
     :effect (effect (set-prop card :rec-counter (count (get-remotes @state))))}
 
    "Manta Grid"
-   {:events {
-     :successful-run
-     {:msg (msg " gain a [Click] next turn")
-      :req    (req (and this-server
-                        (or (< (:credit runner) 6) (zero? (:click runner)))))
-      :effect (req (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}}}
+   {:events {:successful-run-ends
+             {:msg "gain a [Click] next turn"
+              :req (req (and (= (first (:server target)) (second (:zone card)))
+                             (or (< (:credit runner) 6) (zero? (:click runner)))))
+              :effect (req (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}}}
 
    "Marcus Batty"
    {:abilities [{:req (req this-server)

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -367,16 +367,19 @@
     (core/click-draw state :runner nil)
     (core/click-draw state :runner nil)
     (run-empty-server state "HQ")
+    (prompt-choice :runner "No") ; don't trash Manta Grid
     (is (= 1 (:click (get-runner))) "Running last click")
     (run-empty-server state "HQ")
+    (prompt-choice :runner "No") ; don't trash Manta Grid
     (take-credits state :runner)
-    (is (= 5 (:click (get-corp))) "Corp gained 2 clicks due to < 6 runner credits and run last click")
+    (is (= 5 (:click (get-corp))) "Corp gained 2 clicks due to 2 runs with < 6 Runner credits")
     (take-credits state :corp)
     (take-credits state :runner)
     (is (= 3 (:click (get-corp))) "Corp back to 3 clicks")
     (take-credits state :corp)
     (take-credits state :runner 3)
     (run-empty-server state "HQ")
+    (prompt-choice :runner "No") ; don't trash Manta Grid
     (take-credits state :runner)
     (is (= 4 (:click (get-corp))) "Corp gained a click due to running last click")))
 


### PR DESCRIPTION
* Fix #2441: Oberth Protocol wasn't checking for "in or protecting this server"
* Fix #2436: Mark Award Bait effect completed if placing advancements is canceled (e.g., no targets other than itself)
* Fix #2430: Correct format of Jeeves `:leave-play` effect
* Fix #2429: Drop unneeded `:msg` in Another Day, Another Paycheck
* Fix #2428: Move Manta Grid to correct event and fix faulty test
* Fix #2424: Stop Maw from triggering Hostile Infrastructure
* Added missing `:subroutines` to DNA Tracker and IP Block so Runner can signal which ones fire
* Added partial implementation of Inazuma (second subroutine)