### PR TITLE
Fix Leave No Trace derezzing pre-rezzed modified ICE

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -948,24 +948,27 @@
                  (game.core/run state side (make-eid state) target nil card))}
 
    "Leave No Trace"
-   {:prompt "Choose a server"
-    :msg "make a run and derez any ICE that are rezzed during this run"
-    :choices (req runnable-servers)
-    :delayed-completion true
-    :effect (req
-              (let [old-ice (filter #(and (rezzed? %) (is-type? % "ICE")) (all-installed state :corp))]
-                (swap! state assoc :lnt old-ice)
-                (register-events state side (:events (card-def card)) (assoc card :zone '(:discard)))
-                (game.core/run state side (make-eid state) target nil card)))
-    :events {:run-ends {:effect (req (let [new (set (filter #(and (rezzed? %) (is-type? % "ICE")) (all-installed state :corp)))
-                                           old (set (:lnt @state))
-                                           diff (seq (clojure.set/difference new old))]
-                                       (doseq [ice diff]
-                                         (derez state side ice))
-                                       (when-not (empty? diff)
-                                         (system-msg state side (str "derezzes " (join ", " (map :title diff)) " via Leave No Trace")))
-                                       (swap! state dissoc :lnt)
-                                       (unregister-events state side card)))}}}
+   (letfn [(get-rezzed-cids [ice]
+             (map :cid (filter #(and (rezzed? %) (is-type? % "ICE")) ice)))]
+     {:prompt "Choose a server"
+      :msg "make a run and derez any ICE that are rezzed during this run"
+      :choices (req runnable-servers)
+      :delayed-completion true
+      :effect (req
+                (let [old-ice-cids (get-rezzed-cids (all-installed state :corp))]
+                  (swap! state assoc :lnt old-ice-cids)
+                  (register-events state side (:events (card-def card)) (assoc card :zone '(:discard)))
+                  (game.core/run state side (make-eid state) target nil card)))
+      :events {:run-ends {:effect (req (let [new (set (get-rezzed-cids (all-installed state :corp)))
+                                             old (set (:lnt @state))
+                                             diff-cid (seq (clojure.set/difference new old))
+                                             diff (map #(find-cid % (all-installed state :corp)) diff-cid)]
+                                         (doseq [ice diff]
+                                           (derez state side ice))
+                                         (when-not (empty? diff)
+                                           (system-msg state side (str "derezzes " (join ", " (map :title diff)) " via Leave No Trace")))
+                                         (swap! state dissoc :lnt)
+                                         (unregister-events state side card)))}}})
 
    "Legwork"
    {:req (req hq-runnable)

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -1094,6 +1094,38 @@
     (is (= 2 (:click (get-runner))) "Spent 2 clicks")
     (is (= 1 (:tag (get-runner))) "Lost 2 tags")))
 
+(deftest leave-no-trace
+  ;; Leave No Trace should derez ICE that was rezzed during the run
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 2)])
+              (default-runner [(qty "Leave No Trace" 1)]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (core/rez state :corp (get-ice state :hq 1))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Leave No Trace")
+    (prompt-choice :runner "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (run-successful state)
+    (is (not (:rezzed (get-ice state :hq 0))) "Inner Ice Wall should not be rezzed")
+    (is (:rezzed (get-ice state :hq 1)) "Outer Ice Wall should be rezzed still")))
+
+(deftest leave-no-trace-does-not-derez-modified-ice
+  ;; Leave No Trace should not derez ICE that has changed during a run
+  (do-game
+    (new-game (default-corp [(qty "Ice Wall" 1)])
+              (default-runner [(qty "Leave No Trace" 1)]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (is (:rezzed (get-ice state :hq 0)) "Ice Wall should be rezzed initially")
+    (play-from-hand state :runner "Leave No Trace")
+    (prompt-choice :runner "Server 1")
+    (core/add-counter state :corp (get-ice state :hq 0) :advance-counter 1)
+    (run-successful state)
+    (is (= 1 (get-counters (get-ice state :hq 0) :advance-counter)))
+    (is (:rezzed (get-ice state :hq 0)) "Ice Wall should still be rezzed")))
+
 (deftest mad-dash
   ;; Mad Dash - Make a run. Move to score pile as 1 point if steal agenda.  Take 1 meat if not
   (do-game


### PR DESCRIPTION
Fixes #3121 

Compare previously rezzed ICE with post-run rezzed ICE via their :cids instead of the cards themselves.

There's probably still some edge cases for LNT if the runner derezzes midrun with a bird breaker and the corp loops them back somehow and rezzes, but that seems like a pretty crazy edge case and would have been the case with the old implementation as well.