### PR TITLE
Sovereign Sight cards -- untested

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1168,6 +1168,29 @@
     :events {:corp-turn-begins ability}
     :abilities [ability]})
 
+   "Reconstruction Contract"
+   {:events {:damage {:req (req (pos? (nth targets 2)))
+                      :effect (effect (add-counter card :advancement 1)
+                                      (system-msg "adds 1 advancement token to Reconstruction Contract"))}}
+    :abilities [{:label "[Trash]: Move advancement tokens to another card"
+                 :prompt "Select a card that can be advanced"
+                 :choices {:req can-be-advanced?}
+                 :effect (req (let [move-to target
+                                    recon card]
+                                (resolve-ability
+                                  state side
+                                  {:prompt "Move how many tokens?"
+                                   :choices {:number (req (:advance-counter recon 0))
+                                             :default (req (:advance-counter recon 0))}
+                                   :effect (effect (add-counter move-to :advancement target)
+                                                   (system-msg (str "trashes Reconstruction Contract to move " target
+                                                                    (pluralize " advancement token" target) " to "
+                                                                    (card-str state move-to)))
+                                                   (trash recon {:cause :ability-cost}))}
+
+                                  card nil)
+                                ))}]}
+
    "Reversed Accounts"
    {:advanceable :always
     :abilities [{:cost [:click 1]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -104,6 +104,16 @@
    {:msg "gain 1 [Credits] and draw 2 cards"
     :effect (effect (gain :credit 1) (draw 2))}
 
+   "By Any Means"
+   {:effect (effect (register-events (:events (card-def card))
+                                     (assoc card :zone '(:discard))))
+    :events {:runner-turn-ends {:effect (effect (unregister-events card))}
+             :pre-access-card {:req (req (not= [:discard] (:zone target)))
+                               :delayed-completion true
+                               :msg (msg "trash " (:title target) " at no cost and suffer 1 meat damage")
+                               :effect (effect (trash (assoc target :seen true))
+                                               (damage :runner eid :meat 1 {:unboostable true}))}}}
+
    "Calling in Favors"
    {:msg (msg "gain " (count (filter #(and (has-subtype? % "Connection") (is-type? % "Resource"))
                                      (all-installed state :runner))) " [Credits]")

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -184,7 +184,7 @@
       :recurring 4
       :choices (req runnable-servers)
       :effect (req (let [c (move state side (assoc card :zone '(:discard)) :play-area {:force true})]
-                     (card-init state side c false)
+                     (card-init state side c {:resolve-effect false})
                      (game.core/run state side (make-eid state) target
                                     {:end-run {:delayed-completion true
                                                :effect (effect (trash c)
@@ -298,7 +298,7 @@
                     (prompt! card (str "Click Demolition Run in the Temporary Zone to trash a card being accessed at no cost") ["OK"] {})
                     (resolve-ability
                       {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
-                                      (card-init state side c false)
+                                      (card-init state side c {:resolve-effect false})
                                       (register-events state side
                                                        {:run-ends {:effect (effect (trash c))}} c)))}
                      card nil))
@@ -357,7 +357,7 @@
                     (prompt! card (str "Click Diana's Hunt in the Temporary Zone to install a Program") ["OK"] {})
                     (resolve-ability
                       {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
-                                      (card-init state side c false)
+                                      (card-init state side c {:resolve-effect false})
                                       (register-events state side
                                                        {:run-ends {:effect (req (let [hunt (:diana @state)]
                                                                                   (doseq [c hunt]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1076,7 +1076,7 @@
                  :effect (effect (move (last (:deck runner)) :hand))}]}
 
    "Zamba"
-   {:in-play [:memory 2]
-    :events {:expose {:optional {:prompt "Gain 1 [Credits] from Zamba?"
-                                 :yes-ability {:effect (effect (gain :credit 1))
-                                               :msg "gain 1 [Credits]"}}}}}})
+   {:implementation "Credit gain is automatic"
+    :in-play [:memory 2]
+    :events {:expose {:effect (effect (gain :credit 1))
+                      :msg "gain 1 [Credits]"}}}})

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -217,6 +217,13 @@
                                                     (get-card state card)))}
     :events {:pre-rez nil :runner-turn-ends nil :corp-turn-ends nil}}
 
+   "Cyberdelia"
+   {:implementation "Credit gain is manually triggered."
+    :in-play [:memory 1]
+    :abilities [{:msg "gain 1 [Credits] for breaking all subroutines on a piece of ice"
+                 :once :per-turn
+                 :effect (effect (gain :credit 1))}]}
+
    "Cyberfeeder"
    {:recurring 1}
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1073,4 +1073,10 @@
 
    "Window"
    {:abilities [{:cost [:click 1] :msg "draw 1 card from the bottom of their Stack"
-                 :effect (effect (move (last (:deck runner)) :hand))}]}})
+                 :effect (effect (move (last (:deck runner)) :hand))}]}
+
+   "Zamba"
+   {:in-play [:memory 2]
+    :events {:expose {:optional {:prompt "Gain 1 [Credits] from Zamba?"
+                                 :yes-ability {:effect (effect (gain :credit 1))
+                                               :msg "gain 1 [Credits]"}}}}}})

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -86,10 +86,15 @@
 
 (defn do-psi
   "Start a psi game, if not equal do ability"
-  [{:keys [label] :as ability}]
+  ([{:keys [label] :as ability}]
   {:label (str "Psi Game - " label)
    :msg (str "start a psi game (" label ")")
    :psi {:not-equal ability}})
+  ([{:keys [label-neq] :as neq-ability} {:keys [label-eq] :as eq-ability}]
+   {:label (str "Psi Game - " label-neq " / " label-eq)
+    :msg (str "start a psi game (" label-neq " / " label-eq ")")
+    :psi {:not-equal neq-ability
+          :equal     eq-ability}}))
 
 (def take-bad-pub
   "Bad pub on rez effect."
@@ -1236,6 +1241,18 @@
                                                                                (swap-installed state side (first targets) (second targets))
                                                                                (effect-completed state side eid card)))} card nil)))}]}
 
