### PR TITLE
Refactors Freedom Khumalo.

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -152,8 +152,8 @@
   ([selected-cards counter-count target-count]
    {:delayed-completion true
     :prompt (str "Select a card with virus counters ("
-                 counter-count (when (pos? target-count) (str " out of " target-count))
-                 " virus counters taken)")
+                 counter-count (when (pos? target-count) (str " of " target-count))
+                 " virus counters)")
     :choices {:req #(and (installed? %)
                          (pos? (get-in % [:counter :virus] 0)))}
     :effect (req (add-counter state :runner target :virus -1)

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -152,7 +152,7 @@
   ([selected-cards counter-count target-count]
    {:delayed-completion true
     :prompt (str "Select a card with virus counters ("
-                 counter-count (when (pos? target-count) " out of " target-count)
+                 counter-count (when (pos? target-count) (str " out of " target-count))
                  " virus counters taken)")
     :choices {:req #(and (installed? %)
                          (pos? (get-in % [:counter :virus] 0)))}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -334,62 +334,38 @@
                               :effect (req (draw state side eid 1 nil))}}}
 
    "Freedom Khumalo: Crypto-Anarchist"
-   (letfn [(fkca [accessed-card play-or-rez selected-cards]
-             (if (not= 0 play-or-rez)
-               {:delayed-completion true
-                :prompt "Select a card with at least 1 virus counter"
-                :choices {:req #(and (installed? %)
-                                     (> (get-in % [:counter :virus] 0) 0))}
-                :effect (req (when (not= (:cid target) (:cid card))
-                               (add-counter state :runner card :virus 1)
-                               (add-counter state :runner target :virus -1)
-                               (let [card (get-card state card)
-                                     selected-cards (merge-with + selected-cards {(:cid target) 1})]
-                                 (if (< (get-in card [:counter :virus] 0) play-or-rez)
-                                   (continue-ability state side (fkca accessed-card play-or-rez selected-cards) card nil)
-                                   (let [counters (get-in (get-card state card) [:counter :virus] 0)]
-                                     (add-counter state :runner card :virus (- counters))
-                                     (system-msg state :runner
-                                       (str "trash " (:title accessed-card) " at no cost"
-                                         (when (> play-or-rez 0)
-                                           (str " spending "
-                                             (clojure.string/join ", "
-                                               (map #(str (quantify (get selected-cards (:cid %)) "virus counter")
-                                                       " from " (:title %))
-                                                    (map #(find-cid % (all-installed state :runner))
-                                                         (keys selected-cards))))))))
-                                     (clear-wait-prompt state :corp)
-                                     (trash-no-cost state side eid accessed-card))))))
-                :cancel-effect (req (doseq [c (all-installed state :runner)]
-                                      (let [cid (:cid c)]
-                                        (when (contains? selected-cards cid)
-                                          (add-counter state :runner c :virus (get selected-cards cid)))))
-                                    (let [counters (get-in (get-card state card) [:counter :virus] 0)]
-                                      (add-counter state :runner card :virus (- counters)))
-                                    (clear-wait-prompt state :corp)
-                                    (swap! state dissoc-in [:per-turn (:cid card)])
-                                    (access-non-agenda state side eid accessed-card))}
-               {:delayed-completion true
-                :msg (msg "trash " (:title accessed-card) " at no cost")
-                :effect (effect (clear-wait-prompt :corp)
-                                (trash-no-cost eid accessed-card))}))]
-     {:flags {:slow-trash (req true)}
-      :interactions
-      {:trash-ability
-       {:interactive (req true)
-        :delayed-completion true
-        :label "[Freedom]: Trash card"
-        :req (req (and (not (get-in @state [:per-turn (:cid card)]))
-                       (not (is-type? target "Agenda"))
-                       (<= (:cost target)
-                           (reduce + (map #(get-in % [:counter :virus])
-                                          (filter #(> (get-in % [:counter :virus] 0) 0)
-                                                  (all-installed state :runner)))))))
-        :once :per-turn
-        :effect (req (let [accessed-card target
-                           play-or-rez (:cost target)]
-                       (show-wait-prompt state :corp "Runner to use Freedom Khumalo's ability")
-                       (continue-ability state side (fkca accessed-card play-or-rez (hash-map)) card nil)))}}})
+   {:flags {:slow-trash (req true)}
+    :interactions
+    {:trash-ability
+     {:interactive (req true)
+      :delayed-completion true
+      :label "[Freedom]: Trash card"
+      :req (req (and (not (get-in @state [:per-turn (:cid card)]))
+                     (not (is-type? target "Agenda"))
+                     (<= (:cost target)
+                         (reduce + (map #(get-in % [:counter :virus] 0)
+                                        (all-installed state :runner))))))
+      :once :per-turn
+      :effect (req (let [accessed-card target
+                         play-or-rez (:cost target)]
+                     (show-wait-prompt state :corp "Runner to use Freedom Khumalo's ability")
+                     (if (zero? play-or-rez)
+                       (continue-ability state side
+                                         {:delayed-completion true
+                                          :msg (msg "trash " (:title accessed-card) " at no cost")
+                                          :effect (effect (clear-wait-prompt :corp)
+                                                          (trash-no-cost eid accessed-card))}
+                                         card nil)
+                       (when-completed (resolve-ability state side (pick-virus-counters-to-spend play-or-rez) card nil)
+                                       (do (clear-wait-prompt state :corp)
+                                           (if-let [msg (:msg async-result)]
+                                             (do (system-msg state :runner
+                                                             (str "trash " (:title accessed-card)
+                                                                  " at no cost spending " msg))
+                                                 (trash-no-cost state side eid accessed-card))
+                                             ;; Player cancelled ability
+                                             (do (swap! state dissoc-in [:per-turn (:cid card)])
+                                                 (access-non-agenda state side eid accessed-card))))))))}}}
 
    "Fringe Applications: Tomorrow, Today"
    {:events

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -360,8 +360,9 @@
                                        (do (clear-wait-prompt state :corp)
                                            (if-let [msg (:msg async-result)]
                                              (do (system-msg state :runner
-                                                             (str "trash " (:title accessed-card)
-                                                                  " at no cost spending " msg))
+                                                             (str "uses Freedom Khumalo: Crypto-Anarchist to"
+                                                                  " trash " (:title accessed-card)
+                                                                  " at no cost, spending " msg))
                                                  (trash-no-cost state side eid accessed-card))
                                              ;; Player cancelled ability
                                              (do (swap! state dissoc-in [:per-turn (:cid card)])

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -350,16 +350,16 @@
   (testing "Only works with Assets, ICE, Operations, and Upgrades"
     (letfn [(fk-test [card]
               (do-game
-                (new-game (default-corp [(qty card 1)])
-                          (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                                     [(qty "Cache" 1)]))
+                (new-game (default-corp [card])
+                          (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache"]))
                 (take-credits state :corp)
                 (play-from-hand state :runner "Cache")
                 (run-empty-server state "HQ")
                 (prompt-choice-partial :runner "Freedom")
                 (prompt-select :runner (get-program state 0))
                 (prompt-select :runner (get-program state 0))
-                (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")))]
+                (is (= 1 (count (:discard (get-corp))))
+                    (str "Accessed " card " should have been trashed after selecting two virus counters"))))]
       (doall (map fk-test
                   ["Dedicated Response Team"
                    "Consulting Visit"
@@ -368,9 +368,8 @@
   (testing "Triggers when play/rez cost less than or equal to number of available virus counters"
     (letfn [(fk-test [card]
               (do-game
-                (new-game (default-corp [(qty card 1)])
-                          (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                                     [(qty "Cache" 1)]))
+                (new-game (default-corp [card])
+                          (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache"]))
                 (take-credits state :corp)
                 (play-from-hand state :runner "Cache")
                 (run-empty-server state "HQ")
@@ -378,8 +377,9 @@
                   (prompt-choice-partial :runner "Freedom")
                   (when (< 0 cost)
                     (dotimes [_ cost]
-                      (prompt-select :runner (get-program state 0)))))
-                (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")))]
+                      (prompt-select :runner (get-program state 0))))
+                  (is (= 1 (count (:discard (get-corp))))
+                      (str "Accessed " card " should have been trashed after selecting " cost " virus counters")))))]
       (doall (map fk-test
                   ["Beanstalk Royalties"
                    "Aggressive Negotiation"
@@ -388,9 +388,8 @@
   (testing "Doesn't trigger when there aren't enough available virus counters"
     (letfn [(fk-test [card]
               (do-game
-                (new-game (default-corp [(qty card 1)])
-                          (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                                     [(qty "Cache" 1)]))
+                (new-game (default-corp [card])
+                          (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache"]))
                 (take-credits state :corp)
                 (play-from-hand state :runner "Cache")
                 (run-empty-server state "HQ")
@@ -403,9 +402,8 @@
                    "Tyrant"]))))
   (testing "Can use multiple programs for virus counter payment"
     (do-game
-      (new-game (default-corp [(qty "Dedicated Response Team" 1)])
-                (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                           [(qty "Cache" 1) (qty "Virus Breeding Ground" 1)]))
+      (new-game (default-corp ["Dedicated Response Team"])
+                (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache" "Virus Breeding Ground"]))
       (take-credits state :corp)
       (play-from-hand state :runner "Cache")
       (play-from-hand state :runner "Virus Breeding Ground")
@@ -415,12 +413,12 @@
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (prompt-select :runner (get-resource state 0))
-      (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")))
+      (is (= 1 (count (:discard (get-corp))))
+          (str "Accessed Dedicated Response Team should have been trashed after selecting 2 virus counters"))))
   (testing "Can use viruses on hosted cards"
     (do-game
       (new-game (default-corp [(qty "Ice Wall" 2)])
-                (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                           [(qty "Trypano" 1)]))
+                (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Trypano"]))
       (play-from-hand state :corp "Ice Wall" "R&D")
       (let [iw (get-ice state :rd 0)]
         (take-credits state :corp)
@@ -432,12 +430,11 @@
         (run-empty-server state "HQ")
         (prompt-choice-partial :runner "Freedom")
         (prompt-select :runner (->> (refresh iw) :hosted first)))
-      (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")))
+      (is (= 1 (count (:discard (get-corp)))) "Accessed Ice Wall should be discarded after selecting 1 virus counter")))
   (testing "Doesn't trigger when accessing an Agenda"
     (do-game
-      (new-game (default-corp [(qty "Hostile Takeover" 1)])
-                (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                           [(qty "Cache" 1)]))
+      (new-game (default-corp ["Hostile Takeover"])
+                (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache"]))
       (take-credits state :corp)
       (play-from-hand state :runner "Cache")
       (run-empty-server state "HQ")
@@ -445,9 +442,9 @@
       (is (= "Steal" (->> @state :runner :prompt first :choices first)) "Only option should be 'Steal'")))
   (testing "Shows multiple prompts when playing Imp"
     (do-game
-      (new-game (default-corp [(qty "Dedicated Response Team" 1)])
+      (new-game (default-corp ["Dedicated Response Team"])
                 (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                           [(qty "Sure Gamble" 1) (qty "Cache" 1) (qty "Imp" 1)]))
+                           ["Sure Gamble" "Cache" "Imp"]))
       (take-credits state :corp)
       (play-from-hand state :runner "Sure Gamble")
       (play-from-hand state :runner "Cache")
@@ -456,17 +453,18 @@
       (is (= 4 (->> @state :runner :prompt first :choices count)) "Should have 4 options: Freedom, Imp, Trash, No action")))
   (testing "Should return to access prompts when Done is pressed"
     (do-game
-      (new-game (default-corp [(qty "Dedicated Response Team" 1)])
-                (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                           [(qty "Cache" 1)]))
+      (new-game (default-corp ["Dedicated Response Team"])
+                (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache"]))
       (take-credits state :corp)
       (play-from-hand state :runner "Cache")
       (run-empty-server state "HQ")
-      (is (= 3 (->> @state :runner :prompt first :choices count)) "Should have 3 prompts: Freedom, Trash, No action")
+      (is (= 3 (->> @state :runner :prompt first :choices count)) "Should have 3 choices: Freedom, Trash, No action")
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (prompt-choice :runner "Done")
-      (is (= 3 (->> @state :runner :prompt first :choices count)) "Should go back to access prompts")
+      (is (= 3 (->> @state :runner :prompt first :choices count))
+          (str "Should go back to access prompts, with 3 choices: Freedom, Trash, No action. "
+               "Choices seen: " (->> @state :runner :prompt first :choices)))
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (prompt-select :runner (get-program state 0))
@@ -474,14 +472,13 @@
   (testing "Shouldn't grant additional accesses after trashing accessed card. #3423"
     (do-game
       (new-game (default-corp [(qty "Ice Wall" 10)])
-                (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                           [(qty "Cache" 1)]))
+                (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache"]))
       (take-credits state :corp)
       (play-from-hand state :runner "Cache")
       (run-empty-server state "R&D")
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
-      (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")
+      (is (= 1 (count (:discard (get-corp)))) "Accessed Ice Wall should be discarded now")
       (is (not (:run @state)) "Run ended")))
   (testing "Shouldn't give Aumakua additional counters on trash. #3479"
     (do-game


### PR DESCRIPTION
 Adds more generic "pick virus counters from cards" for use with Yusuf and the virus killer.

Some stylistic changes to Khumalo tests. String output not checked locally. Will do tomorrow.

New function written with Yusuf and Musaazi in mind. For the breakers, you can trigger the function's return ability after specifying how many counters to pick. The `async-result` contains the number of virus counters picked and the msg-string of all cards + counters.

Needs support for "Done" + "Cancel" buttons on prompts to be extra snazzy, not sure we can do that yet.