### PR TITLE
Leaking drawn card info to clients

### DIFF
--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -52,7 +52,10 @@
    "close-deck" core/close-deck})
 
 (defn strip [state]
-  (dissoc state :events :turn-events :per-turn :prevent :damage :effect-completed :click-state :turn-state))
+  (-> state
+    (dissoc :events :turn-events :per-turn :prevent :damage :effect-completed :click-state :turn-state)
+    (update-in [:corp :register] dissoc :most-recent-drawn)
+    (update-in [:runner :register] dissoc :most-recent-drawn)))
 
 (defn not-spectator?
   "Returns true if the specified user in the specified state is not a spectator"


### PR DESCRIPTION
The `[:register :most-recent-drawn]` list of cards is sent to both Corp and Runner, allowing the other player to see which cards have been drawn by an opponent.

Stripping that info out of `:register` before sending state changes.