### PR TITLE
partial implementation of MCA Informant

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -650,6 +650,19 @@
                                       :delayed-completion true
                                       :effect (effect (tag-runner :runner eid 1))}}}}
 
+   "MCA Informant"
+   {:implementation "Runner must deduct 1 click and 2 credits, then trash host manually"
+    :req (req (not-empty (filter #(and (has-subtype? % "Connection")
+                                         (installed? %)) (concat (all-installed state :runner)
+                                                                 (all-installed state :corp)))))
+    :prompt "Choose a connection to host MCA Informant on it"
+    :choices {:req #(and (has-subtype? % "Connection") (installed? %))}
+    :msg (msg "host it on " (card-str state target) ". The Runner has an additional tag")
+    :effect (req (host state side (get-card state target) (assoc card :zone [:discard] :seen true))
+                 (swap! state update-in [:runner :tag] inc))
+    :leave-play (req (swap! state update-in [:runner :tag] dec)
+                     (system-msg state :corp "trashes MCA Informant"))}
+
    "Medical Research Fundraiser"
    {:msg "gain 8 [Credits]. The Runner gains 3 [Credits]"
     :effect (effect (gain :credit 8) (gain :runner :credit 3))}


### PR DESCRIPTION
By far the most requested card right now, so maybe "most of the way" is good enough for now. Hosts the card on a Connection and gives the Runner a tag, then the tag goes away when MCA leaves play. The Runner will have to manually remove 1 click and 2 credits and then manually trash the host, as I don't understand how to copy new abilities onto cards. 