### PR TITLE
Fix MWL out-of-sync on client and server.

### DIFF
--- a/src/clj/web/core.clj
+++ b/src/clj/web/core.clj
@@ -9,7 +9,8 @@
             [web.lobby :as lobby]
             [web.game :as game]
             [web.stats :as stats]
-            [jinteki.nav :as nav])
+            [jinteki.nav :as nav]
+            [clj-time.format :as f])
   (:gen-class :main true))
 
 (defonce server (atom nil))
@@ -26,12 +27,16 @@
     (let [cards (mc/find-maps db "cards" nil)
           sets (mc/find-maps db "sets" nil)
           cycles (mc/find-maps db "cycles" nil)
-          mwl (mc/find-maps db "mwl" nil)]
+          mwl (mc/find-maps db "mwl" nil)
+          latest_mwl (->> mwl
+                       (map (fn [e] (update e :date_start #(f/parse (f/formatters :date) %))))
+                       (sort-by :date_start)
+                       (last))]
       (reset! cards/all-cards (into {} (map (juxt :title identity)
                                             (sort-by (complement :rotated) cards))))
       (reset! cards/sets sets)
       (reset! cards/cycles cycles)
-      (reset! cards/mwl mwl))
+      (reset! cards/mwl latest_mwl))
 
     (when (#{"dev" "prod"} (first args))
       (reset! server-mode (first args)))

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -32,7 +32,7 @@
           deck (-> deck
                    (update-in [:cards] (fn [cards] (mapv #(select-keys % [:qty :card :id :art]) cards)))
                    (assoc :username username))
-          status (decks/check-deck-status check-deck)
+          status (decks/calculate-deck-status check-deck)
           deck (assoc deck :status status)]
       (if-let [deck-id (:_id deck)]
         (do (mc/update db "decks"

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -320,9 +320,7 @@
         deck (as-> (mc/find-one-as-map db "decks" {:_id (object-id deck-id) :username username}) d
                    (update-in d [:cards] #(mapv map-card %))
                    (update-in d [:identity] #(@all-cards (:title %)))
-                   (if (:status d)
-                     d
-                     (assoc d :status (decks/check-deck-status d))))]
+                   (assoc d :status (decks/calculate-deck-status d)))]
     (when (and deck (player? client-id gameid))
       (swap! all-games update-in [gameid :players
                               (if (= client-id (:ws-id fplayer)) 0 1)]

--- a/src/cljc/jinteki/decks.cljc
+++ b/src/cljc/jinteki/decks.cljc
@@ -294,7 +294,6 @@
   (and (every? #(released? sets (:card %)) (:cards deck))
        (released? sets (:identity deck))))
 
-
 (defn deck-status
   [mwl-legal valid in-rotation]
   (cond
@@ -302,7 +301,7 @@
     valid "casual"
     :else "invalid"))
 
-(defn check-deck-status [deck]
+(defn calculate-deck-status [deck]
   (let [valid (valid-deck? deck)
         mwl (mwl-legal? deck)
         rotation (only-in-rotation? @cards/sets deck)
@@ -317,11 +316,11 @@
      :cache-refresh cache-refresh}))
 
 (defn trusted-deck-status [{:keys [status name cards date] :as deck}]
-  (let [parse-date #?(:clj  #(f/parse (f/formatters :date) %)
+  (let [parse-date #?(:clj  #(f/parse (f/formatters :date-time) %)
                       :cljs #(js/Date.parse %))
         deck-date (parse-date date)
         mwl-date (:date_start @cards/mwl)]
     (if (and status
              (> deck-date mwl-date))
       status
-      (check-deck-status deck))))
+      (calculate-deck-status deck))))

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -12,11 +12,9 @@
             [netrunner.gameboard :refer [init-game game-state toast launch-game parse-state]]
             [netrunner.cardbrowser :refer [image-url] :as cb]
             [netrunner.stats :refer [notnum->zero]]
-            [netrunner.deckbuilder :refer [deck-status-span deck-status-label process-decks load-decks num->percent]]))
+            [netrunner.deckbuilder :refer [format-deck-status-span deck-status-span process-decks load-decks num->percent]]))
 
 (def socket-channel (chan))
-
-
 
 (defn sort-games-list [games]
   (sort-by #(vec (map (assoc % :started (not (:started %))
@@ -450,14 +448,14 @@
                     (for [player (:players game)]
                       [:div
                        (om/build player-view {:player player})
-                       (when-let [{:keys [_id name] :as deck} (:deck player)]
-                         [:span {:class (deck-status-label sets deck)}
+                       (when-let [{:keys [_id name status] :as deck} (:deck player)]
+                         [:span {:class (:status status)}
                           [:span.label
                            (if (= (:user player) user)
                              name
                              "Deck selected")]])
                        (when-let [deck (:deck player)]
-                         [:div.float-right (deck-status-span sets deck true false true)])
+                         [:div.float-right (format-deck-status-span (:status deck) true false)])
                        (when (= (:user player) user)
                          [:span.fake-link.deck-load
                           {:data-target "#deck-select" :data-toggle "modal"


### PR DESCRIPTION
Client side MWL was caching the latest MWL entry. Server side MWL was caching the MWL array. Shared code to calculate banned/restricted cards didn't work properly.

Also fixed formatting of deck display in game lobby.

Fixes #3092 