### PR TITLE
Allow Pad Factory to put advancement tokens on Runner cards

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -988,8 +988,7 @@
    "PAD Factory"
    {:abilities [{:cost [:click 1]
                  :label "Place 1 advancement token on a card"
-                 :choices {:req #(and (= (:side %) "Corp")
-                                      (installed? %))}
+                 :choices {:req #(installed? %)}
                  :msg (msg "place 1 advancement token on " (card-str state target))
                  :effect (req (add-prop state :corp target :advance-counter 1 {:placed true})
                               (let [tgtcid (:cid target)]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -988,7 +988,7 @@
    "PAD Factory"
    {:abilities [{:cost [:click 1]
                  :label "Place 1 advancement token on a card"
-                 :choices {:req #(installed? %)}
+                 :choices {:req installed?}
                  :msg (msg "place 1 advancement token on " (card-str state target))
                  :effect (req (add-prop state :corp target :advance-counter 1 {:placed true})
                               (let [tgtcid (:cid target)]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -299,7 +299,12 @@
 
    "Dedication Ceremony"
    {:prompt "Choose a faceup card"
-    :choices {:req rezzed?}
+    :choices {:req #(or (and (card-is? % :side :corp)
+                             (:rezzed %))
+                        (and (card-is? % :side :runner)
+                             (or (installed? %)
+                                 (:host %))
+                             (not (facedown? %))))}
     :msg (msg "place 3 advancement tokens on " (card-str state target))
     :effect (req (add-prop state :corp target :advance-counter 3 {:placed true})
                  (effect-completed state side eid card)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -989,8 +989,10 @@
     :req (req (some #(can-be-advanced? %) (all-installed state :corp)))
     :prompt "Select an installed card that can be advanced"
     :choices {:req can-be-advanced?}
-    :effect (req (let [total-adv (reduce + (map :advance-counter (filter #(:advance-counter %) (all-installed state :corp))))]
-                   (doseq [c (all-installed state :corp)]
+    :effect (req (let [installed (get-all-installed state)
+                       total-adv (reduce + (map :advance-counter 
+                                                (filter #(:advance-counter %) installed)))]
+                   (doseq [c installed]
                      (update! state side (dissoc c :advance-counter)))
                    (set-prop state side target :advance-counter total-adv)
                    (update-all-ice state side)


### PR DESCRIPTION
Fix for Issue #2728 