### PR TITLE
Displaying card previews in chat

### DIFF
--- a/src/cljs/netrunner/appstate.cljs
+++ b/src/cljs/netrunner/appstate.cljs
@@ -10,6 +10,11 @@
                           :sounds-volume (let [volume (js->clj (.getItem js/localStorage "sounds_volume"))]
                                            (if (nil? volume) 100 (js/parseInt volume)))}
                          (:options (js->clj js/user :keywordize-keys true)))
-         :cards [] :sets [] :mwl []
+         :cards [] :cards-loaded false
+         :sets [] :mwl []
          :decks [] :decks-loaded false
-         :games [] :gameid nil :messages []}))
+         :games [] :gameid nil :messages []
+         :channels {:general [] :america [] :europe [] :asia-pacific [] :united-kingdom [] :français []
+                    :español [] :italia [] :português [] :sverige [] :stimhack-league []}
+         }))
+

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -15,6 +15,7 @@
 
 (go (let [cards (sort-by :code (:json (<! (GET "/data/cards"))))]
       (swap! app-state assoc :cards cards)
+      (swap! app-state assoc :cards-loaded true)
       (put! cards-channel cards)))
 
 (defn make-span [text symbol class]

--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -3,12 +3,10 @@
   (:require [om.core :as om :include-macros true]
             [sablono.core :as sab :include-macros true]
             [cljs.core.async :refer [chan put! <!] :as async]
+            [netrunner.appstate :refer [app-state]]
             [netrunner.auth :refer [avatar authenticated] :as auth]
+            [netrunner.gameboard :refer [card-preview-mouse-over card-preview-mouse-out get-message-parts create-span card-zoom] :as gameboard]
             [netrunner.ajax :refer [GET]]))
-
-(def app-state
-  (atom {:channels {:general [] :america [] :europe [] :asia-pacific [] :united-kingdom [] :français []
-                    :español [] :italia [] :português [] :sverige [] :stimhack-league []}}))
 
 (def chat-channel (chan))
 (def chat-socket (.connect js/io (str js/iourl "/chat")))
@@ -54,15 +52,22 @@
         (str "#" (name channel))]))))
 
 (defn message-view [message owner]
-  (om/component
-   (sab/html
-    [:div.message
-     (om/build avatar message {:opts {:size 38}})
-     [:div.content
-      [:div
-       [:span.username (:username message)]
-       [:span.date (-> (:date message) js/Date. js/moment (.format "dddd MMM Do - HH:mm"))]]
-      [:div (:msg message)]]])))
+  (reify
+    om/IRenderState
+    (render-state [_ state]
+      (sab/html
+        [:div.message
+         (om/build avatar message {:opts {:size 38}})
+         [:div.content
+          [:div
+           [:span.username (:username message)]
+           [:span.date (-> (:date message) js/Date. js/moment (.format "dddd MMM Do - HH:mm"))]]
+          [:div
+           {:on-mouse-over #(card-preview-mouse-over % (:zoom-ch state))
+            :on-mouse-out  #(card-preview-mouse-out % (:zoom-ch state))}
+           (for [item (get-message-parts (:msg message))]
+               (create-span item))
+           ]]]))))
 
 (defn fetch-messages [owner]
   (let [channel (om/get-state owner :channel)
@@ -74,38 +79,55 @@
 (defn chat [cursor owner]
   (reify
     om/IInitState
-    (init-state [this] {:channel :general :channel-ch (chan)})
+    (init-state [this] {:channel :general
+                        :channel-ch (chan)
+                        :zoom false
+                        :zoom-ch (chan)})
 
     om/IWillMount
     (will-mount [this]
       (fetch-messages owner)
       (go (while true
             (let [ch (<! (om/get-state owner :channel-ch))]
-              (om/set-state! owner :channel ch)))))
+              (om/set-state! owner :channel ch))))
+      (go (while true
+            (let [card (<! (om/get-state owner :zoom-ch))]
+              (om/set-state! owner :zoom card)))))
 
     om/IDidUpdate
     (did-update [this prev-props prev-state]
       (fetch-messages owner)
-      (let [div (om/get-node owner "message-list")
-            scrolltop (.-scrollTop div)
-            height (.-scrollHeight div)]
-        (when (or (zero? scrolltop)
-                  (< (- height scrolltop (.height (js/$ ".chat-app .chat-box"))) 500))
-          (aset div "scrollTop" height))))
+      (let [curr-zoom (om/get-state owner :zoom)
+            prev-zoom (:zoom prev-state)]
+        (when (= curr-zoom prev-zoom)
+          (let [div (om/get-node owner "message-list")
+                scrolltop (.-scrollTop div)
+                height (.-scrollHeight div)]
+            (when (or (zero? scrolltop)
+                      (< (- height scrolltop (.height (js/$ ".chat-app .chat-box"))) 500))
+              (aset div "scrollTop" height))))))
 
     om/IRenderState
     (render-state [this state]
       (sab/html
-       [:div.chat-app
-        [:div.blue-shade.panel.channel-list
-         [:h4 "Channels"]
-         (for [ch [:general :america :europe :asia-pacific :united-kingdom :français :español :italia :polska :português :sverige :stimhack-league]]
-           (om/build channel-view {:channel ch :active-channel (:channel state)}
-                     {:init-state {:channel-ch (:channel-ch state)}}))]
-        [:div.chat-box
-         [:div.blue-shade.panel.message-list {:ref "message-list"}
-          (om/build-all message-view (get-in cursor [:channels (:channel state)]))]
-         [:div
-          (om/build msg-input-view state)]]]))))
+         [:div.chat-app
+          [:div.blue-shade.panel.channel-list
+           [:h4 "Channels"]
+           (for [ch [:general :america :europe :asia-pacific :united-kingdom :français :español :italia :polska :português :sverige :stimhack-league]]
+             (om/build channel-view {:channel ch :active-channel (:channel state)}
+                       {:init-state {:channel-ch (:channel-ch state)}}))]
+          [:div.chat-container
+           [:div.chat-card-zoom
+            (when-let [card (om/get-state owner :zoom)]
+              (om/build card-zoom card))]
+           [:div.chat-box
+            [:div.blue-shade.panel.message-list {:ref "message-list"}
+             (if (not (:cards-loaded cursor))
+               [:h4 "Loading cards..."]
+               (om/build-all message-view (get-in cursor [:channels (:channel state)])
+                             {:init-state {:zoom-ch (:zoom-ch state)}}))
+             ]
+            [:div
+             (om/build msg-input-view state)]]]]))))
 
 (om/root chat app-state {:target (. js/document (getElementById "chat"))})

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -322,14 +322,18 @@
     (when (pos? (count code))
       code)))
 
