### PR TITLE
Malia Z0L0K4

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -822,14 +822,16 @@
     :events {:corp-turn-begins {:effect (effect (add-counter card :credit 2)
                                                 (system-msg (str "adds 2 [Credit] to Long-Term Investment")))}}}
 
-   "Malia Z0l0k4"
+   "Malia Z0L0K4"
    {:effect (effect (update! (assoc card :malia-target target))
-                    (system-msg (str " blank ") target) ;todo: make something nicer
                     (disable-card target))
+    :msg (msg (str "blank " (card-str state target))) ;todo: make something nicer
+
     :choices {:req #(and (= (:side %) "Runner") (installed? %) (resource? %)
                          (not (has-subtype? % "Virtual")))}
-    :leave-play (effect (enable-card (get-card (:malia-target target)))
-                        (system-msg (str "unblank")) ;todo: make this nicer too
+    :leave-play (effect (enable-card (get-card state (:malia-target target)))
+                        (system-msg (str "uses "  (:title card) " to unblank "
+                                         (card-str state (:malia-target card))))
                         )
     }
    "Marilyn Campaign"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -829,9 +829,12 @@
 
     :choices {:req #(and (= (:side %) "Runner") (installed? %) (resource? %)
                          (not (has-subtype? % "Virtual")))}
-    :leave-play (effect (enable-card :runner (get-card state (:malia-target card)))
-                        (system-msg (str "uses "  (:title card) " to unblank "
-                                         (card-str state (:malia-target card)))))}
+    :leave-play (req (let [malia-target (:malia-target card)]
+                       (enable-card state :runner (get-card state malia-target))
+                       (when-let [reactivate-effect (:reactivate (card-def malia-target))]
+                         (resolve-ability state :runner reactivate-effect (get-card state malia-target) nil))
+                       (system-msg state side (str "uses "  (:title card) " to unblank "
+                                                   (card-str state malia-target)))))}
    "Marilyn Campaign"
    (let [ability {:msg "gain 2 [Credits]"
                   :counter-cost [:credit 2]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -824,16 +824,14 @@
 
    "Malia Z0L0K4"
    {:effect (effect (update! (assoc card :malia-target target))
-                    (disable-card target))
-    :msg (msg (str "blank " (card-str state target))) ;todo: make something nicer
+                    (disable-card :runner target))
+    :msg (msg (str "blank the text box of " (card-str state target)))
 
     :choices {:req #(and (= (:side %) "Runner") (installed? %) (resource? %)
                          (not (has-subtype? % "Virtual")))}
-    :leave-play (effect (enable-card (get-card state (:malia-target target)))
+    :leave-play (effect (enable-card :runner (get-card state (:malia-target card)))
                         (system-msg (str "uses "  (:title card) " to unblank "
-                                         (card-str state (:malia-target card))))
-                        )
-    }
+                                         (card-str state (:malia-target card)))))}
    "Marilyn Campaign"
    (let [ability {:msg "gain 2 [Credits]"
                   :counter-cost [:credit 2]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -822,6 +822,16 @@
     :events {:corp-turn-begins {:effect (effect (add-counter card :credit 2)
                                                 (system-msg (str "adds 2 [Credit] to Long-Term Investment")))}}}
 
+   "Malia Z0l0k4"
+   {:effect (effect (update! (assoc card :malia-target target))
+                    (system-msg (str " blank ") target) ;todo: make something nicer
+                    (disable-card target))
+    :choices {:req #(and (= (:side %) "Runner") (installed? %) (resource? %)
+                         (not (has-subtype? % "Virtual")))}
+    :leave-play (effect (enable-card (get-card (:malia-target target)))
+                        (system-msg (str "unblank")) ;todo: make this nicer too
+                        )
+    }
    "Marilyn Campaign"
    (let [ability {:msg "gain 2 [Credits]"
                   :counter-cost [:credit 2]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -823,18 +823,21 @@
                                                 (system-msg (str "adds 2 [Credit] to Long-Term Investment")))}}}
 
    "Malia Z0L0K4"
-   {:effect (effect (update! (assoc card :malia-target target))
-                    (disable-card :runner target))
-    :msg (msg (str "blank the text box of " (card-str state target)))
+   (let [re-enable-target (req (when-let [malia-target (:malia-target card)]
+                                 (system-msg state side (str "uses "  (:title card) " to unblank "
+                                                             (card-str state malia-target)))
+                                 (enable-card state :runner (get-card state malia-target))
+                                 (when-let [reactivate-effect (:reactivate (card-def malia-target))]
+                                   (resolve-ability state :runner reactivate-effect (get-card state malia-target) nil))))]
+     {:effect (effect (update! (assoc card :malia-target target))
+                      (disable-card :runner target))
+      :msg (msg (str "blank the text box of " (card-str state target)))
 
-    :choices {:req #(and (= (:side %) "Runner") (installed? %) (resource? %)
-                         (not (has-subtype? % "Virtual")))}
-    :leave-play (req (let [malia-target (:malia-target card)]
-                       (enable-card state :runner (get-card state malia-target))
-                       (when-let [reactivate-effect (:reactivate (card-def malia-target))]
-                         (resolve-ability state :runner reactivate-effect (get-card state malia-target) nil))
-                       (system-msg state side (str "uses "  (:title card) " to unblank "
-                                                   (card-str state malia-target)))))}
+      :choices {:req #(and (= (:side %) "Runner") (installed? %) (resource? %)
+                           (not (has-subtype? % "Virtual")))}
+      :derez-effect {:effect re-enable-target}
+      :move-zone re-enable-target})
+   
    "Marilyn Campaign"
    (let [ability {:msg "gain 2 [Credits]"
                   :counter-cost [:credit 2]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -558,8 +558,11 @@
                                 (disable-card state side c)
                                 (register-events state side
                                                  {:post-runner-turn-ends
-                                                  {:effect (effect (enable-card (get-card state c))
-                                                                   (unregister-events card))}} card)))}]
+                                                  {:effect (req (enable-card state side (get-card state c))
+                                                                (when-let [reactivate-effect (:reactivate (card-def c))]
+                                                                  (resolve-ability state :runner reactivate-effect
+                                                                                   (get-card state c) nil))
+                                                                (unregister-events state side card))}} card)))}]
     :events {:post-runner-turn-ends nil}}
 
    "Drug Dealer"
