### PR TITLE
Dev only: bypass lock for typing indicator

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -135,10 +135,10 @@
 
 (defn send-command
   ([command] (send-command command nil))
-  ([command args]
-   (when-not @lock
+  ([command {:keys [no-lock] :as args}]
+   (when (or (not @lock) no-lock)
      (try (js/ga "send" "event" "game" command) (catch js/Error e))
-     (reset! lock true)
+     (when-not no-lock (reset! lock true))
      (log command args)
      (send {:action "do" :gameid (:gameid @game-state) :side (:side @game-state)
             :user (:user @app-state)
@@ -161,9 +161,9 @@
   (let [input (om/get-node owner "msg-input")
         text (.-value input)]
     (if (empty? text)
-      (send-command "typingstop" {:user (:user @app-state)})
+      (send-command "typingstop" {:user (:user @app-state) :no-lock true})
       (when (not-any? #{(get-in @app-state [:user :username])} (:typing @game-state))
-        (send-command "typing" {:user (:user @app-state)})))))
+        (send-command "typing" {:user (:user @app-state) :no-lock true})))))
 
 (defn mute-spectators [mute-state]
   (send {:action "mute-spectators" :gameid (:gameid @app-state)


### PR DESCRIPTION
Prospective way to handle the typing indicator by bypassing game lock.
Minor concern is the server side response to this will clear any lock set in the mean-time - however I beleive this is the case for any incoming server side message - such as an opponent doing an action or sending a message.

@nealterrell Can you do a build on dev from this assuming you agree with the above.