### PR TITLE
Film Critic fixes

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -699,7 +699,7 @@
                         :delayed-completion true
                         :effect (effect (continue-ability (host-agenda? target) card nil))}}
       :abilities [{:cost [:click 2] :label "Add hosted agenda to your score area"
-                   :req (req (not (empty? (:hosted card))))
+                   :req (req (get-agenda card))
                    :effect (req (let [c (move state :runner (get-agenda card) :scored)]
                                   (gain-agenda-point state :runner (get-agenda-points state :runner c))))
                    :msg (msg (let [c (get-agenda card)]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -700,8 +700,10 @@
                         :effect (effect (continue-ability (host-agenda? target) card nil))}}
       :abilities [{:cost [:click 2] :label "Add hosted agenda to your score area"
                    :req (req (get-agenda card))
-                   :effect (req (let [c (move state :runner (get-agenda card) :scored)]
-                                  (gain-agenda-point state :runner (get-agenda-points state :runner c))))
+                   :delayed-completion true
+                   :effect (req (let [c (get-agenda card)
+                                      points (get-agenda-points state :runner c)]
+                                  (as-agenda state :runner eid c points)))
                    :msg (msg (let [c (get-agenda card)]
                                (str "add " (:title c) " to their score area and gain "
                                     (quantify (get-agenda-points state :runner c) "agenda point"))))}]})

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -969,6 +969,29 @@
       (is (= 14 (:credit (get-runner))) "Runner gains 2 credits")
       (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed"))))
 
+(deftest jackpot-film-critic
+  ;; Jackpot! should fire when moving agendas from Film Critic to scored area
+  (do-game
+    (new-game (default-corp [(qty "Project Vitruvius" 1)])
+              (default-runner [(qty "Jackpot!" 1) (qty "Film Critic" 1)]))
+    (play-from-hand state :corp "Project Vitruvius" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Film Critic")
+    (play-from-hand state :runner "Jackpot!")
+    (let [fc (get-resource state 0)
+          jak (get-resource state 1)]
+      (run-empty-server state "Server 1")
+      (prompt-choice :runner "Yes")
+      (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (card-ability state :runner fc 0)
+      (prompt-choice :runner "Yes")
+      (prompt-choice :runner 1)
+      (is (= 1 (count (:scored (get-runner)))) "Moved agenda to scored area")
+      (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed")
+      (is (empty? (:hosted (refresh fc))) "Removed agenda hosted on FC"))))
+
 (deftest jackpot-hiro
   ;; Jackpot! - should fire when trashing Chairman Hiro
   (do-game

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -702,6 +702,22 @@
       (is (= 1 (count (:discard (get-corp)))) "Agenda trashed")
       (is (= 3 (count (:hand (get-runner)))) "No damage dealt"))))
 
+(deftest film-critic-mca-informant
+  ;; Film Critic - required hosted cards to be an agenda before firing ability
+  (do-game
+    (new-game (default-corp [(qty "MCA Informant" 1)])
+              (default-runner [(qty "Film Critic" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Film Critic")
+    (let [fc (first (get-in @state [:runner :rig :resource]))]
+      (take-credits state :runner)
+      (play-from-hand state :corp "MCA Informant")
+      (prompt-select :corp fc)
+      (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant hosted on FC")
+      (take-credits state :corp)
+      (card-ability state :runner fc 0)
+      (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant still hosted on FC"))))
+
 (deftest find-the-truth
   ;; Find the Truth
   (testing "Basic test - On successful run see the top card from R&D before access"


### PR DESCRIPTION
Require a hosted agenda to fire the `Film Critic` ability.
Fixes #3462 