### PR TITLE
Bad Publicity triggers and The Outfit

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -784,8 +784,10 @@
    {:interactive (req true)
     :choices ["0" "1" "2" "3"] :prompt "How many bad publicity?"
     :msg (msg "take " target " bad publicity and gain " (* 5 (str->int target)) " [Credits]")
-    :effect (final-effect (gain-bad-publicity :corp eid (str->int target) {:unpreventable true})
-                          (gain :credit (* 5 (str->int target))))}
+    :effect (req (let [bp (:bad-publicity (:corp @state))]
+                   (gain-bad-publicity state :corp eid (str->int target))
+                   (if (< bp (:bad-publicity (:corp @state)))
+                     (gain state :corp :credit (* 5 (str->int target))))))}
 
    "Project Ares"
    (letfn [(trash-count-str [card]

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -272,7 +272,7 @@
    {:msg "remove 1 bad publicity" :effect (effect (lose :bad-publicity 1))
     :silent (req true)
     :stolen {:msg "force the Corp to take 1 bad publicity"
-             :effect (effect (gain :corp :bad-publicity 1))}}
+             :effect (effect (gain-bad-publicity :corp 1))}}
 
    "Corporate Sales Team"
    (let [e {:effect (req (when (pos? (get-in card [:counter :credit] 0))
@@ -450,7 +450,8 @@
     :abilities [{:cost [:click 1]
                  :counter-cost [:agenda 1]
                  :msg "gain 7 [Credits] and take 1 bad publicity"
-                 :effect (effect (gain :credit 7 :bad-publicity 1))}]}
+                 :effect (effect (gain :credit 7)
+                                 (gain-bad-publicity :corp 1))}]}
 
    "Gila Hands Arcology"
    {:abilities [{:cost [:click 2] :effect (effect (gain :credit 3)) :msg "gain 3 [Credits]"}]}
@@ -519,7 +520,8 @@
 
    "Hostile Takeover"
    {:msg "gain 7 [Credits] and take 1 bad publicity"
-    :effect (effect (gain :credit 7 :bad-publicity 1))
+    :effect (effect (gain :credit 7)
+                    (gain-bad-publicity :corp 1))
     :interactive (req true)}
 
    "Hollywood Renovation"
@@ -554,7 +556,7 @@
                      {:optional
                       {:prompt "Take 1 bad publicity from Illicit Sales?"
                        :yes-ability {:msg "take 1 bad publicity"
-                                     :effect (effect (gain :bad-publicity 1))}
+                                     :effect (effect (gain-bad-publicity :corp 1))}
                        :no-ability {:effect (req (effect-completed state side eid))}}}
                      card nil)
                    (do (let [n (* 3 (+ (get-in @state [:corp :bad-publicity]) (:has-bad-pub corp)))]
@@ -765,7 +767,7 @@
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
                :yes-ability {:msg "give the Runner 1 tag and take 1 bad publicity"
                              :delayed-completion true
-                             :effect (effect (gain :bad-publicity 1)
+                             :effect (effect (gain-bad-publicity :corp eid 1)
                                              (tag-runner :runner eid 1)
                                              (forfeit card))}}}
 
@@ -782,8 +784,8 @@
    {:interactive (req true)
     :choices ["0" "1" "2" "3"] :prompt "How many bad publicity?"
     :msg (msg "take " target " bad publicity and gain " (* 5 (str->int target)) " [Credits]")
-    :effect (final-effect (gain :credit (* 5 (str->int target))
-                                :bad-publicity (str->int target)))}
+    :effect (final-effect (gain :credit (* 5 (str->int target)))
+                          (gain-bad-publicity :corp (str->int target)))}
 
    "Project Ares"
    (letfn [(trash-count-str [card]
@@ -803,7 +805,7 @@
                                              (:installed %))}
                         :effect (final-effect (trash-cards targets)
                                               (system-msg (str "trashes " (join ", " (map :title targets))))
-                                              (gain :corp :bad-publicity 1))}
+                                              (gain-bad-publicity :corp 1))}
                        card nil)
                       (clear-wait-prompt :corp))})
 
