### PR TITLE
Fix issue with removing icons from cards with hosts

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -218,12 +218,9 @@
    "Dedicated Processor"
    {:implementation "Click Dedicated Processor to use ability"
     :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))))
-    :prompt "Choose Icebreaker on which to install Dedicated Processor"
-    :choices {:req #(and (has-subtype? % "Icebreaker")
+    :hosting {:req #(and (has-subtype? % "Icebreaker")
                          (not (has-subtype? % "AI"))
                          (installed? %))}
-    :msg (msg "host it on " (card-str state target))
-    :effect (effect (host target card))
     :abilities [{:cost [:credit 2]
                  :req (req run)
                  :effect (effect (pump (get-card state (:host card)) 4))

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -121,7 +121,7 @@
            (card-moved state side (make-eid state) moved-card card))
          (trigger-event state side :card-moved card moved-card)
          (when (#{:discard :hand} to) (reset-card state side moved-card))
-         (when-let [icon-card (get-in moved-card [:icon :card])]
+         (when-let [icon-card (get-card state (get-in moved-card [:icon :card]))]
            ;; remove icon if card moved to :discard or :hand
            (when (#{:discard :hand} to) (remove-icon state side icon-card moved-card)))
          moved-card)))))


### PR DESCRIPTION
Fix #2846. When calling `remove-icon`, pass the updated version of the card that caused the icon.

Also rework Dedicated Processor to use `:hosting` installs like Parasite and Personal Touch.