### PR TITLE
Don't announce when the Runner decides to not pay to steal an agenda in R&D

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -167,9 +167,10 @@
              (if (= target "Don't steal")
                (continue-ability state :runner
                                  {:delayed-completion true
-                                  :effect (effect (system-msg (str "decides not to pay to steal " (:title card)))
-                                                  (trigger-event :no-steal card)
-                                                  (resolve-steal-events eid card))} card nil)
+                                  :effect (req (when-not (find-cid (:cid card) (:deck corp))
+                                                    (system-msg state side (str "decides not to pay to steal " (:title card))))
+                                                  (trigger-event state side :no-steal card)
+                                                  (resolve-steal-events state side eid card))} card nil)
                (let [name (:title card)
                      chosen (cons target chosen)
                      clicks (count (re-seq #"\[Click\]+" target))

--- a/src/clj/test/cards/agendas.clj
+++ b/src/clj/test/cards/agendas.clj
@@ -420,6 +420,20 @@
       (is (= 12 (:credit (get-corp))) "Gain 7 credits")
       (is (= 1 (:bad-publicity (get-corp))) "Take 1 bad publicity"))))
 
+(deftest ikawah-project-not-stealing
+  ;; Ikawah Project - do not reveal when the Runner does not steal from R&D
+  (do-game
+    (new-game (default-corp [(qty "Ikawah Project" 2)])
+              (default-runner))
+    (take-credits state :corp)
+    (starting-hand state :corp ["Ikawah Project"])
+    (run-empty-server state "R&D")
+    (prompt-choice :runner "Don't steal")
+    (is (not (last-log-contains? state "not to pay to steal Ikawah Project")) "Ikawah Project should not be mentioned")
+    (run-empty-server state "HQ")
+    (prompt-choice :runner "Don't steal")
+    (is (last-log-contains? state "not to pay to steal Ikawah Project") "Ikawah Project should be mentioned")))
+
 (deftest labyrinthine-servers
   ;; Labyrinthine Servers - Prevent the Runner from jacking out as long as there is still a power counter
   (do-game


### PR DESCRIPTION
Noticed this happened with Ikawah Project when I couldn't steal from R&D and the Corp got a notification about it.  I think it was only happening in the case where there was more than one cost, otherwise the Runner had a Yes/No prompt that wouldn't announce if they chose No.