### PR TITLE
Fix Enhanced Login Protocol trash and reinstall from New Angeles Sol

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1163,24 +1163,26 @@
                    (move state :runner c :hand)))}
 
    "Service Outage"
-   (let [add-effect (fn [state side card]
-                      (update! state side (assoc card :so-activated true))
-                      (run-cost-bonus state side [:credit 1]))
-         remove-effect (fn [state side card]
-                         (run-cost-bonus state side [:credit -1])
-                         (update! state side (dissoc card :so-activated)))
-         remove-ability {:req (req (:so-activated card))
-                         :effect (effect (remove-effect card))}]
+   (letfn [(so-activated [state]
+             (get-in @state [:corp :register :so-activated] false))
+           (add-effect [state side]
+             (swap! state assoc-in [:corp :register :so-activated] true)
+             (run-cost-bonus state side [:credit 1]))
+           (remove-effect [state side]
+             (run-cost-bonus state side [:credit -1])
+             (swap! state update-in [:corp :register] dissoc :so-activated))]
      {:msg "add a cost of 1 [Credit] for the Runner to make the first run each turn"
       :effect (req (when (and (= :runner (:active-player @state))
                               (empty? (:made-run runner-reg)))
-                     (add-effect state side card)))
+                     (add-effect state side)))
       :events {:runner-turn-begins {:msg "add an additional cost of 1 [Credit] to make the first run this turn"
-                                    :effect (effect (add-effect card))}
-               :runner-turn-ends remove-ability
-               :run-ends remove-ability}
-      :leave-play (req (when (:so-activated card)
-                         (remove-effect state side card)))})
+                                    :effect (effect (add-effect))}
+               :runner-turn-ends {:req (req (so-activated state))
+                                  :effect (effect (remove-effect))}
+               :run-ends {:req (req (so-activated state))
+                          :effect (effect (remove-effect))}}
+      :leave-play (req (when (so-activated state)
+                         (remove-effect state side)))})
 
    "Shipment from Kaguya"
    {:choices {:max 2 :req can-be-advanced?}

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -10,7 +10,7 @@
   "Dissoc relevant keys in card"
   [card keep-counter]
   (let [c (dissoc card :current-strength :abilities :subroutines :runner-abilities :rezzed :special :new
-                  :added-virus-counter :subtype-target :sifr-used :sifr-target)
+                  :added-virus-counter :subtype-target :sifr-used :sifr-target :elp-activated)
         c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter :extra-advance-counter))]
     (if (and (= (:side c) "Runner") (not= (last (:zone c)) :facedown))
       (dissoc c :installed :facedown :counter :rec-counter :pump :server-target) c)))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -10,7 +10,7 @@
   "Dissoc relevant keys in card"
   [card keep-counter]
   (let [c (dissoc card :current-strength :abilities :subroutines :runner-abilities :rezzed :special :new
-                  :added-virus-counter :subtype-target :sifr-used :sifr-target :elp-activated)
+                  :added-virus-counter :subtype-target :sifr-used :sifr-target)
         c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter :extra-advance-counter))]
     (if (and (= (:side c) "Runner") (not= (last (:zone c)) :facedown))
       (dissoc c :installed :facedown :counter :rec-counter :pump :server-target) c)))

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -449,7 +449,7 @@
           "Runner spends 1 additional click to make a run"))))
 
 (deftest enhanced-login-protocol-new-angeles-sol
-  ;; Enahcned Login Protocol trashed and reinstalled on steal doesn't double remove penalty
+  ;; Enhanced Login Protocol trashed and reinstalled on steal doesn't double remove penalty
   (do-game
     (new-game
       (make-deck "New Angeles Sol: Your News" [(qty "Enhanced Login Protocol" 1) (qty "Breaking News" 1)])
@@ -1336,6 +1336,34 @@
     (run-on state :archives)
     (is (= 1 (:credit (get-runner)))
         "Runner doesn't spend 1 additional credit to make a run")))
+
+(deftest service-outage-new-angeles-sol
+  ;; Service Outage trashed and reinstalled on steal doesn't double remove penalty
+  (do-game
+    (new-game
+      (make-deck "New Angeles Sol: Your News" [(qty "Service Outage" 1)
+                                               (qty "Breaking News" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Breaking News" "New remote")
+    (play-from-hand state :corp "Service Outage")
+    (take-credits state :corp)
+
+    (run-on state :remote1)
+    (run-successful state)
+    (prompt-choice :runner "Steal")
+
+    (prompt-choice :corp "Yes")
+    (prompt-select :corp (find-card "Service Outage"
+                                    (:discard (get-corp))))
+
+    (take-credits state :runner)
+
+    (take-credits state :corp)
+
+    (is (= 7 (:credit (get-runner))) "Runner has 7 credits")
+    (run-on state :archives)
+    (is (= 6 (:credit (get-runner)))
+        "Runner spends 1 credit to make a run")))
 
 (deftest shipment-from-sansan
   ;; Shipment from SanSan - placing advancements

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -448,6 +448,27 @@
       (is (= 2 (:click (get-runner)))
           "Runner spends 1 additional click to make a run"))))
 
+(deftest enhanced-login-protocol-new-angeles-sol
+  ;; Enahcned Login Protocol trashed and reinstalled on steal doesn't double remove penalty
+  (do-game
+    (new-game
+      (make-deck "New Angeles Sol: Your News" [(qty "Enhanced Login Protocol" 1) (qty "Breaking News" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Breaking News" "New remote")
+    (play-from-hand state :corp "Enhanced Login Protocol")
+    (take-credits state :corp)
+
+    (run-on state :remote1)
+    (run-successful state)
+    (prompt-choice :runner "Steal")
+
+    (prompt-choice :corp "Yes")
+    (prompt-select :corp (find-card "Enhanced Login Protocol"
+                                    (:discard (get-corp))))
+
+    (run-on state :archives)
+    (is (= 1 (:click (get-runner))) "Runner has 1 click")))
+
 (deftest enhanced-login-protocol-run-events
   ;; Enhanced Login Protocol - Run event don't cost additional clicks
   (do-game


### PR DESCRIPTION
Fixes #2887 

Added a test case and verifies that this fixes the bug (and the spelling error caused by the bug). 

But, I don't understand why the original approach didn't work. It appears that the `remove-effect` function was called and `update!` removed the property, but when the card lands in `discard` the `elp-activated` property is back.