### PR TITLE
Rework Extra Costs, Choice of payment order on steal, implement Obakata Protocol, Donut Taganes, others

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -560,6 +560,9 @@
                        :effect (req (gain state side :credit
                                           (if (>= (:advance-counter (get-card state card)) 5) 3 2)))}}}
 
+   "Obokata Protocol"
+   {:steal-cost-bonus (req [:net-damage 4 :credit 1])}
+
    "Personality Profiles"
    (let [pp {:req (req (pos? (count (:hand runner))))
              :effect (effect (trash (first (shuffle (:hand runner)))))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -561,7 +561,7 @@
                                           (if (>= (:advance-counter (get-card state card)) 5) 3 2)))}}}
 
    "Obokata Protocol"
-   {:steal-cost-bonus (req [:net-damage 4 :credit 1])}
+   {:steal-cost-bonus (req [:net-damage 4])}
 
    "Personality Profiles"
    (let [pp {:req (req (pos? (count (:hand runner))))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1219,6 +1219,12 @@
                                                :effect (effect (add-prop target :advance-counter 1 {:placed true}))}}}
                                card nil))}}
 
+   "Student Loans"
+   {:events {:pre-play-instant
+             {:req (req (and (is-type? target "Event") (seq (filter #(= (:title %) (:title target)) (:discard runner)))))
+              :effect (effect (system-msg :corp (str "makes the runner pay an extra 2 [Credits] due to Student Loans"))
+                              (play-cost-bonus [:credit 2]))}}}
+
    "Sundew"
    {:events {:runner-spent-click {:once :per-turn
                                   :msg (req (when (not this-server) "gain 2 [Credits]"))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1382,18 +1382,19 @@
     :events {:runner-turn-ends nil}}
 
    "Trade-In"
-   {:prompt "Choose a hardware to trash"
-    :choices {:req #(and (installed? %)
-                         (is-type? % "Hardware"))}
-    :msg (msg "trash " (:title target) " and gain " (quot (:cost target) 2) " [Credits]")
-    :effect (effect (trash target) (gain [:credit (quot (:cost target) 2)])
-                    (resolve-ability {:prompt "Choose a Hardware to add to your Grip from your Stack"
-                                      :choices (req (filter #(is-type? % "Hardware")
-                                                            (:deck runner)))
-                                      :msg (msg "add " (:title target) " to their Grip")
-                                      :effect (effect (trigger-event :searched-stack nil)
-                                                      (shuffle! :deck)
-                                                      (move target :hand))} card nil))}
+   {:additional-cost [:hardware 1]
+    :effect (effect (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
+    :events {:runner-trash {:effect (effect (gain :credit (quot (:cost target) 2))
+                                            (system-msg (str "trashes " (:title target) " and gains " (quot (:cost target) 2) " [Credits]"))
+                                            (continue-ability {:prompt "Choose a Hardware to add to your Grip from your Stack"
+                                                               :choices (req (filter #(is-type? % "Hardware")
+                                                                                     (:deck runner)))
+                                                               :msg (msg "add " (:title target) " to their Grip")
+                                                               :effect (effect (trigger-event :searched-stack nil)
+                                                                               (shuffle! :deck)
+                                                                               (move target :hand)
+                                                                               (unregister-events card))} card nil))}}}
+
 
    "Traffic Jam"
    {:effect (effect (update-all-advancement-costs))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -483,10 +483,10 @@
                                (continue-ability state side (hr-choice (remove-once #(not= target %) remaining)
                                                                         chosen n original) card nil)
                                (continue-ability state side (hr-final chosen original) card nil))))})]
-     {:delayed-completion true
+     {:additional-cost [:mill 1]
+      :delayed-completion true
       :msg "trash the top card of R&D, draw 3 cards, and add 3 cards in HQ to the top of R&D"
-      :effect (req (mill state :corp)
-                   (draw state side 3)
+      :effect (req (draw state side 3)
                    (show-wait-prompt state :runner "Corp to add 3 cards in HQ to the top of R&D")
                    (let [from (get-in @state [:corp :hand])]
                      (continue-ability state :corp (hr-choice from '() 3 from) card nil)))})

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -734,15 +734,15 @@
                         card nil))))}
 
    "Observe and Destroy"
-   {:req (req (and (pos? (:tag runner))
+   {:additional-cost [:tag 1]
+    :req (req (and (pos? (:tag runner))
                    (< (:credit runner) 6)))
     :delayed-completion true
     :effect (effect (continue-ability
                       {:prompt "Choose an installed card to trash"
                        :choices {:req installed?}
                        :msg (msg "remove 1 Runner tag and trash " (:title target))
-                       :effect (effect (lose :runner :tag 1)
-                                       (trash target))}
+                       :effect (effect (trash target))}
                      card nil))}
 
    "Oversight AI"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -401,6 +401,11 @@
    {:prevent {:tag [:all]}
     :abilities [{:msg "avoid 1 tag" :effect (effect (tag-prevent 1) (trash card {:cause :ability-cost}))}]}
 
+   "Donut Taganes"
+   {:msg "increase the play cost of operations and events by 1 [Credits]"
+    :events {:pre-play-instant
+             {:effect (effect (play-cost-bonus [:credit 1]))}}}
+
    "Dr. Lovegood"
    {:flags {:runner-phase-12 (req (>= 2 (count (all-installed state :runner))))}
     :abilities [{:prompt "Choose an installed card to make its text box blank for the remainder of the turn" :once :per-turn

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -50,6 +50,18 @@
                                                                   (unregister-events state side card))}} card))}]
     :events {:run-ends nil}}
 
+   "Ben Musashi"
+   (let [bm {:req (req (or (= (:zone card) (:zone target)) (= (central->zone (:zone target)) (butlast (:zone card)))))
+             :effect (effect (steal-cost-bonus [:net-damage 2]))}]
+     {:trash-effect
+              {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
+               :effect (effect (register-events {:pre-steal-cost (assoc bm :req (req (or (= (:zone target) (:previous-zone card))
+                                                                                         (= (central->zone (:zone target))
+                                                                                            (butlast (:previous-zone card))))))
+                                                 :run-ends {:effect (effect (unregister-events card))}}
+                                                (assoc card :zone '(:discard))))}
+      :events {:pre-steal-cost bm :run-ends nil}})
+
    "Bernice Mai"
    {:events {:successful-run {:interactive (req true)
                               :req (req this-server)

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -83,6 +83,18 @@
       (swap! state assoc-in [side (first r)] 0)
       (deduce state side r))))
 
+(defn play-cost-bonus [state side costs]
+  (prn costs)
+  (prn (get-in @state [:bonus :play-cost]))
+  (swap! state update-in [:bonus :play-cost] #(merge-costs (concat % costs))))
+
+(defn play-cost [state side card all-cost]
+  (vec (map #(if (keyword? %) % (max % 0))
+            (-> (concat all-cost (get-in @state [:bonus :play-cost])
+                        (when-let [playfun (:play-cost-bonus (card-def card))]
+                          (playfun state side (make-eid state) card nil)))
+                merge-costs flatten))))
+
 (defn rez-cost-bonus [state side n]
   (swap! state update-in [:bonus :cost] (fnil #(+ % n) 0)))
 

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -84,8 +84,6 @@
       (deduce state side r))))
 
 (defn play-cost-bonus [state side costs]
-  (prn costs)
-  (prn (get-in @state [:bonus :play-cost]))
   (swap! state update-in [:bonus :play-cost] #(merge-costs (concat % costs))))
 
 (defn play-cost [state side card all-cost]

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare forfeit prompt! toast damage mill lose)
+(declare forfeit prompt! toast damage mill)
 
 (defn deduce
   "Deduct the value from the player's attribute."

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare forfeit prompt! toast damage mill)
+(declare forfeit prompt! toast damage mill lose)
 
 (defn deduce
   "Deduct the value from the player's attribute."
@@ -24,6 +24,7 @@
     (when-not (or (some #(= type %) [:memory :net-damage])
                   (and (= type :forfeit) (>= (- (count (get-in @state [side :scored])) amount) 0))
                   (and (= type :mill) (>= (- (count (get-in @state [side :deck])) amount) 0))
+                  (and (= type :tag) (>= (- (get-in @state [:runner :tag]) amount) 0))
                   (>= (- (or (get-in @state [side type]) -1 ) amount) 0))
       "Unable to pay")))
 
@@ -65,6 +66,7 @@
                                                  (swap! state assoc-in [side :register :spent-click] true)
                                                  (deduce state side %))
                         (= (first %) :forfeit) (pay-forfeit state side card scored (second %))
+                        (= (first %) :tag) (deduce state :runner %)
                         (= (first %) :net-damage) (damage state side :net (second %))
                         (= (first %) :mill) (mill state side (second %))
                         :else (deduce state side %)))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -159,7 +159,7 @@
                                                    " to steal " (:title card)))
                        (if (< (count chosen) n)
                          (continue-ability state side
-                                              (pay-choice state :runner (remove-once #(not= target %)
+                                              (steal-pay-choice state :runner (remove-once #(not= target %)
                                                                                      choices) chosen n card) card nil)
                          (resolve-steal state side eid card)))
                    (resolve-steal-events state side eid card)))))})

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -138,6 +138,32 @@
       (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid}))
     (effect-completed state side eid)))
 
