### PR TITLE
Option to allow spectators to view hidden information.

### DIFF
--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -114,6 +114,8 @@
     (private-card-vector state side deck)))
 
 (defn- private-states [state]
+  "Generates privatized states for the Corp, Runner and any spectators from the base state.
+  If `:spectatorhands` is on, all information is passed on to spectators as well."
   ;; corp, runner, spectator
   (let [corp-private (make-private-corp state)
         runner-private (make-private-runner state)
@@ -124,8 +126,7 @@
      (assoc @state :corp corp-private
                    :runner runner-deck)
      (if (get-in @state [:options :spectatorhands])
-       (assoc @state :corp (assoc-in corp-private [:hand] (get-in @state [:corp :hand]))
-                     :runner (assoc-in runner-private [:hand] (get-in @state [:runner :hand])))
+       (assoc @state :corp corp-deck :runner runner-deck)
        (assoc @state :corp corp-private :runner runner-private))]))
 
 (defn- reset-all-cards

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -271,7 +271,7 @@
        [:div
         [:div.lobby-bg]
         [:div.container
-         [:div.lobby.panel.blue-shade 
+         [:div.lobby.panel.blue-shade
           [:div.games
            [:div.button-bar
             (if gameid
@@ -327,10 +327,11 @@
                  [:input {:type "checkbox" :checked (om/get-state owner :spectatorhands)
                           :on-change #(om/set-state! owner :spectatorhands (.. % -target -checked))
                           :disabled (not (om/get-state owner :allowspectator))}]
-                 "Make players' hands visible to spectators"]]
-               [:p {:style {:display (if (om/get-state owner :spectatorhands) "block" "none")}}
-                "This will reveal both players' hands to ALL spectators of your game. We recommend "
-                "using a password to prevent strangers from spoiling the game."]
+                 "Make players' hidden information visible to spectators"]]
+               [:div {:style {:display (if (om/get-state owner :spectatorhands) "block" "none")}}
+                [:p "This will reveal both players' hidden information to ALL spectators of your game, "
+                 "including hand and face-down cards."]
+                [:p "We recommend using a password to prevent strangers from spoiling the game."]]
                [:p
                 [:label
                  [:input {:type "checkbox" :checked (om/get-state owner :private)


### PR DESCRIPTION
Changes specator option to allow view of _all_ hidden cards, not just hand.

Fixes #2743.