### PR TITLE
Reorder lock release in gameboard

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -116,13 +116,13 @@
 
 (go (while true
       (let [msg (<! socket-channel)]
-        (reset! lock false)
         (case (:type msg)
           "rejoin" (launch-game (:state msg))
           ("do" "notification" "quit") (do (swap! game-state (if (:diff msg) #(differ/patch @last-state (:diff msg))
                                                                  #(assoc (:state msg) :side (:side @game-state))))
                                            (swap! last-state #(identity @game-state)))
-          nil))))
+          nil)
+        (reset! lock false))))
 
 (defn send [msg]
   (.emit socket "netrunner" (clj->js msg)))


### PR DESCRIPTION
Just a hypothesis regarding the scores of errors we get that seem to show a prompt or ability being executed on a card that is not there. The theory is that the message is being sent twice, probably by user error. 

The UI employs a client-side lock to prevent a second message from being sent before a server response to the first is received, which you'd think would prevent this problem. If I click twice, the second click does not send a message if we haven't heard back from the server. If we've already heard back, then presumably the card I'm clicking is no longer there / the prompt has been dismissed, so how can I now be sending another message involving that entity? 

Upon further review, my hypothesis is that we are currently releasing the lock BEFORE rebuilding the UI with the new game state. There may be a split second where a user could initiate a second click on a button or card before that entity is removed in the UI, because the lock is released before the UI is rebuilt. Releasing the lock only after the UI is reconstructed may help.