### PR TITLE
Forfeit Targeting

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1111,20 +1111,20 @@
                              (as-agenda state :corp (dissoc card :counter) 1)))} }}
 
    "Quarantine System"
-   (letfn [(rez-ice [cnt ap] {:prompt "Select an ICE to rez"
-                              :delayed-completion true
-                              :choices {:req #(and (ice? %) (complement rezzed?))}
-                              :msg (msg "rez " (:title target))
-                              :effect (req (rez-cost-bonus state side (* ap -2))
-                                           (rez state side target {:no-warning true})
-                                           (if (< cnt 3) (continue-ability state side (rez-ice (inc cnt) ap) card nil)
-                                                         (effect-completed state side eid)))})]
+   (letfn [(rez-ice [cnt] {:prompt "Select an ICE to rez"
+                           :delayed-completion true
+                           :choices {:req #(and (ice? %) (not (rezzed? %)))}
+                           :msg (msg "rez " (:title target))
+                           :effect (req (let [agenda (last (:rfg corp))
+                                              ap (:agendapoints agenda 0)]
+                                          (rez-cost-bonus state side (* ap -2))
+                                          (rez state side target {:no-warning true})
+                                          (if (< cnt 3) (continue-ability state side (rez-ice (inc cnt)) card nil)
+                                                        (effect-completed state side eid))))})]
      {:abilities [{:label "Forfeit agenda to rez up to 3 ICE with a 2 [Credit] discount per agenda point"
                    :req (req (pos? (count (:scored corp))))
                    :cost [:forfeit]
-                   :effect (req (let [agenda (last (:rfg corp))
-                                      ap (if (is-type? agenda "Agenda") (:agendapoints agenda) 0)]
-                                  (continue-ability state side (rez-ice 1 ap) card nil)))}]})
+                   :effect (req (continue-ability state side (rez-ice 1) card nil))}]})
 
    "Raman Rai"
    {:abilities [{:once :per-turn

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1305,13 +1305,12 @@
 
    "Success"
    {:additional-cost [:forfeit]
-    :effect (req (let [adv (advancement-cost state side (last (:rfg corp)))]
-                   (resolve-ability
-                     state side
-                     {:choices {:req can-be-advanced?}
-                      :msg (msg "advance " (card-str state target) " " adv " times")
-                      :effect (req (dotimes [_ adv]
-                                     (advance state :corp target :no-cost)))} card nil)))}
+    :effect (req (resolve-ability state side
+                                  {:choices {:req can-be-advanced?}
+                                   :msg (msg "advance " (card-str state target) " "
+                                             (advancement-cost state side (last (:rfg corp))) " times")
+                                   :effect (req (dotimes [_ (advancement-cost state side (last (:rfg corp)))]
+                                                  (advance state :corp target :no-cost)))} card nil))}
 
    "Successful Demonstration"
    {:req (req (:unsuccessful-run runner-reg))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -51,12 +51,19 @@
   Amount is always 1 but can be extend if we ever need more than a single forfeit"
   ;; If multiples needed in future likely prompt-select needs work to take a function
   ;; instead of an ability
-  [state side card scored amount]
-  (if (= (count scored) 1)
+  [state side card scored n]
+  (resolve-ability state side
+                   {:prompt "Choose an Agenda to forfeit"
+                    :choices {:max n
+                              :req #(and (= (:side %) (side-str side))
+                                         (= (:zone %) [:scored]))}
+                    :effect (effect (forfeit target))}
+                   card nil)
+  #_(if (= (count scored) 1)
     (forfeit state side (first scored))
     (prompt! state side card "Choose an Agenda to forfeit" scored
              {:effect (effect (forfeit target))}))
-  (when-let [cost-name (cost-names amount :forfeit)]
+  (when-let [cost-name (cost-names n :forfeit)]
     cost-name))
 
 (defn pay-trash

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -760,7 +760,7 @@
       (run-empty-server state "Server 1")
       (prompt-choice :corp "Yes") ; choose to do the optional ability
       (is (= 2 (:tag (get-runner))) "Runner given 2 tags"))))
-	  
+
 (deftest honeyfarm
   ;; lose one credit on access
   (do-game
@@ -813,13 +813,13 @@
       (prompt-choice :corp "2 [Credits]")
       (prompt-choice :runner "0 [Credits]")
       (is (= 3 (:credit (get-corp))) "No credits gained from Hyoubu"))))
