### PR TITLE
Force Preemptive Action to take as many cards as possible (Issue #3434)

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -528,7 +528,7 @@
    {:delayed-completion true
     :effect (effect (mill :corp 2)
                     (system-msg "trashes the top 2 cards of R&D")
-                    (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) 4))}
+                    (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) 4 false))}
 
    "Green Level Clearance"
    {:msg "gain 3 [Credits] and draw 1 card"
@@ -949,7 +949,7 @@
    {:events {:pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 2]))}}}
 
    "Preemptive Action"
-   {:effect (effect (rfg-and-shuffle-rd-effect (first (:play-area corp)) 3))}
+   {:effect (effect (rfg-and-shuffle-rd-effect (first (:play-area corp)) (min (count (:discard corp)) 3) true))}
 
    "Priority Construction"
    (letfn [(install-card [chosen]

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -544,14 +544,16 @@
                        #(init-trace state :corp card trace %) {:priority (or priority 2) :base base-trace :bonus bonus})))
 
 (defn rfg-and-shuffle-rd-effect
-  ([state side card n] (rfg-and-shuffle-rd-effect state side (make-eid state) card n))
-  ([state side eid card n]
+  ([state side card n] (rfg-and-shuffle-rd-effect state side (make-eid state) card n false))
+  ([state side card n all?] (rfg-and-shuffle-rd-effect state side (make-eid state) card n all?))
+  ([state side eid card n all?]
    (move state side card :rfg)
    (continue-ability state side
                     {:show-discard  true
                      :choices {:max n
                                :req #(and (= (:side %) "Corp")
-                                          (= (:zone %) [:discard]))}
+                                          (= (:zone %) [:discard]))
+                               :all all?}
                      :msg (msg "shuffle "
                                (let [seen (filter :seen targets)
                                      m (count (filter #(not (:seen %)) targets))]

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -1181,6 +1181,35 @@
     (is (= 0 (count (:discard (get-corp)))))
     (is (= 1 (count (:rfg (get-corp)))))))
 
+(deftest preemptive-action-must-take-three
+  ;; Preemptive Action - Shuffles cards into R&D, forcing you to take 3 if there are three, and removes itself from game
+  (do-game
+    (new-game (default-corp [(qty "Subliminal Messaging" 3)
+                             (qty "Preemptive Action" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Preemptive Action")
+    (prompt-select :corp (first (:discard (get-corp))))
+    (prompt-select :corp (last (:discard (get-corp))))
+    (is (= 3 (count (:discard (get-corp)))))
+    (is (= 1 (count (:rfg (get-corp)))))))
+
+(deftest preemptive-action-small-archives
+  ;; Preemptive Action - Shuffles all archives cards into R&D if Archives has less than 3 cards, and removes itself from game
+  (do-game
+    (new-game (default-corp [(qty "Subliminal Messaging" 2)
+                             (qty "Preemptive Action" 1)])
+              (default-runner))
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Subliminal Messaging")
+    (play-from-hand state :corp "Preemptive Action")
+    (prompt-select :corp (first (:discard (get-corp))))
+    (prompt-select :corp (last (:discard (get-corp))))
+    (is (= 0 (count (:discard (get-corp)))))
+    (is (= 1 (count (:rfg (get-corp)))))))
+
 (deftest psychographics
   ;; Psychographics - Place advancements up to the number of Runner tags on a card
   (do-game


### PR DESCRIPTION
I wasn't sure how to test this beyond writing test cases (I couldn't get the local web interface working correctly), but I think this should fix #3434. The fix was to modify `rfg-and-shuffle-rd-effect` to take an additional `all?` flag indicating if the shuffle effect should force all the choices. (I modified its invocation sites as necessary.) I changed Preemptive Action's implementation to use either the size of Archives or 3, whichever is smaller, as the draw size. (I wasn't sure if it was necessary, or the framework will take care of that automatically, so I erred on the side of caution.)