### PR TITLE
Trigger Runner "when you install..." card effects in same window as :runner-install event

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -248,10 +248,11 @@
    {:flags {:runner-install-draw true}
     :events {:runner-install {:silent (req (not (and (is-type? target "Program")
                                                      (some #{:discard} (:previous-zone target)))))
+                              :delayed-completion true
                               :req (req (and (is-type? target "Program")
                                              (some #{:discard} (:previous-zone target))))
                               :msg (msg "draw a card")
-                              :effect (effect (draw 1))}}}
+                              :effect (req (draw state side eid 1 nil))}}}
 
    "Fringe Applications: Tomorrow, Today"
    {:events

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -245,7 +245,10 @@
    {:recurring 1}
 
    "Exile: Streethawk"
-   {:events {:runner-install {:req (req (and (is-type? target "Program")
+   {:flags {:runner-install-draw true}
+    :events {:runner-install {:silent (req (not (and (is-type? target "Program")
+                                                     (some #{:discard} (:previous-zone target)))))
+                              :req (req (and (is-type? target "Program")
                                              (some #{:discard} (:previous-zone target))))
                               :msg (msg "draw a card")
                               :effect (effect (draw 1))}}}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -132,6 +132,7 @@
                                  (continue-ability state side (custsec-host (remove-once #(not= % target) cards))
                                                    card nil))))})]
      {:delayed-completion true
+      :interactive (req (some #(card-flag? % :runner-install-draw true) (all-active state :runner)))
       :msg (msg "reveal the top 5 cards of their Stack: " (join ", " (map :title (take 5 (:deck runner)))))
       :effect (req (show-wait-prompt state :corp "Runner to host programs on Customized Secretary")
                    (let [from (take 5 (:deck runner))]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1018,7 +1018,8 @@
     :abilities [{:cost [:credit 2] :msg "avoid 1 tag" :effect (effect (tag-prevent 1))}]}
 
    "Off-Campus Apartment"
-   {:abilities [{:label "Install and host a connection on Off-Campus Apartment"
+   {:flags {:runner-install-draw true}
+    :abilities [{:label "Install and host a connection on Off-Campus Apartment"
                  :effect (effect (resolve-ability
                                    {:cost [:click 1]
                                     :prompt "Select a connection in your Grip to install on Off-Campus Apartment"
@@ -1026,14 +1027,16 @@
                                                          (can-pay? state side nil :credit (:cost %))
                                                          (in-hand? %))}
                                     :msg (msg "host " (:title target) " and draw 1 card")
-                                    :effect (effect (runner-install target {:host-card card}) (draw))}
+                                    :effect (effect (runner-install target {:host-card card}))}
                                   card nil))}
                 {:label "Host an installed connection"
                  :prompt "Select a connection to host on Off-Campus Apartment"
                  :choices {:req #(and (has-subtype? % "Connection")
                                       (installed? %))}
                  :msg (msg "host " (:title target) " and draw 1 card")
-                 :effect (effect (host card target) (draw))}]}
+                 :effect (effect (host card target) (draw))}]
+    :events {:runner-install {:req (req (= (:cid card) (:cid (:host target))))
+                              :effect (effect (draw))}}}
 
    "Officer Frank"
    {:abilities [{:cost [:credit 1]
@@ -1410,7 +1413,8 @@
                                  (system-msg state side "uses Stim Dealer to gain [Click]"))))}}}
 
    "Street Peddler"
-   {:effect (req (doseq [c (take 3 (:deck runner))]
+   {:interactive (req (some #(card-flag? % :runner-install-draw true) (all-active state :runner)))
+    :effect (req (doseq [c (take 3 (:deck runner))]
                    (host state side (get-card state card) c {:facedown true})))
     :abilities [{:req (req (not (install-locked? state side)))
                  :prompt "Choose a card on Street Peddler to install"

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -364,6 +364,7 @@
        (continue-ability state side
                          {:choices hosting
                           :prompt (str "Choose a card to host " (:title card) " on")
+                          :delayed-completion true
                           :effect (effect (runner-install eid card (assoc params :host-card target)))}
                          card nil)
        (do (trigger-event state side :pre-install card facedown)
@@ -377,7 +378,7 @@
                        c (assoc c :installed true :new true)
                        installed-card (if facedown
                                         (update! state side c)
-                                        (card-init state side c true))]
+                                        (card-init state side c false))]
                    (runner-install-message state side (:title card) cost-str params)
                    (play-sfx state side "install-runner")
                    (when (and (is-type? card "Program") (neg? (get-in @state [:runner :memory])))
@@ -388,7 +389,7 @@
                    (when (has-subtype? c "Icebreaker")
                      (update-breaker-strength state side c))
                    (trigger-event-simult state side eid :runner-install
-                                         nil
+                                         {:card-ability (card-as-handler installed-card)}
                                          installed-card))
                  (effect-completed state side eid))
                (effect-completed state side eid)))

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -244,6 +244,25 @@
     (run-empty-server state "HQ")
     (is (= 2 (count (:discard (get-corp)))) "One more card trashed from HQ, by Maw")))
 
+
+(deftest exile-customized-secretary
+  ;; Exile - simultaneous-resolution prompt shown for interaction with Customized Secretary
+  (do-game
+    (new-game
+      (default-corp)
+      (make-deck "Exile: Streethawk" [(qty "Customized Secretary" 3) (qty "Clone Chip" 3)
+                                      (qty "Sure Gamble" 3)]))
+    (take-credits state :corp)
+    (starting-hand state :runner ["Customized Secretary" "Clone Chip"])
+    (trash-from-hand state :runner "Customized Secretary")
+    (play-from-hand state :runner "Clone Chip")
+    (card-ability state :runner (get-hardware state 0) 0)
+    (prompt-select :runner (find-card "Customized Secretary" (:discard (get-runner))))
+    ;; Make sure the simultaneous-resolution prompt is showing with 2 choices
+    (is (= 2 (-> (get-runner) :prompt first :choices count)) "Simultaneous-resolution prompt is showing")
+    (prompt-choice :runner "Exile: Streethawk")
+    (is (= 1 (count (:hand (get-runner)))) "Exile drew a card")))
+
 (deftest gabriel-santiago
   ;; Gabriel Santiago - Gain 2c on first successful HQ run each turn
   (do-game


### PR DESCRIPTION
Cards that read "when you install this card..." are supposed to be simultaneously triggered with cards that read "whenever you install a ____ ...". Previously we hard-coded the triggering of the installed-card's `:effect` in `(card-init)`. Now, `(runner-install)` will not trigger the installed card at that point, and instead will pass the card to `trigger-event-simult`, which will place the card into the simultaneous event resolution prompt. 

I only know of two instances where this actually matters, both of which I've fixed:

1. #2588 when Exile installs Customized Secretary from the heap, the Runner needs to decide whether to first draw a card host cards on Secretary. 
2.  Unreported issue, when installing Street Peddler on Off-Campus Apartment, the Runner decides whether to draw a card or host facedown cards on Peddler.

`trigger-event-simult` already had the capability to show a card's effect in the same window as other event handlers, which is how we deal with agendas that say "when you score this agenda" vs. event listeners for `:agenda-scored`. Just had to hook it into `(runner-install)`.