### PR TITLE
Reconstruction Contract should only get an advancement token for meat damage

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1169,7 +1169,7 @@
     :abilities [ability]})
 
    "Reconstruction Contract"
-   {:events {:damage {:req (req (pos? (nth targets 2)))
+   {:events {:damage {:req (req (and (pos? (nth targets 2)) (= :meat target)))
                       :effect (effect (add-counter card :advancement 1)
                                       (system-msg "adds 1 advancement token to Reconstruction Contract"))}}
     :abilities [{:label "[Trash]: Move advancement tokens to another card"

--- a/src/clj/test/cards/assets.clj
+++ b/src/clj/test/cards/assets.clj
@@ -1370,6 +1370,27 @@
       (take-credits state :runner)
       (is (= 13 (:credit (get-corp))) "Gained 2 credits because Runner is tagged"))))
 
+(deftest reconstruction-contract
+  ;; Reconstruction Contract - place advancement token when runner takes meat damage
+  (do-game
+    (new-game (default-corp [(qty "Reconstruction Contract" 1) (qty "Scorched Earth" 1) (qty "Pup" 1)])
+              (default-runner [(qty "Sure Gamble" 3) (qty "Imp" 3)]))
+    (core/gain state :runner :tag 1)
+    (core/gain state :corp :credit 5)
+    (starting-hand state :runner ["Sure Gamble" "Sure Gamble" "Sure Gamble" "Imp" "Imp"])
+    (play-from-hand state :corp "Reconstruction Contract" "New remote")
+    (let [rc (get-content state :remote1 0)]
+      (core/rez state :corp (refresh rc))
+      (play-from-hand state :corp "Scorched Earth")
+      (is (= 4 (count (:discard (get-runner)))))
+      (is (= 1 (:advance-counter (refresh rc))) "Reconstruction Contract has 1 advancement token")
+      (starting-hand state :runner ["Imp" "Imp"])
+      (play-from-hand state :corp "Pup" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (card-subroutine state :corp (get-ice state :hq 0) 0)
+      (is (= 5 (count (:discard (get-runner)))))
+      (is (= 1 (:advance-counter (refresh rc))) "Reconstruction Contract doesn't get advancement token for net damage"))))
+
 (deftest reversed-accounts
   ;; Reversed Accounts - Trash to make Runner lose 4 credits per advancement
   (do-game


### PR DESCRIPTION
Fixes #2981 