### PR TITLE
Clean up optionals and delayed completion key from cards.

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -609,8 +609,7 @@
                      {:optional
                       {:prompt "Take 1 bad publicity from Illicit Sales?"
                        :yes-ability {:msg "take 1 bad publicity"
-                                     :effect (effect (gain-bad-publicity :corp 1))}
-                       :no-ability {:effect (req (effect-completed state side eid))}}}
+                                     :effect (effect (gain-bad-publicity :corp 1))}}}
                      card nil)
                    (do (let [n (* 3 (+ (get-in @state [:corp :bad-publicity]) (:has-bad-pub corp)))]
                          (gain state side :credit n)
@@ -765,20 +764,14 @@
              :unsuccessful-trace nq}})
 
    "NEXT Wave 2"
-   {:delayed-completion true
-    :not-when-scored true
-    :effect (req (if (some #(and (rezzed? %)
-                                 (ice? %)
-                                 (has-subtype? % "NEXT"))
-                           (all-installed state :corp))
-                   (continue-ability state side
-                     {:optional
-                      {:prompt "Do 1 brain damage with NEXT Wave 2?"
-                       :yes-ability {:msg "do 1 brain damage"
-                                     :effect (effect (damage eid :brain 1 {:card card}))}
-                       :no-ability {:effect (req (effect-completed state side eid))}}}
-                    card nil)
-                   (effect-completed state side eid)))}
+   {:not-when-scored true
+    :req (req (some #(and (rezzed? %)
+                          (ice? %)
+                          (has-subtype? % "NEXT"))
+                    (all-installed state :corp)))
+    :optional {:prompt "Do 1 brain damage with NEXT Wave 2?"
+               :yes-ability {:msg "do 1 brain damage"
+                             :effect (effect (damage eid :brain 1 {:card card}))}}}
 
    "Nisei MK II"
    {:silent (req true)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -770,7 +770,6 @@
      {:derezzed-events {:runner-turn-ends corp-rez-toast}
       :events {:corp-turn-begins
                {:optional {:prompt "Initiate trace with Kuwinda K4H1U3?"
-                           :delayed-completion true
                            :yes-ability ability}}}
       :abilities [(assoc ability :label "Trace X - do 1 brain damage (start of turn)")]})
 
