### PR TITLE
Add runner and corp user stats

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -168,10 +168,16 @@ requester.on 'message', (data) ->
         corpAgenda: response.state.corp["agenda-point"]
       }
       # Handle Deck Statistics
-      if response.state[winningSide].options.deckstats is true
+      if response.state[winningSide].options.deckstats is "always"
         db.collection('decks').update {_id: mongoskin.helper.toObjectID(winningDeck)}, {$inc: {"stats.games" : 1, "stats.wins" : 1}}, (err) ->
           throw err if err
-      if response.state[losingSide].options.deckstats is true
+      else if response.state[winningSide].options.deckstats is "competitive" and room is "competitive"
+        db.collection('decks').update {_id: mongoskin.helper.toObjectID(winningDeck)}, {$inc: {"stats.games" : 1, "stats.wins" : 1}}, (err) ->
+          throw err if err
+      if response.state[losingSide].options.deckstats is "always"
+        db.collection('decks').update {_id: mongoskin.helper.toObjectID(losingDeck)}, {$inc: {"stats.games" : 1, "stats.loses" : 1}}, (err) ->
+          throw err if err
+      else if response.state[losingSide].options.deckstats is "competitive" and room is "competitive"
         db.collection('decks').update {_id: mongoskin.helper.toObjectID(losingDeck)}, {$inc: {"stats.games" : 1, "stats.loses" : 1}}, (err) ->
           throw err if err
 

--- a/server.coffee
+++ b/server.coffee
@@ -675,12 +675,13 @@ app.post '/update-profile', (req, res) ->
   if req.user
     db.collection('users').update {username: req.user.username}, {$set: {options: {background: req.body.background,\
       'show-alt-art': req.body['show-alt-art'], 'blocked-users': req.body['blocked-users'], \
-      'alt-arts': req.body['alt-arts']}}},
+      'alt-arts': req.body['alt-arts'], deckstats: req.body['deckstats'], gamestats: req.body['gamestats']}}},
       (err) ->
         console.log(err) if err
         res.status(200).send({message: 'OK', background: req.body.background, \
           altarts: req.body['alt-arts'], \
-          blockedusers: req.body['blocked-users']})
+          blockedusers: req.body['blocked-users'], \
+          deckstats: req.body['deckstats'], gamestats: req.body['gamestats']})
   else
     res.status(401).send({message: 'Unauthorized'})
 

--- a/server.coffee
+++ b/server.coffee
@@ -173,15 +173,31 @@ requester.on 'message', (data) ->
         db.collection('decks').update {_id: mongoskin.helper.toObjectID(losingDeck)}, {$inc: {"stats.games" : 1, "stats.loses" : 1}}, (err) ->
           throw err if err
       if winningSide is "corp"
-        db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.wins": 1, "stats.wins-corp" : 1}}, (err) ->
-          throw err if err
-        db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.loses": 1, "stats.loses-runner" : 1}}, (err) ->
-          throw err if err
+        if response.state[winningSide].options.gamestats is true
+          db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.wins": 1, "stats.wins-corp" : 1}}, (err) ->
+            throw err if err
+        else
+          db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1}}, (err) ->
+            throw err if err
+        if response.state[losingSide].options.gamestats is true
+          db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.loses": 1, "stats.loses-runner" : 1}}, (err) ->
+            throw err if err
+        else
+          db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1}}, (err) ->
+            throw err if err
       else if winningSide is "runner"
-        db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.wins": 1, "stats.wins-runner" : 1}}, (err) ->
-          throw err if err
-        db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.loses": 1, "stats.loses-corp" : 1}}, (err) ->
-          throw err if err
+        if response.state[winningSide].options.gamestats is true
+          db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.wins": 1, "stats.wins-runner" : 1}}, (err) ->
+            throw err if err
+        else
+          db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1}}, (err) ->
+            throw err if err
+        if response.state[losingSide].options.gamestats is true
+          db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.loses": 1, "stats.loses-corp" : 1}}, (err) ->
+            throw err if err
+        else
+          db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1}}, (err) ->
+            throw err if err
       db.collection('gamestats').update {gameid: response.gameid}, {$set: g}, (err) ->
         throw err if err
   else

--- a/server.coffee
+++ b/server.coffee
@@ -166,10 +166,12 @@ requester.on 'message', (data) ->
         runnerAgenda: response.state.runner["agenda-point"]
         corpAgenda: response.state.corp["agenda-point"]
       }
-      db.collection('decks').update {_id: mongoskin.helper.toObjectID(winningDeck)}, {$inc: {"stats.games" : 1, "stats.wins" : 1}}, (err) ->
-        throw err if err
-      db.collection('decks').update {_id: mongoskin.helper.toObjectID(losingDeck)}, {$inc: {"stats.games" : 1, "stats.loses" : 1}}, (err) ->
-        throw err if err
+      if response.state[winningSide].options.deckstats is true
+        db.collection('decks').update {_id: mongoskin.helper.toObjectID(winningDeck)}, {$inc: {"stats.games" : 1, "stats.wins" : 1}}, (err) ->
+          throw err if err
+      if response.state[losingSide].options.deckstats is true
+        db.collection('decks').update {_id: mongoskin.helper.toObjectID(losingDeck)}, {$inc: {"stats.games" : 1, "stats.loses" : 1}}, (err) ->
+          throw err if err
       if winningSide is "corp"
         db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.wins": 1, "stats.wins-corp" : 1}}, (err) ->
           throw err if err

--- a/server.coffee
+++ b/server.coffee
@@ -158,6 +158,7 @@ requester.on 'message', (data) ->
       loser = response.state["losing-user"]
       winningSide = response.state.winner
       losingSide = response.state.loser
+      room = response.state.room
       g = {
         winner: response.state.winner
         reason: response.state.reason
@@ -166,33 +167,48 @@ requester.on 'message', (data) ->
         runnerAgenda: response.state.runner["agenda-point"]
         corpAgenda: response.state.corp["agenda-point"]
       }
+      # Handle Deck Statistics
       if response.state[winningSide].options.deckstats is true
         db.collection('decks').update {_id: mongoskin.helper.toObjectID(winningDeck)}, {$inc: {"stats.games" : 1, "stats.wins" : 1}}, (err) ->
           throw err if err
       if response.state[losingSide].options.deckstats is true
         db.collection('decks').update {_id: mongoskin.helper.toObjectID(losingDeck)}, {$inc: {"stats.games" : 1, "stats.loses" : 1}}, (err) ->
           throw err if err
+
+      # Handle Game Statistics
       if winningSide is "corp"
-        if response.state[winningSide].options.gamestats is true
+        if response.state[winningSide].options.gamestats is "always"
+          db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.wins": 1, "stats.wins-corp" : 1}}, (err) ->
+            throw err if err
+        else if response.state[winningSide].options.gamestats is "competitive" and room is "competitive"
           db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.wins": 1, "stats.wins-corp" : 1}}, (err) ->
             throw err if err
         else
           db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1}}, (err) ->
             throw err if err
-        if response.state[losingSide].options.gamestats is true
+        if response.state[losingSide].options.gamestats is "always"
+          db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.loses": 1, "stats.loses-runner" : 1}}, (err) ->
+            throw err if err
+        else if response.state[losingSide].options.gamestats is "competitive" and room is "competitive"
           db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.loses": 1, "stats.loses-runner" : 1}}, (err) ->
             throw err if err
         else
           db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1}}, (err) ->
             throw err if err
       else if winningSide is "runner"
