### PR TITLE
tDatD: Kill Switch

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -680,10 +680,10 @@
 
    "Kill Switch"
    (let [trace-for-brain-damage {:trace {:base 3 :msg "give the Runner 1 brain damage"
-                                        :delayed-completion true
-                                        :effect (effect (damage :runner eid :brain 1 {:card card}))}}]
-   {:events {:pre-access-card (assoc trace-for-brain-damage :req (req (is-type? target "Agenda")))
-             :agenda-scored trace-for-brain-damage}})
+                                         :delayed-completion true
+                                         :effect (effect (damage :runner eid :brain 1 {:card card}))}}]
+     {:events {:pre-access-card (assoc trace-for-brain-damage :req (req (is-type? target "Agenda")))
+               :agenda-scored trace-for-brain-damage}})
 
    "Lag Time"
    {:effect (effect (update-all-ice))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -678,6 +678,13 @@
    "IPO"
    {:msg "gain 13 [Credits]" :effect (effect (gain :credit 13))}
 
+   "Kill Switch"
+   (let [trace-for-brain-damage {:trace {:base 3 :msg "give the Runner 1 brain damage"
+                                        :delayed-completion true
+                                        :effect (effect (damage :runner eid :brain 1 {:card card}))}}]
+   {:events {:pre-access-card (assoc trace-for-brain-damage :req (req (is-type? target "Agenda")))
+             :agenda-scored trace-for-brain-damage}})
+
    "Lag Time"
    {:effect (effect (update-all-ice))
     :events {:pre-ice-strength {:effect (effect (ice-strength-bonus 1 target))}}


### PR DESCRIPTION
I looked at J:PE for an effect when an agenda is scored. Credit Crash for "when accessed", and Kuwinda for a trace resulting in brain damage.

![screen shot 2018-04-05 at 11 56 11 am](https://user-images.githubusercontent.com/2982395/38380661-06cd6f70-38ca-11e8-9086-c91fb3014478.png)
Corp Scores, wins trace
![screen shot 2018-04-05 at 11 57 53 am](https://user-images.githubusercontent.com/2982395/38380683-1c480e1e-38ca-11e8-8e65-6c57b1f97bbe.png)
Runner steals, wins trace.

