### PR TITLE
Only display cause (not whole stack trace) on Trello API errors

### DIFF
--- a/src/clj/web/news.clj
+++ b/src/clj/web/news.clj
@@ -21,7 +21,10 @@
                 :date  (f/parse trello-time-formatter (:dateLastActivity c))})})
 
     (catch Exception e
-      (prn "Exception in news fetch" e))))
+      (->> e
+        (Throwable->map)
+        (:cause)
+        (prn "Exception in news fetch")))))
 
 (defn get-news []
   (let [{:keys [time news]} @news-items


### PR DESCRIPTION
Trello appears to be unavailable quite frequently, either via DNS issues or something on their end. Currently we dump an enormous stack trace into the server logs. This PR just prints the `:cause`.