### PR TITLE
Turns on action panel pop-up when only action is rez.

### DIFF
--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -754,7 +754,7 @@
       (let [actions (action-list cursor)
             dynabi-count (count (filter :dynamic abilities))]
         (when (or (> (+ (count actions) (count abilities) (count subroutines)) 1)
-                  (some #{"derez" "advance"} actions)
+                  (some #{"derez" "rez" "advance"} actions)
                   (= type "ICE"))
           [:div.panel.blue-shade.abilities {:ref "abilities"}
            (map (fn [action]


### PR DESCRIPTION
Fixes #3323. 

This enables the action panel for all cards that have "rez" as their sole action. Should prevent mistaken rezzes which I will argue are more harmful to the game experience than the extra clicks needed.

Additionally will only really affect asset spam decks, and being "harsher" on them can't hurt right 😉 