### PR TITLE
Another batch of card fixes

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -157,10 +157,10 @@
              :effect (effect (gain :corp :bad-publicity 1))}}
 
    "Corporate Sales Team"
-   (let [e {:msg "gain 1 [Credit]"  :counter-cost [:credit 1]
-            :effect (req (gain state :corp :credit 1)
-                         (when (zero? (:credit (:counter card)))
-                           (unregister-events state :corp card)))}]
+   (let [e {:effect (req (when (pos? (get-in card [:counter :credit] 0))
+                           (gain state :corp :credit 1)
+                           (system-msg state :corp (str "uses Corporate Sales Team to gain 1 [Credits]"))
+                           (add-counter state side card :credit -1)))}]
      {:effect (effect (add-counter card :credit 10))
       :silent (req true)
       :events {:runner-turn-begins e

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -389,16 +389,16 @@
                        {:replace-access
                         {:prompt "Advancements to remove from a card in or protecting this server?"
                          :choices ["0", "1", "2", "3"]
+                         :delayed-completion true
                          :effect (req (let [c (Integer/parseInt target)]
-                                        (resolve-ability
-                                          state side
+                                        (show-wait-prompt state :corp "Runner to remove advancements")
+                                        (continue-ability state side
                                           {:choices {:req #(and (contains? % :advance-counter)
-                                                                (= (:server run) (vec (rest (butlast (:zone %))))))}
-                                          :msg (msg "remove " c " advancements from "
-                                                (card-str state target))
-                                          :effect (req (add-prop state :corp target :advance-counter (- c))
-                                                       (swap! state update-in [:runner :prompt] rest)
-                                                       (handle-end-run state side))}
+                                                                (= (first (:server run)) (second (:zone %))))}
+                                           :msg (msg "remove " c " advancement" (when (> c 1) "s") " from " (card-str state target))
+                                           :effect (req (add-prop state :corp target :advance-counter (- c))
+                                                        (clear-wait-prompt state :corp)
+                                                        (effect-completed state side eid))}
                                          card nil)))}} card))}
 
    "Express Delivery"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -623,8 +623,7 @@
    (letfn [(access-pile [cards pile]
              {:prompt "Select a card to access. You must access all cards."
               :choices [(str "Card from pile " pile)]
-              :effect (req (system-msg state side (str "accesses " (:title (first cards))))
-                           (when-completed
+              :effect (req (when-completed
                              (handle-access state side [(first cards)])
                              (do (if (< 1 (count cards))
                                    (continue-ability state side (access-pile (next cards) pile) card nil)
@@ -835,7 +834,8 @@
                                                                      (assoc card :zone '(:discard))))
                                      (effect-completed state side eid))
                                    (update! state side (dissoc card :run-again)))))
-    :events {:successful-run-ends {:optional {:req (req (= [:rd] (:server target)))
+    :events {:successful-run nil
+             :successful-run-ends {:optional {:req (req (= [:rd] (:server target)))
                                               :prompt "Make another run on R&D?"
                                               :yes-ability {:effect (effect (update! (assoc card :run-again true)))}}}}}
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -852,7 +852,8 @@
               :mandatory true
               :prompt "Which card from the top of R&D would you like to access? (Card 1 is on top.)"
               :choices (take n ["1" "2" "3" "4" "5"])
-              :effect (effect (handle-access eid [(nth (:deck corp) (dec (Integer/parseInt target)))]))})]
+              :effect (effect (system-msg (str "accesses the card at position " (Integer/parseInt target) " of R&D"))
+                              (handle-access eid [(nth (:deck corp) (dec (Integer/parseInt target)))]))})]
      {:events {:successful-run
                {:req (req (= target :rd))
                 :interactive (req true)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -884,7 +884,19 @@
                    :choices {:req in-hand?}
                    :label "Force the Runner to access a card in HQ"
                    :msg (msg "force the Runner to access " (:title target))
-                   :effect (effect (handle-access targets) (trash card))}]}
+                   :effect (req (trash state side card)
+                                (when-completed (handle-access state side targets)
+                                  (when-completed (trigger-event-sync state side :pre-access :hq)
+                                    (let [from-hq (dec (access-count state side :hq-access))]
+                                      (continue-ability
+                                        state :runner
+                                        (access-helper-hq
+                                          state from-hq
+                                          ; access-helper-hq uses a set to keep track of which cards have already
+                                          ; been accessed. by adding HQ root's contents to this set, we make the runner
+                                          ; unable to access those cards, as Kitsune intends.
+                                          (conj (set (get-in @state [:corp :servers :hq :content])) target))
+                                       card nil)))))}]}
 
    "Komainu"
    {:abilities [{:label "Gain subroutines"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -483,7 +483,7 @@
 
    "First Responders"
    {:abilities [{:cost [:credit 2]
-                 :req (req (not-empty (turn-events state side :damage)))
+                 :req (req (some #(= (:side %) "Corp") (map second (turn-events state :runner :damage))))
                  :msg "draw 1 card"
                  :effect (effect (draw))}]}
 


### PR DESCRIPTION
More to come, I'm sure...

* Stops duplicate card access messages from Information Sifting
* First Responders now has a full and accurate usage restriction
* Top Hat logs for the Corp player which card position was accessed by the Runner
* Fix Möbius repeated payout on R&D runs *again* (sorry for the insufficient attempt previously)
* Add delayed completion and wait prompts to Exploratory Romp
* Allow Kitsune access to trigger extra accesses from HQ Interface or Gang Sign(s)
* Change Corporate Sales Team effect to not unregister events when it zeroes out, so an empty one will keep paying out when refilled by Bifrost Array