### PR TITLE
Add option to hide rotated cards in cardbrowser

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -802,6 +802,12 @@ nav ul
     width: 100%
     font-size: 13px
 
+  input.hide-rotated
+    width: auto
+
+  .hide-rotated-div
+    margin-top: 10px
+
   h4
     margin-top: 5px
 


### PR DESCRIPTION
Added a checkbox in the filter area of the cardbrowser.
Rotated cards are hidden by default.

This also hides rotated cycles and packs from the `Sets` filter option.