### PR TITLE
Catching check of blocked-users when user has no options specified

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -114,7 +114,7 @@ getUsername = (socket) ->
 users_blocked_from_game = (game) ->
   blocked_users = []
   for user in game.players
-    if user.options['blocked-users']
+    if user.options? and user.options['blocked-users']
       for blocked in user.options['blocked-users']
         blocked_users.push(blocked)
   blocked_users


### PR DESCRIPTION
Saw this crash in dev, can't seem to reproduce it easily. Appears to happen when a user makes a new account and either starts a game or attempts to watch a game before they have an `options` setting.