### PR TITLE
Alternate rez cost supports bonuses

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -512,9 +512,10 @@
     :abilities [{:choices {:req (complement rezzed?)}
                  :label "Rez a card, lowering the cost by 1 [Credits]"
                  :msg (msg "rez " (:title target))
-                 :effect (effect (rez-cost-bonus -1)
-                                 (rez target {:no-warning true})
-                                 (update! (assoc card :ebc-rezzed (:cid target))))}
+                 :delayed-completion true
+                 :effect (req (rez-cost-bonus state side -1)
+                              (when-completed (rez state side target {:no-warning true})
+                                              (update! state side (assoc card :ebc-rezzed (:cid target)))))}
                 {:prompt "Choose an asset to add to HQ"
                  :msg (msg "add " (:title target) " to HQ")
                  :activatemsg "searches R&D for an asset"

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -231,12 +231,15 @@
 (defn rez-cost-bonus [state side n]
   (swap! state update-in [:bonus :cost] (fnil #(+ % n) 0)))
 
+(defn get-rez-cost-bonus [state side]
+  (get-in @state [:bonus :cost] 0))
+
 (defn rez-cost [state side {:keys [cost] :as card}]
   (when-not (nil? cost)
     (-> (if-let [rezfun (:rez-cost-bonus (card-def card))]
           (+ cost (rezfun state side (make-eid state) card nil))
           cost)
-        (+ (get-in @state [:bonus :cost] 0))
+        (+ (get-rez-cost-bonus state side))
         (max 0))))
 
 (defn run-cost-bonus [state side n]

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -557,6 +557,32 @@
       (is (= 4 (get-in @state [:corp :credit])))
       (is (= 14 (get-counters (refresh eve) :credit))))))
 
+(deftest executive-boot-camp-alternate-rez-cost
+  ;; Executive Boot Camp - works with Ice that has alternate rez costs
+  (do-game
+    (new-game (default-corp [(qty "15 Minutes" 1) (qty "Executive Boot Camp" 1)
+                             (qty "Tithonium" 1)])
+              (default-runner))
+    (core/gain state :corp :credit 3)
+    (score-agenda state :corp (find-card "15 Minutes" (:hand (get-corp))))
+    (play-from-hand state :corp "Tithonium" "HQ")
+    (play-from-hand state :corp "Executive Boot Camp" "New remote")
+    (let [ebc (get-content state :remote1 0)
+          tith (get-ice state :hq 0)]
+      (core/rez state :corp ebc)
+      (take-credits state :corp)
+      (is (= 9 (:credit (get-corp))) "Corp ends turn with 9 credits")
+
+      (take-credits state :runner)
+
+      (is (not (:rezzed (refresh tith))) "Tithonium not rezzed")
+      (is (:corp-phase-12 @state) "Corp in Step 1.2")
+      (card-ability state :corp ebc 0)
+      (prompt-select :corp tith)
+      (prompt-choice :corp "No")
+      (is (and (:installed (refresh tith)) (:rezzed (refresh tith))) "Rezzed Tithonium")
+      (is (= 1 (:credit (get-corp))) "EBC saved 1 credit on the rez of Tithonium"))))
+
 (deftest executive-boot-camp-suppress-start-of-turn
   ;; Executive Boot Camp - suppress the start-of-turn event on a rezzed card. Issue #1346.
   (do-game


### PR DESCRIPTION
When rezing a card with an alternate rez cost, any rez bonuses were cleared before the prompt resolved, which meant to bonus was used in the cost calculation.

Also were filtering args out of the recursive rez call from the prompt, so warnings were not hidden.

Liberal application of  `delayed-completion`, for good measure.

Fixes #3301 