### PR TITLE
Revealing Unseen Cards upon Firing Kill Switch

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -679,7 +679,8 @@
    {:msg "gain 13 [Credits]" :effect (effect (gain :credit 13))}
 
    "Kill Switch"
-   (let [trace-for-brain-damage {:trace {:base 3 :msg "give the Runner 1 brain damage"
+   (let [trace-for-brain-damage {:msg (msg "run a trace when " (:title target) " is accessed")
+                                 :trace {:base 3 :msg "give the Runner 1 brain  upon accessing"
                                          :delayed-completion true
                                          :effect (effect (damage :runner eid :brain 1 {:card card}))}}]
      {:events {:pre-access-card (assoc trace-for-brain-damage :req (req (is-type? target "Agenda")))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -679,8 +679,9 @@
    {:msg "gain 13 [Credits]" :effect (effect (gain :credit 13))}
 
    "Kill Switch"
-   (let [trace-for-brain-damage {:msg (msg "run a trace when " (:title target) " is accessed")
-                                 :trace {:base 3 :msg "give the Runner 1 brain  upon accessing"
+   (let [trace-for-brain-damage {:msg (msg "reveal that they accessed " (:title target))
+                                 :trace {:base 3 
+                                         :msg "do 1 brain damage"
                                          :delayed-completion true
                                          :effect (effect (damage :runner eid :brain 1 {:card card}))}}]
      {:events {:pre-access-card (assoc trace-for-brain-damage :req (req (is-type? target "Agenda")))


### PR DESCRIPTION
Added a message to reveal an agenda upon access per the UFAQ: http://ancur.wikia.com/wiki/The_Devil_and_the_Dragon_UFAQ
![screen shot 2018-04-06 at 8 33 32 am](https://user-images.githubusercontent.com/2982395/38439981-553fa480-39a5-11e8-9155-b884e79c005e.png)
