### PR TITLE
Updated Alt Art controls in Settings

### DIFF
--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -284,13 +284,13 @@
            [:section
             [:h3 "Blocked users"]
             [:div
-             [:input.search {:on-key-down (fn [e]
-                                            (when (= e.keyCode 13)
-                                              (do
-                                                (add-user-to-block-list owner user)
-                                                (.preventDefault e))))
-                             :ref "block-user-input"
-                             :type "text" :placeholder "User name"}]
+             [:input {:on-key-down (fn [e]
+                                     (when (= e.keyCode 13)
+                                       (do
+                                         (add-user-to-block-list owner user)
+                                         (.preventDefault e))))
+                      :ref "block-user-input"
+                      :type "text" :placeholder "User name"}]
              [:button.block-user-btn {:type "button"
                                       :name "block-user-button"
                                       :on-click #(add-user-to-block-list owner user)}

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1924,6 +1924,9 @@ nav ul
   overflow: auto
   margin-top: -31px
 
+  section
+    margin-bottom: 20px
+
   .flash-message
     color: lawngreen
     margin-left: 16px
@@ -1956,6 +1959,8 @@ nav ul
       width: 150px
       margin-top: 5px
 
+    .reset-all
+      margin-top: 10px
 
 @keyframes highlight
   from


### PR DESCRIPTION
Moved `Reset to Official Art` out to a separate button.
Made `Set All` only set alt art for a card if it is present. Previously it reset back to `Official` if not present; now cards without the specified alt art retain their current setting.
Fixed Settings page scrolling to `Block Users` input when entered.