### PR TITLE
Automate Kit's ability

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -784,16 +784,16 @@
     {:encounter-ice {:once :per-turn
                      :effect (req (let [stypes (:subtype target)]
                                     (update! state :runner (-> card
-                                                               (assoc :kit-target target)
-                                                               (assoc :kit-target-stypes stypes)))
+                                                               (assoc-in [:special :kit-target] target)
+                                                               (assoc-in [:special :kit-target-stypes] stypes)))
                                     (update! state side (assoc target :subtype (combine-subtypes true stypes "Code Gate")))
                                     (trigger-event state side :ice-subtype-changed target)
                                     (system-msg state :runner (str "uses Rielle \"Kit\" Peddler: Transhuman to make "
                                                                    (:title target)
                                                                    " gain Code Gate until the end of the run"))))}
-     :run-ends {:effect (req (let [kit-target (:kit-target card)]
+     :run-ends {:effect (req (let [kit-target (get-in card [:special :kit-target])]
                                (when kit-target
-                                 (update! state side (assoc (get-card state kit-target) :subtype (:kit-target-stypes card)))
+                                 (update! state side (assoc (get-card state kit-target) :subtype (get-in card [:special :kit-target-stypes])))
                                  (trigger-event state side :ice-subtype-changed (get-card state kit-target))
                                  (update! state :runner (-> card
                                                             (dissoc :kit-target)

--- a/src/clj/test/cards/identities.clj
+++ b/src/clj/test/cards/identities.clj
@@ -1182,19 +1182,35 @@
       (is (= 5 (:credit (get-corp))) "Rez cost increased by 1"))))
 
 (deftest rielle-kit-peddler-ability
-  ;; Rielle "Kit" Peddler - Give ICE Code Gate
+  ;; Rielle "Kit" Peddler - Give first encountered ICE Code Gate
   (do-game
     (new-game (default-corp [(qty "Ice Wall" 2)])
               (make-deck "Rielle \"Kit\" Peddler: Transhuman" [(qty "Sure Gamble" 3)]))
     (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Ice Wall" "R&D")
     (take-credits state :corp)
-    (run-on state "HQ")
-    (let [k (get-in @state [:runner :identity])
-          iwall (get-ice state :hq 0)]
+    (let [iwall (get-ice state :hq 0)]
       (core/rez state :corp iwall)
-      (card-ability state :runner k 0)
+      (run-on state "HQ")
+      (run-continue state)
       (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
-      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has Code Gate"))))
+      (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has Code Gate")
+      (run-jack-out state)
+      (run-on state "HQ")
+      (run-continue state)
+      (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
+      (is (not (core/has-subtype? (refresh iwall) "Code Gate")) "Ice Wall does not have Code Gate on second run"))
+    (let [iwall (get-ice state :rd 0)]
+      (core/rez state :corp iwall)
+      (run-on state "R&D")
+      (is (not (core/has-subtype? (refresh iwall) "Code Gate")) "Ice Wall on other server does not have Code Gate"))
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (let [iwall (get-ice state :hq 0)]
+      (core/rez state :corp iwall)
+      (run-on state "HQ")
+      (run-continue state)
+      (is (core/has-subtype? (refresh iwall) "Code Gate") "New Turn: Ice Wall has Code Gate again"))))
 
 (deftest skorpios
   ; Remove a card from game when it moves to discard once per round


### PR DESCRIPTION
Noticed that Kit's ability was manually triggered and maybe not super obvious that it wasn't automatically taking effect.  I tried moving over what the old ability did just to events, but it didn't work correctly, so I reimplemented it a bit.  Making sure to grab the latest version of the card when reapplying its old subtypes so that additonal effects from things like Peregine still persist.