### PR TITLE
Titanium Ribs, The Cleaners fix

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -987,7 +987,9 @@
              :effect (effect (tag-runner :runner eid 1))}}
 
    "The Cleaners"
-   {:events {:pre-damage {:req (req (= target :meat)) :msg "do 1 additional meat damage"
+   {:events {:pre-damage {:req (req (and (= target :meat)
+                                         (= side :corp)))
+                          :msg "do 1 additional meat damage"
                           :effect (effect (damage-bonus :meat 1))}}}
 
    "The Future is Now"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -956,7 +956,7 @@
     :delayed-completion true
     :effect (effect (enable-runner-damage-choice)
                     (system-msg (str "suffers 2 meat damage from installing Titanium Ribs"))
-                    (damage eid :meat 2 {:card card}))
+                    (damage eid :meat 2 {:unboostable true :card card}))
     :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-runner))}
 
    "Top Hat"

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -912,6 +912,17 @@
       (play-from-hand state :corp "Scorched Earth")
       (is (= 0 (count (:hand (get-runner)))) "5 damage dealt to Runner"))))
 
+(deftest the-cleaners-cybernetics
+  ;; The Cleaners - No bonus damage when runner "suffers" damage
+  (do-game
+    (new-game (default-corp [(qty "The Cleaners" 1)])
+              (default-runner [(qty "Respirocytes" 3)]))
+    (play-from-hand state :corp "The Cleaners" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Respirocytes")
+    (is (= 1 (count (:hand (get-runner)))) "Only 1 damage dealt to Runner from Cybernetics")))
+
 (deftest the-future-perfect
   ;; The Future Perfect - cannot steal on failed psi game (if not installed)
   (do-game

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -187,13 +187,13 @@
   [state content]
   (not (nil?
          (re-find (re-pattern content)
-                     (get (last (get-in @state [:log])) :text)))))
+                  (get (last (get @state :log)) :text)))))
 
 (defn second-last-log-contains?
   [state content]
   (not (nil?
          (re-find (re-pattern content)
-                  (get (last (butlast (get-in @state [:log]))) :text)))))
+                  (get (last (butlast (get @state :log))) :text)))))
 
 (defn trash-from-hand
   "Trash specified card from hand of specified side"


### PR DESCRIPTION
Fixes the Titanium Ribs extra damage issue and removes The Cleaners messages from other runner sources of Meat Damage.

Adding `:unboostable` should no longer be necessary as The Cleaners will only trigger from Corp source of damage now.