### PR TITLE
Less error logging for actions on closed games

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -61,6 +61,15 @@
       (swap! old-states assoc gameid @state)
       (send-state-diffs! game (main/public-diffs old-state state)))))
 
+(defn- active-game?
+  [gameid-str client-id]
+  (let [gameid (java.util.UUID/fromString gameid-str)
+        game-from-gameid (lobby/game-for-id gameid)
+        game-from-clientid (lobby/game-for-client client-id)]
+    (and game-from-clientid
+         game-from-gameid
+         (= (:gameid game-from-clientid) (:gameid game-from-gameid)))))
+
 (defn handle-game-start
   [{{{:keys [username] :as user} :user} :ring-req
     client-id                           :client-id}]
@@ -86,7 +95,8 @@
 
 (defn handle-game-leave
   [{{{:keys [username] :as user} :user} :ring-req
-    client-id                           :client-id}]
+    client-id                           :client-id
+    {:keys [gameid-str] :as msg}        :?data}]
   (let [{:keys [started players gameid state] :as game} (lobby/game-for-client client-id)]
     (when (and started state)
       (lobby/remove-user client-id gameid)
@@ -116,47 +126,55 @@
 
 (defn handle-game-concede
   [{{{:keys [username] :as user} :user} :ring-req
-    client-id                           :client-id}]
-  (let [{:keys [started players gameid state] :as game} (lobby/game-for-client client-id)
-        side (some #(when (= client-id (:ws-id %)) (:side %)) players)]
-    (when (lobby/player? client-id gameid)
-      (main/handle-concede state (side-from-str side))
-      (swap-and-send-diffs! game))))
+    client-id                           :client-id
+    {:keys [gameid-str] :as msg}        :?data}]
+  (when (active-game? gameid-str client-id)
+    (let [gameid (java.util.UUID/fromString gameid-str)
+          {:keys [started players state] :as game} (lobby/game-for-id gameid)
+          side (some #(when (= client-id (:ws-id %)) (:side %)) players)]
+      (when (lobby/player? client-id gameid)
+        (main/handle-concede state (side-from-str side))
+        (swap-and-send-diffs! game)))))
 
 (defn handle-mute-spectators
-  [{{{:keys [username] :as user} :user} :ring-req
-    client-id                           :client-id
-    mute-state                          :?data}]
-  (let [{:keys [gameid started state] :as game} (lobby/game-for-client client-id)
-        message (if mute-state "muted" "unmuted")]
-    (when (lobby/player? client-id gameid)
-      (swap! all-games assoc-in [gameid :mute-spectators] mute-state)
-      (main/handle-notification state (str username " " message " specatators."))
-      (lobby/refresh-lobby :update gameid)
-      (swap-and-send-diffs! game)
-      (ws/broadcast-to! (lobby/lobby-clients gameid)
-                        :games/diff
-                        {:diff {:update {gameid (lobby/game-public-view (lobby/game-for-id gameid))}}}))))
+  [{{{:keys [username] :as user} :user}          :ring-req
+    client-id                                    :client-id
+    {:keys [gameid-str mute-state] :as msg}      :?data}]
+  (when (active-game? gameid-str client-id)
+    (let [gameid (java.util.UUID/fromString gameid-str)
+          {:keys [started state] :as game} (lobby/game-for-id gameid)
+          message (if mute-state "muted" "unmuted")]
+      (when (lobby/player? client-id gameid)
+        (swap! all-games assoc-in [gameid :mute-spectators] mute-state)
+        (main/handle-notification state (str username " " message " specatators."))
+        (lobby/refresh-lobby :update gameid)
+        (swap-and-send-diffs! game)
+        (ws/broadcast-to! (lobby/lobby-clients gameid)
+                          :games/diff
+                          {:diff {:update {gameid (lobby/game-public-view (lobby/game-for-id gameid))}}})))))
 
 (defn handle-game-action
   [{{{:keys [username] :as user} :user}        :ring-req
     client-id                                  :client-id
     {:keys [gameid-str command args] :as msg}      :?data}]
-  (let [gameid (java.util.UUID/fromString gameid-str)
-        {:keys [players state] :as game} (lobby/game-for-id gameid)
-        old-state (get @old-states gameid)
-        side (some #(when (= client-id (:ws-id %)) (:side %)) players)]
-    (if (and state side)
-      (do
-        (main/handle-action user command state (side-from-str side) args)
-        (swap! all-games assoc-in [gameid :last-update] (t/now))
-        (swap-and-send-diffs! game))
-      (do
-        (println "HandleGameAction: unknown state or side")
-        (println "\tGameID:" gameid)
-        (println "\tGameID by ClientID:" (:gameid (lobby/game-for-client client-id)))
-        (println "\tCommand:" command)
-        (println "\tArgs:" args)))))
+  (when (active-game? gameid-str client-id)
+    (let [gameid (java.util.UUID/fromString gameid-str)
+          {:keys [players state] :as game} (lobby/game-for-id gameid)
+          side (some #(when (= client-id (:ws-id %)) (:side %)) players)]
+      (if (and state side)
+        (do
+          (main/handle-action user command state (side-from-str side) args)
+          (swap! all-games assoc-in [gameid :last-update] (t/now))
+          (swap-and-send-diffs! game))
+        (do
+          (println "HandleGameAction: unknown state or side")
+          (println "\tGameID:" gameid)
+          (println "\tGameID by ClientID:" (:gameid (lobby/game-for-client client-id)))
+          (println "\tClientID:" client-id)
+          (println "\tSide:" side)
+          (println "\tPlayers:" players)
+          (println "\tCommand:" command)
+          (println "\tArgs:" args))))))
 
 (defn handle-game-watch
   "Handles a watch command when a game has started."
@@ -193,28 +211,30 @@
   [{{{:keys [username] :as user} :user} :ring-req
     client-id                           :client-id
     {:keys [gameid-str msg]}                :?data}]
-  (let [gameid (java.util.UUID/fromString gameid-str)
-        {:keys [state mute-spectators] :as game} (lobby/game-for-id gameid)
-        {:keys [side user]} (lobby/player? client-id gameid)]
-    (if (and state side user)
-      (do (main/handle-say state (jinteki.utils/side-from-str side) user msg)
-        (swap-and-send-diffs! game))
-      (let [{:keys [user]} (lobby/spectator? client-id gameid)]
-        (when (and user (not mute-spectators))
-          (main/handle-say state :spectator user msg)
-          (swap! all-games assoc-in [gameid :last-update] (t/now))
-          (swap-and-send-diffs! game))))))
+  (when (active-game? gameid-str client-id)
+    (let [gameid (java.util.UUID/fromString gameid-str)
+          {:keys [state mute-spectators] :as game} (lobby/game-for-id gameid)
+          {:keys [side user]} (lobby/player? client-id gameid)]
+      (if (and state side user)
+        (do (main/handle-say state (jinteki.utils/side-from-str side) user msg)
+          (swap-and-send-diffs! game))
+        (let [{:keys [user]} (lobby/spectator? client-id gameid)]
+          (when (and user (not mute-spectators))
+            (main/handle-say state :spectator user msg)
+            (swap! all-games assoc-in [gameid :last-update] (t/now))
+            (swap-and-send-diffs! game)))))))
 
 (defn handle-game-typing
   [{{{:keys [username] :as user} :user} :ring-req
     client-id                           :client-id
     {:keys [gameid-str typing]}             :?data}]
-  (let [gameid (java.util.UUID/fromString gameid-str)
-        {:keys [state] :as game} (lobby/game-for-id gameid)
-        {:keys [side user]} (lobby/player? client-id gameid)]
-    (when (and state side user)
-      (main/handle-typing state (jinteki.utils/side-from-str side) user typing)
-      (swap-and-send-diffs! game))))
+  (when (active-game? gameid-str client-id)
+    (let [gameid (java.util.UUID/fromString gameid-str)
+          {:keys [state] :as game} (lobby/game-for-id gameid)
+          {:keys [side user]} (lobby/player? client-id gameid)]
+      (when (and state side user)
+        (main/handle-typing state (jinteki.utils/side-from-str side) user typing)
+        (swap-and-send-diffs! game)))))
 
 (defn handle-ws-close [{{{:keys [username] :as user} :user} :ring-req
                         client-id                           :client-id}]

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -148,7 +148,10 @@
         (ws/ws-send! [:netrunner/typing {:gameid-str (:gameid @game-state) :typing true}])))))
 
 (defn mute-spectators [mute-state]
-  (ws/ws-send! [:netrunner/mute-spectators mute-state]))
+  (ws/ws-send! [:netrunner/mute-spectators {:gameid-str (:gameid @game-state) :mute-state mute-state}]))
+
+(defn concede []
+  (ws/ws-send! [:netrunner/concede {:gameid-str (:gameid @game-state)}]))
 
 (defn build-exception-msg [msg error]
   (letfn [(build-report-url [error]

--- a/src/cljs/netrunner/gamelobby.cljs
+++ b/src/cljs/netrunner/gamelobby.cljs
@@ -159,16 +159,13 @@
   (swap! app-state dissoc :password-gameid))
 
 (defn leave-game []
-  (ws/ws-send! [:netrunner/leave])
+  (ws/ws-send! [:netrunner/leave {:gameid-str (:gameid @game-state)}])
   (reset! game-state nil)
   (swap! app-state dissoc :gameid :side :password-gameid :win-shown)
   (.removeItem js/localStorage "gameid")
   (set! (.-onbeforeunload js/window) nil)
   (-> "#gameboard" js/$ .fadeOut)
   (-> "#gamelobby" js/$ .fadeIn))
-
-(defn concede []
-  (ws/ws-send! [:netrunner/concede]))
 
 (defn send-msg [event owner]
   (.preventDefault event)

--- a/src/cljs/netrunner/main.cljs
+++ b/src/cljs/netrunner/main.cljs
@@ -51,7 +51,7 @@
            (when (:started game)
              [:div.float-right
               (when is-player
-                [:a.concede-button {:on-click gamelobby/concede} "Concede"])
+                [:a.concede-button {:on-click gameboard/concede} "Concede"])
               [:a.leave-button {:on-click gamelobby/leave-game} "Leave game"]
               (when is-player
                 [:a.mute-button {:on-click #(gameboard/mute-spectators (not (:mute-spectators game)))}


### PR DESCRIPTION
Updated `Say` and `Typing` to check for a valid server side game before attempting to execute. Not logging errors for any command sent to a non-existent game.