### PR TITLE
Deck stats ws format

### DIFF
--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -128,5 +128,5 @@
               userstats (:stats (stats-for-user user-id))
               deckstats (:stats (stats-for-deck deck-id))]
         (ws/send! (:ws-id p) [:stats/update {:userstats userstats
-                                             :deck-id   deck-id
+                                             :deck-id   (str deck-id)
                                              :deckstats deckstats}])))))

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -340,7 +340,7 @@
         (go (let [result (<! (DELETE (str "/profile/stats/deck/" (:_id deck))))]
               (om/update! cursor :decks (conj decks deck))
               (om/set-state! owner :deck deck)
-              (.focus deck)))))))
+              (put! select-channel deck)))))))
 
 (defn html-escape [st]
   (escape st {\< "&lt;" \> "&gt;" \& "&amp;" \" "#034;"}))


### PR DESCRIPTION
The web socket reader did not like the `#object` format used to pass Mongo ObjectIDs when we update deck stats after a game. Now sending the id as a string, which appears to get handled correctly when we match against the deck list (somewhat surprisingly).

Also fixed deck focus after clearing stats. Not sure how that ever worked.

Fixes #3208