+   "Mganga"
+   {:subroutines [(do-psi {:label "do 2 net damage"
+                           :delayed-completion true
+                           :player :corp
+                           :effect (req (when-completed (damage state :corp :net 2 {:card card})
+                                                        (trash state :corp eid card nil)))}
+                          {:label "do 1 net damage"
+                           :delayed-completion true
+                           :player :corp
+                           :effect (req (when-completed (damage state :corp :net 1 {:card card})
+                                                        (trash state :corp eid card nil)))})]}
+
    "Mind Game"
    {:subroutines [(do-psi {:label "Redirect the run to another server"
                            :player :corp
@@ -1305,6 +1322,10 @@
                   (tag-trace 2)
                   (tag-trace 3)
                   end-the-run-if-tagged]}
+
+   "Najja 1.0"
+   {:subroutines [end-the-run]
+    :runner-abilities [(runner-break [:click 1] 1)]}
 
    "Nebula"
    (space-ice trash-program)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -364,7 +364,8 @@
                                (swap! state assoc-in (cons :corp (:zone card)) newices)
                                (swap! state update-in (cons :corp (:zone target))
                                       (fn [coll] (remove-once #(not= (:cid %) (:cid target)) coll)))
-                               (card-init state side newice false)
+                               (card-init state side newice {:resolve-effect false
+                                                             :init-data true})
                                (trigger-event state side :corp-install newice)))}]})
 
    "Brainstorm"
