### PR TITLE
Relaxed ICE selection criteria for En Passant

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -424,8 +424,7 @@
                    (resolve-ability state side
                      {:prompt (msg "Choose an unrezzed piece of ICE protecting " serv " that you passed on your last run")
                       :choices {:req #(and (ice? %)
-                                           (not (rezzed? %))
-                                           (= runtgt (second (:zone %))))}
+                                           (not (rezzed? %)))}
                       :msg (msg "trash " (card-str state target))
                       :effect (effect (trash target))}
                     card nil)))}


### PR DESCRIPTION
Relaxes ICE selection criteria for En Passant's effect to any unrezzed ICE.

Tested in exact scenario described in #2804, where Sand Storm is used to redirect an Archives run onto HQ with one piece of unrezzed ICE, a rezzed Panic Button and unrezzed Marcus Batty, with Maw active for the Runner. Previously, only unrezzed ICE on Archives could be selected for an En Passant played after the run completes successfully, but now the unrezzed ICE which was passed on HQ can be targeted.

Note: This does now allow Runners playing En Passant to target unrezzed ICE which they did not pass on their previous run, so there is some scope for incorrect usage.

Fixes #2804.