### PR TITLE
Fix #3039 Aumakua / Neutralize All Threats interaction

### DIFF
--- a/src/clj/test/cards/icebreakers.clj
+++ b/src/clj/test/cards/icebreakers.clj
@@ -31,6 +31,35 @@
       (is (= 2 (get-counters atman :power)) "2 power counters")
       (is (= 2 (:current-strength atman)) "2 current strength"))))
 
+(deftest aumakua
+  ;; Aumakua - Gain credit on no-trash
+  (do-game
+    (new-game (default-corp [(qty "PAD Campaign" 3)])
+              (default-runner [(qty "Aumakua" 1)]))
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Aumakua")
+    (run-empty-server state "Server 1")
+    (prompt-choice :runner "No")
+    (is (= 1 (get-counters (get-program state 0) :virus)) "Aumakua gains virus counter from no-trash")
+    (core/gain state :runner :credit 5)
+    (run-empty-server state "Server 1")
+    (prompt-choice :runner "Yes")
+    (is (= 1 (get-counters (get-program state 0) :virus)) "Aumakua does not gain virus counter from trash")))
+
+(deftest aumakua-neutralize-all-threats
+  ;; Aumakua - Neutralize All Threats interaction
+  (do-game
+    (new-game (default-corp [(qty "PAD Campaign" 3)])
+              (default-runner [(qty "Aumakua" 1) (qty "Neutralize All Threats" 1)]))
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Aumakua")
+    (play-from-hand state :runner "Neutralize All Threats")
+    (core/gain state :runner :credit 5)
+    (run-empty-server state "Server 1")
+    (is (zero? (get-counters (get-program state 0) :virus)) "Aumakua does not gain virus counter from ABT-forced trash")))
+
 (deftest baba-yaga
   (do-game
     (new-game


### PR DESCRIPTION
Sorry to @butzopower -- didn't realize you had a WIP on this, I tackled it in response to a dev server message. The reason your solution wasn't working is that `(trash state side eid card nil)` passes the `eid` of the "access" interaction to `trash`, and once that action is complete, the access step is marked complete... and once the access step is marked complete (for a single-access run), the run is terminated and `:run-ends` is fired. All that happens before you swap `:did-trash` into the state, so Aumakua doesn't see it.