### PR TITLE
Accept cards names without accents

### DIFF
--- a/data/fetch.coffee
+++ b/data/fetch.coffee
@@ -5,6 +5,7 @@ mongoskin = require('mongoskin')
 mkdirp = require('mkdirp')
 path = require('path')
 async = require('async')
+removeDiacritics = require('diacritics').remove
 
 mongoUser = process.env.OPENSHIFT_MONGODB_DB_USERNAME
 mongoPassword = process.env.OPENSHIFT_MONGODB_DB_PASSWORD
@@ -71,6 +72,7 @@ mapCycles = {}
 cardFields = {
   "code" : same,
   "title" : same,
+  "normalized_title": (k, t) -> ["normalizedtitle", removeDiacritics(t).toLowerCase()],
   "type_code" : (k, t) -> ["type", if t is "ice" then "ICE" else capitalize(t)],
   "keywords": rename("subtype"),
   "text" : same,
@@ -153,6 +155,7 @@ fetchCards = (callback) ->
         d.set_code = d.pack_code
         d.cycle_code = mapSets[d.set_code].cycle_code
         d.rotated = mapSets[d.set_code].rotated
+        d.normalized_title = d.title
         d
       cards = selectFields(cardFields, data)
       imgDir = path.join(__dirname, "..", "resources", "public", "img", "cards")

--- a/package-lock.json
+++ b/package-lock.json
@@ -496,6 +496,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E="
+    },
     "doctypes": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "connect-mongo": "^1.3.2",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.1",
+    "diacritics": "^1.3.0",
     "express": "^4.14.0",
     "express-session": "^1.14.1",
     "jsonwebtoken": "^8.0.1",

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -192,7 +192,7 @@
     cards
     (filter #(= (field %) filter-value) cards)))
 
-(defn match [query cards]
+(defn filter-title [query cards]
   (if (empty? query)
     cards
     (let [lcquery (.toLowerCase query)]
@@ -303,7 +303,7 @@
                               (filter-cards (:side-filter state) :side)
                               (filter-cards (:faction-filter state) :faction)
                               (filter-cards (:type-filter state) :type)
-                              (match (:search-query state))
+                              (filter-title (:search-query state))
                               (insert-alt-arts)
                               (sort-by (sort-field (:sort-field state)))
                               (take (* (:page state) 28))))

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -195,7 +195,10 @@
 (defn match [query cards]
   (if (empty? query)
     cards
-    (filter #(if (= (.indexOf (.toLowerCase (:title %)) query) -1) false true) cards)))
+    (let [lcquery (.toLowerCase query)]
+      (filter #(or (not= (.indexOf (.toLowerCase (:title %)) lcquery) -1)
+                   (not= (.indexOf (:normalizedtitle %) lcquery) -1))
+              cards))))
 
 (defn sort-field [fieldname]
   (case fieldname
@@ -300,7 +303,7 @@
                               (filter-cards (:side-filter state) :side)
                               (filter-cards (:faction-filter state) :faction)
                               (filter-cards (:type-filter state) :type)
-                              (match (.toLowerCase (:search-query state)))
+                              (match (:search-query state))
                               (insert-alt-arts)
                               (sort-by (sort-field (:sort-field state)))
                               (take (* (:page state) 28))))

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -6,7 +6,7 @@
             [clojure.string :refer [split split-lines join escape] :as s]
             [netrunner.appstate :refer [app-state]]
             [netrunner.auth :refer [authenticated] :as auth]
-            [netrunner.cardbrowser :refer [cards-channel image-url card-view show-alt-art?] :as cb]
+            [netrunner.cardbrowser :refer [cards-channel image-url card-view show-alt-art? filter-title] :as cb]
             [netrunner.account :refer [load-alt-arts alt-art-name]]
             [netrunner.ajax :refer [POST GET]]
             [goog.string :as gstring]
@@ -697,14 +697,13 @@
           [:span.tick (if (:legal onesies) "✔" "✘") ] "1.1.1.1 format compliant"]])])))
 
 (defn match [identity query]
-  (if (empty? query)
-    []
-    (let [cards (->> (:cards @app-state)
-                     (filter #(and (allowed? % identity)
-                                   (not= "Special" (:setname %))
-                                   (alt-art? %)))
-                     (distinct-by :title))]
-      (take 10 (filter #(not= (.indexOf (.toLowerCase (:title %)) (.toLowerCase query)) -1) cards)))))
+  (->> (:cards @app-state)
+    (filter #(and (allowed? % identity)
+                  (not= "Special" (:setname %))
+                  (alt-art? %)))
+    (distinct-by :title)
+    (filter-title query)
+    (take 10)))
 
 (defn handle-keydown [owner event]
   (let [selected (om/get-state owner :selected)


### PR DESCRIPTION
Added a `normalized_title` field to the db. In the card browser and deck editor you can enter the card name with or without the diacritic marks.

Cards need to be fetched to update the db.

Fixes #1538