### PR TITLE
Displaying alt art cards in card browser and deck builder

### DIFF
--- a/data/promo.json
+++ b/data/promo.json
@@ -212,9 +212,6 @@
     "code": "01111",
     "versions": ["wc2015"]
 }, {
-    "code": "01019",
-    "versions": ["alt"]
-}, {
     "code": "01109",
     "versions": ["alt"]
 }

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -20,8 +20,13 @@
 (defn make-span [text symbol class]
   (.replace text (js/RegExp. symbol "g") (str "<span class='anr-icon " class "'></span>")))
 
-(defn image-url [card]
-  (str "/img/cards/" (:code card) ".png"))
+(defn image-url [{code :code}]
+  (let [alt-art (get-in @app-state [:alt-arts code])
+        version (when (and (get-in @app-state [:user :special])
+                           (get-in @app-state [:options :show-alt-art])
+                           alt-art)
+                  (first (:versions alt-art)))]
+    (str "/img/cards/" code (when version (str "-" version)) ".png")))
 
 (defn add-symbols [card-text]
   (-> (if (nil? card-text) "" card-text)

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -647,7 +647,7 @@
   (for [deck (sort-by :date > decks)]
     [:div.deckline {:class (when (= active-deck deck) "active")
                     :on-click #(put! select-channel deck)}
-     [:img {:src (image-url (:identity deck))}]
+     [:img {:src (image-url (assoc (:identity deck) :check_for_alts true))}]
      [:div.float-right (deck-status-span sets deck)]
      [:h4 (:name deck)]
      [:div.float-right (-> (:date deck) js/Date. js/moment (.format "MMM Do YYYY"))]
@@ -739,7 +739,7 @@
               :else (deck-collection sets decks (om/get-state owner :deck)))]
            [:div {:class (when (:edit state) "edit")}
             (when-let [card (om/get-state owner :zoom)]
-              (om/build card-view card))]]
+              (om/build card-view (assoc card :check_for_alts true)))]]
 
           [:div.decklist
            (when-let [deck (:deck state)]
@@ -760,7 +760,7 @@
                          [:button {:on-click #(delete-deck owner)} "Delete"]])
                 [:h3 (:name deck)]
                 [:div.header
-                 [:img {:src (image-url identity)}]
+                 [:img {:src (image-url (assoc identity :check_for_alts true))}]
                  [:h4.fake-link {:on-mouse-enter #(put! zoom-channel identity)
                                  :on-mouse-leave #(put! zoom-channel false)} (:title identity)]
                  (let [count (card-count cards)

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -148,7 +148,7 @@
          [:div {:data-dismiss "modal"}
           (for [deck (sort-by :date > (filter #(= (get-in % [:identity :side]) side) decks))]
             [:div.deckline {:on-click #(send {:action "deck" :gameid (:gameid @app-state) :deck deck})}
-             [:img {:src (image-url (:identity deck))}]
+             [:img {:src (image-url (assoc (:identity deck) :check_for_alts true))}]
              [:div.float-right (deck-status-span sets deck)]
              [:h4 (:name deck)]
              [:div.float-right (-> (:date deck) js/Date. js/moment (.format "MMM Do YYYY"))]


### PR DESCRIPTION
Displaying alternate/promo art cards in the card browser and deck builder if the user is authorized to see them (same logic as used in the game board).

Noticed that there doesn't seem to be an Easy Mark alt art png file, though it is listed in the promo.json file. I removed it from there, but someone will need to re-run `npm run promo` on the server to update the database.

I didn't see any automation around handling of alt art cards, not sure what process is in place today to get them added.