@@ -1140,7 +1142,7 @@
     :msg "do 2 meat damage"
     :effect (effect (damage eid :meat 2 {:card card}))
     :stolen {:msg "force the Corp to take 1 bad publicity"
-             :effect (effect (gain :corp :bad-publicity 1))}}
+             :effect (effect (gain-bad-publicity :corp 1))}}
 
    "Water Monopoly"
    {:events {:pre-install {:req (req (and (is-type? target "Resource")

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -784,8 +784,8 @@
    {:interactive (req true)
     :choices ["0" "1" "2" "3"] :prompt "How many bad publicity?"
     :msg (msg "take " target " bad publicity and gain " (* 5 (str->int target)) " [Credits]")
-    :effect (final-effect (gain :credit (* 5 (str->int target)))
-                          (gain-bad-publicity :corp (str->int target)))}
+    :effect (final-effect (gain-bad-publicity :corp eid (str->int target) {:unpreventable true})
+                          (gain :credit (* 5 (str->int target))))}
 
    "Project Ares"
    (letfn [(trash-count-str [card]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -200,10 +200,10 @@
               :effect (effect (rez-cost-bonus (- (:click runner))))}}}
 
    "Broadcast Square"
-   {:implementation "Removes 1 bad publicity rather than prevent it"
-    :abilities [{:label "Trace 3 - Avoid taking a bad publicity"
-                 :trace {:base 3 :msg "avoid taking a bad publicity"
-                         :effect (effect (lose :bad-publicity 1))}}]}
+   {:abilities [{:label "Trace 3 - Avoid taking a bad publicity"
+                 :trace {:base 3
+                         :msg "avoid taking a bad publicity"
+                         :effect (effect (bad-publicity-prevent 1))}}]}
 
    "Capital Investors"
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}
@@ -457,7 +457,9 @@
     :abilities [{:cost [:click 1] :label "Trash a location"
                  :msg (msg "trash " (:title target) " and take 1 bad publicity")
                  :choices {:req #(has-subtype? % "Location")}
-                 :effect (effect (trash card) (trash target) (gain :bad-publicity 1))}]}
+                 :effect (effect (trash card)
+                                 (trash target)
+                                 (gain-bad-publicity :corp 1))}]}
 
    "Elizas Toybox"
    {:abilities [{:cost [:click 3] :choices {:req #(not (:rezzed %))}
@@ -650,7 +652,7 @@
       :abilities [ability]
       :trash-effect {:req (req (= :servers (first (:previous-zone card)))
                                (= side :runner))
-                     :effect (effect (gain :corp :bad-publicity 1)
+                     :effect (effect (gain-bad-publicity :corp 1)
                                      (system-msg :corp (str "takes 1 bad publicity from Illegal Arms Factory")))}})
 
    "Indian Union Stock Exchange"
@@ -1209,7 +1211,8 @@
                   :label "Gain credits (start of turn)"
                   :once :per-turn
                   :msg (msg (if tagged "gain 2 [Credits]" "gain 1 [Credits]"))}]
-   {:effect (effect (gain :bad-publicity 1) (system-msg "takes 1 bad publicity"))
+   {:effect (effect (gain-bad-publicity :corp 1)
+                    (system-msg "takes 1 bad publicity"))
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     :events {:corp-turn-begins ability}
     :abilities [ability]})

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -200,10 +200,10 @@
               :effect (effect (rez-cost-bonus (- (:click runner))))}}}
 
    "Broadcast Square"
-   {:abilities [{:label "Trace 3 - Avoid taking a bad publicity"
-                 :trace {:base 3
-                         :msg "avoid taking a bad publicity"
-                         :effect (effect (bad-publicity-prevent 1))}}]}
+   {:events {:pre-bad-publicity {:delayed-completion true
+                                 :trace {:base 3
+                                         :msg "prevents all bad publicity"
+                                         :effect (effect (bad-publicity-prevent Integer/MAX_VALUE))}}}}
 
    "Capital Investors"
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -654,7 +654,8 @@
    "Frame Job"
    {:prompt "Choose an agenda to forfeit"
     :choices (req (:scored runner))
-    :effect (effect (forfeit target) (gain :corp :bad-publicity 1))
+    :effect (effect (forfeit target)
+                    (gain-bad-publicity :corp 1))
     :msg (msg "forfeit " (:title target) " and give the Corp 1 bad publicity")}
 
    "Frantic Coding"
