### PR TITLE
small fix to Snatch and Grab

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1298,19 +1298,21 @@
             :choices {:req #(has-subtype? % "Connection")}
             :delayed-completion true
             :effect (req (let [c target]
+                           (show-wait-prompt state :corp "Runner to decide if they will take 1 tag")
                            (continue-ability
                              state side
                              {:prompt (msg "Take 1 tag to prevent " (:title c) " from being trashed?")
                               :choices ["Yes" "No"] :player :runner
                               :delayed-completion true
-                              :effect (effect (continue-ability
+                              :effect (effect (clear-wait-prompt :corp)
+                                              (continue-ability
                                                 (if (= target "Yes")
                                                   {:msg (msg "take 1 tag to prevent " (:title c)
                                                              " from being trashed")
                                                    :delayed-completion true
                                                    :effect (effect (tag-runner eid 1 {:unpreventable true}))}
                                                   {:delayed-completion true
-                                                   :effect (effect (trash eid c nil))
+                                                   :effect (effect (trash :corp eid c nil))
                                                    :msg (msg "trash " (:title c))})
                                                 card nil))}
                              card nil)))}}


### PR DESCRIPTION
Add wait prompt to Corp while Runner is deciding; does the trash as Corp so it won't trigger Wasteland/Reaver or other Apex cards. 