### PR TITLE
Selecting correct card when multiple options exist in deckbuilder

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -87,7 +87,7 @@
           (loop [i 2 matches cards]
             (let [subquery (subs q 0 i)]
               (cond (zero? (count matches)) card
-                    (or (= (count matches) 1) (identical-cards? matches)) (first matches)
+                    (or (= (count matches) 1) (identical-cards? matches)) (take-best-card matches)
                     (found? subquery matches) (found? subquery matches)
                     (<= i (count (:title card))) (recur (inc i) (search subquery matches))
                     :else card))))))


### PR DESCRIPTION
When typing in the name of a card that was rotated, then replaced in Core 2.0, we were selecting the rotated card. This was causing those cards to show a `rotated` symbol and not handle the MWL symbols correctly. When the name was fully completed, the correct card was selected.

Probably only applied to `Aesop's Pawnshop` and `Magnum Opus` for the MWL symbols.