### PR TITLE
WiN: Remote Enforcement

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1032,9 +1032,8 @@
                                                                :choices (filter #(not (#{"HQ" "Archives" "R&D"} %))
                                                                                 (corp-install-list state chosen-ice))
                                                                :effect (effect
-                                                                        (corp-install chosen-ice target {:install-state :rezzed-no-rez-cost})
                                                                         (shuffle! :deck)
-                                                                        (effect-completed eid))}
+                                                                        (corp-install eid chosen-ice target {:install-state :rezzed-no-rez-cost}))}
                                                               card nil)))}}}
 
    "Research Grant"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1019,6 +1019,24 @@
               :effect (effect (gain :hand-size-modification 2))}
     :leave-play (effect (lose :hand-size-modification 2))}
 
+   "Remote Enforcement"
+   {:interactive (req true)
+    :optional {:prompt "Search R&D for a piece of ice to install protecting a remote server?"
+               :yes-ability {:delayed-completion true
+                             :prompt "Choose a piece of ice"
+                             :choices (req (filter ice? (:deck corp)))
+                             :effect (req (let [chosen-ice target]
+                                            (continue-ability state side
+                                                              {:delayed-completion true
+                                                               :prompt (str "Select a server to install " (:title chosen-ice) " on")
+                                                               :choices (filter #(not (#{"HQ" "Archives" "R&D"} %))
+                                                                                (corp-install-list state chosen-ice))
+                                                               :effect (effect
+                                                                        (corp-install chosen-ice target {:install-state :rezzed-no-rez-cost})
+                                                                        (shuffle! :deck)
+                                                                        (effect-completed eid))}
+                                                              card nil)))}}}
+
    "Research Grant"
    {:interactive (req true)
     :silent (req (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp))))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -255,6 +255,10 @@
                                        (= install-state :rezzed-no-cost)
                                        (rez state side eid moved-card {:ignore-cost :all-costs})
 
+                                       ;; ;; Ignore rez cost only. Pass eid to rez.
+                                       (= install-state :rezzed-no-rez-cost)
+                                       (rez state side eid moved-card {:ignore-cost :rez-costs})
+
                                        ;; Pay costs. Pass eid to rez.
                                        (= install-state :rezzed)
                                        (rez state side eid moved-card nil)

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -1999,58 +1999,53 @@
 (deftest remote-enforcement
   ;; Remote Enforcement - Search R&D for a piece of ice and install it on a remote at no rez cost
   (do-game
-   (new-game (default-corp [(qty "Research Grant" 2)
+   (new-game (default-corp [(qty "Remote Enforcement" 2)
                             (qty "Archer" 1)
                             (qty "Chiyashi" 1)])
-             ;; (make-deck "Reina Roja: Freedom Fighter" [])
-             (default-runner)
-             )
-   (starting-hand state :corp ["Research Grant" "Research Grant"])
+             (make-deck "Reina Roja: Freedom Fighter" []))
+   (starting-hand state :corp ["Remote Enforcement" "Remote Enforcement"])
    (is (= 2 (count (:deck (get-corp)))))
-   (play-and-score state "Research Grant")
+   (play-and-score state "Remote Enforcement")
    (let [N (:credit (get-corp))]
      (prompt-choice :corp "Yes")
      (prompt-choice :corp (find-card "Chiyashi" (:deck (get-corp))))
      (prompt-choice :corp "New remote")
-     ;; (println (first (get-in @state [:corp :servers]))) ; nothing anywhere
-     (is (core/rezzed? (get-ice state :server2 0)) "Chiyashi was installed rezzed")
+     (is (core/rezzed? (get-ice state :remote2 0)) "Chiyashi was installed rezzed")
      (is (= N (:credit (get-corp))) "Rezzing Chiyashi was free"))
-   (play-and-score state "Research Grant")
+   (play-and-score state "Remote Enforcement")
    (let [N (:credit (get-corp))]
      (prompt-choice :corp "Yes")
-     (prompt-choice :corp (find-card "Archer" (:deck (get-corp))))
+     (prompt-card :corp (find-card "Archer" (:deck (get-corp))))
      (prompt-choice :corp "Server 2")
      (is (= (dec N) (:credit (get-corp))) "Installing Archer cost a credit")
      (is (not-empty (:prompt (get-corp))) "Corp prompted to forfeit an agenda for Archer")
-     (is (= (dec N) (:credit (get-corp))) "Rezzing Archer didn't cost any credits"))
-   ;; (println (first (get-in @state [:corp :servers]))) ;nothing anywhere
-   ))
+     (is (= (dec N) (:credit (get-corp))) "Rezzing Archer didn't cost any credits"))))
 