@@ -990,7 +991,8 @@
     :prompt "Take 2 bad publicity?"
     :choices ["Yes" "No"]
     :effect (req (if (= target "Yes")
-                   (do (gain state :corp :bad-publicity 2) (system-msg state :corp "takes 2 bad publicity"))
+                   (do (gain-bad-publicity state :corp 2)
+                       (system-msg state :corp "takes 2 bad publicity"))
                    (do (register-events state side
                                         {:pre-damage {:effect (effect (damage-prevent :net Integer/MAX_VALUE)
                                                                       (damage-prevent :meat Integer/MAX_VALUE)
@@ -1093,7 +1095,7 @@
                                           (continue-ability state side (mining) card nil))
 
                                       (= target "Take 1 Bad Publicity")
-                                      (do (gain state :corp :bad-publicity 1)
+                                      (do (gain-bad-publicity state :corp 1)
                                           (system-msg state side "takes 1 Bad Publicity from Mining Accident")
                                           (clear-wait-prompt state :runner)
                                           (effect-completed state side eid))))})]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -98,7 +98,7 @@
 
 (def take-bad-pub
   "Bad pub on rez effect."
-  (effect (gain :bad-publicity 1)
+  (effect (gain-bad-publicity :corp 1)
           (system-msg (str "takes 1 bad publicity from " (:title card)))))
 
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -323,7 +323,7 @@
    {:events {:pre-start-game {:req (req (= :corp side))
                               :effect (req (gain state :corp :credit 5)
                                            (when (= 0 (:bad-publicity corp))
-                                             (gain state :corp :bad-publicity 1)))}}}
+                                             (gain-bad-publicity state :corp 1)))}}}
 
    "Haarpsichord Studios: Entertainment Unleashed"
    (let [haarp (fn [state side card]
@@ -965,6 +965,11 @@
    "The Masque: Cyber General"
    {:events {:pre-start-game {:effect draft-points-target}}}
 
+   "The Outfit: Family Owned and Operated"
+   {:events {:corp-gain-bad-publicity {:delayed-completion true
+                                       :msg "gain 3 [Credit]"
+                                       :effect (effect (gain :credit 3))}}}
+
    ;; No special implementation
    "The Professor: Keeper of Knowledge"
    {}
@@ -980,7 +985,7 @@
    {:events {:pre-start-game
              {:req (req (and (= side :runner)
                              (zero? (get-in @state [:corp :bad-publicity]))))
-              :effect (effect (gain :corp :bad-publicity 1))}}}
+              :effect (effect (gain-bad-publicity :corp 1))}}}
 
    "Weyland Consortium: Because We Built It"
    {:recurring 1}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -590,7 +590,7 @@
             :effect (effect (move :runner target :deck {:front true})
                             (system-msg (str "adds " (:title target) " to the top of the Stack")))
             :unsuccessful {:msg "take 1 bad publicity"
-                           :effect (effect (gain :corp :bad-publicity 1))}}}
+                           :effect (effect (gain-bad-publicity :corp 1))}}}
 
    "Hellion Beta Test"
    {:req (req (last-turn? state :runner :trashed-card))
@@ -605,7 +605,7 @@
             :effect (req (doseq [c targets]
                            (trash state side c)))
             :unsuccessful {:msg "take 1 bad publicity"
-                           :effect (effect (gain :corp :bad-publicity 1))}}}
+                           :effect (effect (gain-bad-publicity :corp 1))}}}
 
    "Heritage Committee"
    {:delayed-completion true
@@ -665,7 +665,7 @@
                                               (join ", " (map :title (sort-by :title (:hand runner))))
                                               " ) and can trash up to " x " resources or events"))
                              (continue-ability state side (iop (dec x)) card nil)))
