### PR TITLE
Checking JWT token for more actions

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -252,6 +252,14 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
       when "join"
         game = games[msg.gameid]
 
+        unless game
+          fn("invalid game")
+          return
+
+        unless socket.request.user
+          fn("invalid user")
+          return
+
         unless user_allowed_in_game(getUsername(socket), game)
           fn("not allowed")
           return
@@ -269,6 +277,14 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
 
       when "watch"
         game = games[msg.gameid]
+
+        unless game
+          fn("invalid game")
+          return
+
+        unless socket.request.user
+          fn("invalid user")
+          return
 
         unless user_allowed_in_game(getUsername(socket), game)
           fn("not allowed")

--- a/server.coffee
+++ b/server.coffee
@@ -193,9 +193,12 @@ io.use (socket, next) ->
 
 chat = io.of('/chat').on 'connection', (socket) ->
   socket.on 'netrunner', (msg) ->
-    msg.date = new Date()
-    chat.emit('netrunner', msg)
-    db.collection('messages').insert msg, (err, result) ->
+    if socket.request.user
+      msg.date = new Date()
+      msg.username = socket.request.user.username
+      msg.emailhash = socket.request.user.emailhash
+      chat.emit('netrunner', msg)
+      db.collection('messages').insert msg, (err, result) ->
 
 lobby = io.of('/lobby').on 'connection', (socket) ->
   socket.emit("netrunner", {type: "games", games: games})


### PR DESCRIPTION
Requiring a valid JWT token to post messages in chat. Using the `username` from the token rather than the one passed in the message request.

Requiring a valid JWT token to `join` or `watch` games. Should prevent one path that was allowing `undefined` users as spectators.