### PR TITLE
Deep Data Mining Fix

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -256,7 +256,7 @@
    {:effect (effect (run :rd nil card)
                     (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
     :events {:successful-run {:silent (req true)
-                              :effect (effect (access-bonus (min 4 (:memory runner))))}
+                              :effect (effect (access-bonus (max 0 (min 4 (:memory runner))))) }
              :run-ends {:effect (effect (unregister-events card))}}}
 
    "Demolition Run"


### PR DESCRIPTION
Keeping Deep Data Mining from lowering access amount in case of < 0 memory
I did not imagine "access-bonus" could be used to lower the number of cards accessed.
(To my knowledge, this has not actually happened to anyone yet.)