### PR TITLE
partial Loki, Data Loop enhancement

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -979,6 +979,7 @@
                    (doseq [c (all-installed state :corp)]
                      (update! state side (dissoc c :advance-counter)))
                    (set-prop state side target :advance-counter total-adv)
+                   (update-all-ice state side)
                    (system-msg state side (str "uses Red Planet Couriers to move " total-adv
                                                " advancement tokens to " (card-str state target)))
                    (effect-completed state side eid)))}


### PR DESCRIPTION
Adds Runner-triggered ability to Data Loop to return cards to the Stack without identifying them.

Also adds a partial implementation of Loki to give the Runner the choice of whether or not to shuffle their hand back into the deck (again without revealing cards). None of the on-encounter effects of subtype/subroutine addition are handled. 

Fixes #2666. 