### PR TITLE
Implemented /roll command

### DIFF
--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -170,6 +170,9 @@
                                             (rez state side c {:ignore-cost :all-costs :force true}))))}}}
     {:title "/rez-all command"} nil))
 
+(defn command-roll [state side value]
+  (system-msg state side (str "rolls a " value " sided die and rolls a " (+ (rand-int (- value 1)) 1))))
+
 (defn command-close-prompt [state side]
   (when-let [fprompt (-> @state side :prompt first)]
     (swap! state update-in [side :prompt] rest)
@@ -235,6 +238,7 @@
                                                           (move %1 %2 c :rfg)))
                                            :choices {:req (fn [t] (card-is? t :side %2))}}
                                           {:title "/rfg command"} nil)
+          "/roll"       #(command-roll %1 %2 value)
           "/tag"        #(swap! %1 assoc-in [%2 :tag] (max 0 value))
           "/take-brain" #(when (= %2 :runner) (damage %1 %2 :brain (max 0 value)))
           "/take-meat"  #(when (= %2 :runner) (damage %1 %2 :meat  (max 0 value)))

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -171,7 +171,7 @@
     {:title "/rez-all command"} nil))
 
 (defn command-roll [state side value]
-  (system-msg state side (str "rolls a " value " sided die and rolls a " (+ (rand-int (- value 1)) 1))))
+  (system-msg state side (str "rolls a " value " sided die and rolls a " (inc (rand-int value)))))
 
 (defn command-close-prompt [state side]
   (when-let [fprompt (-> @state side :prompt first)]

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -66,6 +66,7 @@
                         [:li [:code "/rez"] " - Select a card to rez, ignoring all costs (Corp only)"]
                         [:li [:code "/rez-all"] " - Rez all cards, ignoring all costs and flip cards in archives faceup (Corp only). For revealing your servers at the end of a game."]
                         [:li [:code "/rfg"] " - Select a card to remove from the game"]
+                        [:li [:code "/roll n"] " - Roll an n-sided die"]
                         [:li [:code "/tag n"] " - Set your tags to n"]
                         [:li [:code "/take-brain n"] " - Take n brain damage (Runner only)"]
                         [:li [:code "/take-meat n"] " - Take n meat damage (Runner only)"]


### PR DESCRIPTION
User can type "/roll n" to roll an n-sided die and have the result displayed in the chat

Fixes #1195.