### PR TITLE
Running link_cards script after fetching card data

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "coffee server.coffee",
     "postinstall": "bower install",
-    "fetch": "cd data/ && coffee fetch.coffee",
+    "fetch": "cd data/ && coffee fetch.coffee && coffee link_cards.coffee",
     "promo": "cd data/ && mongo netrunner --eval \"db.altarts.drop()\" && mongoimport --db=netrunner --collection=altarts --file=promo.json --jsonArray",
     "rotate": "cd data/ && coffee rotate.coffee",
     "link_cards": "cd data/ && coffee link_cards.coffee"


### PR DESCRIPTION
Linking cards allows us to find replacements for rotated cards.