-	  
+
 (deftest illegal-arms-factory
   ;; Illegal Arms Factory; draw a card, gain a credit, bad pub when trashed while rezzed
   (do-game
     (new-game (default-corp [(qty "Hedge Fund" 1)
 	                         (qty "Beanstalk Royalties" 1)
-	                         (qty "IPO" 1)							 
+	                         (qty "IPO" 1)
 							 (qty "Illegal Arms Factory" 3)])
               (default-runner))
     (core/gain state :runner :credit 20)
@@ -840,7 +840,7 @@
       (take-credits state :corp)
 	  (run-empty-server state :remote2)
       (prompt-choice :runner "Yes")
-      (is (= 1 (:bad-publicity (get-corp))) "Took a bad pub on rezzed trash")	  
+      (is (= 1 (:bad-publicity (get-corp))) "Took a bad pub on rezzed trash")
 	)))
 
 (deftest it-department
@@ -1317,6 +1317,7 @@
       ; 1 on rez
       (is (= 101 (:credit (get-corp))) "Corp has 101 creds")
       (card-ability state :corp qs 0)
+      (prompt-select :corp (get-in (get-corp) [:scored 0]))
       (prompt-select :corp ch1)
       (prompt-select :corp ch2)
       (prompt-select :corp ch3)
@@ -1767,7 +1768,7 @@
 
     (card-ability state :runner (get-resource state 0) 0)
     (prompt-choice :runner (->> @state :runner :prompt first :choices first))
-    (prompt-choice :runner (first (:scored (get-runner))))
+    (prompt-select :runner (first (:scored (get-runner))))
     (is (= 2 (count (:scored (get-runner)))) "Fan Site removed from Runner score area")
     (is (= -2 (:agenda-point (get-runner))) "Runner has -2 agenda points")
 

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -1437,6 +1437,7 @@
 
     ;; Additional costs to rez should now be applied again
     (core/rez state :corp (get-content state :remote7 0))
+    (prompt-select :corp (get-in (get-corp) [:scored 0]))
     (is (zero? (count (:scored (get-corp)))) "Agenda was auto-forfeit to rez Oberth")
 
     (core/derez state :corp (get-content state :remote4 0))

--- a/src/clj/test/cards/events.clj
+++ b/src/clj/test/cards/events.clj
@@ -1152,6 +1152,7 @@
     (is (= 0 (:agenda-point (get-corp))) "Political Dealings lowered agenda points by 1")
     (take-credits state :runner)
     (play-from-hand state :corp "Sacrifice")
+    (prompt-select :corp (get-scored state :corp 0))
     (is (= 0 (:agenda-point (get-corp))) "Forfeiting agenda did not refund extra agenda points ")
     (is (= 1 (count (:discard (get-runner)))) "Political Graffiti is in the Heap")))
 

--- a/src/clj/test/cards/ice.clj
+++ b/src/clj/test/cards/ice.clj
@@ -758,9 +758,10 @@
       (core/derez state :corp (refresh ti))
       (core/rez state :corp ti)
       (prompt-choice :corp "Yes") ; use alternative cost
+      (prompt-select :corp (get-in (get-corp) [:scored 0]))
       (is (= 3 (:credit (get-corp))) "Still on 3c")
       (is (= 0 (count (:scored (get-corp)))) "Agenda forfeited")
-      ; Can Host Conditions Counters
+      ;; Can Host Conditions Counters
       (play-from-hand state :corp "Patch")
       (prompt-select :corp (refresh ti))
       (is (= 1 (count (:hosted (refresh ti)))) "1 card on Tithonium")

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -444,11 +444,13 @@
       (prompt-choice :runner "Steal")
       (let [dd (get-resource state 0)]
         (card-ability state :runner dd 0)
+        (prompt-select :runner (get-in (get-runner) [:scored 0]))
         (is (empty? (:prompt (get-corp))) "No Jemison prompt for Runner forfeit")
         (take-credits state :runner)
         (play-from-hand state :corp "Global Food Initiative" "New remote")
         (score-agenda state :corp (get-content state :remote2 0))
         (core/rez state :corp enf)
+        (prompt-select :corp (get-in (get-corp) [:scored 0]))
         (prompt-select :corp iwall)
         (is (= 4 (:advance-counter (refresh iwall))) "Jemison placed 4 advancements")))))
 

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -1502,7 +1502,7 @@
       (core/score state :corp {:card (refresh napd)})
       (is (= 2 (:agenda-point (get-corp))))
       (play-from-hand state :corp "Success")
