### PR TITLE
Refactor and improve central-server access

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -401,8 +401,9 @@
                                                                     (if (-> @state :run :shuffled-during-access zone)
                                                                       ;; if the zone was shuffled because of the access,
                                                                       ;; the runner "starts over" excepting any upgrades that were accessed
-                                                                      (set (filter #(= :servers (first (:zone %)))
-                                                                                   already-accessed))
+                                                                      (do (swap! state update-in [:run :shuffled-during-access] dissoc zone)
+                                                                          (set (filter #(= :servers (first (:zone %)))
+                                                                                       already-accessed)))
                                                                       (conj already-accessed accessed)))
                                             card nil)
                                           (effect-completed state side eid)))))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -398,7 +398,12 @@
                                           (continue-ability
                                             state side
                                             (access-helper-hq-or-rd state zone label (dec amount) select-fn title-fn
-                                                                    (conj already-accessed accessed))
+                                                                    (if (-> @state :run :shuffled-during-access zone)
+                                                                      ;; if the zone was shuffled because of the access,
+                                                                      ;; the runner "starts over" excepting any upgrades that were accessed
+                                                                      (set (filter #(= :servers (first (:zone %)))
+                                                                                   already-accessed))
+                                                                      (conj already-accessed accessed)))
                                             card nil)
                                           (effect-completed state side eid)))))
                     ;; accessing a rezzed upgrade

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -336,15 +336,29 @@
                   (handle-access state side eid cards)
                   (continue-ability state side (access-helper-remote cards) card nil)))})
 
