### PR TITLE
All programs from Free Mars, Helheim servers, Mars for Martians

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -82,9 +82,9 @@
     :effect (effect (gain :credit 1) (draw 2))}
 
    "Calling in Favors"
-   {:msg (msg "gain " (count (filter #(has-subtype? % "Connection") (all-installed state :runner)))
-              " [Credits]")
-    :effect (effect (gain :credit (count (filter #(has-subtype? % "Connection")
+   {:msg (msg "gain " (count (filter #(and (has-subtype? % "Connection") (is-type? % "Resource"))
+                                     (all-installed state :runner))) " [Credits]")
+    :effect (effect (gain :credit (count (filter #(and (has-subtype? % "Connection") (is-type? % "Resource"))
                                                  (all-installed state :runner)))))}
 
    "Career Fair"
@@ -841,6 +841,14 @@
       :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their stack")
                    (let [from (take 6 (:deck runner))]
                      (continue-ability state side (entrance-trash from) card nil)))})
+
+   "Mars for Martians"
+   {:msg (msg "draw " (count (filter #(and (has-subtype? % "Clan") (is-type? % "Resource"))
+                                     (all-installed state :runner)))
+              " cards and gain " (:tag runner) " [Credits]")
+    :effect (effect (draw (count (filter #(and (has-subtype? % "Clan") (is-type? % "Resource"))
+                                         (all-installed state :runner))))
+                    (gain :credit (:tag runner)))}
 
    "Mass Install"
    (let [mhelper (fn mi [n] {:prompt "Select a program to install"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -21,6 +21,13 @@
    :msg "end the run"
    :effect (effect (end-run))})
 
+(def end-the-run-if-tagged
+  "ETR subroutine if tagged"
+  {:label "End the run if the Runner is tagged"
+   :req (req tagged)
+   :msg "end the run"
+   :effect (effect (end-run))})
+
 (def give-tag
   "Basic give runner 1 tag subroutine
    Mostly used with tag-trace"
@@ -575,6 +582,11 @@
                                                            (clear-wait-prompt state :runner)
                                                            (effect-completed state side eid card)))))})]})
 
+   "Data Loop"
+   {:implementation "Encounter effect is manual"
+    :subroutines [end-the-run-if-tagged
+                  end-the-run]}
+
    "Data Mine"
    {:subroutines [{:msg "do 1 net damage"
                    :effect (req (damage state :runner eid :net 1 {:card card})
@@ -609,10 +621,7 @@
                         :delayed-completion true
                         :effect (req (system-msg state :runner "chooses to take 1 tag on encountering Data Ward")
                                      (tag-runner state :runner eid 1))}]
-    :subroutines [{:label "End the run if the Runner is tagged"
-                   :req (req tagged)
-                   :msg "end the run"
-                   :effect (effect (end-run))}]}
+    :subroutines [end-the-run-if-tagged]}
 
    "DNA Tracker"
    {:subroutines [{:msg "do 1 net damage and make the Runner lose 2 [Credits]"
@@ -978,10 +987,7 @@
    {:abilities [(assoc give-tag :req (req (not-empty (filter #(has-subtype? % "AI") (all-installed state :runner))))
                                 :label "Give the Runner 1 tag if there is an installed AI")]
     :subroutines [(tag-trace 3)
-                  {:label "End the run if the Runner is tagged"
-                   :req (req tagged)
-                   :msg "end the run"
-                   :effect (effect (end-run))}]}
+                  end-the-run-if-tagged]}
 
    "IQ"
    {:effect (req (add-watch state (keyword (str "iq" (:cid card)))
@@ -1216,8 +1222,7 @@
     :subroutines [(tag-trace 1)
                   (tag-trace 2)
                   (tag-trace 3)
-                  {:msg "end the run if the Runner is tagged" :req (req tagged)
-                   :effect (effect (end-run))}]}
+                  end-the-run-if-tagged]}
 
    "Nebula"
    (space-ice trash-program)
@@ -1297,10 +1302,7 @@
                                    (system-msg (str "adds " (:title target) " to the top of the Runner's Stack")))}]}
 
    "Pachinko"
