### PR TITLE
Block users from the lobby chat screen

### DIFF
--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -40,10 +40,17 @@
             messages (get-in @app-state [:channels ch])]
         (update-message-channel ch (reverse (conj (reverse messages) msg))))))
 
+(defn non-game-toast
+  "Display a toast warning with the specified message."
+  [msg type options]
+  (set! (.-options js/toastr) (netrunner.gameboard/toastr-options options))
+  (let [f (aget js/toastr type)]
+    (f msg)))
+
 (defn- post-response [owner blocked-user response]
   (if (= 200 (:status response))
-    (netrunner.gameboard/toast (str "Blocked user " blocked-user ". Refresh browser to update.") "success" nil)
-    (netrunner.gameboard/toast "Failed to block user" "error" nil)))
+    (non-game-toast (str "Blocked user " blocked-user ". Refresh browser to update.") "success" nil)
+    (non-game-toast "Failed to block user" "error" nil)))
 
 (defn block-user
   [owner blocked-user]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -746,16 +746,35 @@ nav ul
   display-flex()
   margin-bottom: 5px
 
+  .name-menu
+    position: relative
+
+  .clickable
+    cursor: pointer
+
   .content
     flex(1)
 
-  .block-user
-    padding: 0
-    font-size: 8px
-    line-height: 15px
-    height: 15px
-    width: 15px
-    background-color: transparent
+  .block-menu
+    display: none
+    position: absolute
+    z-index: 30
+    width: 200px
+    font-size: 12px
+    line-height: 16px
+
+    > div
+      border: 1px solid white
+      padding: 3px 6px
+      border-radius: 4px
+      margin-bottom: 4px
+      cursor: pointer
+
+      &:last-child
+        margin-bottom: 0
+
+      &:hover
+        border-color: orange
 
 .message-list
   height: 400px

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -157,7 +157,7 @@ button.small
 .username
   font-weight: bold
   font-size: 14px
-  margin-right: 10px
+  margin-right: 5px
 
 .active
   color: orange
@@ -748,6 +748,14 @@ nav ul
 
   .content
     flex(1)
+
+  .block-user
+    padding: 0
+    font-size: 8px
+    line-height: 15px
+    height: 15px
+    width: 15px
+    background-color: transparent
 
 .message-list
   height: 400px


### PR DESCRIPTION
**Need some help with styling**, but the functionality is in place. Click a button by the username in a chat message, they get added to your block list. You get a toast message with confirmation and reminder to refresh your browser.

It should be possible to update the Om state and get it to redraw automatically, but I can't seem to make that happen.

You don't get a button by your username (`test2` in the screenshot) or when not logged in.

<img width="318" alt="screen shot 2018-03-11 at 9 07 59 pm" src="https://user-images.githubusercontent.com/47226/37261116-4dc1d49c-2570-11e8-87ca-95a5bc3006ea.png">