### PR TITLE
Zamba and 419 fixes

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1113,5 +1113,5 @@
    "Zamba"
    {:implementation "Credit gain is automatic"
     :in-play [:memory 2]
-    :events {:expose {:effect (effect (gain :credit 1))
+    :events {:expose {:effect (effect (gain :runner :credit 1))
                       :msg "gain 1 [Credits]"}}}})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -31,7 +31,8 @@
    "419: Amoral Scammer"
    {:events {:corp-install
              {:delayed-completion true
-              :req (req (first-event? state :corp :corp-install))
+              :req (req (and (first-event? state :corp :corp-install)
+                             (not (rezzed? target))))
               :effect
               (req (show-wait-prompt state :corp "Runner to use 419: Amoral Scammer")
                      (let [itarget target]

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -246,7 +246,7 @@
                    (let [moved-card (if host-card
                                       (host state side host-card (assoc c :installed true))
                                       (move state side c slot))]
-                     (trigger-event state side :corp-install moved-card)
+
                      (when (is-type? c "Agenda")
                        (update-advancement-cost state side moved-card))
 
@@ -276,6 +276,7 @@
                                            :else
                                            (effect-completed state side eid))
 
+                                         (trigger-event state side :corp-install (get-card state moved-card))
                                          (when-let [dre (:derezzed-events cdef)]
                                            (when-not (:rezzed (get-card state moved-card))
                                              (register-events state side dre moved-card))))))))))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -576,24 +576,26 @@
   ([state side target] (expose state side (make-eid state) target))
   ([state side eid target] (expose state side eid target nil))
   ([state side eid target {:keys [unpreventable] :as args}]
-   (swap! state update-in [:expose] dissoc :expose-prevent)
-   (when-completed (trigger-event-sync state side :pre-expose target)
-                   (let [prevent (get-in @state [:prevent :expose :all])]
-                     (if (and (not unpreventable) (pos? (count prevent)))
-                       (do (system-msg state :corp "has the option to prevent a card from being exposed")
-                           (show-wait-prompt state :runner "Corp to prevent the expose" {:priority 10})
-                           (show-prompt state :corp nil
-                                        (str "Prevent " (:title target) " from being exposed?") ["Done"]
-                                        (fn [_]
-                                          (clear-wait-prompt state :runner)
-                                          (if-let [_ (get-in @state [:expose :expose-prevent])]
-                                            (effect-completed state side (make-result eid false)) ;; ??
-                                            (do (system-msg state :corp "will not prevent a card from being exposed")
-                                                (resolve-expose state side eid target args))))
-                                        {:priority 10}))
-                       (if-not (get-in @state [:expose :expose-prevent])
-                         (resolve-expose state side eid target args)
-                         (effect-completed state side (make-result eid false))))))))
+    (swap! state update-in [:expose] dissoc :expose-prevent)
+    (if (rezzed? target)
+      (effect-completed state side eid) ; cannot expose faceup cards
+      (when-completed (trigger-event-sync state side :pre-expose target)
+                      (let [prevent (get-in @state [:prevent :expose :all])]
+                        (if (and (not unpreventable) (pos? (count prevent)))
+                          (do (system-msg state :corp "has the option to prevent a card from being exposed")
+                              (show-wait-prompt state :runner "Corp to prevent the expose" {:priority 10})
+                              (show-prompt state :corp nil
+                                           (str "Prevent " (:title target) " from being exposed?") ["Done"]
+                                           (fn [_]
+                                             (clear-wait-prompt state :runner)
+                                             (if-let [_ (get-in @state [:expose :expose-prevent])]
+                                               (effect-completed state side (make-result eid false)) ;; ??
+                                               (do (system-msg state :corp "will not prevent a card from being exposed")
+                                                   (resolve-expose state side eid target args))))
+                                           {:priority 10}))
+                          (if-not (get-in @state [:expose :expose-prevent])
+                            (resolve-expose state side eid target args)
+                            (effect-completed state side (make-result eid false)))))))))
 
 (defn reveal-hand
   "Reveals a side's hand to opponent and spectators."

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -12,7 +12,7 @@
   (do-game
     (new-game
       (make-deck "Weyland Consortium: Builder of Nations"
-                 [(qty "PAD Campaign" 1) (qty "The Cleaners" 1) (qty "Pup" 3)])
+                 [(qty "PAD Campaign" 1) (qty "The Cleaners" 1) (qty "Pup" 3) (qty "Oaktown Renovation" 1)])
       (make-deck "419: Amoral Scammer" []))
     (is (= 5 (:credit (get-corp))) "Starts with 5 credits")
     (play-from-hand state :corp "Pup" "HQ")
@@ -34,6 +34,11 @@
     (prompt-choice :runner "Yes")
     (prompt-choice :corp "No")
     (is (last-log-contains? state "exposes The Cleaners") "Installed card was exposed")
+    (take-credits state :corp)
+    (take-credits state :runner)
+
+    (play-from-hand state :corp "Oaktown Renovation" "New remote")
+    (is (empty? (:prompt (get-corp))) "Cannot expose faceup agendas")
     (take-credits state :corp)
     (take-credits state :runner)
 


### PR DESCRIPTION
Zamba should give credits to runner, not corp 😉 .

419 should not trigger on faceup installs.

I moved the trigger for `:corp-install` to after the installed card is rezzed / turned faceup because of its initial install state. Didn't break any tests so I assume it's OK 😁 .