+(defn- steal-pay-choice
+  "Enables a vector of costs to be resolved in the order of choosing"
+  [state side choices chosen n card]
+  {:delayed-completion true
+   :prompt "Pay steal cost?"
+   :choices (conj (vec choices) "Don't steal")
+   :effect (req
+             (if (= target "Don't steal")
+               (continue-ability state :runner
+                                 {:delayed-completion true
+                                  :effect (effect (system-msg (str "decides not to pay to steal " (:title card)))
+                                                  (resolve-steal-events eid card))} card nil)
+               (let [chosen (cons target chosen)
+                     kw (to-keyword (join "-" (rest (split target #" "))))
+                     val (string->num (first (split target #" ")))]
+                 (if (can-pay? state side name [kw val])
+                   (do (pay state side nil [kw val])
+                       (system-msg state side (str "pays " target
+                                                   " to steal " (:title card)))
+                       (if (< (count chosen) n)
+                         (continue-ability state side
+                                              (pay-choice state :runner (remove-once #(not= target %)
+                                                                                     choices) chosen n card) card nil)
+                         (resolve-steal state side eid card)))
+                   (resolve-steal-events state side eid card)))))})
+
 (defn- access-agenda
   [state side eid c]
   (trigger-event state side :pre-steal-cost c)
@@ -148,24 +174,33 @@
                         (effect-completed state side eid c)))
     ;; The runner can potentially steal this agenda.
     (let [cost (steal-cost state side c)
-          name (:title c)]
+          name (:title c)
+          choices (map costs-to-symbol (partition 2 cost))
+          n (count choices)]
       ;; Steal costs are additional costs and can be denied by the runner.
-      (if-not (empty? cost)
-        ;; Ask if the runner will pay the additional cost to steal.
+      (cond
+        ;; Ask if the runner will pay a single additional cost to steal.
+        (= 1 (count choices))
         (optional-ability
           state :runner eid c (str "Pay " (costs-to-symbol cost) " to steal " name "?")
           {:yes-ability
-                {:delayed-completion true
-                 :effect (req (if (can-pay? state side name cost)
-                                (do (pay state side nil cost)
-                                    (system-msg state side (str "pays " (costs-to-symbol cost)
-                                                                " to steal " name))
-                                    (resolve-steal state side eid c))
-                                (resolve-steal-events state side eid c)))}
+                       {:delayed-completion true
+                        :effect (req (if (can-pay? state side name cost)
+                                       (do (pay state side nil cost)
+                                           (system-msg state side (str "pays " (costs-to-symbol cost)
+                                                                       " to steal " name))
+                                           (resolve-steal state side eid c))
+                                       (resolve-steal-events state side eid c)))}
            :no-ability {:delayed-completion true
                         :effect (effect (resolve-steal-events eid c))}}
           nil)
+
+        ;; For multiple additional costs give the runner the choice of order to pay
+        (> (count choices) 1)
+        (continue-ability state side (steal-pay-choice state :runner choices '() n c) c nil)
+
         ;; Otherwise, show the "You access" prompt with the single option to Steal.
+        :else
         (continue-ability state :runner
                           {:delayed-completion true
                            :prompt (str "You access " name) :choices ["Steal"]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -11,7 +11,7 @@
 (defn clean-forfeit [costs]
   "Takes a flat :forfeit in costs and adds a cost of 1.
   Does not yet handle input of [:forfeit n] and will barf it it gets one
-  Delete this once costs are converted in code (or could i use a macro?)"
+  Delete this once costs are converted in code"
   (replace {[:forfeit] [:forfeit 1],
             :forfeit [:forfeit 1]} (flatten costs)))
 
@@ -131,6 +131,7 @@
     (case attr
       :credit (str value " [$]")
       :click  (->> "[Click]" repeat (take value) (apply str))
+      :forfeit (str value " Agenda" (when (> value 1) "s"))
       nil)))
 
 (defn build-cost-str

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -10,10 +10,12 @@
 
 (defn clean-forfeit [costs]
   "Takes a flat :forfeit in costs and adds a cost of 1.
-  Does not yet handle input of [:forfeit n] and will barf it it gets one
-  Delete this once costs are converted in code"
-  (replace {[:forfeit] [:forfeit 1],
-            :forfeit [:forfeit 1]} (flatten costs)))
+  Ignores cost vectors with an even count as these have forfeit value included"
+  (let [fcosts (flatten costs)]
+  (if (odd? (count fcosts))
+    (replace {[:forfeit] [:forfeit 1],
+              :forfeit [:forfeit 1]} fcosts)
+    costs)))
 
 (defn merge-costs [costs]
   (vec (reduce #(let [key (first %2) value (last %2)]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -8,10 +8,17 @@
 
 (defn abs [n] (max n (- n)))
 
+(defn clean-forfeit [costs]
+  "Takes a flat :forfeit in costs and adds a cost of 1.
+  Does not yet handle input of [:forfeit n] and will barf it it gets one
+  Delete this once costs are converted in code (or could i use a macro?)"
+  (replace {[:forfeit] [:forfeit 1],
+            :forfeit [:forfeit 1]} (flatten costs)))
+
 (defn merge-costs [costs]
   (vec (reduce #(let [key (first %2) value (last %2)]
               (assoc %1 key (+ (or (key %1) 0) value)))
-           {} (partition 2 (flatten costs)))))
+           {} (partition 2 (flatten (clean-forfeit costs))))))
 
 (defn remove-once [pred coll]
   (let [[head tail] (split-with pred coll)]
@@ -53,6 +60,8 @@
                                    (case key
                                      :credit (str value "[Credits]")
                                      :click (reduce str (for [i (range value)] "[Click]"))
+                                     :net-damage (str value " net damage")
+                                     :mill (str value " card mill")
                                      (str value (str key)))) (partition 2 (flatten costs)))))
 
 (defn vdissoc [v n]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -64,12 +64,14 @@
   (str (Character/toUpperCase (first string)) (subs string 1)))
 
 (defn costs-to-symbol [costs]
+  "Used during steal to print runner prompt for payment"
   (clojure.string/join ", " (map #(let [key (first %) value (last %)]
                                    (case key
                                      :credit (str value "[Credits]")
                                      :click (reduce str (for [i (range value)] "[Click]"))
                                      :net-damage (str value " net damage")
                                      :mill (str value " card mill")
+                                     :hardware (str value " installed hardware")
                                      (str value (str key)))) (partition 2 (flatten costs)))))
 
 (defn vdissoc [v n]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -18,9 +18,15 @@
     costs)))
 
 (defn merge-costs [costs]
-  (vec (reduce #(let [key (first %2) value (last %2)]
-              (assoc %1 key (+ (or (key %1) 0) value)))
-           {} (partition 2 (flatten (clean-forfeit costs))))))
+  "This combines costs from a number of sources in the game into a single cost per type
+  Damage is not merged as it needs to be invidual.  Needs augmention more than net-damage appears"
+  (let [fc (partition 2 (flatten (clean-forfeit costs)))
+        jc (filter #(not= :net-damage (first %)) fc)
+        dc (filter #(= :net-damage (first %)) fc)]
+    (vec (map vec (concat
+      (reduce #(let [key (first %2) value (last %2)]
+                    (assoc %1 key (+ (or (key %1) 0) value)))
+                 {} jc) dc)))))
 
 (defn remove-once [pred coll]
   (let [[head tail] (split-with pred coll)]

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -1416,6 +1416,27 @@
     (is (= 2 (:tag (get-runner))) "Runner has 2 tags")
     (is (not (:run @state)) "Run completed")))
 
+(deftest student-loans
+  ;; Student Loans - costs Runner 2c extra to play event if already same one in discard
+  (do-game
+    (new-game (default-corp [(qty "Student Loans" 1) (qty "Hedge Fund" 2)])
+              (default-runner))
+    (core/gain state :corp :credit 2)
+    (play-from-hand state :corp "Student Loans" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (is (= 5 (:credit (get-corp))) "Corp has 5c")
+    (play-from-hand state :corp "Hedge Fund")
+    (is (= 9 (:credit (get-corp))) "Corp has 9c - no penalty from Student Loans")
+    (play-from-hand state :corp "Hedge Fund")
+    (is (= 13 (:credit (get-corp))) "Corp has 13c - no penalty from Student Loans")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Sure Gamble")
+    (is (= 9 (:credit (get-runner))) "1st Gamble played for 4c")
+    (play-from-hand state :runner "Sure Gamble")
+    (is (= 11 (:credit (get-runner))) "2nd Gamble played for 2c")
+    (play-from-hand state :runner "Sure Gamble")
+    (is (= 13 (:credit (get-runner))) "3rd Gamble played for 2c")))
+
 (deftest sundew
   ;; Sundew
   (do-game

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -372,6 +372,21 @@
     (is (= 1 (count (:discard (get-runner)))) "Decoy trashed")
     (is (= 0 (:tag (get-runner))) "Tag avoided")))
 
+(deftest donut-taganes
+  ;; Donut Taganes - add 1 to play cost of Operations & Events when this is in play
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Donut Taganes" 1) (qty "Easy Mark" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Donut Taganes")
+    (is (= 2 (:credit (get-runner))) "Donut played for 3c")
+    (play-from-hand state :runner "Easy Mark")
+    (is (= 4 (:credit (get-runner))) "Easy Mark only gained 2c")
+    (take-credits state :runner)
+    (is (= 8 (:credit (get-corp))) "Corp has 8c")
+    (play-from-hand state :corp "Hedge Fund")
+    (is (= 11 (:credit (get-corp))) "Corp has 11c")))
+
 (deftest eden-shard
   ;; Eden Shard - Install from Grip in lieu of accessing R&D; trash to make Corp draw 2
   (do-game

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -23,7 +23,7 @@
         (is (= 1 (:credit (get-corp))) "Paid only 1 credit to rez")))))
 
 (deftest ben-musashi
-  ;; Ben Musashi - pay 2 net damage to steal from this servr
+  ;; Ben Musashi - pay 2 net damage to steal from this server
   (do-game
     (new-game (default-corp [(qty "Ben Musashi" 1) (qty "House of Knives" 1)])
               (default-runner))
@@ -36,7 +36,7 @@
       (run-empty-server state "Server 1")
       ;; runner now chooses which to access.
       (prompt-select :runner hok)
-      ;; prompt should be asking for the 5cr cost
+      ;; prompt should be asking for the 2 net damage cost
       (is (= "House of Knives" (:title (:card (first (:prompt (get-runner))))))
           "Prompt to pay 2 net damage")
       (prompt-choice :runner "No")
@@ -71,6 +71,30 @@
       (prompt-choice :runner "Yes")
       (is (= 2 (count (:discard (get-runner)))) "Runner took 2 net")
       (is (= 1 (count (:scored (get-runner)))) "1 scored agenda"))))
+
+(deftest ben-musashi-obokata
+  ;; Check runner chooses order of payment
+  (do-game
+    (new-game (default-corp [(qty "Ben Musashi" 1) (qty "Obokata Protocol" 1)])
+              (default-runner [(qty "Sure Gamble" 6)]))
+    (play-from-hand state :corp "Ben Musashi" "New remote")
+    (play-from-hand state :corp "Obokata Protocol" "Server 1")
+    (take-credits state :corp)
+    (let [bm (get-content state :remote1 0)
+          op (get-content state :remote1 1)]
+      (core/rez state :corp bm)
+      (run-empty-server state "Server 1")
+      ;; runner now chooses which to access.
+      (prompt-select :runner op)
+      ;; prompt should be asking for the net damage costs
+      (is (= "Obokata Protocol" (:title (:card (first (:prompt (get-runner))))))
+          "Prompt to pay steal costs")
+      (prompt-choice :runner "2 net damage")
+      (is (= 2 (count (:discard (get-runner)))) "Runner took 2 net damage")
+      (is (= 0 (count (:scored (get-runner)))) "No scored agendas")
+      (prompt-choice :runner "4 net damage")
+      (is (= 5 (count (:discard (get-runner)))) "Runner took 4 net damage")
+      (is (= 1 (count (:scored (get-runner)))) "Scored agenda"))))
 
 (deftest bernice-mai
   ;; Bernice Mai - successful and unsuccessful


### PR DESCRIPTION
Thanks for @JoelCFC25 for the Donut code.
The pay-forfeit function current only takes an amount of 1 - will need work if we ever see 2 or more. 

(Future) Other stuff we might do to move all costs into one place
- Move "pricing" for Doubles and Triples out of play-instance
- Move extra costs out of play 
- Move some of these cards to the "new way" 
https://netrunnerdb.com/find/?q=x%3A%22As+an+additional+cost+to+play%22+s%21Double