### PR TITLE
Updated fetch task to optionally use local json files

### DIFF
--- a/src/clj/tasks/fetch.clj
+++ b/src/clj/tasks/fetch.clj
@@ -1,18 +1,30 @@
 (ns tasks.fetch
   "NetrunnerDB import tasks"
   (:require [web.db :refer [db] :as webdb]
+            [clojure.string :as string]
             [tasks.nrdb :refer :all]
             [tasks.altart :refer [add-art]]))
 
 (defn fetch
-  "Import data from NetrunnerDB"
+  "Import data from NetrunnerDB.
+  Can accept `--local <path>` to use the `netrunner-card-json` project locally,
+  otherwise pulls data from NRDB.
+  Specifying `--no-card-images` will not attempt to download images for cards."
   [& args]
   (webdb/connect)
   (try
-    (let [cycles (fetch-data (:cycle tables))
-          mwls (fetch-data (:mwl tables))
-          sets (fetch-data (:set tables) (partial add-set-fields cycles))
-          cards (fetch-cards (:card tables) sets (not (some #{"--no-card-images"} args)))]
+    (let [use-local (some #{"--local"} args)
+          localpath (first (remove #(string/starts-with? % "--") args))
+          download-fn (if use-local
+                        (partial read-local-data localpath)
+                        download-nrdb-data)
+          cycles (fetch-data download-fn (:cycle tables))
+          mwls (fetch-data download-fn (:mwl tables))
+          sets (fetch-data download-fn (:set tables) (partial add-set-fields cycles))
+          card-download-fn (if use-local
+                             (partial read-card-dir localpath)
+                             download-nrdb-data)
+          cards (fetch-cards card-download-fn (:card tables) sets (not (some #{"--no-card-images"} args)))]
       (println (count cycles) "cycles imported")
       (println (count sets) "sets imported")
       (println (count mwls) "MWL versions imported")


### PR DESCRIPTION
Added a `--local <path>` option to the `lein fetch` script to use a local copy of the `netrunner-cards-json` project (https://github.com/Alsciende/netrunner-cards-json).