-   {:subroutines [{:label "End the run if the Runner is tagged"
-                   :req (req tagged)
-                   :msg "end the run"
-                   :effect (effect (end-run))}]}
+   {:subroutines [end-the-run-if-tagged]}
 
    "Paper Wall"
    {:implementation "Trash on break is manual"

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -395,6 +395,7 @@
     :events {:purge {:effect (effect (update-breaker-strength card))}}
     :abilities [(break-sub 2 1 "ICE")
                 {:label "Place 1 virus counter (start of turn)"
+                 :once :per-turn
                  :cost [:credit 1]
                  :msg "place 1 virus counter"
                  :req (req (:runner-phase-12 @state))

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -664,10 +664,7 @@
                                                           (not= (get-in old [:corp :servers server :ices])
                                                                 (get-in new [:corp :servers server :ices])))
                                                     (update-breaker-strength ref side card))))))
-                     :strength-bonus (req (let [server (first (get-in @state [:run :server]))
-                                                corp_server_config (get-in @state [:corp :servers server :ices])]
-                                            (if-let [numice (count corp_server_config)]
-                                              numice 0)))
+                     :strength-bonus (req (if-let [numice (count run-ices)] numice 0))
                      :leave-play (req (remove-watch state (keyword (str "nanotk" (:cid card)))))
                      :abilities [(break-sub 1 1 "sentry")
                                  (strength-pump 3 2)]})

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -477,6 +477,15 @@
                      :abilities [(break-sub 1 1 "sentry")
                                  (strength-pump 2 1)]})
 