-      (prompt-select :corp (get-in (get-corp) [:scored 0]))
+      (prompt-select :corp (get-scored state :corp 0))
       (is (= "NAPD Contract" (:title (first (:rfg (get-corp))))))
       (prompt-select :corp (refresh beale))
       (is (= 13 (:advance-counter (refresh beale))))
@@ -1520,7 +1520,7 @@
     (play-from-hand state :corp "Oaktown Renovation" "New remote")
     (is (= 5 (:credit (get-corp))))
     (play-from-hand state :corp "Success")
-    (prompt-select :corp (get-in (get-corp) [:scored 0]))
+    (prompt-select :corp (get-scored state :corp))
     (is (= "Vanity Project" (:title (first (:rfg (get-corp))))))
     (let [oaktown (get-content state :remote1 0)]
       (prompt-select :corp (refresh oaktown))
@@ -1528,6 +1528,27 @@
       (is (= 19 (:credit (get-corp))) "Gain 2 + 2 + 2 + 2 + 3 + 3 = 14 credits for advancing Oaktown")
       (core/score state :corp {:card (refresh oaktown)})
       (is (= 2 (:agenda-point (get-corp)))))))
+
+(deftest success-jemison
+  ;; Success interaction with Jemison, regression test for issue #2704
+  (do-game
+    (new-game (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success."
+                         [(qty "Success" 1)
+                          (qty "High-Risk Investment" 1)
+                          (qty "Government Takeover" 1)])
+              (default-runner))
+    (core/gain state :corp :click 1)
+    (score-agenda state :corp (find-card "High-Risk Investment" (:hand (get-corp))))
+    (play-from-hand state :corp "Government Takeover" "New remote")
+    (play-from-hand state :corp "Success")
+    (prompt-select :corp (get-in (get-corp) [:scored 0]))
+    (let [gto (get-content state :remote1 0)]
+      ;; Prompt for Success
+      (prompt-select :corp (refresh gto))
+      (is (= 5 (:advance-counter (refresh gto))) "Advance 5 times from Success")
+      ;; Prompt for Jemison
+      (prompt-select :corp (refresh gto))
+      (is (= 9 (:advance-counter (refresh gto))) "Added 4 counters from Jemison trigger"))))
 
 (deftest successful-demonstration
   ;; Successful Demonstration - Play if only Runner made unsuccessful run last turn; gain 7 credits

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -20,7 +20,7 @@
       (is (= 0 (:tag (get-runner)))) ; tags cleared
       (take-credits state :runner)
       (play-from-hand state :corp "24/7 News Cycle")
-      (prompt-card :corp (find-card "Breaking News" (:scored (get-corp))))
+      (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 1 (:agenda-point (get-corp))) "Forfeited Breaking News")
       (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner given 2 tags")
@@ -41,7 +41,7 @@
       (score-agenda state :corp ag2)
       (prompt-choice :corp "No")
       (play-from-hand state :corp "24/7 News Cycle")
-      (prompt-card :corp (find-card "Posted Bounty" (:scored (get-corp))))
+      (prompt-select :corp (find-card "Posted Bounty" (:scored (get-corp))))
       (is (= 1 (:agenda-point (get-corp))) "Forfeited Posted Bounty")
       (prompt-select :corp (find-card "Posted Bounty" (:scored (get-corp))))
       (prompt-choice :corp "Yes") ; "Forfeit Posted Bounty to give 1 tag?"
@@ -66,7 +66,7 @@
     (is (= 2 (:agenda-point (get-runner))))
     (take-credits state :runner)
     (play-from-hand state :corp "24/7 News Cycle")
-    (prompt-card :corp (find-card "Chronos Project" (:scored (get-corp))))
+    (prompt-select :corp (find-card "Chronos Project" (:scored (get-corp))))
     (is (= "Chronos Project" (:title (first (:rfg (get-corp))))))
     ;; shouldn't work on an agenda in the Runner's scored area
     (is (= 2 (count (:hand (get-runner)))))
@@ -247,7 +247,7 @@
         (prompt-choice :runner "1 [Credits]")
 		(prompt-choice :runner "1 tag")
 	    (is (= 1 (count (:discard (get-runner)))) "Runner took no additional damage")
-		(is (= 1 (:tag (get-runner))) "Runner took a tag from Cerebral Cast choice")))		
+		(is (= 1 (:tag (get-runner))) "Runner took a tag from Cerebral Cast choice")))
 
 
 (deftest cerebral-static-chaos-theory
@@ -745,7 +745,7 @@
     (prompt-choice :corp 0) ; default trace
     (prompt-choice :runner 2) ; Runner matches
     (is (= 1 (:bad-publicity (get-corp))))))
