### PR TITLE
Update server copy of user information on rejoin with new socket.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -294,7 +294,7 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
           in_game = game.originalPlayers.filter (p) -> p.user._id == socket.request.user._id
           if in_game.length > 0
             rejoinGame(socket, msg.gameid, in_game[0], null)
-            requester.send(JSON.stringify({action: "rejoin", gameid: socket.gameid, text: "#{socket.request.user.username} rejoined the game."}))
+            requester.send(JSON.stringify({action: "rejoin", user: socket.request.user, gameid: socket.gameid, text: "#{socket.request.user.username} rejoined the game."}))
 
       when "mute-spectators"
         game = games[msg.gameid]
@@ -400,6 +400,7 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
           if game and msg.side == "spectator" and game.mutespectators
             return
         try
+          msg.user = socket.request.user
           requester.send(JSON.stringify(msg))
         catch err
           console.log(err)

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -150,9 +150,17 @@
              "remove" (do (swap! game-states dissoc gameid)
                           (swap! old-states dissoc gameid))
              "do" (handle-do user command state side args)
-             ("notification" "rejoin")
+             "notification" (when state
+                              (swap! state update-in [:log] #(conj % {:user "__system__" :text text})))
+             "rejoin"
              (when state
-               (swap! state update-in [:log] #(conj % {:user "__system__" :text text}))))
+               ;; when rejoining, there is probably a new socket ID that needs to be set into the user.
+               (let [side (cond
+                            (= (:_id user) (get-in @state [:corp :user :_id])) :corp
+                            (= (:_id user) (get-in @state [:runner :user :_id])) :runner
+                            :else nil)]
+                 (swap! state assoc-in [side :user] user)
+                 (swap! state update-in [:log] #(conj % {:user "__system__" :text text})))))
            true)
        (catch Exception e
          (do (println "Error " action command (get-in args [:card :title]) e)


### PR DESCRIPTION
Also, when receiving a message to update the game state, overwrite the message's `user` key (which can be forged) with the server-side copy of the user in the socket.