-              :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain :corp :bad-publicity 1))}}})
+              :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain-bad-publicity :corp 1))}}})
 
    "IPO"
    {:msg "gain 13 [Credits]" :effect (effect (gain :credit 13))}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1505,7 +1505,7 @@
    {:req (req (< (:credit corp) 10))
     :msg "gain 7 [Credits] and take 1 bad publicity"
     :effect (effect (gain :credit 7)
-                    (gain :corp :bad-publicity 1) ) }
+                    (gain-bad-publicity :corp 1) ) }
 
    "Traffic Accident"
    {:req (req (>= (:tag runner) 2))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -49,7 +49,7 @@
                         :effect (effect (tag-runner :runner eid 1))}
      :runner-turn-begins {:req (req (not has-bad-pub))
                           :msg "give the Corp 1 bad publicity"
-                          :effect (effect (gain :corp :bad-publicity 1))}}}
+                          :effect (effect (gain-bad-publicity :corp 1))}}}
 
    "Adjusted Chronotype"
    {:events {:runner-loss {:req (req (and (some #{:click} target)
@@ -821,7 +821,8 @@
    "Investigative Journalism"
    {:req (req has-bad-pub)
     :abilities [{:cost [:click 4] :msg "give the Corp 1 bad publicity"
-                 :effect (effect (gain :corp :bad-publicity 1) (trash card {:cause :ability-cost}))}]}
+                 :effect (effect (gain-bad-publicity :corp 1)
+                                 (trash card {:cause :ability-cost}))}]}
 
    "Jak Sinclair"
    (let [ability {:label "Make a run (start of turn)"
@@ -1571,7 +1572,7 @@
                                :player :runner
                                :yes-ability {:msg "give the Corp 1 bad publicity and take 1 tag"
                                              :delayed-completion true
-                                             :effect (effect (gain :corp :bad-publicity 1)
+                                             :effect (effect (gain-bad-publicity :corp 1)
                                                              (tag-runner :runner eid 1)
                                                              (clear-wait-prompt :corp))}
                                :no-ability {:effect (effect (clear-wait-prompt :corp))}}}
@@ -1627,7 +1628,7 @@
                              :msg "force the Corp to initiate a trace"
                              :label "Trace 1 - If unsuccessful, take 1 bad publicity"
                              :trace {:base 1
-                                     :unsuccessful {:effect (effect (gain :corp :bad-publicity 1)
+                                     :unsuccessful {:effect (effect (gain-bad-publicity :corp 1)
                                                                     (system-msg :corp (str "takes 1 bad publicity")))}}}}}
 
    "The Black File"

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -317,35 +317,35 @@
   (trigger-event state side :pre-resolve-bad-publicity n)
   (if (pos? n)
     (do (gain state :corp :bad-publicity n)
-        (toast state :corp (str "Took " n "bad publicity!") "info")
+        (toast state :corp (str "Took " n " bad publicity!") "info")
         (trigger-event-sync state side eid :corp-gain-bad-publicity n))
     (effect-completed state side eid)))
 
 (defn gain-bad-publicity
-  "Attempts to give the runner n bad-publicitys, allowing for boosting/prevention effects."
+  "Attempts to give the runner n bad-publicity, allowing for boosting/prevention effects."
   ([state side n] (gain-bad-publicity state side (make-eid state) n nil))
   ([state side eid n] (gain-bad-publicity state side eid n nil))
   ([state side eid n {:keys [unpreventable card] :as args}]
    (swap! state update-in [:bad-publicity] dissoc :bad-publicity-bonus :bad-publicity-prevent)
-   (trigger-event state side :pre-bad-publicity card)
-   (let [n (bad-publicity-count state side n args)]
-     (let [prevent (get-in @state [:prevent :bad-publicity :all])]
-       (if (and (pos? n) (not unpreventable) (pos? (count prevent)))
-         (do (system-msg state :corp "has the option to avoid bad publicity")
-             (show-wait-prompt state :runner "Corp to prevent bad publicity" {:priority 10})
-             (swap! state assoc-in [:prevent :current] :bad-publicity)
-             (show-prompt
-               state :corp nil (str "Avoid any of the " n " bad publicity?") ["Done"]
-               (fn [_]
-                 (let [prevent (get-in @state [:bad-publicity :bad-publicity-prevent])]
-                   (system-msg state :corp
-                               (if prevent
-                                 (str "avoids " (if (= prevent Integer/MAX_VALUE) "all" prevent) "bad publicity")
-                                 "will not avoid bad publicity"))
-                   (clear-wait-prompt state :runner)
-                   (resolve-bad-publicity state side eid (max 0 (- n (or prevent 0))) args)))
-               {:priority 10}))
-         (resolve-bad-publicity state side eid n args))))))
+   (when-completed (trigger-event-sync state side :pre-bad-publicity card)
+     (let [n (bad-publicity-count state side n args)]
+       (let [prevent (get-in @state [:prevent :bad-publicity :all])]
+         (if (and (pos? n) (not unpreventable) (pos? (count prevent)))
+           (do (system-msg state :corp "has the option to avoid bad publicity")
+               (show-wait-prompt state :runner "Corp to prevent bad publicity" {:priority 10})
+               (swap! state assoc-in [:prevent :current] :bad-publicity)
+               (show-prompt
+                 state :corp nil (str "Avoid any of the " n " bad publicity?") ["Done"]
+                 (fn [_]
+                   (let [prevent (get-in @state [:bad-publicity :bad-publicity-prevent])]
+                     (system-msg state :corp
+                                 (if prevent
+                                   (str "avoids " (if (= prevent Integer/MAX_VALUE) "all" prevent) " bad publicity")
+                                   "will not avoid bad publicity"))
+                     (clear-wait-prompt state :runner)
+                     (resolve-bad-publicity state side eid (max 0 (- n (or prevent 0))) args)))
+                 {:priority 10}))
+           (resolve-bad-publicity state side eid n args)))))))
 
 
 ;;; Trashing

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -300,6 +300,54 @@
          (resolve-tag state side eid n args))))))
 
 
