### PR TITLE
Added req to Indexing for redirected runs

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -700,7 +700,8 @@
    "Indexing"
    {:delayed-completion true
     :effect (effect (run :rd
-                         {:replace-access
+                         {:req (req (= target :rd))
+                          :replace-access
                           {:msg "rearrange the top 5 cards of R&D"
                            :delayed-completion true
                            :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of R&D")


### PR DESCRIPTION
In the same vein as for Account Siphon, ensures that the successful run must be on R&D in order to allow the replacement effect of Indexing to fire.

Fixes #2840.