### PR TITLE
#2058 - Cache Refresh and 1.1.1.1 format support

### DIFF
--- a/data/fetch.coffee
+++ b/data/fetch.coffee
@@ -28,6 +28,7 @@ setFields = {
   "name" : same
   "date_release" : (k, t) -> ["available", if t is null then "4096-01-01" else t]
   "cycle_code" : (k, t) -> ["cycle", capitalize(t.replace(/-/g, " "))]
+  "size" : (k, t) -> ["bigbox", t > 20]
 }
 
 mwlFields = {
@@ -75,7 +76,8 @@ cardFields = {
   "memory_cost" : rename("memoryunits"),
   "strength" : same,
   "trash_cost" : rename("trash"),
-  "deck_limit" : rename("limited")
+  "deck_limit" : rename("limited"),
+  "quantity" : rename("packquantity")
 }
 
 baseurl = "http://netrunnerdb.com/api/2.0/public/"

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -369,7 +369,7 @@
                              (:name deck)
                              "Deck selected")]])
                        (when-let [deck (:deck player)]
-                         [:div.float-right (deck-status-span sets deck true)])
+                         [:div.float-right (deck-status-span sets deck true false)])
                        (when (= (:user player) user)
                          [:span.fake-link.deck-load
                           {:data-target "#deck-select" :data-toggle "modal"} "Select deck"])])]


### PR DESCRIPTION
I've pushed my implementation of this feature. It includes both Cache Refresh and 1.1.1.1 format.
_Note: it's my first contact with Clojure, so I'm fairly sure that code is not optimized nor pretty._
Detection of Big Boxes is iffy - currently it's defined as packs with more than 20 cards.

Only in deckbuilder there's an additional tooltip naming example cards from deck violating given format. One card per problem in Cache Refresh, up to two cards per problem in 1.1.1.1. It should be enough for user to narrow down why deck is non-compliant with given format.

![jarek_20170515_cache_refresh_jinteki](https://cloud.githubusercontent.com/assets/28683475/26039475/8e58e7c6-391b-11e7-8165-0f37dcfe7c10.jpg)
