### PR TITLE
Option to block new games on server announcement

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -261,11 +261,6 @@ requester.on 'message', (data) ->
           final_side = response.state["final-user"].side
           inc_game_final_user(response.state[final_side], room)
 
-  else if response.action is "block-games"
-    blockNewGames = true
-    blockMessage = response.message
-    lobbyUpdate = true
-
   else
     if (games[response.gameid])
       sendGameResponse(games[response.gameid], response)
@@ -887,14 +882,25 @@ app.get '/data/:collection/:field/:value', (req, res) ->
 
 app.get '/admin/announce', (req, res) ->
   if req.user and req.user.isadmin
-    res.render('announce.pug', {user : req.user})
+    res.render('announce.pug', {user : req.user, blockNewGames: blockNewGames, blockMessage: blockMessage})
   else
     res.status(401).send({message: 'Unauthorized'})
 
 app.post '/admin/announce', (req, res) ->
   if req.user and req.user.isadmin
-    requester.send(JSON.stringify({action: "alert", command: req.body}))
-    res.redirect("/")
+
+    if req.body.message
+      requester.send(JSON.stringify({action: "alert", command: req.body.message}))
+
+    if req.body.blockgames is "block"
+      blockNewGames = true
+      blockMessage = req.body.message ? ""
+    else
+      blockNewGames = false
+      blockMessage = ""
+
+    lobbyUpdate = true
+    res.redirect("/admin/announce")
   else
     res.status(401).send({message: 'Unauthorized'})
 

--- a/server.coffee
+++ b/server.coffee
@@ -39,6 +39,7 @@ games = {}
 lobbyUpdate = false
 lobbyUpdates = {"create" : {}, "update" : {}, "delete" : {}}
 blockNewGames = false
+blockMessage = ""
 
 swapSide = (side) ->
   if side is "Corp" then "Runner" else "Corp"
@@ -262,6 +263,7 @@ requester.on 'message', (data) ->
 
   else if response.action is "block-games"
     blockNewGames = true
+    blockMessage = response.message
     lobbyUpdate = true
 
   else
@@ -295,7 +297,7 @@ chat = io.of('/chat').on 'connection', (socket) ->
       db.collection('messages').insert msg, (err, result) ->
 
 lobby = io.of('/lobby').on 'connection', (socket) ->
-  socket.emit("netrunner", {type: "games", games: games, blockNewGames: blockNewGames})
+  socket.emit("netrunner", {type: "games", games: games, blockNewGames: blockNewGames, blockMessage: blockMessage})
 
   socket.on 'disconnect', () ->
     gid = socket.gameid
@@ -526,7 +528,7 @@ lobby = io.of('/lobby').on 'connection', (socket) ->
 
 sendLobby = () ->
   if lobby and lobbyUpdate
