### PR TITLE
Rebase of #2116.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(def trash-program {:prompt "Choose a program to trash"
+(def trash-program {:prompt "Select a program to trash"
                     :label "Trash a program"
                     :msg (msg "trash " (:title target))
                     :choices {:req #(and (installed? %)
@@ -8,21 +8,21 @@
                     :effect (effect (trash target {:cause :subroutine})
                                     (clear-wait-prompt :runner))})
 
-(def trash-hardware {:prompt "Choose a piece of hardware to trash"
+(def trash-hardware {:prompt "Select a piece of hardware to trash"
                      :label "Trash a piece of hardware"
                      :msg (msg "trash " (:title target))
                      :choices {:req #(and (installed? %)
                                           (is-type? % "Hardware"))}
                      :effect (effect (trash target {:cause :subroutine}))})
 
-(def trash-resource-sub {:prompt "Choose a resource to trash"
+(def trash-resource-sub {:prompt "Select a resource to trash"
                          :label "Trash a resource"
                          :msg (msg "trash " (:title target))
                          :choices {:req #(and (installed? %)
                                               (is-type? % "Resource"))}
                          :effect (effect (trash target {:cause :subroutine}))})
 
-(def trash-installed {:prompt "Choose an installed card to trash"
+(def trash-installed {:prompt "Select an installed card to trash"
                       :player :runner
                       :label "Force the Runner to trash an installed card"
                       :msg (msg "force the Runner to trash " (:title target))
@@ -47,7 +47,7 @@
 
   ([reorder_side wait_side remaining chosen n original] (reorder-choice reorder_side wait_side remaining chosen n original nil))
   ([reorder_side wait_side remaining chosen n original dest]
-  {:prompt (str "Choose a card to move next "
+  {:prompt (str "Select a card to move next "
                 (if (= dest "bottom") "under " "onto ")
                 (if (= reorder_side :corp) "R&D" "your Stack"))
    :choices remaining

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -35,58 +35,59 @@
   triggers"
   {:effect (req (toast state :corp "Reminder: You have unrezzed cards with \"when turn begins\" abilities." "info"))})
 
-(declare reorder-final) ;forward reference since reorder-choice and reorder-final are mutually recursive
+(declare reorder-final) ; forward reference since reorder-choice and reorder-final are mutually recursive
+
 (defn reorder-choice
   "Generates a recursive prompt structure for cards that do reordering (Indexing, Making an Entrance, etc.)
 
-  reorder_side is the side to be reordered, i.e. :corp for Indexing and Precognition.
-  wait_side is the side that has a wait prompt while ordering is in progress, i.e. :corp for Indexing and Spy Camera.
+  reorder-side is the side to be reordered, i.e. :corp for Indexing and Precognition.
+  wait-side is the side that has a wait prompt while ordering is in progress, i.e. :corp for Indexing and Spy Camera.
 
   This is part 1 - the player keeps choosing cards until there are no more available choices. A wait prompt should
   exist before calling this function. See Indexing and Making an Entrance for examples on how to call this function."
 
-  ([reorder_side wait_side remaining chosen n original] (reorder-choice reorder_side wait_side remaining chosen n original nil))
-  ([reorder_side wait_side remaining chosen n original dest]
+  ([reorder-side wait-side remaining chosen n original] (reorder-choice reorder-side wait-side remaining chosen n original nil))
+  ([reorder-side wait-side remaining chosen n original dest]
   {:prompt (str "Select a card to move next "
                 (if (= dest "bottom") "under " "onto ")
-                (if (= reorder_side :corp) "R&D" "your Stack"))
+                (if (= reorder-side :corp) "R&D" "your Stack"))
    :choices remaining
    :delayed-completion true
    :effect (req (let [chosen (cons target chosen)]
                   (if (< (count chosen) n)
-                    (continue-ability state side (reorder-choice reorder_side wait_side (remove-once #(not= target %) remaining)
+                    (continue-ability state side (reorder-choice reorder-side wait-side (remove-once #(not= target %) remaining)
                                                                  chosen n original dest) card nil)
-                    (continue-ability state side (reorder-final reorder_side wait_side chosen original dest) card nil))))}))
+                    (continue-ability state side (reorder-final reorder-side wait-side chosen original dest) card nil))))}))
 
 (defn- reorder-final
   "Generates a recursive prompt structure for cards that do reordering (Indexing, Making an Entrance, etc.)
   This is part 2 - the player is asked for final confirmation of the reorder and is provided an opportunity to start over."
 
-  ([reorder_side wait_side chosen original] (reorder-final reorder_side wait_side chosen original nil))
-  ([reorder_side wait_side chosen original dest]
+  ([reorder-side wait-side chosen original] (reorder-final reorder-side wait-side chosen original nil))
+  ([reorder-side wait-side chosen original dest]
    {:prompt (if (= dest "bottom")
-              (str "The bottom cards of " (if (= reorder_side :corp) "R&D" "your Stack")
+              (str "The bottom cards of " (if (= reorder-side :corp) "R&D" "your Stack")
                    " will be " (join  ", " (map :title (reverse chosen))) ".")
-              (str "The top cards of " (if (= reorder_side :corp) "R&D" "your Stack")
+              (str "The top cards of " (if (= reorder-side :corp) "R&D" "your Stack")
                    " will be " (join  ", " (map :title chosen)) "."))
    :choices ["Done" "Start over"]
    :delayed-completion true
    :effect (req
              (cond
                (and (= dest "bottom") (= target "Done"))
-               (do (swap! state update-in [reorder_side :deck]
+               (do (swap! state update-in [reorder-side :deck]
                           #(vec (concat (drop (count chosen) %) (reverse chosen))))
-                   (clear-wait-prompt state wait_side)
+                   (clear-wait-prompt state wait-side)
                    (effect-completed state side eid card))
 
                (= target "Done")
-               (do (swap! state update-in [reorder_side :deck]
+               (do (swap! state update-in [reorder-side :deck]
                           #(vec (concat chosen (drop (count chosen) %))))
-                   (clear-wait-prompt state wait_side)
+                   (clear-wait-prompt state wait-side)
                    (effect-completed state side eid card))
 
                :else
-               (continue-ability state side (reorder-choice reorder_side wait_side original '() (count original) original dest) card nil)))}))
+               (continue-ability state side (reorder-choice reorder-side wait-side original '() (count original) original dest) card nil)))}))
 
 (defn swap-ice
   "Swaps two pieces of ICE."

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -2,8 +2,22 @@
 
 (declare is-scored?)
 
-(def cards-agendas
+(defn ice-boost-agenda [subtype]
+  (letfn [(count-ice [corp]
+            (reduce (fn [c server]
+                      (+ c (count (filter #(and (has-subtype? % subtype)
+                                                (rezzed? %))
+                                          (:ices server)))))
+                    0 (flatten (seq (:servers corp)))))]
+    {:msg (msg "gain " (count-ice corp) " [Credits]")
+     :interactive (req true)
+     :effect (effect (gain :credit (count-ice corp))
+                     (update-all-ice))
+     :swapped {:effect (req (update-all-ice state side))}
+     :events {:pre-ice-strength {:req (req (has-subtype? target subtype))
+                                 :effect (effect (ice-strength-bonus 1 target))}}}))
 
+(def cards-agendas
   {"15 Minutes"
    {:abilities [{:cost [:click 1] :msg "shuffle 15 Minutes into R&D"
                  :label "Shuffle 15 Minutes into R&D"
@@ -313,19 +327,7 @@
                  :msg "gain [Click][Click]"}]}
 
    "Encrypted Portals"
-   (letfn [(count-code-gates [corp]
-             (reduce (fn [c server]
-                       (+ c (count (filter #(and (has-subtype? % "Code Gate")
-                                                 (rezzed? %))
-                                           (:ices server)))))
-                     0 (flatten (seq (:servers corp)))))]
-     {:msg (msg "gain " (count-code-gates corp) " [Credits] for rezzed code gates")
-      :interactive (req true)
-      :effect (effect (gain :credit (count-code-gates corp))
-                      (update-all-ice))
-      :swapped {:effect (req (update-all-ice state side))}
-      :events {:pre-ice-strength {:req (req (has-subtype? target "Code Gate"))
-                                  :effect (effect (ice-strength-bonus 1 target))}}})
+   (ice-boost-agenda "Code Gate")
 
    "Escalate Vitriol"
    {:abilities [{:label "Gain 1 [Credit] for each Runner tag"
@@ -965,21 +967,7 @@
                      (continue-ability state side (sft 1 max) card nil)))})
 
    "Superior Cyberwalls"
-   {:interactive (req true)
-    :msg (msg "gain " (reduce (fn [c server]
-                                (+ c (count (filter (fn [ice] (and (has? ice :subtype "Barrier")
-                                                                   (:rezzed ice))) (:ices server)))))
-                              0 (flatten (seq (:servers corp))))
-              " [Credits]")
-    :effect (req (do (gain state :corp :credit
-                           (reduce (fn [c server]
-                                     (+ c (count (filter #(and (has-subtype? % "Barrier")
-                                                               (rezzed? %)) (:ices server)))))
-                                   0 (flatten (seq (:servers corp)))))
-                     (update-all-ice state side)))
-    :swapped {:effect (req (update-all-ice state side))}
-    :events {:pre-ice-strength {:req (req (has? target :subtype "Barrier"))
-                                :effect (effect (ice-strength-bonus 1 target))}}}
+   (ice-boost-agenda "Barrier")
 
    "TGTBT"
    {:access {:msg "give the Runner 1 tag"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -255,28 +255,23 @@
                                                                  (effect-completed state side eid))}}}}})
 
    "Director Haas Pet Project"
-   (let [dhelper (fn dpp [n] {:prompt "Select a card to install"
-                              :show-discard true
-                              :choices {:req #(and (= (:side %) "Corp")
-                                                   (not (is-type? % "Operation"))
-                                                   (#{[:hand] [:discard]} (:zone %)))}
-                              :effect (req (corp-install state side target
-                                                         (last (get-remote-names @state))
-                                                         {:no-install-cost true})
-                                           (if (< n 2)
-                                             (continue-ability state side (dpp (inc n)) card nil)
-                                             (effect-completed state side eid card)))
-                              :msg (msg (corp-install-msg target))})]
-     {:optional {:prompt "Create a new remote server?"
-                 :yes-ability {:prompt "Select a card to install"
-                               :show-discard true
-                               :choices {:req #(and (= (:side %) "Corp")
-                                                    (not (is-type? % "Operation"))
-                                                    (#{[:hand] [:discard]} (:zone %)))}
-                               :effect (req (corp-install state side target "New remote"
-                                                          {:no-install-cost true})
-                                            (continue-ability state side (dhelper 1) card nil))
-                               :msg "create a new remote server, installing cards at no cost"}}})
+   (letfn [(install-ability [server-name n]
+             {:prompt "Select a card to install"
+              :show-discard true
+              :choices {:req #(and (= (:side %) "Corp")
+                                   (not (is-type? % "Operation"))
+                                   (#{[:hand] [:discard]} (:zone %)))}
+              :effect (req (corp-install state side target server-name {:no-install-cost true})
+                           (if (< n 2)
+                             (continue-ability state side
+                                               (install-ability (last (get-remote-names @state)) (inc n))
+                                               card nil)
+                             (effect-completed state side eid card)))
+              :msg (msg (if (pos? n)
+                          (corp-install-msg target)
+                          "create a new remote server, installing cards from HQ or Archives, ignoring all install costs"))})]
+     {:optional {:prompt "Install cards in a new remote server?"
+                 :yes-ability (install-ability "New remote" 0)}})
 
    "Domestic Sleepers"
    {:agendapoints-runner (req (do 0))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -779,7 +779,8 @@
                                 (rezzed? current-ice)
                                 (has-subtype? current-ice "Bioroid")))
                  :counter-cost [:agenda 1]
-                 :msg "make the approached piece of bioroid ICE gain \"[Subroutine] End the run\" after all its other subroutines for the remainder of the run"}]}
+                 :msg (str "make the approached piece of Bioroid ICE gain \"[Subroutine] End the run\""
+                           "after all its other subroutines for the remainder of this run")}]}
 
    "Puppet Master"
    {:events {:successful-run

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -714,8 +714,7 @@
 
    "Project Ares"
    (letfn [(trash-count-str [card]
-             (str (- (:advance-counter card) 4) " installed card"
-                  (when (> (- (:advance-counter card) 4) 1) "s")))]
+             (quantify (- (:advance-counter card) 4) "installed card"))]
      {:silent (req true)
       :req (req (and (> (:advance-counter card) 4)
                      (pos? (count (all-installed state :runner)))))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -710,23 +710,27 @@
                                 :bad-publicity (Integer/parseInt target)))}
 
    "Project Ares"
-   {:silent (req true)
-    :req (req (and (> (:advance-counter card) 4) (pos? (count (all-installed state :runner)))))
-    :msg (msg (str "force the Runner to trash " (- (:advance-counter card) 4)
-                   " installed card" (when (> (- (:advance-counter card) 4) 1) "s")
-                   " and take 1 bad publicity"))
-    :delayed-completion true
-    :effect (req (show-wait-prompt state :corp "Runner to trash installed cards")
-                 (continue-ability
-                   state :runner
-                   {:prompt (msg "Choose " (- (:advance-counter card) 4) " installed card"
-                                 (when (> (- (:advance-counter card) 4) 1) "s") " to trash")
-                    :choices {:req #(and (:installed %) (= (:side %) "Runner"))
-                              :max (min (- (:advance-counter card) 4) (count (all-installed state :runner)))}
-                    :effect (final-effect (trash-cards targets)
-                                          (system-msg (str "trashes " (join ", " (map :title targets))))
-                                          (gain :corp :bad-publicity 1))} card nil)
-                 (clear-wait-prompt state :corp))}
+   (letfn [(trash-count-str [card]
+             (str (- (:advance-counter card) 4) " installed card"
+                  (when (> (- (:advance-counter card) 4) 1) "s")))]
+     {:silent (req true)
+      :req (req (and (> (:advance-counter card) 4)
+                     (pos? (count (all-installed state :runner)))))
+      :msg (msg "force the Runner to trash " (trash-count-str card) " and take 1 bad publicity")
+      :delayed-completion true
+      :effect (effect (show-wait-prompt :corp "Runner to trash installed cards")
+                      (continue-ability
+                       :runner
+                       {:prompt (msg "Select " (trash-count-str card) " installed cards to trash")
+                        :choices {:max (min (- (:advance-counter card) 4)
+                                            (count (all-installed state :runner)))
+                                  :req #(and (= (:side %) "Runner")
+                                             (:installed %))}
+                        :effect (final-effect (trash-cards targets)
+                                              (system-msg (str "trashes " (join ", " (map :title targets))))
+                                              (gain :corp :bad-publicity 1))}
+                       card nil)
+                      (clear-wait-prompt :corp))})
 
    "Project Atlas"
    {:silent (req true)

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -143,7 +143,7 @@
    "Bifrost Array"
    {:req (req (not (empty? (filter #(not= (:title %) "Bifrost Array") (:scored corp)))))
     :optional {:prompt "Trigger the ability of a scored agenda?"
-               :yes-ability {:prompt "Choose an agenda to trigger its \"when scored\" ability"
+               :yes-ability {:prompt "Select an agenda to trigger the \"when scored\" ability of"
                              :choices {:req #(and (is-type? % "Agenda")
                                                   (not= (:title %) "Bifrost Array")
                                                   (= (first (:zone %)) :scored)
@@ -193,7 +193,7 @@
                    (system-msg state side (str "gains " bucks " [Credits] from CFC Excavation Contract"))))}
 
    "Character Assassination"
-   {:prompt "Choose a resource to trash"
+   {:prompt "Select a resource to trash"
     :choices {:req #(and (installed? %)
                          (is-type? % "Resource"))}
     :msg (msg "trash " (:title target))
@@ -427,7 +427,7 @@
 
    "Hades Fragment"
    {:flags {:corp-phase-12 (req (and (not-empty (get-in @state [:corp :discard])) (is-scored? state :corp card)))}
-    :abilities [{:prompt "Choose a card to add to the bottom of R&D"
+    :abilities [{:prompt "Select a card to add to the bottom of R&D"
                  :show-discard true
                  :choices {:req #(and (= (:side %) "Corp") (= (:zone %) [:discard]))}
                  :effect (effect (move target :deck))
@@ -527,11 +527,12 @@
 
    "License Acquisition"
    {:interactive (req true)
-    :prompt "Choose an asset or upgrade to install from Archives or HQ" :show-discard true
-    :msg (msg "install and rez " (:title target))
+    :prompt "Select an asset or upgrade to install from Archives or HQ"
+    :show-discard true
     :choices {:req #(and (#{"Asset" "Upgrade"} (:type %))
                          (#{[:hand] [:discard]} (:zone %))
                          (= (:side %) "Corp"))}
+    :msg (msg "install and rez " (:title target) ", ignoring all costs")
     :effect (effect (corp-install eid target nil {:install-state :rezzed-no-cost}))}
 
    "Mandatory Seed Replacement"
@@ -604,7 +605,7 @@
              {:optional
               {:req (req (= (:cid card) (:cid target)))
                :prompt "Install a card from HQ in a new remote?"
-               :yes-ability {:prompt "Choose a card in HQ to install"
+               :yes-ability {:prompt "Select a card to install"
                              :choices {:req #(and (not (is-type? % "Operation"))
                                                   (not (is-type? % "ICE"))
                                                   (= (:side %) "Corp")
@@ -789,7 +790,8 @@
               :effect (req (show-wait-prompt state :runner "Corp to use Puppet Master")
                            (continue-ability
                              state :corp
-                             {:prompt "Choose a card to place 1 advancement token on with Puppet Master" :player :corp
+                             {:prompt "Select a card to place 1 advancement token on"
+                              :player :corp
                               :choices {:req can-be-advanced?}
                               :cancel-effect (final-effect (clear-wait-prompt :runner))
                               :msg (msg "place 1 advancement token on " (card-str state target))
@@ -876,11 +878,11 @@
     :req (req (not (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp)))))
     :delayed-completion true
     :effect (effect (continue-ability
-                      {:prompt "Choose another installed copy of Research Grant to score"
+                      {:prompt "Select another installed copy of Research Grant to score"
                        :choices {:req #(= (:title %) "Research Grant")}
                        :effect (effect (set-prop target :advance-counter (:advancementcost target))
                                        (score target))
-                       :msg "score another copy of Research Grant"}
+                       :msg "score another installed copy of Research Grant"}
                      card nil))}
 
    "Restructured Datapool"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -313,21 +313,19 @@
                  :msg "gain [Click][Click]"}]}
 
    "Encrypted Portals"
-   {:msg (msg "gain " (reduce (fn [c server]
-                                (+ c (count (filter #(and (has-subtype? % "Code Gate")
-                                                          (rezzed? %)) (:ices server)))))
-                              0 (flatten (seq (:servers corp))))
-              " [Credits]")
-    :interactive (req true)
-    :effect (effect (gain :credit
-                          (reduce (fn [c server]
-                                    (+ c (count (filter #(and (has-subtype? % "Code Gate")
-                                                              (rezzed? %)) (:ices server)))))
-                                  0 (flatten (seq (:servers corp)))))
-                    (update-all-ice))
-    :swapped {:effect (req (update-all-ice state side))}
-    :events {:pre-ice-strength {:req (req (has-subtype? target "Code Gate"))
-                                :effect (effect (ice-strength-bonus 1 target))}}}
+   (letfn [(count-code-gates [corp]
+             (reduce (fn [c server]
+                       (+ c (count (filter #(and (has-subtype? % "Code Gate")
+                                                 (rezzed? %))
+                                           (:ices server)))))
+                     0 (flatten (seq (:servers corp)))))]
+     {:msg (msg "gain " (count-code-gates corp) " [Credits] for rezzed code gates")
+      :interactive (req true)
+      :effect (effect (gain :credit (count-code-gates corp))
+                      (update-all-ice))
+      :swapped {:effect (req (update-all-ice state side))}
+      :events {:pre-ice-strength {:req (req (has-subtype? target "Code Gate"))
+                                  :effect (effect (ice-strength-bonus 1 target))}}})
 
    "Escalate Vitriol"
    {:abilities [{:label "Gain 1 [Credit] for each Runner tag"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -565,7 +565,7 @@
    "Ghost Branch"
    (advance-ambush 0 {:delayed-completion true
                       :req (req (< 0 (:advance-counter (get-card state card) 0)))
-                      :msg (msg "give the Runner " (quantify (:advance-counter (get-card state card) 0) "tag")
+                      :msg (msg "give the Runner " (quantify (:advance-counter (get-card state card) 0) "tag"))
                       :effect (effect (tag-runner :runner eid (:advance-counter (get-card state card) 0)))})
 
    "GRNDL Refinery"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -83,7 +83,7 @@
                                  n (:advance-counter agg 0)
                                  ab (-> trash-program
                                         (assoc-in [:choices :max] n)
-                                        (assoc :prompt (msg "Choose " n " program" (when (> n 1) "s") " to trash")
+                                        (assoc :prompt (msg "Choose " (quantify n "program") " to trash")
                                                :delayed-completion true
                                                :effect (effect (trash-cards eid targets nil))
                                                :msg (msg "trash " (join ", " (map :title targets)))))]
@@ -92,27 +92,27 @@
    "Alexa Belsky"
    {:abilities [{:label "[Trash]: Shuffle all cards in HQ into R&D"
                  :effect (req (trash state side card)
-                              (do (show-wait-prompt state :corp "Runner to decide whether or not to prevent Alexa Belsky")
-                                  (resolve-ability
-                                    state side
-                                    {:prompt "Prevent Alexa Belsky from shuffling back in 1 card for every 2 [Credits] spent. How many credits?"
-                                     :choices :credit :player :runner :priority 2
-                                     :msg (msg "shuffle " (- (count (:hand corp)) (quot target 2)) " card"
-                                               (when-not (= 1 (- (count (:hand corp)) (quot target 2))) "s")
-                                               " in HQ into R&D")
-                                     :effect (req (if (pos? (quot target 2))
-                                                    (do (doseq [c (take (- (count (:hand corp)) (quot target 2))
-                                                                        (shuffle (:hand corp)))]
-                                                          (move state :corp c :deck))
-                                                        (when (pos? (- (count (:hand corp)) (quot target 2)))
-                                                          (shuffle! state :corp :deck))
-                                                        (system-msg state :runner
-                                                                    (str "pays " target " [Credits] to prevent "
-                                                                         (quot target 2) " random card"
-                                                                         (when (> (quot target 2) 1) "s")
-                                                                         " in HQ from being shuffled into R&D")))
-                                                    (shuffle-into-deck state :corp :hand))
-                                                  (clear-wait-prompt state :corp))} card nil)))}]}
+                              (show-wait-prompt state :corp "Runner to decide whether or not to prevent Alexa Belsky")
+                              (resolve-ability
+                                state side
+                                {:prompt "Prevent Alexa Belsky from shuffling back in 1 card for every 2 [Credits] spent. How many credits?"
+                                 :choices :credit
+                                 :player :runner
+                                 :priority 2
+                                 :msg (msg "shuffle " (quantify (- (count (:hand corp)) (quot target 2)) "card")
+                                           " in HQ into R&D")
+                                 :effect (req (if (pos? (quot target 2))
+                                                (let [prevented (quot target 2)
+                                                      unprevented (- (count (:hand corp)) n)]
+                                                  (doseq [c (take unprevented (shuffle (:hand corp)))]
+                                                    (move state :corp c :deck))
+                                                  (when (pos? unprevented) (shuffle! state :corp :deck))
+                                                  (system-msg state :runner
+                                                              (str "pays " target " [Credits] to prevent "
+                                                                   (quantify prevented "random card")
+                                                                   " in HQ from being shuffled into R&D")))
+                                                (shuffle-into-deck state :corp :hand))
+                                              (clear-wait-prompt state :corp))} card nil))}]}
 
    "Alix T4LB07"
    {:events {:corp-install {:effect (effect (add-counter card :power 1))}}
@@ -386,8 +386,8 @@
                                  drawn (get-in @state [:corp :register :most-recent-drawn])]
                              (continue-ability
                                state side
-                               {:prompt (str "Select " dbs " card" (when (> dbs 1) "s") " to add to the bottom of R&D")
-                                :msg (msg "add " dbs " card" (when (> dbs 1) "s") " to the bottom of R&D")
+                               {:prompt (str "Select " (quantify dbs "card") " to add to the bottom of R&D")
+                                :msg (msg "add " (quantify dbs "card") " to the bottom of R&D")
                                 :choices {:max dbs
                                           :req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
                                 :effect (req (doseq [c targets] (move state side c :deck)))} card targets)))}}}
@@ -565,8 +565,7 @@
    "Ghost Branch"
    (advance-ambush 0 {:delayed-completion true
                       :req (req (< 0 (:advance-counter (get-card state card) 0)))
-                      :msg (msg "give the Runner " (:advance-counter (get-card state card) 0) " tag"
-                                (when (> (:advance-counter (get-card state card) 0) 1) "s"))
+                      :msg (msg "give the Runner " (quantify (:advance-counter (get-card state card) 0) "tag")
                       :effect (effect (tag-runner :runner eid (:advance-counter (get-card state card) 0)))})
 
    "GRNDL Refinery"
@@ -901,12 +900,12 @@
                  :once :per-turn
                  :once-key :museum-of-history
                  :msg (msg "shuffle "
-                           (let [seen (filter :seen targets)]
+                           (let [seen (filter :seen targets)
+                                 n (count (filter #(not (:seen %)) targets))]
                              (str (join ", " (map :title seen))
-                                  (let [n (count (filter #(not (:seen %)) targets))]
-                                    (when (pos? n)
-                                      (str (when-not (empty? seen) " and ") n " card"
-                                           (when (> n 1) "s"))))))
+                                  (when (pos? n)
+                                    (str (when-not (empty? seen) " and ")
+                                         (quantify n "card")))))
                            " into R&D")
                  :effect (req (doseq [c targets] (move state side c :deck))
                               (shuffle! state side :deck))}]}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -503,16 +503,16 @@
                               :effect (effect (update! (dissoc card :ebc-rezzed)))}}}
 
    "Executive Search Firm"
-   {:abilities [{:prompt "Choose an executive, sysop, or character to add to HQ"
+   {:abilities [{:prompt "Choose an Executive, Sysop, or Character to add to HQ"
                  :msg (msg "add " (:title target) " to HQ and shuffle R&D")
-                 :activatemsg "searches R&D for an executive, sysop, or character"
+                 :activatemsg "searches R&D for an Executive, Sysop, or Character"
                  :choices (req (cancellable (filter #(or (has-subtype? % "Executive")
                                                          (has-subtype? % "Sysop")
                                                          (has-subtype? % "Character"))
                                                     (:deck corp))
                                             :sorted))
                  :cost [:click 1]
-                 :label "Search R&D for an executive, sysop, or character"
+                 :label "Search R&D for an Executive, Sysop, or Character"
                  :effect (effect (move target :hand) (shuffle! :deck))}]}
 
    "Exposé"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -67,7 +67,7 @@
     :abilities [{:label "[Trash]: Install a non-agenda card from HQ"
                  :effect (effect (trash card) (corp-install target nil))
                  :msg (msg (corp-install-msg target))
-                 :prompt "Choose a non-agenda card to install from HQ"
+                 :prompt "Select a non-agenda card to install from HQ"
                  :priority true
                  :req (req (not (:run @state)))
                  :choices {:req #(and (not (is-type? % "Operation"))
@@ -174,7 +174,7 @@
    {:implementation "Timing restriction of ability use not enforced"
     :abilities [{:label "[Trash]: Install 1 card, paying all costs"
                  :req (req (= (:active-player @state) :corp))
-                 :prompt "Choose a card in HQ to install"
+                 :prompt "Select a card in HQ to install"
                  :choices {:req #(and (not (is-type? % "Operation"))
                                       (in-hand? %)
                                       (= (:side %) "Corp"))}
@@ -266,7 +266,7 @@
     :flags {:corp-phase-12 (req (and (some #(is-type? % "Operation") (:discard corp))
                                      unprotected))}
     :abilities [{:label "Add 1 operation from Archives to HQ"
-                 :prompt "Choose an operation in Archives to add to HQ" :show-discard true
+                 :prompt "Select an operation in Archives to add to HQ" :show-discard true
                  :choices {:req #(and (is-type? % "Operation")
                                       (= (:zone %) [:discard]))}
                  :effect (effect (move target :hand)) :once :per-turn
@@ -356,7 +356,7 @@
     :flags {:corp-phase-12 (req (and (pos? (count (filter #(card-is? % :type "Resource") (all-installed state :runner))))
                                      (:rezzed card)))}
     :abilities [{:label "Trash a resource"
-                 :prompt "Choose a resource to trash with Corporate Town"
+                 :prompt "Select a resource to trash with Corporate Town"
                  :once :per-turn
                  :choices {:req #(is-type? % "Resource")}
                  :msg (msg "trash " (:title target))
@@ -386,7 +386,7 @@
                                  drawn (get-in @state [:corp :register :most-recent-drawn])]
                              (continue-ability
                                state side
-                               {:prompt (str "Choose " dbs " card" (when (> dbs 1) "s") " to add to the bottom of R&D")
+                               {:prompt (str "Select " dbs " card" (when (> dbs 1) "s") " to add to the bottom of R&D")
                                 :msg (msg "add " dbs " card" (when (> dbs 1) "s") " to the bottom of R&D")
                                 :choices {:max dbs
                                           :req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
@@ -533,7 +533,7 @@
     :abilities [{:label "Install an asset or agenda on Full Immersion RecStudio"
                  :req (req (< (count (:hosted card)) 2))
                  :cost [:click 1]
-                 :prompt "Choose an asset or agenda to install"
+                 :prompt "Select an asset or agenda to install"
                  :choices {:req #(and (or (is-type? % "Asset") (is-type? % "Agenda"))
                                       (in-hand? %)
                                       (= (:side %) "Corp"))}
@@ -541,7 +541,7 @@
                  :effect (req (corp-install state side target card))}
                 {:label "Install a previously-installed asset or agenda on Full Immersion RecStudio (fixes only)"
                  :req (req (< (count (:hosted card)) 2))
-                 :prompt "Choose an installed asset or agenda to host on Full Immersion RecStudio"
+                 :prompt "Select an installed asset or agenda to host on Full Immersion RecStudio"
                  :choices {:req #(and (or (is-type? % "Asset") (is-type? % "Agenda"))
                                       (installed? %)
                                       (= (:side %) "Corp"))}
@@ -709,7 +709,7 @@
                  :effect (req (let [c (get-in card [:counter :power])]
                                 (resolve-ability
                                   state side
-                                  {:prompt "Choose an agenda in HQ to reveal"
+                                  {:prompt "Select an agenda in HQ to reveal"
                                    :choices {:req #(and (is-type? % "Agenda")
                                                         (>= c (:agendapoints %)))}
                                    :msg (msg "reveal " (:title target) " from HQ")
@@ -881,7 +881,7 @@
                  :req (req (and (> (get card :advance-counter 0) 0)
                                 (some #(rezzed? %) (all-installed state :corp))))
                  :label "Move an advancement token to a faceup card"
-                 :prompt "Choose a faceup card"
+                 :prompt "Select a faceup card"
                  :choices {:req #(rezzed? %)}
                  :msg (msg "move an advancement token to " (card-str state target))
                  :effect (effect (add-prop card :advance-counter -1 {:placed true})
@@ -892,7 +892,7 @@
     :flags {:corp-phase-12 (req (pos? (count (get-in @state [:corp :discard]))))}
     :abilities [{:label "Shuffle cards in Archives into R&D"
                  :prompt (msg (let [mus (count (filter #(and (= "10019" (:code %)) (rezzed? %)) (all-installed state :corp)))]
-                                (str "Choose " (if (< 1 mus) (str mus " cards") "a card")
+                                (str "Select " (if (< 1 mus) (str mus " cards") "a card")
                                      " in Archives to shuffle into R&D")))
                  :choices {:req #(and (card-is? % :side :corp) (= (:zone %) [:discard]))
                            :max (req (count (filter #(and (= "10019" (:code %)) (rezzed? %)) (all-installed state :corp))))}
@@ -1021,11 +1021,11 @@
     0
     {:req (req (pos? (:advance-counter (get-card state card) 0)))
      :effect
-     (req (show-wait-prompt state :runner "Corp to choose an agenda to score with Plan B")
+     (req (show-wait-prompt state :runner "Corp to select an agenda to score with Plan B")
           (doseq [ag (filter #(is-type? % "Agenda") (get-in @state [:corp :hand]))]
             (update-advancement-cost state side ag))
           (resolve-ability state side
-            {:prompt "Choose an Agenda in HQ to score"
+            {:prompt "Select an Agenda in HQ to score"
              :choices {:req #(and (is-type? % "Agenda")
                                   (<= (:current-cost %) (:advance-counter (get-card state card) 0))
                                   (in-hand? %))}
@@ -1099,7 +1099,7 @@
                              (as-agenda state :corp (dissoc card :counter) 1)))} }}
 
    "Quarantine System"
-   (letfn [(rez-ice [cnt ap] {:prompt "Choose an ICE to rez"
+   (letfn [(rez-ice [cnt ap] {:prompt "Select an ICE to rez"
                               :delayed-completion true
                               :choices {:req #(and (ice? %) (complement rezzed?))}
                               :msg (msg "rez " (:title target))
@@ -1239,7 +1239,7 @@
                  :msg "draw 3 cards"
                  :effect (effect (draw 3)
                                  (resolve-ability
-                                   {:prompt "Choose a card in HQ to add to the bottom of R&D"
+                                   {:prompt "Select a card in HQ to add to the bottom of R&D"
                                     :choices {:req #(and (= (:side %) "Corp")
                                                          (in-hand? %))}
                                     :msg "add 1 card from HQ to the bottom of R&D"
@@ -1282,7 +1282,7 @@
                                          state side
                                          (-> trash-hardware
                                              (assoc-in [:choices :max] (:advance-counter shat))
-                                             (assoc :prompt (msg "Choose " (:advance-counter shat) " pieces of hardware to trash")
+                                             (assoc :prompt (msg "Select " (:advance-counter shat) " pieces of hardware to trash")
                                                     :effect (effect (trash-cards targets))
                                                     :msg (msg "trash " (join ", " (map :title targets)))))
                                         shat nil))))})
@@ -1374,7 +1374,7 @@
 
    "Team Sponsorship"
    {:events {:agenda-scored {:label "Install a card from Archives or HQ"
-                             :prompt "Choose a card from Archives or HQ to install"
+                             :prompt "Select a card from Archives or HQ to install"
                              :show-discard true
                              :interactive (req true)
                              :delayed-completion true
@@ -1438,7 +1438,7 @@
    "Toshiyuki Sakai"
    (advance-ambush 0
     {:effect (effect (resolve-ability
-                       {:prompt "Choose an asset or agenda in HQ"
+                       {:prompt "Select an asset or agenda in HQ"
                         :choices {:req #(and (or (is-type? % "Agenda")
                                                  (is-type? % "Asset"))
                                              (in-hand? %))}
@@ -1498,7 +1498,7 @@
                                                  :effect (effect (trash target))}
                                                card nil)
                                               (continue-ability state side
-                                                {:prompt "Choose a card in Archives to add to the bottom of R&D"
+                                                {:prompt "Select a card in Archives to add to the bottom of R&D"
                                                  :show-discard true
                                                  :choices {:req #(and (in-discard? %) (= (:side %) "Corp"))}
                                                  :msg (msg "trash 1 card from HQ and add "
@@ -1511,7 +1511,7 @@
    {:abilities [{:label "Install an asset on Worlds Plaza"
                  :req (req (< (count (:hosted card)) 3))
                  :cost [:click 1]
-                 :prompt "Choose an asset to install on Worlds Plaza"
+                 :prompt "Select an asset to install on Worlds Plaza"
                  :choices {:req #(and (is-type? % "Asset")
                                       (in-hand? %)
                                       (= (:side %) "Corp"))}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -103,7 +103,7 @@
                                            " in HQ into R&D")
                                  :effect (req (if (pos? (quot target 2))
                                                 (let [prevented (quot target 2)
-                                                      unprevented (- (count (:hand corp)) n)]
+                                                      unprevented (- (count (:hand corp)) prevented)]
                                                   (doseq [c (take unprevented (shuffle (:hand corp)))]
                                                     (move state :corp c :deck))
                                                   (when (pos? unprevented) (shuffle! state :corp :deck))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -486,7 +486,8 @@
                                       (continue-ability state side
                                         {:choices {:req #(and (contains? % :advance-counter)
                                                               (= (first (:server run)) (second (:zone %))))}
-                                         :msg (msg "remove " c " advancement" (when (> c 1) "s") " from " (card-str state target))
+                                         :msg (msg "remove " (quantify c "advancement token")
+                                                   " from " (card-str state target))
                                          :effect (req (add-prop state :corp target :advance-counter (- c))
                                                       (clear-wait-prompt state :corp)
                                                       (effect-completed state side eid))}
@@ -683,13 +684,17 @@
                             card nil))}}}
 
    "Independent Thinking"
-   (let [cards-to-draw (fn [ts] (* (count ts) (if (some #(and (not (facedown? %)) (has-subtype? % "Directive")) ts) 2 1)))]
+   (letfn [(cards-to-draw [targets]
+             (* (count targets)
+                (if (some #(and (not (facedown? %)) (has-subtype? % "Directive")) targets) 2 1)))]
      {:delayed-completion true
       :prompt "Choose up to 5 installed cards to trash with Independent Thinking"
-      :choices {:max 5 :req #(and (installed? %) (= (:side %) "Runner"))}
+      :choices {:max 5
+                :req #(and (installed? %)
+                           (= (:side %) "Runner"))}
       :effect (req (when-completed (trash-cards state side targets nil)
                                    (draw state :runner (cards-to-draw targets))))
-      :msg (msg "trash " (join ", " (map :title targets)) " and draw " (cards-to-draw targets) " cards")})
+      :msg (msg "trash " (join ", " (map :title targets)) " and draw " (quantify (cards-to-draw targets) "card"))})
 
    "Indexing"
    {:delayed-completion true

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -80,7 +80,8 @@
               :can-rez
               (fn [state side card]
                 (if (ice? card)
-                  ((constantly false) (system-msg state side (str "is prevented from rezzing ICE on this run by Blackmail")))
+                  ((constantly false)
+                    (toast state :corp "Cannot rez ICE on this run due to Blackmail"))
                   true)))))
 
    "Bribery"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -94,7 +94,7 @@
                                                  (all-installed state :runner)))))}
 
    "Career Fair"
-   {:prompt "Choose a resource to install from your Grip"
+   {:prompt "Select a resource to install from your Grip"
     :choices {:req #(and (is-type? % "Resource")
                          (in-hand? %))}
     :effect (effect (install-cost-bonus [:credit -3]) (runner-install target))}
@@ -219,7 +219,8 @@
                      state :corp
                      {:optional
                       {:prompt (msg "Rez a piece of ICE protecting " serv "?")
-                       :yes-ability {:prompt (msg "Choose a piece of " serv " ICE to rez") :player :corp
+                       :yes-ability {:prompt (msg "Select a piece of ICE protecting " serv " to rez")
+                                     :player :corp
                                      :choices {:req #(and (not (:rezzed %))
                                                           (= (last (:zone %)) :ices))}
                                      :effect (req (rez state :corp target nil))}
@@ -654,7 +655,7 @@
                               :effect (req (let [icename (:title target)]
                                              (continue-ability state side
                                                {:delayed-completion true
-                                                :prompt (msg "Choose a rezzed copy of " icename " to trash")
+                                                :prompt (msg "Select a rezzed copy of " icename " to trash")
                                                 :choices {:req #(and (ice? %)
                                                                      (rezzed? %)
                                                                      (= (:title %) icename))}
@@ -698,7 +699,7 @@
 
    "Information Sifting"
    (letfn [(access-pile [cards pile]
-             {:prompt "Select a card to access. You must access all cards."
+             {:prompt "Choose a card to access. You must access all cards."
               :choices [(str "Card from pile " pile)]
               :effect (req (when-completed
                              (handle-access state side [(first cards)])
@@ -724,7 +725,7 @@
                                   :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
                                             :max (req (dec (count (:hand corp))))}
                                   :effect (effect (clear-wait-prompt :runner)
-                                                  (show-wait-prompt :corp "Runner to choose a pile")
+                                                  (show-wait-prompt :corp "Runner to select a pile")
                                                   (continue-ability
                                                     :runner
                                                     (which-pile (shuffle targets)
@@ -751,7 +752,7 @@
     :delayed-completion true
     :effect (effect (run target nil card)
                     (continue-ability
-                      {:prompt "Choose an icebreaker"
+                      {:prompt "Select an icebreaker"
                        :choices {:req #(and (installed? %) (has-subtype? % "Icebreaker"))}
                        :effect (effect (pump target 2 :all-run))}
                       card nil))}
@@ -802,7 +803,7 @@
                        servname target]
                    (resolve-ability
                      state :corp
-                     {:prompt (msg "Choose a piece of ICE in " target " to trash")
+                     {:prompt (msg "Select a piece of ICE in " target " to trash")
                       :choices {:req #(and (= (last (:zone %)) :ices)
                                            (= serv (rest (butlast (:zone %)))))}
                       :effect (req (trash state :corp target)
@@ -985,7 +986,7 @@
                                               :yes-ability {:effect (effect (update! (assoc card :run-again true)))}}}}}
 
    "Modded"
-   {:prompt "Choose a program or piece of hardware to install from your Grip"
+   {:prompt "Select a program or piece of hardware to install from your Grip"
     :choices {:req #(and (or (is-type? % "Hardware")
                              (is-type? % "Program"))
                          (in-hand? %))}
@@ -1094,7 +1095,7 @@
       :effect (effect (run :archives
                         {:req (req (= target :archives))
                          :replace-access
-                         {:prompt "Choose an agenda to host Political Graffiti"
+                         {:prompt "Select an agenda to host Political Graffiti"
                           :choices {:req #(in-corp-scored? state side %)}
                           :msg (msg "host Political Graffiti on " (:title target) " as a hosted condition counter")
                           :effect (req (host state :runner (get-card state target)
@@ -1136,7 +1137,8 @@
    {:effect (effect (show-wait-prompt :runner "Corp to guess Odd or Even")
                     (resolve-ability
                       {:player :corp :prompt "Guess whether the Runner will spend an Odd or Even number of credits with Push Your Luck"
-                       :choices ["Even" "Odd"] :msg "make the Corp choose a guess"
+                       :choices ["Even" "Odd"]
+                       :msg "force the Corp to make a guess"
                        :effect (req (let [guess target]
                                       (clear-wait-prompt state :runner)
                                       (resolve-ability
@@ -1247,10 +1249,10 @@
 
    "Rigged Results"
    (letfn [(choose-ice []
-             {:prompt "Choose a piece of ICE to bypass"
+             {:prompt "Select a piece of ICE to bypass"
               :choices {:req #(ice? %)}
-              :effect (final-effect (system-msg :runner (str "chooses to bypass " (card-str state target)))
-                                    (run (second (:zone target))))})
+              :msg (msg "bypass " (card-str state target))
+              :effect (final-effect (run (second (:zone target))))})
            (corp-choice [spent]
              {:prompt "Guess how many credits were spent"
               :choices ["0" "1" "2"]
@@ -1335,14 +1337,14 @@
                                    (expose state side eid card2))))}
 
    "Scavenge"
-   {:prompt "Choose an installed program to trash"
+   {:prompt "Select an installed program to trash"
     :choices {:req #(and (is-type? % "Program")
                          (installed? %))}
     :effect (req (let [trashed target tcost (- (:cost trashed)) st state si side]
                    (trash state side trashed)
                    (resolve-ability
                      state side
-                     {:prompt "Choose a program to install from your Grip or Heap"
+                     {:prompt "Select a program to install from your Grip or Heap"
                       :show-discard true
                       :choices {:req #(and (is-type? % "Program")
                                            (#{[:hand] [:discard]} (:zone %))
@@ -1389,13 +1391,13 @@
                                          (trash state side c))))}} card))}
 
    "Social Engineering"
-   {:prompt "Choose an unrezzed piece of ICE"
+   {:prompt "Select an unrezzed piece of ICE"
     :choices {:req #(and (= (last (:zone %)) :ices) (not (rezzed? %)) (ice? %))}
     :effect (req (let [ice target
                        serv (zone->name (second (:zone ice)))]
               (resolve-ability
                  state :runner
-                 {:msg (msg "choose the ICE at position " (ice-index state ice) " of " serv)
+                 {:msg (msg "select the piece of ICE at position " (ice-index state ice) " of " serv)
                   :effect (effect (register-events {:pre-rez-cost
                                                     {:req (req (= target ice))
                                                      :effect (req (let [cost (rez-cost state side (get-card state target))]
@@ -1558,7 +1560,7 @@
                :msg (msg "gain " (* 2 (count (:successful-run runner-reg))) " [Credits]")}}
 
    "Tinkering"
-   {:prompt "Choose a piece of ICE"
+   {:prompt "Select a piece of ICE"
     :choices {:req #(and (= (last (:zone %)) :ices) (ice? %))}
     :effect (req (let [ice target
                        serv (zone->name (second (:zone ice)))
@@ -1587,7 +1589,6 @@
                                                                                (shuffle! :deck)
                                                                                (move target :hand)
                                                                                (unregister-events card))} card nil))}}}
-
 
    "Traffic Jam"
    {:effect (effect (update-all-advancement-costs))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1565,7 +1565,7 @@
                        stypes (:subtype ice)]
               (resolve-ability
                  state :runner
-                 {:msg (msg "make " (card-str state ice) " gain sentry, code gate, and barrier until the end of the turn")
+                 {:msg (msg "make " (card-str state ice) " gain Sentry, Code Gate, and Barrier until the end of the turn")
                   :effect (effect (update! (assoc ice :subtype (combine-subtypes true (:subtype ice) "Sentry" "Code Gate" "Barrier")))
                                   (update-ice-strength (get-card state ice))
                                   (register-events {:runner-turn-ends

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -128,9 +128,10 @@
                  :cost [:click 1]
                  :effect (req (let [handsize (count (:hand runner))]
                                 (resolve-ability state side
-                                  {:prompt "Choose any number of cards to trash from your Grip"
-                                   :choices {:max handsize :req #(and (= (:side %) "Runner")
-                                                                      (in-hand? %))}
+                                  {:prompt "Select any number of cards to trash from your Grip"
+                                   :choices {:max handsize
+                                             :req #(and (= (:side %) "Runner")
+                                                        (in-hand? %))}
                                    :effect (req (let [trashed (count targets)
                                                       remaining (- handsize trashed)]
                                                   (doseq [c targets]
@@ -157,7 +158,7 @@
                                                    (lose state side :tag 1)))} card nil))}]}
 
    "Clone Chip"
-   {:abilities [{:prompt "Choose a program to install from your Heap"
+   {:abilities [{:prompt "Select a program to install from your Heap"
                  :priority true :show-discard true
                  :req (req (and (not (seq (get-in @state [:runner :locked :discard])))
                                (not (install-locked? state side))))
@@ -175,7 +176,7 @@
                                                    (str "can play another event without spending a [Click] by clicking on Comet"))
                                        (update! state side (assoc card :comet-event true)))}}
     :abilities [{:req (req (:comet-event card))
-                 :prompt "Choose an Event in your Grip to play"
+                 :prompt "Select an Event in your Grip to play"
                  :choices {:req #(and (is-type? % "Event")
                                       (in-hand? %))}
                  :msg (msg "play " (:title target))
@@ -183,7 +184,7 @@
                                  (update! (dissoc (get-card state card) :comet-event)))}]}
 
    "Cortez Chip"
-   {:abilities [{:prompt "Choose a piece of ICE"
+   {:abilities [{:prompt "Select a piece of ICE"
                  :choices {:req ice?}
                  :effect (req (let [ice target]
                                 (update! state side (assoc card :cortez-target ice))
@@ -258,7 +259,7 @@
    "Dinosaurus"
    {:abilities [{:label "Install a non-AI icebreaker on Dinosaurus"
                  :req (req (empty? (:hosted card))) :cost [:click 1]
-                 :prompt "Choose a non-AI icebreaker in your Grip to install on Dinosaurus"
+                 :prompt "Select a non-AI icebreaker in your Grip to install on Dinosaurus"
                  :choices {:req #(and (has-subtype? % "Icebreaker")
                                       (not (has-subtype? % "AI"))
                                       (in-hand? %))}
@@ -267,7 +268,7 @@
                                  (update! (assoc (get-card state card) :dino-breaker (:cid target))))}
                 {:label "Host an installed non-AI icebreaker on Dinosaurus"
                  :req (req (empty? (:hosted card)))
-                 :prompt "Choose an installed non-AI icebreaker to host on Dinosaurus"
+                 :prompt "Select an installed non-AI icebreaker to host on Dinosaurus"
                  :choices {:req #(and (has-subtype? % "Icebreaker")
                                       (not (has-subtype? % "AI"))
                                       (installed? %))}
@@ -495,14 +496,14 @@
              {:delayed-completion true
               :req (req (= target :rd))
               :effect (effect (continue-ability
-                                {:prompt "Choose a card and replace 1 spent [Recurring Credits] on it"
+                                {:prompt "Select a card and replace 1 spent [Recurring Credits] on it"
                                  :choices {:req #(< (:rec-counter % 0) (:recurring (card-def %) 0))}
                                  :msg (msg "replace 1 spent [Recurring Credits] on " (:title target))
                                  :effect (effect (add-prop target :rec-counter 1))}
                                card nil))}}}
 
    "Monolith"
-   (let [mhelper (fn mh [n] {:prompt "Choose a program to install"
+   (let [mhelper (fn mh [n] {:prompt "Select a program to install"
                              :choices {:req #(and (is-type? % "Program")
                                                   (in-hand? %))}
                              :effect (req (install-cost-bonus state side [:credit -4])
@@ -539,8 +540,8 @@
                  :req (req (empty? (:hosted card)))
                  :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
                                 (resolve-ability state side
-                                  {:prompt "Choose a program in your Grip to install on NetChip"
-                                   :cost [:click 1]
+                                  {:cost [:click 1]
+                                   :prompt "Select a program in your Grip to install on NetChip"
                                    :choices {:req #(and (is-type? % "Program")
                                                         (runner-can-install? state side % false)
                                                         (<= (:memoryunits %) n)
@@ -556,7 +557,7 @@
                  :req (req (empty? (:hosted card)))
                  :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
                                 (resolve-ability state side
-                                  {:prompt "Choose an installed program to host on NetChip"
+                                  {:prompt "Select an installed program to host on NetChip"
                                    :choices {:req #(and (is-type? % "Program")
                                                         (<= (:memoryunits %) n)
                                                         (installed? %))}
@@ -598,7 +599,7 @@
     :abilities [{:label "Install and host a program of 1[Memory Unit] or less on Omni-drive"
                  :req (req (empty? (:hosted card)))
                  :cost [:click 1]
-                 :prompt "Choose a program of 1[Memory Unit] or less to install on Omni-drive from your grip"
+                 :prompt "Select a program of 1[Memory Unit] or less to install on Omni-drive from your grip"
                  :choices {:req #(and (is-type? % "Program")
                                       (<= (:memoryunits %) 1)
                                       (in-hand? %))}
@@ -607,7 +608,7 @@
                                  (runner-install target {:host-card card})
                                  (update! (assoc (get-card state card) :Omnidrive-prog (:cid target))))}
                 {:label "Host an installed program of 1[Memory Unit] or less on Omni-drive"
-                 :prompt "Choose an installed program of 1[Memory Unit] or less to host on Omni-drive"
+                 :prompt "Select an installed program of 1[Memory Unit] or less to host on Omni-drive"
                  :choices {:req #(and (is-type? % "Program")
                                       (<= (:memoryunits %) 1)
                                       (installed? %))}
@@ -792,7 +793,7 @@
    {:abilities [{:label "[Trash]: Add [Link] strength to a non-Cloud icebreaker until the end of the run"
                  :msg (msg "add " (:link runner) " strength to " (:title target) " until the end of the run")
                  :req (req (:run @state))
-                 :prompt "Choose one non-Cloud icebreaker"
+                 :prompt "Select one non-Cloud icebreaker"
                  :choices {:req #(and (has-subtype? % "Icebreaker")
                                       (not (has-subtype? % "Cloud"))
                                       (installed? %))}
@@ -801,10 +802,11 @@
                 {:label "[Trash]: Add [Link] strength to any Cloud icebreakers until the end of the run"
                  :msg (msg "add " (:link runner) " strength to " (count targets) " Cloud icebreakers until the end of the run")
                  :req (req (:run @state))
-                 :prompt "Choose any number of Cloud icebreakers"
-                 :choices {:max 50 :req #(and (has-subtype? % "Icebreaker")
-                                              (has-subtype? % "Cloud")
-                                              (installed? %))}
+                 :prompt "Select any number of Cloud icebreakers"
+                 :choices {:max 50
+                           :req #(and (has-subtype? % "Icebreaker")
+                                      (has-subtype? % "Cloud")
+                                      (installed? %))}
                  :effect (req (doseq [t targets]
                                 (pump state side t (:link runner) :all-run)
                                 (update-breaker-strength state side t))
@@ -940,7 +942,8 @@
                      (show-wait-prompt state :corp "Runner to use Titanium Ribs to choose cards to be trashed")
                      (when-completed (resolve-ability state side
                                        {:delayed-completion true
-                                        :prompt (msg "Choose " dmg " cards to trash for the " (name dtype) " damage") :player :runner
+                                        :prompt (msg "Select " dmg " cards to trash for the " (name dtype) " damage")
+                                        :player :runner
                                         :choices {:max dmg :all true :req #(and (in-hand? %) (= (:side %) "Runner"))}
                                         :msg (msg "trash " (join ", " (map :title targets)))
                                         :effect (req (clear-wait-prompt state :corp)
@@ -991,7 +994,7 @@
                                :effect (req
                                          (continue-ability
                                            state side
-                                           {:prompt (str "Choose a scored Corp agenda to swap with " (:title stolen))
+                                           {:prompt (str "Select a scored Corp agenda to swap with " (:title stolen))
                                             :choices {:req #(in-corp-scored? state side %)}
                                             :effect (req (let [scored target]
                                                            (swap-agendas state side scored stolen)
@@ -1017,8 +1020,10 @@
 
    "Unregistered S&W 35"
    {:abilities
-    [{:cost [:click 2] :req (req (some #{:hq} (:successful-run runner-reg)))
-      :label "trash a Bioroid, Clone, Executive or Sysop" :prompt "Choose a Bioroid, Clone, Executive, or Sysop to trash"
+    [{:cost [:click 2]
+      :req (req (some #{:hq} (:successful-run runner-reg)))
+      :label "trash a Bioroid, Clone, Executive or Sysop"
+      :prompt "Select a Bioroid, Clone, Executive, or Sysop to trash"
       :choices {:req #(and (rezzed? %)
                            (or (has-subtype? % "Bioroid")
                                (has-subtype? % "Clone")

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -6,7 +6,7 @@
 
 ;;; Runner abilites for breaking subs
 (defn runner-break
-  "Ability to break a subroutine by spending a resource (bioroids, Negotiator, Turing etc)"
+  "Ability to break a subroutine by spending a resource (Bioroids, Negotiator, Turing etc)"
   [cost subs]
   (let [cost-str (build-cost-str [cost])
         subs-str (str subs " subroutine" (when (< 1 subs) "s"))]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -9,7 +9,7 @@
   "Ability to break a subroutine by spending a resource (Bioroids, Negotiator, Turing etc)"
   [cost subs]
   (let [cost-str (build-cost-str [cost])
-        subs-str (str subs " subroutine" (when (< 1 subs) "s"))]
+        subs-str (quantify subs "subroutine")]
     {:cost cost
      :label (str "break " subs-str)
      :effect (req (system-msg state :runner (str "spends " cost-str " to break " subs-str " on " (:title card))))}))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -261,7 +261,7 @@
                                                     " from R&D (top is 1)"))
                                    (corp-install (move state side target :play-area) nil {:no-install-cost true}))}
                   {:label "Install a card from HQ or Archives"
-                   :prompt "Choose a card to install from Archives or HQ"
+                   :prompt "Select a card to install from Archives or HQ"
                    :show-discard true
                    :priority true
                    :choices {:req #(and (not (is-type? % "Operation"))
@@ -486,7 +486,7 @@
    "Chum"
    {:subroutines [{:label "Give +2 strength to next ICE Runner encounters"
                    :req (req this-server)
-                   :prompt "Choose the ICE the Runner is encountering"
+                   :prompt "Select the ICE the Runner is encountering"
                    :choices {:req #(and (rezzed? %) (ice? %))}
                    :msg (msg "give " (:title target) " +2 strength")
                    :effect (req (let [ice (:cid target)]
@@ -502,7 +502,7 @@
    "Clairvoyant Monitor"
    {:subroutines [(do-psi {:label "Place 1 advancement token and end the run"
                            :player :corp
-                           :prompt "Choose a target for Clairvoyant Monitor"
+                           :prompt "Select a target for Clairvoyant Monitor"
                            :msg (msg "place 1 advancement token on "
                                      (card-str state target) " and end the run")
                            :choices {:req installed?}
@@ -550,12 +550,13 @@
 
    "Crick"
    {:subroutines [{:label "install a card from Archives"
-                   :msg (msg (corp-install-msg target))
-                   :prompt "Choose a card to install from Archives"
-                   :show-discard true :priority true
+                   :prompt "Select a card to install from Archives"
+                   :show-discard true
+                   :priority true
                    :choices {:req #(and (not (is-type? % "Operation"))
                                         (= (:zone %) [:discard])
                                         (= (:side %) "Corp"))}
+                   :msg (msg (corp-install-msg target))
                    :effect (effect (corp-install target nil))}]
     :strength-bonus (req (if (= (second (:zone card)) :archives) 3 0))}
 
@@ -677,9 +678,11 @@
    {:additional-cost [:forfeit]
     :subroutines [trash-program
                   (do-brain-damage 1)
-                  {:label "Trash a console" :effect (effect (trash target))
-                   :prompt "Choose a console to trash" :msg (msg "trash " (:title target))
-                   :choices {:req #(has-subtype? % "Console")}}
+                  {:label "Trash a console"
+                   :prompt "Select a console to trash"
+                   :choices {:req #(has-subtype? % "Console")}
+                   :msg (msg "trash " (:title target))
+                   :effect (effect (trash target))}
                   {:msg "trash all virtual resources"
                    :effect (req (doseq [c (filter #(has-subtype? % "Virtual") (all-installed state :runner))]
                                   (trash state side c)))}]
@@ -766,10 +769,10 @@
                                     :msg "trash 1 hardware, do 2 meat damage, and end the run"
                                     :delayed-completion true
                                     :effect (effect (continue-ability
-                                                     {:prompt "Choose a piece of hardware to trash"
+                                                     {:prompt "Select a piece of hardware to trash"
                                                       :label "Trash a piece of hardware"
-                                                      :msg (msg "trash " (:title target))
                                                       :choices {:req #(is-type? % "Hardware")}
+                                                      :msg (msg "trash " (:title target))
                                                       :effect (req (when-completed
                                                                      (trash state side target {:cause :subroutine})
                                                                      (do (damage state side eid :meat 2 {:unpreventable true
@@ -836,9 +839,10 @@
                                   (when (> delta 0)
                                     (resolve-ability
                                       state :runner
-                                      {:prompt (msg "Choose " delta " cards to discard")
+                                      {:prompt (msg "Select " delta " cards to discard")
                                        :player :runner
-                                       :choices {:max delta :req #(in-hand? %)}
+                                       :choices {:max delta
+                                                 :req #(in-hand? %)}
                                        :effect (req (doseq [c targets]
                                                       (trash state :runner c))
                                                     (system-msg state :runner
@@ -1053,7 +1057,7 @@
     :subroutines [end-the-run]}
 
    "Kitsune"
-   {:subroutines [{:prompt "Choose a card in HQ to force access"
+   {:subroutines [{:prompt "Select a card in HQ to force access"
                    :choices {:req in-hand?}
                    :label "Force the Runner to access a card in HQ"
                    :msg (msg "force the Runner to access " (:title target))
@@ -1609,7 +1613,7 @@
    "Swordsman"
    {:implementation "AI restriction not implemented"
     :subroutines [(do-net-damage 1)
-                  {:prompt "Choose an AI program to trash"
+                  {:prompt "Select an AI program to trash"
                    :msg (msg "trash " (:title target))
                    :label "Trash an AI program"
                    :effect (effect (trash target))

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -181,9 +181,9 @@
 (def cards-icebreakers
   {"Abagnale"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [(break-sub 1 1 "code gate")
+                    {:abilities [(break-sub 1 1 "Code Gate")
                                  (strength-pump 2 2)
-                                 {:label "Bypass code gate being encountered"
+                                 {:label "Bypass Code Gate being encountered"
                                   :req (req (has-subtype? current-ice "Code Gate"))
                                   :msg (msg "trash it and bypass " (:title current-ice))
                                   :effect (effect (trash card {:cause :ability-cost}))}]})
@@ -191,7 +191,7 @@
    "Adept"
    {:abilities [{:cost [:credit 2] :req (req (or (has-subtype? current-ice "Barrier")
                                                  (has-subtype? current-ice "Sentry")))
-                 :msg "break 1 sentry or barrier subroutine"}]
+                 :msg "break 1 Sentry or Barrier subroutine"}]
     :effect (req (add-watch state (keyword (str "adept" (:cid card)))
                             (fn [k ref old new]
                               (when (not= (get-in old [:runner :memory]) (get-in new [:runner :memory]))
@@ -212,14 +212,14 @@
 
    "Alias"
    (central-breaker "Sentry"
-                    (break-sub 1 1 "sentry")
+                    (break-sub 1 1 "Sentry")
                     (strength-pump 2 3))
 
    "Ankusa"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [(break-sub 2 1 "barrier")
+                    {:abilities [(break-sub 2 1 "Barrier")
                                  (strength-pump 1 1)
-                                 {:label "Add barrier to HQ"
+                                 {:label "Add Barrier to HQ"
                                   :req (req (and (has-subtype? current-ice "Barrier")
                                                  (rezzed? current-ice)))
                                   :msg (msg "add " (:title current-ice) " to HQ after breaking all its subroutines")
@@ -254,7 +254,7 @@
 
    "Aurora"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [(break-sub 2 1 "barrier")
+                    {:abilities [(break-sub 2 1 "Barrier")
                                  (strength-pump 2 3)]})
 
    "Baba Yaga"
@@ -284,11 +284,11 @@
 
    "Battering Ram"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [(break-sub 2 2 "barrier")
+                    {:abilities [(break-sub 2 2 "Barrier")
                                  (strength-pump 1 1 :all-run)]})
 
    "Berserker"
-   {:abilities [(break-sub 2 2 "barrier")]
+   {:abilities [(break-sub 2 2 "Barrier")]
     :implementation "Number of subroutines on encountered ICE has to be entered by runner when Corp chooses 'No More Action'"
     :events {:encounter-ice {:req (req (and (= (:cid target) (:cid current-ice))
                                             (has-subtype? target "Barrier")
@@ -303,9 +303,9 @@
 
    "BlacKat"
    {:implementation "Stealth credit restriction not enforced"
-    :abilities [(break-sub 1 1 "barrier")
+    :abilities [(break-sub 1 1 "Barrier")
                 {:cost [:credit 1]
-                 :msg "break up to 3 barrier subroutines (using a stealth [Credits])"}
+                 :msg "break up to 3 Barrier subroutines (using a stealth [Credits])"}
                 (strength-pump 2 1)
                 {:cost [:credit 2]
                  :msg "add 2 strength (using at least 1 stealth [Credits])"
@@ -318,7 +318,7 @@
                  :msg "add 2 strength and break up to 2 subroutines"}])
 
    "Blackstone"
-   {:abilities [(break-sub 1 1 "barrier")
+   {:abilities [(break-sub 1 1 "Barrier")
                 {:cost [:credit 3]
                  :msg "add 4 strength (using at least 1 stealth [Credits])"
                  :effect (effect (pump card 4 :all-run)) :pump 4}]}
@@ -331,9 +331,8 @@
 
    "Breach"
    (central-breaker "Barrier"
-                    (break-sub 2 3 "barrier")
+                    (break-sub 2 3 "Barrier")
                     (strength-pump 2 4))
-
 
    "Cerberus \"Cuj.0\" H3"
    (cerberus "Sentry")
@@ -354,13 +353,13 @@
 
    "Corroder"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [(break-sub 1 1 "barrier")
+                    {:abilities [(break-sub 1 1 "Barrier")
                                  (strength-pump 1 1)]})
 
    "Creeper"
    (cloud-icebreaker
      (auto-icebreaker ["Sentry"]
-                      {:abilities [(break-sub 2 1 "sentry")
+                      {:abilities [(break-sub 2 1 "Sentry")
                                    (strength-pump 1 1)]}))
 
    "Crowbar"
@@ -389,13 +388,13 @@
                      :choices (req servers)
                      :effect (effect (update! (assoc card :server-target target)))
                      :leave-play (effect (update! (dissoc card :server-target)))
-                     :abilities [(break-sub 1 1 "code gate")
+                     :abilities [(break-sub 1 1 "Code Gate")
                                  (strength-pump 1 1)]})
 
    "Dagger"
    (auto-icebreaker ["Sentry"]
                     {:implementation "Stealth credit restriction not enforced"
-                     :abilities [(break-sub 1 1 "sentry")
+                     :abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 1 5)]})
 
    "Dai V"
@@ -420,9 +419,9 @@
 
    "Demara"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [(break-sub 2 2 "barrier")
+                    {:abilities [(break-sub 2 2 "Barrier")
                                  (strength-pump 2 3)
-                                 {:label "Bypass barrier being encountered"
+                                 {:label "Bypass Barrier being encountered"
                                   :req (req (has-subtype? current-ice "Barrier"))
                                   :msg (msg "trash it and bypass " (:title current-ice))
                                   :effect (effect (trash card {:cause :ability-cost}))}]})
@@ -452,7 +451,7 @@
 
    "Faerie"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [(break-sub 0 1 "sentry" (effect (update! (assoc card :faerie-used true))))
+                    {:abilities [(break-sub 0 1 "Sentry" (effect (update! (assoc card :faerie-used true))))
                                  (strength-pump 1 1)]
                      :events {:pass-ice {:req (req (:faerie-used card))
                                          :effect (effect (trash (dissoc card :faerie-used)))}}})
@@ -471,7 +470,7 @@
 
    "Fawkes"
    {:implementation "Stealth credit restriction not enforced"
-    :abilities [(break-sub 1 1 "sentry")
+    :abilities [(break-sub 1 1 "Sentry")
                 {:label (str "X [Credits]: +X strength for the remainder of the run (using at least 1 stealth [Credits])")
                  :choices :credit
                  :prompt "How many credits?"
@@ -489,13 +488,13 @@
                                     (system-msg state side
                                                 (str "chooses " (card-str state ice)
                                                      " for Femme Fatale's bypass ability"))))
-                     :abilities [(break-sub 1 1 "sentry")
+                     :abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 2 1)]})
 
    "Flashbang"
    (auto-icebreaker ["Sentry"]
                     {:abilities [(strength-pump 1 1)
-                                 {:label "Derez a sentry being encountered"
+                                 {:label "Derez a Sentry being encountered"
                                   :cost [:credit 6]
                                   :req (req (and (rezzed? current-ice) (has-subtype? current-ice "Sentry")))
                                   :msg (msg "derez " (:title current-ice))
@@ -503,12 +502,12 @@
 
    "Force of Nature"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [(break-sub 2 2 "code gate")
+                    {:abilities [(break-sub 2 2 "Code Gate")
                                  (strength-pump 1 1)]})
 
    "Garrote"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [(break-sub 1 1 "sentry")
+                    {:abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 1 1)]})
 
    "God of War"
@@ -529,9 +528,9 @@
 
    "Golden"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [(break-sub 2 2 "sentry")
+                    {:abilities [(break-sub 2 2 "Sentry")
                                  (strength-pump 2 4)
-                                 {:label "Derez a sentry and return Golden to your Grip"
+                                 {:label "Derez a Sentry and return Golden to your Grip"
                                   :cost [:credit 2]
                                   :req (req (and (rezzed? current-ice) (has-subtype? current-ice "Sentry")))
                                   :msg (msg "derez " (:title current-ice) " and return Golden to their Grip")
@@ -540,12 +539,12 @@
 
    "Gordian Blade"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [(break-sub 1 1 "code gate")
+                    {:abilities [(break-sub 1 1 "Code Gate")
                                  (strength-pump 1 1 :all-run)]})
 
    "Gingerbread"
    (auto-icebreaker ["Tracer"]
-                    {:abilities [(break-sub 1 1 "tracer")
+                    {:abilities [(break-sub 1 1 "Tracer")
                                  (strength-pump 2 3)]})
 
    "GS Sherman M3"
@@ -558,28 +557,28 @@
    (global-sec-breaker "Code Gate")
 
    "Houdini"
-   {:abilities [(break-sub 1 1 "code gate")
+   {:abilities [(break-sub 1 1 "Code Gate")
                 {:cost [:credit 2]
                  :msg "add 4 strength (using at least 1 stealth [Credits])"
                  :effect (effect (pump card 4 :all-run)) :pump 4}]}
 
    "Inti"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [(break-sub 1 1 "barrier")
+                    {:abilities [(break-sub 1 1 "Barrier")
                                  (strength-pump 2 1 :all-run)]})
 
    "Inversificator"
    (auto-icebreaker ["Code Gate"]
                     {:implementation "No restriction on which pieces of ICE are chosen"
-                     :abilities [{:label "Swap the code gate you just passed with another ICE"
+                     :abilities [{:label "Swap the Code Gate you just passed with another ICE"
                                   :once :per-turn
                                   :req (req (:run @state))
-                                  :prompt "Select the code gate you just passed and another piece of ICE to swap positions"
+                                  :prompt "Select the Code Gate you just passed and another piece of ICE to swap positions"
                                   :choices {:req #(and (installed? %) (ice? %)) :max 2}
                                   :msg (msg "swap the positions of " (card-str state (first targets)) " and " (card-str state (second targets)))
                                   :effect (req (when (= (count targets) 2)
                                                  (swap-ice state side (first targets) (second targets))))}
-                                 (break-sub 1 1 "code gate")
+                                 (break-sub 1 1 "Code Gate")
                                  (strength-pump 1 1)]})
 
    "Knight"
@@ -610,14 +609,14 @@
 
    "Leviathan"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [(break-sub 3 3 "code gate")
+                    {:abilities [(break-sub 3 3 "Code Gate")
                                  (strength-pump 3 5)]})
 
    "Lustig"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [(break-sub 1 1 "sentry")
+                    {:abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 3 5)
-                                 {:label "Bypass sentry being encountered"
+                                 {:label "Bypass Sentry being encountered"
                                   :req (req (has-subtype? current-ice "Sentry"))
                                   :msg (msg "trash it and bypass " (:title current-ice))
                                   :effect (effect (trash card {:cause :ability-cost}))}]})
@@ -641,7 +640,7 @@
    "Mass-Driver"
    (auto-icebreaker ["Code Gate"]
                     {:implementation "Prevention of subroutine resolution on next ICE is manual"
-                     :abilities [(break-sub 2 1 "code gate")
+                     :abilities [(break-sub 2 1 "Code Gate")
                                  (strength-pump 1 1)]})
 
    "Maven"
@@ -653,15 +652,15 @@
     :strength-bonus (req (count (filter #(is-type? % "Program") (all-installed state :runner))))}
 
    "Morning Star"
-   {:abilities [(break-sub 1 0 "barrier")]}
+   {:abilities [(break-sub 1 0 "Barrier")]}
 
    "Mimic"
-   {:abilities [(break-sub 1 1 "sentry")]}
+   {:abilities [(break-sub 1 1 "Sentry")]}
 
    "Mongoose"
    (auto-icebreaker ["Sentry"]
                     {:implementation "Usage restriction is not implemented"
-                     :abilities [(break-sub 1 2 "sentry")
+                     :abilities [(break-sub 1 2 "Sentry")
                                  (strength-pump 2 2)]})
 
    "MKUltra"
@@ -685,7 +684,7 @@
                                                     (update-breaker-strength ref side card))))))
                      :strength-bonus (req (if-let [numice (count run-ices)] numice 0))
                      :leave-play (req (remove-watch state (keyword (str "nanotk" (:cid card)))))
-                     :abilities [(break-sub 1 1 "sentry")
+                     :abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 3 2)]})
 
    "Nfr"
@@ -695,14 +694,13 @@
                  :ability-type :manual-state
                  :effect (effect (add-counter card :power 1)
                                  (update-breaker-strength card))}
-                (break-sub 1 1 "barrier")]
+                (break-sub 1 1 "Barrier")]
     :strength-bonus (req (get-in card [:counter :power] 0))}
 
    "Ninja"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [(break-sub 1 1 "sentry")
+                    {:abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 3 5)]})
-
 
    "Omega"
    (auto-icebreaker ["All"]
@@ -722,24 +720,24 @@
                  :choices :credit
                  :prompt "How many credits?"
                  :effect (effect (pump card target))
-                 :msg (msg "spend " target " [Credits], increase strength by " target ", and break " target " barrier subroutine"
+                 :msg (msg "spend " target " [Credits], increase strength by " target ", and break " target " Barrier subroutine"
                            (when (not= target 1) "s"))}])
 
    "Passport"
    (central-breaker "Code Gate"
-                    (break-sub 1 1 "code gate")
+                    (break-sub 1 1 "Code Gate")
                     (strength-pump 2 2))
 
    "Peacock"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [(break-sub 2 1 "code gate")
+                    {:abilities [(break-sub 2 1 "Code Gate")
                                  (strength-pump 2 3)]})
 
    "Peregrine"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [(break-sub 1 1 "code gate")
+                    {:abilities [(break-sub 1 1 "Code Gate")
                                  (strength-pump 3 3)
-                                 {:label "Derez a code gate and return Peregrine to your Grip"
+                                 {:label "Derez a Code Gate and return Peregrine to your Grip"
                                   :cost [:credit 2]
                                   :req (req (and (rezzed? current-ice) (has-subtype? current-ice "Code Gate")))
                                   :msg (msg "derez " (:title current-ice) " and return Peregrine to their Grip")
@@ -749,7 +747,7 @@
    "Persephone"
    (auto-icebreaker ["Sentry"]
                     {:implementation "Requires runner to input the number of subroutines allowed to resolve"
-                     :abilities [(break-sub 2 1 "sentry")
+                     :abilities [(break-sub 2 1 "Sentry")
                                  (strength-pump 1 1)]
                      :events {:pass-ice {:req (req (and (has-subtype? target "Sentry") (rezzed? target)) (pos? (count (:deck runner))))
                                          :delayed-completion true
@@ -765,13 +763,13 @@
 
    "Pipeline"
    (auto-icebreaker ["Sentry"]
-                    {:abilities [(break-sub 1 1 "sentry")
+                    {:abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 2 1 :all-run)]})
 
    "Refractor"
    (auto-icebreaker ["Code Gate"]
                     {:implementation "Stealth credit restriction not enforced"
-                     :abilities [(break-sub 1 1 "code gate")
+                     :abilities [(break-sub 1 1 "Code Gate")
                                  (strength-pump 1 3)]})
    "Sadyojata"
    (deva "Sadyojata")
@@ -779,7 +777,7 @@
    "Sage"
    {:abilities [{:cost [:credit 2] :req (req (or (has-subtype? current-ice "Barrier")
                                                  (has-subtype? current-ice "Code Gate")))
-                 :msg "break 1 code gate or barrier subroutine"}]
+                 :msg "break 1 Code Gate or Barrier subroutine"}]
     :effect (req (add-watch state (keyword (str "sage" (:cid card)))
                             (fn [k ref old new]
                               (when (not= (get-in old [:runner :memory]) (get-in new [:runner :memory]))
@@ -790,9 +788,9 @@
 
    "Saker"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [(break-sub 1 1 "barrier")
+                    {:abilities [(break-sub 1 1 "Barrier")
                                  (strength-pump 2 2)
-                                 {:label "Derez a barrier and return Saker to your Grip"
+                                 {:label "Derez a Barrier and return Saker to your Grip"
                                   :cost [:credit 2]
                                   :req (req (and (rezzed? current-ice) (has-subtype? current-ice "Barrier")))
                                   :msg (msg "derez " (:title current-ice) " and return Saker to their Grip")
@@ -801,9 +799,9 @@
 
    "Savant"
    {:abilities [{:cost [:credit 2] :req (req (has-subtype? current-ice "Sentry"))
-                 :msg "break 1 sentry subroutine"}
+                 :msg "break 1 Sentry subroutine"}
                 {:cost [:credit 2] :req (req (has-subtype? current-ice "Code Gate"))
-                              :msg "break 2 code gate subroutines"}]
+                              :msg "break 2 Code Gate subroutines"}]
     :effect (req (add-watch state (keyword (str "savant" (:cid card)))
                             (fn [k ref old new]
                               (when (not= (get-in old [:runner :memory]) (get-in new [:runner :memory]))
@@ -814,14 +812,14 @@
 
    "Snowball"
    (auto-icebreaker ["Barrier"]
-                    {:abilities [{:cost [:credit 1] :msg "break 1 barrier subroutine"
+                    {:abilities [{:cost [:credit 1] :msg "break 1 Barrier subroutine"
                                   :effect (effect (pump card 1 :all-run))}
                                  (strength-pump 1 1)]})
 
    "Sharpshooter"
    (auto-icebreaker ["Destroyer"]
-                    {:abilities [{:label "[Trash]: Break any number of destroyer subroutines"
-                                  :msg "break any number of destroyer subroutines"
+                    {:abilities [{:label "[Trash]: Break any number of Destroyer subroutines"
+                                  :msg "break any number of Destroyer subroutines"
                                   :effect (effect (trash card {:cause :ability-cost}))}
                                  (strength-pump 1 2)]})
 
@@ -832,7 +830,7 @@
    (break-and-enter "Barrier")
 
    "Study Guide"
-   {:abilities [(break-sub 1 1 "code gate")
+   {:abilities [(break-sub 1 1 "Code Gate")
                 {:cost [:credit 2] :msg "place 1 power counter"
                  :effect (effect (add-counter card :power 1)
                                  (update-breaker-strength card))}]
@@ -845,18 +843,18 @@
                  :effect (effect (add-counter card :power 1)
                                  (system-msg (str "places 1 power counter on Sūnya"))
                                  (update-breaker-strength card))}
-                (break-sub 2 1 "sentry")]
+                (break-sub 2 1 "Sentry")]
     :strength-bonus (req (get-in card [:counter :power] 0))}
 
    "Switchblade"
    (auto-icebreaker ["Sentry"]
                     {:implementation "Stealth credit restriction not enforced"
-                     :abilities [(break-sub 1 0 "sentry")
+                     :abilities [(break-sub 1 0 "Sentry")
                                  (strength-pump 1 7)]})
 
    "Torch"
    (auto-icebreaker ["Code Gate"]
-                    {:abilities [(break-sub 1 1 "code gate")
+                    {:abilities [(break-sub 1 1 "Code Gate")
                                  (strength-pump 1 1)]})
 
    "Vamadeva"
@@ -886,10 +884,10 @@
                                 :run-ends wy})})
 
    "Yog.0"
-   {:abilities [(break-sub 0 1 "code gate")]}
+   {:abilities [(break-sub 0 1 "Code Gate")]}
 
    "ZU.13 Key Master"
    (cloud-icebreaker
      (auto-icebreaker ["Code Gate"]
-                      {:abilities [(break-sub 1 1 "code gate")
+                      {:abilities [(break-sub 1 1 "Code Gate")
                                    (strength-pump 1 1)]}))})

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -123,7 +123,7 @@
                                 (strength-pump 1 1)
                                 {:req (req (seq (filter #(has-subtype? % "Deva") (:hand runner))))
                                  :label "Swap with a deva program from your Grip" :cost [:credit 2]
-                                 :prompt (str "Choose a deva program in your Grip to swap with " name)
+                                 :prompt (str "Select a deva program in your Grip to swap with " name)
                                  :choices {:req #(and in-hand? (has-subtype? % "Deva"))}
                                  :msg (msg "swap in " (:title target) " from their Grip")
                                  :effect (req (if-let [hostcard (:host card)]
@@ -443,7 +443,7 @@
 
    "Endless Hunger"
    {:abilities [{:label "Trash 1 installed card to break 1 \"End the run.\" subroutine"
-                 :prompt "Choose a card to trash for Endless Hunger"
+                 :prompt "Select a card to trash for Endless Hunger"
                  :choices {:req #(and (= (:side %) "Runner") (:installed %))}
                  :msg (msg "trash " (:title target)
                            " and break 1 \"[Subroutine] End the run.\" subroutine")
@@ -458,12 +458,12 @@
 
    "Faust"
    {:abilities [{:label "Trash 1 card from Grip to break 1 subroutine"
-                 :prompt "Choose a card from your grip to trash for Faust"
+                 :prompt "Select a card from your grip to trash for Faust"
                  :choices {:req in-hand?}
                  :msg (msg "trash " (:title target) " and break 1 subroutine")
                  :effect (effect (trash target {:unpreventable true}))}
                 {:label "Trash 1 card from Grip to add 2 strength"
-                 :prompt "Choose a card from your grip to trash for Faust"
+                 :prompt "Select a card from your grip to trash for Faust"
                  :choices {:req in-hand?}
                  :msg (msg "trash " (:title target) " and add 2 strength")
                  :effect (effect (trash target {:unpreventable true}) (pump card 2))}]}
@@ -479,14 +479,14 @@
 
    "Femme Fatale"
    (auto-icebreaker ["Sentry"]
-                    {:prompt "Choose a piece of ICE to target for bypassing"
+                    {:prompt "Select a piece of ICE to target for bypassing"
                      :choices {:req ice?}
                      :leave-play (req (remove-icon state side card))
                      :effect (req (let [ice target
                                         serv (zone->name (second (:zone ice)))]
                                     (add-icon state side card ice "F" "blue")
                                     (system-msg state side
-                                                (str "chooses " (card-str state ice)
+                                                (str "selects " (card-str state ice)
                                                      " for Femme Fatale's bypass ability"))))
                      :abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 2 1)]})

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -75,14 +75,15 @@
 
 (defn- break-sub
   "Creates a break subroutine ability.
-  If num = 0 then any number of subs are broken."
-  ([cost num] (break-sub cost num nil))
-  ([cost num subtype] (break-sub cost num subtype nil))
-  ([cost num subtype effect]
-   {:msg (str "break " (when (> num 1) "up to ")
-              (if (pos? num) num "any number of")
+  If n = 0 then any number of subs are broken."
+  ([cost n] (break-sub cost n nil))
+  ([cost n subtype] (break-sub cost n subtype nil))
+  ([cost n subtype effect]
+   {:msg (str "break "
+              (when (> n 1) "up to ")
+              (if (pos? n) n "any number of")
               (when subtype (str " " subtype))
-              " subroutine" (when-not (= num 1) "s"))
+              (pluralize " subroutine" n))
     :cost [:credit cost]
     :effect effect}))
 
@@ -720,8 +721,8 @@
                  :choices :credit
                  :prompt "How many credits?"
                  :effect (effect (pump card target))
-                 :msg (msg "spend " target " [Credits], increase strength by " target ", and break " target " Barrier subroutine"
-                           (when (not= target 1) "s"))}])
+                 :msg (msg "spend " target " [Credits], increase strength by " target ", and break "
+                           (quantify target "Barrier subroutine"))}])
 
    "Passport"
    (central-breaker "Code Gate"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -133,7 +133,7 @@
                            (doseq [c (take 6 (:deck runner))]
                              (move state side c :play-area))
                              (continue-ability state side
-                                               {:prompt (str "Choose 4 cards for NVRAM")
+                                               {:prompt (str "Select 4 cards for NVRAM")
                                                 :delayed-completion true
                                                 :choices {:max 4
                                                           :all true
@@ -203,7 +203,7 @@
                                           "Grip to select the first card trashed?")
                              :priority 10
                              :player :corp
-                             :yes-ability {:prompt (msg "Choose a card to trash")
+                             :yes-ability {:prompt (msg "Select a card to trash")
                                            :choices (req (:hand runner)) :not-distinct true
                                            :priority 10
                                            :msg (msg "trash " (:title target)
@@ -253,13 +253,14 @@
    "Fringe Applications: Tomorrow, Today"
    {:events
     {:pre-start-game {:effect draft-points-target}
-     :runner-turn-begins {:req (req (and (not (:disabled card))
+     :runner-turn-begins {:player :corp
+                          :req (req (and (not (:disabled card))
                                          (has-most-faction? state :corp "Weyland Consortium")
                                          (some ice? (all-installed state side))))
+                          :prompt "Select a piece of ICE to place 1 advancement token on"
+                          :choices {:req #(and (installed? %)
+                                               (ice? %))}
                           :msg (msg "place 1 advancement token on " (card-str state target))
-                          :prompt "Choose a piece of ICE to place 1 advancement token on"
-                          :player :corp
-                          :choices {:req #(and (installed? %) (ice? %))}
                           :effect (req (add-prop state :corp target :advance-counter 1 {:placed true}))}}}
 
    "Gabriel Santiago: Consummate Professional"
@@ -303,7 +304,7 @@
                                              (turn-events state side :pass-ice)))))
               :effect (effect (show-wait-prompt :runner "Corp to use Haas-Bioroid: Architects of Tomorrow")
                               (continue-ability
-                                {:prompt "Choose a Bioroid to rez" :player :corp
+                                {:prompt "Select a Bioroid to rez" :player :corp
                                  :choices {:req #(and (has-subtype? % "Bioroid") (not (rezzed? %)))}
                                  :msg (msg "rez " (:title target))
                                  :cancel-effect (final-effect (clear-wait-prompt :runner))
@@ -355,7 +356,7 @@
                        state side
                        {:optional {:prompt (msg "Install another " type " from your Grip?")
                                    :yes-ability
-                                   {:prompt (msg "Choose another " type " to install from your grip")
+                                   {:prompt (msg "Select another " type " to install from your Grip")
                                     :choices {:req #(and (is-type? % type)
                                                          (in-hand? %))}
                                     :msg (msg "install " (:title target))
@@ -399,7 +400,7 @@
               :effect (req (show-wait-prompt state :runner "Corp to place advancement tokens")
                            (let [p (inc (get-agenda-points state :corp target))]
                              (continue-ability state side
-                               {:prompt "Choose a card to place advancement tokens on with Jemison Astronautics: Sacrifice. Audacity. Success."
+                               {:prompt "Select a card to place advancement tokens on with Jemison Astronautics: Sacrifice. Audacity. Success."
                                 :choices {:req #(and (installed? %) (= (:side %) "Corp"))}
                                 :msg (msg "place " p " advancement tokens on " (card-str state target))
                                 :cancel-effect (effect (clear-wait-prompt :runner))
@@ -474,7 +475,7 @@
                                       (update! state side (assoc card :code "greenhouse"))
                                       (resolve-ability
                                         state side
-                                        {:prompt "Choose a card that can be advanced"
+                                        {:prompt "Select a card that can be advanced"
                                          :choices {:req can-be-advanced?}
                                          :effect (effect (add-prop target :advance-counter 4 {:placed true}))} card nil)))
                                 (update! state side (assoc (get-card state card) :biotech-used true))))}]}
@@ -504,9 +505,9 @@
               :delayed-completion true
               :effect (req (if (some #(has-subtype? % "Icebreaker") (:hand runner))
                              (continue-ability state side
-                                               {:prompt "Choose an icebreaker to install from your Grip"
-                                                :delayed-completion true
+                                               {:prompt "Select an icebreaker to install from your Grip"
                                                 :choices {:req #(and (in-hand? %) (has-subtype? % "Icebreaker"))}
+                                                :delayed-completion true
                                                 :msg (msg "install " (:title target))
                                                 :effect (effect (install-cost-bonus [:credit -1])
                                                                 (runner-install eid target nil))}
@@ -622,7 +623,7 @@
                 {:prompt "Play a Current?" :player :corp
                  :req (req (not (empty? (filter #(has-subtype? % "Current")
                                                 (concat (:hand corp) (:discard corp))))))
-                 :yes-ability {:prompt "Choose a Current to play from HQ or Archives"
+                 :yes-ability {:prompt "Select a Current to play from HQ or Archives"
                                :show-discard true
                                :delayed-completion true
                                :choices {:req #(and (has-subtype? % "Current")
@@ -634,7 +635,7 @@
 
    "NEXT Design: Guarding the Net"
    (let [ndhelper (fn nd [n] {:prompt (msg "When finished, click NEXT Design: Guarding the Net to draw back up to 5 cards in HQ. "
-                                           "Choose a piece of ICE in HQ to install:")
+                                           "Select a piece of ICE in HQ to install:")
                               :choices {:req #(and (= (:side %) "Corp")
                                                    (ice? %)
                                                    (in-hand? %))}
@@ -661,7 +662,7 @@
    "Null: Whistleblower"
    {:abilities [{:once :per-turn
                  :req (req (and (:run @state) (rezzed? current-ice)))
-                 :prompt "Choose a card in your Grip to trash"
+                 :prompt "Select a card in your Grip to trash"
                  :choices {:req in-hand?}
                  :msg (msg "trash " (:title target) " and reduce the strength of " (:title current-ice)
                            " by 2 for the remainder of the run")
@@ -730,7 +731,7 @@
    {:implementation "Manually triggered"
     :abilities [{:req (req (:run @state))
                  :once :per-turn
-                 :prompt "Choose a card to add to the top of R&D"
+                 :prompt "Select a card to add to the top of R&D"
                  :show-discard true
                  :choices {:req #(and (= (:side %) "Corp") (in-discard? %))}
                  :effect (effect (move target :deck {:front true}))
@@ -782,7 +783,7 @@
               :delayed-completion true
               :effect (effect (continue-ability
                                 {:delayed-completion true
-                                 :prompt "Choose 2 cards in your Heap"
+                                 :prompt "Select 2 cards in your Heap"
                                  :show-discard true
                                  :choices {:max 2 :req #(and (in-discard? %)
                                                              (= (:side %) "Runner")
@@ -816,7 +817,7 @@
              {:req (req (and (not (:disabled card))
                              (has-most-faction? state :corp "Haas-Bioroid")
                              (pos? (count (:discard corp)))))
-              :prompt "Choose a card in Archives to shuffle into R&D"
+              :prompt "Select a card in Archives to shuffle into R&D"
               :choices {:req #(and (card-is? % :side :corp) (= (:zone %) [:discard]))}
               :player :corp :show-discard true :priority true
               :msg (msg "shuffle " (if (:seen target) (:title target) "a card")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -303,7 +303,7 @@
                                              (turn-events state side :pass-ice)))))
               :effect (effect (show-wait-prompt :runner "Corp to use Haas-Bioroid: Architects of Tomorrow")
                               (continue-ability
-                                {:prompt "Choose a bioroid to rez" :player :corp
+                                {:prompt "Choose a Bioroid to rez" :player :corp
                                  :choices {:req #(and (has-subtype? % "Bioroid") (not (rezzed? %)))}
                                  :msg (msg "rez " (:title target))
                                  :cancel-effect (final-effect (clear-wait-prompt :runner))
@@ -614,7 +614,7 @@
    "Nero Severn: Information Broker"
    {:abilities [{:req (req (has-subtype? current-ice "Sentry"))
                  :once :per-turn
-                 :msg "jack out when encountering a sentry"
+                 :msg "jack out when encountering a Sentry"
                  :effect (effect (jack-out nil))}]}
 
    "New Angeles Sol: Your News"
@@ -703,7 +703,7 @@
                            :effect (effect (gain :corp :credit 1))}}}
 
    "Quetzal: Free Spirit"
-   {:abilities [{:once :per-turn :msg "break 1 barrier subroutine"}]}
+   {:abilities [{:once :per-turn :msg "break 1 Barrier subroutine"}]}
 
    "Reina Roja: Freedom Fighter"
    {:events {:pre-rez {:req (req (and (ice? target) (not (get-in @state [:per-turn (:cid card)]))))
@@ -714,7 +714,7 @@
    "Rielle \"Kit\" Peddler: Transhuman"
    {:abilities [{:req (req (and (:run @state)
                                 (:rezzed (get-card state current-ice))))
-                 :once :per-turn :msg (msg "make " (:title current-ice) " gain code gate until the end of the run")
+                 :once :per-turn :msg (msg "make " (:title current-ice) " gain Code Gate until the end of the run")
                  :effect (req (let [ice current-ice
                                     stypes (:subtype ice)]
                                 (update! state side (assoc ice :subtype (combine-subtypes true stypes "Code Gate")))
@@ -769,7 +769,7 @@
                           (empty? (filter #(has-subtype? % "Advertisement")
                                           (flatten (turn-events state :corp :rez))))))
            :effect (effect (lose :runner :credit 1))
-           :msg (msg "make the Runner lose 1 [Credits] by rezzing an advertisement")}}}
+           :msg (msg "make the Runner lose 1 [Credits] by rezzing an Advertisement")}}}
 
    "Steve Cambridge: Master Grifter"
    {:events {:successful-run

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -43,7 +43,7 @@
 
    "Ad Blitz"
    (let [abhelp (fn ab [n total]
-                  {:prompt "Select an advertisement to install and rez" :show-discard true
+                  {:prompt "Select an Advertisement to install and rez" :show-discard true
                    :delayed-completion true
                    :choices {:req #(and (= (:side %) "Corp")
                                         (has-subtype? % "Advertisement")
@@ -54,10 +54,10 @@
                                   (if (< n total)
                                     (continue-ability state side (ab (inc n) total) card nil)
                                     (effect-completed state side eid))))})]
-     {:prompt "How many advertisements?"
+     {:prompt "How many Advertisements?"
       :delayed-completion true
       :choices :credit
-      :msg (msg "install and rez " target " advertisements")
+      :msg (msg "install and rez " target " Advertisements")
       :effect (effect (continue-ability (abhelp 1 target) card nil))})
 
    "Aggressive Negotiation"
@@ -971,7 +971,7 @@
    "Recruiting Trip"
    (let [rthelp (fn rt [total left selected]
                   (if (pos? left)
-                    {:prompt (str "Select a sysop (" (inc (- total left)) "/" total ")")
+                    {:prompt (str "Select a Sysop (" (inc (- total left)) "/" total ")")
                      :choices (req (cancellable (filter #(and (has-subtype? % "Sysop")
                                                               (not (some #{(:title %)} selected))) (:deck corp)) :sorted))
                      :msg (msg "put " (:title target) " into HQ")
@@ -983,10 +983,10 @@
                                     card nil))}
                     {:effect (effect (shuffle! :corp :deck))
                      :msg (msg "shuffle R&D")}))]
-   {:prompt "How many sysops?"
+   {:prompt "How many Sysops?"
     :delayed-completion true
     :choices :credit
-    :msg (msg "search for " target " sysops")
+    :msg (msg "search for " target " Sysops")
     :effect (effect (continue-ability (rthelp target target []) card nil))})
 
    "Red Planet Couriers"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -7,7 +7,7 @@
     :additional-cost [:forfeit]
     :effect (req (continue-ability
                    state side
-                   {:prompt "Choose an agenda in your score area to trigger its \"when scored\" ability"
+                   {:prompt "Select an agenda in your score area to trigger its \"when scored\" ability"
                     :choices {:req #(and (is-type? % "Agenda")
                                          (when-scored? %)
                                          (is-scored? state :corp %))}
@@ -90,7 +90,8 @@
    "Archived Memories"
    {:effect (req (let [cid (:cid card)]
                    (resolve-ability state side
-                     {:prompt "Choose a card from Archives to add to HQ" :show-discard true
+                     {:prompt "Select a card from Archives to add to HQ"
+                      :show-discard true
                       :choices {:req #(and (not= (:cid %) cid)
                                            (= (:side %) "Corp")
                                            (= (:zone %) [:discard]))}
@@ -131,7 +132,7 @@
                  (continue-ability state side (audacity 1) card nil))})
 
    "Back Channels"
-   {:prompt "Choose an installed card in a server to trash"
+   {:prompt "Select an installed card in a server to trash"
     :choices {:req #(and (= (last (:zone %)) :content)
                          (is-remote? (second (:zone %))))}
     :effect (final-effect (gain :credit (* 3 (get target :advance-counter 0))) (trash target))
@@ -298,7 +299,7 @@
     :effect (effect (purge))}
 
    "Dedication Ceremony"
-   {:prompt "Choose a faceup card"
+   {:prompt "Select a faceup card"
     :choices {:req #(or (and (card-is? % :side :corp)
                              (:rezzed %))
                         (and (card-is? % :side :runner)
@@ -356,7 +357,7 @@
             :effect (req (let [f (:faction (:identity runner))]
                            (continue-ability
                              state side
-                             {:prompt "Choose an installed card not matching the faction of the Runner's identity"
+                             {:prompt "Select an installed card not matching the faction of the Runner's identity"
                               :choices {:req #(and (installed? %) (not= f (:faction %)) (card-is? % :side :runner))}
                               :msg (msg "trash " (:title target))
                               :effect (effect (trash target))}
@@ -392,14 +393,14 @@
     :effect (req
               (continue-ability
                 state side
-                {:prompt "Choose a stolen agenda in the Runner's score area to swap"
+                {:prompt "Select a stolen agenda in the Runner's score area to swap"
                  :choices {:req #(in-runner-scored? state side %)}
                  :delayed-completion true
                  :effect (req
                            (let [stolen target]
                              (continue-ability
                                state side
-                               {:prompt (msg "Choose a scored agenda to swap for " (:title stolen))
+                               {:prompt (msg "Select a scored agenda to swap for " (:title stolen))
                                 :choices {:req #(in-corp-scored? state side %)}
                                 :effect (req (let [scored target]
                                                (swap-agendas state side scored stolen)
@@ -429,7 +430,8 @@
                             :delayed-completion true
                             :effect (final-effect (continue-ability
                                                     (if (= target "Yes")
-                                                      {:prompt "Choose a resource to trash" :player :runner
+                                                      {:player :runner
+                                                       :prompt "Select a resource to trash"
                                                        :choices {:req #(and (is-type? % "Resource") (installed? %))}
                                                        :effect (req (trash state side target {:unpreventable true})
                                                                     (system-msg state :runner
@@ -447,7 +449,7 @@
 
    "Foxfire"
    {:trace {:base 7
-            :prompt "Choose 1 card to trash"
+            :prompt "Select 1 card to trash"
             :not-distinct true
             :choices {:req #(and (installed? %)
                                  (or (has-subtype? % "Virtual")
@@ -562,18 +564,18 @@
    {:delayed-completion true
     :effect (effect (draw 3)
                     (continue-ability
-                      {:prompt "Choose a card in HQ to put on top of R&D"
-                       :choices {:req #(and (in-hand? %)
-                                            (= (:side %) "Corp"))}
+                      {:prompt "Select a card in HQ to put on top of R&D"
+                       :choices {:req #(and (= (:side %) "Corp")
+                                            (in-hand? %))}
                        :msg "draw 3 cards and add 1 card from HQ to the top of R&D"
                        :effect (effect (move target :deck {:front true}))}
                       card nil))}
 
    "Housekeeping"
    {:events {:runner-install {:player :runner
-                              :choices {:req #(and (in-hand? %)
-                                                   (= (:side %) "Runner"))}
-                              :prompt "Choose a card from your Grip to trash for Housekeeping" :once :per-turn
+                              :prompt "Select a card from your Grip to trash for Housekeeping" :once :per-turn
+                              :choices {:req #(and (= (:side %) "Runner")
+                                                   (in-hand? %))}
                               :msg (msg "force the Runner to trash " (:title target) " from their Grip")
                               :effect (effect (trash target {:unpreventable true}))}}}
 
@@ -586,7 +588,7 @@
     :effect (effect (trash target))}
 
    "Interns"
-   {:prompt "Choose a card to install from Archives or HQ"
+   {:prompt "Select a card to install from Archives or HQ"
     :show-discard true
     :not-distinct true
     :choices {:req #(and (not (is-type? % "Operation"))
@@ -631,13 +633,13 @@
     :msg "gain 4 [Credits]"
     :effect (effect (gain :credit 4)
                     (continue-ability {:player :corp
-                                       :prompt "Choose a card to install"
-                                       :delayed-completion true
+                                       :prompt "Select a card to install"
                                        :choices {:req #(and (= (:side %) "Corp")
                                                             (not (is-type? % "Operation"))
                                                             (in-hand? %))}
-                                       :effect (effect (corp-install eid target nil nil))
-                                       :msg (msg (corp-install-msg target))}
+                                       :delayed-completion true
+                                       :msg (msg (corp-install-msg target))
+                                       :effect (effect (corp-install eid target nil nil))}
                                       card nil))}
 
    "Liquidation"
@@ -645,8 +647,10 @@
     :effect (req (let [n (count (filter #(and (rezzed? %)
                                               (not (is-type? % "Agenda"))) (all-installed state :corp)))]
                    (continue-ability state side
-                     {:prompt "Choose any number of rezzed cards to trash"
-                      :choices {:max n :req #(and (rezzed? %) (not (is-type? % "Agenda")))}
+                     {:prompt "Select any number of rezzed cards to trash"
+                      :choices {:max n
+                                :req #(and (rezzed? %)
+                                           (not (is-type? % "Agenda")))}
                       :msg (msg "trash " (join ", " (map :title (sort-by :title targets))) " and gain " (* (count targets) 3) " [Credits]")
                       :effect (req (doseq [c targets]
                                      (trash state side c))
@@ -715,7 +719,7 @@
                             (tag-runner :runner eid (- target (second targets))))}}
 
    "Mushin No Shin"
-   {:prompt "Choose a card to install from HQ"
+   {:prompt "Select a card to install from HQ"
     :choices {:req #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))
                          (= (:side %) "Corp")
                          (in-hand? %))}
@@ -790,7 +794,7 @@
                    (< (:credit runner) 6)))
     :delayed-completion true
     :effect (effect (continue-ability
-                      {:prompt "Choose an installed card to trash"
+                      {:prompt "Select an installed card to trash"
                        :choices {:req installed?}
                        :msg (msg "remove 1 Runner tag and trash " (:title target))
                        :effect (effect (trash target))}
@@ -846,7 +850,7 @@
     :effect (req (mill state :corp target)
                  (let [n target]
                    (continue-ability state :runner
-                                     {:prompt "Choose a Program or piece of Hardware to trash"
+                                     {:prompt "Select a Program or piece of Hardware to trash"
                                       :choices {:req #(and (#{"Hardware" "Program"} (:type %))
                                                            (<= (:cost %) n))}
                                       :msg (msg "trash " (:title target))
@@ -885,7 +889,7 @@
       :effect (effect (continue-ability (install-card target) card nil))})
 
    "Product Recall"
-   {:prompt "Choose a rezzed asset or upgrade to trash"
+   {:prompt "Select a rezzed asset or upgrade to trash"
     :choices {:req #(and (rezzed? %)
                          (or (is-type? % "Asset") (is-type? % "Upgrade")))}
     :effect (req (let [c target]
@@ -940,7 +944,7 @@
                             (system-msg (str "does " (or (:stole-agenda runner-reg) 0) " meat damage")))}}
 
    "Reclamation Order"
-   {:prompt "Choose a card from Archives"
+   {:prompt "Select a card from Archives"
     :show-discard true
     :choices {:req #(and (= (:side %) "Corp")
                          (not= (:title %) "Reclamation Order")
@@ -971,7 +975,7 @@
    "Recruiting Trip"
    (let [rthelp (fn rt [total left selected]
                   (if (pos? left)
-                    {:prompt (str "Select a Sysop (" (inc (- total left)) "/" total ")")
+                    {:prompt (str "Choose a Sysop (" (inc (- total left)) "/" total ")")
                      :choices (req (cancellable (filter #(and (has-subtype? % "Sysop")
                                                               (not (some #{(:title %)} selected))) (:deck corp)) :sorted))
                      :msg (msg "put " (:title target) " into HQ")
@@ -995,7 +999,7 @@
     :prompt "Select an installed card that can be advanced"
     :choices {:req can-be-advanced?}
     :effect (req (let [installed (get-all-installed state)
-                       total-adv (reduce + (map :advance-counter 
+                       total-adv (reduce + (map :advance-counter
                                                 (filter #(:advance-counter %) installed)))]
                    (doseq [c installed]
                      (update! state side (dissoc c :advance-counter)))
@@ -1045,7 +1049,7 @@
                                                           (effect-completed state side eid card))))} card nil))}
 
    "Restoring Face"
-   {:prompt "Choose a Sysop, Executive or Clone to trash"
+   {:prompt "Select a Sysop, Executive or Clone to trash"
     :msg (msg "trash " (card-str state target) " to remove 2 bad publicity")
     :choices {:req #(and (rezzed? %)
                          (or (has-subtype? % "Clone")
@@ -1061,7 +1065,7 @@
    {:delayed-completion true
     :effect (req (let [n (count (:hand corp))]
                    (continue-ability state side
-                     {:prompt (msg "Choose up to " n " cards in HQ to trash with Reuse")
+                     {:prompt (msg "Select up to " n " cards in HQ to trash with Reuse")
                       :choices {:max n
                                 :req #(and (= (:side %) "Corp")
                                            (in-hand? %))}
@@ -1071,9 +1075,9 @@
                                       (gain :credit (* 2 (count targets))))} card nil)))}
 
    "Rework"
-   {:prompt "Choose a card from HQ to shuffle into R&D"
-    :choices {:req #(and (in-hand? %)
-                         (= (:side %) "Corp"))}
+   {:prompt "Select a card from HQ to shuffle into R&D"
+    :choices {:req #(and (= (:side %) "Corp")
+                         (in-hand? %))}
     :msg "shuffle a card from HQ into R&D"
     :effect (final-effect (move target :deck) (shuffle! :deck))}
 
@@ -1232,7 +1236,7 @@
                              card nil)))}}
 
    "Special Report"
-   {:prompt "Choose any number of cards in HQ to shuffle into R&D"
+   {:prompt "Select any number of cards in HQ to shuffle into R&D"
     :choices {:max (req (count (:hand corp)))
               :req #(and (= (:side %) "Corp")
                          (in-hand? %))}
@@ -1436,7 +1440,8 @@
 
    "Voter Intimidation"
    {:req (req (seq (:scored runner)))
-    :psi {:not-equal {:player :corp :prompt "Choose a resource to trash"
+    :psi {:not-equal {:player :corp
+                      :prompt "Select a resource to trash"
                       :choices {:req #(and (installed? %)
                                            (is-type? % "Resource"))}
                       :msg (msg "trash " (:title target))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -675,7 +675,7 @@
                     state side
                     {:prompt "How many copies?"
                      :choices {:number (req (count cs))}
-                     :msg (msg "add " target " cop" (if (= target 1) "y" "ies") " of " c " to HQ")
+                     :msg (msg "add " (quantify target "cop" "y" "ies") " of " c " to HQ")
                      :effect (req (shuffle! state :corp :deck)
                                   (doseq [c (take target cs)]
                                     (move state side c :hand)))}
@@ -957,8 +957,8 @@
                                      {:prompt (str "Choose how many copies of "
                                                    title " to reveal")
                                       :choices {:number (req n)}
-                                      :msg (msg "reveal " target
-                                                " cop" (if (= 1 target) "y" "ies")
+                                      :msg (msg "reveal "
+                                                (quantify target "cop" "y" "ies")
                                                 " of " title
                                                 " from Archives"
                                                 (when (pos? target)
@@ -1069,8 +1069,9 @@
                       :choices {:max n
                                 :req #(and (= (:side %) "Corp")
                                            (in-hand? %))}
-                      :msg (msg "trash " (count targets) " card" (if (not= 1 (count targets)) "s")
-                                " and gain " (* 2 (count targets)) " [Credits]")
+                      :msg (msg (let [m (count targets)]
+                                  (str "trash " (quantify m "card")
+                                       " and gain " (* 2 m) " [Credits]")))
                       :effect (effect (trash-cards targets)
                                       (gain :credit (* 2 (count targets))))} card nil)))}
 

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -800,7 +800,7 @@
                                    (= (:zone %) (:zone cice))
                                    (= 1 (abs (- (ice-index state %)
                                                 (ice-index state cice)))))}
-              :msg "swap a piece of barrier ICE"
+              :msg "swap a piece of Barrier ICE"
               :effect (req (let [tgtndx (ice-index state target)
                                  cidx (ice-index state cice)]
                              (swap! state update-in (cons :corp (:zone cice))
@@ -814,7 +814,7 @@
                    :req (req (and (:run @state)
                                   (rezzed? current-ice)
                                   (has-subtype? current-ice "Barrier")))
-                   :label "Swap the barrier ICE currently being encountered with a piece of ICE directly before or after it"
+                   :label "Swap the Barrier ICE currently being encountered with a piece of ICE directly before or after it"
                    :effect (effect (resolve-ability (surf state current-ice) card nil))}]})
 
    "Tapwrm"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -136,7 +136,7 @@
                                (swap! state assoc-in [:run :run-effect :replace-access]
                                       {:effect (req (if (> (count (filter #(= (:title %) "Bank Job") (all-installed state :runner))) 1)
                                                       (resolve-ability state side
-                                                        {:prompt "Choose a copy of Bank Job to use"
+                                                        {:prompt "Select a copy of Bank Job to use"
                                                          :choices {:req #(and installed? (= (:title %) "Bank Job"))}
                                                          :effect (req (let [c target
                                                                             creds (get-in c [:counter :credit])]
@@ -284,7 +284,7 @@
                  :effect (effect (add-counter card :power 1))}
                 {:cost [:click 1]
                  :label "Install a program from your Grip"
-                 :prompt "Choose a program to install from your Grip"
+                 :prompt "Select a program to install from your Grip"
                  :choices {:req #(and (is-type? % "Program") (in-hand? %))}
                  :msg (msg "install " (:title target))
                  :effect (req (install-cost-bonus state side [:credit (* -1 (get-in card [:counter :power] 0))])
@@ -339,7 +339,7 @@
                    :effect (req (toast state :runner (str "Click Councilman to derez " (card-str state target {:visible true})
                                                           " that was just rezzed") "info")
                                 (toast state :corp (str "Runner has the opportunity to derez with Councilman.") "error"))}}
-    :abilities [{:prompt "Choose an asset or upgrade that was just rezzed"
+    :abilities [{:prompt "Select an asset or upgrade that was just rezzed"
                  :choices {:req #(and (rezzed? %)
                                       (or (is-type? % "Asset") (is-type? % "Upgrade")))}
                  :effect (req (let [c target
@@ -484,7 +484,8 @@
    "Dr. Lovegood"
    {:flags {:runner-phase-12 (req (> (count (all-installed state :runner)) 1))}
     :abilities [{:req (req (:runner-phase-12 @state))
-                 :prompt "Choose an installed card to make its text box blank for the remainder of the turn" :once :per-turn
+                 :prompt "Select an installed card to make its text box blank for the remainder of the turn"
+                 :once :per-turn
                  :choices {:req installed?}
                  :msg (msg "make the text box of " (:title target) " blank for the remainder of the turn")
                  :effect (req (let [c target]
@@ -893,7 +894,8 @@
                                        :choices ["Yes" "No"] :player :corp
                                        :effect (final-effect (resolve-ability
                                                                (if (= target "Yes")
-                                                                 {:prompt "Choose an agenda to forfeit" :player :corp
+                                                                 {:player :corp
+                                                                  :prompt "Select an agenda to forfeit"
                                                                   :choices {:req #(in-corp-scored? state side %)}
                                                                   :effect (effect (forfeit target)
                                                                                   (move :runner card :rfg)
@@ -910,7 +912,7 @@
    "London Library"
    {:abilities [{:label "Install a non-virus program on London Library"
                  :cost [:click 1]
-                 :prompt "Choose a non-virus program to install on London Library from your grip"
+                 :prompt "Select a non-virus program to install on London Library from your grip"
                  :choices {:req #(and (is-type? % "Program")
                                       (not (has-subtype? % "Virus"))
                                       (in-hand? %))}
@@ -953,22 +955,23 @@
                               (let [drawn (get-in @state [:runner :register :most-recent-drawn])]
                                 (resolve-ability
                                   state side
-                                  {:prompt (str "Choose 1 card to add to the bottom of the Stack")
-                                   :msg (msg "add 1 card to the bottom of the Stack")
+                                  {:prompt "Select 1 card to add to the bottom of the Stack"
                                    :choices {:req #(and (in-hand? %)
                                                         (some (fn [c] (= (:cid c) (:cid %))) drawn))}
+                                   :msg (msg "add 1 card to the bottom of the Stack")
                                    :effect (req (move state side target :deck))} card nil)))}]}
 
    "Muertos Gang Member"
    {:effect (req (resolve-ability
                    state :corp
-                   {:prompt "Choose a card to derez"
-                    :choices {:req #(and (= (:side %) "Corp") (:rezzed %))}
+                   {:prompt "Select a card to derez"
+                    :choices {:req #(and (= (:side %) "Corp")
+                                         (:rezzed %))}
                     :effect (req (derez state side target))}
                   card nil))
     :leave-play (req (resolve-ability
                        state :corp
-                       {:prompt "Choose a card to rez, ignoring the rez cost"
+                       {:prompt "Select a card to rez, ignoring the rez cost"
                         :choices {:req #(not (:rezzed %))}
                         :effect (req (rez state side target {:ignore-cost :rez-cost})
                                      (system-msg state side (str "rezzes " (:title target) " at no cost")))}
@@ -1027,7 +1030,7 @@
    {:abilities [{:label "Install and host a connection on Off-Campus Apartment"
                  :effect (effect (resolve-ability
                                    {:cost [:click 1]
-                                    :prompt "Choose a connection in your Grip to install on Off-Campus Apartment"
+                                    :prompt "Select a connection in your Grip to install on Off-Campus Apartment"
                                     :choices {:req #(and (has-subtype? % "Connection")
                                                          (can-pay? state side nil :credit (:cost %))
                                                          (in-hand? %))}
@@ -1035,7 +1038,7 @@
                                     :effect (effect (runner-install target {:host-card card}) (draw))}
                                   card nil))}
                 {:label "Host an installed connection"
-                 :prompt "Choose a connection to host on Off-Campus Apartment"
+                 :prompt "Select a connection to host on Off-Campus Apartment"
                  :choices {:req #(and (has-subtype? % "Connection")
                                       (installed? %))}
                  :msg (msg "host " (:title target) " and draw 1 card")
@@ -1142,7 +1145,7 @@
                          (add-counter state side target :power -1)))}]
      {:flags {:drip-economy true}
       :abilities [{:label "Host a program or piece of hardware" :cost [:click 1]
-                   :prompt "Choose a card to host on Personal Workshop"
+                   :prompt "Select a card to host on Personal Workshop"
                    :choices {:req #(and (#{"Program" "Hardware"} (:type %))
                                         (in-hand? %)
                                         (= (:side %) "Runner"))}
@@ -1175,7 +1178,7 @@
 
    "Political Operative"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
-    :abilities [{:prompt "Choose a rezzed card with a trash cost"
+    :abilities [{:prompt "Select a rezzed card with a trash cost"
                  :choices {:req #(and (:trash %) (rezzed? %))}
                  :effect (req (let [c target]
                                 (trigger-event state side :pre-trash c)
@@ -1361,7 +1364,7 @@
    {:abilities [{:cost [:click 2]
                  :req (req (and (not (seq (get-in @state [:runner :locked :discard])))
                                 (< 0 (count (filter #(is-type? % "Event") (:discard runner))))))
-                 :prompt "Choose an event to play"
+                 :prompt "Select an event to play"
                  :msg (msg "play " (:title target))
                  :show-discard true
                  :choices {:req #(and (is-type? % "Event")
@@ -1580,7 +1583,7 @@
                                                                        (remove-once #(not= (:cid %) (:cid target)) coll)))))))}]
    {:flags {:drip-economy true}  ; not technically drip economy, but has an interaction with Drug Dealer
     :abilities [{:label "Host a resource or piece of hardware" :cost [:click 1]
-                 :prompt "Choose a card to host on The Supplier"
+                 :prompt "Select a card to host on The Supplier"
                  :choices {:req #(and (#{"Resource" "Hardware"} (:type %))
                                       (in-hand? %))}
                  :effect (effect (host card target)) :msg (msg "host " (:title target) "")}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -619,8 +619,8 @@
                    :effect (req (let [c (move state :runner (get-agenda card) :scored)]
                                   (gain-agenda-point state :runner (get-agenda-points state :runner c))))
                    :msg (msg (let [c (get-agenda card)]
-                               (str "add " (:title c) " to their score area and gain " (get-agenda-points state :runner c)
-                                    " agenda point" (when (> (get-agenda-points state :runner c) 1) "s"))))}]})
+                               (str "add " (:title c) " to their score area and gain "
+                                    (quantify (get-agenda-points state :runner c) "agenda point"))))}]})
 
    "Find the Truth"
    {:events {:post-runner-draw {:msg (msg "reveal that they drew: "
@@ -646,8 +646,7 @@
    {:events {:agenda-scored
              {:delayed-completion true
               :interactive (req true)
-              :msg (msg "access " (get-in @state [:runner :hq-access]) " card"
-                        (when (< 1 (get-in @state [:runner :hq-access])) "s") " from HQ")
+              :msg (msg "access " (quantify (get-in @state [:runner :hq-access]) "card") " from HQ")
               :effect (req (when-completed
                              ; manually trigger the pre-access event to alert Nerve Agent.
                              (trigger-event-sync state side :pre-access :hq)
@@ -1098,7 +1097,7 @@
                                                        (trash state side c {:unpreventable true}))
                                                      (when (> (int target) 0)
                                                        (system-msg state side (str "trashes " target
-                                                                                   " cop" (if (not= target 1) "ies" "y")
+                                                                                   (quantify target "cop" "y" "ies")
                                                                                    " of " title)))))}}}))]
      {:events {:runner-install {:req (req (first-event? state side :runner-install))
                                 :delayed-completion true

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -31,7 +31,7 @@
    {:can-host (req (is-type? target "ICE"))
     :abilities [{:label "Host a piece of Bioroid ICE"
                  :cost [:click 1]
-                 :prompt "Choose a piece of Bioroid ICE to host on Awakening Center"
+                 :prompt "Select a piece of Bioroid ICE to host on Awakening Center"
                  :choices {:req #(and (ice? %)
                                       (has-subtype? % "Bioroid")
                                       (in-hand? %))}
@@ -231,7 +231,7 @@
    "Disposable HQ"
    (letfn [(dhq [n i]
              {:req (req (pos? i))
-              :prompt "Choose a card in HQ to add to the bottom of R&D"
+              :prompt "Select a card in HQ to add to the bottom of R&D"
               :choices {:req #(and (= (:side %) "Corp")
                                    (in-hand? %))}
               :msg "add a card to the bottom of R&D"
@@ -383,7 +383,7 @@
    {:abilities [{:req (req this-server)
                  :label "[Trash]: Start a Psi game"
                  :msg "start a Psi game"
-                 :psi {:not-equal {:prompt "Choose a rezzed piece of ICE to resolve one of its subroutines"
+                 :psi {:not-equal {:prompt "Select a rezzed piece of ICE to resolve one of its subroutines"
                                    :choices {:req #(and (ice? %)
                                                         (rezzed? %))}
                                    :msg (msg "resolve a subroutine on " (:title target))}}
@@ -400,7 +400,7 @@
    {:abilities
     [{:req (req this-server)
       :label "Swap the ICE being approached with a piece of ICE from HQ"
-      :prompt "Choose a piece of ICE"
+      :prompt "Select a piece of ICE"
       :choices {:req #(and (ice? %)
                            (in-hand? %))}
       :once :per-run
@@ -703,7 +703,7 @@
            :effect (effect (resolve-ability
                              {:optional
                               {:prompt (msg "Rez another card with Surat City Grid?")
-                               :yes-ability {:prompt "Choose a card to rez"
+                               :yes-ability {:prompt "Select a card to rez"
                                              :choices {:req #(and (not (rezzed? %))
                                                                   (not (is-type? % "Agenda")))}
                                              :msg (msg "rez " (:title target) ", lowering the rez cost by 2 [Credits]")
@@ -719,7 +719,7 @@
                  :effect (req (let [icename (:title (get-in (:ices (card->server state card)) [(:position run)]))]
                                 (resolve-ability
                                   state side
-                                  {:prompt "Choose a copy of the ICE just passed"
+                                  {:prompt "Select a copy of the ICE just passed"
                                    :choices {:req #(and (in-hand? %)
                                                         (ice? %)
                                                         (= (:title %) icename))}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -29,17 +29,17 @@
 
    "Awakening Center"
    {:can-host (req (is-type? target "ICE"))
-    :abilities [{:label "Host a piece of bioroid ICE"
+    :abilities [{:label "Host a piece of Bioroid ICE"
                  :cost [:click 1]
-                 :prompt "Choose a piece of bioroid ICE to host on Awakening Center"
+                 :prompt "Choose a piece of Bioroid ICE to host on Awakening Center"
                  :choices {:req #(and (ice? %)
                                       (has-subtype? % "Bioroid")
                                       (in-hand? %))}
-                 :msg "host a piece of bioroid ICE"
+                 :msg "host a piece of Bioroid ICE"
                  :effect (req (corp-install state side target card {:no-install-cost true}))}
                 {:req (req (and this-server (= (get-in @state [:run :position]) 0)))
-                 :label "Rez a hosted piece of bioroid ICE"
-                 :prompt "Choose a piece of bioroid ICE to rez" :choices (req (:hosted card))
+                 :label "Rez a hosted piece of Bioroid ICE"
+                 :prompt "Choose a piece of Bioroid ICE to rez" :choices (req (:hosted card))
                  :msg (msg "lower the rez cost of " (:title target) " by 7 [Credits] and force the Runner to encounter it")
                  :effect (effect (rez-cost-bonus -7) (rez target)
                                  (update! (dissoc (get-card state target) :facedown))
@@ -763,7 +763,7 @@
                            :effect (effect (gain :credit 1))}}}}
 
    "Tyrs Hand"
-   {:abilities [{:label "[Trash]: Prevent a subroutine on a Bioroid from being broken"
+   {:abilities [{:label "[Trash]: Prevent a subroutine on a piece of Bioroid ICE from being broken"
                  :req (req (and (= (butlast (:zone current-ice)) (butlast (:zone card)))
                                 (has-subtype? current-ice "Bioroid")))
                  :effect (effect (trash card))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -536,7 +536,8 @@
                                 card :can-steal
                                 (fn [state _ card]
                                   (if-not (some #(= (:title %) (:title card)) (:scored runner))
-                                    ((constantly false) (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
+                                    ((constantly false)
+                                      (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
                                     true))))}]
      {:trash-effect
               {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -5,7 +5,7 @@
                                 zones->sorted-names remote->name remote-num->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side same-card? same-side?
                                 combine-subtypes remove-subtypes remove-subtypes-once click-spent? used-this-turn?
-                                pluralize]]
+                                pluralize quantify]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -4,7 +4,8 @@
                                 dissoc-in cancellable card-is? side-str build-cost-str build-spend-msg cost-names
                                 zones->sorted-names remote->name remote-num->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side same-card? same-side?
-                                combine-subtypes remove-subtypes remove-subtypes-once click-spent? used-this-turn?]]
+                                combine-subtypes remove-subtypes remove-subtypes-once click-spent? used-this-turn?
+                                pluralize]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -528,8 +528,8 @@
                                     m (count (filter #(not (:seen %)) targets))]
                                 (str (join ", " (map :title seen))
                                      (when (pos? m)
-                                       (str (when-not (empty? seen) " and ") m " card"
-                                            (when (> m 1) "s")))))
+                                       (str (when-not (empty? seen) " and ")
+                                            (quantify m "unseen card")))))
                               " into R&D")
                     :effect (req (doseq [c targets] (move state side c :deck))
                                  (shuffle! state side :deck))

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -399,9 +399,8 @@
            :after-active-player {:effect (req (let [c (get-card state c)
                                                     points (or (get-agenda-points state :corp c) points)]
                                                 (set-prop state :corp (get-card state moved-card) :advance-counter 0)
-
-                                                (system-msg state :corp (str "scores " (:title c) " and gains " points
-                                                                             " agenda point" (when (> points 1) "s")))
+                                                (system-msg state :corp (str "scores " (:title c) " and gains "
+                                                                             (quantify points "agenda point")))
                                                 (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
                                                 (swap! state dissoc-in [:corp :disable-id])
                                                 (gain-agenda-point state :corp points)

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -102,7 +102,7 @@
                        :effect (req (if (< 1 (count handlers))
                                       (continue-ability state side (choose-handler (next handlers)) nil event-targets)
                                       (effect-completed state side eid nil)))}))
-                  {:prompt "Select a trigger to resolve"
+                  {:prompt "Choose a trigger to resolve"
                    :choices titles
                    :delayed-completion true
                    :effect (req (let [to-resolve (some #(when (= target (:title (:card %))) %) handlers)

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -263,11 +263,8 @@
 (defn event-title
   "Gets a string describing the internal engine event keyword"
   [event]
-  (case event
-    :agenda-scored "agenda-scored"
-    :agenda-stolen "agenda-stolen"
-    :runner-install "runner-install"
-    :successful-run "successful-run"
+  (if (keyword? event)
+    (name event)
     (str event)))
 
 (defn show-error-toast

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -118,8 +118,8 @@
            (prevent-draw state side))))
      (when (< draws-after-prevent draws-wanted)
        (let [prevented (- draws-wanted draws-after-prevent)]
-         (system-msg state (other-side side) (str "prevents " prevented " card"
-                                                  (when (> prevented 1) "s")
+         (system-msg state (other-side side) (str "prevents "
+                                                  (quantify prevented "card")
                                                   " from being drawn")))))))
 
 ;;; Damage
@@ -262,7 +262,7 @@
 (defn resolve-tag [state side eid n args]
   (if (pos? n)
     (do (gain state :runner :tag n)
-        (toast state :runner (str "Took " n " tag" (when (> n 1) "s") "!") "info")
+        (toast state :runner (str "Took " (quantify n "tag") "!") "info")
         (trigger-event-sync state side eid :runner-gain-tag n))
     (effect-completed state side eid)))
 

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -44,8 +44,8 @@
      (when-completed
        (trigger-event-simult
          state :runner :agenda-stolen
-         {:first-ability {:effect (req (system-msg state :runner (str "steals " (:title c) " and gains " points
-                                                                      " agenda point" (when (> points 1) "s")))
+         {:first-ability {:effect (req (system-msg state :runner (str "steals " (:title c) " and gains "
+                                                                      (quantify points "agenda point")))
                                        (swap! state update-in [:runner :register :stole-agenda]
                                               #(+ (or % 0) (:agendapoints c)))
                                        (gain-agenda-point state :runner points)

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -288,3 +288,13 @@
     (if-not (empty? left)
       (remove-subtypes-once part left)
       part)))
+
+(defn pluralize
+  "Makes a string plural based on the number n. Takes specific suffixes for singular and plural cases if necessary."
+  ([string n] (pluralize string "s" n))
+  ([string suffix n] (pluralize string "" suffix n))
+  ([string single-suffix plural-suffix n]
+   (if (or (= 1 n)
+           (= -1 n))
+     (str string single-suffix)
+     (str string plural-suffix))))

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -75,14 +75,14 @@
 (defn costs-to-symbol
   "Used during steal to print runner prompt for payment"
   [costs]
-  (clojure.string/join ", " (map #(let [key (first %) value (last %)]
-                                   (case key
-                                     :credit (str value " [Credits]")
-                                     :click (reduce str (for [i (range value)] "[Click]"))
-                                     :net-damage (str value " net damage")
-                                     :mill (str value " card mill")
-                                     :hardware (str value " installed hardware")
-                                     (str value (str key)))) (partition 2 (flatten costs)))))
+  (join ", " (map #(let [key (first %) value (last %)]
+                     (case key
+                       :credit (str value " [Credits]")
+                       :click (reduce str (for [i (range value)] "[Click]"))
+                       :net-damage (str value " net damage")
+                       :mill (str value " card mill")
+                       :hardware (str value " installed hardware")
+                       (str value (str key)))) (partition 2 (flatten costs)))))
 
 (defn vdissoc [v n]
   (vec (concat (subvec v 0 n) (subvec v (inc n)))))
@@ -102,7 +102,7 @@
       (if (and (> num Integer/MIN_VALUE) (< num Integer/MAX_VALUE)) (int num) num))
   (catch Exception e nil)))
 
-(def safe-split (fnil clojure.string/split ""))
+(def safe-split (fnil split ""))
 
 (defn dissoc-in
   "Dissociates an entry from a nested associative structure returning a new

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -298,3 +298,10 @@
            (= -1 n))
      (str string single-suffix)
      (str string plural-suffix))))
+
+(defn quantify
+  "Ensures the string is correctly pluralized based on the number n."
+  ([n string] (str n " " (pluralize string n)))
+  ([n string suffix] (str n " " (pluralize string suffix n)))
+  ([n string single-suffix plural-suffix]
+   (str n " " (pluralize string single-suffix plural-suffix n))))

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -115,7 +115,7 @@
       (is (= 1 (count (:discard (get-runner)))) "Runner took 1 net damage"))))
 
 (deftest brain-taping-warehouse
-  ;; Brain-Taping Warehouse - Lower rez cost of bioroid ICE by 1 for each unspent Runner click
+  ;; Brain-Taping Warehouse - Lower rez cost of Bioroid ICE by 1 for each unspent Runner click
   (do-game
     (new-game (default-corp [(qty "Brain-Taping Warehouse" 1) (qty "Ichi 1.0" 1)
                              (qty "Eli 1.0" 1)])

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -1695,17 +1695,17 @@
     (play-from-hand state :runner "Tinkering")
     (let [iwall (get-ice state :hq 0)]
       (prompt-select :runner iwall)
-      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has barrier")
-      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has code gate")
-      (is (core/has-subtype? (refresh iwall) "Sentry") "Ice Wall has sentry")
+      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
+      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has Code Gate")
+      (is (core/has-subtype? (refresh iwall) "Sentry") "Ice Wall has Sentry")
       (core/rez state :corp iwall)
-      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has barrier")
-      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has code gate")
-      (is (core/has-subtype? (refresh iwall) "Sentry") "Ice Wall has sentry")
+      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
+      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has Code Gate")
+      (is (core/has-subtype? (refresh iwall) "Sentry") "Ice Wall has Sentry")
       (take-credits state :runner)
-      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has barrier")
-      (is (not (core/has-subtype? (refresh iwall) "Code Gate")) "Ice Wall does not have code gate")
-      (is (not (core/has-subtype? (refresh iwall) "Sentry")) "Ice Wall does not have sentry"))))
+      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
+      (is (not (core/has-subtype? (refresh iwall) "Code Gate")) "Ice Wall does not have Code Gate")
+      (is (not (core/has-subtype? (refresh iwall) "Sentry")) "Ice Wall does not have Sentry"))))
 
 (deftest unscheduled-maintenance
   ;; Unscheduled Maintenance - prevent Corp from installing more than 1 ICE per turn

--- a/src/clj/test/cards/ice.clj
+++ b/src/clj/test/cards/ice.clj
@@ -141,9 +141,9 @@
     (let [ch (get-ice state :hq 0)]
       (core/rez state :corp ch)
       (prompt-choice :corp "Barrier")
-      (is (core/has-subtype? (refresh ch) "Barrier") "Chimera has barrier")
+      (is (core/has-subtype? (refresh ch) "Barrier") "Chimera has Barrier")
       (take-credits state :corp)
-      (is (not (core/has-subtype? (refresh ch) "Barrier")) "Chimera does not have barrier"))))
+      (is (not (core/has-subtype? (refresh ch) "Barrier")) "Chimera does not have Barrier"))))
 
 (deftest cortex-lock
   ;; Cortex Lock - Do net damage equal to Runner's unused memory
@@ -557,12 +557,12 @@
     (let [mg (get-ice state :hq 0)
           nb (get-ice state :rd 0)]
       (core/rez state :corp mg)
-      (is (core/has-subtype? (refresh mg) "Mythic") "Mother Goddess has mythic")
-      (is (not (core/has-subtype? (refresh mg) "Code Gate")) "Mother Goddess does not have code gate")
+      (is (core/has-subtype? (refresh mg) "Mythic") "Mother Goddess has Mythic")
+      (is (not (core/has-subtype? (refresh mg) "Code Gate")) "Mother Goddess does not have Code Gate")
       (is (not (core/has-subtype? (refresh mg) "NEXT")) "Mother Goddess does not have NEXT")
       (core/rez state :corp nb)
-      (is (core/has-subtype? (refresh mg) "Mythic") "Mother Goddess has mythic")
-      (is (core/has-subtype? (refresh mg) "Code Gate") "Mother Goddess has code gate")
+      (is (core/has-subtype? (refresh mg) "Mythic") "Mother Goddess has Mythic")
+      (is (core/has-subtype? (refresh mg) "Code Gate") "Mother Goddess has Code Gate")
       (is (core/has-subtype? (refresh mg) "NEXT") "Mother Goddess has NEXT"))))
 
 (deftest next-bronze

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -1112,7 +1112,7 @@
       (is (= 5 (:credit (get-corp))) "Rez cost increased by 1"))))
 
 (deftest rielle-kit-peddler-ability
-  ;; Rielle "Kit" Peddler - Give ice code gate
+  ;; Rielle "Kit" Peddler - Give ICE Code Gate
   (do-game
     (new-game (default-corp [(qty "Ice Wall" 2)])
               (make-deck "Rielle \"Kit\" Peddler: Transhuman" [(qty "Sure Gamble" 3)]))
@@ -1123,8 +1123,8 @@
           iwall (get-ice state :hq 0)]
       (core/rez state :corp iwall)
       (card-ability state :runner k 0)
-      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has barrier")
-      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has code gate"))))
+      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
+      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has Code Gate"))))
 
 (deftest silhouette-expose-trigger-before-access
   ;; Silhouette - Expose trigger ability resolves completely before access. Issue #2173.

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -1347,7 +1347,7 @@
     (is (= 11 (:credit (get-corp))))))
 
 (deftest sub-boost
-  ;; Sub Boost - Give ice barrier
+  ;; Sub Boost - Give ICE Barrier
   (do-game
     (new-game (default-corp [(qty "Sub Boost" 1) (qty "Quandary" 1)])
               (default-runner))
@@ -1356,8 +1356,8 @@
     (let [qu (get-ice state :hq 0)]
       (core/rez state :corp qu)
       (prompt-select :corp qu)
-      (is (core/has-subtype? (refresh qu) "Code Gate") "Quandary has code gate")
-      (is (core/has-subtype? (refresh qu) "Barrier") "Quandary has barrier"))))
+      (is (core/has-subtype? (refresh qu) "Code Gate") "Quandary has Code Gate")
+      (is (core/has-subtype? (refresh qu) "Barrier") "Quandary ICE Barrier"))))
 
 (deftest subliminal-messaging
   ;; Subliminal Messaging - Playing/trashing/milling will all prompt returning to hand
@@ -1580,7 +1580,7 @@
       (is (= 5 (:credit (get-corp))) "Transparency initiative didn't fire"))))
 
 (deftest wetwork-refit
-  ;; Wetwork Refit - Only works on bioroid ice and adds a subroutine
+  ;; Wetwork Refit - Only works on Bioroid ICE and adds a subroutine
   (do-game
     (new-game (default-corp [(qty "Eli 1.0" 1)
                              (qty "Vanilla" 1)

--- a/src/clj/test/cards/programs.clj
+++ b/src/clj/test/cards/programs.clj
@@ -799,7 +799,7 @@
       (is (empty? (get-in @state [:runner :prompt])) "No option to jack out"))))
 
 (deftest surfer
-  ;; Surfer - Swap position with ice before or after when encountering a barrier ice
+  ;; Surfer - Swap position with ice before or after when encountering a Barrier ICE
   (do-game
    (new-game (default-corp [(qty "Ice Wall" 1) (qty "Quandary" 1)])
              (default-runner [(qty "Surfer" 1)]))


### PR DESCRIPTION
See #2116 for some details.

This is a rebased and slightly tweaked version of @erbridge's PR that implements some good string related functions: `pluralize` and `quantify`. It also adds a constructor for run events, and standardizes all ICE subtypes as Title Caps, and cleans up the use of "Select" and "Choose".

Select for when you use the target icon to pick something, choose when you pick from a list (I think).

Lots of changes from this. Also some refactors that did not need and work rebasing.

Might need some review to make sure it is all still good and wanted, but hopefully this will get some of the older PRs merged 😄 