### PR TITLE
Delete duplicate users task

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,8 @@
                    :source-paths ["src/clj" "src/cljs" "src/dev" "src/cljc"]}}
 
   :aliases {"fetch" ["run" "-m" "tasks.fetch/fetch"]
-            "add-art" ["run" "-m" "tasks.altart/add-art"]}
+            "add-art" ["run" "-m" "tasks.altart/add-art"]
+            "delete-duplicate-users" ["run" "-m" "tasks.db/delete-duplicate-users"]}
 
   ;; Compilation.
   :source-paths ["src/clj" "src/cljs" "src/cljc"]

--- a/src/clj/tasks/db.clj
+++ b/src/clj/tasks/db.clj
@@ -1,0 +1,44 @@
+(ns tasks.db
+  "Database maintenance tasks"
+  (:require [web.db :refer [db] :as webdb]
+            [monger.collection :as mc]))
+            ;; [monger.operators :refer :all]))
+
+(defn- get-all-users
+  "Get all users in the database. Takes a list of fields."
+  [fields]
+  (mc/find-maps db "users" {} fields))
+
+(defn- delete-user
+  "Delete a user by Mongo document id"
+  [id]
+  (mc/remove-by-id db "users" id))
+
+(defn delete-duplicate-users
+  "Delete entries in the users table that share a username. Leave the first registered entry found in the collection."
+  [& args]
+  (webdb/connect)
+  (try
+    (let [dry-run (some #{"--dry-run"} args)
+          users (get-all-users [:email :username :registrationDate :lastConnection])
+          grouped (vals (group-by :username users))
+          duplicates (filter #(> (count %) 1) grouped)]
+      (when dry-run
+        (println "DRY RUN: not deleting accounts"))
+      (println "Found" (count users) "user accounts.")
+      (println "Found" (count duplicates) "duplicated usernames.")
+      (doseq [d duplicates]
+        (let [[f & r] (sort-by :registrationDate d)]
+          (println "Found username:" (:username f))
+          (println "\tKeeping:" (:email f) "," (:registrationDate f))
+          (if dry-run
+            (println "\tWould delete:")
+            (println "\tDeleting:"))
+          (doseq [del r]
+            (println "\t\t" (:email del) "," (:registrationDate del))
+            (when (not dry-run)
+              (delete-user (:_id del)))))))
+    (catch Exception e (do
+                         (println "Delete duplicate users failed" (.getMessage e))
+                         (.printStackTrace e)))
+    (finally (webdb/disconnect))))


### PR DESCRIPTION
Script to delete database entries that share a username. Keeps the entry with the oldest `registrationDate`. Has an argument `--dry-run` which will print what would be deleted, but will leave the database unmodified.