### PR TITLE
Tori Hanzo (again)

### DIFF
--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -200,7 +200,7 @@
                                 (swap! state update-in [:runner :brain-damage] #(+ % n))
                                 (swap! state update-in [:runner :hand-size-modification] #(- % n)))
                               (when-let [trashed-msg (join ", " (map :title cards-trashed))]
-                                (system-msg state :runner (str "trashes " trashed-msg " due to damage")))
+                                (system-msg state :runner (str "trashes " trashed-msg " due to " (name type) " damage")))
                               (if (< (count hand) n)
                                 (do (flatline state)
                                     (trash-cards state side (make-eid state) cards-trashed
@@ -209,6 +209,7 @@
                                                  {:unpreventable true :cause type})
                                     (trigger-event state side :damage type card n)))))))
                       (swap! state update-in [:damage :defer-damage] dissoc type)
+                      (swap! state update-in [:damage] dissoc :damage-replace)
                       (effect-completed state side eid card))))
 
 (defn damage

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -85,7 +85,7 @@
                        :mill (str value " card mill")
                        :hardware (str value " installed hardware")
                        :shuffle-installed-to-stack (str "shuffling " value " installed "
-                                                        (pluralize "program" value) " into the stack")
+                                                        (pluralize "card" value) " into the stack")
                        (str value (str key)))) (partition 2 (flatten costs)))))
 
 (defn vdissoc [v n]

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1261,6 +1261,29 @@
       (prompt-choice :runner "No")
       (is (and (empty (:prompt (get-runner))) (not (:run @state))) "No prompts, run ended"))))
 
+(deftest tori-hanzo-net
+  ;; Tori Hanzō breaking subsequent net damage: Issue #3176
+  (do-game
+    (new-game (default-corp [(qty "Tori Hanzō" 1) (qty "Pup" 2) (qty "Neural EMP" 2)])
+              (default-runner))
+    (core/gain state :corp :credit 8)
+    (play-from-hand state :corp "Tori Hanzō" "New remote")
+    (play-from-hand state :corp "Pup" "Server 1")
+    (take-credits state :corp)
+    (run-on state "Server 1")
+    (let [tori (get-content state :remote1 0)
+          pup (get-ice state :remote1 0)]
+      (core/rez state :corp pup)
+      (core/rez state :corp tori)
+      (card-subroutine state :corp pup 0)
+      (prompt-choice :corp "Yes") ; pay 2c to replace 1 net with 1 brain
+      (is (= 1 (count (:discard (get-runner)))) "1 brain damage suffered")
+      (is (= 1 (:brain-damage (get-runner))))
+      (run-jack-out state)
+      (take-credits state :runner)
+      (play-from-hand state :corp "Neural EMP")
+      (is (= 2 (count (:discard (get-runner)))) "Net damage processed correctly"))))
+
 (deftest underway-grid
   ;; Underway Grid - prevent expose of cards in server
   (do-game


### PR DESCRIPTION
I'm ready to cleave her skull in twain with one of those fancy swords....

Anyway. Fixes subsequent net damage instances after using Tori Hanzo, and adds the type of damage into the card trashing message (requested in #2619). Changes the cost prompt for shuffling cards back into the stack, currently only used in Degree Mill (see #3167). 

Only failing due to the Rebirth test which is fixed elsewhere. 