### PR TITLE
Always Be Running reminder toast

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -47,7 +47,7 @@
                             :effect (req (clear-wait-prompt state :corp)
                                          (if (not (can-pay? state :corp nil :credit 1))
                                            (do
-                                             (toast state :corp "Cannot afford to pay 1 [Credits] to block card exposure" "info")
+                                             (toast state :corp "Cannot afford to pay 1 credit to block card exposure" "info")
                                              (expose state side eid itarget))
                                            (do
                                              (show-wait-prompt state :runner "Corp decision")

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -99,6 +99,8 @@
 
    "Always Be Running"
    {:implementation "Run requirement not enforced"
+    :events {:runner-turn-begins {:effect (req (toast state :runner
+                                              "Reminder: Always Be Running requires a run on the first click" "info"))}}
     :abilities [{:once :per-turn
                  :cost [:click 2]
                  :msg (msg "break 1 subroutine")}]}


### PR DESCRIPTION
Also removed `[Credits]` from `419` warning toast. Toast messages don't support our translations using the netrunner font.