### PR TITLE
Shuffling functions to avoid circular dependencies

### DIFF
--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -4,6 +4,7 @@
             [sablono.core :as sab :include-macros true]
             [cljs.core.async :refer [chan put! >! sub pub] :as async]
             [netrunner.appstate :refer [app-state]]
+            [netrunner.account :refer [alt-art-name]]
             [netrunner.ajax :refer [GET]]))
 
 (def cards-channel (chan))
@@ -47,10 +48,27 @@
                        (:code card))]
     (str "/img/cards/" version-path ".png")))
 
+(defn expand-alts
+  [acc card]
+  (let [alt-card (get (:alt-arts @app-state) (:code card))
+        alt-arts (keys (:alt_art alt-card))]
+    (if (and alt-arts
+             (show-alt-art?))
+    (->> alt-arts
+      (concat [""])
+      (map (fn [art] (if art
+                       (assoc card :art art)
+                       card)))
+      (map (fn [c] (if (:art c)
+                     (assoc c :display-name (str (:display-name c) " [" (alt-art-name (:art c)) "]"))
+                     c)))
+      (concat acc))
+    (conj acc card))))
+
 (defn insert-alt-arts
   "Add copies of all alt art cards to the list of cards"
   [cards]
-  (reduce netrunner.deckbuilder/expand-alts () (reverse cards)))
+  (reduce expand-alts () (reverse cards)))
 
 (defn add-symbols [card-text]
   (-> (if (nil? card-text) "" card-text)
@@ -160,7 +178,7 @@
        (when-let [number (:number card)]
          (str pack " " number
               (when-let [art (:art card)]
-                (str " [" (netrunner.account/alt-art-name art) "]")))))]
+                (str " [" (alt-art-name art) "]")))))]
      (if (selected-alt-art card cursor)
       [:div.selected-alt "Selected Alt Art"]
       (when (:art card)

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -6,8 +6,8 @@
             [clojure.string :refer [split split-lines join escape] :as s]
             [netrunner.appstate :refer [app-state]]
             [netrunner.auth :refer [authenticated] :as auth]
-            [netrunner.cardbrowser :refer [cards-channel image-url card-view show-alt-art? filter-title] :as cb]
-            [netrunner.account :refer [load-alt-arts alt-art-name]]
+            [netrunner.cardbrowser :refer [cards-channel image-url card-view show-alt-art? filter-title expand-alts] :as cb]
+            [netrunner.account :refer [load-alt-arts]]
             [netrunner.ajax :refer [POST GET]]
             [goog.string :as gstring]
             [goog.string.format]))
@@ -230,22 +230,6 @@
       (assoc card :display-name (str (:title card) " (" (:setname card) ")"))
       (assoc card :display-name (:title card)))))
 
-(defn expand-alts
-  [acc card]
-  (let [alt-card (get (:alt-arts @app-state) (:code card))
-        alt-arts (keys (:alt_art alt-card))]
-    (if (and alt-arts
-             (show-alt-art?))
-    (->> alt-arts
-      (concat [""])
-      (map (fn [art] (if art
-                       (assoc card :art art)
-                       card)))
-      (map (fn [c] (if (:art c)
-                     (assoc c :display-name (str (:display-name c) " [" (alt-art-name (:art c)) "]"))
-                     c)))
-      (concat acc))
-    (conj acc card))))
 
 (defn side-identities [side]
   (let [cards


### PR DESCRIPTION
Move some alt-art processing functions into `cardbrowser.cljs` to avoid js error when loading ahead of `deckbuilder.cljs`.