-(defn access-helper-hq [state from-hq already-accessed]
-  (letfn [(get-root-content [state]
-            (filter #(not (contains? already-accessed %)) (get-in @state [:corp :servers :hq :content])))]
+(defn access-helper-hq-or-rd [state zone label amount select-fn title-fn already-accessed]
+  "Shows a prompt to access card(s) from the given zone.
+  zone: :rd or :hq, for finding Upgrades to access.
+  label: a string label to describe what is being accessed, e.g., 'Card from deck' -- 'deck' being the label.
+  amount: how many accesses the runner has remaining.
+  select-fn: a function taking the already-accessed set as argument, and returning the next card to access
+      from the given zone.
+  title-fn: a function taking a card map being accessed and returning a string to print as the card's title, e.g.,
+      'an unseen card from R&D' for an R&D run.
+  already-accessed: a set of cards already accessed from this zone or its root."
+
+  (let [get-root-content (fn [state]
+                           (filter #(not (contains? already-accessed %)) (get-in @state [:corp :servers zone :content])))
+        server-name (central->name zone)
+        unrezzed-upgrade (str "Unrezzed upgrade in " server-name)
+        card-from (str "Card from " label)]
     {:delayed-completion true
      :prompt "Select a card to access."
-     :choices (concat (when (pos? from-hq) ["Card from hand"])
-                      (map #(if (rezzed? %) (:title %) "Unrezzed upgrade in HQ") (get-root-content state)))
-     :effect (req (case target
-                    "Unrezzed upgrade in HQ"
+     :choices (concat (when (pos? amount) [card-from])
+                      (map #(if (rezzed? %) (:title %) unrezzed-upgrade)
+                           (get-root-content state)))
+     :effect (req (cond
+                    (= target unrezzed-upgrade)
                     ;; accessing an unrezzed upgrade
                     (let [from-root (get-root-content state)
                           unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %)))
@@ -352,47 +366,68 @@
                       (if (= 1 (count unrezzed))
                         ;; only one unrezzed upgrade; access it and continue
                         (when-completed (handle-access state side unrezzed)
-                                        (if (or (pos? from-hq) (< 1 (count from-root)))
+                                        (if (or (pos? amount) (< 1 (count from-root)))
                                           (continue-ability
                                             state side
-                                            (access-helper-hq state from-hq (conj already-accessed (first unrezzed)))
+                                            (access-helper-hq-or-rd state zone label amount select-fn title-fn
+                                                                    (conj already-accessed (first unrezzed)))
                                             card nil)
                                           (effect-completed state side eid)))
-                        ;; more than one unrezzed upgrade. allow user to select.
+                        ;; more than one unrezzed upgrade. allow user to select with mouse.
                         (continue-ability
                           state side
                           {:delayed-completion true
-                           :prompt "Choose an upgrade in HQ to access."
-                           :choices {:req #(and (= (second (:zone %)) :hq)
-                                                (not (contains? already-accessed %)))}
+                           :prompt (str "Choose an upgrade in " server-name " to access.")
+                           :choices {:req #(and (= (second (:zone %)) zone)
+                                                (complement already-accessed))}
                            :effect (req (when-completed (handle-access state side [target])
                                                         (continue-ability
                                                           state side
-                                                          (access-helper-hq state from-hq (conj already-accessed target))
+                                                          (access-helper-hq-or-rd state zone label amount select-fn title-fn
+                                                                                  (conj already-accessed target))
                                                           card nil)))}
                           card nil)))
-                    ;; accessing a card in hand
-                    "Card from hand"
-                    (if-let [accessed (some #(when-not (contains? already-accessed %) %)
-                                            (shuffle (get-in @state [:corp :hand])))]
-                      (when-completed (handle-access state side [accessed])
+                    ;; accessing a card in deck
+                    (= target card-from)
+                    (let [accessed (select-fn already-accessed)]
+                      (when-completed (handle-access state side (make-eid state) [accessed]
+                                                     (title-fn accessed))
+
                                       (let [from-root (get-root-content state)]
-                                        (if (or (< 1 from-hq) (not-empty from-root))
+                                        (if (or (< 1 amount) (not-empty from-root))
                                           (continue-ability
                                             state side
-                                            (access-helper-hq state (dec from-hq) (conj already-accessed accessed))
+                                            (access-helper-hq-or-rd state zone label (dec amount) select-fn title-fn
+                                                                    (conj already-accessed accessed))
                                             card nil)
-                                          (effect-completed state side eid))))
-                      (effect-completed state side eid nil))
+                                          (effect-completed state side eid)))))
                     ;; accessing a rezzed upgrade
+                    :else
                     (let [accessed (some #(when (= (:title %) target) %) (get-root-content state))]
                       (when-completed (handle-access state side [accessed])
-                                      (if (or (pos? from-hq) (< 1 (count (get-root-content state))))
+                                      (if (or (pos? amount) (< 1 (count (get-root-content state))))
                                         (continue-ability
                                           state side
-                                          (access-helper-hq state from-hq (conj already-accessed accessed))
+                                          (access-helper-hq-or-rd state zone label amount select-fn title-fn
+                                                                  (conj already-accessed accessed))
                                           card nil)
-                                        (effect-completed state side eid nil))))))}))
+                                        (effect-completed state side eid))))))}))
+
+(defmethod choose-access :rd [cards server]
+  {:delayed-completion true
+   :effect (req (if (pos? (count cards))
+                  (if (= 1 (count cards))
+                    (handle-access state side eid cards "an unseen card from R&D")
+                    (let [from-rd (access-count state side :rd-access)]
+                      (continue-ability state side (access-helper-hq-or-rd
+                                                     state :rd "deck" from-rd
+                                                     ;; access the first card in deck that has not been accessed.
+                                                     (fn [already-accessed] (first (drop-while already-accessed
+                                                                                               (-> @state :corp :deck))))
+                                                     (fn [_] "an unseen card from R&D")
+                                                     #{})
+                                        card nil)))
+                  (effect-completed state side eid)))})
 
 (defmethod choose-access :hq [cards server]
   {:delayed-completion true
@@ -402,74 +437,24 @@
                     (let [from-hq (access-count state side :hq-access)
                           ; Handle root only access - no cards to access in hand
                           from-hq (if (some #(= '[:hand] (:zone %)) cards) from-hq 0)]
-                      (continue-ability state side (access-helper-hq state from-hq #{}) card nil)))
+                      (continue-ability state side (access-helper-hq-or-rd
+                                                     state :hq "hand" from-hq
+                                                     (fn [already-accessed] (some #(when-not (already-accessed %) %)
+                                                                                  (shuffle (-> @state :corp :hand))))
+                                                     (fn [card] (:title card))
+                                                     #{})
+                                        card nil)))
                   (effect-completed state side eid)))})
 
-(defn access-helper-rd [state from-rd already-accessed]
-  (letfn [(get-root-content [state]
-            (filter #(not (contains? already-accessed %)) (get-in @state [:corp :servers :rd :content])))]
-    {:delayed-completion true
-     :prompt "Select a card to access."
-     :choices (concat (when (not-empty from-rd) ["Card from deck"])
-                      (map #(if (rezzed? %) (:title %) "Unrezzed upgrade in R&D")
-                           (get-root-content state)))
-     :effect (req (case target
-                    "Unrezzed upgrade in R&D"
-                    ;; accessing an unrezzed upgrade
-                    (let [from-root (get-root-content state)
-                          unrezzed (filter #(and (= (last (:zone %)) :content) (not (:rezzed %)))
-                                           from-root)]
-                      (if (= 1 (count unrezzed))
-                        ;; only one unrezzed upgrade; access it and continue
-                        (when-completed (handle-access state side unrezzed)
-                                        (if (or (not-empty from-rd) (< 1 (count from-root)))
-                                          (continue-ability
-                                            state side
-                                            (access-helper-rd state from-rd (conj already-accessed (first unrezzed)))
-                                            card nil)
-                                          (effect-completed state side eid)))
-                        ;; more than one unrezzed upgrade. allow user to select with mouse.
-                        (continue-ability
-                          state side
-                          {:delayed-completion true
-                           :prompt "Choose an upgrade in R&D to access."
-                           :choices {:req #(and (= (second (:zone %)) :rd)
-                                                (not (contains? already-accessed %)))}
-                           :effect (req (when-completed (handle-access state side [target])
-                                                        (continue-ability
-                                                          state side
-                                                          (access-helper-rd state from-rd (conj already-accessed target))
-                                                          card nil)))}
-                          card nil)))
-                    ;; accessing a card in deck
-                    "Card from deck"
-                    (let [accessed (first from-rd)]
-                      (when-completed (handle-access state side (make-eid state) [accessed] "an unseen card")
-                                      (let [from-root (get-root-content state)]
-                                        (if (or (< 1 (count from-rd)) (not-empty from-root))
-                                          (continue-ability
-                                            state side
-                                            (access-helper-rd state (next from-rd) (conj already-accessed accessed))
-                                            card nil)
-                                          (effect-completed state side eid)))))
-                    ;; accessing a rezzed upgrade
-                    (let [accessed (some #(when (= (:title %) target) %) (get-root-content state))]
-                      (when-completed (handle-access state side [accessed])
-                                      (if (or (not-empty from-rd) (< 1 (count (get-root-content state))))
-                                        (continue-ability
-                                          state side
-                                          (access-helper-rd state from-rd (conj already-accessed accessed))
-                                          card nil)
-                                        (effect-completed state side eid))))))}))
 
-(defmethod choose-access :rd [cards server]
-  {:delayed-completion true
-   :effect (req (if (pos? (count cards))
-                  (if (= 1 (count cards))
-                    (handle-access state side eid cards "an unseen card")
-                    (let [from-rd (take (access-count state side :rd-access) (-> @state :corp :deck))]
-                      (continue-ability state side (access-helper-rd state from-rd #{}) card nil)))
-                  (effect-completed state side eid)))})
+(defn access-helper-hq [state from-hq already-accessed]
+  "This is a helper for cards to invoke HQ access without knowing how to use the full access method. See Dedicated Neural Net."
+  (access-helper-hq-or-rd state :hq "hand" from-hq
+                          (fn [already-accessed] (some #(when-not (already-accessed %) %)
+                                                       (shuffle (-> @state :corp :hand))))
+                          (fn [card] (:title card))
+                          already-accessed))
+
 
 (defn- get-archives-accessible [state]
   ;; only include agendas and cards with an :access ability whose :req is true

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -516,7 +516,6 @@
                     ;; accessing a card that was added to archives because of the effect of another card
                     (let [accessed (first (shuffle (facedown-cards already-accessed)))
                           already-accessed (conj already-accessed accessed)]
-                      (update! state :corp (assoc accessed :seen true))
                       (when-completed (handle-access state side [accessed])
                                       (if (must-continue? already-accessed)
                                         (next-access state side eid already-accessed card)

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -440,7 +440,8 @@
    :effect (req (if (pos? (count cards))
                   (if (and (= 1 (count cards)) (not (any-flag-fn? state :runner :slow-hq-access true)))
                     (handle-access state side eid cards)
-                    (let [from-hq (access-count state side :hq-access)
+                    (let [from-hq (min (access-count state side :hq-access)
+                                       (-> @state :corp :hand count))
                           ; Handle root only access - no cards to access in hand
                           from-hq (if (some #(= '[:hand] (:zone %)) cards) from-hq 0)]
                       (continue-ability state side (access-helper-hq-or-rd


### PR DESCRIPTION
Updates central-server access in light of Bacterial Programming.

Refactors HQ and R&D access into a single method.

Allows an R&D run to be "started over" if a card triggers a shuffle/reordering during access, like Bacterial Programming, by setting a key in `[:run :shuffled-during-access :rd]` to `true`.

Fixes HQ runs with cards entering HQ during access (Leela, BactProg): the number of cards to access is capped by the number of cards in HQ when access begins, so a Legwork as Leela into a 2-card HQ will not access a third card bounced by Leela.

Handles Bacteria Programming's Archives interaction. If facedown cards enter Archives in the middle of an access routine, the runner can choose to access one of those cards at random. Each card accessed thus results in one fewer card accessed among the faceup cards. If at any point the runner has fewer accesses remaining than there are "uninteresting" cards in Archives (things with no access interaction), they can "access X inactive cards" to complete the access phase without interacting with at least 1 "interesting" card.