### PR TITLE
Improve Jinja City Grid *again*

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -369,39 +369,54 @@
                               :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Jinja City Grid"
-   (letfn [(reveal-next [ices]
-             {:optional
-              {:delayed-completion true
-               :prompt (msg (str "Reveal " (:title (first ices))
-                                 " and install in " (zone->name (second (:zone card)))
-                                 ", lowering the cost by 4 [Credits]?"))
-               :player :corp
-               :yes-ability {:delayed-completion true
-                             :msg (msg "reveal and install the ICE just drawn: " (:title (first ices)))
-                             :effect (req (when-completed (corp-install state side
-                                                                        (first ices)
-                                                                        (zone->name (second (:zone card)))
-                                                                        {:extra-cost [:credit -4]})
-                                                          (if (< 1 (count ices))
-                                                            (continue-ability state side
-                                                                              (reveal-next (next ices))
-                                                                              card nil)
-                                                            (effect-completed state side eid))))}
-               :no-ability {:delayed-completion true
-                            :effect (req (if (< 1 (count ices))
-                                           (continue-ability state side
-                                                             (reveal-next (next ices))
-                                                             card nil)
-                                           (effect-completed state side eid)))}}})]
+   (letfn [(install-ice [ice ices grids server]
+             (let [remaining (remove-once #(not= (:cid %) (:cid ice)) ices)]
+             {:delayed-completion true
+              :effect (req (if (= "None" server)
+                             (continue-ability state side (choose-ice remaining grids) card nil)
+                             (do (system-msg state side (str "reveals that they drew " (:title ice)))
+                                 (when-completed (corp-install state side ice server {:extra-cost [:credit -4]})
+                                                 (if (= 1 (count ices))
+                                                   (effect-completed state side eid)
+                                                   (continue-ability state side (choose-ice remaining grids)
+                                                                     card nil))))))}))
+
+           (choose-grid [ice ices grids]
+             (if (= 1 (count grids))
+               (install-ice ice ices grids (-> (first grids) :zone second zone->name))
+               {:delayed-completion true
+                :prompt (str "Choose a server to install " (:title ice))
+                :choices (conj (mapv #(-> % :zone second zone->name) grids) "None")
+                :effect (effect (continue-ability (install-ice ice ices grids target) card nil))}))
+
+           (choose-ice [ices grids]
+             (if (empty? ices)
+               nil
+               {:delayed-completion true
+                :prompt "Choose an ice to reveal and install, or None to decline"
+                :choices (conj (mapv :title ices) "None")
+                :effect (req (if (= "None" target)
+                               (effect-completed state side eid)
+                               (continue-ability state side
+                                                 (choose-grid (some #(when (= target (:title %)) %) ices)
+                                                              ices grids)
+                                                 card nil)))}))]
+
      {:events {:corp-draw {:req (req (some #(is-type? % "ICE")
                                            (:most-recent-drawn corp-reg)))
+                           ;; THIS IS A HACK: it prevents multiple Jinja from showing the "choose a server to install into" sequence
+                           :once :per-turn
+                           :once-key :jinja-city-grid-draw
                            :delayed-completion true
                            :effect (req (let [ices (filter #(and (is-type? % "ICE")
                                                                  (get-card state %))
-                                                           (:most-recent-drawn corp-reg))]
+                                                           (:most-recent-drawn corp-reg))
+                                              grids (filterv #(and (:rezzed %) (= "Jinja City Grid" (:title %)))
+                                                             (all-installed state :corp))]
                                           (if (not-empty ices)
-                                            (continue-ability state side (reveal-next ices) card nil)
-                                            (effect-completed state side eid))))}}})
+                                            (continue-ability state side (choose-ice ices grids) card nil)
+                                            (effect-completed state side eid))))}
+               :post-corp-draw {:effect (req (swap! state dissoc-in [:per-turn :jinja-city-grid-draw]))}}})
 
    "Keegan Lane"
    {:abilities [{:label "[Trash], remove a tag: Trash a program"

--- a/src/clj/test/cards/upgrades.clj
+++ b/src/clj/test/cards/upgrades.clj
@@ -554,11 +554,11 @@
     (core/rez state :corp (get-content state :remote1 0))
     (dotimes [n 5]
       (core/click-draw state :corp 1)
-      (prompt-choice :corp "Yes")
+      (prompt-choice :corp (-> (get-corp) :prompt first :choices first))
       (is (= 4 (:credit (get-corp))) "Not charged to install ice")
       (is (= (inc n) (count (get-in @state [:corp :servers :remote1 :ices]))) (str n " ICE protecting Remote1")))
     (core/click-draw state :corp 1)
-    (prompt-choice :corp "Yes")
+    (prompt-choice :corp (-> (get-corp) :prompt first :choices first))
     (is (= 3 (:credit (get-corp))) "Charged to install ice")
     (is (= 6 (count (get-in @state [:corp :servers :remote1 :ices]))) "6 ICE protecting Remote1")))
 


### PR DESCRIPTION
So ice can be installed in any order for multi-draw effects.

On draw:

1. Show a prompt to select an ice that was drawn, or None to skip the effect.
2. Given an ice, if there are multiple Jinja City Grids rezzed, show a prompt to select a server and go to step 3, or none to cancel installing this ice. If a single Grid is rezzed, go to step 3.
3. Given an ice and a server, install the ice in the server. If more ice are left to deal with, go to step 1. Otherwise, end.

Whew.