### PR TITLE
Variety of card fixes

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -812,7 +812,8 @@
                   :label "Gain 1 [Credits] (start of turn)"
                   :once :per-turn
                   :effect (effect (gain :credit 1))}]
-     {:derezzed-events {:runner-turn-ends corp-rez-toast}
+     {:implementation "Ability to place power counters is manually triggered"
+      :derezzed-events {:runner-turn-ends corp-rez-toast}
       :events {:corp-turn-begins ability}
       :abilities [ability
                   {:label "Place 1 power counter" :cost [:credit 1]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -812,8 +812,7 @@
                   :label "Gain 1 [Credits] (start of turn)"
                   :once :per-turn
                   :effect (effect (gain :credit 1))}]
-     {:implementation "Ability to place power counters is manually triggered"
-      :derezzed-events {:runner-turn-ends corp-rez-toast}
+     {:derezzed-events {:runner-turn-ends corp-rez-toast}
       :events {:corp-turn-begins ability}
       :abilities [ability
                   {:label "Place 1 power counter" :cost [:credit 1]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -415,8 +415,8 @@
                                 (when (is-type? c "Agenda") ; trashing before the :access events actually fire; fire them manually
                                   (resolve-steal-events state side c))
                                 (move state :corp c :deck)
-                                (close-access-prompt state side)
-                                (tag-runner state :runner eid 1)))}
+                                (tag-runner state :runner eid 1)
+                                (close-access-prompt state side)))}
                 {:once :per-turn
                  :label "Move a previously accessed card to bottom of R&D"
                  :effect (effect (resolve-ability

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1466,7 +1466,7 @@
    {:subroutines [{:label "Force the Runner to lose credits"
                    :msg (msg "force the Runner to lose " (if tagged "all credits" "1 [Credits]"))
                    :effect (req (if tagged
-                                  (do (lose state :runner :credit :all)
+                                  (do (lose state :runner :credit :all :run-credit :all)
                                       (when current-ice
                                         (no-action state side nil)
                                         (continue state side nil))

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -615,14 +615,13 @@
                      :abilities [{:counter-cost [:power 1]
                                   :msg "break 1 subroutine"}
                                  (strength-pump 1 1)]})
-
    "Paperclip"
    (conspiracy "Paperclip" "Barrier"
                [{:label (str "X [Credits]: +X strength, break X subroutines")
                  :choices :credit
                  :prompt "How many credits?"
                  :effect (effect (pump card target))
-                 :msg (msg "increase strength by " target " and break " target " barrier subroutine"
+                 :msg (msg "spend " target " [Credits], increase strength by " target ", and break " target " barrier subroutine"
                            (when (not= target 1) "s"))}])
 
    "Passport"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -509,7 +509,8 @@
                               state :runner
                               {:prompt (msg "Choose a subtype")
                                :choices ["Sentry" "Code Gate" "Barrier"]
-                               :msg (msg "make " (card-str state ice) " gain " (.toLowerCase target) " until the end of the next run this turn")
+                               :msg (msg "spend [Click] and make " (card-str state ice) " gain " (.toLowerCase target)
+                                         " until the end of the next run this turn")
                                :effect (effect (update! (assoc ice :subtype (combine-subtypes true stypes target)))
                                                (update-ice-strength (get-card state ice))
                                                (register-events {:run-ends

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -690,24 +690,23 @@
                                 (gain state side :credit 1)))}]}
 
    "Self-modifying Code"
-   {:abilities  [{:req (req (not (install-locked? state side)))
-                  :effect (req (when-completed (trash state side card {:cause :ability-cost})
-                                               (continue-ability state side
-                                                                  {:prompt "Choose a program to install"
-                                                                   :msg (req (if (not= target "No install")
-                                                                               (str "install " (:title target))
-                                                                               (str "shuffle their Stack")))
-                                                                   :priority true
-                                                                   :choices (req (cancellable
-                                                                                   (conj (vec (sort-by :title (filter #(is-type? % "Program")
-                                                                                                                      (:deck runner))))
-                                                                                         "No install")))
-                                                                   :cost [:credit 2]
-                                                                   :effect (req (trigger-event state side :searched-stack nil)
-                                                                                (trash state side card {:cause :ability-cost})
-                                                                                (shuffle! state side :deck)
-                                                                                (when (not= target "No install")
-                                                                                  (runner-install state side target)))} card nil)))}]}
+   {:abilities [{:req (req (not (install-locked? state side)))
+                 :effect (req (when-completed (trash state side card {:cause :ability-cost})
+                                              (continue-ability state side
+                                                {:prompt "Choose a program to install"
+                                                 :msg (req (if (not= target "No install")
+                                                             (str "install " (:title target))
+                                                             (str "shuffle their Stack")))
+                                                 :priority true
+                                                 :choices (req (cancellable
+                                                                 (conj (vec (sort-by :title (filter #(is-type? % "Program")
+                                                                                                    (:deck runner))))
+                                                                       "No install")))
+                                                 :cost [:credit 2]
+                                                 :effect (req (trigger-event state side :searched-stack nil)
+                                                              (shuffle! state side :deck)
+                                                              (when (not= target "No install")
+                                                                (runner-install state side target)))} card nil)))}]}
 
    "Sneakdoor Beta"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -887,7 +887,7 @@
                  :prompt "Choose card type"
                  :choices ["Event" "Hardware" "Program" "Resource"]
                  :effect (req (let [c (first (get-in @state [:runner :deck]))]
-                                (system-msg state side (str "uses Oracle May, names " target
+                                (system-msg state side (str "spends [Click] to use Oracle May, names " target
                                                             " and reveals " (:title c)))
                                 (if (is-type? c target)
                                   (do (system-msg state side (str "gains 2 [Credits] and draws " (:title c)))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -842,11 +842,12 @@
    "Neutralize All Threats"
    {:in-play [:hq-access 1]
     :events {:pre-access {:req (req (and (= target :archives)
-                                         (seq (filter #(not (nil? (:trash %))) (:discard corp)))))
+                                         (seq (filter #(:trash %) (:discard corp)))))
                           :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}
              :access {:effect (req (swap! state assoc-in [:runner :register :force-trash] false))}
              :pre-trash {:req (req (let [cards (map first (turn-events state side :pre-trash))]
-                                     (empty? (filter #(not (nil? (:trash %))) cards))))
+                                     (and (empty? (filter #(:trash %) cards))
+                                          (number? (:trash target)))))
                          :once :per-turn
                          :effect (req (swap! state assoc-in [:runner :register :force-trash] true))}}}
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -454,7 +454,7 @@
    {:abilities [{:effect (effect (trash card {:cause :ability-cost}) (draw :corp 2))
                  :msg "force the Corp to draw 2 cards"}]
     :install-cost-bonus (req (if (and run (= (:server run) [:rd]) (zero? (:position run)))
-                               [:credit -7 :click -1] nil))
+                               [:credit -15 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:rd]) (zero? (:position run)))
                    (when-completed (register-successful-run state side (:server run))
                                    (do (swap! state update-in [:runner :prompt] rest)
@@ -608,7 +608,7 @@
                                 (swap! state update-in [:run :cards-accessed] (fnil #(+ % (count (:discard corp))) 0)))
                               (resolve-ability state :runner (choose-access (get-in @state [:corp :discard]) '(:archives)) card nil))}]
     :install-cost-bonus (req (if (and run (= (:server run) [:archives]) (= 0 (:position run)))
-                               [:credit -7 :click -1] nil))
+                               [:credit -15 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:archives]) (= 0 (:position run)))
                    (when-completed (register-successful-run state side (:server run))
                                    (do (swap! state update-in [:runner :prompt] rest)
@@ -1447,7 +1447,7 @@
                                  (trash card {:cause :ability-cost}))
                  :msg "force the Corp to discard 2 cards from HQ at random"}]
     :install-cost-bonus (req (if (and run (= (:server run) [:hq]) (zero? (:position run)))
-                               [:credit -7 :click -1] nil))
+                               [:credit -15 :click -1] nil))
     :effect (req (when (and run (= (:server run) [:hq]) (zero? (:position run)))
                    (when-completed (register-successful-run state side (:server run))
                                    (do (swap! state update-in [:runner :prompt] rest)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1085,7 +1085,7 @@
                                                         (get-in runner [:rig :resource]))
                                                 (:hand runner))]
                                 (trash state side c {:cause :ability-cost}))
-                              (lose state side :credit :all :tag :all)
+                              (lose state side :credit :all :tag :all :run-credit :all)
                               (damage-prevent state side :net Integer/MAX_VALUE)
                               (damage-prevent state side :meat Integer/MAX_VALUE)
                               (damage-prevent state side :brain Integer/MAX_VALUE))}]}
@@ -1410,7 +1410,7 @@
                  :effect (effect (update! (update-in card [:counters-spent] #(inc (or % 0)))))}]}
 
    "Theophilius Bagbiter"
-   {:effect (req (lose state :runner :credit :all)
+   {:effect (req (lose state :runner :credit :all :run-credit :all)
                  (add-watch state :theophilius-bagbiter
                             (fn [k ref old new]
                               (let [credit (get-in new [:runner :credit])]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -253,7 +253,7 @@
    {:abilities [{:req (req this-server)
                  :label "Force the Runner to lose all [Credits] from spending or losing a [Click]"
                  :msg (msg "force the Runner to lose all " (:credit runner) " [Credits]") :once :per-run
-                 :effect (effect (lose :runner :credit :all))}]}
+                 :effect (effect (lose :runner :credit :all :run-credit :all))}]}
 
    "Hokusai Grid"
    {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -865,6 +865,26 @@
       (prompt-choice :corp "HQ")
       (is (= 3 (:credit (get-corp))) "Corp has 7 credits"))))
 
+(deftest neutralize-all-threats
+  ;; Neutralize All Threats - Access 2 cards from HQ, force trash first accessed card with a trash cost
+  (do-game
+    (new-game (default-corp [(qty "Hedge Fund" 2) (qty "Breaker Bay Grid" 1) (qty "Elizabeth Mills" 1)])
+              (default-runner [(qty "Neutralize All Threats" 1)]))
+    (play-from-hand state :corp "Breaker Bay Grid" "New remote")
+    (play-from-hand state :corp "Elizabeth Mills" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Neutralize All Threats")
+    (run-empty-server state "HQ")
+    (prompt-choice :runner "Card from hand")
+    (prompt-choice :runner "OK") ; access first Hedge Fund
+    (prompt-choice :runner "Card from hand")
+    (prompt-choice :runner "OK") ; access second Hedge Fund
+    (run-empty-server state "Server 1")
+    (is (= 3 (:credit (get-runner))) "Forced to pay 2c to trash BBG")
+    (is (= 1 (count (:discard (get-corp)))) "Breaker Bay Grid trashed")
+    (run-empty-server state "Server 2")
+    (is (not (empty? (:prompt (get-runner)))) "Runner prompt to trash Elizabeth Mills")))
+
 (deftest new-angeles-city-hall
   ;; New Angeles City Hall - Avoid tags; trash when agenda is stolen
   (do-game


### PR DESCRIPTION
Another grab bag of things that have cropped up. 

* Fix Neutralize All Threats logic determining when the forced trash occurs
* Fix Jesminder to prevent Maya tag. 
* Modify cards that make the Runner lose all credits to also zero out run credits
* Fix Self-modifying Code bug when it's hosted on something else
* Add clarity (costs paid) to Oracle May, Paperclip, and Paintbrush messages
* Increase cost reduction for special Shard installs to cancel out possibility of Scarcity of Resources and/or Docklands Crackdown cost increases