### PR TITLE
WiN: Trypano

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -991,21 +991,21 @@
                            card nil))}]}
 
    "Trypano"
-   (let [trash-if-5 (req (when-let [h (:host card)]
+   (let [trash-if-5 (req (when-let [h (get-card state (:host card))]
                            (when (and (>= (get-virus-counters state side card) 5)
                                       (not (and (card-flag? h :untrashable-while-rezzed true)
                                                 (rezzed? h))))
-                             (system-msg state :runner (str "uses Trypano to trash " (:title  h)))
+                             (system-msg state :runner (str "uses Trypano to trash " (card-str state h)))
                              (trash state :runner h))))]
        {:hosting {:req #(and (ice? %) (can-host? %))}
         :effect trash-if-5
         :events {:runner-turn-begins
-                 {:optional
-                  {:prompt (msg "Place a virus counter on Trypano?")
-                   :yes-ability {:msg (msg "place a virus counter on Trypano")
-                                 :effect (req (add-counter state side card :virus 1))}}}
-                 :counter-added
-                 {:effect trash-if-5}}})
+                 {:optional {:prompt (msg "Place a virus counter on Trypano?")
+                             :yes-ability {:msg (msg "place a virus counter on Trypano")
+                                           :effect (req (add-counter state side card :virus 1))}}}
+                 :counter-added {:effect trash-if-5}
+                 :card-moved {:effect trash-if-5}
+                 :runner-install {:effect trash-if-5}}})
 
    "Upya"
    {:implementation "Power counters added automatically"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -992,20 +992,24 @@
 
    "Trypano"
    (let [trash-if-5 (req (when-let [h (get-card state (:host card))]
-                           (when (and (>= (get-virus-counters state side card) 5)
+                           (if (and (>= (get-virus-counters state side card) 5)
                                       (not (and (card-flag? h :untrashable-while-rezzed true)
                                                 (rezzed? h))))
-                             (system-msg state :runner (str "uses Trypano to trash " (card-str state h)))
-                             (trash state :runner h))))]
+                             (do (system-msg state :runner (str "uses Trypano to trash " (card-str state h)))
+                                 (trash state :runner eid h nil))
+                             (effect-completed state side eid))))]
        {:hosting {:req #(and (ice? %) (can-host? %))}
         :effect trash-if-5
         :events {:runner-turn-begins
                  {:optional {:prompt (msg "Place a virus counter on Trypano?")
                              :yes-ability {:msg (msg "place a virus counter on Trypano")
                                            :effect (req (add-counter state side card :virus 1))}}}
-                 :counter-added {:effect trash-if-5}
-                 :card-moved {:effect trash-if-5}
-                 :runner-install {:effect trash-if-5}}})
+                 :counter-added {:effect trash-if-5
+                                 :delayed-completion true}
+                 :card-moved {:effect trash-if-5
+                              :delayed-completion true}
+                 :runner-install {:effect trash-if-5
+                                  :delayed-completion true}}})
 
    "Upya"
    {:implementation "Power counters added automatically"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -990,6 +990,23 @@
                                          (shuffle! state side :deck))}
                            card nil))}]}
 
+   "Trypano"
+   (let [trash-if-5 (req (when-let [h (:host card)]
+                           (when (and (>= (get-virus-counters state side card) 5)
+                                      (not (and (card-flag? h :untrashable-while-rezzed true)
+                                                (rezzed? h))))
+                             (system-msg state :runner (str "uses Trypano to trash " (:title  h)))
+                             (trash state :runner h))))]
+       {:hosting {:req #(and (ice? %) (can-host? %))}
+        :effect trash-if-5
+        :events {:runner-turn-begins
+                 {:optional
+                  {:prompt (msg "Place a virus counter on Trypano?")
+                   :yes-ability {:msg (msg "place a virus counter on Trypano")
+                                 :effect (req (add-counter state side card :virus 1))}}}
+                 :counter-added
+                 {:effect trash-if-5}}})
+
    "Upya"
    {:implementation "Power counters added automatically"
     :events {:successful-run {:silent (req true)

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1002,6 +1002,36 @@
       (run-continue state)
       (is (= 2 (:current-strength (refresh corr))) "Corroder returned to normal strength"))))
 
+(deftest trypano
+  (testing "Hivemind and Architect interactions"
+    (do-game
+      (new-game (default-corp [(qty "Architect" 2)])
+                (default-runner [(qty "Trypano" 2) (qty "Hivemind" 1)]))
+      (play-from-hand state :corp "Architect" "HQ")
+      (play-from-hand state :corp "Architect" "R&D")
+      (let [architect-rezzed (get-ice state :hq 0)
+            architect-unrezzed (get-ice state :rd 0)]
+        (core/rez state :corp architect-rezzed)
+        (take-credits state :corp)
+        (play-from-hand state :runner "Trypano")
+        (prompt-select :runner (game.core/get-card state architect-rezzed))
+        (play-from-hand state :runner "Trypano")
+        (prompt-select :runner architect-unrezzed)
+        (is (= 2 (:memory (get-runner))) "Trypano consumes 1 MU"))
+      ;; wait 4 turns to make both Trypanos have 4 counters on them
+      (dotimes [n 4]
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (prompt-choice :runner "Yes")
+        (prompt-choice :runner "Yes"))
+      (is (= 0 (count (:discard (get-runner)))) "Trypano not in discard yet")
+      (is (= 1 (count (get-in @state [:corp :servers :rd :ices]))) "Unrezzed Archiect is not trashed")
+      (is (= 1 (count (get-in @state [:corp :servers :hq :ices]))) "Rezzed Archiect is not trashed")
+      (play-from-hand state :runner "Hivemind") ; now Hivemind makes both Trypanos have 5 counters
+      (is (= 0 (count (get-in @state [:corp :servers :rd :ices]))) "Unrezzed Archiect was trashed")
+      (is (= 1 (count (get-in @state [:corp :servers :hq :ices]))) "Rezzed Archiect was not trashed")
+      (is (= 1 (count (:discard (get-runner)))) "Trypano went to discard"))))
+
 (deftest upya
   (do-game
     (new-game (default-corp)


### PR DESCRIPTION
Works well with Hivemind, Architect, and even Hivemind flipped faceup by Assimilator. According to a hunch of @nicohasa , may not work well if a facedown Hivemind with a virus token hosted on Progenitor is flipped faceup, but I would be kind of surprised if it ever came up.

The implementation is sorta awkward because I don't know of a good way to implement constant effects, so the card needs to be informed of what events can possibly make its trigger condition come true and listen for those. `:counter-added` is the most obvious one, with `:runner-install` needed to handle Hivemind being installed (the counter placed on it doesn't seem to trigger :counter-added), and `:card-moved` needed to handle Hivemind being flipped faceup.