### PR TITLE
Check that Akiko is first in Shaper rebirth list

### DIFF
--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -1487,7 +1487,7 @@
                       (let [kate-choice (some #(when (= name (:title %)) %) (:choices (prompt-map :runner)))]
                         (core/resolve-prompt state :runner {:card kate-choice})))
 
-      ayla "Ayla \"Bios\" Rahim: Simulant Specialist"
+      akiko "Akiko Nisei: Head Case"
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"
       kit "Rielle \"Kit\" Peddler: Transhuman"
       professor "The Professor: Keeper of Knowledge"
@@ -1502,7 +1502,7 @@
       (new-game (default-corp) (default-runner ["Magnum Opus" "Rebirth"]) {:start-as :runner})
 
       (play-from-hand state :runner "Rebirth")
-      (is (= (first (prompt-titles :runner)) ayla) "List is sorted")
+      (is (= (first (prompt-titles :runner)) akiko) "List is sorted")
       (is (every?   #(some #{%} (prompt-titles :runner))
                     [kate kit]))
       (is (not-any? #(some #{%} (prompt-titles :runner))


### PR DESCRIPTION
Akiko is now ahead of Ayla alphabetically, so I updated the test to reflect that.  Hopefully they don't release anything like `Aardvark Jones: Mutant Celebrity` or something at some point.