### PR TITLE
Trash now checks if card is active before doing trash-effect

### DIFF
--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -375,9 +375,10 @@
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})
         card-prompts (filter #(= (get-in % [:card :title]) (get moved-card :title)) (get-in @state [side :prompt]))]
 
-    (when-let [trash-effect (and (or (:rezzed card) (not (:facedown card))) (:trash-effect cdef))]
+    (when-let [trash-effect (:trash-effect cdef)]
       (when (and (not disabled) (or (and (= (:side card) "Runner")
-                                         (:installed card))
+                                         (:installed card)
+                                         (not (:facedown card)))
                                     (and (:rezzed card) (not host-trashed))
                                     (and (:when-inactive trash-effect) (not host-trashed))))
         (resolve-ability state side trash-effect moved-card (list cause))))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -375,7 +375,7 @@
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})
         card-prompts (filter #(= (get-in % [:card :title]) (get moved-card :title)) (get-in @state [side :prompt]))]
 
-    (when-let [trash-effect (:trash-effect cdef)]
+    (when-let [trash-effect (and (not (:facedown card)) (:trash-effect cdef))]
       (when (and (not disabled) (or (and (= (:side card) "Runner")
                                          (:installed card))
                                     (and (:rezzed card) (not host-trashed))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -375,7 +375,7 @@
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})
         card-prompts (filter #(= (get-in % [:card :title]) (get moved-card :title)) (get-in @state [side :prompt]))]
 
-    (when-let [trash-effect (and (not (:facedown card)) (:trash-effect cdef))]
+    (when-let [trash-effect (and (or (:rezzed card) (not (:facedown card))) (:trash-effect cdef))]
       (when (and (not disabled) (or (and (= (:side card) "Runner")
                                          (:installed card))
                                     (and (:rezzed card) (not host-trashed))

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -234,7 +234,10 @@
     (let [tmc (get-in @state [:runner :rig :facedown 0])]
       (is (:facedown (refresh tmc)) "Tri-maf Contact is facedown")
       (is (= 3 (count (:hand (get-runner))))
-          "No meat damage dealt by Tri-maf's leave play effect"))))
+          "No meat damage dealt by Tri-maf's leave play effect")
+      (core/trash state :runner tmc)
+      (is (= 3 (count (:hand (get-runner))))
+          "No meat damage dealt by trashing facedown Tri-maf"))))
 
 (deftest because-i-can
   ;; make a successful run on a remote to shuffle its contents into R&D


### PR DESCRIPTION
This fixes bug with trashing a facedown Tri-Maf.