### PR TITLE
Using identity name when selecting version of identity in deck builder

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -105,9 +105,9 @@
 
 (defn parse-identity
   "Parse an id to the corresponding card map"
-  [{:keys [side title code art setname]}]
-  (let [card (lookup side {:title title :id code})]
-    (assoc card :id code :art art :display-name (build-identity-name title setname art))))
+  [{:keys [side title art setname]}]
+  (let [card (lookup side {:title title})]
+    (assoc card :art art :display-name (build-identity-name title setname art))))
 
 (defn add-params-to-card
   "Add art and id parameters to a card hash"


### PR DESCRIPTION
Deck identities are saved with both the identity name and card code. In the identity lookup, card code takes higher precedence than name. If a user had an identity that rotated (eg. HB Stronger Together), it previously would have been saved with the rotated card code and we would mark the deck as not containing released cards.

Now we just match on the name, which selects the non-rotated version of the card.