### PR TITLE
Only register events when swapping ice if ice was previously rezzed

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -106,14 +106,16 @@
     (swap! state update-in (cons :corp (:zone b)) #(assoc % b-index a-new))
     (doseq [newcard [a-new b-new]]
       (unregister-events state side newcard)
-      (register-events state side (:events (card-def newcard)) newcard)
+      (when (rezzed? newcard)
+        (register-events state side (:events (card-def newcard)) newcard))
       (doseq [h (:hosted newcard)]
         (let [newh (-> h
                        (assoc-in [:zone] '(:onhost))
                        (assoc-in [:host :zone] (:zone newcard)))]
           (update! state side newh)
           (unregister-events state side h)
-          (register-events state side (:events (card-def newh)) newh))))
+          (when (rezzed? h)
+            (register-events state side (:events (card-def newh)) newh)))))
     (update-ice-strength state side a-new)
     (update-ice-strength state side b-new)))
 

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -553,7 +553,7 @@
      (run-jack-out state)
      (is (= 2 (count (:hand (get-runner)))) "Runner took damage before swap")
 
-     (core/swap-ice state :corp kakugo ice-wall)
+     (core/swap-ice state :corp (refresh kakugo) (refresh ice-wall))
 
      (run-on state "Archives")
      (run-continue state)

--- a/test/clj/game_test/cards/icebreakers.clj
+++ b/test/clj/game_test/cards/icebreakers.clj
@@ -344,6 +344,33 @@
      (is (= 1 (:tag (get-runner))))
      (is (= 2 (get-counters (refresh gow) :virus)) "God of War has 2 virus counters"))))
 
+(deftest inversificator
+  ;; Inversificator shouldn't hook up events for unrezzed ice
+  (do-game
+    (new-game (default-corp [(qty "Turing" 1) (qty "Kakugo" 1)])
+              (default-runner [(qty "Inversificator" 1) (qty "Sure Gamble" 1)]))
+    (play-from-hand state :corp "Kakugo" "HQ")
+    (play-from-hand state :corp "Turing" "HQ")
+    (take-credits state :corp)
+
+    (core/gain state :runner :credit 10)
+    (play-from-hand state :runner "Inversificator")
+    (let [inv (get-program state 0)
+          tur (get-ice state :hq 1)]
+      (is (= 1 (count (:hand (get-runner)))) "Runner starts with 1 card in hand")
+      (run-on state :hq)
+      (core/rez state :corp (refresh tur))
+      (run-continue state)
+      (card-ability state :runner (refresh inv) 0)
+      (prompt-select :runner (get-ice state :hq 1))
+      (prompt-select :runner (get-ice state :hq 0))
+      (run-jack-out state)
+      (is (= 1 (count (:hand (get-runner)))) "Runner still has 1 card in hand")
+
+      (run-on state :hq)
+      (run-continue state)
+      (is (= 1 (count (:hand (get-runner)))) "Kakugo doesn't fire when unrezzed"))))
+
 (deftest mammon
   ;; Mammon - Pay to add X power counters at start of turn, all removed at end of turn
   (do-game


### PR DESCRIPTION
Also fixed a broken test that verified swapping `Kakugo` retained `registered-events`.

Fixes #3316 