### PR TITLE
Add ability to block users

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -522,10 +522,12 @@ app.post '/reset/:token', (req, res) ->
 app.post '/update-profile', (req, res) ->
   if req.user
     db.collection('users').update {username: req.user.username}, {$set: {options: {background: req.body.background,\
-      'show-alt-art': req.body['show-alt-art']}}}, \
+      'show-alt-art': req.body['show-alt-art'], 'blocked-users': req.body['blocked-users']}}}, \
       (err) ->
         console.log(err) if err
-        res.status(200).send({message: 'OK', background: req.body.background, altarts: req.body['alt-arts']})
+        res.status(200).send({message: 'OK', background: req.body.background, \
+          altarts: req.body['alt-arts'], \
+          blockedusers: req.body['blocked-users']})
   else
     res.status(401).send({message: 'Unauthorized'})
 

--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -3,6 +3,8 @@
   (:require [om.core :as om :include-macros true]
             [sablono.core :as sab :include-macros true]
             [cljs.core.async :refer [chan put!] :as async]
+            [clojure.string :as s]
+            [goog.dom :as gdom]
             [netrunner.auth :refer [authenticated avatar] :as auth]
             [netrunner.appstate :refer [app-state]]
             [netrunner.ajax :refer [POST GET]]
@@ -24,6 +26,7 @@
   (swap! app-state assoc-in [:options :background] (om/get-state owner :background))
   (swap! app-state assoc-in [:options :show-alt-art] (om/get-state owner :show-alt-art))
   (swap! app-state assoc-in [:options :sounds-volume] (om/get-state owner :volume))
+  (swap! app-state assoc-in [:options :blocked-users] (om/get-state owner :blocked-users))
   (.setItem js/localStorage "sounds" (om/get-state owner :sounds))
   (.setItem js/localStorage "sounds_volume" (om/get-state owner :volume))
 
@@ -36,6 +39,25 @@
               421 (om/set-state! owner :flash-message "No account with that email address exists")
               :else (om/set-state! owner :flash-message "Profile updated - Please refresh your browser")))))))
 
+(defn add-user-to-block-list
+  [owner]
+  (let [blocked-user-node (om/get-node owner "block-user-input")
+        blocked-user (.-value blocked-user-node)
+        current-blocked-list (om/get-state owner :blocked-users)]
+    (set! (.-value blocked-user-node) "")
+    (when (and (not (s/blank? blocked-user))
+               (= -1 (.indexOf current-blocked-list blocked-user)))
+      (om/set-state! owner :blocked-users (conj current-blocked-list blocked-user)))))
+
+(defn remove-user-from-block-list
+  [evt owner]
+  (let [currElt (.-currentTarget evt)
+        next-sib (gdom/getNextElementSibling currElt)
+        user-name (gdom/getTextContent next-sib)
+        current-blocked-list (om/get-state owner :blocked-users)]
+    (when user-name
+      (om/set-state! owner :blocked-users (vec (remove #(= % user-name) current-blocked-list))))))
+
 (defn account-view [user owner]
   (reify
     om/IInitState
@@ -46,7 +68,8 @@
       (om/set-state! owner :background (get-in @app-state [:options :background]))
       (om/set-state! owner :sounds (get-in @app-state [:options :sounds]))
       (om/set-state! owner :show-alt-art (get-in @app-state [:options :show-alt-art]))
-      (om/set-state! owner :volume (get-in @app-state [:options :sounds-volume])))
+      (om/set-state! owner :volume (get-in @app-state [:options :sounds-volume]))
+      (om/set-state! owner :blocked-users (sort (get-in @app-state [:options :blocked-users] []))))
 
     om/IRenderState
     (render-state [this state]
@@ -103,6 +126,26 @@
                                :checked (om/get-state owner :show-alt-art)
                                :on-change #(om/set-state! owner :show-alt-art (.. % -target -checked))}]
                "Show alternate card arts"]]]
+
+            [:section
+             [:h3 "Blocked users"]
+             [:div
+              [:input.search {:on-key-down (fn [e]
+                                             (when (= e.keyCode 13)
+                                               (do
+                                                 (add-user-to-block-list owner)
+                                                 (.preventDefault e))))
+                              :ref "block-user-input"
+                              :type "text" :placeholder "User name"}]
+              [:button.block-user-btn {:type "button"
+                                       :name "block-user-button"
+                                       :on-click #(add-user-to-block-list owner)}
+               "Block user"]]
+             (for [bu (om/get-state owner :blocked-users)]
+               [:div.line
+                [:button.small.unblock-user {:type "button"
+                                             :on-click #(remove-user-from-block-list % owner)} "X" ]
+                [:span.blocked-user-name (str "  " bu)]])]
 
             [:p
              [:button "Update Profile"]

--- a/src/cljs/netrunner/main.cljs
+++ b/src/cljs/netrunner/main.cljs
@@ -47,7 +47,7 @@
    (sab/html
     [:div
      [:div.float-right
-      (let [c (count (:games cursor))]
+      (let [c (count (gamelobby/filter-blocked-games (:user cursor) (:games cursor)))]
         (str c " Game" (when (not= c 1) "s")))]
      (if-let [game (some #(when (= (:gameid cursor) (:gameid %)) %) (:games cursor))]
        (when (:started game)


### PR DESCRIPTION
There are a few changes here to allow you to filter out unwanted attention from other users.

1. A UI update to the Account page which allows you to add a username to your Block List and remove names from the list. It could use some UI help, but I'm at the limit of my CSS knowledge.

2. Client side filtering of messages from blocked users in the main Chat window

3. Server side check if any of the players in a game have a user on the blocked list on a `join` or `watch` request.

4. Client side filtering of the games lobby to both hide games from users on your blocked list and hide their games from you.

Updating the list requires you to submit an update on your Account page and refresh the browser. It appear that we push `user` info only on initial connection.