@@ -964,7 +965,8 @@
                                                         (swap! state update-in (cons :corp (:zone target))
                                                                (fn [coll] (remove-once #(not= (:cid %) (:cid target)) coll)))
                                                         (update! state side (assoc card :howler-target newice))
-                                                        (card-init state side newice false)
+                                                        (card-init state side newice {:resolve-effect false
+                                                                                      :init-data true})
                                                         (trigger-event state side :corp-install newice)))} card nil)))}]
       :events {:run-ends {:req (req (:howler-target card))
                           :effect (effect (trash card {:cause :self-trash})

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -720,7 +720,11 @@
    "Paperclip"
    (conspiracy "Paperclip" "Barrier"
                [{:label (str "X [Credits]: +X strength, break X subroutines")
-                 :choices :credit
+                 :choices {:number (req (:credit runner))
+                           :default (req (if current-ice
+                                           (- (:current-strength current-ice)
+                                              (:current-strength card))
+                                           1))}
                  :prompt "How many credits?"
                  :effect (effect (pump card target))
                  :msg (msg "spend " target " [Credits], increase strength by " target ", and break "

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -767,6 +767,21 @@
                     {:abilities [(break-sub 1 1 "Sentry")
                                  (strength-pump 2 1 :all-run)]})
 
+   "Puffer"
+   (auto-icebreaker ["Sentry"]
+                    {:implementation "Memory use must be manually tracked by the Runner"
+                     :abilities [(break-sub 1 1 "Sentry")
+                                 (strength-pump 2 1)
+                                 {:cost [:click 1]
+                                  :label "Place 1 power counter"
+                                  :effect (effect (add-counter card :power 1)
+                                                  (update-breaker-strength card))}
+                                 {:cost [:click 1]
+                                  :label "Remove 1 power counter"
+                                  :effect (effect (add-counter card :power -1)
+                                                  (update-breaker-strength card))}]
+                     :strength-bonus (req (get-in card [:counter :power] 0))})
+
    "Refractor"
    (auto-icebreaker ["Code Gate"]
                     {:implementation "Stealth credit restriction not enforced"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -123,7 +123,6 @@
               :req (req (first-event? state :corp :corp-install))
               :effect (req (let [installed-card target
                                  z (butlast (:zone installed-card))]
-                             (prn z)
                              (continue-ability
                                state side
                                {:prompt (str "Select a "

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -117,6 +117,24 @@
                             :msg "draw a card"
                             :effect (effect (draw 1))}}}
 
+   "Asa Group: Security Through Vigilance"
+   {:events {:corp-install
+             {:delayed-completion true
+              :req (req (and (first-event? state :corp :corp-install)
+                             ;; doesn't fire when installing ice on a central server
+                             (not (and (ice? target)
+                                       (is-central? (:zone target))))))
+              :effect (req (let [installed-card target]
+                             (continue-ability
+                               state side
+                               {:prompt "Select a non-agenda card in HQ to install (optional)"
+                                :delayed-completion true
+                                :choices {:req #(and (in-hand? %)
+                                                 (= (:side %) "Corp")
+                                                 (not (is-type? % "Agenda")))}
+                                :effect (effect (corp-install eid target (zone->name installed-card) nil))}
+                               card nil)))}}}
+
    "Ayla \"Bios\" Rahim: Simulant Specialist"
    {:abilities [{:label "[:click] Add 1 card from NVRAM to your grip"
                  :cost [:click 1]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -120,18 +120,17 @@
    "Asa Group: Security Through Vigilance"
    {:events {:corp-install
              {:delayed-completion true
-              :req (req (and (first-event? state :corp :corp-install)
-                             ;; doesn't fire when installing ice on a central server
-                             (not (and (ice? target)
-                                       (is-central? (:zone target))))))
+              :req (req (first-event? state :corp :corp-install))
               :effect (req (let [installed-card target]
                              (continue-ability
                                state side
                                {:prompt "Select a non-agenda card in HQ to install (optional)"
                                 :delayed-completion true
                                 :choices {:req #(and (in-hand? %)
-                                                 (= (:side %) "Corp")
-                                                 (not (is-type? % "Agenda")))}
+                                                     (= (:side %) "Corp")
+                                                     (not (is-type? % "Agenda"))
+                                                     (or (is-remote? (:zone installed-card))
+                                                         (ice? %)))}
                                 :effect (effect (corp-install eid target (zone->name installed-card) nil))}
                                card nil)))}}}
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -121,17 +121,23 @@
    {:events {:corp-install
              {:delayed-completion true
               :req (req (first-event? state :corp :corp-install))
-              :effect (req (let [installed-card target]
+              :effect (req (let [installed-card target
+                                 z (butlast (:zone installed-card))]
+                             (prn z)
                              (continue-ability
                                state side
-                               {:prompt "Select a non-agenda card in HQ to install (optional)"
+                               {:prompt (str "Select a "
+                                             (if (is-remote? z)
+                                               "non-agenda"
+                                               "piece of ice")
+                                             " in HQ to install with Asa Group: Security Through Vigilance (optional)")
                                 :delayed-completion true
                                 :choices {:req #(and (in-hand? %)
                                                      (= (:side %) "Corp")
                                                      (not (is-type? % "Agenda"))
-                                                     (or (is-remote? (:zone installed-card))
+                                                     (or (is-remote? z)
                                                          (ice? %)))}
-                                :effect (effect (corp-install eid target (zone->name installed-card) nil))}
+                                :effect (effect (corp-install eid target (zone->name z) nil))}
                                card nil)))}}}
 
    "Ayla \"Bios\" Rahim: Simulant Specialist"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1145,6 +1145,16 @@
             :delayed-completion true
             :effect (effect (tag-runner :runner eid 1))}}
 
+   "Self-Growth Program"
+   {:req (req tagged)
+    :prompt "Select two installed Runner cards"
+    :choices {:req #(and (installed? %)
+                         (= "Runner" (:side %)))
+              :max 2}
+    :msg (msg (str "move " (join ", " (map :title targets)) " to the Runner's grip"))
+    :effect (req (doseq [c targets]
+                   (move state :runner c :hand)))}
+
    "Service Outage"
    (let [add-effect (fn [state side card]
                       (update! state side (assoc card :so-activated true))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -483,6 +483,12 @@
      {:delayed-completion true
       :effect (effect (continue-ability (fhelper 1) card nil))})
 
+   "Genotyping"
+   {:delayed-completion true
+    :effect (effect (mill 2)
+                    (system-msg "trashes the top 2 cards of R&D")
+                    (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) 4))}
+
    "Green Level Clearance"
    {:msg "gain 3 [Credits] and draw 1 card"
     :effect (effect (gain :credit 3) (draw))}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -873,8 +873,7 @@
    {:events {:pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 2]))}}}
 
    "Preemptive Action"
-   {:msg "remove Preemptive Action from the game"
-    :effect (effect (rfg-and-shuffle-rd-effect (first (:play-area corp)) 3))}
+   {:effect (effect (rfg-and-shuffle-rd-effect (first (:play-area corp)) 3))}
 
    "Priority Construction"
    (letfn [(install-card [chosen]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -757,7 +757,7 @@
                                                (swap! state assoc-in (cons :corp (:zone target)) newices)
                                                (swap! state update-in [:corp :deck] (fn [coll] (remove-once #(not= (:cid %) (:cid newice)) coll)))
                                                (trigger-event state side :corp-install newice)
-                                               (card-init state side newice false)
+                                               (card-init state side newice {:resolve-effect false})
                                                (system-msg state side (str "uses Mutate to install and rez " (:title newice) " from R&D at no cost"))
                                                (trigger-event state side :rez newice))
                                              (system-msg state side (str "does not find any ICE to install from R&D")))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1458,6 +1458,30 @@
                       :msg (msg "trash " (:title target))
                       :effect (effect (trash target))}}}
 
+   "Wake Up Call"
+   {:req (req (:trashed-card runner-reg-last))
+    :prompt "Select a piece of hardware or non-virtual resource"
+    :choices {:req #(or (hardware? %)
+                        (and (resource? %) (not (has-subtype? % "Virtual"))))}
+    :delayed-completion true
+    :effect (req (let [chosen target
+                       wake card]
+                   (show-wait-prompt state side "Runner to resolve Wake Up Call")
+                   (continue-ability state :runner
+                                     {:prompt (str "Trash " (:title chosen) " or suffer 4 meat damage?")
+                                      :choices [(str "Trash " (:title chosen))
+                                                "4 meat damage"]
+                                      :delayed-completion true
+                                      :effect (req (clear-wait-prompt state :corp)
+                                                   (move state side (last (:discard corp)) :rfg)
+                                                   (if (.startsWith target "Trash")
+                                                     (do (system-msg state side (str "chooses to trash " (:title chosen)))
+                                                         (trash state side eid chosen nil))
+                                                     (do (system-msg state side "chooses to suffer meat damage")
+                                                         (damage state side eid :meat 4 {:card wake
+                                                                                         :unboostable true}))))}
+                                     card nil)))}
+
    "Wetwork Refit"
    {:choices {:req #(and (ice? %)
                          (has-subtype? % "Bioroid")

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -146,11 +146,15 @@
                  :choices {:req #(and (facedown? %)
                                       (installed? %)
                                       (= "Runner" (:side %)))}
-                 :effect (req (let [temp (move state side target :play-area)
-                                    moved (move state side temp (type->rig-zone (:type temp)))]
-                                (card-init state side (make-eid state) moved {:resolve-effect false
-                                                                              :init-data false})))
-                 :msg (msg (str "turn" (:title target) "faceup"))}]}
+                 :effect (req (if (or (is-type? target "Event")
+                                      (has-subtype? target "Console"))
+                                ;; Consoles and events are immediately unpreventably trashed.
+                                (trash state side target {:unpreventable true})
+                                ;; Other cards are moved to rig and have events wired.
+                                (let [temp (move state side target :play-area)
+                                      moved (move state side temp (type->rig-zone (:type temp)))]
+                                  (card-init state side (make-eid state) moved {:resolve-effect false :init-data false}))))
+                 :msg (msg "turn " (:title target) " faceup")}]}
 
    "Bhagat"
    {:events {:successful-run {:req (req (and (= target :hq)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -866,6 +866,32 @@
    "Laguna Velasco District"
    {:events {:runner-click-draw {:msg "draw 1 card" :effect (effect (draw))}}}
 
+   "Lewi Guilherme"
+   (let [ability {:once :per-turn
+                  :delayed-completion true
+                  :effect (req (if (zero? (:credit runner))
+                                 (do (trash state side card)
+                                     (system-msg state side "must trash Lewi Guilherme")
+                                     (effect-completed state side eid))
+                                 (continue-ability
+                                   state side
+                                   {:optional {:once :per-turn
+                                               :prompt "Pay 1 [Credits] to keep Lewi Guilherme?"
+                                               :yes-ability {:effect (effect (lose :credit 1)
+                                                                             (system-msg "pays 1 [Credits] to keep Lewi Guilherme"))}
+                                               :no-ability {:effect (effect (trash card)
+                                                                            (system-msg "trashed Lewi Guilherme"))}}}
+                                   card nil)))}]
+   {:flags {:drip-economy true ;; for Drug Dealer
+            :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :drip-economy true)
+                                                      (all-installed state :runner)))))}
+
+    ;; KNOWN ISSUE: :effect is not fired when Assimilator turns cards over.
+    :effect (effect (lose :corp :hand-size-modification 1))
+    :leave-play (effect (gain :corp :hand-size-modification 1))
+    :abilities [(assoc-in ability [:req] (req (:runner-phase-12 @state)))]
+    :events {:runner-turn-begins ability}})
+
    "Levy Advanced Research Lab"
    (letfn [(lab-keep [cards]
              {:prompt "Choose a Program to keep"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -139,6 +139,20 @@
                                  (shuffle! :deck)
                                  (runner-install target))}]}
 
