### PR TITLE
Fix delayed completion of Information Sifting.

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -731,6 +731,7 @@
    (letfn [(access-pile [cards pile]
              {:prompt "Choose a card to access. You must access all cards."
               :choices [(str "Card from pile " pile)]
+              :delayed-completion true
               :effect (req (when-completed
                              (handle-access state side [(first cards)])
                              (do (if (< 1 (count cards))
@@ -739,8 +740,10 @@
            (which-pile [p1 p2]
              {:prompt "Choose a pile to access"
               :choices [(str "Pile 1 (" (count p1) " cards)") (str "Pile 2 (" (count p2) " cards)")]
+              :delayed-completion true
               :effect (req (let [choice (if (.startsWith target "Pile 1") 1 2)]
                              (clear-wait-prompt state :corp)
+                             (system-msg state side (str "chooses to access " target))
                              (continue-ability state side
                                 (access-pile (if (= 1 choice) p1 p2) choice)
                                 card nil)))})]
@@ -751,7 +754,8 @@
                            (do (show-wait-prompt state :runner "Corp to create two piles")
                                (continue-ability
                                  state :corp
-                                 {:prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
+                                 {:delayed-completion true
+                                  :prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
                                   :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
                                             :max (req (dec (count (:hand corp))))}
                                   :effect (effect (clear-wait-prompt :runner)


### PR DESCRIPTION
This card was marking the run as ended before being fully resolved, giving credits for Dirty Laundry while going through one of the piles to access.