### PR TITLE
Fix hosting of free-mu-based breakers

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -288,7 +288,7 @@
                                       (in-hand? %))}
                  :effect (effect (gain :memory (:memoryunits target))
                                  (runner-install target {:host-card card})
-                                 (update! (assoc (get-card state card) :dino-breaker (:cid target))))}
+                                 (update! (assoc-in (get-card state card) [:special :dino-breaker] (:cid target))))}
                 {:label "Host an installed non-AI icebreaker on Dinosaurus"
                  :req (req (empty? (:hosted card)))
                  :prompt "Select an installed non-AI icebreaker to host on Dinosaurus"
@@ -301,11 +301,11 @@
                                 (get-card state)
                                 (host state side card)
                                 (update-breaker-strength state side))
-                              (update! state side (assoc (get-card state card) :dino-breaker (:cid target))))}]
+                              (update! state side (assoc-in (get-card state card) [:special :dino-breaker] (:cid target))))}]
     :events {:pre-breaker-strength {:req (req (= (:cid target) (:cid (first (:hosted card)))))
                                     :effect (effect (breaker-strength-bonus 2))}
-             :card-moved {:req (req (= (:cid target) (:dino-breaker (get-card state card))))
-                          :effect (effect (update! (dissoc card :dino-breaker))
+             :card-moved {:req (req (= (:cid target) (get-in (get-card state card) [:special :dino-breaker])))
+                          :effect (effect (update! (dissoc-in card [:special :dino-breaker]))
                                           (lose :memory (:memoryunits target)))}}}
 
    "Doppelgänger"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -296,9 +296,13 @@
                                       (not (has-subtype? % "AI"))
                                       (installed? %))}
                  :msg (msg "host " (:title target))
-                 :effect (req (update-breaker-strength state side (host state side card target))
-                              (update! state side (assoc (get-card state card) :dino-breaker (:cid target)))
-                              (gain state side :memory (:memoryunits target)))}]
+                 :effect (req (gain state side :memory (:memoryunits target))
+                              (update-breaker-strength state side target)
+                              (->> target
+                                (get-card state)
+                                (host state side card)
+                                (update-breaker-strength state side))
+                              (update! state side (assoc (get-card state card) :dino-breaker (:cid target))))}]
     :events {:pre-breaker-strength {:req (req (= (:cid target) (:cid (first (:hosted card)))))
                                     :effect (effect (breaker-strength-bonus 2))}
              :card-moved {:req (req (= (:cid target) (:dino-breaker (get-card state card))))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -297,7 +297,6 @@
                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (req (gain state side :memory (:memoryunits target))
-                              (update-breaker-strength state side target)
                               (->> target
                                 (get-card state)
                                 (host state side card)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -216,7 +216,7 @@
 
    "Dhegdheer"
    {:abilities [{:label "Install a program on Dhegdheer"
-                 :req (req (empty? (:hosted card)))
+                 :req (req (nil? (get-in card [:special :dheg-prog])))
                  :effect (effect (resolve-ability
                                    {:cost [:click 1]
                                     :prompt "Choose a program in your Grip to install on Dhegdheer"
@@ -228,10 +228,10 @@
                                                     (when (-> target :cost pos?)
                                                       (install-cost-bonus state side [:credit -1]))
                                                     (runner-install target {:host-card card})
-                                                    (update! (assoc (get-card state card) :dheg-prog (:cid target))))}
+                                                    (update! (assoc-in (get-card state card) [:special :dheg-prog] (:cid target))))}
                                   card nil))}
                 {:label "Host an installed program on Dhegdheer with [Credit] discount"
-                 :req (req (empty? (:hosted card)))
+                 :req (req (nil? (get-in card [:special :dheg-prog])))
                  :prompt "Choose an installed program to host on Dhegdheer with [Credit] discount"
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
@@ -241,9 +241,9 @@
                                 (gain state side :credit 1))
                               (update-breaker-strength state side target)
                               (host state side card (get-card state target))
-                              (update! state side (assoc (get-card state card) :dheg-prog (:cid target))))}
+                              (update! state side (assoc-in (get-card state card) [:special :dheg-prog] (:cid target))))}
                 {:label "Host an installed program on Dhegdheer"
-                 :req (req (empty? (:hosted card)))
+                 :req (req (nil? (get-in card [:special :dheg-prog])))
                  :prompt "Choose an installed program to host on Dhegdheer"
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
@@ -251,9 +251,9 @@
                  :effect (effect (gain :memory (:memoryunits target))
                                  (update-breaker-strength target)
                                  (host card (get-card state target))
-                                 (update! (assoc (get-card state card) :dheg-prog (:cid target))))}]
-    :events {:card-moved {:req (req (= (:cid target) (:dheg-prog (get-card state card))))
-                          :effect (effect (update! (dissoc card :dheg-prog))
+                                 (update! (assoc-in (get-card state card) [:special :dheg-prog] (:cid target))))}]
+    :events {:card-moved {:req (req (= (:cid target) (get-in (get-card state card) [:special :dheg-prog])))
+                          :effect (effect (update! (dissoc-in card [:special :dheg-prog]))
                                           (lose :memory (:memoryunits target)))}}}
 
    "Diwan"
