### PR TITLE
implement Unscheduled Maintenance

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -71,7 +71,7 @@
    "Build Script"
    {:msg "gain 1 [Credits] and draw 2 cards"
     :effect (effect (gain :credit 1) (draw 2))}
-   
+
    "Calling in Favors"
    {:msg (msg "gain " (count (filter #(has-subtype? % "Connection") (all-installed state :runner)))
               " [Credits]")
@@ -246,7 +246,7 @@
     :events {:successful-run {:silent (req true)
                               :effect (effect (access-bonus (min 4 (:memory runner))))}
              :run-ends {:effect (effect (unregister-events card))}}}
-   
+
    "Demolition Run"
    {:prompt "Choose a server" :choices ["HQ" "R&D"]
     :abilities [{:msg (msg "trash " (:title (:card (first (get-in @state [side :prompt])))) " at no cost")
@@ -1246,7 +1246,7 @@
     :prompt "Choose a server"
     :choices (req runnable-servers)
     :effect (effect (run target nil card))}
-   
+
    "Special Order"
    {:prompt "Choose an Icebreaker"
     :effect (effect (trigger-event :searched-stack nil)
@@ -1408,6 +1408,17 @@
                          (#{"Program" "Hardware"} (:type %)))}
     :msg (msg "move " (:title target) " to their Grip")
     :effect (effect (move target :hand))}
+
+   "Unscheduled Maintenance"
+   {:events {:corp-install {:req (req (ice? target))
+                            :effect (effect (register-turn-flag!
+                                              card :can-install-ice
+                                              (fn [state side card]
+                                                (if (ice? card)
+                                                  ((constantly false)
+                                                   (toast state :corp "Cannot install ICE the rest of this turn due to Unscheduled Maintenance"))
+                                                  true))))}}
+    :leave-play (effect (clear-turn-flag! card :can-install-ice))}
 
    "Vamp"
    {:effect (effect (run :hq {:req (req (= target :hq))

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -1606,6 +1606,24 @@
       (is (not (core/has-subtype? (refresh iwall) "Code Gate")) "Ice Wall does not have code gate")
       (is (not (core/has-subtype? (refresh iwall) "Sentry")) "Ice Wall does not have sentry"))))
 
+(deftest unscheduled-maintenance
+  ;; Unscheduled Maintenance - prevent Corp from installing more than 1 ICE per turn
+  (do-game
+    (new-game
+      (default-corp [(qty "Vanilla" 2) (qty "Breaking News" 1)])
+      (default-runner [(qty "Unscheduled Maintenance" 1)]))
+    (play-from-hand state :corp "Breaking News" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Unscheduled Maintenance")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Vanilla" "HQ")
+    (is (= 1 (count (get-in @state [:corp :servers :hq :ices]))) "First ICE install of turn allowed")
+    (play-from-hand state :corp "Vanilla" "R&D")
+    (is (empty? (get-in @state [:corp :servers :rd :ices])) "Second ICE install of turn blocked")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (play-from-hand state :corp "Vanilla" "R&D")
+    (is (= 1 (count (get-in @state [:corp :servers :rd :ices]))) "Current trashed; second ICE install of turn allowed")))
+
 (deftest vamp
   ;; Vamp - Run HQ and use replace access to pay credits to drain equal amount from Corp
   (do-game


### PR DESCRIPTION
Adds Unscheduled Maintenance, and updates Corp install routines to match the Runner install scheme (checking for allowability, composing toasts according to the reason). Includes a test. 