### PR TITLE
Display card influence dots

### DIFF
--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -65,7 +65,14 @@
   "Generate text html representation a card"
   [card]
   [:div
-   [:h4 (:title card)]
+   [:h4 (str (:title card) " ")
+    [:span.influence
+     {:class (if-let [faction (:faction card)]
+               (-> faction .toLowerCase (.replace " " "-"))
+               "neutral")}
+     (when (netrunner.deckbuilder/banned? card) netrunner.deckbuilder/banned-dot)
+     (when (netrunner.deckbuilder/restricted? card) netrunner.deckbuilder/restricted-dot)
+     (when (:rotated card) netrunner.deckbuilder/rotated-dot)]]
    (when-let [memory (:memoryunits card)]
      (if (< memory 3)
        [:div.anr-icon {:class (str "mu" memory)} ""]
@@ -88,7 +95,7 @@
      (when-let [faction (:faction card)]
        [:div.heading "Influence "
         [:span.influence
-         {:dangerouslySetInnerHTML #js {:__html (apply str (for [i (range influence)] "&#8226;"))}
+         {:dangerouslySetInnerHTML #js {:__html (netrunner.deckbuilder/influence-dots influence)}
           :class                   (-> faction .toLowerCase (.replace " " "-"))}]]))
    [:div.text
     [:p [:span.type (str (:type card))] (if (empty? (:subtype card))

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -526,8 +526,9 @@
 (def zws "\u200B")                                          ; zero-width space for wrapping dots
 (def influence-dot (str "●" zws))                           ; normal influence dot
 (def banned-dot (str "✘" zws))                              ; on the banned list
-(def restricted-dot (str "🦄" zws))                          ; on the restricted list
+(def restricted-dot (str "🦄" zws))                         ; on the restricted list
 (def alliance-dot (str "○" zws))                            ; alliance free-inf dot
+(def rotated-dot (str "↻" zws))                             ; on the rotation list
 
 (defn- make-dots
   "Returns string of specified dots and number. Uses number for n > 20"
@@ -709,23 +710,19 @@
                          :else "invalid")
                 :on-mouse-enter #(put! zoom-channel card)
                 :on-mouse-leave #(put! zoom-channel false)} name]
-        (when (or banned (not infaction))
-          (let [influence (* (:factioncost card) modqty)]
-            (list " "
-                  [:span.influence
-                   {:class (faction-label card)
-                    :dangerouslySetInnerHTML
-                    #js {:__html
+        (let [influence (* (:factioncost card) modqty)]
+          (list " "
+                [:span.influence
+                 {:class (faction-label card)
+                  :dangerouslySetInnerHTML
+                  #js {:__html
+                       (if banned
+                         banned-dot
                          (str
-                           (if banned
-                             banned-dot
-                             (do
-                               ;; normal influence
-                               (when (and (not infaction) (not allied)) (influence-dots influence))
-                               ;; satisfies alliance criterion
-                               (when allied (alliance-dots influence))
-                               ;; restricted card
-                               (when restricted restricted-dot))))}}])))])
+                           (when (and (not infaction) (not allied)) (influence-dots influence))
+                           (when allied (alliance-dots influence))
+                           (when restricted restricted-dot)
+                           (when (:rotated card) rotated-dot)))}}]))])
      card)])
 
 (defn deck-builder


### PR DESCRIPTION
Fixes bug where influence dots were not displayed next to card names.
Also added a rotated symbol.
Displaying status symbols next to cardbrowser text.

Fixes #2815 