### PR TITLE
TDatD: Consume

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -723,10 +723,6 @@
                   end-the-run]
     :runner-abilities [(runner-break [:click 2] 2)]}
 
-   "Endless EULA"
-   {:subroutines [end-the-run]
-    :runner-abilities [(runner-break [:credit 1] 1)]}
-
    "Enforcer 1.0"
    {:additional-cost [:forfeit]
     :subroutines [trash-program

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -152,16 +152,15 @@
                                {:effect (effect (add-counter :runner card :virus 1)
                                                 (system-msg :runner (str "places 1 virus counter on Consume")))}}}}
     :abilities [{:cost [:click 1]
+                 :effect (effect (gain :credit (* 2 (get-virus-counters state side card)))
+                                 (update! (assoc-in card [:counter :virus] 0)))
                  :msg (msg (let [local-virus (get-in card [:counter :virus])
                             global-virus (get-virus-counters state side card)
                             hivemind-virus (- global-virus local-virus)]
-                            (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counters from Consume"
+                            (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counter(s) from Consume"
                             (when (pos? hivemind-virus)
-                                  (str " (and " hivemind-virus " from Hivemind)"))))
-                                 )
-                 :effect (effect (gain :credit (* 2 (get-virus-counters state side card)))
-                                 (update! (assoc-in card [:counter :virus] 0)))
-                 }]}
+                                  (str " (and " hivemind-virus " from Hivemind)")))
+                                 )}]}
 
    "D4v1d"
    {:implementation "Does not check that ICE strength is 5 or greater"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -144,6 +144,24 @@
                    :msg (msg "install " (:title target))
                    :effect (req (when (can-pay? state side nil :credit (:cost target))
                                   (runner-install state side target)))}]})
+   "Consume"
+   {:events {:runner-trash {:req (req (= (:side target) "Corp"))
+                              :optional
+                              {:prompt "Place a virus counter on Consume?"
+                               :yes-ability
+                               {:effect (effect (add-counter :runner card :virus 1)
+                                                (system-msg :runner (str "places 1 virus counter on Consume")))}}}}
+    :abilities [{:cost [:click 1]
+                 :msg (msg (let [local-virus (get-in card [:counter :virus])
+                            global-virus (get-virus-counters state side card)
+                            hivemind-virus (- global-virus local-virus)]
+                            (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counters from Consume"
+                            (when (pos? hivemind-virus)
+                                  (str " (and " hivemind-virus " from Hivemind)"))))
+                                 )
+                 :effect (effect (gain :credit (* 2 (get-virus-counters state side card)))
+                                 (update! (assoc-in card [:counter :virus] 0)))
+                 }]}
 
    "D4v1d"
    {:implementation "Does not check that ICE strength is 5 or greater"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -146,24 +146,23 @@
                                   (runner-install state side target)))}]})
    "Consume"
    {:events {:runner-trash {:req (req (= (:side target) "Corp"))
-                              :optional
-                              {:prompt "Place a virus counter on Consume?"
-                               :yes-ability
-                               {:effect (effect (add-counter :runner card :virus 1)
+                            :optional {:prompt "Place a virus counter on Consume?"
+                                       :yes-ability
+                                       {:effect (effect (add-counter :runner card :virus 1)
                                                 (system-msg :runner (str "places 1 virus counter on Consume")))}}}}
     :abilities [{:cost [:click 1]
                  :effect (req (gain state side :credit (* 2 (get-virus-counters state side card)))
                               (update! state side (assoc-in card [:counter :virus] 0))
-                         (when-let [hiveminds (filter #(= "Hivemind" (:title %)) (all-active-installed state :runner))]
-                                   (doseq [h hiveminds]
-                                          (update! state side (assoc-in h [:counter :virus] 0)))))
+                              (when-let [hiveminds (filter #(= "Hivemind" (:title %)) (all-active-installed state :runner))]
+                                        (doseq [h hiveminds]
+                                               (update! state side (assoc-in h [:counter :virus] 0)))))
                  :msg (msg (let [local-virus (get-in card [:counter :virus])
-                            global-virus (get-virus-counters state side card)
-                            hivemind-virus (- global-virus local-virus)]
-                            (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counter(s) from Consume"
-                            (when (pos? hivemind-virus)
-                                  (str " (and " hivemind-virus " from Hivemind)")))
-                                 ))}]}
+                                 global-virus (get-virus-counters state side card)
+                                 hivemind-virus (- global-virus local-virus)]
+                                 (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counter(s) from Consume"
+                                 (when (pos? hivemind-virus)
+                                       (str " (and " hivemind-virus " from Hivemind)")))
+                                     ))}]}
 
    "D4v1d"
    {:implementation "Does not check that ICE strength is 5 or greater"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -159,10 +159,9 @@
                  :msg (msg (let [local-virus (get-in card [:counter :virus])
                                  global-virus (get-virus-counters state side card)
                                  hivemind-virus (- global-virus local-virus)]
-                                 (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counter(s) from Consume"
-                                 (when (pos? hivemind-virus)
-                                       (str " (and " hivemind-virus " from Hivemind)")))
-                                     ))}]}
+                             (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counter(s) from Consume"
+                             (when (pos? hivemind-virus)
+                                   (str " (and " hivemind-virus " from Hivemind)")))))}]}
 
    "D4v1d"
    {:implementation "Does not check that ICE strength is 5 or greater"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -152,15 +152,18 @@
                                {:effect (effect (add-counter :runner card :virus 1)
                                                 (system-msg :runner (str "places 1 virus counter on Consume")))}}}}
     :abilities [{:cost [:click 1]
-                 :effect (effect (gain :credit (* 2 (get-virus-counters state side card)))
-                                 (update! (assoc-in card [:counter :virus] 0)))
+                 :effect (req (gain state side :credit (* 2 (get-virus-counters state side card)))
+                              (update! state side (assoc-in card [:counter :virus] 0))
+                         (when-let [hiveminds (filter #(= "Hivemind" (:title %)) (all-active-installed state :runner))]
+                                   (doseq [h hiveminds]
+                                          (update! state side (assoc-in h [:counter :virus] 0)))))
                  :msg (msg (let [local-virus (get-in card [:counter :virus])
                             global-virus (get-virus-counters state side card)
                             hivemind-virus (- global-virus local-virus)]
                             (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counter(s) from Consume"
                             (when (pos? hivemind-virus)
                                   (str " (and " hivemind-virus " from Hivemind)")))
-                                 )}]}
+                                 ))}]}
 
    "D4v1d"
    {:implementation "Does not check that ICE strength is 5 or greater"


### PR DESCRIPTION
Friday Chip contributed the code to prompt to the runner to add a counter per Consume's "may add" clause.

Displays prompt depending on if counters from Hivemind are used or not.

![screen shot 2018-04-04 at 4 39 38 pm](https://user-images.githubusercontent.com/2982395/38336991-627380e0-3829-11e8-8477-594397f1c91a.png)
![screen shot 2018-04-04 at 4 39 46 pm](https://user-images.githubusercontent.com/2982395/38336996-63711160-3829-11e8-8d54-9b9f85947676.png)

#### Currently not implemented - removing counters from Hivemind.