### PR TITLE
fix for Tori Hanzō (all-time garbage card)

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -666,9 +666,12 @@
 
    "Independent Thinking"
    (let [cards-to-draw (fn [ts] (* (count ts) (if (some #(and (not (facedown? %)) (has-subtype? % "Directive")) ts) 2 1)))]
-     {:choices {:max 5 :req #(and (:installed %) (= (:side %) "Runner"))}
-      :effect (effect (trash-cards targets) (draw :runner (cards-to-draw targets)))
-      :msg (msg "trash " (count targets) " card" (when (not= 1(count targets)) "s") " and draw " (cards-to-draw targets) " cards")})
+     {:delayed-completion true
+      :prompt "Choose up to 5 installed cards to trash with Independent Thinking"
+      :choices {:max 5 :req #(and (installed? %) (= (:side %) "Runner"))}
+      :effect (req (when-completed (trash-cards state side targets nil)
+                                   (draw state :runner (cards-to-draw targets))))
+      :msg (msg "trash " (join ", " (map :title targets)) " and draw " (cards-to-draw targets) " cards")})
 
    "Indexing"
    {:delayed-completion true

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -583,12 +583,13 @@
                                  (strength-pump 1 1)]})
 
    "Knight"
-   {:abilities [{:cost [:click 1] :label "Host Knight on a piece of ICE"
+   {:abilities [{:label "Host Knight on a piece of ICE"
                  :effect (req (let [k (get-card state card)
                                     hosted (ice? (:host k))
                                     icepos (ice-index state (get-card state (:host k)))]
                                 (resolve-ability state side
                                  {:prompt (msg "Host Knight on a piece of ICE" (when hosted " not before or after the current host ICE"))
+                                  :cost [:click 1]
                                   :choices {:req #(if hosted
                                                     (and (or (when (= (:zone %) (:zone (:host k)))
                                                                (not= 1 (abs (- (ice-index state %) icepos))))
@@ -603,7 +604,9 @@
                                                          (not (some (fn [c] (has? c :subtype "Caïssa")) (:hosted %)))))}
                                   :msg (msg "host it on " (card-str state target))
                                   :effect (effect (host target card))} card nil)))}
-                {:cost [:credit 2] :msg "break 1 subroutine on the host ICE"}]}
+                {:cost [:credit 2]
+                 :req (req (ice? (get-nested-host card)))
+                 :msg "break 1 subroutine on the host ICE"}]}
 
    "Leviathan"
    (auto-icebreaker ["Code Gate"]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -600,24 +600,26 @@
 
    "Film Critic"
    (letfn [(get-agenda [card] (first (filter #(= "Agenda" (:type %)) (:hosted card))))]
-   {:abilities [{:req (req (and (empty? (filter #(= "Agenda" (:type %)) (:hosted card)))
-                                (is-type? (:card (first (get-in @state [side :prompt]))) "Agenda")))
-                 :label "Host an agenda being accessed"
-                 :effect (req (when-let [agenda (:card (first (get-in @state [side :prompt])))]
-                                (host state side card (move state side agenda :play-area))
-                                (trigger-event state side :no-steal agenda)
-                                (close-access-prompt state side)
-                                (effect-completed state side eid nil)
-                                (when-not (:run @state)
-                                  (swap! state dissoc :access))))
-                 :msg (msg "host " (:title (:card (first (get-in @state [side :prompt])))) " instead of accessing it")}
-                {:cost [:click 2] :label "Add hosted agenda to your score area"
-                 :req (req (not (empty? (:hosted card))))
-                 :effect (req (let [c (move state :runner (get-agenda card) :scored)]
-                                (gain-agenda-point state :runner (get-agenda-points state :runner c))))
-                 :msg (msg (let [c (get-agenda card)]
-                             (str "add " (:title c) " to their score area and gain " (get-agenda-points state :runner c)
-                                  " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]})
+     {:implementation "Use hosting ability when presented with Access prompt for an agenda"
+      :abilities [{:req (req (and (empty? (filter #(= "Agenda" (:type %)) (:hosted card)))
+                                  (not (:psi @state)) ; hack for The Future Perfect
+                                  (is-type? (:card (first (get-in @state [side :prompt]))) "Agenda")))
+                   :label "Host an agenda being accessed"
+                   :effect (req (when-let [agenda (:card (first (get-in @state [side :prompt])))]
+                                  (host state side card (move state side agenda :play-area))
+                                  (trigger-event state side :no-steal agenda)
+                                  (close-access-prompt state side)
+                                  (effect-completed state side eid nil)
+                                  (when-not (:run @state)
+                                    (swap! state dissoc :access))))
+                   :msg (msg "host " (:title (:card (first (get-in @state [side :prompt])))) " instead of accessing it")}
+                  {:cost [:click 2] :label "Add hosted agenda to your score area"
+                   :req (req (not (empty? (:hosted card))))
+                   :effect (req (let [c (move state :runner (get-agenda card) :scored)]
+                                  (gain-agenda-point state :runner (get-agenda-points state :runner c))))
+                   :msg (msg (let [c (get-agenda card)]
+                               (str "add " (:title c) " to their score area and gain " (get-agenda-points state :runner c)
+                                    " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]})
 
    "Find the Truth"
    {:events {:post-runner-draw {:msg (msg "reveal that they drew: "

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -738,18 +738,20 @@
       :effect (req (swap! state assoc-in [:damage :damage-replace] true)
                    (damage-defer state side :net (last targets))
                    (show-wait-prompt state :runner "Corp to use Tori Hanzō")
-                   (resolve-ability state side
+                   (continue-ability state side
                      {:optional {:prompt (str "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?") :player :corp
-                                 :delayed-completion true
-                                 :yes-ability {:msg "do 1 brain damage instead of net damage"
+                                 :yes-ability {:delayed-completion true
+                                               :msg "do 1 brain damage instead of net damage"
                                                :effect (req (swap! state update-in [:damage] dissoc :damage-replace :defer-damage)
                                                             (clear-wait-prompt state :runner)
                                                             (pay state :corp card :credit 2)
-                                                            (damage state side eid :brain 1 {:card card}))}
-                                 :no-ability {:effect (req (swap! state update-in [:damage] dissoc :damage-replace)
+                                                            (when-completed (damage state side :brain 1 {:card card})
+                                                                            (do (swap! state assoc-in [:damage :damage-replace] true)
+                                                                                (effect-completed state side eid))))}
+                                 :no-ability {:delayed-completion true
+                                              :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
                                                            (clear-wait-prompt state :runner)
-                                                           (damage state side eid :net (get-defer-damage state side :net nil)
-                                                                   {:card card}))}}} card nil))}
+                                                           (effect-completed state side eid))}}} card nil))}
      :prevented-damage {:req (req (and this-server (= target :net) (> (last targets) 0)))
                         :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}}}
 

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -1101,6 +1101,38 @@
       (is (= 2 (count (:discard (get-runner)))) "1 brain damage suffered")
       (is (= 1 (:brain-damage (get-runner)))))))
 
+(deftest tori-hanzo-hokusai
+  ;; Tori Hanzō + Hokusai Grid: Issue #2702
+  (do-game
+    (new-game (default-corp [(qty "Tori Hanzō" 1) (qty "Hokusai Grid" 1)])
+              (default-runner))
+    (core/gain state :corp :credit 5)
+    (play-from-hand state :corp "Hokusai Grid" "Archives")
+    (play-from-hand state :corp "Tori Hanzō" "Archives")
+    (take-credits state :corp)
+    (run-on state "Archives")
+    (let [hg (get-content state :archives 0)
+          tori (get-content state :archives 1)]
+      (core/rez state :corp hg)
+      (core/rez state :corp tori)
+      (run-successful state)
+      (prompt-choice :corp "No") ; Tori prompt to pay 2c to replace 1 net with 1 brain
+      (is (= 1 (count (:discard (get-runner)))) "1 net damage suffered")
+      (prompt-choice :runner "Hokusai Grid")
+      (prompt-choice :runner "No")
+      (prompt-choice :runner "Tori Hanzō")
+      (prompt-choice :runner "No")
+      (is (and (empty (:prompt (get-runner))) (not (:run @state))) "No prompts, run ended")
+      (run-empty-server state "Archives")
+      (prompt-choice :corp "Yes") ; Tori prompt to pay 2c to replace 1 net with 1 brain
+      (is (= 2 (count (:discard (get-runner)))))
+      (is (= 1 (:brain-damage (get-runner))) "1 brain damage suffered")
+      (prompt-choice :runner "Hokusai Grid")
+      (prompt-choice :runner "No")
+      (prompt-choice :runner "Tori Hanzō")
+      (prompt-choice :runner "No")
+      (is (and (empty (:prompt (get-runner))) (not (:run @state))) "No prompts, run ended"))))
+
 (deftest underway-grid
   ;; Underway Grid - prevent expose of cards in server
   (do-game


### PR DESCRIPTION
Fix #2702, crucially with a test this time. This card is beyond idiotic and I have no more to say about it than that. 

Also re-work Independent Thinking to complete all trashing before drawing new cards (fixes an interaction with Tri-maf Contact for janky self-damaging Vanadis Armory decks). 