### PR TITLE
Update Trello dep to handle exceptions better

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [digest "1.4.6"]
                  [http-kit "2.2.0"]
                  [org.slf4j/slf4j-nop "1.7.12"]
-                 [jwarwick/trello "0.3.2"]
+                 [jwarwick/trello "0.3.3"]
                  [clj-time "0.14.2"]
                  [com.draines/postal "2.0.2"]
                  [throttler "1.0.0"]


### PR DESCRIPTION
Currently if Trello is unavailable (with a `502`, `503`, or `504`) error, we write a very large stack trace and body of the response into the log file. This update minimizes that output to a single line.