+   "Assimilator"
+   {:abilities [{:label "Turn a facedown card faceup"
+                 :cost [:click 2]
+                 :prompt "Select a facedown installed card"
+                 :choices {:req #(and (facedown? %)
+                                      (installed? %)
+                                      (= "Runner" (:side %)))}
+                 :effect (req (let [temp (move state side target :play-area)
+                                    moved (move state side temp (type->rig-zone (:type temp)))]
+                                (card-init state side moved false)))
+                 :msg (msg (str "turn" (:title target) "faceup"))}
+
+                 ]}
+
    "Bhagat"
    {:events {:successful-run {:req (req (and (= target :hq)
                                              (first-successful-run-on-server? state :hq)))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -148,10 +148,9 @@
                                       (= "Runner" (:side %)))}
                  :effect (req (let [temp (move state side target :play-area)
                                     moved (move state side temp (type->rig-zone (:type temp)))]
-                                (card-init state side moved false)))
-                 :msg (msg (str "turn" (:title target) "faceup"))}
-
-                 ]}
+                                (card-init state side (make-eid state) moved {:resolve-effect false
+                                                                              :init-data false})))
+                 :msg (msg (str "turn" (:title target) "faceup"))}]}
 
    "Bhagat"
    {:events {:successful-run {:req (req (and (= target :hq)

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -141,6 +141,19 @@
                                                           (has-subtype? % "Transaction")) (:discard corp)) :sorted))
                  :effect (effect (play-instant nil target {:ignore-cost true}) (move target :rfg))}]}
 
