### PR TITLE
Stats Bug!!!

### DIFF
--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -147,11 +147,12 @@
                                :runnerIdentity (get-in runner [:deck :identity :title])})))
 
 (defn game-finished [{:keys [state gameid]}]
-  (mc/update db "gamestats"
-             {:gameid (str gameid)}
-             {"$set" {:winner       (:winner @state)
-                      :reason       (:reason @state)
-                      :endDate      (java.util.Date.)
-                      :turn         (:turn @state)
-                      :corpAgenda   (get-in @state [:corp :agenda-point])
-                      :runnerAgenda (get-in @state [:runner :agenda-point])}}))
+  (when state
+    (mc/update db "gamestats"
+               {:gameid (str gameid)}
+               {"$set" {:winner       (:winner @state)
+                        :reason       (:reason @state)
+                        :endDate      (java.util.Date.)
+                        :turn         (:turn @state)
+                        :corpAgenda   (get-in @state [:corp :agenda-point])
+                        :runnerAgenda (get-in @state [:runner :agenda-point])}})))


### PR DESCRIPTION
Catch a stats corner case, when a user creates a new game, then leaves, we attempt to record stats, but the `state` is `null`.

Also disabled `New Game` and `Join`/`Watch` buttons while users are creating games.
Fixes #1632