### PR TITLE
Stylus -> Garden Migration for CSS - not a real PR

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,13 +31,15 @@
                  [clj-time "0.14.2"]
                  [com.draines/postal "2.0.2"]
                  [throttler "1.0.0"]
-                 [clj-http "3.7.0"]]
+                 [clj-http "3.7.0"]
+                 [garden "1.3.5"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-figwheel "0.5.11"]
             [com.gfredericks/lein-sha-version "0.1.1-p1"]
             [lein-ring "0.9.7"]
-            [lein-exec "0.3.7"]]
+            [lein-exec "0.3.7"]
+            [lein-garden "0.3.0"]]
 
   :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.11"]
                                   [com.cemerick/piggieback "0.2.1"]]
@@ -59,6 +61,20 @@
   :omit-source true
   :main web.core
 
+  ;; Garden CSS - need to add optimised version for prod
+  :garden {:builds [{:id "dev"
+                     :source-paths ["src/clj"]
+                     ;; Stylesheet location:
+                     :stylesheet styles.chat/chat
+                     ;; Compiler flags passed to `garden.core/css`:
+                     :compiler {;; Where to save the file:
+                                :output-to "resources/public/css/chat2.css"
+                                ;; generate all vendor prefixes
+                                :vendors ["webkit" "moz" "o"]
+                                ;; Compress the output
+                                :pretty-print? true}}]}
+  ;; Should auto compile CSS when lein is run
+  :prep-tasks [["garden" "once"]]
 
   ;; Misc
   :test-paths ["test/clj"]

--- a/project.clj
+++ b/project.clj
@@ -65,16 +65,18 @@
   :garden {:builds [{:id "dev"
                      :source-paths ["src/clj"]
                      ;; Stylesheet location:
-                     :stylesheet styles.chat/chat
+                     :stylesheet styles.netrunner/netrunner
                      ;; Compiler flags passed to `garden.core/css`:
                      :compiler {;; Where to save the file:
-                                :output-to "resources/public/css/chat2.css"
+                                ;:output-to "resources/public/css/netrunner2.css"
+                                :output-to "src/clj/styles/netrunner.css"
                                 ;; generate all vendor prefixes
                                 :vendors ["webkit" "moz" "o"]
                                 ;; Compress the output
                                 :pretty-print? true}}]}
   ;; Should auto compile CSS when lein is run
-  :prep-tasks [["garden" "once"]]
+  ;; disable for Cursive due to cursive defect with prep-tasks
+  ;:prep-tasks [["garden" "once"]]
 
   ;; Misc
   :test-paths ["test/clj"]

--- a/src/clj/styles/chat.clj
+++ b/src/clj/styles/chat.clj
@@ -1,9 +1,11 @@
 (ns styles.chat
-  (:require [garden.def :refer [defstyles defrule defkeyframes]]
+  (:require [garden.def :refer [defstyles defkeyframes]]
             [garden.selectors :as gs :refer [& nth-child]]
             [garden.units :refer [px]]))
 
-(defn get-delay [i]
+(defn get-delay
+  "Takes a time interval and generates it as a string"
+  [i]
   (str (float (* 0.1 i)) "s"))
 
 (defkeyframes blink
@@ -11,8 +13,9 @@
               [:20% {:opacity 1}]
               [:100% {:opacity 0.2}])
 
-(def animate-dots
-  (for [i (range 1 11)] [(gs/& (gs/nth-child i)) {:animation-delay (get-delay i)}]))
+(def animate-typing
+  (for [i (range 1 11)]
+    [(-> i str nth-child &) {:animation-delay (get-delay i)}]))
 
 (defstyles chat
            [:.typing {:position "absolute"
@@ -24,6 +27,6 @@
             [:span {:animation-name "blink"
                     :animation-duration "1.5s"
                     :animation-iteration-count "infinite"
-                    :animation=fill-mode "both"}]]
-           animate-dots
+                    :animation-fill-mode "both"}
+             animate-typing]]
            blink)

