### PR TITLE
Fix Stinson+Current interaction

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -134,12 +134,13 @@
                  :req (req (and (< (:credit runner) 6)
                                 (< 0 (count (filter #(and (is-type? % "Operation")
                                                           (has-subtype? % "Transaction")) (:discard corp))))))
-                 :label "Play a transaction operation from Archives ignoring all costs and remove it from the game"
+                 :label "Play a transaction operation from Archives, ignoring all costs, and remove it from the game"
                  :prompt "Choose a transaction operation to play"
-                 :msg (msg "play " (:title target) " from Archives ignoring all costs and remove it from the game")
+                 :msg (msg "play " (:title target) " from Archives, ignoring all costs, and removes it from the game")
                  :choices (req (cancellable (filter #(and (is-type? % "Operation")
                                                           (has-subtype? % "Transaction")) (:discard corp)) :sorted))
-                 :effect (effect (play-instant nil target {:ignore-cost true}) (move target :rfg))}]}
+                 :effect (effect (play-instant nil (assoc-in target [:special :rfg-when-trashed] true) {:ignore-cost true})
+                                 (move target :rfg))}]}
 
    "Calibration Testing"
    {:abilities [{:label "[Trash]: Place 1 advancement token on a card in this server"

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -53,8 +53,13 @@
              (if (has-subtype? c "Current")
                (do (doseq [s [:corp :runner]]
                      (when-let [current (first (get-in @state [s :current]))] ; trash old current
-                       (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
-                       (trash state side current)))
+                       (if (get-in current [:special :rfg-when-trashed])
+                         (do
+                           (say state side {:user "__system__" :text (str (:title current) " is removed from the game.")})
+                           (move state (other-side side) current :rfg))
+                         (do
+                           (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
+                           (trash state side current)))))
                    (let [c (some #(when (= (:cid %) (:cid card)) %) (get-in @state [side :play-area]))
                          moved-card (move state side c :current)]
                      (card-init state side eid moved-card {:resolve-effect true

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -55,8 +55,13 @@
                                        (when (card-flag? c :has-events-when-stolen true)
                                          (register-events state side (:events (card-def c)) c))
                                        (when-let [current (first (get-in @state [:corp :current]))]
-                                         (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
-                                         (trash state side current)))}
+                                         (if (get-in current [:special :rfg-when-trashed])
+                                           (do
+                                             (say state side {:user "__system__" :text (str (:title current) " is removed from the game.")})
+                                             (move state (other-side side) current :rfg))
+                                           (do
+                                             (say state side {:user "__system__" :text (str (:title current) " is trashed.")})
+                                             (trash state side current)))))}
           :card-ability (ability-as-handler c (:stolen (card-def c)))}
          c)
        (effect-completed state side eid nil)))))

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -218,6 +218,47 @@
        (core/rez state :corp sbox)
        (is (= 1 (:credit (get-corp))) "Paid full 3 credits to rez Strongbox")))))
 
+(deftest bryan-stinson-current
+  ;; Bryan Stinson - play a transaction from archives and remove from game. Ensure Currents are RFG and not trashed.
+  (do-game
+   (new-game (default-corp [(qty "Bryan Stinson" 1) (qty "Death and Taxes" 1)
+                            (qty "Paywall Implementation" 1) (qty "Global Food Initiative" 1)
+                            (qty "IPO" 1)])
+             (default-runner [(qty "Interdiction" 1)]))
+    (trash-from-hand state :corp "Death and Taxes")
+    (play-from-hand state :corp "Bryan Stinson" "New remote")
+    (let [bs (get-content state :remote1 0)]
+      (core/rez state :corp (refresh bs))
+      (card-ability state :corp (refresh bs) 0)
+      (prompt-choice :corp (find-card "Death and Taxes" (:discard (get-corp))))
+      (is (find-card "Death and Taxes" (:current (get-corp))) "Death and Taxes is active Current")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Interdiction")
+      (is (find-card "Interdiction" (:current (get-runner))) "Interdiction is active Current")
+      (is (find-card "Death and Taxes" (:rfg (get-corp))) "Death and Taxes removed from game")
+      (is (not= "Death and Taxes" (:title (first (:discard (get-corp))))) "Death and Taxes not moved to trash")
+      (take-credits state :runner)
+
+      (core/lose state :runner :credit 3)
+      (trash-from-hand state :corp "Paywall Implementation")
+      (card-ability state :corp (refresh bs) 0)
+      (prompt-choice :corp (find-card "Paywall Implementation" (:discard (get-corp))))
+      (is (find-card "Paywall Implementation" (:current (get-corp))) "Paywall Implementation is active Current")
+      (is (find-card "Interdiction" (:discard (get-runner))) "Interdiction is trashed")
+      (trash-from-hand state :corp "IPO")
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (run-successful state)
+      (prompt-choice :runner "Steal")
+      (is (find-card "Paywall Implementation" (:rfg (get-corp))) "Paywall Implementation removed from game")
+      (is (not= "Paywall Implementation" (:title (first (:discard (get-corp))))) "Paywall Implementation not moved to trash")
+      (take-credits state :runner)
+
+      (core/lose state :runner :credit 3)
+      (card-ability state :corp (refresh bs) 0)
+      (prompt-choice :corp (find-card "IPO" (:discard (get-corp))))
+      (is (find-card "IPO" (:rfg (get-corp))) "IPO is removed from game"))))
+
 (deftest calibration-testing
   ;; Calibration Testing - advanceable / non-advanceable
   (do-game


### PR DESCRIPTION
When using Bryan Stinson to install a Current, we now remove the Current from the game when it would be trashed (ie., agenda steal, new current played).

Fixes #3216 