-(defn card-preview-mouse-over [e]
+(defn card-preview-mouse-over [e channel]
+  (.preventDefault e)
   (when-let [code (get-card-code e)]
     (when-let [card (some #(when (= (:code %) code) %) (:cards @app-state))]
-     (put! zoom-channel (assoc card :implementation :full)))))
+      (put! channel (assoc card :implementation :full))))
+  nil)
 
-(defn card-preview-mouse-out [e]
+(defn card-preview-mouse-out [e channel]
+  (.preventDefault e)
   (when-let [code (get-card-code e)]
-    (put! zoom-channel false)))
+    (put! channel false))
+  nil)
 
 (defn log-pane [messages owner]
   (reify
@@ -349,8 +353,8 @@
     om/IRenderState
     (render-state [this state]
       (sab/html
-       [:div.log {:on-mouse-over card-preview-mouse-over
-                  :on-mouse-out  card-preview-mouse-out}
+       [:div.log {:on-mouse-over #(card-preview-mouse-over % zoom-channel)
+                  :on-mouse-out  #(card-preview-mouse-out % zoom-channel)}
         [:div.panel.blue-shade.messages {:ref "msg-list"}
          (for [msg messages]
            (when-not (and (= (:user msg) "__system__") (= (:text msg) "typing"))
@@ -1005,8 +1009,8 @@
     om/IRenderState
     (render-state [this state]
       (sab/html
-        [:div.button-pane {:on-mouse-over card-preview-mouse-over
-                           :on-mouse-out  card-preview-mouse-out}
+        [:div.button-pane {:on-mouse-over #(card-preview-mouse-over % zoom-channel)
+                           :on-mouse-out  #(card-preview-mouse-out % zoom-channel)}
          (if-let [prompt (first (:prompt me))]
            [:div.panel.blue-shade
             [:h4 (for [item (get-message-parts (:msg prompt))] (create-span item))]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -678,6 +678,16 @@ nav ul
   flex-direction(column)
   min-height: 1px
 
+.chat-container
+  flex(2)
+  display-flex()
+  flex-direction(column)
+
+  .chat-card-zoom
+    position: absolute
+    left: -70px
+    transition(all 0.2s ease-in-out)
+
 .message
   display-flex()
   margin-bottom: 5px
@@ -700,6 +710,7 @@ nav ul
   .date
     font-weight: 300
     font-size: 12px
+
 
 .msg-box
   display-flex()


### PR DESCRIPTION
Fixes issue #2531 

Moved the chat state into the main app-state. Using text parsing and preview display code from the gameboard. 