### PR TITLE
Maw, Access, Film Critic, By Any Means Fixes

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -116,12 +116,13 @@
    {:effect (effect (register-events (:events (card-def card))
                                      (assoc card :zone '(:discard))))
     :events {:runner-turn-ends {:effect (effect (unregister-events card))}
-             :pre-access-card {:req (req (not= [:discard] (:zone target)))
-                               :delayed-completion true
-                               :msg (msg "trash " (:title target) " at no cost and suffer 1 meat damage")
-                               :effect (req (when-completed (trash state side (assoc target :seen true) nil)
-                                                            (do (swap! state assoc-in [:runner :register :trashed-card] true)
-                                                                (damage state :runner eid :meat 1 {:unboostable true}))))}}}
+             :access {:req (req (not= [:discard] (:zone target)))
+                      :interactive (req true)
+                      :delayed-completion true
+                      :msg (msg "trash " (:title target) " at no cost and suffer 1 meat damage")
+                      :effect (req (when-completed (trash state side (assoc target :seen true) nil)
+                                                   (do (swap! state assoc-in [:runner :register :trashed-card] true)
+                                                       (damage state :runner eid :meat 1 {:unboostable true}))))}}}
 
    "Calling in Favors"
    {:msg (msg "gain " (count (filter #(and (has-subtype? % "Connection") (is-type? % "Resource"))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -398,8 +398,8 @@
                   :effect (req (add-counter state :runner card :virus -1)
                                (add-counter state :runner target :virus 1))}]
      {:abilities [{:effect (effect (update! (update-in card [:special :auto-accept] #(not %)))
-                                   (toast (str "Friday Chip will now " 
-                                               (if (get-in card [:special :auto-accept]) "no longer " "") 
+                                   (toast (str "Friday Chip will now "
+                                               (if (get-in card [:special :auto-accept]) "no longer " "")
                                                "automatically add counters.") "info"))
                    :label "Toggle auomatically adding virus counters"}]
       :effect (effect (toast "Tip: You can toggle automatically adding virus counters by clicking Friday Chip."))
@@ -418,7 +418,7 @@
                                                           :msg (msg "place " (quantify target "virus counter") " on Friday Chip")
                                                           :effect (effect (add-counter :runner card :virus target))}
                                                  ab (if (> amt-trashed 1) mult-ab sing-ab)
-                                                 ab (if (get-in card [:special :auto-accept]) auto-ab ab)] 
+                                                 ab (if (get-in card [:special :auto-accept]) auto-ab ab)]
                                              (continue-ability state side ab card targets)))}}})
 
    "Gebrselassie"
@@ -522,8 +522,7 @@
 
    "Maw"
    (let [ability {:label "Trash a card from HQ"
-                  :req (req (and (first-event? state side :no-trash)
-                                 (first-event? state side :no-steal)
+                  :req (req (and (= 1 (get-in @state [:runner :register :no-trash-or-steal]))
                                  (pos? (count (:hand corp)))
                                  (not= (first (:zone target)) :discard)))
                   :once :per-turn
@@ -532,11 +531,13 @@
                                      card-seen? (= (:cid target) (:cid card-to-trash))
                                      card-to-trash (if card-seen? (assoc card-to-trash :seen true)
                                                                   card-to-trash)]
-                                 (trash state :corp card-to-trash)))}]
+                                 ;; toggle access flag to prevent Hiro issue #2638
+                                 (swap! state dissoc :access)
+                                 (trash state :corp card-to-trash)
+                                 (swap! state assoc :access true)))}]
      {:in-play [:memory 2]
       :abilities [ability]
-      :events {:no-trash ability
-               :no-steal ability}})
+      :events {:post-access-card ability}})
 
    "Maya"
    {:in-play [:memory 2]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -689,17 +689,11 @@
            (host-agenda? [agenda]
              {:optional {:prompt (str "You access " (:title agenda) ". Host it on Film Critic?")
                         :yes-ability {:effect (req (host state side card (move state side agenda :play-area))
-
-
-                                                   ;;TODO: is this necessary?
-                                                   (trigger-event state side :no-steal agenda)
-
-                                                   ;;(close-access-prompt state side)
+                                                   (access-end state side eid agenda)
                                                    (when-not (:run @state)
                                                      (swap! state dissoc :access)))
                                       :msg (msg "host " (:title agenda) " instead of accessing it")}}})]
