### PR TITLE
Handle null blocked-users

### DIFF
--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -19,8 +19,9 @@
 
 (defn filter-blocked-messages
   [messages]
-  (let [blocked-users (get-in @app-state [:options :blocked-users] [])]
-    (filter #(= -1 (.indexOf blocked-users (:username %))) messages)))
+  (if-let [blocked-users (get-in @app-state [:options :blocked-users] nil)]
+    (filter #(= -1 (.indexOf blocked-users (:username %))) messages)
+    messages))
 
 (defn update-message-channel
   [channel messages]


### PR DESCRIPTION
Catches the case where a user has nil for `options.blocked-users` (`null` in MongoDB) and we attempt to index into it.

Fixes #3190 