-        if response.state[winningSide].options.gamestats is true
+        if response.state[winningSide].options.gamestats is "always"
+          db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.wins": 1, "stats.wins-runner" : 1}}, (err) ->
+            throw err if err
+        else if response.state[winningSide].options.gamestats is "competitive" and room is "competitive"
           db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1, "stats.wins": 1, "stats.wins-runner" : 1}}, (err) ->
             throw err if err
         else
           db.collection('users').update {username: winner}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-runner" : 1}}, (err) ->
             throw err if err
-        if response.state[losingSide].options.gamestats is true
+        if response.state[losingSide].options.gamestats is "always"
+          db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.loses": 1, "stats.loses-corp" : 1}}, (err) ->
+            throw err if err
+        else if response.state[losingSide].options.gamestats is "competitive" and room is "competitive"
           db.collection('users').update {username: loser}, {$inc: {"stats.games-completed" : 1, "stats.games-completed-corp" : 1, "stats.loses": 1, "stats.loses-corp" : 1}}, (err) ->
             throw err if err
         else

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -545,7 +545,9 @@
   [state side reason]
   (system-msg state side "wins the game")
   (play-sfx state side "game-end")
-  (swap! state assoc :winner side
+  (swap! state assoc
+         :winner side
+         :loser (other-side side)
          :winning-user (get-in @state [side :user :username])
          :losing-user (get-in @state [(other-side side) :user :username])
          :reason reason :end-time (java.util.Date.)

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -43,7 +43,7 @@
 
 (defn init-game
   "Initializes a new game with the given players vector."
-  [{:keys [players gameid spectatorhands] :as game}]
+  [{:keys [players gameid spectatorhands room] :as game}]
   (let [corp (some #(when (= (:side %) "Corp") %) players)
         runner (some #(when (= (:side %) "Runner") %) players)
         corp-deck (create-deck (:deck corp) (:user corp))
@@ -58,6 +58,7 @@
         runner-identity (assoc runner-identity :implementation (card-implemented runner-identity))
         state (atom
                 {:gameid gameid :log [] :active-player :runner :end-turn true
+                 :room room
                  :rid 0 :turn 0 :eid 0
                  :sfx [] :sfx-current-id 0
                  :options {:spectatorhands spectatorhands}

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -50,6 +50,8 @@
         runner-deck (create-deck (:deck runner) (:user runner))
         corp-deck-id (get-in corp [:deck :_id])
         runner-deck-id (get-in runner [:deck :_id])
+        corp-options (get-in corp [:options])
+        runner-options (get-in runner [:options])
         corp-identity (assoc (or (get-in corp [:deck :identity]) {:side "Corp" :type "Identity"}) :cid (make-cid))
         corp-identity (assoc corp-identity :implementation (card-implemented corp-identity))
         runner-identity (assoc (or (get-in runner [:deck :identity]) {:side "Runner" :type "Identity"}) :cid (make-cid))
@@ -60,6 +62,7 @@
                  :sfx [] :sfx-current-id 0
                  :options {:spectatorhands spectatorhands}
                  :corp {:user (:user corp) :identity corp-identity
+                        :options corp-options
                         :deck (zone :deck corp-deck)
                         :deck-id corp-deck-id
                         :hand []
@@ -71,6 +74,7 @@
                         :agenda-point 0
                         :click-per-turn 3 :agenda-point-req 7 :keep false}
                  :runner {:user (:user runner) :identity runner-identity
+                          :options runner-options
                           :deck (zone :deck runner-deck)
                           :deck-id runner-deck-id
                           :hand []

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -150,6 +150,9 @@
              "remove" (do (swap! game-states dissoc gameid)
                           (swap! old-states dissoc gameid))
              "do" (handle-do user command state side args)
+             "finaluser-add" (swap! state assoc :final-user {:username (get-in user [:user :username])
+                                                             :side (clojure.string/lower-case (:side user))})
+             "finaluser-del" (swap! state dissoc :final-user)
              ("notification" "rejoin")
              (when state
                (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))

--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -203,15 +203,18 @@
                                  :checked (= (om/get-state owner :gamestats) (:ref option))}]
                  (:name option)]])]
 
-
             [:section
              [:h3 " Deck Statistics "]
-             [:div
-              [:label [:input {:type "checkbox"
-                               :value true
-                               :checked (om/get-state owner :deckstats)
-                               :on-change #(om/set-state! owner :deckstats (.. % -target -checked))}]
-               "Enable Deck Statistics"]]]
+             (for [option [{:name "Always"                   :ref "always"}
+                           {:name "Competitive Lobby Only"   :ref "competitive"}
+                           {:name "None"                     :ref "none"}]]
+               [:div
+                [:label [:input {:type "radio"
+                                 :name "deckstats"
+                                 :value (:ref option)
+                                 :on-change #(om/set-state! owner :deckstats (.. % -target -value))
+                                 :checked (= (om/get-state owner :deckstats) (:ref option))}]
+                 (:name option)]])]
 
             [:section {:id "alt-art"}
              [:h3 "Alt arts"]

--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -53,7 +53,9 @@
   (swap! app-state assoc-in [:options :sounds-volume] (om/get-state owner :volume))
   (swap! app-state assoc-in [:options :blocked-users] (om/get-state owner :blocked-users))
   (swap! app-state assoc-in [:options :alt-arts] (om/get-state owner :alt-arts))
+  (swap! app-state assoc-in [:options :gamestats] (om/get-state owner :gamestats))
   (swap! app-state assoc-in [:options :deckstats] (om/get-state owner :deckstats))
+  (.setItem js/localStorage "gamestats" (om/get-state owner :gamestats))
   (.setItem js/localStorage "deckstats" (om/get-state owner :deckstats))
   (.setItem js/localStorage "sounds" (om/get-state owner :sounds))
   (.setItem js/localStorage "sounds_volume" (om/get-state owner :volume))
@@ -130,6 +132,7 @@
       (om/set-state! owner :sounds (get-in @app-state [:options :sounds]))
       (om/set-state! owner :show-alt-art (get-in @app-state [:options :show-alt-art]))
       (om/set-state! owner :volume (get-in @app-state [:options :sounds-volume]))
+      (om/set-state! owner :gamestats (get-in @app-state [:options :gamestats]))
       (om/set-state! owner :deckstats (get-in @app-state [:options :deckstats]))
       (om/set-state! owner :blocked-users (sort (get-in @app-state [:options :blocked-users] [])))
       (go (while true
@@ -189,6 +192,12 @@
 
             [:section
              [:h3 "Statistics"]
+             [:div
+              [:label [:input {:type "checkbox"
+                               :value true
+                               :checked (om/get-state owner :gamestats)
+                               :on-change #(om/set-state! owner :gamestats (.. % -target -checked))}]
+               "Enable Game Win/Lose Statistics"]]
              [:div
               [:label [:input {:type "checkbox"
                                :value true

--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -53,6 +53,8 @@
   (swap! app-state assoc-in [:options :sounds-volume] (om/get-state owner :volume))
   (swap! app-state assoc-in [:options :blocked-users] (om/get-state owner :blocked-users))
   (swap! app-state assoc-in [:options :alt-arts] (om/get-state owner :alt-arts))
+  (swap! app-state assoc-in [:options :deckstats] (om/get-state owner :deckstats))
+  (.setItem js/localStorage "deckstats" (om/get-state owner :deckstats))
   (.setItem js/localStorage "sounds" (om/get-state owner :sounds))
   (.setItem js/localStorage "sounds_volume" (om/get-state owner :volume))
 
@@ -128,6 +130,7 @@
       (om/set-state! owner :sounds (get-in @app-state [:options :sounds]))
       (om/set-state! owner :show-alt-art (get-in @app-state [:options :show-alt-art]))
       (om/set-state! owner :volume (get-in @app-state [:options :sounds-volume]))
+      (om/set-state! owner :deckstats (get-in @app-state [:options :deckstats]))
       (om/set-state! owner :blocked-users (sort (get-in @app-state [:options :blocked-users] [])))
       (go (while true
             (let [cards (<! alt-arts-channel)
@@ -183,6 +186,15 @@
                                  :on-change #(om/set-state! owner :background (.. % -target -value))
                                  :checked (= (om/get-state owner :background) (:ref option))}]
                  (:name option)]])]
+
+            [:section
+             [:h3 "Statistics"]
+             [:div
+              [:label [:input {:type "checkbox"
+                               :value true
+                               :checked (om/get-state owner :deckstats)
+                               :on-change #(om/set-state! owner :deckstats (.. % -target -checked))}]
+               "Enable Deck Statistics"]]]
 
             [:section {:id "alt-art"}
              [:h3 "Alt arts"]

--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -55,8 +55,6 @@
   (swap! app-state assoc-in [:options :alt-arts] (om/get-state owner :alt-arts))
   (swap! app-state assoc-in [:options :gamestats] (om/get-state owner :gamestats))
   (swap! app-state assoc-in [:options :deckstats] (om/get-state owner :deckstats))
-  (.setItem js/localStorage "gamestats" (om/get-state owner :gamestats))
-  (.setItem js/localStorage "deckstats" (om/get-state owner :deckstats))
   (.setItem js/localStorage "sounds" (om/get-state owner :sounds))
   (.setItem js/localStorage "sounds_volume" (om/get-state owner :volume))
 
@@ -191,7 +189,7 @@
                  (:name option)]])]
 
             [:section
-             [:h3 " Game Statistics "]
+             [:h3 " Game Win/Lose Statistics "]
              (for [option [{:name "Always"                   :ref "always"}
                            {:name "Competitive Lobby Only"   :ref "competitive"}
                            {:name "None"                     :ref "none"}]]

--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -191,13 +191,21 @@
                  (:name option)]])]
 
             [:section
-             [:h3 "Statistics"]
-             [:div
-              [:label [:input {:type "checkbox"
-                               :value true
-                               :checked (om/get-state owner :gamestats)
-                               :on-change #(om/set-state! owner :gamestats (.. % -target -checked))}]
-               "Enable Game Win/Lose Statistics"]]
+             [:h3 " Game Statistics "]
+             (for [option [{:name "Always"                   :ref "always"}
+                           {:name "Competitive Lobby Only"   :ref "competitive"}
+                           {:name "None"                     :ref "none"}]]
+               [:div
+                [:label [:input {:type "radio"
+                                 :name "gamestats"
+                                 :value (:ref option)
+                                 :on-change #(om/set-state! owner :gamestats (.. % -target -value))
+                                 :checked (= (om/get-state owner :gamestats) (:ref option))}]
+                 (:name option)]])]
+
+
+            [:section
+             [:h3 " Deck Statistics "]
              [:div
               [:label [:input {:type "checkbox"
                                :value true

--- a/src/cljs/netrunner/appstate.cljs
+++ b/src/cljs/netrunner/appstate.cljs
@@ -7,6 +7,8 @@
                           :show-alt-art true
                           :deckstats (let [deckstats (js->clj (.getItem js/localStorage "deckstats"))]
                                        (if (nil? deckstats) true (= deckstats "true")))
+                          :gamestats (let [gamestats (js->clj (.getItem js/localStorage "gamestats"))]
+                                       (if (nil? gamestats) true (= gamestats "true")))
                           :sounds (let [sounds (js->clj (.getItem js/localStorage "sounds"))]
                                     (if (nil? sounds) true (= sounds "true")))
                           :sounds-volume (let [volume (js->clj (.getItem js/localStorage "sounds_volume"))]

--- a/src/cljs/netrunner/appstate.cljs
+++ b/src/cljs/netrunner/appstate.cljs
@@ -5,6 +5,8 @@
          :user (js->clj js/user :keywordize-keys true)
          :options (merge {:background "lobby-bg"
                           :show-alt-art true
+                          :deckstats (let [deckstats (js->clj (.getItem js/localStorage "deckstats"))]
+                                       (if (nil? deckstats) true (= deckstats "true")))
                           :sounds (let [sounds (js->clj (.getItem js/localStorage "sounds"))]
                                     (if (nil? sounds) true (= sounds "true")))
                           :sounds-volume (let [volume (js->clj (.getItem js/localStorage "sounds_volume"))]

--- a/src/cljs/netrunner/appstate.cljs
+++ b/src/cljs/netrunner/appstate.cljs
@@ -6,9 +6,9 @@
          :options (merge {:background "lobby-bg"
                           :show-alt-art true
                           :deckstats (let [deckstats (js->clj (.getItem js/localStorage "deckstats"))]
-                                       (if (nil? deckstats) true (= deckstats "true")))
+                                       (if (nil? deckstats) "always" deckstats))
                           :gamestats (let [gamestats (js->clj (.getItem js/localStorage "gamestats"))]
-                                       (if (nil? gamestats) "all" gamestats))
+                                       (if (nil? gamestats) "always" gamestats))
                           :sounds (let [sounds (js->clj (.getItem js/localStorage "sounds"))]
                                     (if (nil? sounds) true (= sounds "true")))
                           :sounds-volume (let [volume (js->clj (.getItem js/localStorage "sounds_volume"))]

--- a/src/cljs/netrunner/appstate.cljs
+++ b/src/cljs/netrunner/appstate.cljs
@@ -8,7 +8,7 @@
                           :deckstats (let [deckstats (js->clj (.getItem js/localStorage "deckstats"))]
                                        (if (nil? deckstats) true (= deckstats "true")))
                           :gamestats (let [gamestats (js->clj (.getItem js/localStorage "gamestats"))]
-                                       (if (nil? gamestats) true (= gamestats "true")))
+                                       (if (nil? gamestats) "all" gamestats))
                           :sounds (let [sounds (js->clj (.getItem js/localStorage "sounds"))]
                                     (if (nil? sounds) true (= sounds "true")))
                           :sounds-volume (let [volume (js->clj (.getItem js/localStorage "sounds_volume"))]

--- a/src/cljs/netrunner/appstate.cljs
+++ b/src/cljs/netrunner/appstate.cljs
@@ -5,10 +5,8 @@
          :user (js->clj js/user :keywordize-keys true)
          :options (merge {:background "lobby-bg"
                           :show-alt-art true
-                          :deckstats (let [deckstats (js->clj (.getItem js/localStorage "deckstats"))]
-                                       (if (nil? deckstats) "always" deckstats))
-                          :gamestats (let [gamestats (js->clj (.getItem js/localStorage "gamestats"))]
-                                       (if (nil? gamestats) "always" gamestats))
+                          :deckstats "always"
+                          :gamestats "always"
                           :sounds (let [sounds (js->clj (.getItem js/localStorage "sounds"))]
                                     (if (nil? sounds) true (= sounds "true")))
                           :sounds-volume (let [volume (js->clj (.getItem js/localStorage "sounds_volume"))]

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -619,7 +619,8 @@
         (try (js/ga "send" "event" "deckbuilder" "cleardeckstats") (catch js/Error e))
         (go (let [result (<! (POST "/data/decks/clearstats" data :json))]
               (om/update! cursor :decks (conj decks deck))
-              (om/set-state! owner :deck deck)))))))
+              (om/set-state! owner :deck deck)
+              (.focus deck)))))))
 
 (defn html-escape [st]
   (escape st {\< "&lt;" \> "&gt;" \& "&amp;" \" "#034;"}))

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -9,13 +9,17 @@
             [netrunner.cardbrowser :refer [cards-channel image-url card-view show-alt-art?] :as cb]
             [netrunner.account :refer [load-alt-arts alt-art-name]]
             [netrunner.ajax :refer [POST GET]]
-            [netrunner.stats :refer [num->percent]]
             [goog.string :as gstring]
             [goog.string.format]))
 
 (def select-channel (chan))
 (def zoom-channel (chan))
 (def INFINITY 2147483647)
+
+(defn num->percent
+  "Converts an input number to a percent of the second input number for display"
+  [num1 num2]
+  (gstring/format "%.0f" (* 100 (float (/ num1 num2)))))
 
 (defn identical-cards? [cards]
   (let [name (:title (first cards))]
@@ -617,12 +621,6 @@
               (om/update! cursor :decks (conj decks deck))
               (om/set-state! owner :deck deck)))))))
 
-(defn refresh-deck-stats [cursor owner]
-  (authenticated
-    (fn [user]
-      (go (let [decks (process-decks (:json (<! (GET (str "/data/decks")))))]
-            (load-decks decks))))))
-
 (defn html-escape [st]
   (escape st {\< "&lt;" \> "&gt;" \& "&amp;" \" "#034;"}))
 
@@ -917,8 +915,6 @@
                   :else [:div.button-bar
                          [:button {:on-click #(edit-deck owner)} "Edit"]
                          [:button {:on-click #(delete-deck owner)} "Delete"]
-                         (when-not (= "none" (get-in @app-state [:options :deckstats]))
-                           [:button {:on-click #(refresh-deck-stats cursor owner)} "Refresh Stats"])
                          (when (and (:stats deck) (not= "none" (get-in @app-state [:options :deckstats])))
                            [:button {:on-click #(clear-deck-stats cursor owner)} "Clear Stats"])])
                 [:h3 (:name deck)]

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -788,7 +788,7 @@
                     [:h4 (:name deck)]
                     [:div.float-right (-> (:date deck) js/Date. js/moment (.format "MMM Do YYYY"))]
                     [:p (get-in deck [:identity :title]) [:br]
-                     (when (and (:stats deck) (get-in @app-state [:options :deckstats]))
+                     (when (and (:stats deck) (not= "none" (get-in @app-state [:options :deckstats])))
                        (let [stats (:stats deck)]
                          [:span "  Games: " (:games stats)
                           " - Win: " (or (:wins stats) 0)
@@ -917,9 +917,9 @@
                   :else [:div.button-bar
                          [:button {:on-click #(edit-deck owner)} "Edit"]
                          [:button {:on-click #(delete-deck owner)} "Delete"]
-                         (when (get-in @app-state [:options :deckstats])
+                         (when-not (= "none" (get-in @app-state [:options :deckstats]))
                            [:button {:on-click #(refresh-deck-stats cursor owner)} "Refresh Stats"])
-                         (when (and (:stats deck) (get-in @app-state [:options :deckstats]))
+                         (when (and (:stats deck) (not= "none" (get-in @app-state [:options :deckstats])))
                            [:button {:on-click #(clear-deck-stats cursor owner)} "Clear Stats"])])
                 [:h3 (:name deck)]
                 [:div.header

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -9,6 +9,7 @@
             [netrunner.cardbrowser :refer [cards-channel image-url card-view show-alt-art?] :as cb]
             [netrunner.account :refer [load-alt-arts alt-art-name]]
             [netrunner.ajax :refer [POST GET]]
+            [netrunner.stats :refer [num->percent]]
             [goog.string :as gstring]
             [goog.string.format]))
 
@@ -787,11 +788,12 @@
                     [:h4 (:name deck)]
                     [:div.float-right (-> (:date deck) js/Date. js/moment (.format "MMM Do YYYY"))]
                     [:p (get-in deck [:identity :title]) [:br]
-                     (when-let [stats (:stats deck)]
-                       [:span "  Games: " (:games stats)
-                        " - Win: " (or (:wins stats) 0)
-                        " - Lose: " (or (:loses stats) 0)
-                        " - Percent Win: " (gstring/format "%.0f" (* 100 (float (/ (:wins stats) (:games stats))))) "%"])]])])))))
+                     (when (and (:stats deck) (get-in @app-state [:options :deckstats]))
+                       (let [stats (:stats deck)]
+                         [:span "  Games: " (:games stats)
+                          " - Win: " (or (:wins stats) 0)
+                          " - Lose: " (or (:loses stats) 0)
+                          " - Percent Win: " (num->percent (:wins stats) (:games stats)) "%"]))]])])))))
 
 (defn line-span
   "Make the view of a single line in the deck - returns a span"
@@ -915,8 +917,9 @@
                   :else [:div.button-bar
                          [:button {:on-click #(edit-deck owner)} "Edit"]
                          [:button {:on-click #(delete-deck owner)} "Delete"]
-                         [:button {:on-click #(refresh-deck-stats cursor owner)} "Refresh Stats"]
-                         (when (:stats deck)
+                         (when (get-in @app-state [:options :deckstats])
+                           [:button {:on-click #(refresh-deck-stats cursor owner)} "Refresh Stats"])
+                         (when (and (:stats deck) (get-in @app-state [:options :deckstats]))
                            [:button {:on-click #(clear-deck-stats cursor owner)} "Clear Stats"])])
                 [:h3 (:name deck)]
                 [:div.header

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -9,8 +9,8 @@
             [netrunner.auth :refer [authenticated avatar] :as auth]
             [netrunner.gameboard :refer [init-game game-state toast launch-game]]
             [netrunner.cardbrowser :refer [image-url] :as cb]
-            [netrunner.stats :refer [notnum->zero num->percent]]
-            [netrunner.deckbuilder :refer [deck-status-span deck-status-label process-decks load-decks]]))
+            [netrunner.stats :refer [notnum->zero]]
+            [netrunner.deckbuilder :refer [deck-status-span deck-status-label process-decks load-decks num->percent]]))
 
 (def socket-channel (chan))
 (def socket (.connect js/io (str js/iourl "/lobby")))
@@ -109,9 +109,6 @@
 (defn leave-game []
   (send {:action "leave-game" :gameid (:gameid @app-state)
          :user (:user @app-state) :side (:side @game-state)})
-  ; Update decks to get new stats
-  (go (let [decks (process-decks (:json (<! (GET (str "/data/decks")))))]
-        (load-decks decks)))
   (reset! game-state nil)
   (swap! app-state dissoc :gameid :side :password-gameid)
   (.removeItem js/localStorage "gameid")

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -9,6 +9,7 @@
             [netrunner.auth :refer [authenticated avatar] :as auth]
             [netrunner.gameboard :refer [init-game game-state toast launch-game]]
             [netrunner.cardbrowser :refer [image-url] :as cb]
+            [netrunner.stats :refer [notnum->zero num->percent]]
             [netrunner.deckbuilder :refer [deck-status-span deck-status-label process-decks load-decks]]))
 
 (def socket-channel (chan))
@@ -167,12 +168,23 @@
       "Weyland Consortium" (icon-span "weyland")
       [:span.side "(Unknown)"])))
 
+(defn user-status-span
+  "Returns a [:span] showing players game completion rate"
+  [player]
+  (let [started (get-in player [:user :stats :games-started])
+        completed (get-in player [:user :stats :games-completed])
+        completion-rate (str (notnum->zero (num->percent completed started)) "%")
+        completion-rate (if (< started 10) "Too little data" completion-rate)]
+    [:span.deck-status (get-in player [:user :username])
+     [:div.status-tooltip.blue-shade
+      [:div "Game Completion Rate: " completion-rate]]]))
+
 (defn player-view [{:keys [player game] :as args}]
   (om/component
    (sab/html
     [:span.player
      (om/build avatar (:user player) {:opts {:size 22}})
-     (get-in player [:user :username])
+     (user-status-span player)
      (let [side (:side player)
            faction (:faction player)
            identity (:identity player)

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -151,10 +151,14 @@
                              "testing future spoilers, playing on a touchscreen, playing at work and likely to have to quit on short notice, etc. "
                              "All of these circumstances may cause needless frustration of players expecting to play a game in a competitive setting."])}
             {:id "aboutstats"
-             :title "Why are the deck & user stats not updated instantly??"
-             :content [:p "Deck & user stats are only updated when everyone has left a game."
-                       "This is to allow re-joining of games, and also clean detection of a finalised game"
-                       "Note: Games commenced are logged as soon as you start a game"]}
+             :title "What are the options for tracking Game and Deck Statistics"
+             :content [:p "Games Started vs. Completed is always logged and displayed.  We want to discourage people dropping in games. "
+                       "You can toggle between the modes listed below if you feel like being a casual player one moment then logging stats the next. "
+                       "No data is lost or cleared when you toggle between modes."
+                       [:ul
+                        [:li "Always - statistics are kept and displayed for all games you play"]
+                        [:li "Competitive lobby only - statistics are kept and displayed only for competitive games"]
+                        [:li "None - statistics are neither logged or displayed"]]]}
             )}
     {:id "cards"
      :title "Cards and Specific Interactions"

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -151,14 +151,23 @@
                              "testing future spoilers, playing on a touchscreen, playing at work and likely to have to quit on short notice, etc. "
                              "All of these circumstances may cause needless frustration of players expecting to play a game in a competitive setting."])}
             {:id "aboutstats"
-             :title "What are the options for tracking Game and Deck Statistics"
-             :content [:p "Games Started vs. Completed is always logged and displayed.  We want to discourage people dropping in games. "
-                       "You can toggle between the modes listed below if you feel like being a casual player one moment then logging stats the next. "
-                       "No data is lost or cleared when you toggle between modes."
-                       [:ul
-                        [:li "Always - statistics are kept and displayed for all games you play"]
-                        [:li "Competitive lobby only - statistics are kept and displayed only for competitive games"]
-                        [:li "None - statistics are neither logged or displayed"]]]}
+             :title "What are the options for tracking Game and Deck Statistics, and what do they mean?"
+             :content (list [:p "Games Started vs. Completed is always logged and displayed.  We want to discourage people dropping in games. "
+                             "You can toggle between the modes listed below if you feel like being a casual player one moment then logging stats the next. "
+                             "No data is lost or cleared when you toggle between modes."
+                             [:ul
+                              [:li "Always - statistics are kept and displayed for all games you play"]
+                              [:li "Competitive lobby only - statistics are kept and displayed only for competitive games"]
+                              [:li "None - statistics are neither logged or displayed"]]]
+                            [:p "What do the game statistics mean?"
+                             [:ul
+                              [:li "Games Started - games you have entered. The same is used for deck stats."]
+                              [:li "Games Completed - games that had a winner, or games that did not complete but opponent dropped first."]
+                              [:li "Games Incomplete -  games with no winner where you dropped first, and did not concede."]
+                              [:li "Games Won - games won.  The percentage is compared to those games lost.  The same is used for deck stats."]
+                              [:li "Games Lost - games lost.  The percentage is compared to those games won. The same is used for deck stats."]]]
+                            [:p "Your game completion rate is visible in the player lobby so people can determine if they should play against you."
+                             " Don't quit during games - please concede if you have to leave."])}
             )}
     {:id "cards"
      :title "Cards and Specific Interactions"

--- a/src/cljs/netrunner/stats.cljs
+++ b/src/cljs/netrunner/stats.cljs
@@ -2,12 +2,16 @@
   (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [om.core :as om :include-macros true]
             [sablono.core :as sab :include-macros true]
-            [cljs.core.async :refer [<!] :as async]
+            [cljs.core.async :refer [chan put! <!] :as async]
             [netrunner.appstate :refer [app-state]]
             [netrunner.auth :refer [authenticated] :as auth]
             [netrunner.ajax :refer [POST GET]]
             [goog.string :as gstring]
             [goog.string.format]))
+
+(def stats-channel (chan))
+(def stats-socket (.connect js/io (str js/iourl "/stats")))
+(.on stats-socket "netrunner" #(put! stats-channel (js->clj % :keywordize-keys true)))
 
 (defn num->percent
   "Converts an input number to a percent of the second input number for display"
@@ -19,109 +23,64 @@
   [input]
   (if (pos? (int input)) input 0))
 
-(defn clear-user-stats [owner]
-  (authenticated
-    (fn [user]
-      (let [data (:user @app-state)]
-        (try (js/ga "send" "event" "user" "clearuserstats") (catch js/Error e))
-        (go (let [result (<! (POST "/user/clearstats" data :json))])
-            (om/set-state! owner :games-started 0)
-            (om/set-state! owner :games-completed 0)
-            (om/set-state! owner :wins 0)
-            (om/set-state! owner :loses 0)
-            (om/set-state! owner :dnf 0)
-            ; Corp
-            (om/set-state! owner :games-started-corp 0)
-            (om/set-state! owner :games-completed-corp 0)
-            (om/set-state! owner :wins-corp 0)
-            (om/set-state! owner :loses-corp 0)
-            (om/set-state! owner :dnf-corp 0)
-            ; Runner
-            (om/set-state! owner :games-started-runner 0)
-            (om/set-state! owner :games-completed-runner 0)
-            (om/set-state! owner :wins-runner 0)
-            (om/set-state! owner :loses-runner 0)
-            (om/set-state! owner :dnf-runner 0))))))
-
 (defn refresh-user-stats [owner]
   (authenticated
     (fn [user]
       (try (js/ga "send" "event" "user" "refreshstats") (catch js/Error e))
       (go (let [result (-> (<! (GET (str "/user"))) :json first :stats)]
-            (om/set-state! owner :games-started (:games-started result))
-            (om/set-state! owner :games-completed (:games-completed result))
-            (om/set-state! owner :wins (:wins result))
-            (om/set-state! owner :loses (:loses result))
-            (om/set-state! owner :dnf (- (:games-started result) (:games-completed result)))
-            ; Corp
-            (om/set-state! owner :games-started-corp (:games-started-corp result))
-            (om/set-state! owner :games-completed-corp (:games-completed-corp result))
-            (om/set-state! owner :wins-corp (:wins-corp result))
-            (om/set-state! owner :loses-corp (:loses-corp result))
-            (om/set-state! owner :dnf-corp (- (:games-started-corp result) (:games-completed-corp result)))
-            ; Runner
-            (om/set-state! owner :games-started-runner (:games-started-runner result))
-            (om/set-state! owner :games-completed-runner (:games-completed-runner result))
-            (om/set-state! owner :wins-runner (:wins-runner result))
-            (om/set-state! owner :loses-runner (:loses-runner result))
-            (om/set-state! owner :dnf-runner (- (:games-started-runner result) (:games-completed-runner result))))))))
+            (swap! app-state assoc :stats result))))))
 
-(defn stats-view [user owner]
+(defn clear-user-stats [owner]
+  (authenticated
+    (fn [user]
+      (let [data (:user @app-state)]
+        (try (js/ga "send" "event" "user" "clearuserstats") (catch js/Error e))
+        (go (let [result (<! (POST "/user/clearstats" data :json))]
+              (swap! app-state assoc :stats result)))))))
+
+;; Go loop to receive messages from node server to refresh stats on game-end
+(go (while true
+      (let [msg (<! stats-channel)
+            result (-> (<! (GET (str "/user"))) :json first :stats)]
+        (try (js/ga "send" "event" "user" "refreshstats") (catch js/Error e))
+        (swap! app-state assoc :stats result))))
+
+(defn stats [{:keys [user stats] :as cursor} owner]
   (reify
     om/IInitState
     (init-state [this] {:flash-message ""})
 
-    om/IWillMount
-    (will-mount [this]
-      (om/set-state! owner :games-started (get-in @app-state [:stats :games-started]))
-      (om/set-state! owner :games-completed (get-in @app-state [:stats :games-completed]))
-      (om/set-state! owner :wins (get-in @app-state [:stats :wins]))
-      (om/set-state! owner :loses (get-in @app-state [:stats :loses]))
-      (om/set-state! owner :dnf (- (om/get-state owner :games-started) (om/get-state owner :games-completed)))
-      ;; Corp
-      (om/set-state! owner :games-started-corp (get-in @app-state [:stats :games-started-corp]))
-      (om/set-state! owner :games-completed-corp (get-in @app-state [:stats :games-completed-corp]))
-      (om/set-state! owner :wins-corp (get-in @app-state [:stats :wins-corp]))
-      (om/set-state! owner :loses-corp (get-in @app-state [:stats :loses-corp]))
-      (om/set-state! owner :dnf-corp (- (om/get-state owner :games-started-corp) (om/get-state owner :games-completed-corp)))
-      ;; Runner
-      (om/set-state! owner :games-started-runner (get-in @app-state [:stats :games-started-runner]))
-      (om/set-state! owner :games-completed-runner (get-in @app-state [:stats :games-completed-runner]))
-      (om/set-state! owner :wins-runner (get-in @app-state [:stats :wins-runner]))
-      (om/set-state! owner :loses-runner (get-in @app-state [:stats :loses-runner]))
-      (om/set-state! owner :dnf-runner (- (om/get-state owner :games-started-runner) (om/get-state owner :games-completed-runner))))
-
     om/IRenderState
     (render-state [this state]
       (sab/html
-        (let [started (notnum->zero (om/get-state owner :games-started))
-              completed (notnum->zero (om/get-state owner :games-completed))
+        (let [started (notnum->zero (:games-started stats))
+              completed (notnum->zero (:games-completed stats))
               pc (notnum->zero (num->percent completed started))
-              win (notnum->zero (om/get-state owner :wins))
-              lose (notnum->zero (om/get-state owner :loses))
+              win (notnum->zero (:wins stats))
+              lose (notnum->zero (:loses stats))
               pw (notnum->zero (num->percent win (+ win lose)))
               pl (notnum->zero (num->percent lose (+ win lose)))
-              incomplete (notnum->zero (om/get-state owner :dnf))
+              incomplete (notnum->zero (- started completed))
               pi (notnum->zero (num->percent incomplete started))
               ;; Corp Stats
-              started-corp (notnum->zero (om/get-state owner :games-started-corp))
-              completed-corp (notnum->zero (om/get-state owner :games-completed-corp))
+              started-corp (notnum->zero (:games-started-corp stats))
+              completed-corp (notnum->zero (:games-completed-corp stats))
               pc-corp (notnum->zero (num->percent completed-corp started-corp))
-              win-corp (notnum->zero (om/get-state owner :wins-corp))
-              lose-corp (notnum->zero (om/get-state owner :loses-corp))
+              win-corp (notnum->zero (:wins-corp stats))
+              lose-corp (notnum->zero (:loses-corp stats))
               pw-corp (notnum->zero (num->percent win-corp (+ win-corp lose-corp)))
               pl-corp (notnum->zero (num->percent lose-corp (+ win-corp lose-corp)))
-              incomplete-corp (notnum->zero (om/get-state owner :dnf-corp))
+              incomplete-corp (notnum->zero (- started-corp completed-corp))
               pi-corp (notnum->zero (num->percent incomplete-corp started-corp))
               ;; Runner Stats
-              started-runner (notnum->zero (om/get-state owner :games-started-runner))
-              completed-runner (notnum->zero (om/get-state owner :games-completed-runner))
+              started-runner (notnum->zero (:games-started-runner stats))
+              completed-runner (notnum->zero (:games-completed-runner stats))
               pc-runner (notnum->zero (num->percent completed-runner started-runner))
-              win-runner (notnum->zero (om/get-state owner :wins-runner))
-              lose-runner (notnum->zero (om/get-state owner :loses-runner))
+              win-runner (notnum->zero (:wins-runner stats))
+              lose-runner (notnum->zero (:loses-runner stats))
               pw-runner (notnum->zero (num->percent win-runner (+ win-runner lose-runner)))
               pl-runner (notnum->zero (num->percent lose-runner (+ win-runner lose-runner)))
-              incomplete-runner (notnum->zero (om/get-state owner :dnf-runner))
+              incomplete-runner (notnum->zero (- started-runner completed-runner))
               pi-runner (notnum->zero (num->percent incomplete-runner started-runner))]
           [:div.blue-shade.panel.stats-main
             [:div.stats-left
@@ -155,10 +114,5 @@
              (when-not (= "none" (get-in @app-state [:options :gamestats]))
                [:div [:div "Won: " win-runner  " (" pw-runner "%)"]
                 [:div "Lost: " lose-runner  " (" pl-runner "%)"]])]]])))))
-
-(defn stats [{:keys [user]} owner]
-  (om/component
-    (when user
-      (om/build stats-view user))))
 
 (om/root stats app-state {:target (. js/document (getElementById "stats"))})

--- a/src/cljs/netrunner/stats.cljs
+++ b/src/cljs/netrunner/stats.cljs
@@ -29,7 +29,19 @@
             (om/set-state! owner :games-completed 0)
             (om/set-state! owner :wins 0)
             (om/set-state! owner :loses 0)
-            (om/set-state! owner :dnf 0))))))
+            (om/set-state! owner :dnf 0)
+            ; Corp
+            (om/set-state! owner :games-started-corp 0)
+            (om/set-state! owner :games-completed-corp 0)
+            (om/set-state! owner :wins-corp 0)
+            (om/set-state! owner :loses-corp 0)
+            (om/set-state! owner :dnf-corp 0)
+            ; Runner
+            (om/set-state! owner :games-started-runner 0)
+            (om/set-state! owner :games-completed-runner 0)
+            (om/set-state! owner :wins-runner 0)
+            (om/set-state! owner :loses-runner 0)
+            (om/set-state! owner :dnf-runner 0))))))
 
 (defn refresh-user-stats [owner]
   (authenticated
@@ -40,7 +52,19 @@
             (om/set-state! owner :games-completed (:games-completed result))
             (om/set-state! owner :wins (:wins result))
             (om/set-state! owner :loses (:loses result))
-            (om/set-state! owner :dnf (- (:games-started result) (:games-completed result))))))))
+            (om/set-state! owner :dnf (- (:games-started result) (:games-completed result)))
+            ; Corp
+            (om/set-state! owner :games-started-corp (:games-started-corp result))
+            (om/set-state! owner :games-completed-corp (:games-completed-corp result))
+            (om/set-state! owner :wins-corp (:wins-corp result))
+            (om/set-state! owner :loses-corp (:loses-corp result))
+            (om/set-state! owner :dnf-corp (- (:games-started-corp result) (:games-completed-corp result)))
+            ; Runner
+            (om/set-state! owner :games-started-runner (:games-started-runner result))
+            (om/set-state! owner :games-completed-runner (:games-completed-runner result))
+            (om/set-state! owner :wins-runner (:wins-runner result))
+            (om/set-state! owner :loses-runner (:loses-runner result))
+            (om/set-state! owner :dnf-runner (- (:games-started-runner result) (:games-completed-runner result))))))))
 
 (defn stats-view [user owner]
   (reify
@@ -53,7 +77,19 @@
       (om/set-state! owner :games-completed (get-in @app-state [:stats :games-completed]))
       (om/set-state! owner :wins (get-in @app-state [:stats :wins]))
       (om/set-state! owner :loses (get-in @app-state [:stats :loses]))
-      (om/set-state! owner :dnf (- (om/get-state owner :games-started) (om/get-state owner :games-completed))))
+      (om/set-state! owner :dnf (- (om/get-state owner :games-started) (om/get-state owner :games-completed)))
+      ;; Corp
+      (om/set-state! owner :games-started-corp (get-in @app-state [:stats :games-started-corp]))
+      (om/set-state! owner :games-completed-corp (get-in @app-state [:stats :games-completed-corp]))
+      (om/set-state! owner :wins-corp (get-in @app-state [:stats :wins-corp]))
+      (om/set-state! owner :loses-corp (get-in @app-state [:stats :loses-corp]))
+      (om/set-state! owner :dnf-corp (- (om/get-state owner :games-started-corp) (om/get-state owner :games-completed-corp)))
+      ;; Runner
+      (om/set-state! owner :games-started-runner (get-in @app-state [:stats :games-started-runner]))
+      (om/set-state! owner :games-completed-runner (get-in @app-state [:stats :games-completed-runner]))
+      (om/set-state! owner :wins-runner (get-in @app-state [:stats :wins-runner]))
+      (om/set-state! owner :loses-runner (get-in @app-state [:stats :loses-runner]))
+      (om/set-state! owner :dnf-runner (- (om/get-state owner :games-started-runner) (om/get-state owner :games-completed-runner))))
 
     om/IRenderState
     (render-state [this state]
@@ -66,9 +102,29 @@
               lose (notnum->zero (om/get-state owner :loses))
               pl (notnum->zero (num->percent lose started))
               incomplete (notnum->zero (om/get-state owner :dnf))
-              pi (notnum->zero (num->percent incomplete started))]
-          [:div
-            [:div.panel.blue-shade
+              pi (notnum->zero (num->percent incomplete started))
+              ;; Corp Stats
+              started-corp (notnum->zero (om/get-state owner :games-started-corp))
+              completed-corp (notnum->zero (om/get-state owner :games-completed-corp))
+              pc-corp (notnum->zero (num->percent completed-corp started-corp))
+              win-corp (notnum->zero (om/get-state owner :wins-corp))
+              pw-corp (notnum->zero (num->percent win-corp started-corp))
+              lose-corp (notnum->zero (om/get-state owner :loses-corp))
+              pl-corp (notnum->zero (num->percent lose-corp started-corp))
+              incomplete-corp (notnum->zero (om/get-state owner :dnf-corp))
+              pi-corp (notnum->zero (num->percent incomplete-corp started-corp))
+              ;; Runner Stats
+              started-runner (notnum->zero (om/get-state owner :games-started-runner))
+              completed-runner (notnum->zero (om/get-state owner :games-completed-runner))
+              pc-runner (notnum->zero (num->percent completed-runner started-runner))
+              win-runner (notnum->zero (om/get-state owner :wins-runner))
+              pw-runner (notnum->zero (num->percent win-runner started-runner))
+              lose-runner (notnum->zero (om/get-state owner :loses-runner))
+              pl-runner (notnum->zero (num->percent lose-runner started-runner))
+              incomplete-runner (notnum->zero (om/get-state owner :dnf-runner))
+              pi-runner (notnum->zero (num->percent incomplete-runner started-runner))]
+          [:div.blue-shade.panel.stats-main
+            [:div.stats-left
              [:h2 "Game Stats"]
               [:section
                [:div "Started: " started]
@@ -78,7 +134,23 @@
                [:div "Lost: " lose  " (" pl "%)"]]
              [:div.button-bar
               [:button {:on-click #(refresh-user-stats owner)} "Refresh Stats"]
-              [:button {:on-click #(clear-user-stats owner)} "Clear Stats"]]]])))))
+              [:button {:on-click #(clear-user-stats owner)} "Clear Stats"]]]
+           [:div.stats-middle
+            [:h2 "Corp Stats"]
+            [:section
+             [:div "Started: " started-corp]
+             [:div "Completed: " completed-corp " (" pc-corp "%)"]
+             [:div "Not completed: " incomplete-corp  " (" pi-corp "%)"]
+             [:div "Won: " win-corp  " (" pw-corp "%)"]
+             [:div "Lost: " lose-corp  " (" pl-corp "%)"]]]
+           [:div.stats-right
+            [:h2 "Runner Stats"]
+            [:section
+             [:div "Started: " started-runner]
+             [:div "Completed: " completed-runner " (" pc-runner "%)"]
+             [:div "Not completed: " incomplete-runner  " (" pi-runner "%)"]
+             [:div "Won: " win-runner  " (" pw-runner "%)"]
+             [:div "Lost: " lose-runner  " (" pl-runner "%)"]]]])))))
 
 (defn stats [{:keys [user]} owner]
   (om/component

--- a/src/cljs/netrunner/stats.cljs
+++ b/src/cljs/netrunner/stats.cljs
@@ -130,8 +130,10 @@
                [:div "Started: " started]
                [:div "Completed: " completed " (" pc "%)"]
                [:div "Not completed: " incomplete  " (" pi "%)"]
-               [:div "Won: " win  " (" pw "%)"]
-               [:div "Lost: " lose  " (" pl "%)"]]
+               (if (get-in @app-state [:options :gamestats])
+                 [:div [:div "Won: " win  " (" pw "%)"]
+                  [:div "Lost: " lose  " (" pl "%)"]]
+                 [:div [:br] [:br]])]
              [:div.button-bar
               [:button {:on-click #(refresh-user-stats owner)} "Refresh Stats"]
               [:button {:on-click #(clear-user-stats owner)} "Clear Stats"]]]
@@ -141,16 +143,18 @@
              [:div "Started: " started-corp]
              [:div "Completed: " completed-corp " (" pc-corp "%)"]
              [:div "Not completed: " incomplete-corp  " (" pi-corp "%)"]
-             [:div "Won: " win-corp  " (" pw-corp "%)"]
-             [:div "Lost: " lose-corp  " (" pl-corp "%)"]]]
+             (when (get-in @app-state [:options :gamestats])
+               [:div [:div "Won: " win-corp  " (" pw-corp "%)"]
+                [:div "Lost: " lose-corp  " (" pl-corp "%)"]])]]
            [:div.stats-right
             [:h2 "Runner Stats"]
             [:section
              [:div "Started: " started-runner]
              [:div "Completed: " completed-runner " (" pc-runner "%)"]
              [:div "Not completed: " incomplete-runner  " (" pi-runner "%)"]
-             [:div "Won: " win-runner  " (" pw-runner "%)"]
-             [:div "Lost: " lose-runner  " (" pl-runner "%)"]]]])))))
+             (when (get-in @app-state [:options :gamestats])
+               [:div [:div "Won: " win-runner  " (" pw-runner "%)"]
+                [:div "Lost: " lose-runner  " (" pl-runner "%)"]])]]])))))
 
 (defn stats [{:keys [user]} owner]
   (om/component

--- a/src/cljs/netrunner/stats.cljs
+++ b/src/cljs/netrunner/stats.cljs
@@ -130,7 +130,7 @@
                [:div "Started: " started]
                [:div "Completed: " completed " (" pc "%)"]
                [:div "Not completed: " incomplete  " (" pi "%)"]
-               (if (get-in @app-state [:options :gamestats])
+               (if-not (= "none" (get-in @app-state [:options :gamestats]))
                  [:div [:div "Won: " win  " (" pw "%)"]
                   [:div "Lost: " lose  " (" pl "%)"]]
                  [:div [:br] [:br]])]
@@ -143,7 +143,7 @@
              [:div "Started: " started-corp]
              [:div "Completed: " completed-corp " (" pc-corp "%)"]
              [:div "Not completed: " incomplete-corp  " (" pi-corp "%)"]
-             (when (get-in @app-state [:options :gamestats])
+             (when-not (= "none" (get-in @app-state [:options :gamestats]))
                [:div [:div "Won: " win-corp  " (" pw-corp "%)"]
                 [:div "Lost: " lose-corp  " (" pl-corp "%)"]])]]
            [:div.stats-right
@@ -152,7 +152,7 @@
              [:div "Started: " started-runner]
              [:div "Completed: " completed-runner " (" pc-runner "%)"]
              [:div "Not completed: " incomplete-runner  " (" pi-runner "%)"]
-             (when (get-in @app-state [:options :gamestats])
+             (when-not (= "none" (get-in @app-state [:options :gamestats]))
                [:div [:div "Won: " win-runner  " (" pw-runner "%)"]
                 [:div "Lost: " lose-runner  " (" pl-runner "%)"]])]]])))))
 

