### PR TITLE
Rework Jinja City Grid to use delayed completion...

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -369,16 +369,39 @@
                               :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinja City Grid"
-    {:events {:corp-draw {:req (req (is-type? (last (:hand corp)) "ICE"))
-                          :optional
-                          {:prompt (msg (str "Reveal " (:title (last (:hand corp)))
-                                             " and install in " (zone->name (second (:zone card)))
-                                             ", lowering the cost by 4 [Credits]?"))
-                           :player :corp
-                           :yes-ability {:msg (msg "reveal and install the ICE just drawn: " (:title (last (:hand corp))))
-                                         :effect (effect (corp-install (last (:hand corp))
-                                                                       (zone->name (second (:zone card)))
-                                                                       {:extra-cost [:credit -4]}))}}}}}
+   (letfn [(reveal-next [ices]
+             {:optional
+              {:delayed-completion true
+               :prompt (msg (str "Reveal " (:title (first ices))
+                                 " and install in " (zone->name (second (:zone card)))
+                                 ", lowering the cost by 4 [Credits]?"))
+               :player :corp
+               :yes-ability {:delayed-completion true
+                             :msg (msg "reveal and install the ICE just drawn: " (:title (first ices)))
+                             :effect (req (when-completed (corp-install state side
+                                                                        (first ices)
+                                                                        (zone->name (second (:zone card)))
+                                                                        {:extra-cost [:credit -4]})
+                                                          (if (< 1 (count ices))
+                                                            (continue-ability state side
+                                                                              (reveal-next (next ices))
+                                                                              card nil)
+                                                            (effect-completed state side eid))))}
+               :no-ability {:delayed-completion true
+                            :effect (req (if (< 1 (count ices))
+                                           (continue-ability state side
+                                                             (reveal-next (next ices))
+                                                             card nil)
+                                           (effect-completed state side eid)))}}})]
+     {:events {:corp-draw {:req (req (some #(is-type? % "ICE")
+                                           (:most-recent-drawn corp-reg)))
+                           :delayed-completion true
+                           :effect (req (let [ices (filter #(and (is-type? % "ICE")
+                                                                 (get-card state %))
+                                                           (:most-recent-drawn corp-reg))]
+                                          (if (not-empty ices)
+                                            (continue-ability state side (reveal-next ices) card nil)
+                                            (effect-completed state side eid))))}}})
 
    "Keegan Lane"
    {:abilities [{:label "[Trash], remove a tag: Trash a program"


### PR DESCRIPTION
Upgrades to @jwarwick's Jinja City Grid. Uses delayed completion and some recursion to allow multiple Grids to respond to the same draws. uses `:most-recent-drawn` to support bulk-draw effects, instead of looking only at the last card of the hand. If multiple copies are installed:

1. The "first" Grid (chosen by engine) shows a prompt to install the first drawn card. 
2. The first Grid then shows another prompt for the next drawn card, etc., until all drawn cards have been resolved with respect to the first Grid.
3. The second Grid then acts, but only on cards that were rejected by the first Grid (if any), recursively until all cards have been resolved with respect to the second Grid.
4. If there are still ice that have not been installed, the third Grid triggers.

Gif: 

https://imgur.com/a/0dSNq