### PR TITLE
implement System Seizure

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1478,6 +1478,17 @@
                          :msg "force the Corp to lose 1 [Credits]"
                          :effect (effect (lose :corp :credit 1))}}}
 
+   "System Seizure"
+   (let [ss {:effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}]
+     {:effect (effect (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
+      :events {:pump-breaker {:silent (req true)
+                              :req (req (not (get-in @state [:per-turn (:cid card)])))
+                              :effect (effect (update! (update-in (second targets) [:pump :all-run] (fnil #(+ % (first targets)) 0)))
+                                              (update-breaker-strength (second targets)))}
+               :pass-ice ss :run-ends ss}
+      :move-zone (req (when (= [:discard] (:zone card))
+                        (unregister-events state side card)))})
+
    "Test Run"
    {:prompt "Install a program from your Stack or Heap?"
     :choices (cancellable ["Stack" "Heap"])

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -76,8 +76,8 @@
   ([state side card n] (pump state side card n :encounter))
   ([state side card n duration]
    (update! state side (update-in card [:pump duration] (fnil #(+ % n) 0)))
-   (update-breaker-strength state side (get-card state card))))
-
+   (update-breaker-strength state side (get-card state card))
+   (trigger-event state side :pump-breaker n card)))
 
 ;;; Others
 (defn ice-index


### PR DESCRIPTION
The funky checks for `:per-turn` and manually setting it will allow icebreakers that can't auto-pump to strength match (e.g., Faust) to still get the all-run boost. 