### PR TITLE
FIX: Milling doesn't trigger trash effects

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1087,23 +1087,15 @@
                                                                  (fn [_ _ c] (not= (:cid c) (:cid card)))))}}}}
 
    "Underway Renovation"
-   {:install-state :face-up
-    :events {:advance {:req (req (= (:cid card) (:cid target))) 
-                       :msg (msg (let [deck (:deck runner)
-                                       anydeck? (pos? (count deck)) 
-                                       adv4? (>= (:advance-counter (get-card state card)) 4)] 
-                         (cond
-                           (and anydeck? adv4?)
-                           (str "trash " (join ", " (map :title (take 2 deck))) " from the Runner's stack")
-
-                           (and anydeck? (not adv4?) )
-                           (str "trash " (:title (first deck)) " from the Runner's stack")
-
-                           (false? anydeck?)  
-                           "trash from the Runner's stack but it is empty")))
-
-                       :effect (effect (mill :runner
-                                             (if (>= (:advance-counter (get-card state card)) 4)  2 1)))}}}
+   (letfn [(adv4? [s c] (if (>= (:advance-counter (get-card s c)) 4) 2 1))]
+     {:install-state :face-up
+      :events {:advance {:req (req (= (:cid card) (:cid target)))
+                         :msg (msg (if (pos? (count (:deck runner)))
+                                     (str "trash "
+                                          (join ", " (map :title (take (adv4? state card) (:deck runner))))
+                                          " from the Runner's stack")
+                                     "trash from the Runner's stack but it is empty"))
+                         :effect (effect (mill :corp :runner (adv4? state card)))}}})
 
    "Unorthodox Predictions"
    {:implementation "Prevention of subroutine breaking is not enforced"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -191,7 +191,7 @@
              :effect (req (let [c (first (get-in @state [:runner :deck]))]
                             (system-msg state :corp (str "uses Breached Dome to do one meat damage and to trash " (:title c)
                                                          " from the top of the Runner's Stack"))
-                            (mill state :runner)
+                            (mill state :corp :runner 1)
                             (damage state side eid :meat 1 {:card card})))}}
 
    "Brain-Taping Warehouse"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -214,7 +214,7 @@
                                               (str "uses Aimor to trash "
                                                    (join ", " (map :title (take 3 (:deck runner))))
                                                    " from the Runner's Stack"))
-                                  (mill state :runner 3))
+                                  (mill state :corp :runner 3))
                                 (when current-ice
                                   (no-action state :corp nil)
                                   (continue state :runner nil))
@@ -512,7 +512,7 @@
     :abilities [{:label "Trash the top 2 cards of the Runner's Stack"
                  :req (req (some #(has-subtype? % "AI") (all-installed state :runner)))
                  :msg (msg (str "trash " (join ", " (map :title (take 2 (:deck runner)))) " from the Runner's Stack"))
-                 :effect (effect (mill :runner 2))}]
+                 :effect (effect (mill :corp :runner 2))}]
     :subroutines [(do-net-damage 2)
                   end-the-run]}
 

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -769,8 +769,8 @@
                                                                   :msg (msg (if (pos? target)
                                                                               (str "trash " (:title (first (:deck runner))) " from their Stack and trash " target " cards from R&D")
                                                                               (str "trash " (:title (first (:deck runner))) " from their Stack and nothing from R&D")))
-                                                                  :effect (effect (mill :runner 1)
-                                                                                  (mill :corp target))}}}}})
+                                                                  :effect (effect (mill :runner)
+                                                                                  (mill :runner :corp target))}}}}})
 
    "Pipeline"
    (auto-icebreaker ["Sentry"]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -476,7 +476,7 @@
               :effect (req (let [c (first (get-in @state [:runner :deck]))]
                              (system-msg state :corp (str "uses Jinteki: Potential Unleashed to trash " (:title c)
                                                           " from the top of the Runner's Stack"))
-                             (mill state :runner)))}}}
+                             (mill state :corp :runner 1)))}}}
 
    "Jinteki: Replicating Perfection"
    {:events
@@ -620,7 +620,7 @@
                                 (str "trash " (join ", " (map :title (take 2 deck))) " from their Stack and draw 1 card")
                                 "trash the top 2 cards from their Stack and draw 1 card - but their Stack is empty")))
                   :once :per-turn
-                  :effect (effect (mill 2) (draw))}]
+                  :effect (effect (mill :runner 2) (draw))}]
      {:flags {:runner-turn-draw true
               :runner-phase-12 (req (and (not (:disabled card))
                                          (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner))))}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -524,7 +524,7 @@
 
    "Genotyping"
    {:delayed-completion true
-    :effect (effect (mill 2)
+    :effect (effect (mill :corp 2)
                     (system-msg "trashes the top 2 cards of R&D")
                     (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) 4))}
 
