### PR TITLE
update monger with 3.1.0 fork to resolve compiler problem 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [cheshire "5.6.3"]
                  [org.omcljs/om "0.9.0"]
                  [sablono "0.3.4"]
-                 [com.novemberain/monger "3.1.0"]
+                 [danhut/monger "3.1.0"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [differ "0.3.1"]
                  [com.taoensso/sente "1.11.0"]


### PR DESCRIPTION
Updated to Monger to use a personal fork from the 3.1.0 package - with a fix for Clojure 1.9 compilation.  Excludes any? from collections.clj
`(:refer-clojure :exclude [find remove count drop distinct empty? any? update])`

Have subscribed to Monger for as and when they patch this.

Fix #3328 