-     {;:implementation "Use hosting ability when presented with Access prompt for an agenda"
-      :events {:access {:req (req (and (empty? (filter #(= "Agenda" (:type %)) (:hosted card)))
+     {:events {:access {:req (req (and (empty? (filter #(= "Agenda" (:type %)) (:hosted card)))
                                        (is-type? target "Agenda")))
                         :delayed-completion true
                         :effect (effect (continue-ability (host-agenda? target) card nil))}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -695,6 +695,7 @@
                                       :msg (msg "host " (:title agenda) " instead of accessing it")}}})]
      {:events {:access {:req (req (and (empty? (filter #(= "Agenda" (:type %)) (:hosted card)))
                                        (is-type? target "Agenda")))
+                        :interactive (req true)
                         :delayed-completion true
                         :effect (effect (continue-ability (host-agenda? target) card nil))}}
       :abilities [{:cost [:click 2] :label "Add hosted agenda to your score area"

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -372,9 +372,7 @@
   ([state side eid {:keys [zone type disabled] :as card} oid
    {:keys [unpreventable cause keep-server-alive suppress-event host-trashed] :as args}]
   (let [cdef (card-def card)
-        moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})
-        card-prompts (filter #(= (get-in % [:card :title]) (get moved-card :title)) (get-in @state [side :prompt]))]
-
+        moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
     (when-let [trash-effect (:trash-effect cdef)]
       (when (and (not disabled)
                  (or (and (= (:side card) "Runner")

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -43,6 +43,8 @@
   (when (and (is-type? c "Agenda")
              (not (find-cid (:cid c) (get-in @state [:runner :scored]))))
     (trigger-event state side :no-steal c))
+  (when (get-card state c)
+    (swap! state update-in [:runner :register :no-trash-or-steal] (fnil inc 0)))
   (trigger-event-sync state side eid :post-access-card c))
 
 ;;; Stealing agendas
@@ -148,12 +150,7 @@
                :choices choices
                :effect (req (cond
                               (= target "No action")
-                              (do
-                                ;; toggle access flag to prevent Hiro issue #2638
-                                (swap! state dissoc :access)
-                                (trigger-event state side :no-trash c)
-                                (swap! state assoc :access true)
-                                (access-end state side eid c))
+                              (access-end state side eid c)
 
                               (.contains target "Pay")
                               (do (lose state side :credit trash-cost)

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -367,6 +367,32 @@
       (prompt-choice :corp "No") ;; Don't trigger CTM trace
       (is (empty? (:prompt (get-runner))) "No prompt to steal since agenda was trashed")
       (is (= 1 (count (:discard (get-corp)))) "Agenda was trashed")
+      (is (= 0 (count (:hand (get-runner)))) "Took 1 meat damage")))
+  (testing "alongside Film Critic: should get the option to trigger either"
+    (do-game
+      (new-game (default-corp [(qty "Hostile Takeover" 2)])
+                (default-runner [(qty "By Any Means" 1) (qty "Film Critic" 1) (qty "Sure Gamble" 2)]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "By Any Means")
+      (play-from-hand state :runner "Film Critic")
+      (is (= 1 (count (:discard (get-runner)))) "By Any Means has been played")
+      (run-empty-server state "HQ")
+      (is (= #{"Film Critic" "By Any Means"}
+             (->> (get-runner) :prompt first :choices (into #{}))) "A choice of which to trigger first")
+      (prompt-choice :runner "Film Critic")
+      (prompt-choice :runner "No")
+      (is (= 1 (count (:discard (get-corp)))) "Agenda was trashed")
+      (is (= 1 (count (:hand (get-runner)))) "Took 1 meat damage")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (core/move state :runner (find-card "By Any Means" (:discard (get-runner))) :hand)
+      (play-from-hand state :runner "By Any Means")
+      (run-empty-server state "HQ")
+      (is (= #{"Film Critic" "By Any Means"}
+             (->> (get-runner) :prompt first :choices (into #{}))) "A choice of which to trigger first")
+      (prompt-choice :runner "By Any Means")
+      (is (nil? (->> (get-runner) :prompt first :choices)) "By Any Means trashes with no prompt")
+      (is (= 2 (count (:discard (get-corp)))) "Agenda was trashed")
       (is (= 0 (count (:hand (get-runner)))) "Took 1 meat damage"))))
 
 (deftest careful-planning

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -503,7 +503,7 @@
       (prompt-choice :runner "No action")
       (is (= 1 (count (:discard (get-corp)))) "HQ card trashed by Maw now")
       (is (:seen (first (:discard (get-corp)))) "Trashed card is registered as seen since it was accessed")))
-  (testing "with Hiro in hand - Hiro not moved to runner scored area on trash decline #2638"
+  (testing "with Hiro in hand - Hiro not moved to runner scored area on trash decline. #2638"
     (do-game
       (new-game (default-corp [(qty "Chairman Hiro" 1)])
                 (default-runner [(qty "Maw" 1)]))
@@ -512,8 +512,20 @@
       (play-from-hand state :runner "Maw")
       (run-empty-server state :hq)
       (prompt-choice :runner "No action")
-      (is (= 0 (count (:scored (get-corp)))) "Hiro not scored")
-      (is (= 1 (count (:discard (get-corp)))) "Hiro trashed by Maw"))))
+      (is (= 0 (count (:scored (get-runner)))) "Hiro not scored")
+      (is (= 1 (count (:discard (get-corp)))) "Hiro trashed by Maw")))
+  (testing "Maw shouldn't trigger on stolen agenda. #3433"
+    (do-game
+      (new-game (default-corp [(qty "Hostile Takeover" 1)
+                               (qty "Ice Wall" 5)])
+                (default-runner [(qty "Maw" 1)]))
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 20)
+      (play-from-hand state :runner "Maw")
+      (run-empty-server state :remote1)
+      (prompt-choice :runner "Steal")
+      (is (= 0 (count (:discard (get-corp)))) "No HQ card in discard as agenda was stolen"))))
 
 (deftest maya
   ;; Maya - Move accessed card to bottom of R&D

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -499,7 +499,7 @@
       (core/gain state :runner :credit 20)
       (play-from-hand state :runner "Maw")
       (run-empty-server state :hq)
-      ;; (is (= 0 (count (:discard (get-corp)))) "HQ card not trashed by Maw yet")
+      (is (= 0 (count (:discard (get-corp)))) "HQ card not trashed by Maw yet")
       (prompt-choice :runner "No action")
       (is (= 1 (count (:discard (get-corp)))) "HQ card trashed by Maw now")
       (is (:seen (first (:discard (get-corp)))) "Trashed card is registered as seen since it was accessed")))


### PR DESCRIPTION
- [x] Refactored Maw to work on `:post-access-card`, and changed requirement only trigger when `[:runner :register :no-trash-or-steal]`, which is an counter of the number of times accessed cards are not trashed or stolen in a given turn, is at 1 (the first time each turn).
- [x] Removed `(steal-trigger-events)` which was a hold-over for previously wonky Film Critic handling.
- [x] Refactored Film Critic slightly to call `(access-end)` directly instead of `:no-steal`.
- [x] Moved By Any Means from `:pre-access-card` to `:access`, ~~and changed the auto-trash to use the `:interactions` system,~~ and added `:interactive (req true)` to both By Any Means and Film Critic, so now you choose whether to use Film Critic before trashing with By Any Means.