### PR TITLE
Handling next() middleware in register user

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -380,7 +380,7 @@ app.get '/logout', (req, res) ->
   req.logout()
   res.redirect('/')
 
-app.post '/register', (req, res) ->
+app.post '/register', (req, res, next) ->
   if req.body.username.length > 20
     res.status(423).send({message: 'Usernames are limited to 20 characters'})
   else
@@ -399,19 +399,24 @@ app.post '/register', (req, res) ->
             hashPassword req.body.password, (err, hash) ->
               req.body.password = hash
               db.collection('users').insert req.body, (err) ->
-                res.send("error: #{err}") if err
-                req.login req.body, (err) -> next(err) if err
-                db.collection('decks').find({username: '__demo__'}).toArray (err, demoDecks) ->
-                  throw err if err
-                  for deck in demoDecks
-                    delete deck._id
-                    deck.username = req.body.username
-                  if demoDecks.length > 0
-                    db.collection('decks').insert demoDecks, (err, newDecks) ->
-                      throw err if err
-                      res.status(200).json({user: req.user, decks: newDecks})
-                  else
-                    res.status(200).json({user: req.user, decks: []})
+                if err
+                  res.send("error: #{err}")
+                else
+                  req.login req.body, (err) ->
+                    if err
+                      next(err)
+                    else
+                      db.collection('decks').find({username: '__demo__'}).toArray (err, demoDecks) ->
+                        throw err if err
+                        for deck in demoDecks
+                          delete deck._id
+                          deck.username = req.body.username
+                        if demoDecks.length > 0
+                          db.collection('decks').insert demoDecks, (err, newDecks) ->
+                            throw err if err
+                            res.status(200).json({user: req.user, decks: newDecks})
+                        else
+                          res.status(200).json({user: req.user, decks: []})
 
 app.post '/forgot', (req, res) ->
   async.waterfall [


### PR DESCRIPTION
The user registration handler was calling an undefined function (`next`) in certain error cases and attempting to send multiple responses in others. This was generating errors in the server log file.

Added the `next` parameter to the function args and straightened up the error flow.