### PR TITLE
WIP: Implement all ICE On Encounter abilities

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -885,10 +885,17 @@
              card nil)))
 
    "Inside Job"
-   {:implementation "Bypass is manual"
-    :prompt "Choose a server"
+   {:prompt "Choose a server by choosing the ice you wish to bypass"
     :choices (req runnable-servers)
-    :effect (effect (run target nil card))}
+    :delayed-completion true
+    :effect (req (swap! state assoc-in [:runner :register :bypass-current-ice] true)
+                 (register-events state side (:events (card-def card)) (assoc card :zone '(:discard)))
+                 (game.core/run state side (make-eid state) target nil card))
+    :events {:approach-ice {:once :per-run
+                            :msg "bypass the first piece of ice"
+                            :effect (req (game.core/continue state :runner nil))}
+             :pass-ice {:effect (req
+                                  (swap! state update-in [:runner :register] dissoc :bypass-current-ice))}}}
 
    "Interdiction"
    (let [ab (effect (register-turn-flag!

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -674,17 +674,22 @@
                   end-the-run]}
 
    "Data Raven"
-   {:implementation "Encounter effect is manual"
-    :abilities [give-tag
-                (power-counter-ability give-tag)]
-    :runner-abilities [{:label "End the run"
-                        :effect (req (end-run state :runner)
-                                     (system-msg state :runner "chooses to end the run on encountering Data Raven"))}
-                       {:label "Take 1 tag"
-                        :delayed-completion true
-                        :effect (req (system-msg state :runner "chooses to take 1 tag on encountering Data Raven")
-                                     (tag-runner state :runner eid 1))}]
-    :subroutines [(trace-ability 3 add-power-counter)]}
+   {:abilities [(power-counter-ability give-tag)]
+    :subroutines [(trace-ability 3 add-power-counter)]
+    :events {:encounter-ice {:delayed-completion true
+                             :effect (effect (show-wait-prompt :corp "Runner to decide to take 1 tag or end the run")
+                                             (continue-ability
+                                               :runner {:player :runner
+                                                        :prompt "Take 1 tag or end the run?"
+                                                        :choices ["Take 1 tag" "End the run"]
+                                                        :effect (req (if (= target "Take 1 tag")
+                                                                        (do (system-msg state :runner "chooses to take 1 tag on encountering Data Raven")
+                                                                            (tag-runner state :runner eid 1)
+                                                                            (clear-wait-prompt state :corp))
+                                                                        (do (system-msg state :runner "chooses to end the run on encountering Data Raven")
+                                                                            (end-run state :runner)
+                                                                            (clear-wait-prompt state :corp))))}
+                                             card nil))}}}
 
    "Data Ward"
    {:runner-abilities [{:label "Pay 3 [Credits]"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1820,10 +1820,13 @@
     :subroutines [end-the-run]}
 
    "Tollbooth"
-   {:implementation "Encounter effect is manual"
-    :abilities [{:msg "make the Runner pay 3 [Credits], if able"
-                 :effect (effect (pay :runner card :credit 3))}]
-    :subroutines [end-the-run]}
+   {:subroutines [end-the-run]
+    :events {:encounter-ice {:effect (req (if (>= (:credit runner) 3)
+                                            (do (lose state :runner :credit 3)
+                                                (system-msg state side "Runner loses 3 [Credits]"))
+                                            (do (end-run state side)
+                                                (system-msg state side "Runner can't pay 3")
+                                                (system-msg state side "Tollbooth ends the run"))))}}}
 
    "Tour Guide"
    {:abilities [{:label "Gain subroutines"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -677,19 +677,20 @@
    {:abilities [(power-counter-ability give-tag)]
     :subroutines [(trace-ability 3 add-power-counter)]
     :events {:encounter-ice {:delayed-completion true
-                             :effect (effect (show-wait-prompt :corp "Runner to decide to take 1 tag or end the run")
-                                             (continue-ability
-                                               :runner {:player :runner
-                                                        :prompt "Take 1 tag or end the run?"
-                                                        :choices ["Take 1 tag" "End the run"]
-                                                        :effect (req (if (= target "Take 1 tag")
-                                                                        (do (system-msg state :runner "chooses to take 1 tag on encountering Data Raven")
-                                                                            (tag-runner state :runner eid 1)
-                                                                            (clear-wait-prompt state :corp))
-                                                                        (do (system-msg state :runner "chooses to end the run on encountering Data Raven")
-                                                                            (end-run state :runner)
-                                                                            (clear-wait-prompt state :corp))))}
-                                             card nil))}}}
+                             :req (req (not= (get-in @state [:runner :register :bypass-current-ice])))
+                             :effect (req (show-wait-prompt state :corp "Runner to decide to take 1 tag or end the run")
+                                          (continue-ability state :runner
+                                            {:player :runner
+                                             :prompt "Take 1 tag or end the run?"
+                                             :choices ["Take 1 tag" "End the run"]
+                                             :effect (req (if (= target "Take 1 tag")
+                                                             (do (system-msg state :runner "chooses to take 1 tag on encountering Data Raven")
+                                                                 (tag-runner state :runner eid 1)
+                                                                 (clear-wait-prompt state :corp))
+                                                             (do (system-msg state :runner "chooses to end the run on encountering Data Raven")
+                                                                 (end-run state :runner)
+                                                                 (clear-wait-prompt state :corp))))}
+                                          card nil))}}}
 
    "Data Ward"
    {:runner-abilities [{:label "Pay 3 [Credits]"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -425,9 +425,12 @@
   (let [run-ice (get-run-ices state)
         pos (get-in @state [:run :position])
         ice (when (and pos (pos? pos) (<= pos (count run-ice)))
-              (get-card state (nth run-ice (dec pos))))]
+              (get-card state (nth run-ice (dec pos))))
+        bypass-current-ice (get-in @state [:runner :register :bypass-current-ice])]
     (when (rezzed? ice)
-      (trigger-event state side :encounter-ice ice)
+      (trigger-event state side :approach-ice ice)
+      (if-not bypass-current-ice
+        (trigger-event state side :encounter-ice ice))
       (update-ice-strength state side ice))))
 
 ;;; Runner actions


### PR DESCRIPTION
This is a feature branch to track my status on implementing all manual On Encounter abilities across all ICE. I got Data Raven to work, so now I suspect I can do the same with the rest. We'll see?!?

- [ ] Authenticator
- [ ] Brainstorm??
- [ ] Bulwark
- [ ] Data Loop
- [x] Data Raven
- [ ] Data Ward
- [ ] Information Overload
- [ ] Jua
- [ ] Matrix Analyzer
- [ ] Oduduwa
- [ ] Pop-up Window
- [ ] Quicksand
- [ ] Snoop
- [ ] Thoth
- [ ] TL;DR
- [x] Tollbooth
- [ ] Troll
- [ ] Turnpike