### PR TITLE
tDatD: Rogue Trading

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1380,6 +1380,15 @@
                                                 (when (not= target "No install")
                                                   (install-cost-bonus state side [:credit (- n)])
                                                   (runner-install state side target)))} card nil)))}]}
+   "Rogue Trading"
+   {:data {:counter {:credit 18}}
+    :abilities [{:cost [:click 2]
+                 :counter-cost [:credit 6]
+                 :msg "gain 6 [Credits] and take 1 tag"
+                 :effect (req (gain state :runner :credit 6)
+                              (when (zero? (get-in card [:counter :credit] 0))
+                                (trash state :runner card {:unpreventable true}))
+                              (tag-runner state :runner eid 1))}]}
 
    "Sacrificial Clone"
    {:prevent {:damage [:meat :net :brain]}


### PR DESCRIPTION
Used Armitage Codebusting as the card archetype for this. Prisec had an example of a tag provided to the runner within a `req`.

![screen shot 2018-04-05 at 1 00 58 pm](https://user-images.githubusercontent.com/2982395/38383842-297338ee-38d3-11e8-8116-c48d53d8d78b.png)
![screen shot 2018-04-05 at 1 01 05 pm](https://user-images.githubusercontent.com/2982395/38383843-2a820454-38d3-11e8-9635-f92e04d83a1f.png)
![screen shot 2018-04-05 at 1 01 15 pm](https://user-images.githubusercontent.com/2982395/38383844-2b9f7b32-38d3-11e8-9912-4711c9791181.png)
