### PR TITLE
Pull images from CardgameDB

### DIFF
--- a/src/clj/tasks/nrdb.clj
+++ b/src/clj/tasks/nrdb.clj
@@ -14,7 +14,7 @@
 (declare faction-map)
 
 (def ^:const base-url "http://www.netrunnerdb.com/api/2.0/public/")
-(def ^:const base-image-url "http://www.netrunnerdb.com/card_image/")
+(def ^:const base-image-url "https://www.cardgamedb.com/forums/uploads/an/")
 
 (defmacro rename
   "Rename a card field"
@@ -38,6 +38,7 @@
    :size (fn [[k v]] [:bigbox (> (or v -1) 20)])
    :code identity
    :position identity
+   :ffg_id identity
    })
 
 (def mwl-fields
@@ -185,12 +186,17 @@
               acc))
           c fields))
 
+(defn- make-image-url
+  "Create a URI to the card in CardGameDB"
+  [card set]
+  (str base-image-url "med_ADN" (:ffg_id set) "_" (:number card) ".png"))
+
 (defn- get-uri
   "Figure out the card art image uri"
-  [card]
+  [card set]
   (if (contains? card :image_url)
     (:image_url card)
-    (str base-image-url (:code card) ".png")))
+    (make-image-url card set)))
 
 (defn- add-card-fields
   "Add additional fields to the card documents"
@@ -201,7 +207,7 @@
       (assoc :setname (:name s)
              :cycle_code (:cycle_code s)
              :rotated (:rotated s)
-             :image_url (get-uri c)
+             :image_url (get-uri c s)
              :normalizedtitle (string/lower-case (deaccent (:title c)))))))
 
 (defn fetch-data


### PR DESCRIPTION
If the `fetch`ed json does not have an `image_url` specified for a card, we attempt to get it from [CardGameDB](http://www.cardgamedb.com/index.php/netrunner/android-netrunner-card-spoilers). This doesn't always works, since not all sets have an `ffg_id` specified and CGDB does some interesting/clever things to work around that (see `Corroder`). We fall back to trying to get the card from NRDB in that case. Currently NRDB has copies of all the cards that are missing the `ffg_id`.

In addition, I moved the file writing into the asynchronous callback of the `GET`, which allows the images to be saved incrementally. So if you don't have enough memory in your machine and the `fetch` dies, you will at least have the images you retrieved up to that point. Then when you `fetch` again, it will pickup where it left off.

Sorta fixes #3215 