-;; (deftest research-grant
-;;   ;; Research Grant
-;;   (testing "Basic test"
-;;     (do-game
-;;       (new-game (default-corp [(qty "Research Grant" 2)])
-;;                 (default-runner))
-;;       (play-from-hand state :corp "Research Grant" "New remote")
-;;       (play-and-score state "Research Grant")
-;;       (prompt-select :corp (get-content state :remote1 0))
-;;       (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")))
-;;   (testing "vs Leela"
-;;     ;; Issue #3069
-;;     (do-game
-;;       (new-game (default-corp [(qty "Research Grant" 2) (qty "Ice Wall" 2)])
-;;                 (make-deck "Leela Patel: Trained Pragmatist" [(qty "Sure Gamble" 1)]))
-;;       (core/gain state :corp :click 1)
-;;       (play-from-hand state :corp "Ice Wall" "HQ")
-;;       (play-from-hand state :corp "Ice Wall" "R&D")
-;;       (play-from-hand state :corp "Research Grant" "New remote")
-;;       (play-and-score state "Research Grant")
-;;       (prompt-select :corp (get-content state :remote1 0))
-;;       (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")
-;;       (prompt-select :runner (get-ice state :hq 0))
-;;       (prompt-select :runner (get-ice state :rd 0))
-;;       (is (empty? (:effect-completed @state)) "All score and Leela effects resolved"))))
+(deftest research-grant
+  ;; Research Grant
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Research Grant" 2)])
+                (default-runner))
+      (play-from-hand state :corp "Research Grant" "New remote")
+      (play-and-score state "Research Grant")
+      (prompt-select :corp (get-content state :remote1 0))
+      (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")))
+  (testing "vs Leela"
+    ;; Issue #3069
+    (do-game
+      (new-game (default-corp [(qty "Research Grant" 2) (qty "Ice Wall" 2)])
+                (make-deck "Leela Patel: Trained Pragmatist" [(qty "Sure Gamble" 1)]))
+      (core/gain state :corp :click 1)
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Ice Wall" "R&D")
+      (play-from-hand state :corp "Research Grant" "New remote")
+      (play-and-score state "Research Grant")
+      (prompt-select :corp (get-content state :remote1 0))
+      (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")
+      (prompt-select :runner (get-ice state :hq 0))
+      (prompt-select :runner (get-ice state :rd 0))
+      (is (empty? (:effect-completed @state)) "All score and Leela effects resolved"))))
 
 (deftest restructured-datapool
   ;; Restructured Datapool

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -1996,6 +1996,33 @@
     (play-and-score state "Remote Data Farm")
     (is (= 7 (get-hand-size :corp)))))
 
+(deftest remote-enforcement
+  ;; Remote Enforcement - Search R&D for a piece of ice and install it on a remote at no rez cost
+  (do-game
+   (new-game (default-corp [(qty "Research Grant" 2)
+                            (qty "Archer" 1)
+                            (qty "Chiyashi" 1)])
+             ;; (make-deck "Reina Roja: Freedom Fighter" [])
+             (default-runner)
+             )
+   (starting-hand state :corp ["Research Grant" "Research Grant"])
+   (is (= 2 (count (:deck (get-corp)))))
+   (play-and-score state "Research Grant")
+   (let [N (:credit (get-corp))]
+     (prompt-choice :corp "Yes")
+     (prompt-choice :corp "Chiyashi")
+     (prompt-choice :corp "New remote")
+     (is (core/rezzed? (get-ice state :server2 0)) "Chiyashi was installed rezzed")
+     (is (= N (:credit (get-corp))) "Rezzing Chiyashi was free"))
+   (play-and-score state "Research Grant")
+   (let [N (:credit (get-corp))]
+     (prompt-choice :corp "Yes")
+     (prompt-choice :corp "Archer")
+     (prompt-choice :corp "Server 2")
+     (is (= (dec N) (:credit (get-corp))) "Installing Archer cost a credit")
+     (is (not-empty (:prompt (get-corp))) "Corp prompted to forfeit an agenda for Archer")
+     (is (= N (:credit (get-corp))) "Rezzing Archer didn't cost any credits"))))
+
 (deftest research-grant
   ;; Research Grant
   (testing "Basic test"

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -2010,44 +2010,47 @@
    (play-and-score state "Research Grant")
    (let [N (:credit (get-corp))]
      (prompt-choice :corp "Yes")
-     (prompt-choice :corp "Chiyashi")
+     (prompt-choice :corp (find-card "Chiyashi" (:deck (get-corp))))
      (prompt-choice :corp "New remote")
+     ;; (println (first (get-in @state [:corp :servers]))) ; nothing anywhere
      (is (core/rezzed? (get-ice state :server2 0)) "Chiyashi was installed rezzed")
      (is (= N (:credit (get-corp))) "Rezzing Chiyashi was free"))
    (play-and-score state "Research Grant")
    (let [N (:credit (get-corp))]
      (prompt-choice :corp "Yes")
-     (prompt-choice :corp "Archer")
+     (prompt-choice :corp (find-card "Archer" (:deck (get-corp))))
      (prompt-choice :corp "Server 2")
      (is (= (dec N) (:credit (get-corp))) "Installing Archer cost a credit")
      (is (not-empty (:prompt (get-corp))) "Corp prompted to forfeit an agenda for Archer")
-     (is (= N (:credit (get-corp))) "Rezzing Archer didn't cost any credits"))))
+     (is (= (dec N) (:credit (get-corp))) "Rezzing Archer didn't cost any credits"))
+   ;; (println (first (get-in @state [:corp :servers]))) ;nothing anywhere
+   ))
 
-(deftest research-grant
-  ;; Research Grant
-  (testing "Basic test"
-    (do-game
-      (new-game (default-corp [(qty "Research Grant" 2)])
-                (default-runner))
-      (play-from-hand state :corp "Research Grant" "New remote")
-      (play-and-score state "Research Grant")
-      (prompt-select :corp (get-content state :remote1 0))
-      (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")))
-  (testing "vs Leela"
-    ;; Issue #3069
-    (do-game
-      (new-game (default-corp [(qty "Research Grant" 2) (qty "Ice Wall" 2)])
-                (make-deck "Leela Patel: Trained Pragmatist" [(qty "Sure Gamble" 1)]))
-      (core/gain state :corp :click 1)
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (play-from-hand state :corp "Ice Wall" "R&D")
-      (play-from-hand state :corp "Research Grant" "New remote")
-      (play-and-score state "Research Grant")
-      (prompt-select :corp (get-content state :remote1 0))
-      (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")
-      (prompt-select :runner (get-ice state :hq 0))
-      (prompt-select :runner (get-ice state :rd 0))
-      (is (empty? (:effect-completed @state)) "All score and Leela effects resolved"))))
+;; (deftest research-grant
+;;   ;; Research Grant
+;;   (testing "Basic test"
+;;     (do-game
+;;       (new-game (default-corp [(qty "Research Grant" 2)])
+;;                 (default-runner))
+;;       (play-from-hand state :corp "Research Grant" "New remote")
+;;       (play-and-score state "Research Grant")
+;;       (prompt-select :corp (get-content state :remote1 0))
+;;       (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")))
+;;   (testing "vs Leela"
+;;     ;; Issue #3069
+;;     (do-game
+;;       (new-game (default-corp [(qty "Research Grant" 2) (qty "Ice Wall" 2)])
+;;                 (make-deck "Leela Patel: Trained Pragmatist" [(qty "Sure Gamble" 1)]))
+;;       (core/gain state :corp :click 1)
+;;       (play-from-hand state :corp "Ice Wall" "HQ")
+;;       (play-from-hand state :corp "Ice Wall" "R&D")
+;;       (play-from-hand state :corp "Research Grant" "New remote")
+;;       (play-and-score state "Research Grant")
+;;       (prompt-select :corp (get-content state :remote1 0))
+;;       (is (= 2 (count (:scored (get-corp)))) "2 copies of Research Grant scored")
+;;       (prompt-select :runner (get-ice state :hq 0))
+;;       (prompt-select :runner (get-ice state :rd 0))
+;;       (is (empty? (:effect-completed @state)) "All score and Leela effects resolved"))))
 
 (deftest restructured-datapool
   ;; Restructured Datapool


### PR DESCRIPTION
Card implementation seems to work fine. However, the test fails on the line `(prompt-choice :corp "New remote")`, and I have no idea why. Testing out the test scenario manually, everything seems to go fine, so I'm fairly confident the card implementation is not at fault. Looking at the stack trace, it seems like at some point a string (one might guess the string "New remote") tries to be converted into a map and causes an exception, so my guess would be that the game expects a card as choice here, somehow, but I don't understand why. Any pointers would be appreciated!