--- a/src/clj/styles/chat.clj
+++ b/src/clj/styles/chat.clj
@@ -1,6 +1,6 @@
 (ns styles.chat
   (:require [garden.def :refer [defstyles defkeyframes]]
-            [garden.selectors :as gs :refer [& nth-child]]
+            [garden.selectors :refer [& nth-child]]
             [garden.units :refer [px]]))
 
 (defn get-delay

--- a/src/clj/styles/chat.clj
+++ b/src/clj/styles/chat.clj
@@ -1,0 +1,29 @@
+(ns styles.chat
+  (:require [garden.def :refer [defstyles defrule defkeyframes]]
+            [garden.selectors :as gs :refer [& nth-child]]
+            [garden.units :refer [px]]))
+
+(defn get-delay [i]
+  (str (float (* 0.1 i)) "s"))
+
+(defkeyframes blink
+              [:0% {:opacity 0.2}]
+              [:20% {:opacity 1}]
+              [:100% {:opacity 0.2}])
+
+(def animate-dots
+  (for [i (range 1 11)] [(gs/& (gs/nth-child i)) {:animation-delay (get-delay i)}]))
+
+(defstyles chat
+           [:.typing {:position "absolute"
+                      :margin 0
+                      :padding 0
+                      :overflow "hidden"
+                      :bottom 0
+                      :left (px 1)}
+            [:span {:animation-name "blink"
+                    :animation-duration "1.5s"
+                    :animation-iteration-count "infinite"
+                    :animation=fill-mode "both"}]]
+           animate-dots
+           blink)

--- a/src/clj/styles/fonts.clj
+++ b/src/clj/styles/fonts.clj
@@ -1,0 +1,43 @@
+(ns styles.fonts
+  (:require [garden.def :refer [defstyles]]))
+
+(defn at-font-face
+  "Create a CSS @font-face rule.  Garden library not functional for this"
+  [& properties]
+  [(keyword "@font-face") properties])
+
+(defn titilium-web
+  [type weight]
+  {:font-family "'Titillium Web'"
+   :font-style  :normal
+   :font-weight weight
+   :src        [(str "url(\".. / fonts/TitilliumWeb-" type  ".woff\") format('woff')")
+                (str "url(\".. / fonts/TitilliumWeb-" type ".ttf\") format('truetype')")]})
+
+(def anr-icon
+  {:font-family "'anr-icon'"
+   :font-style  :normal
+   :font-weight :normal
+   :src [(str "url(\"../fonts/netrunner.eot\") format('eot'))")
+         (str "url(\"../fonts/netrunner.eot?#iefix\") format('embedded-opentype')")
+         (str "url(\"../fonts/netrunner.woff\") format('woff')")
+         (str "url(\"../fonts/netrunner.ttf\") format('truetype')")
+         (str "url(\"../fonts/netrunner.svg\") format('svg') active;")]})
+
+(def fontello
+  {:font-family "'fontello'"
+   :font-style  :normal
+   :font-weight :normal
+   :src [(str "url(\"../fonts/fontello.eot\")")
+         (str "url(\"../fonts/fontello.eot#iefix\") format('embedded-opentype')")
+         (str "url(\"../fonts/fontello.woff\") format('woff')")
+         (str "url(\"../fonts/fontello.ttf\") format('truetype')")
+         (str "url(\"../fonts/netrunner.svg\") format('svg') active;")]})
+
+(defstyles fonts
+           (at-font-face (titilium-web "ExtraLight" 200))
+           (at-font-face (titilium-web "Light" 300))
+           (at-font-face (titilium-web "Regular" 400))
+           (at-font-face (titilium-web "Bold" 700))
+           (at-font-face anr-icon)
+           (at-font-face fontello))

--- a/src/clj/styles/netrunner.clj
+++ b/src/clj/styles/netrunner.clj
@@ -1,0 +1,11 @@
+(ns styles.netrunner
+  (:require [garden.def :refer [defstyles]]
+            [styles.toastr :refer [toastr]]
+            [styles.fonts :refer [fonts]]
+            [styles.chat :refer [chat]]
+            [styles.variables :as v]))
+
+(defstyles netrunner
+           fonts
+           chat
+           toastr)

--- a/src/clj/styles/netrunner.css
+++ b/src/clj/styles/netrunner.css
@@ -1,0 +1,177 @@
+@font-face {
+  font-family: 'Titillium Web';
+  font-style: normal;
+  font-weight: 200;
+  src: url(".. / fonts/TitilliumWeb-ExtraLight.woff") format('woff'), url(".. / fonts/TitilliumWeb-ExtraLight.ttf") format('truetype');
+}
+
+@font-face {
+  font-family: 'Titillium Web';
+  font-style: normal;
+  font-weight: 300;
+  src: url(".. / fonts/TitilliumWeb-Light.woff") format('woff'), url(".. / fonts/TitilliumWeb-Light.ttf") format('truetype');
+}
+
+@font-face {
+  font-family: 'Titillium Web';
+  font-style: normal;
+  font-weight: 400;
+  src: url(".. / fonts/TitilliumWeb-Regular.woff") format('woff'), url(".. / fonts/TitilliumWeb-Regular.ttf") format('truetype');
+}
+
+@font-face {
+  font-family: 'Titillium Web';
+  font-style: normal;
+  font-weight: 700;
+  src: url(".. / fonts/TitilliumWeb-Bold.woff") format('woff'), url(".. / fonts/TitilliumWeb-Bold.ttf") format('truetype');
+}
+
+@font-face {
+  font-family: 'anr-icon';
+  font-style: normal;
+  font-weight: normal;
+  src: url("../fonts/netrunner.eot") format('eot')), url("../fonts/netrunner.eot?#iefix") format('embedded-opentype'), url("../fonts/netrunner.woff") format('woff'), url("../fonts/netrunner.ttf") format('truetype'), url("../fonts/netrunner.svg") format('svg') active;;
+}
+
+@font-face {
+  font-family: 'fontello';
+  font-style: normal;
+  font-weight: normal;
+  src: url("../fonts/fontello.eot"), url("../fonts/fontello.eot#iefix") format('embedded-opentype'), url("../fonts/fontello.woff") format('woff'), url("../fonts/fontello.ttf") format('truetype'), url("../fonts/netrunner.svg") format('svg') active;;
+}
+
+.typing {
+  position: absolute;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  bottom: 0;
+  left: 1px;
+}
+
+.typing span {
+  animation-name: blink;
+  animation-duration: 1.5s;
+  animation-iteration-count: infinite;
+  animation-fill-mode: both;
+}
+
+.typing span:nth-child(1) {
+  animation-delay: 0.1s;
+}
+
+.typing span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typing span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+.typing span:nth-child(4) {
+  animation-delay: 0.4s;
+}
+
+.typing span:nth-child(5) {
+  animation-delay: 0.5s;
+}
+
+.typing span:nth-child(6) {
+  animation-delay: 0.6s;
+}
+
+.typing span:nth-child(7) {
+  animation-delay: 0.7s;
+}
+
+.typing span:nth-child(8) {
+  animation-delay: 0.8s;
+}
+
+.typing span:nth-child(9) {
+  animation-delay: 0.9s;
+}
+
+.typing span:nth-child(10) {
+  animation-delay: 1.0s;
+}
+
+@keyframes blink {
+
+0% {
+    opacity: 0.2;
+  }
+  
+20% {
+    opacity: 1;
+  }
+  
+100% {
+    opacity: 0.2;
+  }
+
+}
+
+@-webkit-keyframes blink {
+
+0% {
+    opacity: 0.2;
+  }
+  
+20% {
+    opacity: 1;
+  }
+  
+100% {
+    opacity: 0.2;
+  }
+
+}
+
+@-moz-keyframes blink {
+
+0% {
+    opacity: 0.2;
+  }
+  
+20% {
+    opacity: 1;
+  }
+  
+100% {
+    opacity: 0.2;
+  }
+
+}
+
+@-o-keyframes blink {
+
+0% {
+    opacity: 0.2;
+  }
+  
+20% {
+    opacity: 1;
+  }
+  
+100% {
+    opacity: 0.2;
+  }
+
+}
+
+.toast-hand {
+  bottom: 100px;
+  left: 16px;
+}
+
+.toast-left-center {
+  bottom: 320px;
+  left: 5px;
+  width: 60px;
+}
+
+.toast-card {
+  top: 36px;
+  right: 5px;
+}

