### PR TITLE
Fixes Marathon + damage shenanigans

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1070,7 +1070,7 @@
                              (when (:successful run)
                                (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
                                (gain state :runner :click 1)
-                               (move state :runner (last (:discard runner)) :hand)))}})
+                               (move state :runner (assoc card :zone [:discard]) :hand)))}})
 
 
    "Mars for Martians"


### PR DESCRIPTION
Marathon fetches itself from heap instead of just whatever
the top card is.

Closes #3188 