### PR TITLE
Paperclip and GPI Net Tap fixes

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -395,16 +395,10 @@
                  :effect (effect (trash card {:cause :ability-cost}) (lose :tag 1))}]}
 
    "GPI Net Tap"
-   {:abilities [{:req (req (and (ice? current-ice) (not (rezzed? current-ice))))
+   {:implementation "Trash and jack out effect is manual"
+    :abilities [{:req (req (and (ice? current-ice) (not (rezzed? current-ice))))
                  :delayed-completion true
-                 :effect (req (when-completed (expose state side current-ice)
-                                              (continue-ability
-                                                state side
-                                                {:optional {:prompt "Trash GPI Net Tap to jack out?"
-                                                            :yes-ability {:msg "trash it and jack out"
-                                                                          :effect (effect (trash card {:unpreventable true})
-                                                                                          (jack-out nil))}}}
-                                                card nil)))}]}
+                 :effect (effect (expose eid current-ice))}]}
 
    "Grimoire"
    {:in-play [:memory 2]

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -724,11 +724,13 @@
                [{:label (str "X [Credits]: +X strength, break X subroutines")
                  :choices {:number (req (:credit runner))
                            :default (req (if current-ice
-                                           (- (:current-strength current-ice)
-                                              (:current-strength card))
+                                           (max (- (:current-strength current-ice)
+                                                   (:current-strength card))
+                                                1)
                                            1))}
                  :prompt "How many credits?"
-                 :effect (effect (pump card target))
+                 :effect (effect (lose :credit target)
+                                 (pump card target))
                  :msg (msg "spend " target " [Credits], increase strength by " target ", and break "
                            (quantify target "Barrier subroutine"))}])
 


### PR DESCRIPTION
When I switched Paperclip to a smarter prompt, I forgot to make it spend credits. Whoops.

Also removing the "Trash and jack out?" prompt from GPI Net Tap. The primary use for this card is in combination with on-expose effects, not as a jack out mechanism, so this change reduces the number of clicks for those interactions by not showing a prompt. The runner can trash the card and use the run UI to jack out by hand if that's what they want.