### PR TITLE
Client Lock Update

### DIFF
--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -13,43 +13,41 @@
    "typingstop" core/typingstop})
 
 (def commands
-  {"typing" core/typing
-   "typingstop" core/typingstop
-   "concede" core/concede
-   "system-msg" #(core/system-msg %1 %2 (:msg %3))
+  {"ability" core/play-ability
+   "access" core/successful-run
+   "advance" core/advance
    "change" core/change
-   "move" core/move-card
-   "mulligan" core/mulligan
-   "keep" core/keep-hand
-   "start-turn" core/start-turn
+   "choice" core/resolve-prompt
+   "close-deck" core/close-deck
+   "concede" core/concede
+   "continue" core/continue
+   "corp-phase-43" core/corp-phase-43
+   "credit" core/click-credit
+   "derez" #(core/derez %1 %2 (:card %3))
+   "draw" core/click-draw
+   "dynamic-ability" core/play-dynamic-ability
    "end-phase-12" core/end-phase-12
    "end-turn" core/end-turn
-   "draw" core/click-draw
-   "credit" core/click-credit
+   "jack-out" core/jack-out
+   "keep" core/keep-hand
+   "move" core/move-card
+   "mulligan" core/mulligan
+   "no-action" core/no-action
+   "play" core/play
    "purge" core/do-purge
    "remove-tag" core/remove-tag
-   "play" core/play
    "rez" #(core/rez %1 %2 (:card %3) nil)
-   "derez" #(core/derez %1 %2 (:card %3))
    "run" core/click-run
-   "no-action" core/no-action
-   "corp-phase-43" core/corp-phase-43
-   "continue" core/continue
-   "access" core/successful-run
-   "jack-out" core/jack-out
-   "advance" core/advance
+   "runner-ability" core/play-runner-ability
    "score" #(core/score %1 %2 (game.core/get-card %1 (:card %3)))
-   "choice" core/resolve-prompt
    "select" core/select
    "shuffle" core/shuffle-deck
-   "ability" core/play-ability
-   "runner-ability" core/play-runner-ability
+   "start-turn" core/start-turn
    "subroutine" core/play-subroutine
-   "trash-resource" core/trash-resource
-   "dynamic-ability" core/play-dynamic-ability
+   "system-msg" #(core/system-msg %1 %2 (:msg %3))
    "toast" core/toast
-   "view-deck" core/view-deck
-   "close-deck" core/close-deck})
+   "trash-resource" core/trash-resource
+   "view-deck" core/view-deck})
 
 (defn strip [state]
   (-> state
@@ -135,12 +133,17 @@
      :corp-diff   corp-diff
      :spect-diff  spect-diff}))
 
+(defn set-action-id
+  "Creates a unique action id for each server response - used in client lock"
+  [state side]
+  (swap! state update-in [side :aid] (fnil inc 0)))
 
 (defn handle-action
   "Ensures the user is allowed to do command they are trying to do"
   [user command state side args]
   (if (not-spectator? state user)
-    ((commands command) state side args)
+    (do (set-action-id state side)
+        ((commands command) state side args))
     (when-let [cmd (spectator-commands command)]
       (cmd state side args))))
 

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -142,8 +142,8 @@
   "Ensures the user is allowed to do command they are trying to do"
   [user command state side args]
   (if (not-spectator? state user)
-    (do (set-action-id state side)
-        ((commands command) state side args))
+    (do ((commands command) state side args)
+        (set-action-id state side))
     (when-let [cmd (spectator-commands command)]
       (cmd state side args))))
 

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -65,6 +65,14 @@
 
 (def zoom-channel (chan))
 
+(defn check-lock?
+  "Check if we can clear client lock based on action-id"
+  []
+  (let [aid [(:side @game-state) :aid]]
+    (when (not= (get-in @game-state aid)
+                (get-in @last-state aid))
+      (reset! lock false))))
+
 (defn handle-state [{:keys [state]}]
   (init-game state)
   (reset! lock false))
@@ -72,8 +80,8 @@
 (defn handle-diff [{:keys [gameid diff]}]
   (when (= gameid (:gameid @game-state))
     (swap! game-state #(differ/patch @last-state diff))
-    (reset! last-state @game-state)
-    (reset! lock false)))
+    (check-lock?)
+    (reset! last-state @game-state)))
 
 (defn handle-timeout [{:keys [gameid]}]
   (when (= gameid (:gameid @game-state))

--- a/test/clj/game_test/rules.clj
+++ b/test/clj/game_test/rules.clj
@@ -454,8 +454,6 @@
       (take-credits state :runner))
     (testing "Turn 4 Corp"
       (is (= 4 (:agenda-point (get-corp)))) ; PS2 should get scored
-      ; (prn "publics2" (refresh publics2))
-      ; (is (= :scored (:zone (refresh publics2))))
       (is (= 12 (:credit (get-corp))))))))
 
 (deftest run-bad-publicity-credits


### PR DESCRIPTION
Improves how we handle client to server locking.  Full brain dump here:
https://github.com/mtgred/netrunner/wiki/Client-Lock-and-Handling-Client-Commands

Build failing due to unrelated TFP and Embezzle checks.  Nothing to do with this.

**Solution:**
*Create and track an action id (:aid) for each player
*This is incremented by 1 with each call for the side to handle-action
*This is sent to the client
*The client checks for each new game state. If its own side :aid has changed it can clear the lock safely.

Also cleans up two now unused typing commands, and re-orders commands to alphabetical.

Fixes #2930 
