### PR TITLE
Fix Trypano infinite recursion.

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1010,9 +1010,9 @@
                  {:optional {:prompt (msg "Place a virus counter on Trypano?")
                              :yes-ability {:msg (msg "place a virus counter on Trypano")
                                            :effect (req (add-counter state side card :virus 1))}}}
-                 :counter-added {:effect trash-if-5
+                 :counter-added {:delayed-completion true
                                  :req (req (= (:cid card) (:cid target)))
-                                 :delayed-completion true}
+                                 :effect trash-if-5}
                  :card-moved {:effect trash-if-5
                               :delayed-completion true}
                  :runner-install {:effect trash-if-5


### PR DESCRIPTION
`:counter-added` is triggered on ANY card getting a counter. Tryp trashes ice -> Friday Chip gets a counter -> Tryp sees new counter, trashes ice again -> Friday Chip gets a counter -> etc.