### PR TITLE
Awaitable costs for accessing and stealing

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare forfeit prompt! toast damage mill installed? is-type? is-scored? system-msg)
+(declare forfeit prompt! toast damage mill installed? is-type? is-scored? system-msg facedown? make-result)
 
 (defn deduce
   "Deduct the value from the player's attribute."
@@ -51,76 +51,93 @@
   Amount is always 1 but can be extend if we ever need more than a single forfeit"
   ;; If multiples needed in future likely prompt-select needs work to take a function
   ;; instead of an ability
-  [state side card n]
-  (resolve-ability state side
-                   {:prompt "Choose an Agenda to forfeit"
-                    :delayed-completion true
-                    :choices {:max n
-                              :req #(is-scored? state side %)}
-                    :effect (effect (forfeit eid target))}
-                   card nil)
-  (when-let [cost-name (cost-names n :forfeit)]
+  [state side eid card n]
+  (let [cost-name (cost-names n :forfeit)]
+    (continue-ability state side
+                    {:prompt "Choose an Agenda to forfeit"
+                     :delayed-completion true
+                     :choices {:max n
+                               :req #(is-scored? state side %)}
+                     :effect (req (when-completed (forfeit state side target)
+                                                  (effect-completed state side (make-result eid cost-name))))}
+                    card nil)
     cost-name))
 
 (defn pay-trash
   "Trash a card as part of paying for a card or ability"
   ;; If multiples needed in future likely prompt-select needs work to take a function
   ;; instead of an ability
-  ([state side card type amount choices] (pay-trash state side card type amount choices nil))
-  ([state side card type amount choices args]
-   (prompt! state side card (str "Choose a " (name type) " to trash") choices
-            {:effect (effect (trash target args))})
-   (when-let [cost-name (cost-names amount type)] cost-name)))
+  ([state side eid card type amount select-fn] (pay-trash state side eid card type amount select-fn nil))
+  ([state side eid card type amount select-fn args]
+   (let [cost-name (cost-names amount type)]
+     (continue-ability state side
+                       {:prompt (str "Choose a " type "to trash")
+                        :choices {:max amount
+                                  :req select-fn}
+                        :delayed-completion true
+                        :effect (req (when-completed (trash state side target (merge args {:unpreventable true}))
+                                                     (effect-completed state side (make-result eid cost-name))))}
+                       card nil)
+     cost-name)))
 
 (defn pay-shuffle-installed-to-stack
   "Shuffle installed runner card(s) into the stack as part of paying for a card or ability"
-  [state card amount]
-  (resolve-ability state :runner
-                   {:prompt (str "Choose " amount " " (pluralize "card" amount) " to shuffle into the stack")
-                    :delayed-completion true
-                    :choices {:max amount
-                              :all true
-                              :req #(and (installed? %) (= (:side %) "Runner"))}
-                    :effect (req
-                              (doseq [c targets]
-                                (move state :runner c :deck))
-                              (system-msg state :runner
-                                          (str "shuffles " (join ", " (map :title targets))
-                                               " into their stack"))
-                              (shuffle! state :runner :deck))}
-                   card nil)
-  (when-let [cost-name (cost-names amount :shuffle-installed-to-stack)] cost-name))
+  [state side eid card amount]
+  (let [cost-name (cost-names amount :shuffle-installed-to-stack)]
+    (continue-ability state :runner
+                    {:prompt (str "Choose " amount " " (pluralize "card" amount) " to shuffle into the stack")
+                     :choices {:max amount
+                               :all true
+                               :req #(and (installed? %) (= (:side %) "Runner"))}
+                     :delayed-completion true
+                     :effect (req
+                               (doseq [c targets]
+                                 (move state :runner c :deck))
+                               (system-msg state :runner
+                                           (str "shuffles " (join ", " (map :title targets))
+                                                " into their stack"))
+                               (shuffle! state :runner :deck)
+                               (effect-completed state side (make-result eid cost-name)))}
+                    card nil)
+    cost-name))
 
 (defn- cost-handler
   "Calls the relevant function for a cost depending on the keyword passed in"
-  [state side card action costs cost]
-  (case (first cost)
-    :click (do (trigger-event state side
-                              (if (= side :corp) :corp-spent-click :runner-spent-click)
-                              (first (keep :action action)) (:click (into {} costs)))
-               (swap! state assoc-in [side :register :spent-click] true)
-               (deduce state side cost))
-    :forfeit (pay-forfeit state side card (second cost))
-    :hardware (pay-trash state side card :hardware (second cost) (get-in @state [:runner :rig :hardware]))
-    :program (pay-trash state side card :program (second cost) (get-in @state [:runner :rig :program]))
+  ([state side card action costs cost] (cost-handler state side (make-eid state) card action costs cost))
+  ([state side eid card action costs cost]
+   (case (first cost)
+     :click (do (trigger-event state side
+                               (if (= side :corp) :corp-spent-click :runner-spent-click)
+                               (first (keep :action action)) (:click (into {} costs)))
+                (swap! state assoc-in [side :register :spent-click] true)
+                (let [r (deduce state side cost) ]
+                  (effect-completed state side (make-result eid r))
+                  r))
+     :forfeit (pay-forfeit state side eid card (second cost))
+     :hardware (pay-trash state side eid card "piece of hardware" (second cost) (every-pred installed? #(is-type? % :hardware) (complement facedown?)))
+     :program (pay-trash state side eid card "program" (second cost) (every-pred installed? #(is-type? % :program) (complement facedown?)))
 
-    ;; Connection
-    :connection (pay-trash state side card :connection (second cost) (filter (fn [c] (has-subtype? c "Connection"))
-                                                                          (all-installed state :runner)))
+     ;; Connection
+     :connection (pay-trash state side eid card "connection" (second cost) (every-pred installed? #(has-subtype? % "Connection") (complement facedown?)))
 
-    ;; Rezzed ICE
-    :ice (pay-trash state :corp card :ice (second cost) (filter (every-pred rezzed? ice?) (all-installed state :corp))
-                    {:cause :ability-cost :keep-server-alive true})
+     ;; Rezzed ICE
+     :ice (pay-trash state :corp card :ice (second cost) (every-pred rezzed? ice?) {:cause :ability-cost :keep-server-alive true})
 
-    :tag (deduce state :runner cost)
-    :net-damage (damage state side :net (second cost) {:unpreventable true})
-    :mill (mill state side (second cost))
+     :tag (let [r (deduce state :runner cost)]
+            (effect-completed state side (make-result eid r))
+            r)
+     :net-damage (damage state side eid :net (second cost) {:unpreventable true})
+     :mill (let [r (mill state side (second cost))]
+             (effect-completed state side (make-result eid r))
+             r)
 
-    ;; Shuffle installed runner cards into the stack (eg Degree Mill)
-    :shuffle-installed-to-stack (pay-shuffle-installed-to-stack state card (second cost))
+     ;; Shuffle installed runner cards into the stack (eg Degree Mill)
+     :shuffle-installed-to-stack (pay-shuffle-installed-to-stack state side eid card (second cost))
 
-    ;; Else
-    (deduce state side cost)))
+     ;; Else
+     (let [r (deduce state side cost)]
+       (effect-completed state side (make-result eid r))
+       r))))
 
 (defn pay
   "Deducts each cost from the player.
@@ -131,10 +148,31 @@
         action (not-empty (filter map? args))]
     (when-let [costs (apply can-pay? state side (:title card) raw-costs)]
         (->> costs
-             (map (partial cost-handler state side card action costs))
+             (map (partial cost-handler state side (make-eid state) card action costs))
              (filter some?)
              (interpose " and ")
              (apply str)))))
+
+(defn- pay-sync-next
+  [state side eid costs card action msgs]
+  (if (empty? costs)
+    (effect-completed state side (make-result eid msgs))
+    (when-completed (cost-handler state side card action costs (first costs))
+                    (pay-sync-next state side eid (next costs) card action (conj msgs async-result)))))
+
+(defn pay-sync
+  "Same as pay, but awaitable with when-completed. "
+  [state side eid card & args]
+  (let [raw-costs (not-empty (remove map? args))
+        action (not-empty (filter map? args))]
+    (if-let [costs (apply can-pay? state side (:title card) raw-costs)]
+      (when-completed (pay-sync-next state side costs card action [])
+                      (effect-completed state side
+                                        (make-result eid (->> async-result
+                                                              (filter some?)
+                                                              (interpose " and ")
+                                                              (apply str)))))
+      (effect-completed state side (make-result eid nil)))))
 
 (defn gain [state side & args]
   (doseq [r (partition 2 args)]

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -182,14 +182,15 @@
                      kw (if (pos? clicks) :click (to-keyword (join "-" (rest (split target #" ")))))
                      val (if (pos? clicks) clicks (string->num (first (split target #" "))))]
                  (if (can-pay? state side name [kw val])
-                   (do (pay state side nil [kw val])
-                       (system-msg state side (str "pays " target
+                   (when-completed
+                     (pay-sync state side nil [kw val])
+                     (do (system-msg state side (str "pays " target
                                                    " to steal " (:title card)))
-                       (if (< (count chosen) n)
-                         (continue-ability state side
-                                              (steal-pay-choice state :runner (remove-once #(not= target %)
+                         (if (< (count chosen) n)
+                           (continue-ability state side
+                                             (steal-pay-choice state :runner (remove-once #(not= target %)
                                                                                      choices) chosen n card) card nil)
-                         (resolve-steal state side eid card)))
+                           (resolve-steal state side eid card))))
                    (resolve-steal-events state side eid card)))))})
 
 (defn- access-agenda
@@ -215,10 +216,10 @@
           {:yes-ability
                        {:delayed-completion true
                         :effect (req (if (can-pay? state side name cost)
-                                       (do (pay state side nil cost)
-                                           (system-msg state side (str "pays " (costs-to-symbol cost)
-                                                                       " to steal " name))
-                                           (resolve-steal state side eid c))
+                                       (when-completed (pay-sync state side nil cost)
+                                                       (do (system-msg state side (str "pays " (costs-to-symbol cost)
+                                                                                   " to steal " name))
+                                                           (resolve-steal state side eid c)))
                                        (resolve-steal-events state side eid c)))}
            :no-ability {:delayed-completion true
                         :effect (effect (trigger-event :no-steal card)
@@ -245,6 +246,62 @@
                     (str " from " (->> cards first :zone (name-zone side)))))]
      (system-msg state side msg))))
 
+(defn- resolve-handle-access
+  [state side eid c title]
+  (let [cdef (card-def c)
+        c (assoc c :seen true)
+        access-effect (:access cdef)]
+    (msg-handle-access state side cards title)
+    (when-let [name (:title c)]
+      (if (is-type? c "Agenda")
+        ;; Accessing an agenda
+        (if (and access-effect
+                 (can-trigger? state side access-effect c nil))
+          ;; deal with access effects first. This is where Film Critic can be used to prevent these
+          (continue-ability state :runner
+                            {:delayed-completion true
+                             :prompt             (str "You must access " name)
+                             :choices            ["Access"]
+                             :effect             (req (when-completed
+                                                        (resolve-ability state (to-keyword (:side c)) access-effect c nil)
+                                                        (access-agenda state side eid c)))} c nil)
+          (access-agenda state side eid c))
+        ;; Accessing a non-agenda
+        (if (and access-effect
+                 (= (:zone c) (:zone (get-card state c))))
+          ;; if card wasn't moved by a pre-access effect
+          (when-completed (resolve-ability state (to-keyword (:side c)) access-effect c nil)
+                          (do (if (= (:zone c) (:zone (get-card state c)))
+                                ;; if the card wasn't moved by the access effect
+                                (access-non-agenda state side eid c)
+                                (effect-completed state side eid))))
+          (access-non-agenda state side eid c))))))
+
+(defn- handle-access-pay
+  [state side eid c title]
+  (let [acost (access-cost state side c)
+        ;; hack to prevent toasts when playing against Gagarin and accessing on 0 credits
+        anon-card (dissoc c :title)
+        cant-pay #(prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {})]
+    (cond
+      ;; Check if a pre-access-card effect trashed the card (By Any Means)
+      (not (get-card state c))
+      (effect-completed state side eid)
+
+      ;; Either there were no access costs, or the runner could pay them.
+      (empty? acost)
+      (resolve-handle-access state side eid c title)
+
+      (not-empty acost)
+      (when-completed (pay-sync state side anon-card acost)
+                      (if async-result
+                        (resolve-handle-access state side eid c title)
+                        (cant-pay)))
+      :else
+      ;; The runner cannot afford the cost to access the card
+      (cant-pay)))
+  (trigger-event state side :post-access-card c))
+
 (defn handle-access
   "Apply game rules for accessing the given list of cards (which generally only contains 1 card.)"
   ([state side cards] (handle-access state side (make-eid state) cards nil))
@@ -257,49 +314,7 @@
      (swap! state update-in [:bonus] dissoc :steal-cost)
      (swap! state update-in [:bonus] dissoc :access-cost)
      (when-completed (trigger-event-sync state side :pre-access-card c)
-                     (do (let [acost (access-cost state side c)
-                               ;; hack to prevent toasts when playing against Gagarin and accessing on 0 credits
-                               anon-card (dissoc c :title)]
-                           (cond
-                             ;; Check if a pre-access-card effect trashed the card (By Any Means)
-                             (not (get-card state c))
-                             (effect-completed state side eid)
-
-                             ;; Either there were no access costs, or the runner could pay them.
-                             (or (empty? acost) (pay state side anon-card acost))
-                             (let [cdef (card-def c)
-                                   c (assoc c :seen true)
-                                   access-effect (:access cdef)]
-                               (msg-handle-access state side cards title)
-                               (when-let [name (:title c)]
-                                 (if (is-type? c "Agenda")
-                                   ;; Accessing an agenda
-                                   (if (and access-effect
-                                            (can-trigger? state side access-effect c nil))
-                                     ;; deal with access effects first. This is where Film Critic can be used to prevent these
-                                     (continue-ability state :runner
-                                                       {:delayed-completion true
-                                                        :prompt (str "You must access " name)
-                                                        :choices ["Access"]
-                                                        :effect (req (when-completed
-                                                                       (resolve-ability state (to-keyword (:side c)) access-effect c nil)
-                                                                       (access-agenda state side eid c)))} c nil)
-                                     (access-agenda state side eid c))
-                                   ;; Accessing a non-agenda
-                                   (if (and access-effect
-                                            (= (:zone c) (:zone (get-card state c))))
-                                     ;; if card wasn't moved by a pre-access effect
-                                     (when-completed (resolve-ability state (to-keyword (:side c)) access-effect c nil)
-                                                     (do (if (= (:zone c) (:zone (get-card state c)))
-                                                           ;; if the card wasn't moved by the access effect
-                                                           (access-non-agenda state side eid c)
-                                                           (effect-completed state side eid))))
-                                     (access-non-agenda state side eid c)))))
-
-                             :else
-                             ;; The runner cannot afford the cost to access the card
-                             (prompt! state :runner nil "You can't pay the cost to access this card" ["OK"] {})))
-                         (trigger-event state side :post-access-card c))))))
+                     (handle-access-pay state side eid c title)))))
 
 (defn max-access
   "Put an upper limit on the number of cards that can be accessed in this run. For Eater."

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -238,12 +238,10 @@
                            :effect (req (resolve-steal state :runner eid c))} c nil)))))
 
 (defn msg-handle-access
-  ([state side cards]
-   (msg-handle-access state side cards (:title (first cards))))
-  ([state side cards title]
+  ([state side card title]
    (let [msg (str "accesses " title
-                  (when (pos? (count cards))
-                    (str " from " (->> cards first :zone (name-zone side)))))]
+                  (when card
+                    (str " from " (->> card :zone (name-zone side)))))]
      (system-msg state side msg))))
 
 (defn- resolve-handle-access
@@ -251,7 +249,7 @@
   (let [cdef (card-def c)
         c (assoc c :seen true)
         access-effect (:access cdef)]
-    (msg-handle-access state side cards title)
+    (msg-handle-access state side c title)
     (when-let [name (:title c)]
       (if (is-type? c "Agenda")
         ;; Accessing an agenda

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2000,8 +2000,8 @@
     (is (= 1 (count (get-in @state [:runner :rig :resource]))) "Kati Jones was installed")
     (play-from-hand state :runner "The Price of Freedom")
     (is (= 0 (count (get-in @state [:runner :hand]))) "The Price of Freedom can be played because a connection is in play")
-    (let [kj (find-card "Kati Jones" (:resource (:rig (get-runner))))]
-      (prompt-choice :runner kj)
+    (let [kj (get-resource state 0)]
+      (prompt-select :runner kj)
       (is (= 0 (count (get-in (get-runner) [:rig :resource]))) "Kati Jones was trashed wth The Price of Freedom")
       (is (= 1 (count (get-in (get-runner) [:discard]))) "The Price of Freedom was removed from game, and only Kati Jones is in the discard"))
     (take-credits state :runner)


### PR DESCRIPTION
I know @danhut and @butzopower were interested in looking at this, but it was more complicated than I anticipated so I thought to do it myself.

Adds an awaitable function `pay-sync`, which takes the same parameters as `pay` but can be awaited with `when-completed`. Integrated this functionality into access and steal costs, so Degree Mill can work again.

As a brief walkthrough:

1. Each of the individual cost-payment methods had to be made awaitable.  (`pay-trash`, `pay-forfeit`, `pay-shuffle-into-stack`.) To do this, we:
    1. Add a new third parameter `eid`.
    2. Pass that eid to the prompt we are using to resolve the cost with `continue-ability`. 
    3. Each of those prompts must be delayed completion, so that we can...
    4. Complete the payment effect with `effect-completed`, "returning" the string we use to describe the cost was paid in the user interface. This is the tricky part. The non-awaited version of these functions returns that string (`cost-name`) immediately, but an awaitable function does not participate in the normal function-return sequence. (The call site continues executing while the awaitable function is still active.) To return something from an awaitable function, we use `make-result` to wrap the `eid` we trigger as completed with a "return value", in this case the string description. Whoever calls `when-completed` can then capture this returned value with the variable `async-result`, automatically bound in the body of the `when-completed` follow-up function.

2. `cost-handler` is also made awaitable. For complicated costs, its `eid` is passed to the appropriate handler (`pay-X` above), so when that function is complete, so too is `cost-handler`. For simple costs, `effect-completed` is triggered manually. In all cases, the return value from the handler is the string description returned from the `pay-X` functions (or from `deduce`), and we wrap that as the async result for `cost-handler`.  We also return that value (called `r` in the code) so that `cost-handler` can continue to be used in a non-awaitable fashion with the existing `pay` function.

3. `pay-sync` then triggers `cost-handler` for each cost in its list, and awaits the completion of the handler. The next cost is then recursively handled. Each async result (the string description of the cost) from a handler is added to a vector, and all those strings are joined together to make a single description as in `pay` itself.

4. To use the new function, we do something like this:

```clojure
(when-completed 
  (pay-sync state side card costs)
  (if async-result
    ;; cost was paid
    ;; cost was not paid
  )
)
```

Whew.

Fixes #3167