@@ -1135,7 +1135,7 @@
                      (let [post-purge-virus (number-of-virus-counters state)
                            num-virus-purged (- pre-purge-virus post-purge-virus)
                            num-to-trash (quot num-virus-purged 3)]
-                       (mill state :runner num-to-trash)
+                       (mill state :corp :runner num-to-trash)
                        (system-msg state side (str "uses Reverse Infection to purge "
                                                    num-virus-purged (pluralize " virus counter" num-virus-purged)
                                                    " and trash "

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -319,7 +319,7 @@
                              (if (pos? (count deck))
                                (str "trash " (join ", " (map :title (take 2 deck))) " from the Stack")
                                "trash the top 2 cards from their Stack - but the Stack is empty")))
-                 :effect (effect (mill :runner 2))}]}
+                 :effect (effect (mill :corp :runner 2))}]}
 
    "Georgia Emelyov"
    {:events {:unsuccessful-run {:req (req (= (first (:server target)) (second (:zone card))))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -402,8 +402,8 @@
       (if (is-type? card "Agenda")
         (when-completed (resolve-steal-events state side card)
                         (resolve-trash-no-cost state side card))
-        (resolve-trash-no-cost state side card)))
-    (close-access-prompt state side)))
+        (resolve-trash-no-cost state side card))
+      (close-access-prompt state side))))
 
 
 ;;; Agendas

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -387,8 +387,9 @@
      (trashrec cards))))
 
 (defn- resolve-trash-no-cost
-  [state side card & seen]
-  (trash state side (assoc card :seen (or seen true)))
+  [state side card & {:keys [seen]
+                      :or {seen true}}]
+  (trash state side (assoc card :seen seen))
   (swap! state assoc-in [side :register :trashed-card] true))
 
 (defn trash-no-cost
@@ -493,12 +494,13 @@
   (trigger-event state side :purge))
 
 (defn mill
-  "Force the discard of n cards from :deck to :discard."
-  ([state side] (mill state side 1))
-  ([state side n]
-   (let [milltargets (take n (get-in @state [side :deck]))]
+  "Force the discard of n cards by trashing them."
+  ([state side] (mill state side side 1))
+  ([state side n] (mill state side side n))
+  ([state from-side to-side n]
+   (let [milltargets (take n (get-in @state [to-side :deck]))]
      (doseq [card milltargets]
-       (resolve-trash-no-cost state side card false)))))
+       (resolve-trash-no-cost state from-side card :seen false)))))
 
 ;; Exposing
 (defn expose-prevent

--- a/test/clj/game_test/cards/icebreakers.clj
+++ b/test/clj/game_test/cards/icebreakers.clj
@@ -419,6 +419,37 @@
     (prompt-choice :runner "No")
     (is (empty? (:prompt (get-runner))) "No additional prompts to rez other copies of Paperclip")))
 
+(deftest persephone
+  ;; Persephone's ability trashes cards from R&D, triggering AR-Enhanced Security
+  ;; See #3187
+  (do-game
+    (new-game
+      (default-corp [(qty "Zed 1.0" 1) (qty "Zed 2.0" 3) (qty "AR-Enhanced Security" 1)])
+      (default-runner [(qty "Persephone" 10)]))
+    (core/move state :corp (find-card "Zed 2.0" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Zed 2.0" (:hand (get-corp))) :deck)
+    (play-from-hand state :corp "AR-Enhanced Security" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (play-from-hand state :corp "Zed 1.0" "Archives")
+    (core/rez state :corp (get-ice state :archives 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Persephone")
+    (run-on state "Archives")
+    (run-continue state)
+    (prompt-choice :runner "Yes")
+    (prompt-choice :runner 2)
+    (is (= 1 (:tag (get-runner))) "Runner took 1 tag from using Persephone's ability while AR-Enhanced Security is scored")
+    (take-credits state :runner)
+    ;; Gotta move the discarded cards back to the deck
+    (core/move state :corp (find-card "Zed 2.0" (:discard (get-corp))) :deck)
+    (core/move state :corp (find-card "Zed 2.0" (:discard (get-corp))) :deck)
+    (take-credits state :corp)
+    (run-on state "Archives")
+    (run-continue state)
+    (prompt-choice :runner "Yes")
+    (prompt-choice :runner 2)
+    (is (= 2 (:tag (get-runner))) "Runner took 1 tag from using Persephone's ability while AR-Enhanced Security is scored")))
+
 (deftest shiv
   ;; Shiv - Gain 1 strength for each installed breaker; no MU cost when 2+ link
   (do-game


### PR DESCRIPTION
~~**NOTE:** Not actually intended to be a fix, but a good start on a fix for someone who can actually test the code (as I can't get my dev environment working).~~ Just kidding, see below.

If I understand things correctly, this should solve the issue in #3183 where milling doesn't count as "trashing cards" for each side (meaning that AR-Enhanced Security doesn't fire when Persephone fires) because `:trashed-card` isn't being set.

I've added an additional parameter to `resolve-trash-no-cost`, so that by default it sets all trashed cards to `:seen true`, but with milling, we can call `(resolve-trash-no-cost state side card false)` and they *should* be discarded facedown. Additionally, I moved the `closed-access-prompt` to `trash-no-cost`, as it can't be closed if it's not opened when `mill` is called. 

Honestly, I am only partially sure I got this right. Someone come steal my thunder and fix my mistakes!