@@ -500,7 +500,7 @@
 
    "Leprechaun"
    {:abilities [{:label "Install a program on Leprechaun"
-                 :req (req (< (count (:hosted card)) 2))
+                 :req (req (< (count (get-in card [:special :hosted-programs])) 2))
                  :effect (effect (resolve-ability
                                    {:cost [:click 1]
                                     :prompt "Choose a program in your Grip to install on Leprechaun"
@@ -510,12 +510,13 @@
                                     :msg (msg "host " (:title target))
                                     :effect (effect (gain :memory (:memoryunits target))
                                                     (runner-install target {:host-card card})
-                                                    (update! (assoc (get-card state card)
-                                                                    :hosted-programs
-                                                                    (cons (:cid target) (:hosted-programs card)))))}
+                                                    (update! (assoc-in (get-card state card)
+                                                                    [:special :hosted-programs]
+                                                                    (cons (:cid target)
+                                                                          (get-in card [:special :hosted-programs])))))}
                                   card nil))}
                 {:label "Host an installed program on Leprechaun"
-                 :req (req (< (count (:hosted card)) 2))
+                 :req (req (< (count (get-in card [:special :hosted-programs])) 2))
                  :prompt "Choose an installed program to host on Leprechaun"
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
@@ -523,11 +524,15 @@
                  :effect (effect (gain :memory (:memoryunits target))
                                  (update-breaker-strength target)
                                  (host card (get-card state target))
-                                 (update! (assoc (get-card state card)
-                                                 :hosted-programs (cons (:cid target) (:hosted-programs card)))))}]
-    :events {:card-moved {:req (req (some #{(:cid target)} (:hosted-programs card)))
-                          :effect (effect (update! (assoc card
-                                                          :hosted-programs (remove #(= (:cid target) %) (:hosted-programs card))))
+                                 (update! (assoc-in (get-card state card)
+                                                    [:special :hosted-programs]
+                                                    (cons (:cid target)
+                                                          (get-in card [:special :hosted-programs])))))}]
+    :events {:card-moved {:req (req (some #{(:cid target)} (get-in card [:special :hosted-programs])))
+                          :effect (effect (update! (assoc-in card
+                                                             [:special :hosted-programs]
+                                                             (remove #(= (:cid target) %)
+                                                                     (get-in card [:special :hosted-programs]))))
                                           (lose :memory (:memoryunits target)))}}}
 
    "LLDS Energy Regulator"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -236,19 +236,21 @@
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
                  :msg (msg "host " (:title target) (when (-> target :cost pos?) ", lowering its cost by 1 [Credit]"))
-                 :effect (effect (host card target)
-                                 (when (-> target :cost pos?)
-                                   (gain state side :credit 1))
-                                 (gain :memory (:memoryunits target))
-                                 (update! (assoc (get-card state card) :dheg-prog (:cid target))))}
+                 :effect (req (gain state side :memory (:memoryunits target))
+                              (when (-> target :cost pos?)
+                                (gain state side :credit 1))
+                              (update-breaker-strength state side target)
+                              (host state side card (get-card state target))
+                              (update! state side (assoc (get-card state card) :dheg-prog (:cid target))))}
                 {:label "Host an installed program on Dhegdheer"
                  :req (req (empty? (:hosted card)))
                  :prompt "Choose an installed program to host on Dhegdheer"
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
                  :msg (msg "host " (:title target) (when (-> target :cost pos?)))
-                 :effect (effect (host card target)
-                                 (gain :memory (:memoryunits target))
+                 :effect (effect (gain :memory (:memoryunits target))
+                                 (update-breaker-strength target)
+                                 (host card (get-card state target))
                                  (update! (assoc (get-card state card) :dheg-prog (:cid target))))}]
     :events {:card-moved {:req (req (= (:cid target) (:dheg-prog (get-card state card))))
                           :effect (effect (update! (dissoc card :dheg-prog))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -520,14 +520,16 @@
                  :choices {:req #(and (is-type? % "Program")
                                       (installed? %))}
                  :msg (msg "host " (:title target))
-                 :effect (effect (host card target)
-                                 (gain :memory (:memoryunits target))
+                 :effect (effect (gain :memory (:memoryunits target))
+                                 (update-breaker-strength target)
+                                 (host card (get-card state target))
                                  (update! (assoc (get-card state card)
                                                  :hosted-programs (cons (:cid target) (:hosted-programs card)))))}]
     :events {:card-moved {:req (req (some #{(:cid target)} (:hosted-programs card)))
                           :effect (effect (update! (assoc card
                                                           :hosted-programs (remove #(= (:cid target) %) (:hosted-programs card))))
                                           (lose :memory (:memoryunits target)))}}}
+
    "LLDS Energy Regulator"
    {:prevent {:trash [:hardware]}
     :abilities [{:cost [:credit 3]

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -231,6 +231,26 @@
     (is (= 5 (:memory (get-runner))) "Gain 1 memory")
     (is (= 3 (:credit (get-runner))) "Got 1c for successful run on Desperado")))
 
+(deftest dinosaurus-adept
+  ;; Dinosaurus - hosting a breaker with strength based on unused MU should calculate correctly
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Adept" 1)
+                               (qty "Dinosaurus" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 5)
+    (play-from-hand state :runner "Dinosaurus")
+    (play-from-hand state :runner "Adept")
+    (is (= 2 (:memory (get-runner))) "2 MU used")
+    (let [dino (get-hardware state 0)
+          adpt (get-program state 0)]
+      (is (= 4 (:current-strength (refresh adpt))) "Adept at 4 strength individually")
+      (card-ability state :runner dino 1)
+      (prompt-select :runner (refresh adpt))
+      (let [hosted-adpt (first (:hosted (refresh dino)))]
+        (is (= 4 (:memory (get-runner))) "0 MU used")
+        (is (= 8 (:current-strength (refresh hosted-adpt))) "Adept at 8 strength hosted")))))
+
 (deftest dinosaurus-strength-boost-mu-savings
   ;; Dinosaurus - Boost strength of hosted icebreaker; keep MU the same when hosting or trashing hosted breaker
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -95,6 +95,28 @@
       (is (find-card "Spiderweb" (:discard (get-corp))) "Spiderweb trashed by Parasite + Datasucker")
       (is (= 7 (:current-strength (refresh wrap))) "Wraparound not reduced by Datasucker"))))
 
+(deftest dhegdheer-adept
+  ;; Dheghdheer - hosting a breaker with strength based on unused MU should calculate correctly
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Adept" 1)
+                               (qty "Dhegdheer" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 5)
+    (play-from-hand state :runner "Dhegdheer")
+    (play-from-hand state :runner "Adept")
+    (is (= 3 (:credit (get-runner))) "3 credits left after individual installs")
+    (is (= 2 (:memory (get-runner))) "2 MU used")
+    (let [dheg (get-program state 0)
+          adpt (get-program state 1)]
+      (is (= 4 (:current-strength (refresh adpt))) "Adept at 4 strength individually")
+      (card-ability state :runner dheg 1)
+      (prompt-select :runner (refresh adpt))
+      (let [hosted-adpt (first (:hosted (refresh dheg)))]
+        (is (= 4 (:credit (get-runner))) "4 credits left after hosting")
+        (is (= 4 (:memory (get-runner))) "0 MU used")
+        (is (= 6 (:current-strength (refresh hosted-adpt))) "Adept at 6 strength hosted")))))
+
 (deftest diwan
   ;; Diwan - Full test
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -413,6 +413,26 @@
       (core/purge state :corp)
       (is (empty? (get-in @state [:runner :rig :program])) "Lamprey trashed by purge"))))
 
+(deftest leprechaun-adept
+  ;; Leprechaun - hosting a breaker with strength based on unused MU should calculate correctly
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Adept" 1)
+                               (qty "Leprechaun" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 5)
+    (play-from-hand state :runner "Leprechaun")
+    (play-from-hand state :runner "Adept")
+    (is (= 1 (:memory (get-runner))) "3 MU used")
+    (let [lep (get-program state 0)
+          adpt (get-program state 1)]
+      (is (= 3 (:current-strength (refresh adpt))) "Adept at 3 strength individually")
+      (card-ability state :runner lep 1)
+      (prompt-select :runner (refresh adpt))
+      (let [hosted-adpt (first (:hosted (refresh lep)))]
+        (is (= 3 (:memory (get-runner))) "1 MU used")
+        (is (= 5 (:current-strength (refresh hosted-adpt))) "Adept at 5 strength hosted")))))
+
 (deftest leprechaun-mu-savings
   ;; Leprechaun - Keep MU the same when hosting or trashing hosted programs
   (do-game


### PR DESCRIPTION
Better support for `Adept` and `Savant` when hosted on `Dhegdheer`, `Leprechaun`, and `Dinosaurus`. 

Previously the strength of the breakers was not increased by the amount of MU freed up when they were hosted.

Fixes #2535 