+   "Calibration Testing"
+   {:abilities [{:label "[Trash]: Place 1 advancement token on a card in this server"
+                 :delayed-completion true
+                 :effect (effect (continue-ability
+                                   {:prompt "Select a card in this server"
+                                    :choices {:req #(in-same-server? % card)}
+                                    :delayed-completion true
+                                    :msg (msg "place an advancement token on " (card-str state target))
+                                    :effect (effect (add-prop target :advance-counter 1 {:placed true})
+                                                    (trash eid card {:cause :ability-cost}))}
+                                   card nil))}]}
+
+
    "Caprice Nisei"
    {:events {:pass-ice {:req (req (and this-server
                                        (= (:position run) 1))) ; trigger when last ice passed

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -5,7 +5,7 @@
                                 zones->sorted-names remote->name remote-num->name central->name zone->name central->zone
                                 is-remote? is-central? get-server-type other-side same-card? same-side?
                                 combine-subtypes remove-subtypes remove-subtypes-once click-spent? used-this-turn?
-                                pluralize quantify]]
+                                pluralize quantify type->rig-zone]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case]]
             [clojure.core.match :refer [match]]))

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -516,22 +516,24 @@
     (show-trace-prompt state :corp card "Boost trace strength?"
                        #(init-trace state :corp card trace %) {:priority 2 :base base-trace :bonus bonus})))
 
-(defn rfg-and-shuffle-rd-effect [state side card n]
-  (move state side card :rfg)
-  (resolve-ability state side
-                   {:show-discard true
-                    :choices {:max n
-                              :req #(and (= (:side %) "Corp")
-                                         (= (:zone %) [:discard]))}
-                    :msg (msg "shuffle "
-                              (let [seen (filter :seen targets)
-                                    m (count (filter #(not (:seen %)) targets))]
-                                (str (join ", " (map :title seen))
-                                     (when (pos? m)
-                                       (str (when-not (empty? seen) " and ")
-                                            (quantify m "unseen card")))))
-                              " into R&D")
-                    :effect (req (doseq [c targets] (move state side c :deck))
-                                 (shuffle! state side :deck))
-                    :cancel-effect (req (shuffle! state side :deck))}
-                   card nil))
+(defn rfg-and-shuffle-rd-effect
+  ([state side card n] (rfg-and-shuffle-rd-effect state side (make-eid state) card n))
+  ([state side eid card n]
+   (move state side card :rfg)
+   (continue-ability state side
+                    {:show-discard  true
+                     :choices       {:max n
+                                     :req #(and (= (:side %) "Corp")
+                                                (= (:zone %) [:discard]))}
+                     :msg           (msg "shuffle "
+                                         (let [seen (filter :seen targets)
+                                               m (count (filter #(not (:seen %)) targets))]
+                                           (str (join ", " (map :title seen))
+                                                (when (pos? m)
+                                                  (str (when-not (empty? seen) " and ")
+                                                       (quantify m "unseen card")))))
+                                         " into R&D")
+                     :effect        (req (doseq [c targets] (move state side c :deck))
+                                         (shuffle! state side :deck))
+                     :cancel-effect (req (shuffle! state side :deck))}
+                    card nil)))

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -388,7 +388,8 @@
 
       ;; do not card-init necessarily. if card-def has :effect, wrap a fake event
       (let [moved-card (move state :corp card :scored)
-            c (card-init state :corp moved-card false)
+            c (card-init state :corp moved-card {:resolve-effect false
+                                                 :init-data true})
             points (get-agenda-points state :corp c)]
         (trigger-event-simult
           state :corp (make-eid state) :agenda-scored

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -238,4 +238,4 @@
     (let [c (dissoc card :disabled)]
       (update! state side c)
       (when (active? card)
-        (card-init state side c false)))))
+        (card-init state side c {:resolve-effect false})))))

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -1,7 +1,7 @@
 (in-ns 'game.core)
 
-(declare active? all-installed cards card-init deactivate card-flag? get-card-hosted handle-end-run has-subtype? ice?
-         make-eid register-events remove-from-host remove-icon reset-card rezzed? trash trigger-event update-hosted!
+(declare active? all-installed cards card-init deactivate card-flag? get-card-hosted handle-end-run hardware? has-subtype? ice?
+         make-eid program? register-events remove-from-host remove-icon reset-card resource? rezzed? trash trigger-event update-hosted!
          update-ice-strength unregister-events)
 
 ;;; Functions for loading card information.

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -265,6 +265,15 @@
 (defn ice? [card]
   (is-type? card "ICE"))
 
+(defn program? [card]
+  (is-type? card "Program"))
+
+(defn hardware? [card]
+  (is-type? card "Hardware"))
+
+(defn resource? [card]
+  (is-type? card "Resource"))
+
 (defn rezzed? [card]
   (:rezzed card))
 

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -80,7 +80,8 @@
          (when-let [events (:events tdef)]
            (register-events state side events c))
          (when (or (:recurring tdef) (:prevent tdef))
-           (card-init state side c false)))
+           (card-init state side c {:resolve-effect false
+                                    :init-data true})))
 
        (when-let [events (:events tdef)]
          (when (and installed (:recurring tdef))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -80,16 +80,16 @@
 
 (defn card-init
   "Initializes the abilities and events of the given card."
-  ([state side card] (card-init state side card true))
-  ([state side card resolve] (card-init state side (make-eid state) card resolve))
-  ([state side eid card resolve]
+  ([state side card] (card-init state side card {:resolve-effect true :init-data true}))
+  ([state side card args] (card-init state side (make-eid state) card args))
+  ([state side eid card {:keys [resolve-effect init-data] :as args}]
    (let [cdef (card-def card)
          recurring (:recurring cdef)
          abilities (ability-init cdef)
          run-abs (runner-ability-init cdef)
          subroutines (subroutines-init cdef)
          c (merge card
-                  (when resolve (:data cdef))
+                  (when init-data (:data cdef))
                   {:abilities abilities :subroutines subroutines :runner-abilities run-abs})
          c (if (number? recurring) (assoc c :rec-counter recurring) c)
          c (if (string? (:strength c)) (assoc c :strength 0) c)]
@@ -107,7 +107,7 @@
      (update! state side c)
      (when-let [events (:events cdef)]
        (register-events state side events c))
-     (if (and resolve (is-ability? cdef))
+     (if (and resolve-effect (is-ability? cdef))
        (resolve-ability state side eid cdef c nil)
        (effect-completed state side eid))
      (when-let [in-play (:in-play cdef)]
@@ -260,7 +260,9 @@
                                            (= install-state :face-up)
                                            (do (if (:install-state cdef)
                                                  (card-init state side
-                                                            (assoc (get-card state moved-card) :rezzed true :seen true) false)
+                                                            (assoc (get-card state moved-card) :rezzed true :seen true)
+                                                            {:resolve-effect false
+                                                             :init-data true})
                                                  (update! state side (assoc (get-card state moved-card) :rezzed true :seen true)))
                                                (when-not (:delayed-completion cdef)
                                                  (effect-completed state side eid)))
@@ -380,7 +382,8 @@
                        c (assoc c :installed true :new true)
                        installed-card (if facedown
                                         (update! state side c)
-                                        (card-init state side c false))]
+                                        (card-init state side c {:resolve-effect false
+                                                                 :init-data true}))]
                    (runner-install-message state side (:title card) cost-str params)
                    (play-sfx state side "install-runner")
                    (when (and (is-type? card "Program") (neg? (get-in @state [:runner :memory])))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -88,7 +88,9 @@
          abilities (ability-init cdef)
          run-abs (runner-ability-init cdef)
          subroutines (subroutines-init cdef)
-         c (merge card (:data cdef) {:abilities abilities :subroutines subroutines :runner-abilities run-abs})
+         c (merge card
+                  (when resolve (:data cdef))
+                  {:abilities abilities :subroutines subroutines :runner-abilities run-abs})
          c (if (number? recurring) (assoc c :rec-counter recurring) c)
          c (if (string? (:strength c)) (assoc c :strength 0) c)]
      (when recurring

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -57,7 +57,8 @@
                        (trash state side current)))
                    (let [c (some #(when (= (:cid %) (:cid card)) %) (get-in @state [side :play-area]))
                          moved-card (move state side c :current)]
-                     (card-init state side eid moved-card true)))
+                     (card-init state side eid moved-card {:resolve-effect true
+                                                           :init-data true})))
                (do (resolve-ability state side (assoc cdef :eid eid) card nil)
                    (when-let [c (some #(when (= (:cid %) (:cid card)) %) (get-in @state [side :play-area]))]
                      (move state side c :discard))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -252,8 +252,13 @@
                      (do (let [acost (access-cost state side c)
                                ;; hack to prevent toasts when playing against Gagarin and accessing on 0 credits
                                anon-card (dissoc c :title)]
-                           (if (or (empty? acost) (pay state side anon-card acost))
+                           (cond
+                             ;; Check if a pre-access-card effect trashed the card (By Any Means)
+                             (not (get-card state c))
+                             (effect-completed state side eid)
+
                              ;; Either there were no access costs, or the runner could pay them.
+                             (or (empty? acost) (pay state side anon-card acost))
                              (let [cdef (card-def c)
                                    c (assoc c :seen true)
                                    access-effect (:access cdef)]
@@ -282,6 +287,8 @@
                                                            (access-non-agenda state side eid c)
                                                            (effect-completed state side eid))))
                                      (access-non-agenda state side eid c)))))
+
+                             :else
                              ;; The runner cannot afford the cost to access the card
                              (prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {})))
                          (trigger-event state side :post-access-card c))))))

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -254,6 +254,11 @@
     :deck [:servers :rd]
     nil))
 
+(defn type->rig-zone
+  "Converts a runner's card type to a vector zone, e.g. 'Program' -> [:rig :program]"
+  [type]
+  (vec [:rig (-> type .toLowerCase keyword)]))
+
 (defn get-server-type [zone]
   (or (#{:hq :rd :archives} zone) :remote))
 


### PR DESCRIPTION
Could use some more eyes on these cards. Others are still up for grabs.
 
Implementation notes:

* By Any Means: yes, this is supposed to stop ambushes from firing.
* Zamba: the credit gain is technically optional, but I have made it automatic for convenience.
* Puffer: runner must manually adjust memory units.
* Cyberdelia: we do not track how many subroutines you break, so the credit gain is triggered manually by clicking the card.
* Assimilator: resistance is futile.

* Asa Group: click Done if you don't want to install something.
* Reconstruction Contract: another case of "technically it's optional, but why would you turn it down, so now it's automatic".
