### PR TITLE
Update Trello dependency to get rid of `Invalid Cookie header` warning

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -1,1 +1,0 @@
-exports.salt = "Dev salt"

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [digest "1.4.6"]
                  [http-kit "2.2.0"]
                  [org.slf4j/slf4j-nop "1.7.12"]
-                 [me.bsima/trello "0.3.0"]
+                 [jwarwick/trello "0.3.1"]
                  [clj-time "0.14.2"]
                  [com.draines/postal "2.0.2"]
                  [throttler "1.0.0"]


### PR DESCRIPTION
Currently our production log files have a warning for every call to Trello for the News section:
`Apr  7 00:39:58 betajin java[30500]: WARNING: Invalid cookie header: "Set-Cookie: dsc=0b16bb645cc77c6f0ac62827d10e1284df82c7311971fb4fa7b57aafca90b770; Path=/; Expires=Tue, 10 Apr 2018 00:39:58 GMT; Secure". Invalid 'expires' attribute: Tue, 10 Apr 2018 00:39:58 GMT`

The `GET` call from the Trello dependency needs an additional flag, but we cannot set it in the current version. I forked the project and added the flag. Then added my fork as the dependency. I'll try to get my commit pulled into the original repo, but it looks like it hasn't been touched in quite awhile.

Also deleted an old coffeescript config file.