-    lobby.emit('netrunner', {type: "games", gamesdiff: lobbyUpdates, blockNewGames: blockNewGames})
+    lobby.emit('netrunner', {type: "games", gamesdiff: lobbyUpdates, blockNewGames: blockNewGames, blockMessage: blockMessage})
     lobbyUpdate = false
     lobbyUpdates["create"] = {}
     lobbyUpdates["update"] = {}

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -191,10 +191,13 @@
       (try
         (let [{:keys [gameid action command args] :as msg} (convert (.recv socket))]
           (if (= action "alert")
-            (do (doseq [state (vals @game-states)]
+            (do
+              (doseq [state (vals @game-states)]
                   (doseq [side [:runner :corp]]
-                    (toast state side command "warning" {:time-out 0 :close-button true})))
-                (.send socket (generate-string "ok")))
+                    (toast state side (:message command) "warning" {:time-out 0 :close-button true})))
+              (if (:blockgames command)
+                (.send socket (generate-string {:action "block-games"}))
+                (.send socket (generate-string "ok"))))
             (let [state (@game-states (:gameid msg))
                   old-state (when state (@old-states (:gameid msg)))
                   [old-corp old-runner old-spect] (when old-state (private-states (atom old-state)))]

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -196,7 +196,7 @@
                   (doseq [side [:runner :corp]]
                     (toast state side (:message command) "warning" {:time-out 0 :close-button true})))
               (if (:blockgames command)
-                (.send socket (generate-string {:action "block-games"}))
+                (.send socket (generate-string {:action "block-games" :message (:message command)}))
                 (.send socket (generate-string "ok"))))
             (let [state (@game-states (:gameid msg))
                   old-state (when state (@old-states (:gameid msg)))

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -191,13 +191,10 @@
       (try
         (let [{:keys [gameid action command args] :as msg} (convert (.recv socket))]
           (if (= action "alert")
-            (do
-              (doseq [state (vals @game-states)]
+            (do (doseq [state (vals @game-states)]
                   (doseq [side [:runner :corp]]
-                    (toast state side (:message command) "warning" {:time-out 0 :close-button true})))
-              (if (:blockgames command)
-                (.send socket (generate-string {:action "block-games" :message (:message command)}))
-                (.send socket (generate-string "ok"))))
+                    (toast state side command "warning" {:time-out 0 :close-button true})))
+                (.send socket (generate-string "ok")))
             (let [state (@game-states (:gameid msg))
                   old-state (when state (@old-states (:gameid msg)))
                   [old-corp old-runner old-spect] (when old-state (private-states (atom old-state)))]

--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -129,31 +129,38 @@
     om/IRenderState
     (render-state [this state]
       (sab/html
-         [:div.chat-app
+        [:div.chat-app
+         (when (:block-new-games cursor)
+           [:div.blue-shade.panel.server-message
+            [:h3 "Server Maintenance"]
+            (when-let [msg (:block-message cursor)]
+              [:span msg])
+            [:div "No new games may be started until maintenance is completed."]])
+         [:div.chat-interface
           [:div.blue-shade.panel.channel-list
-           [:h4 "Channels"]
-           (for [ch [:general :america :europe :asia-pacific :united-kingdom :français :español :italia :polska :português :sverige :stimhack-league]]
-             (om/build channel-view {:channel ch :active-channel (:channel state)}
-                       {:init-state {:channel-ch (:channel-ch state)}}))]
-          [:div.chat-container
-           [:div.chat-card-zoom
-            (when-let [card (om/get-state owner :zoom)]
-              (om/build card-zoom card))]
-           [:div.chat-box
-            [:div.blue-shade.panel.message-list {:ref "message-list"
-                                                 :on-scroll #(let [currElt (.-currentTarget %)
-                                                                   scroll-top (.-scrollTop currElt)
-                                                                   scroll-height (.-scrollHeight currElt)
-                                                                   client-height (.-clientHeight currElt)
-                                                                   scrolling (< (+ scroll-top client-height) scroll-height)]
-                                                               (om/set-state! owner :scrolling scrolling))}
-             (if (not (:cards-loaded cursor))
-               [:h4 "Loading cards..."]
-               (om/build-all message-view (get-in cursor [:channels (:channel state)])
-                             {:init-state {:zoom-ch (:zoom-ch state)}}))
-             ]
-            (when (:user @app-state)
-              [:div
-               (om/build msg-input-view state)])]]]))))
+            [:h4 "Channels"]
+            (for [ch [:general :america :europe :asia-pacific :united-kingdom :français :español :italia :polska :português :sverige :stimhack-league]]
+              (om/build channel-view {:channel ch :active-channel (:channel state)}
+                        {:init-state {:channel-ch (:channel-ch state)}}))]
+           [:div.chat-container
+            [:div.chat-card-zoom
+             (when-let [card (om/get-state owner :zoom)]
+               (om/build card-zoom card))]
+            [:div.chat-box
+             [:div.blue-shade.panel.message-list {:ref "message-list"
+                                                  :on-scroll #(let [currElt (.-currentTarget %)
+                                                                    scroll-top (.-scrollTop currElt)
+                                                                    scroll-height (.-scrollHeight currElt)
+                                                                    client-height (.-clientHeight currElt)
+                                                                    scrolling (< (+ scroll-top client-height) scroll-height)]
+                                                                (om/set-state! owner :scrolling scrolling))}
+              (if (not (:cards-loaded cursor))
+                [:h4 "Loading cards..."]
+                (om/build-all message-view (get-in cursor [:channels (:channel state)])
+                              {:init-state {:zoom-ch (:zoom-ch state)}}))
+              ]
+             (when (:user @app-state)
+               [:div
+                (om/build msg-input-view state)])]]]]))))
 
 (om/root chat app-state {:target (. js/document (getElementById "chat"))})

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -41,9 +41,9 @@
                                    (sort-games-list (vals delete))))))
                     (when (:games msg)
                       (swap! app-state assoc :games (sort-games-list (vals (:games msg)))))
