### PR TITLE
priority fix: Severnius Stim Implant

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -725,13 +725,14 @@
                                              " and access " (quot (count targets) 2) " additional cards")
                                    :effect (req (let [bonus (quot (count targets) 2)]
                                                    (trash-cards state side targets)
+                                                   (game.core/run state side srv nil card)
                                                    (register-events state side
                                                      {:successful-run
                                                       {:silent (req true)
                                                        :effect (effect (access-bonus bonus))}
-                                                      :run-ends {:effect (effect (unregister-events card))}} card)
-                                                   (game.core/run state side srv nil card)))}
-                                 card nil)))}]}
+                                                      :run-ends {:effect (effect (unregister-events card))}} card)))}
+                                 card nil)))}]
+    :events {:successful-run nil :run-ends nil}}
 
    "Şifr"
    {:in-play [:memory 2]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -264,9 +264,11 @@
    "Haas-Bioroid: Architects of Tomorrow"
    {:events {:pass-ice
              {:delayed-completion true
+              :once :per-turn
               :req (req (and (rezzed? target)
                              (has-subtype? target "Bioroid")
-                             (first-event? state :corp :pass-ice)))
+                             (empty? (filter #(and (rezzed? %) (has-subtype? % "Bioroid"))
+                                             (turn-events state side :pass-ice)))))
               :effect (effect (show-wait-prompt :runner "Corp to use Haas-Bioroid: Architects of Tomorrow")
                               (continue-ability
                                 {:prompt "Choose a bioroid to rez" :player :corp

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -120,6 +120,8 @@
               :delayed-completion true
               :effect (req (if (or (= target "None") (not (is-type? target "Program")))
                              (do (clear-wait-prompt state :corp)
+                                 (shuffle! state side :deck)
+                                 (system-msg state side (str "shuffles their Stack"))
                                  (effect-completed state side eid card))
                              (do (host state side (get-card state card) target)
                                  (system-msg state side (str "hosts " (:title target) " on Customized Secretary"))

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -303,12 +303,16 @@
   ;; Architects of Tomorrow - prompt to rez after passing bioroid
   (do-game
     (new-game
-      (make-deck "Haas-Bioroid: Architects of Tomorrow" [(qty "Eli 1.0" 3)])
+      (make-deck "Haas-Bioroid: Architects of Tomorrow" [(qty "Eli 1.0" 2) (qty "Pup" 1)])
       (default-runner))
+    (core/gain state :corp :credit 3)
     (play-from-hand state :corp "Eli 1.0" "Archives")
+    (play-from-hand state :corp "Pup" "Archives")
     (play-from-hand state :corp "Eli 1.0" "HQ")
     (take-credits state :corp)
     (run-on state "Archives")
+    (core/rez state :corp (get-ice state :archives 1))
+    (run-continue state)
     (core/rez state :corp (get-ice state :archives 0))
     (is (= 3 (:credit (get-corp))) "Corp has 3 credits after rezzing Eli 1.0")
     (run-continue state)


### PR DESCRIPTION
@mtgred sooner the better before we get lots of reports...

Botched this card, extra accesses are persisting on all subsequent runs. 

Also includes fixes for Customized Secretary and HB: Architects of Tomorrow. 