-	
+
 (deftest ipo-terminal
   ;; IPO - credits with Terminal operations
   (do-game
@@ -756,7 +756,7 @@
     (take-credits state :runner)
     (play-from-hand state :corp "IPO")
 	(is (= 13 (:credit (get-corp))))
-	(is (= 0 (:click (get-corp))) "Terminal ends turns")))	
+	(is (= 0 (:click (get-corp))) "Terminal ends turns")))
 
 (deftest lag-time
   (do-game
@@ -783,7 +783,7 @@
     (is (= "Breaking News" (:title (get-content state :remote1 0)))
       "Breaking News installed by Lateral Growth")
     (is (= 7 (:credit (get-corp))))))
-	
+
 (deftest mass-commercialization
   ;; Mass Commercialization
   (do-game
@@ -1020,7 +1020,7 @@
 (deftest psychokinesis
   ;; Pyschokinesis - Terminal Event (end the turn); Look at R&D, install an Asset, Agenda, or Upgrade in a Remote Server
   (do-game
-    (new-game (default-corp [(qty "Psychokinesis" 3) (qty "Caprice Nisei" 1) (qty "Adonis Campaign" 1) 
+    (new-game (default-corp [(qty "Psychokinesis" 3) (qty "Caprice Nisei" 1) (qty "Adonis Campaign" 1)
                               (qty "Global Food Initiative" 1)])
               (default-runner))
     (starting-hand state :corp ["Psychokinesis","Psychokinesis","Psychokinesis"])
@@ -1502,6 +1502,7 @@
       (core/score state :corp {:card (refresh napd)})
       (is (= 2 (:agenda-point (get-corp))))
       (play-from-hand state :corp "Success")
+      (prompt-select :corp (get-in (get-corp) [:scored 0]))
       (is (= "NAPD Contract" (:title (first (:rfg (get-corp))))))
       (prompt-select :corp (refresh beale))
       (is (= 13 (:advance-counter (refresh beale))))
@@ -1519,6 +1520,7 @@
     (play-from-hand state :corp "Oaktown Renovation" "New remote")
     (is (= 5 (:credit (get-corp))))
     (play-from-hand state :corp "Success")
+    (prompt-select :corp (get-in (get-corp) [:scored 0]))
     (is (= "Vanity Project" (:title (first (:rfg (get-corp))))))
     (let [oaktown (get-content state :remote1 0)]
       (prompt-select :corp (refresh oaktown))

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -78,6 +78,7 @@
     (is (= 2 (:agenda-point (get-runner))))
     (let [dd (get-in @state [:runner :rig :resource 0])]
       (card-ability state :runner dd 0)
+      (prompt-select :runner (get-in (get-runner) [:scored 0]))
       (is (= 1 (:click (get-runner))) "Didn't lose a click")
       (is (= 4 (:click-per-turn (get-runner))) "Still have 4 clicks per turn"))))
 
@@ -92,6 +93,7 @@
     (play-from-hand state :corp "Corporate Town" "New remote")
     (let [ctown (get-content state :remote2 0)]
       (core/rez state :corp ctown)
+      (prompt-select :corp (get-in (get-corp) [:scored 0]))
       (is (= 3 (:click-per-turn (get-corp))) "Back down to 3 clicks per turn"))))
 
 (deftest refresh-recurring-credits-hosted

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -101,6 +101,18 @@
   [state pos]
   (get-in @state [:runner :rig :resource pos]))
 
+(defn get-scored
+  "Get a card from the score area. Can find by name or index.
+  If no index or name provided, get the first scored agenda."
+  ([state side] (get-scored state side 0))
+  ([state side x]
+   (if (number? x)
+     ;; Find by index
+     (get-in @state [side :scored x])
+     ;; Find by name
+     (when (string? x)
+       (find-card x (get-in @state [side :scored]))))))
+
 (defn get-counters
   "Get number of counters of specified type."
   [card type]


### PR DESCRIPTION
Changes forfeit costs to use a target instead text choices.

Updates tests to work with the new system and rewrote Success and Quarantine System to still work.

Refactored the cost function a little bit.

Fixes #2801.