### PR TITLE
Deck validation fixes

### DIFF
--- a/src/cljc/jinteki/decks.cljc
+++ b/src/cljc/jinteki/decks.cljc
@@ -313,8 +313,8 @@
      :mwl           mwl
      :rotation      rotation
      :status        status
-     :onesies       (:legal onesies)
-     :cache-refresh (:legal cache-refresh)}))
+     :onesies       onesies
+     :cache-refresh cache-refresh}))
 
 (defn trusted-deck-status [{:keys [status name cards] :as deck}]
   (or status (check-deck-status deck)))

--- a/src/cljc/jinteki/decks.cljc
+++ b/src/cljc/jinteki/decks.cljc
@@ -316,5 +316,12 @@
      :onesies       onesies
      :cache-refresh cache-refresh}))
 
-(defn trusted-deck-status [{:keys [status name cards] :as deck}]
-  (or status (check-deck-status deck)))
+(defn trusted-deck-status [{:keys [status name cards date] :as deck}]
+  (let [parse-date #?(:clj  #(f/parse (f/formatters :date) %)
+                      :cljs #(js/Date.parse %))
+        deck-date (parse-date date)
+        mwl-date (:date_start @cards/mwl)]
+    (if (and status
+             (> deck-date mwl-date))
+      status
+      (check-deck-status deck))))

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -433,8 +433,11 @@
      [:div {:class (if (:legal onesies) "legal" "invalid") :title (if onesies-details? (:reason onesies))}
       [:span.tick (if (:legal onesies) "✔" "✘") ] "1.1.1.1 format compliant"]]))
 
-(defn deck-status-span-impl [sets deck tooltip? onesies-details?]
-   (let [{:keys [valid mwl rotation cache-refresh onesies status]} (decks/trusted-deck-status deck)
+(defn deck-status-span-impl [sets deck tooltip? onesies-details? use-trusted-info]
+   (let [{:keys [valid mwl rotation cache-refresh onesies status]}
+         (if use-trusted-info
+           (decks/trusted-deck-status deck)
+           (decks/check-deck-status deck))
          message (case status
                    "legal" "Tournament legal"
                    "casual" "Casual play only"
@@ -447,10 +450,9 @@
 
 (defn deck-status-span
   "Returns a [:span] with standardized message and colors depending on the deck validity."
-  ([sets deck] (deck-status-span sets deck false))
-  ([sets deck tooltip?] (deck-status-span sets deck tooltip? false))
-  ([sets deck tooltip? onesies-details?]
-   (deck-status-span-memoize sets deck tooltip? onesies-details?)))
+  ([sets deck] (deck-status-span sets deck false false true))
+  ([sets deck tooltip? onesies-details? use-trusted-info]
+   (deck-status-span-memoize sets deck tooltip? onesies-details? use-trusted-info)))
 
 (defn match [identity query]
   (->> @all-cards
@@ -701,7 +703,7 @@
                         [:span.invalid " (minimum " min-point ")"])
                       (when (> points (inc min-point))
                         [:span.invalid " (maximum " (inc min-point) ")"])]))
-                 [:div (deck-status-span sets deck true true)]]
+                 [:div (deck-status-span sets deck true true false)]]
                 [:div.cards
                  (for [group (sort-by first (group-by #(get-in % [:card :type]) cards))]
                    [:div.group

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -457,7 +457,7 @@
                              name
                              "Deck selected")]])
                        (when-let [deck (:deck player)]
-                         [:div.float-right (deck-status-span sets deck true false)])
+                         [:div.float-right (deck-status-span sets deck true false true)])
                        (when (= (:user player) user)
                          [:span.fake-link.deck-load
                           {:data-target "#deck-select" :data-toggle "modal"


### PR DESCRIPTION
Updated format of deck status as stored in db.
Only use cached deck status when not editing deck.

Fixes #3111 