### PR TITLE
Fix #3162, Hayley and Corporate Grant

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -206,7 +206,8 @@
                                     c)))})
 
   "Corporate \"Grant\""
-  {:events {:runner-install {:req (req (first-event? state side :runner-install))
+  {:events {:runner-install {:silent (req true) ;; there are no current interactions where we'd want Grant to not be last, and this fixes a bug with Hayley
+                             :req (req (first-event? state side :runner-install))
                              :msg "force the Corp to lose 1 [Credit]"
                              :effect (effect (lose :corp :credit 1))}}}
 

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -369,6 +369,20 @@
     (is (empty? (:hand (get-runner))) "Played all cards in hand")
     (is (= 7 (:credit (get-corp))) "Corp doesn't lose 1 credit")))
 
+(deftest corporate-grant-hayley
+  ;; Corporate "Grant" - with Hayley Kaplan. Issue #3162.
+  (do-game
+    (new-game (default-corp)
+              (make-deck "Hayley Kaplan: Universal Scholar" [(qty "Corporate \"Grant\"" 1) (qty "Clone Chip" 2)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 5)
+    (play-from-hand state :runner "Corporate \"Grant\"")
+    (is (= 8 (:credit (get-corp))) "Corp starts with 8 credits")
+    (play-from-hand state :runner "Clone Chip")
+    (prompt-choice :runner "Yes")
+    (prompt-select :runner (find-card "Clone Chip" (:hand (get-runner))))
+    (is (= 7 (:credit (get-corp))) "Corp only loses 1 credit")))
+
 (deftest corporate-scandal
   ;; Corporate Scandal - Corp has 1 additional bad pub even with 0
   (do-game
@@ -1486,8 +1500,8 @@
 (let [choose-runner (fn [name state prompt-map]
                       (let [kate-choice (some #(when (= name (:title %)) %) (:choices (prompt-map :runner)))]
                         (core/resolve-prompt state :runner {:card kate-choice})))
-
-      ayla "Ayla \"Bios\" Rahim: Simulant Specialist"
+  
+      akiko "Akiko Nisei: Head Case"
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"
       kit "Rielle \"Kit\" Peddler: Transhuman"
       professor "The Professor: Keeper of Knowledge"
@@ -1502,7 +1516,7 @@
       (new-game (default-corp) (default-runner ["Magnum Opus" "Rebirth"]) {:start-as :runner})
 
       (play-from-hand state :runner "Rebirth")
-      (is (= (first (prompt-titles :runner)) ayla) "List is sorted")
+      (is (= (first (prompt-titles :runner)) akiko) "List is sorted")
       (is (every?   #(some #{%} (prompt-titles :runner))
                     [kate kit]))
       (is (not-any? #(some #{%} (prompt-titles :runner))


### PR DESCRIPTION
Also fixes a failing Rebirth test now that Akiko is the first Shaper alphabetically.