### PR TITLE
Fix list item formatting in cardbrowser text

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -824,6 +824,10 @@ nav ul
   .alt-art-selector
     margin-top: 10px
 
+  ul
+    padding-left: revert
+    padding-top: 8px
+
 .filters
   flex(0 0 180px)
   margin: 10px


### PR DESCRIPTION
Cards like `Deuces Wild` and `Reverse Infection` had their lists of options shifted too far to the left of the text box.