### PR TITLE
add Market Forces

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -735,6 +735,16 @@
                                       :delayed-completion true
                                       :effect (effect (tag-runner :runner eid 1))}}}}
 
+   "Market Forces"
+   (letfn [(credit-diff [runner]
+             (min (* 3 (:tag runner))
+                  (:credit runner)))]
+     {:req (req tagged)
+      :msg (msg (let [c (credit-diff runner)]
+                  (str "make the runner lose " c " [Credits], and gain " c " [Credits]")))
+      :effect (effect (gain :corp :credit (credit-diff runner))
+                      (lose :runner :credit (credit-diff runner)))})
+
    "Mass Commercialization"
    {:msg (msg "gain " (* 2 (count (filter #(pos? (+ (:advance-counter % 0) (:extra-advance-counter % 0)))
                                           (concat (all-installed state :runner) (all-installed state :corp))))) " [Credits]")

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -742,8 +742,9 @@
      {:req (req tagged)
       :msg (msg (let [c (credit-diff runner)]
                   (str "make the runner lose " c " [Credits], and gain " c " [Credits]")))
-      :effect (effect (gain :corp :credit (credit-diff runner))
-                      (lose :runner :credit (credit-diff runner)))})
+      :effect (req (let [c (credit-diff runner)]
+                     (lose state :runner :credit c)
+                     (gain state :corp :credit c)))})
 
    "Mass Commercialization"
    {:msg (msg "gain " (* 2 (count (filter #(pos? (+ (:advance-counter % 0) (:extra-advance-counter % 0)))

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -454,6 +454,55 @@
     (play-from-hand state :corp "Economic Warfare")
     (is (= 3 (:credit (get-runner))) "Runner has 3 credits")))
 
+(deftest market-forces
+  (testing "when the runner is not tagged"
+    (do-game
+     (new-game (default-corp [(qty "Market Forces" 6)])
+               (default-runner))
+
+     (play-from-hand state :corp "Market Forces")
+
+     (is (= 6 (count (:hand (get-corp))))
+         "Market Forces is not played")
+     (is (= 3 (:click (get-corp)))
+         "the corp does not spend a click")
+     (is (= 5 (:credit (get-corp)) (:credit (get-runner)))
+         "credits are unaffected")))
+
+    (letfn [(market-forces-credit-test
+              [{:keys [tag-count runner-creds expected-credit-diff]}]
+              (testing (str "when the runner has " tag-count " tags and " runner-creds " credits")
+                (do-game
+                 (new-game (default-corp [(qty "Market Forces" 6)])
+                           (default-runner))
+
+                 (swap! state assoc-in [:corp :credit] 0)
+                 (swap! state assoc-in [:runner :credit] runner-creds)
+                 (core/gain state :runner :tag tag-count)
+
+                 (play-from-hand state :corp "Market Forces")
+
+                 (is (= expected-credit-diff (:credit (get-corp)))
+                     (str "the corp gains " expected-credit-diff " credits"))
+                 (is (= expected-credit-diff (- runner-creds (:credit (get-runner))))
+                     (str "the runner loses " expected-credit-diff " credits")))))]
+      (doall (map market-forces-credit-test
+                  [{:tag-count            1
+                    :runner-creds         10
+                    :expected-credit-diff 3}
+                   {:tag-count            2
+                    :runner-creds         10
+                    :expected-credit-diff 6}
+                   {:tag-count            3
+                    :runner-creds         10
+                    :expected-credit-diff 9}
+                   {:tag-count            3
+                    :runner-creds         0
+                    :expected-credit-diff 0}
+                   {:tag-count            3
+                    :runner-creds         5
+                    :expected-credit-diff 5}]))))
+
 (deftest enhanced-login-protocol
   ;; Enhanced Login Protocol - First click run each turn costs an additional click
   (do-game


### PR DESCRIPTION
I did named parameters in the examples on this one.

Is there a nice way to avoid calling credit-diff twice in the effect here? It seems like it would need a new macro, but idk if I'm missing something.