### PR TITLE
Alt art selection in cardbrowser

### DIFF
--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -44,6 +44,19 @@
   (let [alt (first (filter #(= (name version) (:version %)) (:alt-info @app-state)))]
     (get alt :name "Official")))
 
+(defn post-response [owner response]
+  (if (= (:status response) 200)
+    (om/set-state! owner :flash-message "Profile updated - Please refresh your browser")
+    (case (:status response)
+      401 (om/set-state! owner :flash-message "Invalid login or password")
+      421 (om/set-state! owner :flash-message "No account with that email address exists")
+      :else (om/set-state! owner :flash-message "Profile updated - Please refresh your browser"))))
+
+(defn post-options [url callback]
+  (let [params (:options @app-state)]
+    (go (let [response (<! (POST url params :json))]
+          (callback response)))))
+
 (defn handle-post [event owner url ref]
   (.preventDefault event)
   (om/set-state! owner :flash-message "Updating profile...")
@@ -57,15 +70,7 @@
   (swap! app-state assoc-in [:options :deckstats] (om/get-state owner :deckstats))
   (.setItem js/localStorage "sounds" (om/get-state owner :sounds))
   (.setItem js/localStorage "sounds_volume" (om/get-state owner :volume))
-
-  (let [params (:options @app-state)]
-    (go (let [response (<! (POST url params :json))]
-          (if (= (:status response) 200)
-            (om/set-state! owner :flash-message "Profile updated - Please refresh your browser")
-            (case (:status response)
-              401 (om/set-state! owner :flash-message "Invalid login or password")
-              421 (om/set-state! owner :flash-message "No account with that email address exists")
-              :else (om/set-state! owner :flash-message "Profile updated - Please refresh your browser")))))))
+  (post-options url (partial post-response owner)))
 
 (defn add-user-to-block-list
   [owner user]

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -86,9 +86,9 @@
 (defn selected-alt-art [card]
   (let [code (keyword (:code card))
         selected-alts (:alt-arts (:options @app-state))
-        selected-art (keyword (get selected-alts code))
+        selected-art (get selected-alts code "")
         card-art (:art card)]
-  (and card-art (= card-art selected-art))))
+  (= card-art (if (empty? selected-art) selected-art (keyword selected-art)))))
 
 (defn- card-text
   "Generate text html representation a card"

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -83,6 +83,13 @@
       (make-span "\\[weyland\\]" "weyland-consortium")
       (make-span "\\[weyland-consortium\\]" "weyland-consortium")))
 
+(defn selected-alt-art [card]
+  (let [code (keyword (:code card))
+        selected-alts (:alt-arts (:options @app-state))
+        selected-art (keyword (get selected-alts code))
+        card-art (:art card)]
+  (and card-art (= card-art selected-art))))
+
 (defn- card-text
   "Generate text html representation a card"
   [card]
@@ -128,7 +135,10 @@
        (when-let [number (:number card)]
          (str pack " " number
               (when-let [art (:art card)]
-                (str " [" (netrunner.account/alt-art-name art) "]")))))]]
+                (str " [" (netrunner.account/alt-art-name art) "]")))))]
+     (when (selected-alt-art card)
+      [:div.selected-alt "Selected Alt Art"])
+    ]
    ])
 
 (defn card-view [card owner]
@@ -139,7 +149,8 @@
     (render-state [_ state]
       (sab/html
         [:div.card-preview.blue-shade
-         {:class (when (:selected card) "selected")}
+         {:class (cond (:selected card) "selected"
+                       (selected-alt-art card) "selected-alt")}
          (if (:showText state)
            (card-text card)
            (when-let [url (image-url card)]

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -94,6 +94,8 @@
          (= card-art selected-art) true
          (and (nil? selected-art)
               (not (keyword? card-art))) true
+         (and (= :default selected-art)
+              (not (keyword? card-art))) true
          :else false))))
 
 (defn select-alt-art [card cursor]

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -158,8 +158,10 @@
       (sab/html
         (if (nil? card)
           [:div {:display "none"}]
-          [:div.blue-shade.panel
-           (card-text card)])))))
+          [:div
+           [:h4 "Card text"]
+           [:div.blue-shade.panel
+            (card-text card)]])))))
 
 (defn types [side]
   (let [runner-types ["Identity" "Program" "Hardware" "Resource" "Event"]

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -83,6 +83,13 @@
       (make-span "\\[weyland\\]" "weyland-consortium")
       (make-span "\\[weyland-consortium\\]" "weyland-consortium")))
 
+(defn- post-response [cursor response]
+  (if (= 200 (:status response))
+    (let [new-alts (get-in response [:json :altarts] {})]
+      (swap! app-state assoc-in [:user :options :alt-arts] new-alts)
+      (netrunner.gameboard/toast "Updated Art" "success" nil))
+    (netrunner.gameboard/toast "Failed to Update Art" "error" nil)))
+
 (defn selected-alt-art [card cursor]
   (let [code (keyword (:code card))
         alt-card (get (:alt-arts @app-state) (name code) nil)
@@ -105,7 +112,8 @@
           new-alts (if (keyword? art)
                      (assoc alts code (name art))
                      (dissoc alts code))]
-      (om/update! cursor [:options :alt-arts] new-alts))))
+      (om/update! cursor [:options :alt-arts] new-alts)
+      (netrunner.account/post-options "/update-profile" (partial post-response cursor)))))
 
 (defn- card-text
   "Generate text html representation a card"

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -894,7 +894,7 @@
               (let [art (:art line)
                     id (:id line)
                     updated-card (add-params-to-card (:card line) id art)]
-              (om/build card-view updated-card)))]]
+              (om/build card-view updated-card {:state {:cursor cursor}})))]]
 
           [:div.decklist
            (when-let [deck (:deck state)]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -778,6 +778,10 @@ nav ul
   .pack
     font-style: italic
 
+  .selected-alt
+    font-style: italic
+    color: orange
+
 .filters
   flex(0 0 180px)
   margin: 10px
@@ -858,6 +862,9 @@ nav ul
 
   &.selected
     box-shadow(0 0 1px 2px limegreen)
+
+  &.selected-alt
+    box-shadow(0 0 1px 2px orange)
 
   > h4
     margin-bottom: 5px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -782,6 +782,9 @@ nav ul
     font-style: italic
     color: orange
 
+  .alt-art-selector
+    margin-top: 10px
+
 .filters
   flex(0 0 180px)
   margin: 10px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -851,9 +851,12 @@ nav ul
   position: relative
   height: 348px
   width: 250px
-  margin: 0 10px 10px 0
+  margin: 0 10px 10px 2px
   border-radius: 8px
   padding: 10px
+
+  &.selected
+    box-shadow(0 0 1px 2px limegreen)
 
   > h4
     margin-bottom: 5px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -792,6 +792,7 @@ nav ul
 
   .hide-rotated-div
     margin-top: 10px
+    margin-bottom: 20px
 
   h4
     margin-top: 5px


### PR DESCRIPTION
Added an `Alt Art` option to the `Set` filter (for `:special` users).
Highlighted the currently selected alt art card and added text to the bottom of the text info area to indicate selection.
For non-selected alt art cards, added a button at the bottom of the text info area to select that as the alt art card to be used. Clicking the button pushes the change to the server.

It would be quite nice if you could make the filter panel resizable, but I haven't had any luck making it resizable and retaining the scroll behavior in the card list.