### PR TITLE
Obelus checks against `successful-run-ends` to support Crisium Grid

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -655,7 +655,7 @@
     :events {:successful-run-ends {:once :per-turn
                                    :req (req (let [successes (turn-events state side :successful-run-ends)]
                                                (and (#{[:rd] [:hq]} (:server target))
-                                                    (empty? (filter #(some #{:rd :hq} (:server (first %))) successes)))))
+                                                    (not-any? #(some #{:rd :hq} (:server (first %))) successes))))
                                    :msg (msg "draw " (:cards-accessed target 0) " cards")
                                    :effect (effect (draw (:cards-accessed target 0)))}}}
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -653,9 +653,9 @@
     :leave-play (req (remove-watch state :obelus)
                      (lose state :runner :hand-size {:mod (:tag runner)}))
     :events {:successful-run-ends {:once :per-turn
-                                   :req (req (let [successes (rest (turn-events state side :successful-run))]
+                                   :req (req (let [successes (turn-events state side :successful-run-ends)]
                                                (and (#{[:rd] [:hq]} (:server target))
-                                                    (empty? (filter #(#{'(:rd) '(:hq)} %) successes)))))
+                                                    (empty? (filter #(some #{:rd :hq} (:server (first %))) successes)))))
                                    :msg (msg "draw " (:cards-accessed target 0) " cards")
                                    :effect (effect (draw (:cards-accessed target 0)))}}}
 

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -626,6 +626,30 @@
       (prompt-choice :runner "No action")
       (is (= 3 (count (:hand (get-runner)))) "Obelus drew 3 cards"))))
 
+(deftest obelus-crisium
+  ;; Obelus - running and trashing Crisium Grid makes run neither successful/unsuccessful
+  (do-game
+    (new-game (default-corp [(qty "Hedge Fund" 1) (qty "Crisium Grid" 1)])
+              (default-runner [(qty "Obelus" 1) (qty "Sure Gamble" 3)]))
+    (starting-hand state :corp ["Crisium Grid"])
+    (play-from-hand state :corp "Crisium Grid" "R&D")
+    (core/rez state :corp (get-content state :rd 0))
+    (take-credits state :corp)
+
+    (starting-hand state :runner ["Obelus"])
+    (play-from-hand state :runner "Obelus")
+    (is (empty? (:hand (get-runner))) "No cards in hand")
+    (run-empty-server state "R&D")
+    (prompt-choice :runner "Crisium Grid")
+    (prompt-choice-partial :runner "Pay")
+    (prompt-choice-partial :runner "Card")
+    (prompt-choice-partial :runner "No")
+    (is (empty? (:hand (get-runner))) "Crisium Grid blocked successful run")
+
+    (run-empty-server state "R&D")
+    (prompt-choice-partial :runner "No")
+    (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run")))
+
 (deftest obelus-hades-shard
   ;; Obelus - using Hades Shard during run to increase draw
   (do-game
@@ -644,6 +668,25 @@
     (card-ability state :runner (get-resource state 0) 0)
     (prompt-choice :runner "No action")
     (is (= 3 (count (:hand (get-runner)))) "Obelus drew 3 cards")))
+
+(deftest obelus-remote-server
+  ;; Obelus - running a remote server first doesn't block card draw
+  (do-game
+    (new-game (default-corp [(qty "Urban Renewal" 1) (qty "Hedge Fund" 1)])
+              (default-runner [(qty "Obelus" 1) (qty "Sure Gamble" 3)]))
+    (starting-hand state :corp ["Urban Renewal"])
+    (play-from-hand state :corp "Urban Renewal" "New remote")
+    (take-credits state :corp)
+
+    (starting-hand state :runner ["Obelus"])
+    (play-from-hand state :runner "Obelus")
+    (is (empty? (:hand (get-runner))) "No cards in hand")
+    (run-empty-server state "Server 1")
+    (prompt-choice-partial :runner "No")
+
+    (run-empty-server state "R&D")
+    (prompt-choice-partial :runner "No")
+    (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run")))
 
 (deftest plascrete
   ;; Plascrete Carapace - Prevent meat damage


### PR DESCRIPTION
Fixes #3375 