+;;;; Bad Publicity
+(defn bad-publicity-count
+  "Calculates the number of bad publicity to give, taking into account prevention and boosting effects."
+  [state side n {:keys [unpreventable unboostable] :as args}]
+  (-> n
+      (+ (or (when-not unboostable (get-in @state [:bad-publicity :bad-publicity-bonus])) 0))
+      (- (or (when-not unpreventable (get-in @state [:bad-publicity :bad-publicity-prevent])) 0))
+      (max 0)))
+
+(defn bad-publicity-prevent [state side n]
+  (swap! state update-in [:bad-publicity :bad-publicity-prevent] (fnil #(+ % n) 0))
+  (trigger-event state side (if (= side :corp) :corp-prevent :runner-prevent) `(:bad-publicity ~n)))
+
+(defn resolve-bad-publicity [state side eid n args]
+  (trigger-event state side :pre-resolve-bad-publicity n)
+  (if (pos? n)
+    (do (gain state :corp :bad-publicity n)
+        (toast state :corp (str "Took " n "bad publicity!") "info")
+        (trigger-event-sync state side eid :corp-gain-bad-publicity n))
+    (effect-completed state side eid)))
+
+(defn gain-bad-publicity
+  "Attempts to give the runner n bad-publicitys, allowing for boosting/prevention effects."
+  ([state side n] (gain-bad-publicity state side (make-eid state) n nil))
+  ([state side eid n] (gain-bad-publicity state side eid n nil))
+  ([state side eid n {:keys [unpreventable card] :as args}]
+   (swap! state update-in [:bad-publicity] dissoc :bad-publicity-bonus :bad-publicity-prevent)
+   (trigger-event state side :pre-bad-publicity card)
+   (let [n (bad-publicity-count state side n args)]
+     (let [prevent (get-in @state [:prevent :bad-publicity :all])]
+       (if (and (pos? n) (not unpreventable) (pos? (count prevent)))
+         (do (system-msg state :corp "has the option to avoid bad publicity")
+             (show-wait-prompt state :runner "Corp to prevent bad publicity" {:priority 10})
+             (swap! state assoc-in [:prevent :current] :bad-publicity)
+             (show-prompt
+               state :corp nil (str "Avoid any of the " n " bad publicity?") ["Done"]
+               (fn [_]
+                 (let [prevent (get-in @state [:bad-publicity :bad-publicity-prevent])]
+                   (system-msg state :corp
+                               (if prevent
+                                 (str "avoids " (if (= prevent Integer/MAX_VALUE) "all" prevent) "bad publicity")
+                                 "will not avoid bad publicity"))
+                   (clear-wait-prompt state :runner)
+                   (resolve-bad-publicity state side eid (max 0 (- n (or prevent 0))) args)))
+               {:priority 10}))
+         (resolve-bad-publicity state side eid n args))))))
+
+
 ;;; Trashing
 (defn trash-resource-bonus
   "Applies a cost increase of n to trashing a resource with the click action. (SYNC.)"

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -139,6 +139,29 @@
       (core/rez state :corp eli)
       (is (= 1 (:credit (get-corp))) "Paid only 1c to rez Eli; reduction of 2c"))))
 
+(deftest broadcast-square
+  ;; Broadcast Square - Trace 3: Prevent all bad publicity
+  (do-game
+    (new-game (default-corp [(qty "Profiteering" 1) (qty "Hostile Takeover" 1) (qty "Broadcast Square" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Broadcast Square" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (play-from-hand state :corp "Profiteering" "New remote")
+    (score-agenda state :corp (get-content state :remote2 0))
+    (prompt-choice :corp "3")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 1 (:agenda-point (get-corp))))
+    (is (= 0 (:bad-publicity (get-corp))) "Prevented all bad publicity")
+    (is (= 3 (:credit (get-corp))) "Gained 0 credits")
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (score-agenda state :corp (get-content state :remote3 0))
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 3)
+    (is (= 2 (:agenda-point (get-corp))))
+    (is (= 1 (:bad-publicity (get-corp))) "Gained a bad publicity through failed trace")
+    (is (= 10 (:credit (get-corp))) "Gained 7 credits")))
+
 (deftest capital-investors
   ;; Capital Investors - Click for 2 credits
   (do-game

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -146,21 +146,22 @@
               (default-runner))
     (play-from-hand state :corp "Broadcast Square" "New remote")
     (core/rez state :corp (get-content state :remote1 0))
+    (is (= 3 (:credit (get-corp))) "Corp should have spent 2 credits: (= 3 (- 5 2))")
     (play-from-hand state :corp "Profiteering" "New remote")
     (score-agenda state :corp (get-content state :remote2 0))
-    (prompt-choice :corp "3")
-    (prompt-choice :corp 0)
-    (prompt-choice :runner 0)
-    (is (= 1 (:agenda-point (get-corp))))
-    (is (= 0 (:bad-publicity (get-corp))) "Prevented all bad publicity")
-    (is (= 3 (:credit (get-corp))) "Gained 0 credits")
+    (prompt-choice :corp "3")  ;; Take 3 bad publicity from Profiteering, gain 15 (if bad publicity actually taken)
+    (prompt-choice :corp 0)  ;; Corp doesn't pump trace, base 3
+    (prompt-choice :runner 0)  ;; Runner doesn't pump trace; loses trace
+    (is (= 1 (:agenda-point (get-corp))) "Corp should score a 1-point agenda")
+    (is (= 0 (:bad-publicity (get-corp))) "Corp should gain 0 bad publicity")
+    (is (= 3 (:credit (get-corp))) "Corp should gain 0 credits: (= 3 (+ 3 0))")
     (play-from-hand state :corp "Hostile Takeover" "New remote")
     (score-agenda state :corp (get-content state :remote3 0))
-    (prompt-choice :corp 0)
-    (prompt-choice :runner 3)
-    (is (= 2 (:agenda-point (get-corp))))
-    (is (= 1 (:bad-publicity (get-corp))) "Gained a bad publicity through failed trace")
-    (is (= 10 (:credit (get-corp))) "Gained 7 credits")))
+    (prompt-choice :corp 0)  ;; Corp doesn't pump trace, base 3
+    (prompt-choice :runner 3)  ;; Runner pumps trace; wins trace
+    (is (= 2 (:agenda-point (get-corp))) "Corp should score a 1-point agenda: (= 2 (+ 1 1))")
+    (is (= 1 (:bad-publicity (get-corp))) "Corp should gain 1 bad publicity from failed trace")
+    (is (= 10 (:credit (get-corp))) "Corp should gain 7 credits: (= 10 (+ 3 7))")))
 
 (deftest capital-investors
   ;; Capital Investors - Click for 2 credits

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1363,12 +1363,17 @@
   ;; The Outfit - Gain 3 whenever you take at least 1 bad publicity
   (do-game
     (new-game
-      (make-deck "The Outfit: Family Owned and Operated" [(qty "Hostile Takeover" 1)])
+      (make-deck "The Outfit: Family Owned and Operated" [(qty "Hostile Takeover" 1) (qty "Profiteering" 1)])
       (default-runner))
     (play-from-hand state :corp "Hostile Takeover" "New remote")
     (score-agenda state :corp (get-content state :remote1 0))
     (is (= 1 (:bad-publicity (get-corp))) "Take 1 bad publicity")
-    (is (= 15 (:credit (get-corp))) "Gain 7 from Hostile Takeover + 3 from The Outfit")))
+    (is (= 15 (:credit (get-corp))) "Corp should gain 10 credits: (= 15 (+ 5 7 3))")
+    (play-from-hand state :corp "Profiteering" "New remote")
+    (score-agenda state :corp (get-content state :remote2 0))
+    (prompt-choice :corp "3")  ;; Take 3 bad publicity from Profiteering, gain 15 (if bad publicity actually taken)
+    (is (= 4 (:bad-publicity (get-corp))) "Corp should gain 1 bad publicity")
+    (is (= 33 (:credit (get-corp))) "Corp should gain 18 credits: (= 33 (+ 15 15 3))")))
 
 (deftest the-outfit-profiteering
   ;; The Outfit & Profiteering - Only gain 3 credits when taking more than 1 bad publicity in a single effect

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1359,6 +1359,42 @@
     (prompt-choice :corp "Yes")
     (is (empty? (:play-area (get-corp))) "Play area shuffled into R&D")))
 
+(deftest the-outfit
+  ;; The Outfit - Gain 3 whenever you take at least 1 bad publicity
+  (do-game
+    (new-game
+      (make-deck "The Outfit: Family Owned and Operated" [(qty "Hostile Takeover" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (is (= 1 (:bad-publicity (get-corp))) "Take 1 bad publicity")
+    (is (= 15 (:credit (get-corp))) "Gain 7 from Hostile Takeover + 3 from The Outfit")))
+
+(deftest the-outfit-profiteering
+  ;; The Outfit & Profiteering - Only gain 3 credits when taking more than 1 bad publicity in a single effect
+  (do-game
+    (new-game
+      (make-deck "The Outfit: Family Owned and Operated" [(qty "Profiteering" 1)])
+      (default-runner))
+    (play-from-hand state :corp "Profiteering" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (prompt-choice :corp "3")
+    (is (= 3 (:bad-publicity (get-corp))) "Take 3 bad publicity")
+    (is (= 23 (:credit (get-corp))) "Gain 15 from Profiteering + 3 from The Outfit")))
+
+(deftest the-outfit-valencia
+  ;; The Outfit vs Valencia - 1 bad pub at start means 8 credits to start with
+  (do-game
+    (new-game
+      (make-deck "The Outfit: Family Owned and Operated" [(qty "Hostile Takeover" 1)])
+      (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Sure Gamble" 3)]))
+    (is (= 1 (:bad-publicity (get-corp))) "The Outfit starts with 1 bad publicity")
+    (is (= 8 (:credit (get-corp))) "The Outfit starts with 8 credits")
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (score-agenda state :corp (get-content state :remote1 0))
+    (is (= 2 (:bad-publicity (get-corp))) "Take 1 bad publicity")
+    (is (= 18 (:credit (get-corp))) "Gain 7 from Hostile Takeover + 3 from The Outfit")))
+
 (deftest titan-agenda-counter
   ;; Titan Transnational - Add a counter to a scored agenda
   (do-game


### PR DESCRIPTION
Changes out bad publicity is gained to mirror taking tags: in fact, this is a copy-paste of the tagging code, with the necessary changes, and all gain bad publicity references modified to follow suit.

This allows for The Outfit to work as needed: when gaining any amount of bad publicity, the effect triggers `:corp-gain-bad-publicity`, and the corp gains 3 credits.