### PR TITLE
Added all-active-installed to differentiate between installed and active+installed runner cards. Fixes bugs with Degree Mill + Jua (and more!).

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -249,7 +249,7 @@
                :msg "make the Runner lose 2 tags"}}
 
    "CFC Excavation Contract"
-   {:effect (req (let [bios (count (filter #(and (rezzed? %) (has-subtype? % "Bioroid")) (all-installed state :corp)))
+   {:effect (req (let [bios (count (filter #(has-subtype? % "Bioroid") (all-active-installed state :corp)))
                        bucks (* bios 2)]
                    (gain state side :credit bucks)
                    (system-msg state side (str "gains " bucks " [Credits] from CFC Excavation Contract"))))}
@@ -744,7 +744,7 @@
             :msg "trash all connection and job resources"
             :effect (req (doseq [resource (filter #(or (has-subtype? % "Job")
                                                        (has-subtype? % "Connection"))
-                                                  (all-installed state :runner))]
+                                                  (all-active-installed state :runner))]
                                    (trash state side resource)))}}
 
    "Personality Profiles"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -353,7 +353,7 @@
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     ; not-empty doesn't work for the next line, because it does not return literal true; it returns the collection.
     ; flags need exact equality of value to work.
-    :flags {:corp-phase-12 (req (and (pos? (count (filter #(card-is? % :type "Resource") (all-installed state :runner))))
+    :flags {:corp-phase-12 (req (and (pos? (count (filter #(card-is? % :type "Resource") (all-active-installed state :runner))))
                                      (:rezzed card)))}
     :abilities [{:label "Trash a resource"
                  :prompt "Select a resource to trash with Corporate Town"
@@ -918,7 +918,7 @@
     :events {:corp-turn-begins {:effect (effect (add-prop card :advance-counter 1 {:placed true}))}}
     :abilities [{:cost [:credit 2]
                  :req (req (and (> (get card :advance-counter 0) 0)
-                                (some #(rezzed? %) (all-installed state :corp))))
+                                (not-empty (all-active-installed state :corp))))
                  :label "Move an advancement token to a faceup card"
                  :prompt "Select a faceup card"
                  :choices {:req #(rezzed? %)}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -60,7 +60,7 @@
                      (trash state side (get-card state c))))
 
                  ;; do hosted cards first so they don't get trashed twice
-                 (let [installedcards (remove :facedown (all-installed state :runner))
+                 (let [installedcards (all-active-installed state :runner)
                        ishosted (fn [c] (or (= ["onhost"] (get c :zone)) (= '(:onhost) (get c :zone))))
                        hostedcards (filter ishosted installedcards)
                        nonhostedcards (remove ishosted installedcards)]
@@ -120,9 +120,9 @@
 
    "Calling in Favors"
    {:msg (msg "gain " (count (filter #(and (has-subtype? % "Connection") (is-type? % "Resource"))
-                                     (all-installed state :runner))) " [Credits]")
+                                     (all-active-installed state :runner))) " [Credits]")
     :effect (effect (gain :credit (count (filter #(and (has-subtype? % "Connection") (is-type? % "Resource"))
-                                                 (all-installed state :runner)))))}
+                                                 (all-active-installed state :runner)))))}
 
    "Career Fair"
    {:prompt "Select a resource to install from your Grip"
@@ -948,10 +948,10 @@
    {:prompt "Choose a server"
     :choices (req runnable-servers)
     :delayed-completion true
-    :msg (msg "make a run on " target (when (< (count (filter #(is-type? % "Program") (all-installed state :runner))) 4)
+    :msg (msg "make a run on " target (when (< (count (filter #(is-type? % "Program") (all-active-installed state :runner))) 4)
                                         ", adding +2 strength to all icebreakers"))
-    :effect (req (when (< (count (filter #(is-type? % "Program") (all-installed state :runner))) 4)
-                   (doseq [c (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
+    :effect (req (when (< (count (filter #(is-type? % "Program") (all-active-installed state :runner))) 4)
+                   (doseq [c (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
                      (pump state side c 2 :all-run)))
                  (game.core/run state side (make-eid state) target nil card))}
 
@@ -1062,10 +1062,10 @@
 
    "Mars for Martians"
    {:msg (msg "draw " (count (filter #(and (has-subtype? % "Clan") (is-type? % "Resource"))
-                                     (all-installed state :runner)))
+                                     (all-active-installed state :runner)))
               " cards and gain " (:tag runner) " [Credits]")
     :effect (effect (draw (count (filter #(and (has-subtype? % "Clan") (is-type? % "Resource"))
-                                         (all-installed state :runner))))
+                                         (all-active-installed state :runner))))
                     (gain :credit (:tag runner)))}
 
    "Mass Install"
@@ -1161,7 +1161,7 @@
     :msg "add it to their score area as an agenda worth 1 agenda point"}
 
    "On the Lam"
-   {:req (req (some #(is-type? % "Resource") (all-installed state :runner)))
+   {:req (req (some #(is-type? % "Resource") (all-active-installed state :runner)))
     :prompt "Choose a resource to host On the Lam"
     :choices {:req #(and (is-type? % "Resource")
                          (installed? %))}
@@ -1252,7 +1252,7 @@
                                        (update-agenda-points state :corp target -1))}} card))})
 
    "Populist Rally"
-   {:req (req (seq (filter #(has-subtype? % "Seedy") (all-installed state :runner))))
+   {:req (req (seq (filter #(has-subtype? % "Seedy") (all-active-installed state :runner))))
     :msg "give the Corp 1 fewer [Click] to spend on their next turn"
     :effect (effect (lose :corp :click-per-turn 1)
                     (register-events (:events (card-def card))
@@ -1308,7 +1308,7 @@
     :choices (req runnable-servers)
     :delayed-completion true
     :effect (req (when (<= (hsize @state) 2)
-                   (let [breakers (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
+                   (let [breakers (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
                      (doseq [t breakers] (pump state side t 2 :all-run))))
                  (game.core/run state side (make-eid state) target))})
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -60,13 +60,15 @@
                      (trash state side (get-card state c))))
 
                  ;; do hosted cards first so they don't get trashed twice
-                 (doseq [c (all-installed state :runner)]
-                   (when (or (= ["onhost"] (get c :zone)) (= '(:onhost) (get c :zone)))
+                 (let [installedcards (remove :facedown (all-installed state :runner))
+                       ishosted (fn [c] (or (= ["onhost"] (get c :zone)) (= '(:onhost) (get c :zone))))
+                       hostedcards (filter ishosted installedcards)
+                       nonhostedcards (remove ishosted installedcards)]
+                   (doseq [oc hostedcards :let [c (get-card state oc)]]
                      (move state side c [:rig :facedown])
                      (if (:memoryunits c)
-                       (gain state :runner :memory (:memoryunits c)))))
-                 (doseq [c (all-installed state :runner)]
-                   (when (not (or (= ["onhost"] (get c :zone)) (= '(:onhost) (get c :zone))))
+                       (gain state :runner :memory (:memoryunits c))))
+                   (doseq [oc nonhostedcards :let [c (get-card state oc)]]
                      (move state side c [:rig :facedown])
                      (if (:memoryunits c)
                        (gain state :runner :memory (:memoryunits c))))))}

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -21,7 +21,7 @@
 
    "Adjusted Matrix"
    {:implementation "Click Adjusted Matrix to use ability."
-    :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))))
+    :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
     :prompt "Choose Icebreaker on which to install Adjusted Matrix"
     :choices {:req #(and (= (:side %) "Runner") (has-subtype? % "Icebreaker") (installed? %))}
     :msg (msg "host it on " (card-str state target))
@@ -154,7 +154,7 @@
                                                       remaining (- handsize trashed)]
                                                   (doseq [c targets]
                                                     (when (not (empty? (filter #(= (:title c) (:title %))
-                                                                               (all-installed state :runner))))
+                                                                               (all-active-installed state :runner))))
                                                       (draw state side)))
                                                   (trash-cards state side targets)
                                                   (system-msg state side
@@ -243,7 +243,7 @@
 
    "Dedicated Processor"
    {:implementation "Click Dedicated Processor to use ability"
-    :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))))
+    :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
     :hosting {:req #(and (has-subtype? % "Icebreaker")
                          (not (has-subtype? % "AI"))
                          (installed? %))}
@@ -451,7 +451,7 @@
                                 (update! state side (dissoc card :llds-target))
                                 (doseq [c cards]
                                 (update-breaker-strength state side
-                                                         (find-cid (:cid c) (all-installed state :runner))))))}]
+                                                         (find-cid (:cid c) (all-active-installed state :runner))))))}]
        {:runner-turn-ends llds :corp-turn-ends llds
         :runner-install {:silent (req true)
                          :req (req (has-subtype? target "Icebreaker"))
@@ -576,7 +576,7 @@
    "NetChip"
    {:abilities [{:label "Install a program on NetChip"
                  :req (req (empty? (:hosted card)))
-                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
+                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-active-installed state :runner)))]
                                 (resolve-ability state side
                                   {:cost [:click 1]
                                    :prompt "Select a program in your Grip to install on NetChip"
@@ -593,7 +593,7 @@
                                  card nil)))}
                 {:label "Host an installed program on NetChip"
                  :req (req (empty? (:hosted card)))
-                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
+                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-active-installed state :runner)))]
                                 (resolve-ability state side
                                   {:prompt "Select an installed program to host on NetChip"
                                    :choices {:req #(and (is-type? % "Program")
@@ -733,7 +733,7 @@
    "Ramujan-reliant 550 BMI"
    {:prevent {:damage [:net :brain]}
     :abilities [{:req (req (not-empty (:deck runner)))
-                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-installed state :runner)))]
+                 :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-active-installed state :runner)))]
                                 (resolve-ability state side
                                   {:prompt "Choose how much damage to prevent"
                                    :priority 50
@@ -930,7 +930,7 @@
                  :msg "look at the top X cards of their Stack and rearrange them"
                  :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their stack")
                               (let [n (count (filter #(= (:title %) (:title card))
-                                                     (all-installed state :runner)))
+                                                     (all-active-installed state :runner)))
                                     from (take n (:deck runner))]
                                 (if (pos? (count from))
                                   (continue-ability state side (reorder-choice :runner :corp from '()
@@ -1058,7 +1058,7 @@
       :flags {:runner-turn-draw true
               :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :runner-turn-draw true)
                                                         (cons (get-in @state [:runner :identity])
-                                                              (all-installed state :runner))))))}
+                                                              (all-active-installed state :runner))))))}
       :events {:runner-turn-begins ability}
       :abilities [ability]})
 

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -364,7 +364,7 @@
 
    "Bloodletter"
    {:subroutines [{:label "Runner trashes 1 program or top 2 cards of their Stack"
-                   :effect (req (if (empty? (filter #(is-type? % "Program") (all-installed state :runner)))
+                   :effect (req (if (empty? (filter #(is-type? % "Program") (all-active-installed state :runner)))
                                    (do (mill state :runner 2)
                                        (system-msg state :runner (str "trashes the top 2 cards of their Stack")))
                                    (do (show-wait-prompt state :corp "Runner to choose an option for Bloodletter")
@@ -443,7 +443,7 @@
    "Bulwark"
    {:effect take-bad-pub
     :abilities [{:msg "gain 2 [Credits] if there is an installed AI"
-                 :req (req (some #(has-subtype? % "AI") (all-installed state :runner)))
+                 :req (req (some #(has-subtype? % "AI") (all-active-installed state :runner)))
                  :effect (effect (gain :credit 2))}]
     :subroutines [(assoc trash-program :player :runner
                                        :msg "force the Runner to trash 1 program"
@@ -510,7 +510,7 @@
    "Chiyashi"
    {:implementation "Trash effect when using an AI to break is activated manually"
     :abilities [{:label "Trash the top 2 cards of the Runner's Stack"
-                 :req (req (some #(has-subtype? % "AI") (all-installed state :runner)))
+                 :req (req (some #(has-subtype? % "AI") (all-active-installed state :runner)))
                  :msg (msg (str "trash " (join ", " (map :title (take 2 (:deck runner)))) " from the Runner's Stack"))
                  :effect (effect (mill :runner 2))}]
     :subroutines [(do-net-damage 2)
@@ -590,7 +590,7 @@
                   {:msg "force the Runner to lose 1 [Click] if able"
                    :effect (effect (lose :runner :click 1))}
                   end-the-run]
-    :strength-bonus (req (if (some #(has-subtype? % "AI") (all-installed state :runner)) 3 0))}
+    :strength-bonus (req (if (some #(has-subtype? % "AI") (all-active-installed state :runner)) 3 0))}
 
    "Cortex Lock"
    {:subroutines [{:label "Do 1 net damage for each unused memory unit the Runner has"
@@ -733,7 +733,7 @@
                    :msg (msg "trash " (:title target))
                    :effect (effect (trash target))}
                   {:msg "trash all virtual resources"
-                   :effect (req (doseq [c (filter #(has-subtype? % "Virtual") (all-installed state :runner))]
+                   :effect (req (doseq [c (filter #(has-subtype? % "Virtual") (all-active-installed state :runner))]
                                   (trash state side c)))}]
     :runner-abilities [(runner-break [:click 1] 1)]}
 
@@ -1062,7 +1062,7 @@
     :subroutines [trash-installed]}
 
    "IP Block"
-   {:abilities [(assoc give-tag :req (req (not-empty (filter #(has-subtype? % "AI") (all-installed state :runner))))
+   {:abilities [(assoc give-tag :req (req (not-empty (filter #(has-subtype? % "AI") (all-active-installed state :runner))))
                                 :label "Give the Runner 1 tag if there is an installed AI")]
     :subroutines [(tag-trace 3)
                   end-the-run-if-tagged]}
@@ -1233,7 +1233,7 @@
                    (continue-ability
                      state side
                      {:req (req (some #(some (fn [h] (card-is? h :type "Program")) (:hosted %))
-                                      (remove-once #(not= (:cid %) (:cid magnet)) (all-installed state corp))))
+                                      (remove-once #(not= (:cid %) (:cid magnet)) (all-active-installed state corp))))
                       :prompt "Select a Program to host on Magnet"
                       :choices {:req #(and (card-is? % :type "Program")
                                            (ice? (:host %))
@@ -1491,9 +1491,8 @@
    "NEXT Silver"
    {:abilities [{:label "Gain subroutines"
                  :msg (msg "gain " (count (filter #(and (is-type? % "ICE")
-                                                        (has-subtype? % "NEXT")
-                                                        (rezzed? %))
-                                                  (all-installed state :corp))) " subroutines")}]
+                                                        (has-subtype? % "NEXT"))
+                                                  (all-active-installed state :corp))) " subroutines")}]
     :subroutines [end-the-run]}
 
    "Nightdancer"
@@ -1603,7 +1602,7 @@
    {:subroutines [trash-program]
     :access {:delayed-completion true
              :req (req (and (not= (first (:zone card)) :discard)
-                            (some #(is-type? % "Program") (all-installed state :runner))))
+                            (some #(is-type? % "Program") (all-active-installed state :runner))))
              :effect (effect (show-wait-prompt :corp "Runner to decide to break Sapper subroutine")
                              (continue-ability
                                :runner {:optional
@@ -1822,8 +1821,8 @@
 
    "Tour Guide"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "gain " (count (filter #(and (is-type? % "Asset") (rezzed? %))
-                                                  (all-installed state :corp))) " subroutines")}]
+                 :msg (msg "gain " (count (filter #(is-type? % "Asset")
+                                                  (all-active-installed state :corp))) " subroutines")}]
     :subroutines [end-the-run]}
 
    "Tribunal"
@@ -2009,7 +2008,7 @@
 
    "Wraparound"
    {:subroutines [end-the-run]
-    :strength-bonus (req (if (some #(has-subtype? % "Fracter") (all-installed state :runner))
+    :strength-bonus (req (if (some #(has-subtype? % "Fracter") (all-active-installed state :runner))
                            0 7))
     :events (let [wr {:silent (req true)
                       :req (req (and (not= (:cid target) (:cid card))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1122,11 +1122,11 @@
                                         {:player :runner
                                          :priority 1
                                          :prompt "Select a card to move to the Stack"
-                                         :choices [(card-str state (first targets)) (card-str state (second targets))]
-                                         :effect (req (let [c (installed-byname state :runner target)]
+                                         :choices targets ;{:req (fn [x] (some #(= % x) targets))} - Alternative version
+                                         :effect (req (let [c target]
                                                         (clear-wait-prompt state :corp)
                                                         (move state :runner c :deck {:front true})
-                                                        (system-msg state :runner (str "selected " (:title c) " to move to the Stack"))))}
+                                                        (system-msg state :runner (str "selected " (card-str state c) " to move to the Stack"))))}
                                          card nil)))}]}
 
    "Kakugo"

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -108,7 +108,7 @@
                                            :effect (effect (update-breaker-strength card))}]
                                 {:runner-install cloud :trash cloud :card-moved cloud})
                       :strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
-                                                          (all-installed state :runner))))}))
+                                                          (all-active-installed state :runner))))}))
 
 (defn- global-sec-breaker
   "GlobalSec breakers for Sunny"
@@ -149,7 +149,7 @@
                                        (rezzed? current-ice)
                                        (has-subtype? current-ice type)
                                        (not (install-locked? state side))
-                                       (not (some #(= title (:title %)) (all-installed state :runner)))
+                                       (not (some #(= title (:title %)) (all-active-installed state :runner)))
                                        (not (get-in @state [:run :register :conspiracy (:cid current-ice)]))))
                         :optional {:player :runner
                                    :prompt (str "Install " title "?")
@@ -654,7 +654,7 @@
                          :req (req (is-type? target "Program"))
                          :effect (effect (update-breaker-strength card))}]
               {:runner-install maven :trash maven :card-moved maven})
-    :strength-bonus (req (count (filter #(is-type? % "Program") (all-installed state :runner))))}
+    :strength-bonus (req (count (filter #(is-type? % "Program") (all-active-installed state :runner))))}
 
    "Morning Star"
    {:abilities [(break-sub 1 0 "Barrier")]}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -9,9 +9,7 @@
 (defn- has-most-faction?
   "Checks if the faction has a plurality of rezzed / installed cards"
   [state side fc]
-  (let [card-list (if (= side :corp)
-                    (filter :rezzed (all-installed state :corp))
-                    (all-installed state :runner))
+  (let [card-list ((all-active-installed state side))
         faction-freq (frequencies (map :faction card-list))
         reducer (fn [{:keys [max-count] :as acc} faction count]
                   (cond
@@ -543,9 +541,9 @@
                                  (install-cost-bonus [:credit -1])
                                  (runner-install (assoc-in target [:special :kabonesa] true)))
                  :end-turn
-                 {:req (req (get-in (find-cid (:cid target) (all-installed state :runner)) [:special :kabonesa]))
+                 {:req (req (get-in (find-cid (:cid target) (all-active-installed state :runner)) [:special :kabonesa]))
                   :msg (msg "remove " (:title target) " from the game")
-                  :effect (req (move state side (find-cid (:cid target) (all-installed state :runner))
+                  :effect (req (move state side (find-cid (:cid target) (all-active-installed state :runner))
                                      :rfg))}}]}
 
    "Kate \"Mac\" McCaffrey: Digital Tinker"
@@ -623,7 +621,7 @@
                   :effect (effect (mill 2) (draw))}]
      {:flags {:runner-turn-draw true
               :runner-phase-12 (req (and (not (:disabled card))
-                                         (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner))))}
+                                         (some #(card-flag? % :runner-turn-draw true) (all-active-installed state :runner))))}
       :events {:runner-turn-begins ability}
       :abilities [ability]})
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -9,7 +9,7 @@
 (defn- has-most-faction?
   "Checks if the faction has a plurality of rezzed / installed cards"
   [state side fc]
-  (let [card-list ((all-active-installed state side))
+  (let [card-list (all-active-installed state side)
         faction-freq (frequencies (map :faction card-list))
         reducer (fn [{:keys [max-count] :as acc} faction count]
                   (cond

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -168,11 +168,11 @@
 
    "Biased Reporting"
    {:delayed-completion true
-    :req (req (not-empty (all-installed state :runner)))
+    :req (req (not-empty (all-active-installed state :runner)))
     :prompt "Choose a card type"
     :choices ["Resource" "Hardware" "Program"]
     :effect (req (let [t target
-                       num (count (filter #(is-type? % t) (all-installed state :runner)))]
+                       num (count (filter #(is-type? % t) (all-active-installed state :runner)))]
                    (show-wait-prompt state :corp "Runner to choose cards to trash")
                    (when-completed
                      (resolve-ability state :runner
@@ -186,7 +186,7 @@
                                                                     " and gains " (count targets) " [Credits]"))
                                      (clear-wait-prompt state :corp))}
                       card nil)
-                     (do (let [n (* 2 (count (filter #(is-type? % t) (all-installed state :runner))))]
+                     (do (let [n (* 2 (count (filter #(is-type? % t) (all-active-installed state :runner))))]
                            (when (pos? n)
                              (gain state :corp :credit n)
                              (system-msg state :corp (str "uses Biased Reporting to gain " n " [Credits]")))
@@ -458,8 +458,8 @@
 
    "Financial Collapse"
    {:delayed-completion true
-    :req (req (and (>= (:credit runner) 6) (seq (filter #(is-type? % "Resource") (all-installed state :runner)))))
-    :effect (req (let [rcount (count (filter #(is-type? % "Resource") (all-installed state :runner)))]
+    :req (req (and (>= (:credit runner) 6) (seq (filter #(is-type? % "Resource") (all-active-installed state :runner)))))
+    :effect (req (let [rcount (count (filter #(is-type? % "Resource") (all-active-installed state :runner)))]
                    (if (pos? rcount)
                      (do (show-wait-prompt state :corp "Runner to trash a resource to prevent Financial Collapse")
                          (continue-ability
@@ -596,7 +596,7 @@
    {:req (req (last-turn? state :runner :trashed-card))
     :trace {:base 2
             :label "Trash 2 installed non-program cards"
-            :choices {:max (req (min 2 (count (filter #(not (is-type? % "Program")) (concat (all-installed state :corp)
+            :choices {:max (req (min 2 (count (filter #(or (:facedown %) (not (is-type? % "Program"))) (concat (all-installed state :corp)
                                                                                             (all-installed state :runner))))))
                       :all true
                       :req #(and (installed? %)
@@ -691,8 +691,7 @@
 
    "Liquidation"
    {:delayed-completion true
-    :effect (req (let [n (count (filter #(and (rezzed? %)
-                                              (not (is-type? % "Agenda"))) (all-installed state :corp)))]
+    :effect (req (let [n (count (filter #(not (is-type? % "Agenda")) (all-active-installed state :corp)))]
                    (continue-ability state side
                      {:prompt "Select any number of rezzed cards to trash"
                       :choices {:max n
@@ -737,13 +736,13 @@
 
    "Mass Commercialization"
    {:msg (msg "gain " (* 2 (count (filter #(pos? (+ (:advance-counter % 0) (:extra-advance-counter % 0)))
-                                          (concat (all-installed state :runner) (all-installed state :corp))))) " [Credits]")
+                                          (get-all-installed state)))) " [Credits]")
     :effect (effect (gain :credit (* 2 (count (filter #(pos? (+ (:advance-counter % 0) (:extra-advance-counter % 0)))
-                                                      (concat (all-installed state :runner) (all-installed state :corp)))))))}
+                                                      (get-all-installed state))))))}
 
    "MCA Informant"
    {:implementation "Runner must deduct 1 click and 2 credits, then trash host manually"
-    :req (req (not-empty (filter #(has-subtype? % "Connection") (all-installed state :runner))))
+    :req (req (not-empty (filter #(has-subtype? % "Connection") (all-active-installed state :runner))))
     :prompt "Choose a connection to host MCA Informant on it"
     :choices {:req #(and (= (:side %) "Runner") (has-subtype? % "Connection") (installed? %))}
     :msg (msg "host it on " (card-str state target) ". The Runner has an additional tag")
@@ -892,7 +891,7 @@
    "Power Shutdown"
    {:req (req (last-turn? state :runner :made-run))
     :prompt "Trash how many cards from the top R&D?"
-    :choices {:number (req (apply max (map :cost (filter #(or (= "Program" (:type %)) (= "Hardware" (:type %))) (all-installed state :runner)))))}
+    :choices {:number (req (apply max (map :cost (filter #(or (= "Program" (:type %)) (= "Hardware" (:type %))) (all-active-installed state :runner)))))}
     :msg (msg "trash " target " cards from the top of R&D")
     :delayed-completion true
     :effect (req (mill state :corp target)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -565,10 +565,10 @@
    "Origami"
    {:effect (effect (gain :hand-size-modification
                           (dec (* 2 (count (filter #(= (:title %) "Origami")
-                                                   (all-installed state :runner)))))))
+                                                   (all-active-installed state :runner)))))))
     :leave-play (effect (lose :hand-size-modification
                               (dec (* 2 (count (filter #(= (:title %) "Origami")
-                                                       (all-installed state :runner)))))))}
+                                                       (all-active-installed state :runner)))))))}
 
    "Paintbrush"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -148,7 +148,7 @@
                                       (= "Runner" (:side %)))}
                  :effect (req (if (or (is-type? target "Event")
                                       (and (has-subtype? target "Console")
-                                           (some #(has-subtype? % "Console") (all-installed state :runner))))
+                                           (some #(has-subtype? % "Console") (all-active-installed state :runner))))
                                 ;; Consoles and events are immediately unpreventably trashed.
                                 (trash state side target {:unpreventable true})
                                 ;; Other cards are moved to rig and have events wired.
@@ -171,7 +171,7 @@
               :effect (req (let [bj card]
                              (when-not (:replace-access (get-in @state [:run :run-effect]))
                                (swap! state assoc-in [:run :run-effect :replace-access]
-                                      {:effect (req (if (> (count (filter #(= (:title %) "Bank Job") (all-installed state :runner))) 1)
+                                      {:effect (req (if (> (count (filter #(= (:title %) "Bank Job") (all-active-installed state :runner))) 1)
                                                       (resolve-ability state side
                                                         {:prompt "Select a copy of Bank Job to use"
                                                          :choices {:req #(and installed? (= (:title %) "Bank Job"))}
@@ -563,7 +563,7 @@
     :events {:post-runner-turn-ends nil}}
 
    "Drug Dealer"
-   {:flags {:runner-phase-12 (req (some #(card-flag? % :drip-economy true) (all-installed state :runner)))}
+   {:flags {:runner-phase-12 (req (some #(card-flag? % :drip-economy true) (all-active-installed state :runner)))}
     :abilities [{:label "Lose 1 [Credits] (start of turn)"
                  :msg (msg (if (= (get-in @state [:runner :credit]) 0) "lose 0 [Credits] (runner has no credits to lose)" "lose 1 [Credits]"))
                  :req (req (:runner-phase-12 @state))
@@ -607,7 +607,7 @@
    {:flags {:runner-turn-draw true
             :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :runner-turn-draw true)
                                                       (cons (get-in @state [:runner :identity])
-                                                            (all-installed state :runner))))))}
+                                                            (all-active-installed state :runner))))))}
     :data {:counter {:power  3}}
     :events {:runner-turn-begins ability}
     :abilities [ability]})
@@ -922,7 +922,7 @@
                                                           (system-msg "chooses to trash Lewi Guilherme"))}}}]
    {:flags {:drip-economy true ;; for Drug Dealer
             :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :drip-economy true)
-                                                      (all-installed state :runner)))))}
+                                                      (all-active-installed state :runner)))))}
 
     ;; KNOWN ISSUE: :effect is not fired when Assimilator turns cards over.
     :effect (effect (lose :corp :hand-size-modification 1))
@@ -1021,7 +1021,7 @@
                   :effect (effect (prompt! card (str "The top card of your Stack is "
                                                      (:title (first (:deck runner)))) ["OK"] {}))}]
    {:flags {:runner-turn-draw true
-            :runner-phase-12 (req (some #(card-flag? % :runner-turn-draw true) (all-installed state :runner)))}
+            :runner-phase-12 (req (some #(card-flag? % :runner-turn-draw true) (all-active-installed state :runner)))}
     :events {:runner-turn-begins ability}
     :abilities [ability]})
 
@@ -1355,7 +1355,7 @@
 
    "Rosetta 2.0"
    {:abilities [{:req (req (and (not (install-locked? state side))
-                                (some #(is-type? % "Program") (all-installed state :runner))))
+                                (some #(is-type? % "Program") (all-active-installed state :runner))))
                  :cost [:click 1]
                  :prompt "Choose an installed program to remove from the game"
                  :choices {:req #(and installed? (is-type? % "Program"))}
@@ -1819,7 +1819,7 @@
    {:flags {:runner-turn-draw true
             :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :runner-turn-draw true)
                                                       (cons (get-in @state [:runner :identity])
-                                                            (all-installed state :runner))))))}
+                                                            (all-active-installed state :runner))))))}
 
     :events {:runner-turn-begins {:effect (req (lose state side :click 1)
                                                (when-not (get-in @state [:per-turn (:cid card)])

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -422,8 +422,8 @@
                            :effect (req (let [ices (filter #(and (is-type? % "ICE")
                                                                  (get-card state %))
                                                            (:most-recent-drawn corp-reg))
-                                              grids (filterv #(and (:rezzed %) (= "Jinja City Grid" (:title %)))
-                                                             (all-installed state :corp))]
+                                              grids (filterv #(= "Jinja City Grid" (:title %))
+                                                             (all-active-installed state :corp))]
                                           (if (not-empty ices)
                                             (continue-ability state side (choose-ice ices grids) card nil)
                                             (effect-completed state side eid))))}
@@ -434,7 +434,7 @@
                  :req (req (and this-server
                                 (pos? (get-in @state [:runner :tag]))
                                 (not (empty? (filter #(is-type? % "Program")
-                                                     (all-installed state :runner))))))
+                                                     (all-active-installed state :runner))))))
                  :msg (msg "remove 1 tag")
                  :effect (req (resolve-ability state side trash-program card nil)
                               (trash state side card {:cause :ability-cost})
@@ -923,7 +923,7 @@
      {:interactive (req true)
       :delayed-completion true
       :req (req (and this-server
-                     (some #(has-subtype? % "Icebreaker") (all-installed state :runner))))
+                     (some #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
       :effect (req (show-wait-prompt state :runner "Corp to use Will-o'-the-Wisp")
                    (continue-ability state side
                      {:optional

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -266,8 +266,8 @@
       (resolve-ability state side
                        {:prompt  "Choose a resource to trash"
                         :choices {:req (fn [card]
-                                         (if (and (seq (filter (fn [c] (untrashable-while-resources? c)) (all-installed state :runner)))
-                                                  (> (count (filter #(is-type? % "Resource") (all-installed state :runner))) 1))
+                                         (if (and (seq (filter (fn [c] (untrashable-while-resources? c)) (all-active-installed state :runner)))
+                                                  (> (count (filter #(is-type? % "Resource") (all-active-installed state :runner))) 1))
                                            (and (is-type? card "Resource") (not (untrashable-while-resources? card)))
                                            (is-type? card "Resource")))}
                         :cancel-effect (effect (gain :credit trash-cost :click 1))
@@ -475,7 +475,7 @@
                             (update-ice-strength state side cur-ice))
                           (when next-ice
                             (trigger-event-sync state side (make-eid state) :approach-ice next-ice))
-                          (doseq [p (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
+                          (doseq [p (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
                             (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
                             (update-breaker-strength state side p)))))))
 

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare active? all-installed cards card-init deactivate card-flag? get-card-hosted handle-end-run hardware? has-subtype? ice?
+(declare active? all-installed all-active-installed cards card-init deactivate card-flag? get-card-hosted handle-end-run hardware? has-subtype? ice?
          make-eid program? register-events remove-from-host remove-icon reset-card resource? rezzed? trash trigger-event update-hosted!
          update-ice-strength unregister-events)
 
@@ -194,13 +194,13 @@
 (defn get-virus-counters
   "Calculate the number of virus counters on the given card, taking Hivemind into account."
   [state side card]
-  (let [hiveminds (filter #(= (:title %) "Hivemind") (all-installed state :runner))]
+  (let [hiveminds (filter #(= (:title %) "Hivemind") (all-active-installed state :runner))]
     (reduce + (map #(get-in % [:counter :virus] 0) (cons card hiveminds)))))
 
 (defn count-virus-programs
   "Calculate the number of virus programs in play"
   [state]
-  (count (filter #(has-subtype? % "Virus") (all-installed state :runner))))
+  (count (filter #(has-subtype? % "Virus") (all-active-installed state :runner))))
 
 (defn card->server
   "Returns the server map that this card is installed in or protecting."

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -29,7 +29,7 @@
                   (and (= type :hardware) (>= (- (count (get-in @state [:runner :rig :hardware])) amount) 0))
                   (and (= type :program) (>= (- (count (get-in @state [:runner :rig :program])) amount) 0))
                   (and (= type :connection) (>= (- (count (filter #(has-subtype? % "Connection")
-                                                                  (all-installed state :runner))) amount) 0))
+                                                                  (all-active-installed state :runner))) amount) 0))
                   (and (= type :shuffle-installed-to-stack) (>= (- (count (all-installed state :runner)) amount) 0))
                   (>= (- (or (get-in @state [side type]) -1 ) amount) 0))
       "Unable to pay")))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -47,7 +47,7 @@
    (handle-prevent-effect state card)
    (when (and (:memoryunits card) (:installed card) (not (:facedown card)))
      (gain state :runner :memory (:memoryunits card)))
-   (when (and (find-cid (:cid card) (all-installed state side))
+   (when (and (find-cid (:cid card) (all-active-installed state side))
               (not (:disabled card))
               (or (:rezzed card) (:installed card)))
      (when-let [in-play (:in-play (card-def card))]
@@ -299,7 +299,7 @@
       facedown true
       ;; Console check
       (and (has-subtype? card "Console")
-           (some #(has-subtype? % "Console") (all-installed state :runner)))
+           (some #(has-subtype? % "Console") (all-active-installed state :runner)))
       :console
       ;; Installing not locked
       (install-locked? state side) :lock-install

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare set-prop get-nested-host get-nested-zone)
+(declare set-prop get-nested-host get-nested-zone all-active-installed)
 
 (defn get-zones [state]
   (keys (get-in state [:corp :servers])))
@@ -98,11 +98,19 @@
   currents, or the corp's scored area."
   [state side]
   (if (= side :runner)
-    (cons (get-in @state [:runner :identity]) (concat (get-in @state [:runner :current]) (remove :facedown (all-installed state side))))
+    (cons (get-in @state [:runner :identity]) (concat (get-in @state [:runner :current]) (all-active-installed state side)))
     (cons (get-in @state [:corp :identity]) (filter #(not (:disabled %))
-                                                    (concat (all-installed state side)
+                                                    (concat (all-active-installed state side)
                                                             (get-in @state [:corp :current])
                                                             (get-in @state [:corp :scored]))))))
+
+(defn all-active-installed
+  "Returns a vector of active AND installed cards for the given side. This is all face-up installed cards."
+  [state side]
+  (let [installed (all-installed state side)]
+   (if (= side :runner)
+     (remove :facedown installed)
+     (filter :rezzed installed))))
 
 (defn installed-byname
   "Returns a truthy card map if a card matching title is installed"

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -98,7 +98,7 @@
   currents, or the corp's scored area."
   [state side]
   (if (= side :runner)
-    (cons (get-in @state [:runner :identity]) (concat (get-in @state [:runner :current]) (all-installed state side)))
+    (cons (get-in @state [:runner :identity]) (concat (get-in @state [:runner :current]) (remove :facedown (all-installed state side))))
     (cons (get-in @state [:corp :identity]) (filter #(not (:disabled %))
                                                     (concat (all-installed state side)
                                                             (get-in @state [:corp :current])

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -66,7 +66,7 @@
   but not including 'inactive hosting' like Personal Workshop."
   [state side]
   (if (= side :runner)
-    (let [top-level-cards (flatten (for [t [:program :hardware :resource]] (get-in @state [:runner :rig t])))
+    (let [top-level-cards (flatten (for [t [:program :hardware :resource :facedown]] (get-in @state [:runner :rig t])))
           hosted-on-ice (->> (:corp @state) :servers seq flatten (mapcat :ices) (mapcat :hosted))]
       (loop [unchecked (concat top-level-cards (filter #(= (:side %) "Runner") hosted-on-ice)) installed ()]
         (if (empty? unchecked)

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -347,7 +347,7 @@
 
        (and (= side :corp)
             (untrashable-while-resources? card)
-            (> (count (filter #(is-type? % "Resource") (all-installed state :runner))) 1))
+            (> (count (filter #(is-type? % "Resource") (all-active-installed state :runner))) 1))
        (do (enforce-msg state card "cannot be trashed while there are other resources installed")
            (effect-completed state side eid))
 

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -775,7 +775,7 @@
         eid (:eid run)]
     (swap! state assoc-in [:run :ending] true)
     (trigger-event state side :run-ends (first server))
-    (doseq [p (filter #(has-subtype? % "Icebreaker") (all-installed state :runner))]
+    (doseq [p (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
       (update! state side (update-in (get-card state p) [:pump] dissoc :all-run))
       (update! state side (update-in (get-card state p) [:pump] dissoc :encounter ))
       (update-breaker-strength state side p))

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -289,7 +289,7 @@
     (take-credits state :corp)
 
     (play-from-hand state :runner "Hunting Grounds")
-    (let [hg (get-in @state [:runner :rig :resource 0])]
+    (let [hg (get-resource state 0)]
       (run-on state "Server 2")
       (run-successful state)
       (prompt-choice :runner "Yes")
@@ -306,11 +306,7 @@
         (prompt-select :runner fd2)
         (is (= 6 (:agenda-point (get-runner))) "Runner failed to steal Degree Mill with facedown cards")
         (is (empty? (get-in (get-runner)  [:rig :facedown])) "Degree Mill didn't remove facedown cards")
-        (is (= 2 (count (:deck (get-runner)))) "Degree Mill didn't put cards back in deck")
-        )
-                     )
-
-    ))
+        (is (= 2 (count (:deck (get-runner)))) "Degree Mill didn't put cards back in deck")))))
 
 (deftest eden-fragment
   ;; Test that Eden Fragment ignores the install cost of the first ice

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -272,8 +272,8 @@
     (play-from-hand state :runner "Ice Analyzer")
     (play-from-hand state :runner "All-nighter")
 
-    (let [ia (get-in @state [:runner :rig :resource 0])
-          an (get-in @state [:runner :rig :resource 1])]
+    (let [ia (get-resource state 0)
+          an (get-resource state 1)]
       (run-on state "Server 1")
       (run-successful state)
       (prompt-choice :runner "Yes")
@@ -297,8 +297,8 @@
       (card-ability state :runner hg 1)
       (is (= 2 (count (get-in (get-runner) [:rig :facedown]))) "Hunting Ground did not install cards facedown")
       (is (empty? (:deck (get-runner))) "Hunting Grounds did not remove cards from deck")
-      (let [fd1 (get-in (get-runner) [:rig :facedown 0])
-            fd2 (get-in (get-runner) [:rig :facedown 1])]
+      (let [fd1 (get-runner-facedown state 0)
+            fd2 (get-runner-facedown state 1)]
         (run-on state "Server 2")
         (run-successful state)
         (prompt-choice :runner "Yes")

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -106,6 +106,11 @@
   [state pos]
   (get-in @state [:runner :rig :resource pos]))
 
+(defn get-runner-facedown
+  "Get non-hosted runner facedown by position."
+  [state pos]
+  (get-in @state [:runner :rig :facedown pos]))
+
 (defn get-scored
   "Get a card from the score area. Can find by name or index.
   If no index or name provided, get the first scored agenda."


### PR DESCRIPTION
Changed all-installed to also count facedown cards. This introduced a bug in Apocalypse where hosted cards got facedowned twice, so had to change apocalypse slightly. Also made a test for facedown cards for Degree Mill.

Closes #3206 