### PR TITLE
Further refining the hunt for nil identities when checking decks

### DIFF
--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -34,6 +34,10 @@
                    (assoc :username username))
           status (decks/calculate-deck-status check-deck)
           deck (assoc deck :status status)]
+      (when (nil? (:identity check-deck))
+        (println "NIL IDENTITY WHEN SAVING DECK")
+        (println "Deck:" deck)
+        (println "-----------------------------"))
       (if-let [deck-id (:_id deck)]
         (if (:identity deck)
           (do (mc/update db "decks"

--- a/src/cljc/jinteki/decks.cljc
+++ b/src/cljc/jinteki/decks.cljc
@@ -289,17 +289,14 @@
            (not= (:faction card) "Jinteki"))))
 
 (defn valid-deck? [{:keys [identity cards] :as deck}]
-  (when (not (and cards identity))
-    (println "Valid Deck: Deck" deck))
-  (let [cnt (card-count cards)
-        min-size (min-deck-size identity)]
-    (and (>= (card-count cards) (min-deck-size identity))
-         (<= (influence-count deck) (id-inf-limit identity))
-         (every? #(and (allowed? (:card %) identity)
-                       (legal-num-copies? identity %)) cards)
-         (or (= (:side identity) "Runner")
-             (let [min (min-agenda-points deck)]
-               (<= min (agenda-points deck) (inc min)))))))
+  (and (not (nil? identity))
+       (>= (card-count cards) (min-deck-size identity))
+       (<= (influence-count deck) (id-inf-limit identity))
+       (every? #(and (allowed? (:card %) identity)
+                     (legal-num-copies? identity %)) cards)
+       (or (= (:side identity) "Runner")
+           (let [min (min-agenda-points deck)]
+             (<= min (agenda-points deck) (inc min))))))
 
 (defn mwl-legal?
   "Returns true if the deck does not contain banned cards or more than one type of restricted card"


### PR DESCRIPTION
The `valid_deck` call is failing because we are still getting decks with a `nil` identity. I'm catching the `nil` and marking the deck as invalid rather than crash now.

Printing out further debug info upstream.