### PR TITLE
Exploratory Romp shouldn't result in negative advancement tokens

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -581,9 +581,10 @@
                                                               (= (first (:server run)) (second (:zone %))))}
                                          :msg (msg "remove " (quantify c "advancement token")
                                                    " from " (card-str state target))
-                                         :effect (req (add-prop state :corp target :advance-counter (- c))
-                                                      (clear-wait-prompt state :corp)
-                                                      (effect-completed state side eid))}
+                                         :effect (req (let [to-remove (min c (:advance-counter target 0))]
+                                                        (add-prop state :corp target :advance-counter (- to-remove))
+                                                        (clear-wait-prompt state :corp)
+                                                        (effect-completed state side eid)))}
                                         card nil)))}})
 
    "Express Delivery"

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -871,6 +871,24 @@
       (is (= 0 (:tag (get-runner))) "No tags, didn't access TGTBT")
       (is (= 0 (:advance-counter (refresh tg))) "Advancements removed"))))
 
+(deftest exploratory-romp-negative
+  ;; Exploratory Romp - Don't remove more than the existing number of advancement tokens
+  (do-game
+    (new-game (default-corp [(qty "TGTBT" 1)])
+              (default-runner [(qty "Exploratory Romp" 1)]))
+    (play-from-hand state :corp "TGTBT" "New remote")
+    (let [tg (get-content state :remote1 0)]
+      (advance state tg 2)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Exploratory Romp")
+      (prompt-choice :runner "Server 1")
+      (run-successful state)
+      (prompt-choice :runner "Run ability")
+      (prompt-choice :runner "3")
+      (prompt-select :runner (refresh tg))
+      (is (= 0 (:tag (get-runner))) "No tags, didn't access TGTBT")
+      (is (= 0 (:advance-counter (refresh tg))) "Advancements removed"))))
+
 (deftest falsified-credentials
   ;; Falsified Credentials - Expose card in remote
   ;; server and correctly guess its type to gain 5 creds


### PR DESCRIPTION
Limit number of advancement tokens to remove to the minimum of the selected number and the number on the target.