### PR TITLE
Add a test for Zamba

### DIFF
--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -936,3 +936,22 @@
     (take-credits state :corp)
     (is (not= (count (:hand (get-corp))) (core/hand-size state :corp)) "Corp hand below max")
     (is (= 1 (count (:hand (get-runner)))) "No card drawn")))
+
+(deftest zamba
+  ;; Zamba - Whenever corp card is exposed you may gain 1 credit
+  (do-game
+   (new-game (default-corp [(qty "Ice Wall" 1)])
+             (default-runner [(qty "Zamba" 1) (qty "Infiltration" 2)]))
+   (play-from-hand state :corp "Ice Wall" "Archives")
+   (take-credits state :corp)
+   (play-from-hand state :runner "Zamba")
+   (is (= 6 (:memory (get-runner))) "Gain 2 memory")
+   (is (= 1 (:credit (get-runner))) "At 1 credit")
+   (play-from-hand state :runner "Infiltration")
+   (prompt-choice :runner "Expose a card")
+   (prompt-select :runner (get-ice state :archives 0))
+   (is (= 2 (:credit (get-runner))) "Gained 1 credit from exposing")
+   (play-from-hand state :runner "Infiltration")
+   (prompt-choice :runner "Expose a card")
+   (prompt-select :runner (get-ice state :archives 0))
+   (is (= 3 (:credit (get-runner))) "Gained 1 more credit from exposing")))


### PR DESCRIPTION
Backfilled test for Zamba.  Seems like the credit gained could be made optional, but maybe it would slow down the pace of the game?