### PR TITLE
Implement Reverse Infection

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -2,15 +2,15 @@
 
 (def cards-hardware
   {"Acacia"
-   {:events {:pre-purge {:effect (req (let [virus (filter #(has-subtype? % "Virus") (all-installed state :runner))
-                                            counters (reduce + (map #(get-virus-counters state :runner %) virus))]
+   {:events {:pre-purge {:effect (req (let [counters (number-of-virus-counters state)]
                                         (update! state side (assoc-in (get-card state card) [:special :numpurged] counters))))}
              :purge {:delayed-completion true
                      :effect (effect (show-wait-prompt  :corp "Runner to decide if they will use Acacia")
                                   (continue-ability {:optional
                                                      {:player :runner
                                                       :prompt "Use Acacia?"
-                                                      :yes-ability {:effect (req (let [counters (get-in (get-card state card) [:special :numpurged])]
+                                                      :yes-ability {:effect (req (let [counters (- (get-in (get-card state card) [:special :numpurged])
+                                                                                                   (number-of-virus-counters state))]
                                                                                    (gain state side :credit counters)
                                                                                    (system-msg state side (str "uses Acacia and gains " counters "[Credit]"))
                                                                                    (trash state side card)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1117,25 +1117,23 @@
                                       (gain :credit (* 2 (count targets))))} card nil)))}
 
    "Reverse Infection"
-   (letfn [(num-virus-tokens [cards]
-             (reduce + (map #(get-in % [:counter :virus] 0) cards)))]
-     {:prompt "Choose One:"
-      :choices ["Purge virus counters."
-                "Gain 2 [Credits]"]
-      :effect (req (if (= target "Gain 2 [Credits]")
-                     (do (gain state side :credit 2)
-                         (system-msg state side "uses Reverse Infection to gain 2 [Credits]"))
-                     (let [pre-purge-virus (num-virus-tokens (all-installed state :runner))]
-                       (purge state side)
-                       (let [post-purge-virus (num-virus-tokens (all-installed state :runner))
-                             num-virus-purged (- pre-purge-virus post-purge-virus)
-                             num-to-trash (quot num-virus-purged 3)]
-                         (mill state :runner num-to-trash)
-                         (system-msg state side (str "uses Reverse Infection to purge "
-                                                     num-virus-purged (pluralize " virus counter" num-virus-purged)
-                                                     " and trash "
-                                                     num-to-trash (pluralize " card" num-to-trash)
-                                                     " from the top of the stack"))))))})
+   {:prompt "Choose One:"
+    :choices ["Purge virus counters."
+              "Gain 2 [Credits]"]
+    :effect (req (if (= target "Gain 2 [Credits]")
+                   (do (gain state side :credit 2)
+                       (system-msg state side "uses Reverse Infection to gain 2 [Credits]"))
+                   (let [pre-purge-virus (number-of-virus-counters state)]
+                     (purge state side)
+                     (let [post-purge-virus (number-of-virus-counters state)
+                           num-virus-purged (- pre-purge-virus post-purge-virus)
+                           num-to-trash (quot num-virus-purged 3)]
+                       (mill state :runner num-to-trash)
+                       (system-msg state side (str "uses Reverse Infection to purge "
+                                                   num-virus-purged (pluralize " virus counter" num-virus-purged)
+                                                   " and trash "
+                                                   num-to-trash (pluralize " card" num-to-trash)
+                                                   " from the top of the stack"))))))}
 
    "Rework"
    {:prompt "Select a card from HQ to shuffle into R&D"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1116,6 +1116,27 @@
                       :effect (effect (trash-cards targets)
                                       (gain :credit (* 2 (count targets))))} card nil)))}
 
+   "Reverse Infection"
+   (letfn [(num-virus-tokens [cards]
+             (reduce + (map #(get-in % [:counter :virus] 0) cards)))]
+     {:prompt "Choose One:"
+      :choices ["Purge virus counters."
+                "Gain 2 [Credits]"]
+      :effect (req (if (= target "Gain 2 [Credits]")
+                     (do (gain state side :credit 2)
+                         (system-msg state side "uses Reverse Infection to gain 2 [Credits]"))
+                     (let [pre-purge-virus (num-virus-tokens (all-installed state :runner))]
+                       (purge state side)
+                       (let [post-purge-virus (num-virus-tokens (all-installed state :runner))
+                             num-virus-purged (- pre-purge-virus post-purge-virus)
+                             num-to-trash (quot num-virus-purged 3)]
+                         (mill state :runner num-to-trash)
+                         (system-msg state side (str "uses Reverse Infection to purge "
+                                                     num-virus-purged (pluralize " virus counter" num-virus-purged)
+                                                     " and trash "
+                                                     num-to-trash (pluralize " card" num-to-trash)
+                                                     " from the top of the stack"))))))})
+
    "Rework"
    {:prompt "Select a card from HQ to shuffle into R&D"
     :choices {:req #(and (= (:side %) "Corp")

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -88,6 +88,11 @@
   [state]
   (concat (all-installed state :corp) (all-installed state :runner)))
 
+(defn number-of-virus-counters
+  "Returns number of actual virus counters (excluding virtual counters from Hivemind)"
+  [state]
+  (reduce + (map #(get-in % [:counter :virus] 0) (all-installed state :runner))))
+
 (defn all-active
   "Returns a vector of all active cards for the given side. Active cards are either installed, the identity,
   currents, or the corp's scored area."

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -7,6 +7,24 @@
 
 (use-fixtures :once load-all-cards)
 
+(deftest acacia
+  ;; Acacia - Optionally gain credits for number of virus tokens then trash
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Acacia" 1) (qty "Virus Breeding Ground" 1) (qty "Datasucker" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Acacia")
+    (play-from-hand state :runner "Virus Breeding Ground")
+    (play-from-hand state :runner "Datasucker")
+    (core/add-counter state :runner (get-resource state 0) :virus 4)
+    (core/add-counter state :runner (get-program state 0) :virus 3)
+    (take-credits state :runner)
+    (is (= 2 (:credit (get-runner))) "Runner initial credits")
+    (core/purge state :corp)
+    (prompt-choice :runner "Yes")
+    (is (= 9 (:credit (get-runner))) "Runner gained 9 credits")
+    (is (= 1 (count (:discard (get-runner)))) "Acacia has trashed")))
+
 (deftest akamatsu-mem
   ;; Akamatsu Mem Chip - Gain 1 memory
   (do-game

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -1141,6 +1141,28 @@
     (prompt-choice :runner 0)
     (is (empty? (:hand (get-runner))) "Runner took 3 meat damage")))
 
+(deftest reverse-infection
+  ;; Reverse Infection - purge and trash 1 card from stack for every 3 counters purged - or gain 2 credits
+  (do-game
+    (new-game (default-corp [(qty "Reverse Infection" 2)])
+              (default-runner [(qty "Virus Breeding Ground" 1) (qty "Datasucker" 1) (qty "Sure Gamble" 3)]))
+    (starting-hand state :runner ["Virus Breeding Ground" "Datasucker"])
+    (play-from-hand state :corp "Reverse Infection")
+    (prompt-choice :corp "Gain 2 [Credits]")
+    (is (= 7 (:credit (get-corp))) "Corp gained 2 credits")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Virus Breeding Ground")
+    (play-from-hand state :runner "Datasucker")
+    (take-credits state :runner)
+    (core/add-counter state :runner (get-resource state 0) :virus 4)
+    (core/add-counter state :runner (get-program state 0) :virus 3)
+    (play-from-hand state :corp "Reverse Infection")
+    (prompt-choice :corp "Purge virus counters.")
+    (is (= 9 (:credit (get-corp))) "Corp did not gain credits")
+    (is (zero? (get-counters (get-resource state 0) :virus)) "Viruses purged from VBG")
+    (is (zero? (get-counters (get-program state 0) :virus)) "Viruses purged from Datasucker")
+    (is (= 2 (count (:discard (get-runner)))) "Two cards trashed from stack")))
+
 (deftest reuse
   ;; Reuse - Gain 2 credits for each card trashed from HQ
   (do-game


### PR DESCRIPTION
#3096

Due to things like Progenitor I figure out removed tokens by counting pre-purge tokens and taking the difference post-purge to see how many tokens total were purged.