### PR TITLE
Limit deck builder add function to legal number of cards

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -748,8 +748,10 @@
         best-card (lookup (:side card) card)]
     (if (js/isNaN qty)
       (om/set-state! owner :quantity 3)
-      (do (put! (om/get-state owner :edit-channel)
-                {:qty qty
+      (let [max-qty (or (:limited best-card) 3)
+            limit-qty (if (> qty max-qty) max-qty qty)]
+        (put! (om/get-state owner :edit-channel)
+                {:qty limit-qty
                  :card best-card})
           (om/set-state! owner :quantity 3)
           (om/set-state! owner :query "")


### PR DESCRIPTION
Saw this as a comment in Jinteki chat about `Astroscript Pilot Program` (retro decks are all the rage). Trying to use the `Add` button in the deck builder with an illegal number of card copies as the quantity creates an `1x Unknown` card in the deck list.

Now checking for `:limited` field (or 3 if not specified) and constraining quantity to that limit.