### PR TITLE
Fixing issue #2654 - Personality Profiles

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -665,7 +665,7 @@
    "Personality Profiles"
    (let [pp {:req (req (pos? (count (:hand runner))))
              :effect (effect (trash (first (shuffle (:hand runner)))))
-             :msg (msg "force the Runner to trash " (:title (first (:discard runner))) " from their Grip at random")}]
+             :msg (msg "force the Runner to trash " (:title (last (:discard runner))) " from their Grip at random")}]
      {:events {:searched-stack pp
                :runner-install (assoc pp :req (req (and (some #{:discard} (:previous-zone target))
                                                         (pos? (count (:hand runner))))))}})


### PR DESCRIPTION
Per [#2654](https://github.com/mtgred/netrunner/issues/2654) Personality Profiles was always naming the lowest card in the Runner's discard pile instead of the one it actually discarded; this fixes that. Big ups to Joel for doing all the hard work of identifying the problem and exactly where to fix it. ;)