### PR TITLE
Wari

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -880,45 +880,48 @@
                    :effect (effect (gain :click 2))}]}
 
    "Wari"
-   {:events {:successful-run
-             {:interactive (req )
+   (letfn [(prompt-for-subtype []
+             {:prompt "Choose a subtype"
+              :choices ["Barrier" "Code Gate" "Sentry"]
               :delayed-completion true
-              :req (req (and (= target :hq)
-                             (first-successful-run-on-server? state :hq)
-                             (some #(and (ice? %)
-                                         (not (rezzed? %)))
-                                   (all-installed state :corp))))
-              :effect (effect
-                       (continue-ability
-                        {:prompt "Use Wari?"
-                         :choices ["Yes" "No"]
-                         :delayed-completion true
-                         :effect (effect 
-                                  (continue-ability
+              :effect (req
+                       (when-completed (trash state side card {:unpreventable true})
+                         (continue-ability
+                          state side
+                          (expose-and-maybe-bounce target)
+                          card nil)))})
+           
+           (expose-and-maybe-bounce [chosen-subtype]
+             {:choices {:req #(and (ice? %)
+                                   (not (rezzed? %)))}
+              :delayed-completion true
+              :msg (str "name " chosen-subtype)
+              :effect (req
+                       (when-completed (expose state side target)
+                         (do (if (and async-result
+                                      (has-subtype? target chosen-subtype))
+                               (do (move state :corp target :hand)
+                                   (system-msg state :runner
+                                               (str "add " (:title target) " to HQ"))))
+                             (effect-completed state side eid))))})]
+     {:events {:successful-run
+              {:interactive (req true)
+               :delayed-completion true
+               :req (req (and (= target :hq)
+                              (first-successful-run-on-server? state :hq)
+                              (some #(and (ice? %)
+                                          (not (rezzed? %)))
+                                    (all-installed state :corp))))
+               :effect (effect
+                        (continue-ability
+                         {:prompt "Use Wari?"
+                          :choices ["Yes" "No"]
+                          :delayed-completion true
+                          :effect (req
                                    (if (= target "Yes")
-                                     {:prompt "Choose a subtype"
-                                      :choices ["Barrier" "Code Gate" "Sentry"]
-                                      :delayed-completion true
-                                      :effect (effect
-                                               (trash card)
-                                               (continue-ability
-                                                (let [chosen-subtype target]
-                                                  {:choices {:req #(and (ice? %)
-                                                                        (not (rezzed? %)))}
-                                                   :delayed-completion true
-                                                   :msg (str "name " chosen-subtype)
-                                                   :effect (req
-                                                            (when-completed (expose state side target)
-                                                              (if (and async-result
-                                                                       (has-subtype? target chosen-subtype))
-                                                                (continue-ability
-                                                                   state :corp
-                                                                   (let [ice target]
-                                                                     {:effect (effect (move ice :hand))
-                                                                      :msg (str "add " (:title target) " to HQ")})
-                                                                   card nil)
-                                                                (effect-completed state side eid))))})
-                                                card nil))}
-                                     (effect-completed state side eid))
-                                   card nil))}
-                        card nil))}}}})
+                                     (continue-ability
+                                      state side
+                                      (prompt-for-subtype)
+                                      card nil)
+                                     (effect-completed state side eid)))}
+                         card nil))}}})})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -877,4 +877,48 @@
                    :counter-cost [:power 3]
                    :once :per-turn
                    :msg "gain [Click][Click]"
