### PR TITLE
fix Mutate

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -71,7 +71,7 @@
   ([state side eid card type amount select-fn args]
    (let [cost-name (cost-names amount type)]
      (continue-ability state side
-                       {:prompt (str "Choose a " type "to trash")
+                       {:prompt (str "Choose a " type " to trash")
                         :choices {:max amount
                                   :req select-fn}
                         :delayed-completion true
@@ -121,7 +121,7 @@
      :connection (pay-trash state side eid card "connection" (second cost) (every-pred installed? #(has-subtype? % "Connection") (complement facedown?)))
 
      ;; Rezzed ICE
-     :ice (pay-trash state :corp card :ice (second cost) (every-pred rezzed? ice?) {:cause :ability-cost :keep-server-alive true})
+     :ice (pay-trash state :corp eid card "rezzed ICE" (second cost) (every-pred rezzed? ice?) {:cause :ability-cost :keep-server-alive true})
 
      :tag (let [r (deduce state :runner cost)]
             (effect-completed state side (make-result eid r))


### PR DESCRIPTION
Fix #3220. Adds missing `eid` to the trash function and tweaks the prompt.