@@ -1501,8 +1500,7 @@
              :effect (effect (show-wait-prompt :runner "Corp to use Space Camp")
                              (continue-ability
                                {:optional
-                                {:delayed-completion true
-                                 :prompt "Place 1 advancement token with Space Camp?"
+                                {:prompt "Place 1 advancement token with Space Camp?"
                                  :cancel-effect (req (clear-wait-prompt state :runner)
                                                      (effect-completed state side eid))
                                  :yes-ability {:msg (msg "place 1 advancement token on " (card-str state target))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -242,8 +242,7 @@
                                (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent the trash")
                                    (continue-ability state :corp
                                      {:optional
-                                      {:delayed-completion true
-                                       :prompt (msg "Spend " cost " [Credits] to prevent the trash of " title "?")
+                                      {:prompt (msg "Spend " cost " [Credits] to prevent the trash of " title "?")
                                        :player :corp
                                        :yes-ability {:effect (req (lose state :corp :credit cost)
                                                                   (system-msg state :corp (str "spends " cost " [Credits] to prevent "
@@ -303,9 +302,9 @@
                                      (update! state side (dissoc card :run-again))))))
     :events {:successful-run-ends
              {:optional {:req (req (= [:rd] (:server target)))
-                                              :prompt "Make another run on R&D?"
-                                              :yes-ability {:effect (effect (clear-wait-prompt :corp)
-                                                                            (update! (assoc card :run-again true)))}}}}}
+                         :prompt "Make another run on R&D?"
+                         :yes-ability {:effect (effect (clear-wait-prompt :corp)
+                                                       (update! (assoc card :run-again true)))}}}}}
 
    "Day Job"
    {:additional-cost [:click 3]
@@ -1199,8 +1198,7 @@
                                                         (assoc card :zone '(:discard))))
                                      (update! state side (dissoc card :run-again))))))
     :events {:successful-run nil
-             :successful-run-ends {
-                                   :interactive (req true)
+             :successful-run-ends {:interactive (req true)
                                    :optional {:req (req (= [:rd] (:server target)))
                                               :prompt "Make another run on R&D?"
                                               :yes-ability {:effect (effect (clear-wait-prompt :corp)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -437,14 +437,12 @@
                              (pos? (count-virus-programs state))))
               :optional
                    {:prompt "Place a virus counter?"
-                    :yes-ability {:effect (effect (continue-ability
-                                                    {:prompt "Select an installed virus program"
-                                                     :choices {:req #(and (installed? %)
-                                                                          (has-subtype? % "Virus")
-                                                                          (is-type? % "Program"))}
-                                                     :msg (msg "place 1 virus counter on " (:title target))
-                                                     :effect (effect (add-counter target :virus 1))}
-                                                    card nil))}}}}}
+                    :yes-ability {:prompt "Select an installed virus program"
+                                  :choices {:req #(and (installed? %)
+                                                       (has-subtype? % "Virus")
+                                                       (is-type? % "Program"))}
+                                  :msg (msg "place 1 virus counter on " (:title target))
+                                  :effect (effect (add-counter target :virus 1))}}}}}
 
    "Lemuria Codecracker"
    {:abilities [{:cost [:click 1 :credit 1] :req (req (some #{:hq} (:successful-run runner-reg)))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -48,15 +48,10 @@
                    (continue-ability state side
                      {:optional
                       {:prompt "Use Archives Interface to remove a card from the game instead of accessing it?"
-                       :yes-ability
-                               {:delayed-completion true
-                                :effect (effect (continue-ability
-                                                  {:prompt "Choose a card in Archives to remove from the game instead of accessing"
-                                                   :choices (req (:discard corp))
-                                                   :msg (msg "remove " (:title target) " from the game")
-                                                   :effect (effect (move :corp target :rfg))} card nil))}}}
-                                     card nil))}}}
-
+                       :yes-ability {:prompt "Choose a card in Archives to remove from the game instead of accessing"
+                                     :choices (req (:discard corp))
+                                     :msg (msg "remove " (:title target) " from the game")
+                                     :effect (effect (move :corp target :rfg))}}} card nil))}}}
    "Astrolabe"
    {:in-play [:memory 1]
     :events {:server-created {:msg "draw 1 card"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -47,16 +47,15 @@
       :effect (req (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                    (continue-ability state side
                      {:optional
-                      {:delayed-completion true
-                       :prompt "Use Archives Interface to remove a card from the game instead of accessing it?"
+                      {:prompt "Use Archives Interface to remove a card from the game instead of accessing it?"
                        :yes-ability
-                       {:delayed-completion true
-                        :effect (effect (continue-ability
-                                          {:prompt "Choose a card in Archives to remove from the game instead of accessing"
-                                           :choices (req (:discard corp))
-                                           :msg (msg "remove " (:title target) " from the game")
-                                           :effect (effect (move :corp target :rfg))} card nil))}
-                       :no-ability {:effect (req (effect-completed state side eid))}}} card nil))}}}
+                               {:delayed-completion true
+                                :effect (effect (continue-ability
+                                                  {:prompt "Choose a card in Archives to remove from the game instead of accessing"
+                                                   :choices (req (:discard corp))
+                                                   :msg (msg "remove " (:title target) " from the game")
+                                                   :effect (effect (move :corp target :rfg))} card nil))}}}
+                                     card nil))}}}
 
    "Astrolabe"
    {:in-play [:memory 1]
@@ -257,8 +256,7 @@
     :in-play [:memory 3]
     :events {:runner-install
              {:optional
-              {:delayed-completion true
-               :req (req (has-subtype? target "Caïssa"))
+              {:req (req (has-subtype? target "Caïssa"))
                :prompt "Use Deep Red?" :priority 1
                :yes-ability {:delayed-completion true
                              :effect (req (let [cid (:cid target)]
@@ -271,8 +269,7 @@
                                                :effect (req (gain state :runner :click 1)
                                                             (play-ability state side {:card target :ability 0})
                                                             (effect-completed state side eid))}
-                                             card nil)))}
-               :no-ability {:effect (req (effect-completed state side eid))}}}}}
+                                             card nil)))}}}}}
 
    "Desperado"
    {:in-play [:memory 1]
@@ -444,17 +441,15 @@
              {:req (req (and (first-event? state :runner :successful-run)
                              (pos? (count-virus-programs state))))
               :optional
-              {:prompt "Place a virus counter?"
-               :yes-ability
-               {:delayed-completion true
-                :effect (effect (continue-ability
-                                  {:prompt "Select an installed virus program"
-                                   :choices {:req #(and (installed? %)
-                                                        (has-subtype? % "Virus")
-                                                        (is-type? % "Program"))}
-                                   :msg (msg "place 1 virus counter on " (:title target))
-                                   :effect (effect (add-counter target :virus 1))}
-                                  card nil))}}}}}
+                   {:prompt "Place a virus counter?"
+                    :yes-ability {:effect (effect (continue-ability
+                                                    {:prompt "Select an installed virus program"
+                                                     :choices {:req #(and (installed? %)
+                                                                          (has-subtype? % "Virus")
+                                                                          (is-type? % "Program"))}
+                                                     :msg (msg "place 1 virus counter on " (:title target))
+                                                     :effect (effect (add-counter target :virus 1))}
+                                                    card nil))}}}}}
 
    "Lemuria Codecracker"
    {:abilities [{:cost [:click 1 :credit 1] :req (req (some #{:hq} (:successful-run runner-reg)))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1373,11 +1373,9 @@
     :subroutines [{:label "Draw 1 card, then shuffle 1 card from HQ into R&D"
                    :effect (req (when-completed (resolve-ability state side
                                                   {:optional
-                                                   {:delayed-completion true
-                                                    :prompt "Draw 1 card?"
+                                                   {:prompt "Draw 1 card?"
                                                     :yes-ability {:msg "draw 1 card"
-                                                                  :effect (effect (draw))}
-                                                    :no-ability {:effect (req (effect-completed state side eid))}}}
+                                                                  :effect (effect (draw))}}}
                                                  card nil)
                                                 (resolve-ability state side
                                                   {:prompt "Choose 1 card in HQ to shuffle into R&D"
@@ -1430,8 +1428,7 @@
                                                   {:optional
                                                    {:prompt "Draw 1 card?"
                                                     :yes-ability {:msg "draw 1 card"
-                                                                  :effect (effect (draw))}
-                                                    :no-ability {:effect (req (effect-completed state side eid))}}}
+                                                                  :effect (effect (draw))}}}
                                                  card nil)))}]
     :runner-abilities [(runner-break [:click 2] 2)]}
 
