### PR TITLE
Filtering 'Watch' on the server side

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -267,6 +267,14 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
       when "watch"
         game = games[msg.gameid]
 
+        unless game
+          fn("unknown game")
+          return
+
+        unless game.allowspectator
+          fn("not allowed")
+          return
+
         unless user_allowed_in_game(getUsername(socket), game)
           fn("not allowed")
           return


### PR DESCRIPTION
Previously only hiding the `Watch` button on the client side, so you could modify the javascript to join a game as a watcher. Now filtering on the server side and dropping requests based on the game state.