### PR TITLE
Accelerated Diagnostics with Current - select correct card from play-area

### DIFF
--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -55,7 +55,8 @@
                      (when-let [current (first (get-in @state [s :current]))] ; trash old current
                        (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
                        (trash state side current)))
-                   (let [moved-card (move state side (first (get-in @state [side :play-area])) :current)]
+                   (let [c (some #(when (= (:cid %) (:cid card)) %) (get-in @state [side :play-area]))
+                         moved-card (move state side c :current)]
                      (card-init state side eid moved-card true)))
                (do (resolve-ability state side (assoc cdef :eid eid) card nil)
                    (when-let [c (some #(when (= (:cid %) (:cid card)) %) (get-in @state [side :play-area]))]

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -107,6 +107,34 @@
       (prompt-select :corp (refresh co))
       (is (= 15 (:credit (get-corp))) "Corp gained 6 credits for Back Channels"))))
 
+(deftest accelerated-diagnostics-with-current
+  ;; Accelerated Diagnostics - Interaction with Current
+  (do-game
+    (new-game (default-corp [(qty "Accelerated Diagnostics" 1) (qty "Cerebral Overwriter" 1)
+                             (qty "Enhanced Login Protocol" 1) (qty "Shipment from SanSan" 1)
+                             (qty "Hedge Fund" 1)])
+              (default-runner))
+    (starting-hand state :corp ["Accelerated Diagnostics" "Cerebral Overwriter"])
+    (play-from-hand state :corp "Cerebral Overwriter" "New remote")
+    (core/gain state :corp :credit 3)
+    (play-from-hand state :corp "Accelerated Diagnostics")
+
+    (let [playarea (get-in @state [:corp :play-area])
+          hf (find-card "Hedge Fund" playarea)
+          ss (find-card "Shipment from SanSan" playarea)
+          elp (find-card "Enhanced Login Protocol" playarea)
+          co (get-content state :remote1 0)]
+      (is (= 3 (count playarea)) "3 cards in play area")
+      (prompt-select :corp elp)
+      (is (= "Enhanced Login Protocol" (:title (first (get-in @state [:corp :current]))))
+        "Enhanced Login Protocol active in Current area")
+      (prompt-select :corp ss)
+      (prompt-choice :corp "2")
+      (prompt-select :corp co)
+      (is (= 2 (:advance-counter (refresh co))) "Cerebral Overwriter gained 2 advancements")
+      (prompt-select :corp hf)
+      (is (= 9 (:credit (get-corp))) "Corp gained credits from Hedge Fund"))))
+
 (deftest an-offer-you-cant-refuse
   ;; An Offer You Can't Refuse - exact card added to score area, not the last discarded one
   (do-game


### PR DESCRIPTION
Fix for #2578 
When playing currents, first card from play-area was used instead of card with correct name.
Maybe surrounding code could be rewritten a bit. Selecting card by name is common case for both branches of "if current".
Also I've added test for this case. Initially it failed, now passes.