### PR TITLE
Handling decks with missing identities

### DIFF
--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -35,10 +35,12 @@
           status (decks/check-deck-status check-deck)
           deck (assoc deck :status status)]
       (if-let [deck-id (:_id deck)]
-        (do (mc/update db "decks"
-                       {:_id (object-id deck-id) :username username}
-                       {"$set" (dissoc deck :_id)})
+        (if (:identity deck)
+          (do (mc/update db "decks"
+                         {:_id (object-id deck-id) :username username}
+                         {"$set" (dissoc deck :_id)})
             (response 200 {:message "OK"}))
+          (response 409 {:message "Deck is missing identity"}))
         (response 409 {:message "Deck is missing _id"})))
     (response 401 {:message "Unauthorized"})))
 

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -80,8 +80,10 @@
 (defn parse-identity
   "Parse an id to the corresponding card map"
   [{:keys [side title art setname]}]
-  (let [card (lookup side {:title title})]
-    (assoc card :art art :display-name (build-identity-name title setname art))))
+  (if (nil? title)
+    {:display-name "Missing Identity"}
+    (let [card (lookup side {:title title})]
+      (assoc card :art art :display-name (build-identity-name title setname art)))))
 
 (defn add-params-to-card
   "Add art and id parameters to a card hash"


### PR DESCRIPTION
Catching decks with missing identities when loaded. Leaves the deck in an unplayable state, but a user can still get to the included cards (to rebuild).

Checking for an `:identity` on deck save as well.