### PR TITLE
Fix #3011 : Allow multiple Respirocytes effects to be active

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -784,15 +784,17 @@
                                (when (= (get-in (get-card state card) [:counter :power]) 3)
                                  (system-msg state :runner "trashes Respirocytes as it reached 3 power counters")
                                  (trash state side card {:unpreventable true})))}]
-   {:effect (req (add-watch state :respirocytes
+   {:effect (req (let [watch-id (keyword "respirocytes" (str (:cid card)))]
+                   (update! state side (assoc card :respirocytes-watch-id watch-id))
+                   (add-watch state watch-id
                             (fn [k ref old new]
                               (when (and (seq (get-in old [:runner :hand]))
                                          (empty? (get-in new [:runner :hand])))
-                                (resolve-ability ref side ability card nil))))
+                                (resolve-ability ref side ability card nil)))))
                  (damage state side eid :meat 1 {:unboostable true :card card}))
     :msg "suffer 1 meat damage"
-    :trash-effect {:effect (req (remove-watch state :respirocytes))}
-    :leave-play (req (remove-watch state :respirocytes))
+    :trash-effect {:effect (req (remove-watch state (:respirocytes-watch-id card)))}
+    :leave-play (req (remove-watch state (:respirocytes-watch-id card)))
     :events {:runner-turn-begins {:req (req (empty? (get-in @state [:runner :hand])))
                                   :effect (effect (resolve-ability ability card nil))}
              :corp-turn-begins {:req (req (empty? (get-in @state [:runner :hand])))

--- a/src/clj/test/cards/hardware.clj
+++ b/src/clj/test/cards/hardware.clj
@@ -680,6 +680,18 @@
       (prompt-choice :runner "Yes")  ; 6 installed
       (is (count-spy 6) "6 Spy Cameras installed"))))
 
+(deftest respirocytes-multiple
+  ;; Should draw multiple cards when multiple respirocytes are in play
+  (do-game
+   (new-game (default-corp)
+             (default-runner [(qty "Respirocytes" 3) (qty "Sure Gamble" 3)]))
+   (take-credits state :corp)
+   (starting-hand state :runner ["Respirocytes" "Respirocytes" "Respirocytes" "Sure Gamble"])
+   (dotimes [_ 2]
+     (play-from-hand state :runner "Respirocytes"))
+   (is (= 2 (count (:discard (get-runner)))) "2 damage done")
+   (is (= 2 (count (:hand (get-runner)))) "Drew 2 cards")))
+
 (deftest sifr
   ;; Once per turn drop encountered ICE to zero strenght
   ;; Also handle archangel then re-install sifr should not break the game #2576


### PR DESCRIPTION
Fix for #3011.

I'm still super junior on Clojure, so I wasn't sure if I'm using `keyword` correctly here.  Essentially I'm trying to have multiple watches for each Respirocytes that is in play and associate the watch key with the card itself so that it can be unwatched when the card trashes or leaves play.