### PR TITLE
Fix Old Hollywood Grid blocking steals after trash.

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -685,22 +685,28 @@
    "Old Hollywood Grid"
    (let [ohg {:req (req (or (in-same-server? card target)
                             (from-same-server? card target)))
-              :effect (effect (register-persistent-flag!
-                                card :can-steal
-                                (fn [state _ card]
-                                  (if-not (some #(= (:title %) (:title card)) (:scored runner))
-                                    ((constantly false)
-                                      (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
-                                    true))))}]
+              :effect (req (register-persistent-flag!
+                             state side
+                             card :can-steal
+                             (fn [state _ card]
+                               (if-not (some #(= (:title %) (:title card)) (:scored runner))
+                                 ((constantly false)
+                                    (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
+                                 true))))}]
      {:trash-effect
-              {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
-               :effect (effect (register-events {:pre-steal-cost (assoc ohg :req (req (or (= (:zone (get-nested-host target)) (:previous-zone card))
-                                                                                          (= (central->zone (:zone target))
-                                                                                             (butlast (:previous-zone card))))))
-                                                 :run-ends {:effect (effect (unregister-events card))}}
-                                                (assoc card :zone '(:discard))))}
+      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
+       :effect (req (register-events
+                      state side
+                      {:pre-steal-cost (assoc ohg :req (req (or (= (:zone (get-nested-host target))
+                                                                   (:previous-zone card))
+                                                                (= (central->zone (:zone target))
+                                                                   (butlast (:previous-zone card))))))
+                       :run-ends {:effect (req (unregister-events state side (find-latest state card))
+                                               (clear-persistent-flag! state side card :can-steal))}}
+                      (assoc card :zone '(:discard))))}
       :events {:pre-steal-cost ohg
-               :access {:effect (effect (clear-persistent-flag! target :can-steal))}}})
+               :access {:effect (req (clear-persistent-flag! state side card :can-steal))}
+               :run-ends nil}})
 
    "Overseer Matrix"
    (let [om {:req (req (in-same-server? card target))


### PR DESCRIPTION
Old Hollwood Grid - clear persistent `:can-steal` at end of run when OHG is trashed

Fixes #2344 