--- a/src/clj/styles/toastr.clj
+++ b/src/clj/styles/toastr.clj
@@ -1,0 +1,12 @@
+(ns styles.toastr
+  (:require [garden.def :refer [defstyles]]
+            [garden.units :refer [px]]))
+
+(defstyles toastr
+           [:.toast-hand {:bottom (px 100)
+                          :left (px 16)}]
+           [:.toast-left-center {:bottom (px 320)
+                                 :left (px 5)
+                                 :width (px 60)}]
+           [:.toast-card {:top (px 36)
+                          :right (px 5)}])

--- a/src/clj/styles/variables.clj
+++ b/src/clj/styles/variables.clj
@@ -1,0 +1,26 @@
+(ns styles.variables
+  (:require [garden.color :refer [rgba]]))
+
+(def light-grey "#ddd")
+(def grey "#999")
+(def dark-grey "#383838")
+(def obsidian "#282828") ; Very very dark grey
+(def blue "#00AEFF")
+(def text-color "#333")
+(def orange "#FFA500")
+
+;; Darker colours in the spirit of each faction
+(def anarch-orange "#cc5200")
+(def shaper-green "#29a329")
+(def criminal-blue "#007acc")
+
+(def transparent-orange (rgba 255 165 0 0.35))
+(def transparent-blue (rgba 39 56 76 0.82))
+(def transparent-lightblue (rgba 0 174 255 0.85))
+(def transparent-green (rgba 50 205 50 0.85))
+(def transparent-red (rgba 255 0 0 0.85))
+(def transparent-orange-bright (rgba 255 165 0 0.90))
+(def transparent-gold (rgba 200 130 0 0.90))
+(def transparent-darkblue (rgba 0 0 102 0.85))
+(def transparent-purple (rgba 67 0 102 0.85))
+(def transparent-black (rgba 0 0 0 0.6))


### PR DESCRIPTION
Based on discussion with @Saintis and then him goading me into trying this out.  Here is a first piece of a move to an all-clojure CSS compiler.  

Value TBD... certainly can be used to compile and used in-line with code too which seems nice.

A couple of blogs:
https://blog.estimate-work.com/a-new-world-writing-css-in-clojurescript-and-life-after-sass-bdf5bc80a24f
http://userbound.com/blog/Garden-with-Clojurescript/

Run: `lein garden once` to compile.  Currently outputs a file to `netrunner.css` which is included in this PR located in` src/clj/styles`

TODO:

- [ ] Conversion of existing style sheet and styles
- [ ] Import into CLJS files to allow inline CSS functions, and add goog_require to HTML for garden
- [ ] Workflow for live CSS reloading
- [ ] Look into Cursive problem with lein and :prep-tasks (https://github.com/cursive-ide/cursive/issues/1667)

COMMENTS:
- Garden is a very thin layer between native clojure data structures and CSS
- Some things required fixing - for example handling of `@font-face` was not correct
- Do we want to proceed here?  