### PR TITLE
Enable rejoining of games after a browser refresh / "leave-game"

### DIFF
--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -150,11 +150,9 @@
              "remove" (do (swap! game-states dissoc gameid)
                           (swap! old-states dissoc gameid))
              "do" (handle-do user command state side args)
-             "notification" (when state
-                              (swap! state update-in [:log] #(conj % {:user "__system__" :text text})))
-             "rejoin" (when state
-                        (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))
-
+             ("notification" "rejoin")
+             (when state
+               (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))
            true)
        (catch Exception e
          (do (println "Error " action command (get-in args [:card :title]) e)

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -17,8 +17,12 @@
 
 
 (defn sort-games-list [games]
-  (sort-by #(vec (map (assoc % :started (not (:started %)))
-                      [:started :date]))
+   (sort-by #(vec (map (assoc % :started (not (:started %))
+                                :mygame (if-let [og (:originalPlayers %)]
+                                          (some (fn [p] (= p (get-in @app-state [:user :_id])))
+                                                (map (fn [g] (get-in g [:user :_id])) og))
+                                          false))
+                       [:mygame :started :date]))
            > games))
 
 (go (while true


### PR DESCRIPTION
Currently a `reconnect` message is sent when a client's websocket experiences a brief disconnect from the web server. This solution is fragile and doesn't work if the disconnection lasts for more than some unknown time. It also does not work if the user accidentally leaves the game or refreshes the browser.

This PR adds a Rejoin button on the game lobby for any game that you've left by either disconnect, page refresh, or Leave Game button. Rejoining causes the game server to emit a full game state, allowing the client to reinitialize the game board.  A rejoinable game shows up first in the game list.

This could use a once-over by anyone with some time.