--- a/src/cljs/netrunner/stats.cljs
+++ b/src/cljs/netrunner/stats.cljs
@@ -98,9 +98,9 @@
               completed (notnum->zero (om/get-state owner :games-completed))
               pc (notnum->zero (num->percent completed started))
               win (notnum->zero (om/get-state owner :wins))
-              pw (notnum->zero (num->percent win started))
               lose (notnum->zero (om/get-state owner :loses))
-              pl (notnum->zero (num->percent lose started))
+              pw (notnum->zero (num->percent win (+ win lose)))
+              pl (notnum->zero (num->percent lose (+ win lose)))
               incomplete (notnum->zero (om/get-state owner :dnf))
               pi (notnum->zero (num->percent incomplete started))
               ;; Corp Stats
@@ -108,9 +108,9 @@
               completed-corp (notnum->zero (om/get-state owner :games-completed-corp))
               pc-corp (notnum->zero (num->percent completed-corp started-corp))
               win-corp (notnum->zero (om/get-state owner :wins-corp))
-              pw-corp (notnum->zero (num->percent win-corp started-corp))
               lose-corp (notnum->zero (om/get-state owner :loses-corp))
-              pl-corp (notnum->zero (num->percent lose-corp started-corp))
+              pw-corp (notnum->zero (num->percent win-corp (+ win-corp lose-corp)))
+              pl-corp (notnum->zero (num->percent lose-corp (+ win-corp lose-corp)))
               incomplete-corp (notnum->zero (om/get-state owner :dnf-corp))
               pi-corp (notnum->zero (num->percent incomplete-corp started-corp))
               ;; Runner Stats
