### PR TITLE
Update Trello dep to get rid of warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [digest "1.4.6"]
                  [http-kit "2.2.0"]
                  [org.slf4j/slf4j-nop "1.7.12"]
-                 [jwarwick/trello "0.3.1"]
+                 [jwarwick/trello "0.3.2"]
                  [clj-time "0.14.2"]
                  [com.draines/postal "2.0.2"]
                  [throttler "1.0.0"]


### PR DESCRIPTION
Fix from @danhut to get rid of function masking warning.