### PR TITLE
Fixed game control buttons

### DIFF
--- a/src/cljs/netrunner/main.cljs
+++ b/src/cljs/netrunner/main.cljs
@@ -40,32 +40,32 @@
 
 (defn status [cursor owner]
   (om/component
-   (sab/html
-    [:div
-     [:div.float-right
-      (let [c (count (gamelobby/filter-blocked-games (:user cursor) (:games cursor)))]
-        (str c " Game" (when (not= c 1) "s")))]
-     (if-let [game (some #(when (= (:gameid cursor) (:gameid %)) %) (:games cursor))]
-       (let [user-id (-> @app-state :user :_id)
-             is-player (some #(= user-id (-> % :user :_id)) (:players game))]
+    (sab/html
+      [:div
+       [:div.float-right
+        (let [c (count (gamelobby/filter-blocked-games (:user cursor) (:games cursor)))]
+          (str c " Game" (when (not= c 1) "s")))]
+       (if-let [game (some #(when (= (:gameid cursor) (:gameid %)) %) (:games cursor))]
+         (let [user-id (-> cursor :user :_id)
+               is-player (some #(= user-id (-> % :user :_id)) (:players game))]
+           (when (:started game)
+             [:div.float-right
+              (when is-player
+                [:a.concede-button {:on-click gamelobby/concede} "Concede"])
+              [:a.leave-button {:on-click gamelobby/leave-game} "Leave game"]
+              (when is-player
+                [:a.mute-button {:on-click #(gameboard/mute-spectators (not (:mute-spectators game)))}
+                 (if (:mute-spectators game) "Unmute spectators" "Mute spectators")])]))
+         (when (not (nil? (:gameid cursor)))
+           [:div.float-right [:a {:on-click gamelobby/leave-game} "Leave game"]]))
+       (when-let [game (some #(when (= (:gameid cursor) (:gameid %)) %) (:games cursor))]
          (when (:started game)
-           [:div.float-right
-            (when is-player
-              [:a.concede-button {:on-click gamelobby/concede} "Concede"])
-            [:a.leave-button {:on-click gamelobby/leave-game} "Leave game"]
-            (when is-player
-              [:a.mute-button {:on-click #(gameboard/mute-spectators (not (:mute-spectators game)))}
-               (if (:mute-spectators game) "Unmute spectators" "Mute spectators")])])
-         (when (not is-player)
-           [:div.float-right [:a {:on-click gamelobby/leave-game} "Leave game"]])))
-     (when-let [game (some #(when (= (:gameid cursor) (:gameid %)) %) (:games cursor))]
-       (when (:started game)
-         (let [c (count (:spectators game))]
-           (when (pos? c)
-             [:div.spectators-count.float-right (str c " Spectator" (when (> c 1) "s"))
-              [:div.blue-shade.spectators (om/build-all gamelobby/player-view
-                                                        (map (fn [%] {:player % :game game})
-                                                             (:spectators game)))]]))))])))
+           (let [c (count (:spectators game))]
+             (when (pos? c)
+               [:div.spectators-count.float-right (str c " Spectator" (when (> c 1) "s"))
+                [:div.blue-shade.spectators (om/build-all gamelobby/player-view
+                                                          (map (fn [%] {:player % :game game})
+                                                               (:spectators game)))]]))))])))
 
 (om/root navbar app-state {:target (. js/document (getElementById "left-menu"))})
 (om/root status app-state {:target (. js/document (getElementById "status"))})


### PR DESCRIPTION
I broke the `Leave`, `Concede`, and `Mute` button ribbon at the top of games when fixing the `merge old game state` bug. This PR does the checking in a better way and capture the appropriate `else` condition of the main `(if game..` section.