@@ -118,9 +118,9 @@
               completed-runner (notnum->zero (om/get-state owner :games-completed-runner))
               pc-runner (notnum->zero (num->percent completed-runner started-runner))
               win-runner (notnum->zero (om/get-state owner :wins-runner))
-              pw-runner (notnum->zero (num->percent win-runner started-runner))
               lose-runner (notnum->zero (om/get-state owner :loses-runner))
-              pl-runner (notnum->zero (num->percent lose-runner started-runner))
+              pw-runner (notnum->zero (num->percent win-runner (+ win-runner lose-runner)))
+              pl-runner (notnum->zero (num->percent lose-runner (+ win-runner lose-runner)))
               incomplete-runner (notnum->zero (om/get-state owner :dnf-runner))
               pi-runner (notnum->zero (num->percent incomplete-runner started-runner))]
           [:div.blue-shade.panel.stats-main

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -490,6 +490,26 @@ nav ul
 .active-player
   border: 1px solid #ffa500
 
+// For Stats screens
+.stats-main
+  height: 220px
+
+.stats-left
+  width: 30%
+  float: left
+  padding: 5px 15px
+
+.stats-middle
+  width: 33%
+  float: left
+  padding: 5px 15px
+  margin: 0px 5px 5px 5px
+
+.stats-right
+  width: 30%
+  float: left
+  padding: 5px 15px
+
 // Influence dots
 
 .influence.neutral


### PR DESCRIPTION
Extension to the stats system to give data per side.  Not retro-active for any user stats that pre-date this if that code goes live first.

<img width="1235" alt="screen shot 2017-10-04 at 4 14 07 pm" src="https://user-images.githubusercontent.com/11830223/31165928-6a0b4426-a91f-11e7-8448-46dadea31fc1.png">

Also added support to use opponent's game completion rate in lobby if they have played at least 10 games.  

<img width="471" alt="screen shot 2017-10-05 at 4 42 29 pm" src="https://user-images.githubusercontent.com/11830223/31218211-3cf67a32-a9ec-11e7-8342-c581999ed50f.png">

User Options to enable/disable stats
<img width="276" alt="screen shot 2017-10-07 at 11 42 45 am" src="https://user-images.githubusercontent.com/11830223/31307081-b1a7329a-ab54-11e7-8f54-010618741c4b.png">

Added a new channel "stats" to socket.io  
When a game is finalised - socket.io sends a message to the player browser telling to fetch updated stats.  This solves a timing issue where player stats can be stale if they are first to leave before other players/specators.


Fix #2806
Fix #2822
Fix #2816