### PR TITLE
Adds trace information to trace prompts.

### DIFF
--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -353,7 +353,7 @@
   "Specific function for displaying a trace prompt. Works like `show-prompt` with some extensions.
   Always uses `:credit` as the `choices` variable, and passes on some extra properties, such as base and bonus."
   ([state side card msg f args] (show-trace-prompt state side (make-eid state) card msg f args))
-  ([state side eid card msg f {:keys [priority base bonus] :as args}]
+  ([state side eid card msg f {:keys [priority base bonus strength] :as args}]
    (let [prompt (if (string? msg) msg (msg state side nil card nil))
          newitem {:eid eid
                   :msg prompt
@@ -362,7 +362,8 @@
                   :card card
                   :priority priority
                   :base base
-                  :bonus bonus}]
+                  :bonus bonus
+                  :strength strength}]
      (add-to-prompt-queue state side newitem))))
 
 (defn show-select
@@ -509,7 +510,7 @@
                                  " + " boost " [Credits]) (" (make-label ability) ")"))
     (swap! state update-in [:bonus] dissoc :trace)
     (show-trace-prompt state :runner card "Boost link strength?"
-                       #(resolve-trace state side eid %) {:priority 2 :base link})
+                       #(resolve-trace state side eid %) {:priority 2 :base link :strength total})
     (swap! state assoc :trace {:strength total :ability ability :card card})
     (trigger-event state side :trace nil)))
 

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -1166,6 +1166,14 @@
                 ;; choice of number of credits
                 (= (:choices prompt) "credit")
                 [:div
+                 (when (:base prompt)
+                   ;; This is trace prompt
+                   (if (= side :corp)
+                     ;; This is a trace prompt for the corp, show runner link + credits
+                     [:div.info "Runner has " (:link runner) [:span {:class "anr-icon link"}]
+                      " + " (:credit runner) [:span {:class "anr-icon credit"}]]
+                     ;; This is a trace prompt for the runner, show trace strength
+                     [:div.info (str "Trace - " (:strength prompt))]))
                  [:div.credit-select
                   ;; Inform user of base trace / link and any bonuses
                   (when-let [base (:base prompt)]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -533,7 +533,7 @@ nav ul
 #stats
   .content-page
     margin-top: 9px
-  
+
 
 // Influence dots
 
@@ -1613,6 +1613,12 @@ nav ul
           h4
             text-align: center
             margin-bottom: 10px
+
+          .info
+            text-align: center
+            margin: 0 0 5px 0
+            font-size: 10pt
+            font-style: italic
 
           button
             width: 100%


### PR DESCRIPTION
Adds more information to trace prompts to ease players doing hard maths.

(At least Midseasons Maths is gone, for now...)

Pics:
<img width="192" alt="screen shot 2018-03-04 at 22 18 04" src="https://user-images.githubusercontent.com/13198563/37053462-2406dd64-2174-11e8-8ceb-97f3e1295148.png">
<img width="191" alt="screen shot 2018-03-06 at 19 21 54" src="https://user-images.githubusercontent.com/13198563/37053467-25d0e7fc-2174-11e8-9e2e-2ea9a08448d5.png">

Fixes #3135