### PR TITLE
prevent win firing more than once, add clear-win command

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -417,9 +417,12 @@
    "Jinteki: Personal Evolution"
    {:events {:agenda-scored {:interactive (req true)
                              :delayed-completion true
+                             :req (req (not (:winner @state)))
                              :msg "do 1 net damage"
                              :effect (effect (damage eid :net 1 {:card card}))}
-             :agenda-stolen {:msg "do 1 net damage" :effect (effect (damage eid :net 1 {:card card}))}}}
+             :agenda-stolen {:msg "do 1 net damage"
+                             :req (req (not (:winner @state)))
+                             :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinteki: Potential Unleashed"
    {:events {:pre-resolve-damage

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -421,6 +421,7 @@
                              :msg "do 1 net damage"
                              :effect (effect (damage eid :net 1 {:card card}))}
              :agenda-stolen {:msg "do 1 net damage"
+                             :delayed-completion true
                              :req (req (not (:winner @state)))
                              :effect (effect (damage eid :net 1 {:card card}))}}}
 

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -197,6 +197,7 @@
                                                                             ": " (get-card state target))))
                                            :choices {:req (fn [t] (card-is? t :side %2))}}
                                           {:title "/card-info command"} nil)
+          "/clear-win"  #(clear-win %1 %2)
           "/click"      #(swap! %1 assoc-in [%2 :click] (max 0 value))
           "/close-prompt" #(command-close-prompt %1 %2)
           "/counter"    #(command-counter %1 %2 args)

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -540,19 +540,30 @@
   [state side]
   (swap! state update-in [side] dissoc :openhand))
 
+(defn clear-win
+  "Clears the current win condition.  Requires both sides to have issued the command"
+  [state side]
+  (swap! state assoc-in [side :clear-win] true)
+  (when (and (-> @state :runner :clear-win) (-> @state :corp :clear-win))
+    (system-msg state side "cleared the win condition")
+    (swap! state dissoc-in [:runner :clear-win])
+    (swap! state dissoc-in [:corp :clear-win])
+    (swap! state dissoc :winner :loser :winning-user :losing-user :reason :winning-deck-id :losing-deck-id :end-time)))
+
 (defn win
   "Records a win reason for statistics."
   [state side reason]
-  (system-msg state side "wins the game")
-  (play-sfx state side "game-end")
-  (swap! state assoc
-         :winner side
-         :loser (other-side side)
-         :winning-user (get-in @state [side :user :username])
-         :losing-user (get-in @state [(other-side side) :user :username])
-         :reason reason :end-time (java.util.Date.)
-         :winning-deck-id (get-in @state [side :deck-id])
-         :losing-deck-id (get-in @state [(other-side side) :deck-id])))
+  (when-not (:winner @state)
+    (system-msg state side "wins the game")
+    (play-sfx state side "game-end")
+    (swap! state assoc
+           :winner side
+           :loser (other-side side)
+           :winning-user (get-in @state [side :user :username])
+           :losing-user (get-in @state [(other-side side) :user :username])
+           :reason reason :end-time (java.util.Date.)
+           :winning-deck-id (get-in @state [side :deck-id])
+           :losing-deck-id (get-in @state [(other-side side) :deck-id]))))
 
 (defn win-decked
   "Records a win via decking the corp."

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -607,6 +607,21 @@
       (is (= 9 (:credit (get-corp)))
           "Spent 1 credit to advance, gained 3 credits from Oaktown"))))
 
+(deftest obokata-protocol
+  ;; Pay 4 net damage to steal.  Runner win retained on flatline
+  (do-game
+    (new-game (make-deck "Jinteki: Personal Evolution" [(qty "Obokata Protocol" 10)])
+              (default-runner [(qty "Sure Gamble" 4)]))
+    (play-from-hand state :corp "Obokata Protocol" "New remote")
+    (take-credits state :corp)
+    (core/gain state :runner :agenda-point 6)
+    (run-empty-server state "Server 1")
+    (prompt-choice :runner "Yes")
+    (is (= 4 (count (:discard (get-runner)))) "Runner paid 4 net damage")
+    (is (= :runner (:winner @state)) "Runner wins")
+    (is (= "Agenda" (:reason @state)) "Win condition reports agenda points")
+    (is (last-log-contains? state "wins the game") "PE did not fire")))
+
 (deftest personality-profiles
   ;; Personality Profiles - Full test
   (do-game

--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -196,7 +196,7 @@
   ;; Multiple sources of net damage vs. Deus X
   (do-game
     (new-game
-      (make-deck "Jinteki: Personal Evolution" [(qty "Fetal AI" 1)])
+      (make-deck "Jinteki: Personal Evolution" [(qty "Fetal AI" 6)])
       (default-runner [(qty "Deus X" 3) (qty "Sure Gamble" 2)]))
     (play-from-hand state :corp "Fetal AI" "New remote")
     (take-credits state :corp)

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -506,7 +506,7 @@
   ;; Personal Evolution - Prevent runner from running on remotes unless they first run on a central
   (do-game
     (new-game
-      (make-deck "Jinteki: Personal Evolution" [(qty "Braintrust" 1)])
+      (make-deck "Jinteki: Personal Evolution" [(qty "Braintrust" 6)])
       (default-runner [(qty "Sure Gamble" 3)]))
     (play-from-hand state :corp "Braintrust" "New remote")
     (take-credits state :corp)
@@ -1132,7 +1132,7 @@
   ;; Silhouette - Expose trigger ability resolves completely before access. Issue #2173.
   (do-game
     (new-game
-      (default-corp [(qty "Psychic Field" 1) (qty "Fetal AI" 3)])
+      (default-corp [(qty "Psychic Field" 1) (qty "Fetal AI" 10)])
       (make-deck "Silhouette: Stealth Operative" [(qty "Feedback Filter" 1) (qty "Inside Job" 1)]))
     (starting-hand state :corp ["Psychic Field" "Fetal AI"])
     (play-from-hand state :corp "Psychic Field" "New remote")

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -1118,7 +1118,7 @@
 (deftest scorched-earth-flatline
   ;; Scorched Earth - murderize 'em
   (do-game
-    (new-game (default-corp [(qty "Scorched Earth" 1)])
+    (new-game (default-corp [(qty "Scorched Earth" 10)])
               (default-runner))
     (core/gain state :runner :tag 1)
     (play-from-hand state :corp "Scorched Earth")

--- a/src/cljs/netrunner/help.cljs
+++ b/src/cljs/netrunner/help.cljs
@@ -46,6 +46,7 @@
                         [:li [:code "/adv-counter n"] " - set advancement counters on a card to n (player's own cards only). Deprecated in favor of " [:code "/counter ad n"]]
                         [:li [:code "/bp n"] " - Set your bad publicity to n"]
                         [:li [:code "/card-info"] " - display debug info about a card (player's own cards only)"]
+                        [:li [:code "/clear-win"] " - requests game to clear the current win state.  Requires both players to request it"]
                         [:li [:code "/click n"] " - Set your clicks to n"]
                         [:li [:code "/close-prompt"] " - close an active prompt and show the next waiting prompt, or the core click actions"]
                         [:li [:code "/counter n"] " - set counters on a card to n (player's own cards only). Attempts to infer the type of counter to place. If the inference fails, you must use the next command to specify the counter type."]


### PR DESCRIPTION
/clear-win allows clearing of win condition to allow manual fix

Fix #1037