### PR TITLE
Fixes for Political Graffiti and Punitive Counterstrike.

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1085,12 +1085,12 @@
                                                  (play-instant target {:no-additional-cost true}))}
 
    "Political Graffiti"
-   (let [update-agendapoints (fn [state side target amount]
+   (let [update-agenda-points (fn [state side target amount]
                                (set-prop state side (get-card state target) :agendapoints (+ amount (:agendapoints (get-card state target))))
                                (gain-agenda-point state side amount))]
      {:events {:purge {:effect (effect (trash card))}}
       :trash-effect {:effect (req (let [current-side (get-scoring-owner state {:cid (:agenda-cid card)})]
-                                    (update-agendapoints state current-side (find-cid (:agenda-cid card) (get-in @state [current-side :scored])) 1)))}
+                                    (update-agenda-points state current-side (find-cid (:agenda-cid card) (get-in @state [current-side :scored])) 1)))}
       :effect (effect (run :archives
                         {:req (req (= target :archives))
                          :replace-access
@@ -1100,7 +1100,7 @@
                           :effect (req (host state :runner (get-card state target)
                                          ; keep host cid in :agenda-cid because `trash` will clear :host
                                          (assoc card :zone [:discard] :installed true :agenda-cid (:cid (get-card state target))))
-                                       (update-agendapoints state :corp target -1))}} card))})
+                                       (update-agenda-points state :corp target -1))}} card))})
 
    "Populist Rally"
    {:req (req (seq (filter #(has-subtype? % "Seedy") (all-installed state :runner))))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -935,9 +935,9 @@
                      (continue-ability state side (choose-card from) card nil)))})
 
    "Punitive Counterstrike"
-   {:trace {:base 5 :msg "do meat damage equal to the number of agenda points stolen last turn"
-            :effect (effect (damage eid :meat (or (get-in runner [:register :stole-agenda]) 0) {:card card})
-                            (system-msg (str "does " (or (:stole-agenda runner-reg) 0) " meat damage")))}}
+   {:trace {:base 5
+            :msg (msg "do " (:stole-agenda runner-reg 0) " meat damage")
+            :effect (effect (damage eid :meat (:stole-agenda runner-reg 0) {:card card}))}}
 
    "Reclamation Order"
    {:prompt "Choose a card from Archives"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -936,6 +936,7 @@
 
    "Punitive Counterstrike"
    {:trace {:base 5
+            :delayed-completion true
             :msg (msg "do " (:stole-agenda runner-reg 0) " meat damage")
             :effect (effect (damage eid :meat (:stole-agenda runner-reg 0) {:card card}))}}
 

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -448,7 +448,13 @@
   "Forfeits the given agenda to the :rfg zone."
   ([state side card] (forfeit state side (make-eid state) card))
   ([state side eid card]
-   (let [c (if (in-corp-scored? state side card)
+   ;; Remove all hosted cards first
+   (doseq [h (:hosted card)]
+     (trash state side
+            (update-in h [:zone] #(map to-keyword %))
+            {:unpreventable true :suppress-event true}))
+   (let [card (get-card state card)
+         c (if (in-corp-scored? state side card)
              (deactivate state side card) card)]
      (system-msg state side (str "forfeits " (:title c)))
      (gain-agenda-point state side (- (get-agenda-points state side c)))

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -1134,6 +1134,25 @@
       (is (= 1 (:agenda-point (get-corp))))
       (is (= 1 (:agenda-point (get-runner)))))))
 
+(deftest political-graffiti-forfeit
+  ;; Political Graffiti - forfeiting agenda with Political Graffiti does not refund double points
+  (do-game
+    (new-game (default-corp [(qty "Hostile Takeover" 1) (qty "Sacrifice" 1)])
+              (default-runner [(qty "Political Graffiti" 1)]))
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (is (= 1 (:agenda-point (get-corp))))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Political Graffiti")
+    (is (= [:archives] (get-in @state [:run :server])) "Run initiated on Archives")
+    (run-successful state)
+    (prompt-choice :runner "Run ability")
+    (prompt-select :runner (find-card "Hostile Takeover" (:scored (get-corp))))
+    (is (= 0 (:agenda-point (get-corp))) "Political Dealings lowered agenda points by 1")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Sacrifice")
+    (is (= 0 (:agenda-point (get-corp))) "Forfeiting agenda did not refund extra agenda points ")))
+
 (deftest push-your-luck-correct-guess
   ;; Push Your Luck - Corp guesses correctly
   (do-game

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -1136,6 +1136,7 @@
 
 (deftest political-graffiti-forfeit
   ;; Political Graffiti - forfeiting agenda with Political Graffiti does not refund double points
+  ;; Regression test for issue #2765
   (do-game
     (new-game (default-corp [(qty "Hostile Takeover" 1) (qty "Sacrifice" 1)])
               (default-runner [(qty "Political Graffiti" 1)]))
@@ -1151,7 +1152,8 @@
     (is (= 0 (:agenda-point (get-corp))) "Political Dealings lowered agenda points by 1")
     (take-credits state :runner)
     (play-from-hand state :corp "Sacrifice")
-    (is (= 0 (:agenda-point (get-corp))) "Forfeiting agenda did not refund extra agenda points ")))
+    (is (= 0 (:agenda-point (get-corp))) "Forfeiting agenda did not refund extra agenda points ")
+    (is (= 1 (count (:discard (get-runner)))) "Political Graffiti is in the Heap")))
 
 (deftest push-your-luck-correct-guess
   ;; Push Your Luck - Corp guesses correctly


### PR DESCRIPTION
Fixes part 1 and 3 of #2765.

Makes forfeited agendas trash all hosted cards and update themselves before moving to RFG area.