@@ -1608,7 +1605,6 @@
                          {:optional
                           {:player :corp
                            :prompt "Draw 1 card?"
-                           :delayed-completion true
                            :yes-ability
                            {:delayed-completion true
                             :effect (effect (clear-wait-prompt :runner)

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -762,7 +762,6 @@
                      :abilities [(break-sub 2 1 "Sentry")
                                  (strength-pump 1 1)]
                      :events {:pass-ice {:req (req (and (has-subtype? target "Sentry") (rezzed? target)) (pos? (count (:deck runner))))
-                                         :delayed-completion true
                                          :optional {:prompt (msg "Use Persephone's ability??")
                                                     :yes-ability {:prompt "How many subroutines resolved on the passed ICE?"
                                                                   :delayed-completion true

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -54,7 +54,8 @@
    {:implementation "Can only pay to see last card drawn after multiple draws"
     :req (req (some #{:hq} (:successful-run runner-reg)))
     :events {:corp-draw {:optional
-                         {:prompt (msg "Pay 2 [Credits] to reveal card just drawn?") :player :runner
+                         {:prompt (msg "Pay 2 [Credits] to reveal card just drawn?")
+                          :player :runner
                           :yes-ability {:msg (msg "reveal the card just drawn: " (:title (last (:hand corp))))
                                         :cost [:credit 2]}}}}}
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -943,7 +943,6 @@
 
    "Lewi Guilherme"
    (let [ability {:once :per-turn
-                  :delayed-completion true
                   :optional {:once :per-turn
                              :prompt "Pay 1 [Credits] to keep Lewi Guilherme?"
                              :yes-ability {:effect (req (if (pos? (:credit runner))

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -867,7 +867,6 @@
     (let [sadaka (get-ice state :archives 0)
           sadakaHQ (get-ice state :hq 0)]
       (take-credits state :corp)
-
       (play-from-hand state :runner "Bank Job")
       (run-on state "archives")
       (core/rez state :corp sadaka)
@@ -880,7 +879,6 @@
       (prompt-choice :corp "Done")
       (is (= 2 (count (:discard (get-corp)))) "Sadaka trashed")
       (run-jack-out state)
-
       (run-on state "archives")
       (core/rez state :corp sadakaHQ)
       (is (= 2 (count (:hand (get-corp)))) "Corp starts with 2 cards in hand")
@@ -893,8 +891,8 @@
       (prompt-select :corp (get-resource state 0))
       (is (= 1 (count (:discard (get-runner)))) "Runner resource trashed")
       (is (= 4 (count (:discard (get-corp)))) "sadakaHQ trashed"))))
-(deftest sandman
 
+(deftest sandman
   ;; Sandman - add an installed runner card to the grip
   (do-game
     (new-game (default-corp [(qty "Sandman" 1)])


### PR DESCRIPTION
Based on the recent Find the Truth wiki entry and a walk through the prompt code - this is a clean up of cards which are slightly wrong though the issue is non-impacting.

Removes :no-ability keys which only call effect-complete since this happens for free.
:delayed completion keys do nothing in this part of the structure so delete them too.

```clojure
{:optional
 :delayed-completion true
 {:prompt "say-something"
  :delayed-completion true}
```

clean up off NEXT WAVE 2