### PR TITLE
Fixes uniqueness-issues with facedown cards

### DIFF
--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -304,8 +304,7 @@
       ;; Installing not locked
       (install-locked? state side) :lock-install
       ;; Uniqueness check
-      (and uniqueness (some #(= (:title %) (:title card)) (all-active-installed state side)))
-      :unique
+      (and uniqueness (in-play? state card)) :unique
       ;; Req check
       (and req (not (req state side (make-eid state) card nil))) :req
       ;; Nothing preventing install

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -115,7 +115,7 @@
 (defn installed-byname
   "Returns a truthy card map if a card matching title is installed"
   [state side title]
-  (some #(when (= (:title %) title) %) (all-installed state side)))
+  (some #(when (= (:title %) title) %) (all-active-installed state side)))
 
 (defn in-play?
   "Returns a truthy card map if the given card is in play (installed)."


### PR DESCRIPTION
changes installed-byname to check only faceup cards, which is again used by in-play? which is used to check if another card is installed when checking for uniqueness.

I have checked where in-play? and installed-byname is used, and this should be the correct behaviour as far as I can see.

Mentioned in #3214, should make the heartbeat test in #3222 work again.