### PR TITLE
Refactor "in this server" and "from this server" checks

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -771,7 +771,7 @@
 
    "Underway Grid"
    {:implementation "Bypass prevention is not implemented"
-    :events {:pre-expose {:req (req (protecting-same-server? card target))
+    :events {:pre-expose {:req (req (same-server? card target))
                           :msg "prevent 1 card from being exposed"
                           :effect (effect (expose-prevent 1))}}}
 

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -82,7 +82,8 @@
                               (continue-ability state side (dome card) card nil))}]})
 
    "Ben Musashi"
-   (let [bm {:req (req (or (= (:zone card) (:zone target)) (= (central->zone (:zone target)) (butlast (:zone card)))))
+   (let [bm {:req (req (or (in-same-server? card target)
+                           (from-same-server? card target)))
              :effect (effect (steal-cost-bonus [:net-damage 2]))}]
      {:trash-effect
               {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
@@ -125,9 +126,7 @@
                                card nil))}}}
 
    "Breaker Bay Grid"
-   {:events {:pre-rez-cost {:req (req (and (is-remote? (second (:zone card)))
-                                           (or (= (:zone card) (:zone target))
-                                               (= (:zone card) (:zone (get-card state (:host target)))))))
+   {:events {:pre-rez-cost {:req (req (in-same-server? card target))
                             :effect (effect (rez-cost-bonus -5))}}}
 
    "Bryan Stinson"
@@ -506,9 +505,7 @@
                            (effect-completed state side eid card)))))}}}
 
    "Oaktown Grid"