+   "Flashbang"
+   (auto-icebreaker ["Sentry"]
+                    {:abilities [(strength-pump 1 1)
+                                 {:label "Derez a sentry being encountered"
+                                  :cost [:credit 6]
+                                  :req (req (and (rezzed? current-ice) (has-subtype? current-ice "Sentry")))
+                                  :msg (msg "derez " (:title current-ice))
+                                  :effect (effect (derez current-ice))}]})
+
    "Force of Nature"
    (auto-icebreaker ["Code Gate"]
                     {:abilities [(break-sub 2 2 "code gate")

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -615,6 +615,14 @@
                      :abilities [(break-sub 2 1 "code gate")
                                  (strength-pump 1 1)]})
 
+   "Maven"
+   {:abilities [(break-sub 2 1 "ICE")]
+    :events (let [maven {:silent (req true)
+                         :req (req (is-type? target "Program"))
+                         :effect (effect (update-breaker-strength card))}]
+              {:runner-install maven :trash maven :card-moved maven})
+    :strength-bonus (req (count (filter #(is-type? % "Program") (all-installed state :runner))))}
+
    "Morning Star"
    {:abilities [(break-sub 1 0 "barrier")]}
 

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -651,6 +651,27 @@
                  :effect (effect (pump card 2)) :pump 2
                  :msg "add 2 strength and break up to 2 subroutines"}])
 
+   "NaNotK"
+   (auto-icebreaker ["Sentry"]
+                    {:effect (req (add-watch state (keyword (str "nanotk" (:cid card)))
+                                              (fn [k ref old new]
+                                                (let [server (first (get-in @state [:run :server]))]
+                                                  (when (or
+                                                          ; run initiated or ended
+                                                          (not= (get-in old [:run])
+                                                                (get-in new [:run]))
+                                                          ; server configuration changed (redirected or newly installed ICE)
+                                                          (not= (get-in old [:corp :servers server :ices])
+                                                                (get-in new [:corp :servers server :ices])))
+                                                    (update-breaker-strength ref side card))))))
+                     :strength-bonus (req (let [server (first (get-in @state [:run :server]))
+                                                corp_server_config (get-in @state [:corp :servers server :ices])]
+                                            (if-let [numice (count corp_server_config)]
+                                              numice 0)))
+                     :leave-play (req (remove-watch state (keyword (str "nanotk" (:cid card)))))
+                     :abilities [(break-sub 1 1 "sentry")
+                                 (strength-pump 3 2)]})
+
    "Nfr"
    {:implementation "Adding power counter is manual"
     :abilities [{:label "Place 1 power counter on Nfr"

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -488,20 +488,21 @@
                                  (strength-pump 1 1)]})
 
    "God of War"
-   {:flags {:runner-phase-12 (req true)}
-    :abilities [(strength-pump 2 1)
-                {:counter-cost [:virus 1]
-                 :msg "break 1 subroutine"}
-                {:label "Take 1 tag to place 2 virus counters (start of turn)"
-                 :once :per-turn
-                 :req (req (:runner-phase-12 @state))
-                 :effect (req (when-completed (tag-runner state :runner 1)
-                                              (if (not (get-in @state [:tag :tag-prevent]))
-                                                (do (add-counter state side card :virus 2)
-                                                    (system-msg state side
-                                                                (str "takes 1 tag to place 2 virus counters on God of War"))
-                                                    (effect-completed state side eid))
-                                                (effect-completed state side eid))))}]}
+   (auto-icebreaker ["All"]
+                    {:flags {:runner-phase-12 (req true)}
+                     :abilities [(strength-pump 2 1)
+                                 {:counter-cost [:virus 1]
+                                  :msg "break 1 subroutine"}
+                                 {:label "Take 1 tag to place 2 virus counters (start of turn)"
+                                  :once :per-turn
+                                  :req (req (:runner-phase-12 @state))
+                                  :effect (req (when-completed (tag-runner state :runner 1)
+                                                               (if (not (get-in @state [:tag :tag-prevent]))
+                                                                 (do (add-counter state side card :virus 2)
+                                                                     (system-msg state side
+                                                                                 (str "takes 1 tag to place 2 virus counters on God of War"))
+                                                                     (effect-completed state side eid))
+                                                                 (effect-completed state side eid))))}]})
 
    "Golden"
    (auto-icebreaker ["Sentry"]

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -486,6 +486,22 @@
                     {:abilities [(break-sub 1 1 "sentry")
                                  (strength-pump 1 1)]})
 
+   "God of War"
+   {:flags {:runner-phase-12 (req true)}
+    :abilities [(strength-pump 2 1)
+                {:counter-cost [:virus 1]
+                 :msg "break 1 subroutine"}
+                {:label "Take 1 tag to place 2 virus counters (start of turn)"
+                 :once :per-turn
+                 :req (req (:runner-phase-12 @state))
+                 :effect (req (when-completed (tag-runner state :runner 1)
+                                              (if (not (get-in @state [:tag :tag-prevent]))
+                                                (do (add-counter state side card :virus 2)
+                                                    (system-msg state side
+                                                                (str "takes 1 tag to place 2 virus counters on God of War"))
+                                                    (effect-completed state side eid))
+                                                (effect-completed state side eid))))}]}
+
    "Golden"
    (auto-icebreaker ["Sentry"]
                     {:abilities [(break-sub 2 2 "sentry")

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -298,6 +298,29 @@
                  :msg (msg "force the Runner to lose all " (:credit runner) " [Credits]") :once :per-run
                  :effect (effect (lose :runner :credit :all :run-credit :all))}]}
 
+   "Helheim Servers"
+   {:abilities [{:label "Trash 1 card from HQ: All ice protecting this server has +2 strength until the end of the run"
+                 :req (req (and this-server (pos? (count run-ices)) (pos? (count (:hand corp)))))
+                 :delayed-completion true
+                 :effect (req (show-wait-prompt state :runner "Corp to use Helheim Servers")
+                              (when-completed
+                                (resolve-ability
+                                  state side
+                                  {:prompt "Choose a card in HQ to trash"
+                                   :choices {:req #(and (in-hand? %) (= (:side %) "Corp"))}
+                                   :effect (effect (trash target) (clear-wait-prompt :runner))} card nil)
+                                (do (register-events
+                                      state side
+                                      {:pre-ice-strength {:req (req (= (card->server state card)
+                                                                       (card->server state target)))
+                                                          :effect (effect (ice-strength-bonus 2 target))}
+                                       :run-ends {:effect (effect (unregister-events card))}} card)
+                                    (continue-ability
+                                      state side
+                                      {:effect (req (update-ice-in-server
+                                                      state side (card->server state card)))} card nil))))}]
+    :events {:pre-ice-strength nil}}
+
    "Henry Phillips"
    {:implementation "Manually triggered by Corp"
     :abilities [{:req (req (and this-server tagged))

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -477,12 +477,12 @@
     (take-credits state :corp)
     (run-empty-server state "Archives")
     (play-from-hand state :runner "Early Bird")
-	(is (= 3 (:click (get-runner))) "Card not played, Early Bird priority restriction")
+    (is (= 3 (:click (get-runner))) "Card not played, Early Bird priority restriction")
     (take-credits state :runner)
     (take-credits state :corp)
     (play-from-hand state :runner "Early Bird")
     (prompt-choice :runner "Archives")
-	(is (= 4 (:click (get-runner))) "Early Bird gains click")))
+    (is (= 4 (:click (get-runner))) "Early Bird gains click")))
 
 (deftest employee-strike-blue-sun
   ;; Employee Strike - vs Blue Sun, suppress Step 1.2
@@ -936,6 +936,29 @@
     (is (= 1 (count (:hand (get-runner)))))
     (play-from-hand state :runner "Making an Entrance")
     (is (= 1 (count (:hand (get-runner)))) "Can only play on first click")))
+
+(deftest mars-for-martians
+  ;; Mars for Martians - Full test
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Mars for Martians" 1) (qty "Clan Vengeance" 1) (qty "Counter Surveillance" 1)
+                               (qty "Jarogniew Mercs" 1) (qty "Sure Gamble" 3)]))
+    (starting-hand state :runner ["Mars for Martians" "Clan Vengeance" "Counter Surveillance" "Jarogniew Mercs"])
+    (take-credits state :corp)
+    (play-from-hand state :runner "Clan Vengeance")
+    (play-from-hand state :runner "Counter Surveillance")
+    (play-from-hand state :runner "Jarogniew Mercs")
+    (play-from-hand state :runner "Mars for Martians")
+    (is (= 1 (:click (get-runner))) "Mars for Martians not played, priority event")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (core/gain state :runner :tag 4)
+    (is (= 5 (:tag (get-runner))) "+1 tag from Jarogniew Mercs")
+    (is (= 1 (count (:hand (get-runner)))))
+    (is (= 2 (:credit (get-runner))))
+    (play-from-hand state :runner "Mars for Martians")
+    (is (= 3 (count (:hand (get-runner)))) "3 clan resources, +3 cards but -1 for playing Mars for Martians")
+    (is (= 7 (:credit (get-runner))) "5 tags, +5 credits")))
 
 (deftest modded
   ;; Modded - Install a program or piece of hardware at a 3 credit discount

--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -288,6 +288,48 @@
     (core/trash state :corp iw)
     (is (not (:icon (refresh iw))) "Ice Wall does not have an icon after itself trashed"))))
 
