### PR TITLE
Implemented Amani Senai

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -128,6 +128,19 @@
                  :effect (effect (trash card))
                  :msg (msg "swap " (:advance-counter card 0) " cards in HQ and Archives")}]}
 
+   "Amani Sendai"
+   (let [get-last-stolen-pts (fn [state] (:agendapoints (last (get-in @state [:runner :scored]))))
+         get-last-scored-pts (fn [state] (:agendapoints (last (get-in @state [:corp :scored]))))
+         sendai-ability (fn [trace-base-func]
+                          {:optional {:prompt "Trace with Amani Sendai?" :player :corp
+                                      :yes-ability {:trace {:base (req (trace-base-func state))
+                                                            :choices {:req #(and (installed? %)
+                                                                                 (card-is? % :side :runner))}
+                                                            :msg "add an installed Runner card to the grip"
+                                                            :effect (effect (move :runner target :hand true))}}}})]
+     {:events {:agenda-scored (sendai-ability get-last-scored-pts)
+               :agenda-stolen (sendai-ability get-last-stolen-pts)}})
+
    "Anson Rose"
    (let [ability {:label "Place 1 advancement token on Anson Rose (start of turn)"
                   :once :per-turn

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -129,8 +129,8 @@
                  :msg (msg "swap " (:advance-counter card 0) " cards in HQ and Archives")}]}
 
    "Amani Senai"
