### PR TITLE
WIP: Change all events to use single map

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1059,7 +1059,7 @@
       :events {:corp-turn-ends nil :runner-turn-ends nil}}
 
    "Sentinel Defense Program"
-   {:events {:pre-resolve-damage {:req (req (and (= target :brain) (> (last targets) 0)))
+   {:events {:pre-resolve-damage {:req (req (and (= (:type target) :brain) (> (:amount target) 0)))
                                   :msg "do 1 net damage"
                                   :effect (effect (damage eid :net 1 {:card card}))}}}
 
@@ -1136,7 +1136,7 @@
              :effect (effect (tag-runner :runner eid 1))}}
 
    "The Cleaners"
-   {:events {:pre-damage {:req (req (and (= target :meat)
+   {:events {:pre-damage {:req (req (and (= (:type target) :meat)
                                          (= side :corp)))
                           :msg "do 1 additional meat damage"
                           :effect (effect (damage-bonus :meat 1))}}}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1289,7 +1289,7 @@
     :abilities [ability]})
 
    "Reconstruction Contract"
-   {:events {:damage {:req (req (and (pos? (nth targets 2)) (= :meat target)))
+   {:events {:damage {:req (req (and (pos? (:amount target)) (= :meat (:type target))))
                       :effect (effect (add-counter card :advancement 1)
                                       (system-msg "adds 1 advancement token to Reconstruction Contract"))}}
     :abilities [{:label "[Trash]: Move advancement tokens to another card"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -263,11 +263,11 @@
      :runner-phase-12 {:effect (effect (enable-corp-damage-choice))}
      :pre-resolve-damage
      {:delayed-completion true
-      :req (req (and (= target :net)
+      :req (req (and (= (:type target) :net)
                      (corp-can-choose-damage? state)
-                     (> (last targets) 0)
+                     (> (:amount target) 0)
                      (empty? (filter #(= :net (first %)) (turn-events state :runner :damage)))))
-      :effect (req (damage-defer state side :net (last targets))
+      :effect (req (damage-defer state side :net (:amount target))
                    (if (= 0 (count (:hand runner)))
                      (do (swap! state update-in [:damage] dissoc :damage-choose-corp)
                          (damage state side eid :net (get-defer-damage state side :net nil)
@@ -512,7 +512,7 @@
 
    "Jinteki: Potential Unleashed"
    {:events {:pre-resolve-damage
-             {:req (req (and (-> @state :corp :disable-id not) (= target :net) (pos? (last targets))))
+             {:req (req (and (-> @state :corp :disable-id not) (= (:type target) :net) (pos? (:amount target))))
               :effect (req (let [c (first (get-in @state [:runner :deck]))]
                              (system-msg state :corp (str "uses Jinteki: Potential Unleashed to trash " (:title c)
                                                           " from the top of the Runner's Stack"))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -331,7 +331,7 @@
                          true)))))}
 
    "Defective Brainchips"
-   {:events {:pre-damage {:req (req (= target :brain)) :msg "do 1 additional brain damage"
+   {:events {:pre-damage {:req (req (= (:type target) :brain)) :msg "do 1 additional brain damage"
                           :once :per-turn :effect (effect (damage-bonus :brain 1))}}}
 
    "Distract the Masses"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -254,8 +254,8 @@
 
    "Bio-Modeled Network"
    {:prevent {:damage [:net]}
-    :events {:pre-damage {:req (req (= target :net))
-                          :effect (effect (update! (assoc card :dmg-amount (nth targets 2))))}}
+    :events {:pre-damage {:req (req (= (:type target) :net))
+                          :effect (effect (update! (assoc card :dmg-amount (:amount target))))}}
     :abilities [{:msg (msg "prevent " (dec (:dmg-amount card)) " net damage")
                  :effect (effect (damage-prevent :net (dec (:dmg-amount card)))
                                  (trash card {:cause :ability-cost}))}]}
@@ -332,8 +332,8 @@
 
    "Chrome Parlor"
    {:events
-    {:pre-damage {:req (req (has-subtype? (second targets) "Cybernetic"))
-                  :effect (effect (damage-prevent target Integer/MAX_VALUE))}}}
+    {:pre-damage {:req (req (has-subtype? (:card target) "Cybernetic"))
+                  :effect (effect (damage-prevent (:type target) Integer/MAX_VALUE))}}}
 
    "Citadel Sanctuary"
    {:prevent {:damage [:meat]}
@@ -351,7 +351,7 @@
                                              :msg "remove 1 tag"}}}}}
 
    "Clan Vengeance"
-   {:events {:pre-resolve-damage {:req (req (pos? (last targets)))
+   {:events {:pre-resolve-damage {:req (req (pos? (:amount target)))
                                   :effect (effect (add-counter card :power 1)
                                                   (system-msg :runner (str "places 1 power counter on Clan Vengeance")))}}
     :abilities [{:label "[Trash]: Trash 1 random card from HQ for each power counter"
@@ -716,7 +716,7 @@
 
    "First Responders"
    {:abilities [{:cost [:credit 2]
-                 :req (req (some #(= (:side %) "Corp") (map second (turn-events state :runner :damage))))
+                 :req (req (some #(= (get-in % [:card :side]) "Corp") (map first (turn-events state :runner :damage))))
                  :msg "draw 1 card"
                  :effect (effect (draw))}]}
 
@@ -782,9 +782,9 @@
    "Guru Davinder"
    {:flags {:cannot-pay-net-damage true}
     :events {:pre-damage
-             {:req    (req (and (or (= target :meat) (= target :net))
-                                (pos? (last targets))))
-              :msg (msg "prevent all " (if (= target :meat) "meat" "net") " damage")
+             {:req    (req (and (or (= (:type target) :meat) (= (:type target) :net))
+                                (pos? (:amount target))))
+              :msg (msg "prevent all " (if (= (:type target) :meat) "meat" "net") " damage")
               :effect (req (damage-prevent state side :meat Integer/MAX_VALUE)
                            (damage-prevent state side :net Integer/MAX_VALUE)
                            (if (< (:credit runner) 4)
@@ -1185,7 +1185,7 @@
 
    "Officer Frank"
    {:abilities [{:cost [:credit 1]
-                 :req (req (some #(= :meat %) (map first (turn-events state :runner :damage))))
+                 :req (req (some #(= :meat (:type %)) (map first (turn-events state :runner :damage))))
                  :msg "force the Corp to trash 2 random cards from HQ"
                  :effect (effect (trash-cards :corp (take 2 (shuffle (:hand corp))))
                                  (trash card {:cause :ability-cost}))}]}
@@ -1270,7 +1270,7 @@
 
    "Paparazzi"
    {:effect (req (swap! state update-in [:runner :tagged] inc))
-    :events {:pre-damage {:req (req (= target :meat)) :msg "prevent all meat damage"
+    :events {:pre-damage {:req (req (= (:type target) :meat)) :msg "prevent all meat damage"
                           :effect (effect (damage-prevent :meat Integer/MAX_VALUE))}}
     :leave-play (req (swap! state update-in [:runner :tagged] dec))}
 

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -875,9 +875,9 @@
     {:pre-resolve-damage
      {:once :per-run
       :delayed-completion true
-      :req (req (and this-server (= target :net) (> (last targets) 0) (can-pay? state :corp nil [:credit 2])))
+      :req (req (and this-server (= (:type target) :net) (> (:amount target) 0) (can-pay? state :corp nil [:credit 2])))
       :effect (req (swap! state assoc-in [:damage :damage-replace] true)
-                   (damage-defer state side :net (last targets))
+                   (damage-defer state side :net (:amount target))
                    (show-wait-prompt state :runner "Corp to use Tori Hanzō")
                    (continue-ability state side
                      {:optional {:prompt (str "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?") :player :corp
@@ -893,7 +893,7 @@
                                               :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
                                                            (clear-wait-prompt state :runner)
                                                            (effect-completed state side eid))}}} card nil))}
-     :prevented-damage {:req (req (and this-server (= target :net) (> (last targets) 0)))
+     :prevented-damage {:req (req (and this-server (= (:type target) :net) (> (:amount target) 0)))
                         :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}}}
 
    "Traffic Analyzer"

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -260,7 +260,7 @@
 (defn get-turn-damage
   "Returns the value of damage take this turn"
   [state side]
-  (apply + (map #(nth % 2) (turn-events state :runner :damage))))
+  (apply + (map #(:amount (first %)) (turn-events state :runner :damage))))
 
 (defn get-installed-trashed
   "Returns list of cards trashed this turn owned by side that were installed"


### PR DESCRIPTION
Instead of having to remember that for damage, first target is type,
second is card-source, third is amount, it would be better
to have a single target {:type :net :amount 3 :card snare}.

Have changed the following events to use a single map as target (and
fixed errors introduced by this change)

```
:pre-resolve-damage
:damage
:pre-damage
:prevented-damage
:pre-resolve-tag
:runner-gain-tag
:pre-tag
```

More to come!