-                   :effect (effect (gain :click 2))}]}})
+                   :effect (effect (gain :click 2))}]}
+
+   "Wari"
+   {:events {:successful-run
+             {:interactive (req )
+              :delayed-completion true
+              :req (req (and (= target :hq)
+                             (first-successful-run-on-server? state :hq)
+                             (some #(and (ice? %)
+                                         (not (rezzed? %)))
+                                   (all-installed state :corp))))
+              :effect (effect
+                       (continue-ability
+                        {:prompt "Use Wari?"
+                         :choices ["Yes" "No"]
+                         :delayed-completion true
+                         :effect (effect 
+                                  (continue-ability
+                                   (if (= target "Yes")
+                                     {:prompt "Choose a subtype"
+                                      :choices ["Barrier" "Code Gate" "Sentry"]
+                                      :delayed-completion true
+                                      :effect (effect
+                                               (trash card)
+                                               (continue-ability
+                                                (let [chosen-subtype target]
+                                                  {:choices {:req #(and (ice? %)
+                                                                        (not (rezzed? %)))}
+                                                   :delayed-completion true
+                                                   :msg (str "name " chosen-subtype)
+                                                   :effect (req
+                                                            (when-completed (expose state side target)
+                                                              (if (and async-result
+                                                                       (has-subtype? target chosen-subtype))
+                                                                (continue-ability
+                                                                   state :corp
+                                                                   (let [ice target]
+                                                                     {:effect (effect (move ice :hand))
+                                                                      :msg (str "add " (:title target) " to HQ")})
+                                                                   card nil)
+                                                                (effect-completed state side eid))))})
+                                                card nil))}
+                                     (effect-completed state side eid))
+                                   card nil))}
+                        card nil))}}}})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -884,44 +884,36 @@
              {:prompt "Choose a subtype"
               :choices ["Barrier" "Code Gate" "Sentry"]
               :delayed-completion true
-              :effect (req
-                       (when-completed (trash state side card {:unpreventable true})
-                         (continue-ability
-                          state side
-                          (expose-and-maybe-bounce target)
-                          card nil)))})
+              :effect (req (when-completed (trash state side card {:unpreventable true})
+                             (continue-ability state side
+                                               (expose-and-maybe-bounce target)
+                                               card nil)))})
            
            (expose-and-maybe-bounce [chosen-subtype]
-             {:choices {:req #(and (ice? %)
-                                   (not (rezzed? %)))}
+             {:choices {:req #(and (ice? %) (not (rezzed? %)))}
               :delayed-completion true
               :msg (str "name " chosen-subtype)
-              :effect (req
-                       (when-completed (expose state side target)
-                         (do (if (and async-result
-                                      (has-subtype? target chosen-subtype))
-                               (do (move state :corp target :hand)
-                                   (system-msg state :runner
-                                               (str "add " (:title target) " to HQ"))))
-                             (effect-completed state side eid))))})]
+              :effect (req (when-completed (expose state side target)
+                             (do (if (and async-result
+                                          (has-subtype? target chosen-subtype))
+                                   (do (move state :corp target :hand)
+                                       (system-msg state :runner
+                                                   (str "add " (:title target) " to HQ"))))
+                                 (effect-completed state side eid))))})]
      {:events {:successful-run
               {:interactive (req true)
                :delayed-completion true
                :req (req (and (= target :hq)
                               (first-successful-run-on-server? state :hq)
-                              (some #(and (ice? %)
-                                          (not (rezzed? %)))
+                              (some #(and (ice? %) (not (rezzed? %)))
                                     (all-installed state :corp))))
-               :effect (effect
-                        (continue-ability
-                         {:prompt "Use Wari?"
-                          :choices ["Yes" "No"]
-                          :delayed-completion true
-                          :effect (req
-                                   (if (= target "Yes")
-                                     (continue-ability
-                                      state side
-                                      (prompt-for-subtype)
-                                      card nil)
-                                     (effect-completed state side eid)))}
-                         card nil))}}})})
+               :effect (effect (continue-ability
+                                {:prompt "Use Wari?"
+                                 :choices ["Yes" "No"]
+                                 :delayed-completion true
+                                 :effect (req (if (= target "Yes")
+                                                (continue-ability state side
+                                                                  (prompt-for-subtype)
+                                                                  card nil)
+                                                (effect-completed state side eid)))}
+                                card nil))}}})})

--- a/src/clj/test/cards/programs.clj
+++ b/src/clj/test/cards/programs.clj
@@ -844,3 +844,17 @@
       (card-ability state :runner upya 0)
       (is (= 0 (get-counters (refresh upya) :power)) "3 counters spent")
       (is (= 5 (:click (get-runner))) "Gained 2 clicks"))))
+
+(deftest wari
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 1)])
+              (default-runner [(qty "Wari" 1)]))
+    (play-from-hand state :corp "Ice Wall" "R&D")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Wari")
+    (run-empty-server state "HQ")
+    (prompt-choice :runner "Yes")
+    (prompt-choice :runner "Barrier")
+    (prompt-select :runner (get-ice state :rd 0))
+    (is (= 1 (count (:discard (get-runner)))) "Wari in heap")
+    (is (not (empty? (get-in @state [:runner :prompt]))) "Runner is currently accessing Ice Wall")))


### PR DESCRIPTION
Implemented Wari. (#3025) On the first successful HQ run each turn, if there are unrezzed ice, Wari prompts the user for whether they want to trigger Wari. If yes, Wari is trashed, the user is prompted for a subtype, and then to select a piece of ice to expose.

This got more intricate than I anticipated, so there's probably some abuse of the effect system going on here. Comments about how to simplify this are appreciated. :)