-   (let [get-last-stolen-pts (fn [state] (:advancementcost (last (get-in @state [:runner :scored]))))
-         get-last-scored-pts (fn [state] (:advancementcost (last (get-in @state [:corp :scored]))))
+   (let [get-last-stolen-pts (fn [state] (advancement-cost state :corp (last (get-in @state [:runner :scored]))))
+         get-last-scored-pts (fn [state] (advancement-cost state :corp (last (get-in @state [:corp :scored]))))
          senai-ability (fn [trace-base-func]
                          {:interactive (req true)
                           :optional {:prompt "Trace with Amani Senai?" :player :corp

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -128,18 +128,18 @@
                  :effect (effect (trash card))
                  :msg (msg "swap " (:advance-counter card 0) " cards in HQ and Archives")}]}
 
-   "Amani Sendai"
+   "Amani Senai"
    (let [get-last-stolen-pts (fn [state] (:agendapoints (last (get-in @state [:runner :scored]))))
          get-last-scored-pts (fn [state] (:agendapoints (last (get-in @state [:corp :scored]))))
-         sendai-ability (fn [trace-base-func]
-                          {:optional {:prompt "Trace with Amani Sendai?" :player :corp
+         senai-ability (fn [trace-base-func]
+                          {:optional {:prompt "Trace with Amani Senai?" :player :corp
                                       :yes-ability {:trace {:base (req (trace-base-func state))
                                                             :choices {:req #(and (installed? %)
                                                                                  (card-is? % :side :runner))}
                                                             :msg "add an installed Runner card to the grip"
                                                             :effect (effect (move :runner target :hand true))}}}})]
-     {:events {:agenda-scored (sendai-ability get-last-scored-pts)
-               :agenda-stolen (sendai-ability get-last-stolen-pts)}})
+     {:events {:agenda-scored (senai-ability get-last-scored-pts)
+               :agenda-stolen (senai-ability get-last-stolen-pts)}})
 
    "Anson Rose"
    (let [ability {:label "Place 1 advancement token on Anson Rose (start of turn)"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -129,15 +129,15 @@
                  :msg (msg "swap " (:advance-counter card 0) " cards in HQ and Archives")}]}
 
    "Amani Senai"
-   (let [get-last-stolen-pts (fn [state] (:agendapoints (last (get-in @state [:runner :scored]))))
-         get-last-scored-pts (fn [state] (:agendapoints (last (get-in @state [:corp :scored]))))
+   (let [get-last-stolen-pts (fn [state] (:advancementcost (last (get-in @state [:runner :scored]))))
+         get-last-scored-pts (fn [state] (:advancementcost (last (get-in @state [:corp :scored]))))
          senai-ability (fn [trace-base-func]
-                          {:optional {:prompt "Trace with Amani Senai?" :player :corp
-                                      :yes-ability {:trace {:base (req (trace-base-func state))
-                                                            :choices {:req #(and (installed? %)
-                                                                                 (card-is? % :side :runner))}
-                                                            :msg "add an installed Runner card to the grip"
-                                                            :effect (effect (move :runner target :hand true))}}}})]
+                         {:optional {:prompt "Trace with Amani Senai?" :player :corp
+                                     :yes-ability {:trace {:base (req (trace-base-func state))
+                                                           :choices {:req #(and (installed? %)
+                                                                                (card-is? % :side :runner))}
+                                                           :msg "add an installed Runner card to the grip"
+                                                           :effect (effect (move :runner target :hand true))}}}})]
      {:events {:agenda-scored (senai-ability get-last-scored-pts)
                :agenda-stolen (senai-ability get-last-stolen-pts)}})
 

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -132,7 +132,8 @@
    (let [get-last-stolen-pts (fn [state] (:advancementcost (last (get-in @state [:runner :scored]))))
          get-last-scored-pts (fn [state] (:advancementcost (last (get-in @state [:corp :scored]))))
          senai-ability (fn [trace-base-func]
-                         {:optional {:prompt "Trace with Amani Senai?" :player :corp
+                         {:interactive (req true)
+                          :optional {:prompt "Trace with Amani Senai?" :player :corp
                                      :yes-ability {:trace {:base (req (trace-base-func state))
                                                            :choices {:req #(and (installed? %)
                                                                                 (card-is? % :side :runner))}

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -83,26 +83,23 @@
   ;; Amani Senai - trace on score/steal to bounce, with base strength = advancement req of the agenda
   (do-game
     (new-game (default-corp [(qty "Amani Senai" 1)
-                             (qty "Global Food Initiative" 1)
-                             (qty "Domestic Sleepers" 1)])
+                             (qty "Medical Breakthrough" 2)])
               (default-runner [(qty "Analog Dreamers" 1)]))
     (play-from-hand state :corp "Amani Senai" "New remote")
-    (play-from-hand state :corp "Global Food Initiative" "New remote")
-    (play-from-hand state :corp "Domestic Sleepers" "New remote")
+    (play-from-hand state :corp "Medical Breakthrough" "New remote")
+    (play-from-hand state :corp "Medical Breakthrough" "New remote")
     (take-credits state :corp)
     (let [senai (get-content state :remote1 0)
-          sleepers (get-content state :remote3 0)]
+          breakthrough (get-content state :remote3 0)]
       (core/rez state :corp senai)
       (play-from-hand state :runner "Analog Dreamers")
       (run-empty-server state "Server 2")
-      (is (= 1 (count (get-in @state [:corp :servers :remote2 :content])))
-          "Agenda was not stolen")
       (prompt-choice :runner "Steal")
       (is (= 0 (count (get-in @state [:corp :servers :remote2 :content]))) "Agenda was stolen")
+      (prompt-choice :corp "Medical Breakthrough") ;simult. effect resolution
       (prompt-choice :corp "Yes")
-      ;; (is (= 2 (get-in @state [:corp :prompt])) "Corp is prompted for trace")
       (prompt-choice :corp 0)  ;; Corp doesn't pump trace
-      (is (= 5  (get-in @state [:trace :strength])) "Trace base strength is 5 after stealing a GFI")
+      (is (= 3  (get-in @state [:trace :strength])) "Trace base strength is 3 after stealing first Breakthrough")
       (prompt-choice :runner 0)
       (let [n (count (get-in @state [:runner :hand]))]
         (is (= 1 (count (get-in @state [:runner :rig :program]))) "There is an Analog Dreamers installed")
@@ -110,10 +107,11 @@
         (is (= 0 (count (get-in @state [:runner :rig :program]))) "Analog Dreamers was uninstalled")
         (is (= (+ n 1) (count (get-in @state [:runner :hand]))) "Analog Dreamers was added to hand"))
       (take-credits state :runner)
-      (score-agenda state :corp sleepers)
+      (score-agenda state :corp breakthrough)
+      ;; (prompt-choice :corp "Medical Breakthrough") ; there is no simult. effect resolution on score for some reason
       (prompt-choice :corp "Yes")       ;corp should get to trigger trace even when no runner cards are installed
       (prompt-choice :corp 0)
-      (is (= 2 (get-in @state [:trace :strength])) "Trace base strength is 2 after scoring a Sleepers"))))
+      (is (= 2 (get-in @state [:trace :strength])) "Trace base strength is 2 after scoring second Breakthrough"))))
 
 (deftest blacklist-steal
   ;; Blacklist - #2426.  Need to allow steal.

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -80,7 +80,7 @@
       (is (= 8 (get-in @state [:corp :credit]))))) "Gain 4 credits from Alix")
 
 (deftest amani-senai
-  ;; Team Sponsorship - Install from HQ
+  ;; Amani Senai - trace on score/steal to bounce, with base strength = advancement req of the agenda
   (do-game
     (new-game (default-corp [(qty "Amani Senai" 1)
                              (qty "Global Food Initiative" 1)
@@ -102,7 +102,7 @@
       (prompt-choice :corp "Yes")
       ;; (is (= 2 (get-in @state [:corp :prompt])) "Corp is prompted for trace")
       (prompt-choice :corp 0)  ;; Corp doesn't pump trace
-      (is (= 3  (get-in @state [:trace :strength])) "Trace base strength is 3 after stealing a GFI")
+      (is (= 5  (get-in @state [:trace :strength])) "Trace base strength is 5 after stealing a GFI")
       (prompt-choice :runner 0)
       (let [n (count (get-in @state [:runner :hand]))]
         (is (= 1 (count (get-in @state [:runner :rig :program]))) "There is an Analog Dreamers installed")
@@ -113,7 +113,7 @@
       (score-agenda state :corp sleepers)
       (prompt-choice :corp "Yes")       ;corp should get to trigger trace even when no runner cards are installed
       (prompt-choice :corp 0)
-      (is (= 0 (get-in @state [:trace :strength])) "Trace base strength is 0 after scoring a Sleepers"))))
+      (is (= 2 (get-in @state [:trace :strength])) "Trace base strength is 2 after scoring a Sleepers"))))
 
 (deftest blacklist-steal
   ;; Blacklist - #2426.  Need to allow steal.


### PR DESCRIPTION
Ignore branch name typo. Implementation allows corp to trigger trace even if there are no installed Runner cards on score/steal, which is intentional. I was unsure if anything here needed to be delayed, but I think maybe not? Or do traces need to?