### PR TITLE
En Passant marks card as trashed. Make Wake Up Call go in Corp RFG.

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -519,7 +519,8 @@
                       :choices {:req #(and (ice? %)
                                            (not (rezzed? %)))}
                       :msg (msg "trash " (card-str state target))
-                      :effect (effect (trash target))}
+                      :effect (req (trash state side target)
+                                   (swap! state assoc-in [:runner :register :trashed-card] true))}
                     card nil)))}
 
    "Escher"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1615,7 +1615,7 @@
                                                 "4 meat damage"]
                                       :delayed-completion true
                                       :effect (req (clear-wait-prompt state :corp)
-                                                   (move state side (last (:discard corp)) :rfg)
+                                                   (move state :corp (last (:discard corp)) :rfg)
                                                    (if (.startsWith target "Trash")
                                                      (do (system-msg state side (str "chooses to trash " (:title chosen)))
                                                          (trash state side eid chosen nil))

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -2002,6 +2002,31 @@
       (core/advance state :corp {:card (refresh atlas)})
       (is (= 5 (:credit (get-corp))) "Transparency initiative didn't fire"))))
 
+(deftest wake-up-call-en-passant
+  ;; Wake Up Call - should fire after using En Passant to trash ice
+  (do-game
+    (new-game (default-corp [(qty "Enigma" 1) (qty "Wake Up Call" 1)])
+              (default-runner [(qty "En Passant" 1) (qty "Maya" 1)]))
+    (play-from-hand state :corp "Enigma" "HQ")
+    (take-credits state :corp)
+
+    (play-from-hand state :runner "Maya")
+    (run-on state :hq)
+    (run-successful state)
+    (prompt-choice :runner "Ok")
+    (is (= 0 (count (:discard (get-corp)))) "Corp starts with no discards")
+    (play-from-hand state :runner "En Passant")
+    (prompt-select :runner (get-ice state :hq 0))
+    (is (= 1 (count (:discard (get-corp)))) "Corp trashes installed ice")
+    (take-credits state :runner)
+
+    (is (= 1 (count (:discard (get-runner)))) "Runner starts with 1 trashed card (En Passant)")
+    (play-from-hand state :corp "Wake Up Call")
+    (prompt-select :corp (get-in @state [:runner :rig :hardware 0]))
+    (prompt-choice :runner "Trash Maya")
+    (is (= 2 (count (:discard (get-runner)))) "Maya is trashed")
+    (is (= 1 (count (:rfg (get-corp)))) "Wake Up Call is removed from the game")))
+
 (deftest wetwork-refit
   ;; Wetwork Refit - Only works on Bioroid ICE and adds a subroutine
   (do-game


### PR DESCRIPTION
By marking a card as trashed, `En Passant` then allows `Wake Up Call` to be played on the Corp's next turn.

Noticed that `Wake Up Call` was being placed in the Runner's RFG Area, so specified it should use Corp side.