### PR TITLE
Fixed trash-within-trash + All-Seeing I

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1460,7 +1460,7 @@
 
    "The All-Seeing I"
    (let [trash-all-resources {:player :runner
-                              :effect (req (trash-cards state side (get-in runner  [:rig :resource])))
+                              :effect (req (trash-cards state side (filter #(is-type? % "Resource") (all-active-installed state :runner))))
                               :msg (msg "trash all resources")}]
        {:req (req tagged)
         :delayed-completion true

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -368,7 +368,8 @@
   (swap! state update-in [:trash :trash-prevent type] (fnil #(+ % n) 0)))
 
 (defn- resolve-trash-end
-  [state side eid {:keys [zone type disabled] :as card}
+  ([state side eid card args] (resolve-trash-end state side eid card eid args))
+  ([state side eid {:keys [zone type disabled] :as card} oid
    {:keys [unpreventable cause keep-server-alive suppress-event host-trashed] :as args}]
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})
@@ -381,20 +382,22 @@
                                     (and (:when-inactive trash-effect) (not host-trashed))))
         (resolve-ability state side trash-effect moved-card (list cause))))
     (swap! state update-in [:per-turn] dissoc (:cid moved-card))
-    (effect-completed state side eid)))
+    (swap! state update-in [:trash :trash-list] dissoc oid)
+    (effect-completed state side eid))))
 
 (defn- resolve-trash
-  [state side eid {:keys [zone type] :as card}
+  ([state side eid card args] (resolve-trash state side eid card eid args))
+  ([state side eid {:keys [zone type] :as card} oid
    {:keys [unpreventable cause keep-server-alive suppress-event] :as args}]
   (if (and (not suppress-event) (not= (last zone) :current)) ; Trashing a current does not trigger a trash event.
     (when-completed (trigger-event-sync state side (keyword (str (name side) "-trash")) card cause)
-                    (resolve-trash-end state side eid card args))
-    (resolve-trash-end state side eid card args)))
+                    (resolve-trash-end state side eid card oid args))
+    (resolve-trash-end state side eid card args))))
 
 (defn- prevent-trash
-  ([state side card] (prevent-trash state side (make-eid state) card nil))
-  ([state side card args] (prevent-trash state side (make-eid state) card nil))
-  ([state side eid {:keys [zone type] :as card}
+  ([state side card oid] (prevent-trash state side (make-eid state) card oid nil))
+  ([state side card oid args] (prevent-trash state side (make-eid state) card oid args))
+  ([state side eid {:keys [zone type] :as card} oid
     {:keys [unpreventable cause keep-server-alive suppress-event] :as args}]
    (if (and card (not (some #{:discard} zone)))
      (cond
@@ -428,11 +431,11 @@
                                       (swap! state update-in [:trash :trash-prevent] dissoc ktype)
                                       (effect-completed state side eid))
                                   (do (system-msg state :runner (str "will not prevent the trashing of " (:title card)))
-                                      (swap! state update-in [:trash :trash-list] concat [card])
+                                      (swap! state update-in [:trash :trash-list oid] concat [card])
                                       (effect-completed state side eid))))
                               {:priority 10}))
              ;; No prevention effects: add the card to the trash-list
-             (do (swap! state update-in [:trash :trash-list] concat [card])
+             (do (swap! state update-in [:trash :trash-list oid] concat [card])
                  (effect-completed state side eid))))))
      (effect-completed state side eid))))
 
@@ -441,9 +444,8 @@
   ([state side card] (trash state side (make-eid state) card nil))
   ([state side card args] (trash state side (make-eid state) card args))
   ([state side eid {:keys [zone type] :as card} {:keys [unpreventable cause suppress-event] :as args}]
-   (swap! state update-in [:trash] dissoc :trash-list)
-   (when-completed (prevent-trash state side card args)
-                   (if-let [c (first (get-in @state [:trash :trash-list]))]
+   (when-completed (prevent-trash state side card eid args)
+                   (if-let [c (first (get-in @state [:trash :trash-list eid]))]
                      (resolve-trash state side eid c args)
                      (effect-completed state side eid)))))
 
@@ -451,17 +453,16 @@
   ([state side cards] (trash-cards state side (make-eid state) cards nil))
   ([state side eid cards] (trash-cards state side eid cards nil))
   ([state side eid cards {:keys [suppress-event] :as args}]
-   (swap! state update-in [:trash] dissoc :trash-list)
    (letfn [(trashrec [cs]
              (if (not-empty cs)
-               (when-completed (resolve-trash-end state side (get-card state (first cs)) args)
+               (when-completed (resolve-trash-end state side (get-card state (first cs)) eid args)
                                (trashrec (rest cs)))
                (effect-completed state side eid)))
            (preventrec [cs]
              (if (not-empty cs)
-               (when-completed (prevent-trash state side (get-card state (first cs)) args)
+               (when-completed (prevent-trash state side (get-card state (first cs)) eid args)
                                (preventrec (rest cs)))
-               (let [trashlist (get-in @state [:trash :trash-list])]
+               (let [trashlist (get-in @state [:trash :trash-list eid])]
                  (when-completed (apply trigger-event-sync state side (keyword (str (name side) "-trash")) trashlist)
                                  (trashrec trashlist)))))]
      (preventrec cards))))


### PR DESCRIPTION
New trash system had list of cards to trash, so if you e.g. trash a
fall-guy to prevent a trash, old trash list get overwritten. Now have
trash-list linked to eid of trash-effect, so will no longer be a
problem.

Made All-Seeing I trash all resources instead of only non-hosted
resources.

Made two more tests for All-Seeing I

Closes #1724 and #3329