### PR TITLE
KA: Amina - Card Implemented

### DIFF
--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -218,6 +218,16 @@
                     (break-sub 1 1 "Sentry")
                     (strength-pump 2 3))
 
+   "Amina"
+   (auto-icebreaker ["Code Gate"]
+                    {:abilities [(break-sub 2 3 "Code Gate")
+                                 (strength-pump 2 3)
+                                 {:label "Corp loses 1 [Credits]"
+                                  :req (req (and (has-subtype? current-ice "Code Gate")
+                                                 (rezzed? current-ice)))
+                                  :msg (msg "make the corp lose 1 [Credits]")
+                                  :effect (effect (lose :corp :credit 1))}]})
+
    "Ankusa"
    (auto-icebreaker ["Barrier"]
                     {:abilities [(break-sub 2 1 "Barrier")

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -225,7 +225,7 @@
                                  {:label "Corp loses 1 [Credits]"
                                   :req (req (and (has-subtype? current-ice "Code Gate")
                                                  (rezzed? current-ice)))
-                                  :msg (msg "make the corp lose 1 [Credits]")
+                                  :msg (msg "make the Corp lose 1 [Credits]")
                                   :effect (effect (lose :corp :credit 1))}]})
 
    "Ankusa"


### PR DESCRIPTION
I used Ankusa as the archetype for this card. Simple icebreakers like this turned out to be easy. Just took out a few additional things Ankusa had and added the corp losing 1[c].

Unsure of what is typical - do we always refer to the Corp by name, or do we refer to it like the card says "the Corp"?