### PR TITLE
WIP - first cut - prevention upgrade

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -380,7 +380,8 @@
              :run-ends nil}}
 
    "Feedback Filter"
-   {:prevent {:damage [:net :brain]}
+   {:prevent {:damage {:net {:req (req true)}
+                       :brain {:req (req true)}}}
     :abilities [{:cost [:credit 3] :msg "prevent 1 net damage" :effect (effect (damage-prevent :net 1))}
                 {:label "[Trash]: Prevent up to 2 brain damage"
                  :msg "prevent up to 2 brain damage"
@@ -767,9 +768,12 @@
    "Recon Drone"
    ; eventmap uses reverse so we get the most recent event of each kind into map
    (let [eventmap (fn [s] (into {} (reverse (get s :turn-events))))]
-     {:abilities [{:req (req (and (true? (:access @state)) (= (:cid (second (:pre-damage (eventmap @state))))
-                                                              (:cid (first (:post-access-card (eventmap @state)))))))
-                :effect (effect (resolve-ability
+     {:prevent {:damage {:net {:req (req (:access @state))}
+                         :meat {:req (req (:access @state))}
+                         :brain {:req (req (:access @state))}}}
+      :abilities [{:req (req (= (:cid (second (:pre-damage (eventmap @state))))
+                                (:cid (first (:post-access-card (eventmap @state))))))
+                   :effect (effect (resolve-ability
                                   {:prompt "Choose how much damage to prevent"
                                    :priority 50
                                    :choices {:number (req (min (last (:pre-damage (eventmap @state)))
@@ -777,9 +781,7 @@
                                    :msg (msg "prevent " target " damage")
                                    :effect (effect (damage-prevent (first (:pre-damage (eventmap @state))) target)
                                                    (lose :credit target)
-                                                   (trash card {:cause :ability-cost}))} card nil))}]
-     :events    {:pre-access {:effect (req (doseq [dtype [:net :brain :meat]] (swap! state update-in [:prevent :damage dtype] #(conj % card))))}
-                 :run-ends   {:effect (req (doseq [dtype [:net :brain :meat]] (swap! state update-in [:prevent :damage dtype] #(drop 1 %))))}}})
+                                                   (trash card {:cause :ability-cost}))} card nil))}]})
 
    "Record Reconstructor"
    {:events

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -245,6 +245,11 @@
   [state side ev]
   (= (count (turn-events state side ev)) 1))
 
+(defn event-count
+  "Returns the number of an event this turn."
+  [state side ev]
+  (count (turn-events state side ev)))
+
 (defn first-successful-run-on-server?
   "Returns true if the active run is the first succesful run on the given server"
   [state server]

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -31,10 +31,10 @@
   "Handles prevent effects on the card"
   [state card]
   (when-let [prevent (:prevent (card-def card))]
-     (doseq [[ptype pvec] prevent]
-       (doseq [psub pvec]
-         (swap! state update-in [:prevent ptype psub]
-                (fn [pv] (remove #(= (:cid %) (:cid card)) pv)))))))
+    (doseq [[ptype subtypes] prevent
+            [stype _] subtypes]
+      (swap! state update-in [:prevent ptype stype]
+             (fn [pv] (remove #(= (:cid %) (:cid card)) pv))))))
 
 (defn deactivate
   "Deactivates a card, unregistering its events, removing certain attribute keys, and triggering
@@ -100,9 +100,9 @@
                           {(if (= side :corp) :corp-phase-12 :runner-phase-12)
                            {:effect r}} c)))
      (when-let [prevent (:prevent cdef)]
-       (doseq [[ptype pvec] prevent]
-         (doseq [psub pvec]
-           (swap! state update-in [:prevent ptype psub] #(conj % card)))))
+       (doseq [[ptype subtypes] prevent
+               [stype _] subtypes]
+         (swap! state update-in [:prevent ptype stype] #(conj % card))))
      (update! state side c)
      (when-let [events (:events cdef)]
        (register-events state side events c))


### PR DESCRIPTION
This is an upgrade to the damage and tag prevention system.  The card-def now includes a :req check for a given type and subtype like so:
```clojure
{:prevent {:damage {:net {:req (req (first-chance? state side))}}
                :tag {:all {:req (req (first-chance? state side))}}}
```

For simple cards this will just be 
```clojure
(req true)
```

Three cards are shown so far in this WIP
- Feedback Filter
- No One Nome
- Recon Drone

Let me know concerns or something I am missing - I will migrate everything shortly otherwise.