### PR TITLE
Update to deckbuilder for latest MWL rules

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -324,7 +324,7 @@
 (defn influence-count
   "Returns sum of influence count used by a deck."
   [deck]
-  (apply + (vals (influence-map deck))))
+  (+ (universalinf-count deck) (apply + (vals (influence-map deck)))))
 
 (defn deck-inf-limit [deck]
   (let [originf (id-inf-limit (:identity deck))
@@ -334,7 +334,7 @@
 
 (defn deck-inf-limit-ui [deck]
   (let [originf (id-inf-limit (:identity deck))
-        postmwlinf (- originf (universalinf-count deck))]
+        postmwlinf originf]
     (if (= originf INFINITY) ; FIXME this ugly 'if' could get cut when we get a proper nonreducible infinity in CLJS
       INFINITY (if (> 1 postmwlinf) 1 postmwlinf))))
 
@@ -727,7 +727,7 @@
                     (when (< count min-count)
                       [:span.invalid (str " (minimum " min-count ")")])])
                  (let [inf (influence-count deck)
-                       limit (deck-inf-limit deck)
+                       limit (deck-inf-limit-ui deck)
                        id-limit (id-inf-limit identity)
                        mwl (universalinf-count deck)]
                    [:div "Influence: "

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -45,7 +45,7 @@
                        [:ul
                         [:li [:code "/adv-counter n"] " - set advancement counters on a card to n (player's own cards only). Deprecated in favor of " [:code "/counter ad n"]]
                         [:li [:code "/bp n"] " - Set your bad publicity to n"]
-                        [:li [:code "/card-info"] " - display debug info about a card (player's own cards only)"]]]}
+                        [:li [:code "/card-info"] " - display debug info about a card (player's own cards only)"]
                         [:li [:code "/click n"] " - Set your clicks to n"]
                         [:li [:code "/close-prompt"] " - close an active prompt and show the next waiting prompt, or the core click actions"]
                         [:li [:code "/counter n"] " - set counters on a card to n (player's own cards only). Attempts to infer the type of counter to place. If the inference fails, you must use the next command to specify the counter type."]
@@ -69,7 +69,7 @@
                         [:li [:code "/take-brain n"] " - Take n brain damage (Runner only)"]
                         [:li [:code "/take-meat n"] " - Take n meat damage (Runner only)"]
                         [:li [:code "/take-net n"] " - Take n net damage (Runner only)"]
-                        [:li [:code "/trace n"] " - Start a trace with base strength n (Corp only)"]
+                        [:li [:code "/trace n"] " - Start a trace with base strength n (Corp only)"]]]}
             {:id "documentation"
              :title "Is there more documentation on how to use Jinteki.net?"
              :content [:p "Read the "


### PR DESCRIPTION
Ready but likely needs to wait on NRDB API update - as I assume players would rather have MWL 1.1 rules rather than something in between.

Tried this out for the following:
1/ 3 universal inf cards (mongoDB manual update)
2/ The "17-influence Omar" deck - now illegal
3/ Infinite inf ID

It assumes NRDB update the MWL API to just show the universal inf as a value where they always have one as the val today.   It will need a change if they do something else.

https://netrunnerdb.com/api/2.0/public/mwl

{"data":[{"id":1,"date_creation":"-001-11-30T00:00:00+00:00","date_update":"2016-08-01T00:00:03+00:00","code":"NAPD_MWL_1.0","name":"NAPD MWL 1.0","active":false,"date_start":"2016-02-01","cards":{"01012":1,"01014":1,"01024":1,"01081":1,"01092":1,"02110":1,"03038":1,"04029":1,"04119":1,"06061":1,"06099":1}},{"id":5,"date_creation":"2016-07-12T19:18:47+00:00","date_update":"2016-08-01T00:00:03+00:00","code":"NAPD_MWL_1.1","name":"NAPD MWL 1.1","active":true,"date_start":"2016-08-01","cards":{"01012":1,"01014":1,"01016":1,"01024":1,"01082":1,"01092":1,"02110":1,"03038":1,"04029":1,"04119":1,"06033":1,"06061":1,"06099":1,"08061":1,"10018":1}}],"total":2,"success":true,"version_number":"2.0","last_updated":"2016-08-01T00:00:03+00:00"}