### PR TITLE
Maw update

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -446,7 +446,11 @@
                                  (not= (first (:zone target)) :discard)))
                   :once :per-turn
                   :msg "force the Corp to trash a random card from HQ"
-                  :effect (req (trash state :corp (first (shuffle (:hand corp)))))}]
+                  :effect (req (let [card-to-trash (first (shuffle (:hand corp)))
+                                     card-seen? (= (:cid target) (:cid card-to-trash))
+                                     card-to-trash (if card-seen? (assoc card-to-trash :seen true)
+                                                                  card-to-trash)]
+                                 (trash state :corp card-to-trash)))}]
      {:in-play [:memory 2]
       :abilities [ability]
       :events {:no-trash ability

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -142,7 +142,9 @@
                                                            (system-msg state side (str "pays " trash-msg)))}}}
                               card nil))))
       ;; The card does not have a trash cost
-      (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid}))
+      (do (prompt! state :runner c (str "You accessed " (:title c)) ["OK"] {:eid eid})
+          ;; TODO: Trigger :no-trash after hit "OK" on access
+          (trigger-event state side :no-trash c)))
     (effect-completed state side eid)))
 
 (defn- steal-pay-choice

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -336,6 +336,21 @@
     (prompt-choice :runner "No")
     (is (= 1 (count (:discard (get-corp)))) "2nd HQ card on same turn not trashed by Maw")))
 
+(deftest maw-card-seen
+  ;; Check trashed card is trashed face-up if it's the card that is accessed, issue #2695
+  ;; Also checks Maw auto-trashes on Operation with no trash cost
+  (do-game
+    (new-game (default-corp [(qty "Hedge Fund" 1)])
+              (default-runner [(qty "Maw" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 20)
+    (play-from-hand state :runner "Maw")
+    (run-empty-server state :hq)
+    ;; (is (= 0 (count (:discard (get-corp)))) "HQ card not trashed by Maw yet")
+    (prompt-choice :runner "OK")
+    (is (= 1 (count (:discard (get-corp)))) "HQ card trashed by Maw now")
+    (is (:seen (first (:discard (get-corp)))) "Trashed card is registered as seen since it was accessed")))
+
 (deftest maw-hiro
   ;; Maw with Hiro in hand - Hiro not moved to runner scored area on trash decline #2638
   (do-game


### PR DESCRIPTION
Adds :no-trash trigger for non-agenda cards with no trash cost. Makes Maw card discard face-up if it is the card being accessed (triggering the :no-trash event hook).

Adds test for this.

Currently auto-maw's once a non-agenda card with no trash cost is accessed. Would like some `when-complete` magic to only trash after the "OK" button is selected.

Fixes #2695