### PR TITLE
More fixes

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -867,12 +867,17 @@
     :effect (effect (rfg-and-shuffle-rd-effect (first (:play-area corp)) 3))}
 
    "Priority Construction"
-   {:delayed-completion true
-    :prompt "Choose an ICE in HQ to install"
-    :choices {:req #(and (in-hand? %) (= (:side %) "Corp") (ice? %))}
-    :msg "install an ICE from HQ and place 3 advancements on it"
-    :cancel-effect (req (effect-completed state side eid))
-    :effect (effect (corp-install (assoc target :advance-counter 3) nil {:no-install-cost true}))}
+   (letfn [(install-card [chosen]
+            {:prompt "Select a remote server"
+             :choices (req (conj (vec (get-remote-names @state)) "New remote"))
+             :delayed-completion true
+             :effect (effect (corp-install (assoc (move state side chosen :play-area) :advance-counter 3) target {:no-install-cost true}))})]
+     {:delayed-completion true
+      :prompt "Choose a piece of ICE in HQ to install"
+      :choices {:req #(and (in-hand? %) (= (:side %) "Corp") (ice? %))}
+      :msg "install an ICE from HQ and place 3 advancements on it"
+      :cancel-effect (req (effect-completed state side eid))
+      :effect (effect (continue-ability (install-card target) card nil))})
 
    "Product Recall"
    {:prompt "Choose a rezzed asset or upgrade to trash"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -216,7 +216,7 @@
                  :effect (effect (host card target)
                                  (when (-> target :cost pos?)
                                    (gain state side :credit 1))
-                                 (gain :memory (:memoryunits target) :credit 1)
+                                 (gain :memory (:memoryunits target))
                                  (update! (assoc (get-card state card) :dheg-prog (:cid target))))}]
     :events {:card-moved {:req (req (= (:cid target) (:dheg-prog (get-card state card))))
                           :effect (effect (update! (dissoc card :dheg-prog))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -742,7 +742,7 @@
                      {:optional {:prompt (str "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?") :player :corp
                                  :delayed-completion true
                                  :yes-ability {:msg "do 1 brain damage instead of net damage"
-                                               :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
+                                               :effect (req (swap! state update-in [:damage] dissoc :damage-replace :defer-damage)
                                                             (clear-wait-prompt state :runner)
                                                             (pay state :corp card :credit 2)
                                                             (damage state side eid :brain 1 {:card card}))}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -36,7 +36,7 @@
                                       (has-subtype? % "Bioroid")
                                       (in-hand? %))}
                  :msg "host a piece of bioroid ICE"
-                 :effect (req (corp-install state side target card))}
+                 :effect (req (corp-install state side target card {:no-install-cost true}))}
                 {:req (req (and this-server (= (get-in @state [:run :position]) 0)))
                  :label "Rez a hosted piece of bioroid ICE"
                  :prompt "Choose a piece of bioroid ICE to rez" :choices (req (:hosted card))


### PR DESCRIPTION
* Limit Priority Construction to installs in remotes
* Remove costs for installing bioroid ICE on Awakening Center
* Remove duplicate credit adjustment on Dhegdheer retroactive hosting ability
* Fix Tori Hanzō + Hokusai Grid interaction