### PR TITLE
Remove :selected cards when closing a prompt.

### DIFF
--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -186,6 +186,7 @@
 (defn command-close-prompt [state side]
   (when-let [fprompt (-> @state side :prompt first)]
     (swap! state update-in [side :prompt] rest)
+    (swap! state dissoc-in [side :selected])
     (effect-completed state side (:eid fprompt))))
 
 (defn parse-command [text]


### PR DESCRIPTION
Scenario: play a card that opens a targeted selection prompt that allows multiple selections, like Special Report. Select one target, then use /close-prompt. 

Later play another card that at some point uses a targeted selection prompt, like Ultraviolet Clearance. The state has a field `:selected` containing all cards selected _by the previous prompt_. UVC sees that this vector has 1 entry, which is what it needs, and completes the prompt with that selected card.

Fix by removing `:selected` when calling /close-prompt.