### PR TITLE
No One Home

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1416,8 +1416,8 @@
                                  :yes-ability {:delayed-completion true
                                                :cost [:credit 4]
                                                :msg "do 3 net damage and give the Runner 1 tag"
-                                               :effect (effect (damage eid :net 3 {:card card})
-                                                               (tag-runner :runner eid 1))}}}
+                                               :effect (req (when-completed (damage state side :net 3 {:card card})
+                                                                            (tag-runner state :runner eid 1)))}}}
                                card nil))}}
 
    "Space Camp"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1099,6 +1099,30 @@
     :events {:agenda-stolen {:msg "trash itself" :effect (effect (trash card))}}
     :abilities [{:cost [:credit 2] :msg "avoid 1 tag" :effect (effect (tag-prevent 1))}]}
 
+   "No One Home"
+   (letfn [(start-trace [type]
+             (let [message (str "avoid any " (if (= type :net) "amount of net damage" "number of tags"))]
+             {:player :corp
+              :label (str "Trace 0 - if unsuccessful, " message)
+              :trace {:base 0
+                      :priority 11
+                      :unsuccessful {:msg message
+                                     :effect (req (if (= type :net)
+                                                    (damage-prevent state side :net Integer/MAX_VALUE)
+                                                    (tag-prevent state side Integer/MAX_VALUE)))}}}))]
+   {:prevent {:tag [:all]
+              :damage [:net]}
+    :abilities [{:msg "force the Corp to trace"
+                 :delayed-completion true
+                 :once :per-turn
+                 :effect (req (let [type (get-in @state [:prevent :current])]
+                                (when-completed (trash state side card {:unpreventable true})
+                                                (continue-ability state side (start-trace type)
+                                                                  card nil))))}]
+    :events {:pre-resolve-damage {:silent (req true)
+                                  :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}
+             :pre-resolve-tag {:silent (req true)
+                               :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}})
    "Off-Campus Apartment"
    {:flags {:runner-install-draw true}
     :abilities [{:label "Install and host a connection on Off-Campus Apartment"

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -493,7 +493,7 @@
 ;;; Traces
 (defn- init-trace
   "Shows a trace prompt to the runner, after the corp has already spent credits to boost."
-  [state side card {:keys [base eid] :as ability} boost]
+  [state side card {:keys [base eid priority] :as ability} boost]
   (clear-wait-prompt state :runner)
   (show-wait-prompt state :corp "Runner to boost Link strength" {:priority 2})
   (trigger-event state side :pre-init-trace card)
@@ -508,7 +508,7 @@
                                  " + " boost " [Credits]) (" (make-label ability) ")"))
     (swap! state update-in [:bonus] dissoc :trace)
     (show-trace-prompt state :runner card "Boost link strength?"
-                       #(resolve-trace state side eid %) {:priority 2 :base link})
+                       #(resolve-trace state side eid %) {:priority (or priority 2) :base link})
     (swap! state assoc :trace {:strength total :ability ability :card card})
     (trigger-event state side :trace nil)))
 
@@ -532,12 +532,12 @@
 
 (defn corp-trace-prompt
   "Starts the trace process by showing the boost prompt to the corp."
-  [state card {:keys [base] :as trace}]
+  [state card {:keys [base priority] :as trace}]
   (let [base-trace (if (fn? base) (base state :corp (make-eid state) card nil) base)
         bonus (or (get-in @state [:bonus :trace]) 0)]
-    (show-wait-prompt state :runner (str "Corp to initiate a trace from " (:title card)) {:priority 2})
+    (show-wait-prompt state :runner (str "Corp to initiate a trace from " (:title card)) {:priority (or priority 2)})
     (show-trace-prompt state :corp card "Boost trace strength?"
-                       #(init-trace state :corp card trace %) {:priority 2 :base base-trace :bonus bonus})))
+                       #(init-trace state :corp card trace %) {:priority (or priority 2) :base base-trace :bonus bonus})))
 
 (defn rfg-and-shuffle-rd-effect
   ([state side card n] (rfg-and-shuffle-rd-effect state side (make-eid state) card n))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -227,6 +227,7 @@
          ;; runner can prevent the damage.
          (do (system-msg state :runner "has the option to avoid damage")
              (show-wait-prompt state :corp "Runner to prevent damage" {:priority 10})
+             (swap! state assoc-in [:prevent :current] type)
              (show-prompt
                state :runner nil (str "Prevent any of the " n " " (name type) " damage?") ["Done"]
                (fn [_]
@@ -263,6 +264,7 @@
   (swap! state update-in [:runner :tag-remove-bonus] (fnil #(+ % n) 0)))
 
 (defn resolve-tag [state side eid n args]
+  (trigger-event state side :pre-resolve-tag n)
   (if (pos? n)
     (do (gain state :runner :tag n)
         (toast state :runner (str "Took " (quantify n "tag") "!") "info")
@@ -281,6 +283,7 @@
        (if (and (pos? n) (not unpreventable) (pos? (count prevent)))
          (do (system-msg state :runner "has the option to avoid tags")
              (show-wait-prompt state :corp "Runner to prevent tags" {:priority 10})
+             (swap! state assoc-in [:prevent :current] :tag)
              (show-prompt
                state :runner nil (str "Avoid any of the " n " tags?") ["Done"]
                (fn [_]


### PR DESCRIPTION
This implementation is imperfect.

1. It doesn't handle the UFAQ entry for Snare! which is complete bonkers anyways.
2. If the runner takes damage/tag, then installs No One Home, they can prevent the next source of damage on their turn.

But I'm out of time for today.