### PR TITLE
Fixed invalid argument in call to add-prop from add-counter

### DIFF
--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -168,7 +168,7 @@
      (update! state side (update-in updated-card [:counter type] #(+ (or % 0) n)))
      (if (= type :advancement)
        ;; if advancement counter use existing system
-       (add-prop state side card :advancement n args)
+       (add-prop state side card :advance-counter n args)
        (trigger-event state side :counter-added (get-card state updated-card))))))
 
 ;;; Deck-related functions


### PR DESCRIPTION
Fixed invalid `:advancement` argument in call to `add-prop` in function definition of `add-counter`.