### PR TITLE
Mind Game should not allow Corp to choose server Runner is running on

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1273,7 +1273,7 @@
    {:subroutines [(do-psi {:label "Redirect the run to another server"
                            :player :corp
                            :prompt "Choose a server"
-                           :choices (req servers)
+                           :choices (req (remove #{(-> @state :run :server central->name)} servers))
                            :msg (msg "redirect the run to " target)
                            :effect (req (let [dest (server->zone state target)]
                                           (swap! state update-in [:run]

--- a/src/clj/test/cards/ice.clj
+++ b/src/clj/test/cards/ice.clj
@@ -523,6 +523,23 @@
     (is (= 4 (:current-strength (get-ice state :hq 0))) "HQ Meru Mati at 4 strength")
 	(is (= 1 (:current-strength (get-ice state :rd 0))) "R&D at 0 strength")))
 
+(deftest mind-game
+  ;; Mind game - PSI redirect to different server
+  (do-game
+    (new-game (default-corp [(qty "Mind Game" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Mind Game" "HQ")
+    (take-credits state :corp)
+    (run-on state :hq)
+    (let [mindgame (get-ice state :hq 0)]
+      (core/rez state :corp mindgame)
+      (card-subroutine state :corp mindgame 0))
+    (prompt-choice :corp "1 [Credits]")
+    (prompt-choice :runner "0 [Credits]")
+    (is (= (set ["R&D" "Archives"]) (set (:choices (prompt-map :corp)))) "Corp cannot choose server Runner is on")
+    (prompt-choice :corp "Archives")
+    (is (= [:archives] (get-in @state [:run :server])) "Runner now running on Archives")))
+
 (deftest minelayer
   ;; Minelayer - Install a piece of ICE in outermost position of Minelayer's server at no cost
   (do-game


### PR DESCRIPTION
Fixes #3030

"_choose another server_" has been interpreted as the server the Runner is *not* currently on for other cards including _**AgInfusion**_, so it probably makes sense to be consistent with that.  

UFAQ on _AgInfusion_ actually uses differing language than the card: "... _the Corp uses AgInfusion to redirect the Runner to a different server_ ...", so I think "another server" should be interpreted as "different server".