-   {:events {:pre-trash {:req (req (and (is-remote? (second (:zone card)))
-                                           (or (= (:zone card) (:zone target))
-                                               (= (:zone card) (:zone (get-card state (:host target)))))))
+   {:events {:pre-trash {:req (req (in-same-server? card target))
                          :effect (effect (trash-cost-bonus 3))}}}
 
    "Oberth Protocol"
@@ -531,7 +528,8 @@
     :leave-play (req (enable-run-on-server state card (second (:zone card))))}
 
    "Old Hollywood Grid"
-   (let [ohg {:req (req (or (= (:zone card) (:zone (get-nested-host target))) (= (central->zone (:zone target)) (butlast (:zone card)))))
+   (let [ohg {:req (req (or (in-same-server? card target)
+                            (from-same-server? card target)))
               :effect (effect (register-persistent-flag!
                                 card :can-steal
                                 (fn [state _ card]
@@ -582,7 +580,8 @@
              :msg "gain 2 [Credits]" :effect (effect (gain :corp :credit 2))}}
 
    "Red Herrings"
-   (let [ab {:req (req (or (= (:zone card) (:zone target)) (= (central->zone (:zone target)) (butlast (:zone card)))))
+   (let [ab {:req (req (or (in-same-server? card target)
+                           (from-same-server? card target)))
              :effect (effect (steal-cost-bonus [:credit 5]))}]
      {:trash-effect
       {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
@@ -622,9 +621,9 @@
                                          (:content (card->server state card)))]
                    (update-advancement-cost state side agenda)))
     :events {:corp-install {:req (req (and (is-type? target "Agenda")
-                                           (= (:zone card) (:zone target))))
+                                           (in-same-server? card target)))
                             :effect (effect (update-advancement-cost target))}
-             :pre-advancement-cost {:req (req (= (:zone card) (:zone target)))
+             :pre-advancement-cost {:req (req (in-same-server? card target))
                                     :effect (effect (advancement-cost-bonus -1))}}}
 
    "Satellite Grid"
@@ -681,7 +680,8 @@
    {:recurring 2}
 
    "Strongbox"
-   (let [ab {:req (req (or (= (:zone card) (:zone target)) (= (central->zone (:zone target)) (butlast (:zone card)))))
+   (let [ab {:req (req (or (in-same-server? card target)
+                           (from-same-server? card target)))
              :effect (effect (steal-cost-bonus [:click 1]))}]
      {:trash-effect
       {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -5,6 +5,9 @@
   [card]
   (if (:host card) (recur (:host card)) card))
 
+(defn get-nested-zone [card]
+  (:zone (get-nested-host card)))
+
 (defn update-hosted!
   "Updates a card that is hosted on another, by recursively updating the host card's
   :hosted vector."

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -39,15 +39,14 @@
   "True if the two cards are IN or PROTECTING the same server."
   (let [zone1 (get-nested-zone card1)
         zone2 (get-nested-zone card2)]
-    (and (= zone1 zone2)
-         #{:ices :content} (last zone1))))
+    (= (second zone1) (second zone2))))
 
-(defn protecting-same-server? [card1 card2]
-  "True if two cards are PROTECTING the same server."
-  (let [zone1 (get-nested-zone card1)
-        zone2 (get-nested-zone card2)]
-    (and (= zone1 zone2)
-         (= :ices (last zone1)))))
+(defn protecting-same-server? [card ice]
+  "True if an ice is protecting the server that the card is in or protecting."
+  (let [zone1 (get-nested-zone card)
+        zone2 (get-nested-zone ice)]
+    (and (= (second zone1) (second zone2))
+         (= :ices (last zone2)))))
 
 (defn in-same-server? [card1 card2]
   "True if the two cards are installed IN the same server, or hosted on cards IN the same server."

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare set-prop)
+(declare set-prop get-nested-host get-nested-zone)
 
 (defn get-zones [state]
   (keys (get-in state [:corp :servers])))
@@ -34,6 +34,33 @@
       "Archives" [:servers :archives]
       "New remote" [:servers (keyword (str "remote" (make-rid state)))]
       [:servers (->> (split server #" ") last (str "remote") keyword)])))
+
+(defn same-server? [card1 card2]
+  "True if the two cards are IN or PROTECTING the same server."
+  (let [zone1 (get-nested-zone card1)
+        zone2 (get-nested-zone card2)]
+    (and (= zone1 zone2)
+         #{:ices :content} (last zone1))))
+
+(defn protecting-same-server? [card1 card2]
+  "True if two cards are PROTECTING the same server."
+  (let [zone1 (get-nested-zone card1)
+        zone2 (get-nested-zone card2)]
+    (and (= zone1 zone2)
+         (= :ices (last zone1)))))
+
+(defn in-same-server? [card1 card2]
+  "True if the two cards are installed IN the same server, or hosted on cards IN the same server."
+  (let [zone1 (get-nested-zone card1)
+        zone2 (get-nested-zone card2)]
+    (and (= zone1 zone2)
+         (is-remote? (second zone1)) ; cards in centrals are in the server's root, not in the server.
+         (= :content (last zone1)))))
+
+(defn from-same-server? [upgrade target]
+  "True if the upgrade is in the root of the server that the target is in."
+  (= (central->zone (:zone target))
+     (butlast (get-nested-zone upgrade))))
 
 (defn all-installed
   "Returns a vector of all installed cards for the given side, including those hosted on other cards,

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -50,6 +50,33 @@
       (is (= 2 (count (:discard (get-runner)))) "Runner took 2 net")
       (is (= 1 (count (:scored (get-runner)))) "1 scored agenda"))))
 
+(deftest ben-musashi-rd
+  ;; Ben Musashi - on R&D access
+  (do-game
+    (new-game (default-corp [(qty "Ben Musashi" 1) (qty "House of Knives" 1)])
+              (default-runner))
+    (starting-hand state :corp ["Ben Musashi"])
+    (play-from-hand state :corp "Ben Musashi" "R&D")
+    (take-credits state :corp)
+    (let [bm (get-content state :rd 0)]
+      (core/rez state :corp bm)
+      (run-empty-server state "R&D")
+      ;; runner now chooses which to access.
+      (prompt-choice :runner "Card from deck")
+      ;; prompt should be asking for the 2 net damage cost
+      (is (= "House of Knives" (:title (:card (first (:prompt (get-runner))))))
+          "Prompt to pay 2 net damage")
+      (prompt-choice :runner "No")
+      (is (= 5 (:credit (get-runner))) "Runner did not pay 2 net damage")
+      (is (= 0 (count (:scored (get-runner)))) "No scored agendas")
+      (prompt-choice :runner "Ben Musashi")
+      (prompt-choice :runner "No")
+      (run-empty-server state "R&D")
+      (prompt-choice :runner "Card from deck")
+      (prompt-choice :runner "Yes")
+      (is (= 2 (count (:discard (get-runner)))) "Runner took 2 net")
+      (is (= 1 (count (:scored (get-runner)))) "1 scored agenda"))))
+
 (deftest ben-musashi-trash
   ;; Ben Musashi - pay even when trashed
   (do-game


### PR DESCRIPTION
Adds a few utilities for:

* Getting the zone of a card's most-nested host.
* Testing two cards to see if they are *in* the same server (game rules: in the content of the same remote server)
* Testing two cards to see if they are *protecting* the same server (in the ice of the same server)
* Testing two cards if they are in-or-protecting the same server.
* Testing two cards if they are *from* the same server (game rules: one card is an upgrade in the root of a central, the other is in that central itself. Example: Red Herrings in the root of HQ, and an agenda in corp's hand.)

Cleans up the logic for *some* of the cards that affect other cards in/from the same server, notably Oaktown and BB Grid, and the "in order to steal an agenda from this server" upgrades (Red Herrings, Old Hollywood Grid, Strongbox, Ben Musashi). Also enables these cards to work even when they or their target are hosted on other cards like RecStudio.

Addresses the concerns of #2811.