### PR TITLE
Hivemind updates strength of programs on change

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -425,29 +425,39 @@
                                card nil))}]}
 
    "Hivemind"
-   {:data {:counter {:virus 1}}
-    :abilities [{:req (req (> (get-in card [:counter :virus]) 0))
-                 :priority true
-                 :prompt "Move a virus counter to which card?"
-                 :choices {:req #(has-subtype? % "Virus")}
-                 :effect (req (let [abilities (:abilities (card-def target))
-                                    virus target]
-                                (add-counter state :runner virus :virus 1)
-                                (add-counter state :runner card :virus -1)
-                                (if (= (count abilities) 1)
-                                  (do (swap! state update-in [side :prompt] rest) ; remove the Hivemind prompt so Imp works
+   (let [update-programs (req (let [virus-programs (->> (all-installed state :runner)
+                                                  (filter #(and (program? %)
+                                                                (has-subtype? % "Virus")
+                                                                (not (facedown? %)))))]
+                                (doseq [p virus-programs]
+                                  (update-breaker-strength state side p))))]
+     {:data {:counter {:virus 1}}
+      :effect update-programs
+      :trash-effect {:effect update-programs}
+      :events {:counter-added {:req (req (= (:cid target) (:cid card)))
+                               :effect update-programs}}
+      :abilities [{:req (req (> (get-in card [:counter :virus]) 0))
+                   :priority true
+                   :prompt "Move a virus counter to which card?"
+                   :choices {:req #(has-subtype? % "Virus")}
+                   :effect (req (let [abilities (:abilities (card-def target))
+                                      virus target]
+                                  (add-counter state :runner virus :virus 1)
+                                  (add-counter state :runner card :virus -1)
+                                  (if (= (count abilities) 1)
+                                    (do (swap! state update-in [side :prompt] rest) ; remove the Hivemind prompt so Imp works
                                       (resolve-ability state side (first abilities) (get-card state virus) nil))
-                                  (resolve-ability
-                                    state side
-                                    {:prompt "Choose an ability to trigger"
-                                     :choices (vec (map :msg abilities))
-                                     :effect (req (swap! state update-in [side :prompt] rest)
-                                                  (resolve-ability
-                                                    state side
-                                                    (first (filter #(= (:msg %) target) abilities))
-                                                    card nil))}
-                                    (get-card state virus) nil))))
-                 :msg (msg "trigger an ability on " (:title target))}]}
+                                    (resolve-ability
+                                      state side
+                                      {:prompt "Choose an ability to trigger"
+                                       :choices (vec (map :msg abilities))
+                                       :effect (req (swap! state update-in [side :prompt] rest)
+                                                    (resolve-ability
+                                                      state side
+                                                      (first (filter #(= (:msg %) target) abilities))
+                                                      card nil))}
+                                      (get-card state virus) nil))))
+                   :msg (msg "trigger an ability on " (:title target))}]})
 
    "Hyperdriver"
    {:flags {:runner-phase-12 (req true)}

--- a/src/clj/tasks/nrdb.clj
+++ b/src/clj/tasks/nrdb.clj
@@ -71,7 +71,7 @@
    :side_code  (fn [[k v]] [:side (string/capitalize v)])
    :uniqueness  identity
    :memory_cost (rename :memoryunits)
-   :strength  identity
+   :strength  (fn [[k v]] [:strength (if (nil? v) 0 v)])
    :trash_cost (rename :trash)
    :deck_limit (rename :limited)
    :quantity (rename :packquantity)

--- a/test/clj/game_test/cards/icebreakers.clj
+++ b/test/clj/game_test/cards/icebreakers.clj
@@ -213,6 +213,22 @@
       (is (= "Crypsis" (:title (first (:discard (get-runner)))))
           "Crypsis was trashed"))))
 
+(deftest darwin
+  ;; Darwin - starts at 0 strength
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Darwin" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Darwin")
+    (let [darwin (get-program state 0)]
+      (is (zero? (get-counters (refresh darwin) :virus)) "Darwin starts with 0 virus counters")
+      (is (= 0 (:current-strength (refresh darwin ))) "Darwin starts at 0 strength")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (card-ability state :runner (refresh darwin) 1) ; add counter
+      (is (= 1 (get-counters (refresh darwin) :virus)) "Darwin gains 1 virus counter")
+      (is (= 1 (:current-strength (refresh darwin ))) "Darwin is at 1 strength"))))
+
 (deftest deus-x-multiple-hostile-infrastructure
   ;; Multiple Hostile Infrastructure vs. Deus X
   (do-game


### PR DESCRIPTION
Made `Hivemind` update the `current-strength` of installed virus programs when it is added to play, leaves play, or gains a counter. This mostly servers to update the UI so the breaker strength of things like `Aumakua` is accurately displayed.