### PR TITLE
Paperclip shouldn't crash if fired on facedown ice

### DIFF
--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -753,7 +753,7 @@
    (conspiracy "Paperclip" "Barrier"
                [{:label (str "X [Credits]: +X strength, break X subroutines")
                  :choices {:number (req (:credit runner))
-                           :default (req (if current-ice
+                           :default (req (if (:current-strength current-ice)
                                            (max (- (:current-strength current-ice)
                                                    (:current-strength card))
                                                 1)

--- a/test/clj/game_test/cards/icebreakers.clj
+++ b/test/clj/game_test/cards/icebreakers.clj
@@ -486,6 +486,18 @@
     (run-on state "Archives")
     (is (empty? (:prompt (get-runner))) "No prompt to install second Paperclip")))
 
+(deftest paperclip-facedown
+  ;; Paperclip - firing on facedown ice shouldn't crash
+  (do-game
+    (new-game (default-corp [(qty "Vanilla" 1)])
+              (default-runner [(qty "Paperclip" 1)]))
+    (play-from-hand state :corp "Vanilla" "Archives")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Paperclip")
+    (run-on state "Archives")
+    (card-ability state :runner (get-program state 0) 0)
+    (prompt-choice :runner 0)))
+
 (deftest paperclip-multiple
   ;; Paperclip - do not show a second install prompt if user said No to first, when multiple are in heap
   (do-game


### PR DESCRIPTION
`current-strength` isn't set for facedown ice. It was being used to set the default strength in the `Paperclip` prompt.