### PR TITLE
Remove `Confirm Delete` button when selecting deck in deckbuilder

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -198,7 +198,6 @@
       (assoc card :display-name (str (:title card) " (" (:setname card) ")"))
       (assoc card :display-name (:title card)))))
 
-
 (defn side-identities [side]
   (let [cards
         (->> @all-cards
@@ -228,19 +227,6 @@
   (let [cards (om/get-state owner [:deck :cards])
         str (reduce #(str %1 (:qty %2) " " (get-in %2 [:card :title]) (insert-params %2) "\n") "" cards)]
     (om/set-state! owner :deck-edit str)))
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 (defn edit-deck [owner]
   (let [deck (om/get-state owner :deck)]
@@ -293,9 +279,11 @@
          (end-delete owner))))))
 
 (defn new-deck [side owner]
-  (om/set-state! owner :deck {:name "New deck" :cards [] :identity (-> side side-identities first)})
-  (try (js/ga "send" "event" "deckbuilder" "new" side) (catch js/Error e))
-  (edit-deck owner))
+  (let [old-deck (om/get-state owner :deck)]
+    (om/set-state! owner :deck {:name "New deck" :cards [] :identity (-> side side-identities first)})
+    (try (js/ga "send" "event" "deckbuilder" "new" side) (catch js/Error e))
+    (edit-deck owner)
+    (om/set-state! owner :old-deck old-deck)))
 
 (defn save-deck [cursor owner]
   (authenticated

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -30,9 +30,6 @@
   (let [name (:title (first cards))]
     (every? #(= (:title %) name) cards)))
 
-
-
-
 (defn noinfcost? [identity card]
   (or (= (:faction card) (:faction identity))
       (= 0 (:factioncost card)) (= INFINITY (decks/id-inf-limit identity))))
@@ -664,7 +661,9 @@
                   (om/set-state! owner [:deck :cards] new-cards))
                 (deck->str owner)))))
       (go (while true
-            (om/set-state! owner :deck (<! select-channel)))))
+            (let [deck (<! select-channel)]
+              (end-delete owner)
+              (om/set-state! owner :deck deck)))))
 
     om/IRenderState
     (render-state [this state]


### PR DESCRIPTION
If a user clicks on the `Delete` button of a deck, then selects another deck from the deckbuilder list, the `Confirm Delete` button remained active and would delete the currently selected deck when clicked.

Fixes #1364