### PR TITLE
Reset game state when starting a game

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -163,9 +163,9 @@
             ; TODO: this would be better if a full state was only sent to the new spectator, and diffs sent to the existing players.
             (lobby/spectate-game user client-id gameid)
             (main/handle-notification state (str username " joined the game as a spectator."))
-            (swap-and-send-state! (lobby/game-for-id gameid))
             (ws/send! client-id [:lobby/select {:gameid gameid
                                                 :started started}])
+            (swap-and-send-state! (lobby/game-for-id gameid))
             (when reply-fn (reply-fn 200))
             true)
           (when reply-fn

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -41,7 +41,7 @@
 
 (defn init-game [game side]
   (.setItem js/localStorage "gameid" (:gameid @app-state))
-  (swap! game-state merge game)
+  (reset! game-state game)
   (swap! game-state assoc :side side)
   (reset! last-state @game-state))
 


### PR DESCRIPTION
When a new game was launched, any existing game state was merged into the new game state. This likely was causing the problem where games started with runs happening or win prompts being displayed.

When `Watching` a game, we were relying on the stale game state being set. Moved the state update message until after launching the game.

Fixes #3101