### PR TITLE
Open game count

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -500,10 +500,10 @@
   (escape st {\< "&lt;" \> "&gt;" \& "&amp;" \" "#034;"}))
 
 ;; Dot definitions
-(def zws "&#8203;")                                         ; zero-width space for wrapping dots
-(def influence-dot (str "&#9679;" zws))                     ; normal influence dot
-(def mwl-dot (str "&#9733;" zws))                           ; influence penalty from MWL
-(def alliance-dot (str "&#9675;" zws))                      ; alliance free-inf dot
+(def zws "\u200B")                                          ; zero-width space for wrapping dots
+(def influence-dot (str "●" zws))                           ; normal influence dot
+(def mwl-dot (str "★" zws))                                 ; influence penalty from MWL
+(def alliance-dot (str "○" zws))                            ; alliance free-inf dot
 
 (defn- make-dots
   "Returns string of specified dots and number. Uses number for n > 20"

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -530,9 +530,7 @@
   "Make a hiccup-ready vector for the specified dot and cost-map (influence or mwl)"
   [dot cost-map]
   (for [factionkey (sort (keys cost-map))]
-    [:span.influence
-     {:class (name factionkey)
-      :dangerouslySetInnerHTML #js {:__html (make-dots dot (factionkey cost-map))}}]))
+    [:span.influence {:class (name factionkey)} (make-dots dot (factionkey cost-map))]))
 
 (defn influence-html
   "Returns hiccup-ready vector with dots colored appropriately to deck's influence."

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -804,7 +804,7 @@
                                        :fn (fn [cursor] (let [total (count cursor)
                                                               face-up (count (filter faceup? cursor))]
                                                           ;; use non-breaking space to keep counts on same line.
-                                                          (str face-up "\u2191\u00A0" (- total face-up) "\u2193")))}})
+                                                          (str face-up "↑ " (- total face-up) "↓")))}})
 
        [:div.panel.blue-shade.popup {:ref "popup" :class (if (= (:side @game-state) :runner) "opponent" "me")}
         [:div

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -259,6 +259,22 @@
        (for [game roomgames]
         (om/build game-view (assoc game :current-game gameid :password-game password-game))))]))
 
+(def open-games-symbol "○")
+(def closed-games-symbol "●")
+
+(defn- room-tab
+  "Creates the room tab for the specified room"
+  [owner games room room-name]
+  (let [room-games (filter #(= room (:room %)) games)
+        closed-games (count (filter #(:started %) room-games))
+        open-games (- (count room-games) closed-games)]
+    [:span.roomtab
+     (if (= room (om/get-state owner :current-room))
+       {:class "current"}
+       {:on-click #(om/set-state! owner :current-room room)})
+     room-name " (" open-games open-games-symbol " "
+     closed-games closed-games-symbol ")"]))
+
 (defn game-lobby [{:keys [games gameid messages sets user password-gameid] :as cursor} owner]
   (reify
     om/IInitState
@@ -277,16 +293,9 @@
             (if gameid
               [:button.float-left {:class "disabled"} "New game"]
               [:button.float-left {:on-click #(new-game cursor owner)} "New game"])
-            (let [count-games (fn [room] (count (filter #(= room (:room %)) games)))
-                  room-tab (fn [room roomname]
-                             [:span.roomtab
-                              (if (= room (om/get-state owner :current-room))
-                                {:class "current"}
-                                {:on-click #(om/set-state! owner :current-room room)})
-                              roomname " (" (count-games room) ")"])]
-              [:div.rooms
-               (room-tab "competitive" "Competitive")
-               (room-tab "casual" "Casual")])]
+            [:div.rooms
+             (room-tab owner games "competitive" "Competitive")
+             (room-tab owner games "casual" "Casual")]]
            (let [password-game (some #(when (= password-gameid (:gameid %)) %) games)]
              (game-list (assoc cursor :password-game password-game) owner))]
 


### PR DESCRIPTION
Adds icons indicating number of open / closed games to each room tab.

Also moves influence icons to unicode chars.

Note that this uses the actual unicode chars rather than `\uXXXX` since that's what my IDE did when I copy pasted, and I think this looks prettier.

Fixes #1544 and #1918.

Replaces #2107.


Preview:
<img width="487" alt="screen shot 2017-09-06 at 00 39 53" src="https://user-images.githubusercontent.com/13198563/30086724-ef05bace-929c-11e7-817e-efb8573be58e.png">