@@ -1314,7 +1317,9 @@
     :events {:runner-gain-tag {:effect (effect (trash card {:unpreventable true}))
                                :msg (msg "trashes Rachel Beckman for being tagged")}}
     :effect (req (when tagged
-                   (trash state :runner card {:unpreventable true})))}
+                   (trash state :runner card {:unpreventable true})))
+    :reactivate {:effect (req (when tagged
+                                (trash state :runner card {:unpreventable true})))}}
 
    "Raymond Flint"
    {:effect (req (add-watch state :raymond-flint
@@ -1845,4 +1850,6 @@
                               (when (is-tagged? new)
                                 (remove-watch ref (keyword (str "zona-sul-shipping" (:cid card))))
                                 (trash ref :runner card)
-                                (system-msg ref side "trashes Zona Sul Shipping for being tagged")))))}})
+                                (system-msg ref side "trashes Zona Sul Shipping for being tagged")))))
+    :reactivate {:effect (req (when tagged
+                                (trash state :runner card {:unpreventable true})))}}})

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1310,20 +1310,11 @@
    {:in-play [:hand-size-modification 2]}
 
    "Rachel Beckman"
-   (let [installed-active-beckman (fn [state]
-                             (some #(= "Rachel Beckman" %)
-                                   (map :title
-                                        (filter #(not (:disabled %))
-                                                (get-in @state [:runner :rig :resource]))))) ]
-     {:in-play [:click 1 :click-per-turn 1]
-      :effect (req (add-watch state :rachel-beckman
-                              (let [beckman card] 
-                                (fn [k ref old new]
-                                  (when (and (is-tagged? new)
-                                             (installed-active-beckman state))
-                                    (remove-watch ref :rachel-beckman)
-                                    (trash ref :runner card)
-                                    (system-msg ref side "trashes Rachel Beckman for being tagged"))))))})
+   {:in-play [:click 1 :click-per-turn 1]
+    :events {:runner-gain-tag {:effect (effect (trash card {:unpreventable true}))
+                               :msg (msg "trashes Rachel Beckman for being tagged")}}
+    :effect (req (when tagged
+                   (trash state :runner card {:unpreventable true})))}
 
    "Raymond Flint"
    {:effect (req (add-watch state :raymond-flint

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1310,13 +1310,20 @@
    {:in-play [:hand-size-modification 2]}
 
    "Rachel Beckman"
-   {:in-play [:click 1 :click-per-turn 1]
-    :effect (req (add-watch state :rachel-beckman
-                            (fn [k ref old new]
-                              (when (is-tagged? new)
-                                (remove-watch ref :rachel-beckman)
-                                (trash ref :runner card)
-                                (system-msg ref side "trashes Rachel Beckman for being tagged")))))}
+   (let [installed-active-beckman (fn [state]
+                             (some #(= "Rachel Beckman" %)
+                                   (map :title
+                                        (filter #(not (:disabled %))
+                                                (get-in @state [:runner :rig :resource]))))) ]
+     {:in-play [:click 1 :click-per-turn 1]
+      :effect (req (add-watch state :rachel-beckman
+                              (let [beckman card] 
+                                (fn [k ref old new]
+                                  (when (and (is-tagged? new)
+                                             (installed-active-beckman state))
+                                    (remove-watch ref :rachel-beckman)
+                                    (trash ref :runner card)
+                                    (system-msg ref side "trashes Rachel Beckman for being tagged"))))))})
 
    "Raymond Flint"
    {:effect (req (add-watch state :raymond-flint

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -1140,7 +1140,11 @@
      (card-subroutine state :corp mausolus 2)
      (is (and (= 1 (:tag (get-runner)))
               (= 0 (count (:discard (get-runner))))) "Runner has 1 tag, but Rachel Beckman not trashed")
-     (core/derez state :corp malia)
+     (take-credits state :runner)
+     (is (= 0 (count (:discard (get-runner)))) "Rachel Beckman still not trashed")
+     (is (= 0 (count (:hand (get-corp)))) "Malia is not in hand")
+     (core/move-card state :corp {:card malia :server "HQ"})
+     (is (= 1 (count (:hand (get-corp)))) "Malia is in hand")
      (is (= 1 (count (:discard (get-runner)))) "Rachel Beckman got trashed on unblanking"))))
 
 (deftest mark-yale


### PR DESCRIPTION
Implementation uses `disable-card` and `enable-card`. The latter is called when Malia's `:move-zone` or `:derez` events are triggered. Rachel Beckman was also modified to not use a watch, instead listening for tag events.