### PR TITLE
Dismiss prompts associated with a trashed card

### DIFF
--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -1542,6 +1542,29 @@
           "Tech Trader was installed")
       (is (= 5 (:credit (get-runner))) "Did not gain 1cr from Tech Trader ability"))))
 
+(deftest street-peddler-trash-while-choosing-card
+  ;; Street Peddler - trashing Street Peddler while choosing which card to
+  ;; discard shouldn't duplicate cards. Issue #587.
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Street Peddler" 1)
+                               (qty "Gordian Blade" 1)
+                               (qty "Torch" 1)
+                               (qty "Sure Gamble" 2)]))
+    (take-credits state :corp)
+    (starting-hand state :runner ["Street Peddler" "Sure Gamble"])
+    (play-from-hand state :runner "Street Peddler")
+    (let [sp (get-in @state [:runner :rig :resource 0])]
+      (is (= 3 (count (:hosted sp))) "Street Peddler is hosting 3 cards")
+      (card-ability state :runner sp 0)
+      (println "Before trash")
+      (trash-resource state "Street Peddler")
+      (println "After trash")
+      (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
+      (is (= 4 (count (:discard (get-runner)))) "Street Peddler and hosted cards trashed")
+      (is (zero? (count (get-in @state [:runner :rig :program])))
+          "Gordian Blade was not installed"))))
+
 (deftest symmetrical-visage
   ;; Symmetrical Visage - Gain 1 credit the first time you click to draw each turn
   (do-game

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -1544,7 +1544,7 @@
 
 (deftest street-peddler-trash-while-choosing-card
   ;; Street Peddler - trashing Street Peddler while choosing which card to
-  ;; discard shouldn't duplicate cards. Issue #587.
+  ;; discard should dismiss the choice prompt. Issue #587.
   (do-game
     (new-game (default-corp)
               (default-runner [(qty "Street Peddler" 1)
@@ -1557,13 +1557,8 @@
     (let [sp (get-in @state [:runner :rig :resource 0])]
       (is (= 3 (count (:hosted sp))) "Street Peddler is hosting 3 cards")
       (card-ability state :runner sp 0)
-      (println "Before trash")
       (trash-resource state "Street Peddler")
-      (println "After trash")
-      (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
-      (is (= 4 (count (:discard (get-runner)))) "Street Peddler and hosted cards trashed")
-      (is (zero? (count (get-in @state [:runner :rig :program])))
-          "Gordian Blade was not installed"))))
+      (is (zero? (count (get-in @state [:runner :prompt])))))))
 
 (deftest symmetrical-visage
   ;; Symmetrical Visage - Gain 1 credit the first time you click to draw each turn

--- a/src/clj/test/cards/resources.clj
+++ b/src/clj/test/cards/resources.clj
@@ -1554,9 +1554,9 @@
     (take-credits state :corp)
     (starting-hand state :runner ["Street Peddler" "Sure Gamble"])
     (play-from-hand state :runner "Street Peddler")
-    (let [sp (get-in @state [:runner :rig :resource 0])]
-      (is (= 3 (count (:hosted sp))) "Street Peddler is hosting 3 cards")
-      (card-ability state :runner sp 0)
+    (let [street-peddler (get-in @state [:runner :rig :resource 0])]
+      (is (= 3 (count (:hosted street-peddler))) "Street Peddler is hosting 3 cards")
+      (card-ability state :runner street-peddler 0)
       (trash-resource state "Street Peddler")
       (is (zero? (count (get-in @state [:runner :prompt])))))))
 

--- a/src/clj/test/core.clj
+++ b/src/clj/test/core.clj
@@ -212,6 +212,11 @@
   [state side title]
   (core/trash state side (find-card title (get-in @state [side :hand]))))
 
+(defn trash-resource
+  "Trash specified card from rig of the runner"
+  [state title]
+  (core/trash state :runner (find-card title (get-in @state [:runner :rig :resource]))))
+
 (defn starting-hand
   "Moves all cards in the player's hand to their draw pile, then moves the specified card names
   back into the player's hand."


### PR DESCRIPTION
This closes issue #587; when a card is manually trashed while it has prompts open, automatically close all prompts associated with the card (more precisely, any card of the same name). This stops an exception being thrown when the user tries to interact with the prompt after trashing the card.