### PR TITLE
TDatD: Endless EULA

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -724,8 +724,10 @@
     :runner-abilities [(runner-break [:click 2] 2)]}
 
    "Endless EULA"
-   {:subroutines [end-the-run]
-    :runner-abilities [(runner-break [:credit 1] 1)]}
+   {:implementation "Encounter effect is manual. Runner choice is not implemented"
+    :subroutines [end-the-run]
+    :runner-abilities [(runner-break [:credit 1] 1)
+                       (runner-break [:credit 6] 6)]}
 
    "Enforcer 1.0"
    {:additional-cost [:forfeit]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -724,7 +724,7 @@
     :runner-abilities [(runner-break [:click 2] 2)]}
 
    "Endless EULA"
-   {:implementation "Encounter effect is manual. Runner choice is not implemented"
+   {:implementation "Subroutine effect is manual. Runner choice is not implemented"
     :subroutines [end-the-run]
     :runner-abilities [(runner-break [:credit 1] 1)
                        (runner-break [:credit 6] 6)]}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -723,6 +723,10 @@
                   end-the-run]
     :runner-abilities [(runner-break [:click 2] 2)]}
 
+   "Endless EULA"
+   {:subroutines [end-the-run]
+    :runner-abilities [(runner-break [:credit 1] 1)]}
+
    "Enforcer 1.0"
    {:additional-cost [:forfeit]
     :subroutines [trash-program


### PR DESCRIPTION
I used Pup as an archetype for Endless EULA because it has subroutines which do not fire if the runner pays a credit.

```
   "Pup"
   {:subroutines [(do-net-damage 1)]
    :runner-abilities [(runner-break [:credit 1] 1)]}
```
