### PR TITLE
Fixes: Titanium Ribs, Security Nexus, The Price of Freedom, Space Camp

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1335,11 +1335,17 @@
              :effect (effect (show-wait-prompt :runner "Corp to use Space Camp")
                              (continue-ability
                                {:optional
-                                {:prompt "Place 1 advancement token?"
-                                 :end-effect (effect (clear-wait-prompt :runner))
+                                {:delayed-completion true
+                                 :prompt "Place 1 advancement token with Space Camp?"
+                                 :cancel-effect (req (clear-wait-prompt state :runner)
+                                                     (effect-completed state side eid))
                                  :yes-ability {:msg (msg "place 1 advancement token on " (card-str state target))
+                                               :prompt "Select a card to place an advancement token on with Space Camp"
                                                :choices {:req can-be-advanced?}
-                                               :effect (effect (add-prop target :advance-counter 1 {:placed true}))}}}
+                                               :effect (effect (add-prop target :advance-counter 1 {:placed true})
+                                                               (clear-wait-prompt :runner))}
+                                 :no-ability {:effect (req (clear-wait-prompt state :runner)
+                                                           (effect-completed state side eid))}}}
                                card nil))}}
 
    "Student Loans"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1529,18 +1529,15 @@
 
    "The Price of Freedom"
    {:additional-cost [:connection 1]
-    :effect (effect (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
-
-    :events {:runner-trash {:effect (effect
-                                      (move (find-cid (:cid card) (:discard runner)) :rfg)
-                                      (unregister-events card)
-                                      (register-events (:events (card-def card)) (assoc card :zone '(:rfg)))
-                                      (system-msg (str "trashes " (:title target) " to prevent the corp from advancing cards during their next turn"))
-                                      (register-persistent-flag! card :can-advance
-                                                                 (fn [state side card] ((constantly false)
-                                                                                         (toast state :corp "Cannot advance cards this turn due to The Price of Freedom." "warning")))))}
-             :corp-turn-ends {:effect (effect (clear-persistent-flag! card :can-advance)
-                                              (unregister-events card))}}}
+    :msg "prevent the Corp from advancing cards during their next turn"
+    :effect (effect (register-events (:events (card-def card)) (assoc card :zone '(:rfg)))
+                    (move (first (:play-area runner)) :rfg))
+    :events {:corp-turn-begins
+             {:effect (effect (register-turn-flag! card :can-advance
+                                (fn [state side card]
+                                  ((constantly false)
+                                   (toast state :corp "Cannot advance cards this turn due to The Price of Freedom." "warning"))))
+                              (unregister-events card))}}}
 
    "Three Steps Ahead"
    {:end-turn {:effect (effect (gain :credit (* 2 (count (:successful-run runner-reg)))))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -813,10 +813,11 @@
    "Security Nexus"
    {:in-play [:memory 1 :link 1]
     :abilities [{:req (req (:run @state))
+                 :once :per-turn
                  :delayed-completion true
                  :msg "force the Corp to initiate a trace"
                  :label "Trace 5 - Give the Runner 1 tag and end the run"
-                 :trace {:once :per-turn :base 5 :msg "give the Runner 1 tag and end the run"
+                 :trace {:base 5 :msg "give the Runner 1 tag and end the run"
                          :effect (effect (tag-runner :runner eid 1) (end-run))
                          :unsuccessful {:msg "bypass the current ICE"}}}]}
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -93,9 +93,11 @@
                   :choices {:max 1
                             :req #(and (= (:side %) "Runner")
                                        (in-hand? %))}
-                  :req (req (> (count (:hand runner)) 0))
+                  :req (req (and (pos? (count (:hand runner)))
+                                 (:runner-phase-12 @state)))
                   :effect (effect (runner-install target {:facedown true}))}]
      {:events {:runner-turn-begins ability}
+      :flags {:runner-phase-12 (req (pos? (count (:hand runner))))}
       :abilities [ability]})
 
    "Argus Security: Protection Guaranteed"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -236,7 +236,8 @@
 
    "Bloo Moose"
    {:flags {:runner-phase-12 (req true)}
-    :abilities [{:req (req (:runner-phase-12 @state))
+    :abilities [{:req (req (and (:runner-phase-12 @state)
+                                (not (seq (get-in @state [:runner :locked :discard])))))
                  :once :per-turn
                  :prompt "Choose a card in the Heap to remove from the game and gain 2 [Credits]"
                  :show-discard true

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -48,6 +48,7 @@
    (when (and (:memoryunits card) (:installed card) (not (:facedown card)))
      (gain state :runner :memory (:memoryunits card)))
    (when (and (find-cid (:cid card) (all-installed state side))
+              (not (:disabled card))
               (or (:rezzed card) (:installed card)))
      (when-let [in-play (:in-play (card-def card))]
        (apply lose state side in-play)))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -452,7 +452,7 @@
              (deactivate state side card) card)]
      (system-msg state side (str "forfeits " (:title c)))
      (gain-agenda-point state side (- (get-agenda-points state side c)))
-     (move state :corp c :rfg)
+     (move state side c :rfg)
      (when-completed (trigger-event-sync state side (keyword (str (name side) "-forfeit-agenda")) c)
                      (effect-completed state side eid)))))
 

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -187,7 +187,8 @@
   (swap! state update-in [:damage :defer-damage] dissoc type)
   (damage-choice-priority state)
   (when-completed (trigger-event-sync state side :pre-resolve-damage type card n)
-                  (do (when-not (get-in @state [:damage :damage-replace])
+                  (do (when-not (or (get-in @state [:damage :damage-replace])
+                                    (runner-can-choose-damage? state))
                         (let [n (if-let [defer (get-defer-damage state side type args)] defer n)]
                           (when (pos? n)
                             (let [hand (get-in @state [:runner :hand])

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -732,6 +732,7 @@
                                   "Independent Thinking"
                                   "Independent Thinking"])
     (take-credits state :corp)
+    (core/end-phase-12 state :runner nil)
     (prompt-select :runner (find-card "Neutralize All Threats" (:hand (get-runner))))
     (play-from-hand state :runner "Fan Site")
     (let [fs (get-in @state [:runner :rig :resource 0])

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -99,11 +99,13 @@
       (default-corp)
       (make-deck "Apex: Invasive Predator" [(qty "Heartbeat" 2)]))
     (take-credits state :corp)
+    (core/end-phase-12 state :runner nil)
     (prompt-choice :runner "Done") ; no facedown install on turn 1
     (play-from-hand state :runner "Heartbeat")
     (is (= 1 (count (get-in @state [:runner :rig :hardware]))))
     (take-credits state :runner)
     (take-credits state :corp)
+    (core/end-phase-12 state :runner nil)
     (prompt-select :runner (find-card "Heartbeat" (:hand (get-runner))))
     (is (= 1 (count (get-in @state [:runner :rig :facedown]))) "2nd console installed facedown")))
 

--- a/src/clj/test/cards/programs.clj
+++ b/src/clj/test/cards/programs.clj
@@ -445,6 +445,7 @@
     (new-game (default-corp)
               (make-deck "Apex: Invasive Predator" [(qty "Parasite" 1)]))
     (take-credits state :corp)
+    (core/end-phase-12 state :runner nil)
     (prompt-select :runner (find-card "Parasite" (:hand (get-runner))))
     (is (empty? (:prompt (get-runner))) "No prompt to host Parasite")
     (is (= 1 (count (get-in @state [:runner :rig :facedown]))) "Parasite installed face down")))


### PR DESCRIPTION
* Fixes the much-plagued Titanium Ribs card (interactions with Stimhack and Salvaged Vanadis Armory) which is seeing a bewildering amount of use lately. 
* Reworks Apex to play nicer with other "when your turn begins" cards (per #2701) and update tests. 
* More thorough attempt at hard-to-reproduce Space Camp issue
* Fix hideously broken code for The Price of Freedom
* Fix once-per-turn on Security Nexus
* Prevent Bloo Moose if a Blacklist is rezzed
* Check for card being disabled when doing `deactivate` to take care of Rumor Mill + Cybernetics Court trashing and using Dr. Lovegood on an Independent Thinking that subsequently gets trashed. 