### PR TITLE
Down the White Nile: Implement Distract the Masses

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -332,11 +332,9 @@
                                              (in-hand? %))}
                         :msg (msg "trash " (quantify (count targets) "card") " from HQ")
                         :effect (req (when-completed
-                                       (trash-cards state side eid targets nil)
+                                       (trash-cards state side targets nil)
                                        (continue-ability state side shuffle-two card nil)))
-                        :cancel-effect (req (continue-ability state side shuffle-two card nil))
-      }]
-
+                        :cancel-effect (req (continue-ability state side shuffle-two card nil))}]
      {:delayed-completion true
       :msg "give The Runner 2 [Credits]"
       :effect (effect (gain :runner :credit 2)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -322,6 +322,26 @@
    {:events {:pre-damage {:req (req (= target :brain)) :msg "do 1 additional brain damage"
                           :once :per-turn :effect (effect (damage-bonus :brain 1))}}}
 
+   "Distract the Masses"
+   (let [shuffle-two {:delayed-completion true
+                      :effect (effect (rfg-and-shuffle-rd-effect (find-cid (:cid card) (:discard corp)) 2))}
+         trash-from-hq {:delayed-completion true
+                        :prompt "Select up to 2 cards in HQ to trash"
+                        :choices {:max 2
+                                  :req #(and (= (:side %) "Corp")
+                                             (in-hand? %))}
+                        :msg (msg "trash " (quantify (count targets) "card") " from HQ")
+                        :effect (req (when-completed
+                                       (trash-cards state side eid targets nil)
+                                       (continue-ability state side shuffle-two card nil)))
+                        :cancel-effect (req (continue-ability state side shuffle-two card nil))
+      }]
+
+     {:delayed-completion true
+      :msg "give The Runner 2 [Credits]"
+      :effect (effect (gain :runner :credit 2)
+                      (continue-ability trash-from-hq card nil))})
+
    "Diversified Portfolio"
    {:msg (msg "gain " (count (filter #(not (empty? %)) (map #(:content (second %)) (get-remotes @state))))
               " [Credits]")

--- a/src/clj/test/cards/operations.clj
+++ b/src/clj/test/cards/operations.clj
@@ -365,6 +365,30 @@
       (is (= 3 (count (:discard (get-runner)))) "2 cards lost to brain damage")
       (is (= 3 (:brain-damage (get-runner))) "Brainchips didn't do additional brain dmg"))))
 
+(deftest distract-the-masses
+  (do-game
+    (new-game (default-corp [(qty "Distract the Masses" 2) (qty "Hedge Fund" 3)])
+              (default-runner))
+    (starting-hand state :corp ["Hedge Fund" "Hedge Fund" "Hedge Fund" "Distract the Masses" "Distract the Masses"])
+    (play-from-hand state :corp "Distract the Masses")
+    (prompt-select :corp (first (:hand (get-corp))))
+    (prompt-select :corp (first (next (:hand (get-corp)))))
+    (prompt-select :corp (first (:discard (get-corp))))
+    (prompt-choice :corp "Done")
+    (is (= 1 (count (:discard (get-corp)))) "1 card still discarded")
+    (is (= 1 (count (:deck (get-corp)))) "1 card shuffled into R&D")
+    (is (= 1 (count (:rfg (get-corp)))) "Distract the Masses removed from game")
+    (is (= 7 (:credit (get-runner))) "Runner gained 2 credits")
+    (play-from-hand state :corp "Distract the Masses")
+    (prompt-select :corp (first (:hand (get-corp))))
+    (prompt-choice :corp "Done")
+    (prompt-select :corp (first (:discard (get-corp))))
+    (prompt-select :corp (first (next (:discard (get-corp)))))
+    (is (= 0 (count (:discard (get-corp)))) "No cards left in archives")
+    (is (= 3 (count (:deck (get-corp)))) "2 more cards shuffled into R&D")
+    (is (= 2 (count (:rfg (get-corp)))) "Distract the Masses removed from game")
+    (is (= 9 (:credit (get-runner))) "Runner gained 2 credits")))
+
 (deftest diversified-portfolio
   (do-game
     (new-game (default-corp [(qty "Diversified Portfolio" 1)


### PR DESCRIPTION
> _The Great Work was completed on a rainy Saturday afternoon._ 

This was a bit more challenging than I thought and took me a good couple of days of playing around with it.  Definitely helped really wrap my head around the code base, though, so I was glad it was challenging.  The biggest bit I got stuck on was trying to move DtM to `:rfg` from `:play-area`, but no matter what I did, it always seemed to have made its way to `:discard`.  I'm not sure if this is due to something completing too soon, or what, but I ended up having to work around it and grabbing it from Archives via `:cid`.  I noticed _Wake Up Call_ doing something similar, so I think it might be more an issue with delayed RFG operations.

I imagine there's potentially some optimisations to be made, let me know if I'm doing anything completely wrong!