### PR TITLE
Removing server side message filtering to test dropped message bug

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -323,9 +323,9 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
 
       when "say"
         game = games[msg.gameid]
-        unless user_allowed_in_game(getUsername(socket), game)
-          fn("not allowed")
-          return
+        # unless user_allowed_in_game(getUsername(socket), game)
+        #   fn("not allowed")
+        #   return
 
         lobby.to(msg.gameid).emit("netrunner", {type: "say", user: socket.request.user, text: msg.text})
 
@@ -395,10 +395,10 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
             refreshLobby("update", msg.gameid)
 
       when "do"
-        if msg.command == "say"
-          game = games[socket.gameid]
-          if game and msg.side == "spectator" and game.mutespectators
-            return
+        # if msg.command == "say"
+        #   game = games[socket.gameid]
+        #   if game and msg.side == "spectator" and game.mutespectators
+        #     return
         try
           requester.send(JSON.stringify(msg))
         catch err


### PR DESCRIPTION
**For testing purposes only.**

This disables server side filtering of messages from blocked or muted users. Trying to track down the dropped chat message problem.