-                    (when (:blockNewGames msg)
-                      (swap! app-state assoc :block-new-games true)
-                      (when (:blockMessage msg)
+                    (when (contains? msg :blockNewGames)
+                      (swap! app-state assoc :block-new-games (:blockNewGames msg))
+                      (when (contains? msg :blockMessage)
                         (swap! app-state assoc :block-message (:blockMessage msg))))
                     (when-let [sound (:notification msg)]
                       (when-not (:gameid @app-state)

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -42,7 +42,9 @@
                     (when (:games msg)
                       (swap! app-state assoc :games (sort-games-list (vals (:games msg)))))
                     (when (:blockNewGames msg)
-                      (swap! app-state assoc :block-new-games true))
+                      (swap! app-state assoc :block-new-games true)
+                      (when (:blockMessage msg)
+                        (swap! app-state assoc :block-message (:blockMessage msg))))
                     (when-let [sound (:notification msg)]
                       (when-not (:gameid @app-state)
                         (.play (.getElementById js/document sound)))))

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -701,13 +701,27 @@ nav ul
   cover-color: obsidian
 
 // Chat
+#chat
+  .server-message
+    flex(0)
+    margin-left: 0
+    margin-right: 0
+    margin-top: 0
+    padding-bottom: 20px
+    background-color: rgba(30, 130, 30, 0.85)
+    font-weight: bold
 
 .chat-app
   display-flex()
   position: absolute
+  flex-direction(column)
   top: 196px
   bottom: 15px
   width: 995px
+
+  .chat-interface
+    flex(2)
+    display-flex()
 
 .channel-list
   flex(0 0 180px)

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -608,13 +608,16 @@ nav ul
   button
     margin-right: 5px
 
-.reset-form
+.reset-form, .announce-form
   position: absolute
   top: 50%
   left: 50%
   padding: 10px 20px
   width: 282px
   margin: -92px 0 0 -141px
+
+.announce-form
+  color: white
 
 .flash-message
   color: orangered
@@ -1146,6 +1149,11 @@ nav ul
   .games .button-bar
     box-sizing: initial
     padding: 0 15px 15px
+
+    .server-message
+      line-height: 24px
+      color: red
+      font-weight: bold
 
     .rooms .roomtab
       display: block

--- a/views/announce.pug
+++ b/views/announce.pug
@@ -8,13 +8,23 @@ html
     div.reset-bg
     form.panel.blue-shade.announce-form(method='POST')
       h3 Announcement
-      p
-        textarea.form-control(rows=5, style='height: 80px; width: 250px', name='message', value='', autofocus=true required)
-      div
-        input(type='checkbox' id='block' name='blockgames' value='blocked' checked)
-        label(for='block') Prevent new games from starting
+      if !blockNewGames
+        p
+          textarea.form-control(rows=5, style='height: 80px; width: 250px', name='message', value='', autofocus=true required)
         div
-          p Once new games are blocked, you must restart the Node.js server to allow games to be started again.
-
-      p
-        button.btn.btn-primary(type='submit') Submit
+          input(type='checkbox' id='block' name='blockgames' value='block' checked)
+          label(for='block') Prevent new games from starting
+          div
+            p Once new games are blocked, restarting the Node.js server will allow games to be started again.
+        p
+          button.btn.btn-primary(type='submit') Submit
+      else
+        p
+          em New games are currently blocked.
+        div
+          h4 Current Message:
+        div
+          p= blockMessage
+        input(type='hidden' id='unblock' name='blockgames' value='unblock')
+        p
+          button.btn.btn-primary(type='submit') Unblock

--- a/views/announce.pug
+++ b/views/announce.pug
@@ -6,9 +6,15 @@ html
     link(rel='stylesheet', href='/css/netrunner.css')
   body
     div.reset-bg
-    form.panel.blue-shade.reset-form(method='POST')
+    form.panel.blue-shade.announce-form(method='POST')
       h3 Announcement
       p
         textarea.form-control(rows=5, style='height: 80px; width: 250px', name='message', value='', autofocus=true required)
+      div
+        input(type='checkbox' id='block' name='blockgames' value='blocked' checked)
+        label(for='block') Prevent new games from starting
+        div
+          p Once new games are blocked, you must restart the Node.js server to allow games to be started again.
+
       p
         button.btn.btn-primary(type='submit') Submit


### PR DESCRIPTION
Added a checkbox to the `admin/announce` page that blocks (on the client side) new games from being started. Added the ability to unblock games as well (if currently blocked).

If games are blocked, an announcement message is displayed at the top of the chat page.