+(deftest nanotk-install-ice-during-run
+  ;; Na'Not'K - Strength adjusts accordingly when ice installed during run
+  (do-game
+    (new-game (default-corp [(qty "Architect" 1) (qty "Eli 1.0" 1)])
+              (default-runner [(qty "Na'Not'K" 1)]))
+    (play-from-hand state :corp "Architect" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Na'Not'K")
+    (let [nanotk (get-program state 0)
+          architect (get-ice state :hq 0)]
+      (is (= 1 (:current-strength (refresh nanotk))) "Default strength")
+      (run-on state "HQ")
+      (core/rez state :corp architect)
+      (is (= 2 (:current-strength (refresh nanotk))) "1 ice on HQ")
+      (card-subroutine state :corp (refresh architect) 1)
+      (prompt-select :corp (find-card "Eli 1.0" (:hand (get-corp))))
+      (prompt-choice :corp "HQ")
+      (is (= 3 (:current-strength (refresh nanotk))) "2 ice on HQ")
+      (run-jack-out state)
+      (is (= 1 (:current-strength (refresh nanotk))) "Back to default strength"))))
+
+(deftest nanotk-redirect
+  ;; Na'Not'K - Strength adjusts accordingly when run redirected to another server
+  (do-game
+    (new-game (default-corp [(qty "Susanoo-no-Mikoto" 1) (qty "Crick" 1) (qty "Cortex Lock" 1)])
+              (default-runner [(qty "Na'Not'K" 1)]))
+    (play-from-hand state :corp "Cortex Lock" "HQ")
+    (play-from-hand state :corp "Susanoo-no-Mikoto" "HQ")
+    (play-from-hand state :corp "Crick" "Archives")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Na'Not'K")
+    (let [nanotk (get-program state 0)
+          susanoo (get-ice state :hq 1)]
+      (is (= 1 (:current-strength (refresh nanotk))) "Default strength")
+      (run-on state "HQ")
+      (core/rez state :corp susanoo)
+      (is (= 3 (:current-strength (refresh nanotk))) "2 ice on HQ")
+      (card-subroutine state :corp (refresh susanoo) 0)
+      (is (= 2 (:current-strength (refresh nanotk))) "1 ice on Archives")
+      (run-jack-out state)
+      (is (= 1 (:current-strength (refresh nanotk))) "Back to default strength"))))
+
 (deftest overmind-counters
   ;; Overmind - Start with counters equal to unused MU
   (do-game

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -393,7 +393,42 @@
         (is (= 2 (count (:discard (get-runner)))) "Runner took 1 net damage")
         (run-on state "HQ")
         (run-jack-out state)
-        (is (= 2 (count (:discard (get-runner)))) "Runner did not take  damage")))))
+        (is (= 2 (count (:discard (get-runner)))) "Runner did not take damage")))))
+
+(deftest helheim-servers
+  ;; Helheim Servers - Full test
+  (do-game
+    (new-game (default-corp [(qty "Helheim Servers" 1) (qty "Gutenberg" 1) (qty "Vanilla" 1)
+                             (qty "Jackson Howard" 1) (qty "Hedge Fund" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Helheim Servers" "R&D")
+    (play-from-hand state :corp "Gutenberg" "R&D")
+    (play-from-hand state :corp "Vanilla" "R&D")
+    (take-credits state :corp)
+    (run-on state "R&D")
+    (is (:run @state))
+    (let [helheim (get-content state :rd 0)
+          gutenberg (get-ice state :rd 0)
+          vanilla (get-ice state :rd 1)]
+      (core/rez state :corp helheim)
+      (core/rez state :corp gutenberg)
+      (core/rez state :corp vanilla)
+      (is (= 6 (:current-strength (refresh gutenberg))))
+      (is (= 0 (:current-strength (refresh vanilla))))
+      (card-ability state :corp helheim 0)
+      (prompt-select :corp (find-card "Jackson Howard" (:hand (get-corp))))
+      (is (= 1 (count (:discard (get-corp)))))
+      (is (= 8 (:current-strength (refresh gutenberg))))
+      (is (= 2 (:current-strength (refresh vanilla))))
+      (card-ability state :corp helheim 0)
+      (prompt-select :corp (find-card "Hedge Fund" (:hand (get-corp))))
+      (is (= 2 (count (:discard (get-corp)))))
+      (is (= 10 (:current-strength (refresh gutenberg))))
+      (is (= 4 (:current-strength (refresh vanilla))))
+      (run-jack-out state)
+      (is (not (:run @state)))
+      (is (= 6 (:current-strength (refresh gutenberg))))
+      (is (= 0 (:current-strength (refresh vanilla)))))))
 
 (deftest hokusai-grid
   ;; Hokusai Grid - Do 1 net damage when run successful on its server


### PR DESCRIPTION
Refactors the tagged ETR subroutine into its own function (IP block, pachinko, etc) in preparation for Data Loop.

I think Data Loop's on encounter effect is actually easier to do manually than through prompts so I'm leaving it manual until I hear otherwise

Also did god of war