### PR TITLE
End of Game Stats

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -7,6 +7,7 @@
                                 combine-subtypes remove-subtypes remove-subtypes-once click-spent? used-this-turn?
                                 pluralize quantify type->rig-zone safe-zero? safe-inc-n sub->0]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
+            [clj-time.core :as t]
             [clojure.string :refer [split-lines split join lower-case includes?]]
             [clojure.core.match :refer [match]]
             [clojure.stacktrace :refer [print-stack-trace]]

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -36,6 +36,7 @@
     (system-msg state side "spends [Click] to draw a card")
     (trigger-event state side (if (= side :corp) :corp-click-draw :runner-click-draw) (->> @state side :deck (take 1)))
     (draw state side)
+    (swap! state update-in [:stats side :click :draw] (fnil inc 0))
     (play-sfx state side "click-card")))
 
 (defn click-credit
@@ -44,6 +45,7 @@
   (when (pay state side nil :click 1 {:action :corp-click-credit})
     (system-msg state side "spends [Click] to gain 1 [Credits]")
     (gain state side :credit 1)
+    (swap! state update-in [:stats side :click :credit] (fnil inc 0))
     (trigger-event state side (if (= side :corp) :corp-click-credit :runner-click-credit))
     (play-sfx state side "click-credit")))
 

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -372,6 +372,7 @@
                        (do (update-ice-strength state side card)
                            (play-sfx state side "rez-ice"))
                        (play-sfx state side "rez-other"))
+                     (swap! state update-in [:stats :corp :cards :rezzed] (fnil inc 0))
                      (trigger-event-sync state side eid :rez card)))))
            (effect-completed state side eid))
          (swap! state update-in [:bonus] dissoc :cost))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -206,17 +206,22 @@
       ;; amount is a map, merge-update map
       (map? amount)
       (doseq [[subtype amount] amount]
-        (swap! state update-in [side type subtype] (safe-inc-n amount)))
+        (swap! state update-in [side type subtype] (safe-inc-n amount))
+        (swap! state update-in [:stats side :gain type subtype] (fnil + 0) amount))
       ;; Else assume amount is a number and try to increment type by it.
       :else
-      (swap! state update-in [side type] (safe-inc-n amount)))))
+      (do (swap! state update-in [side type] (safe-inc-n amount))
+          (swap! state update-in [:stats side :gain type] (fnil + 0) amount)))))
 
 (defn lose [state side & args]
   (doseq [r (partition 2 args)]
     (trigger-event state side (if (= side :corp) :corp-loss :runner-loss) r)
     (if (= (last r) :all)
-      (swap! state assoc-in [side (first r)] 0)
-      (deduct state side r))))
+      (do (swap! state assoc-in [side (first r)] 0)
+          (swap! state update-in [:stats side :lose (first r)] (fnil + 0) (get-in @state [side (first r)])))
+      (do (when (number? (second r))
+            (swap! state update-in [:stats side :lose (first r)] (fnil + 0) (second r)))
+          (deduct state side r)))))
 
 (defn play-cost-bonus [state side costs]
   (swap! state update-in [:bonus :play-cost] #(merge-costs (concat % costs))))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -280,7 +280,6 @@
   (if (pos? n)
     (do (gain state :runner :tag n)
         (toast state :runner (str "Took " (quantify n "tag") "!") "info")
-        (swap! state update-in [:stats :runner :gain :tag] (fnil + 0) n)
         (trigger-event-sync state side eid :runner-gain-tag n))
     (effect-completed state side eid)))
 

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -118,6 +118,7 @@
          (swap! state update-in [side :deck] (partial drop draws-after-prevent))
          (swap! state assoc-in [side :register :most-recent-drawn] drawn)
          (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % draws-after-prevent) 0))
+         (swap! state update-in [:stats side :gain :card] (fnil + 0) n)
          (swap! state update-in [:bonus] dissoc :draw)
          (if (and (not suppress-event) (pos? deck-count))
            (when-completed
@@ -279,6 +280,7 @@
   (if (pos? n)
     (do (gain state :runner :tag n)
         (toast state :runner (str "Took " (quantify n "tag") "!") "info")
+        (swap! state update-in [:stats :runner :gain :tag] (fnil + 0) n)
         (trigger-event-sync state side eid :runner-gain-tag n))
     (effect-completed state side eid)))
 

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -25,6 +25,7 @@
        (gain-run-credits state side (+ (get-in @state [:corp :bad-publicity]) (get-in @state [:corp :has-bad-pub])))
        (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
        (update-all-ice state :corp)
+       (swap! state update-in [:stats side :runs :started] (fnil inc 0))
        (trigger-event-sync state :runner (make-eid state) :run s)
        (when (>= n 2) (trigger-event state :runner :run-big s n))))))
 
@@ -114,6 +115,7 @@
   "Access a non-agenda. Show a prompt to trash for trashable cards."
   [state side eid c]
   (trigger-event state side :pre-trash c)
+  (swap! state update-in [:stats :runner :access :cards] (fnil inc 0))
   (if (not= (:zone c) [:discard]) ; if not accessing in Archives
     ;; The card has a trash cost (Asset, Upgrade)
     (let [trash-cost (trash-cost state side c)
@@ -210,6 +212,7 @@
   "Rules interactions for a runner that has accessed an agenda and may be able to steal it."
   [state side eid c]
   (trigger-event state side :pre-steal-cost c)
+  (swap! state update-in [:stats :runner :access :cards] (fnil inc 0))
   (let [cost (steal-cost state side c)
         card-name (:title c)
         cost-strs (map costs-to-symbol (partition 2 cost))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -61,6 +61,7 @@
        :room room
        :rid 0 :turn 0 :eid 0
        :sfx [] :sfx-current-id 0
+       :stats {:time {:started (t/now)}}
        :options {:spectatorhands spectatorhands}
        :corp {:user (:user corp) :identity corp-identity
               :options corp-options

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -1,18 +1,18 @@
 (ns netrunner.gameboard
   (:require-macros [cljs.core.async.macros :refer [go]])
-  (:require [om.core :as om :include-macros true]
-            [sablono.core :as sab :include-macros true]
-            [cljs.core.async :refer [chan put! <!] :as async]
+  (:require [cljs.core.async :refer [chan put! <!] :as async]
             [clojure.string :refer [capitalize includes? join lower-case split]]
+            [differ.core :as differ]
+            [jinteki.utils :refer [str->int]]
+            [jinteki.cards :refer [all-cards]]
             [netrunner.appstate :refer [app-state]]
             [netrunner.auth :refer [avatar] :as auth]
             [netrunner.cardbrowser :refer [add-symbols] :as cb]
             [netrunner.utils :refer [toastr-options influence-dot map-longest]]
-            [differ.core :as differ]
-            [om.dom :as dom]
             [netrunner.ws :as ws]
-            [jinteki.utils :refer [str->int]]
-            [jinteki.cards :refer [all-cards]]))
+            [om.core :as om :include-macros true]
+            [om.dom :as dom]
+            [sablono.core :as sab :include-macros true]))
 
 (defonce game-state (atom {}))
 (defonce last-state (atom {}))
@@ -1279,25 +1279,25 @@
     (om/set-state! owner :sfx-last-played {:gameid gameid :id sfx-current-id})))
 
 (def corp-stats
-  (let [s (-> @game-state :stats :corp)]
-    [["Clicks Gained" #(-> s :gain :click)]
-     ["Credits Gained" #(-> s :gain :credit)]
-     ["Credits Lost" #(-> s :lose :credit)]
-     ["Credits by Click" #(-> s :click :credit)]
-     ["Cards Drawn" #(-> s :gain :card)]
-     ["Cards Drawn by Click" #(-> s :click :draw)]]))
+  (let [s #(-> @game-state :stats :corp)]
+    [["Clicks Gained" #(-> (s) :gain :click)]
+     ["Credits Gained" #(-> (s) :gain :credit)]
+     ["Credits Lost" #(-> (s) :lose :credit)]
+     ["Credits by Click" #(-> (s) :click :credit)]
+     ["Cards Drawn" #(-> (s) :gain :card)]
+     ["Cards Drawn by Click" #(-> (s) :click :draw)]]))
 
 (def runner-stats
-  (let [s (-> @game-state :stats :runner)]
-    [["Clicks Gained" #(-> s :gain :click)]
-     ["Credits Gained" #(-> s :gain :credit)]
-     ["Credits Lost" #(-> s :lose :credit)]
-     ["Credits by Click" #(-> s :click :credit)]
-     ["Cards Drawn" #(-> s :gain :card)]
-     ["Cards Drawn by Click" #(-> s :click :draw)]
-     ["Tags Gained" #(-> s :gain :tag)]
-     ["Runs Made" #(-> s :runs :started)]
-     ["Cards Accessed" #(-> s :access :cards)]]))
+  (let [s #(-> @game-state :stats :runner)]
+    [["Clicks Gained" #(-> (s) :gain :click)]
+     ["Credits Gained" #(-> (s) :gain :credit)]
+     ["Credits Lost" #(-> (s) :lose :credit)]
+     ["Credits by Click" #(-> (s) :click :credit)]
+     ["Cards Drawn" #(-> (s) :gain :card)]
+     ["Cards Drawn by Click" #(-> (s) :click :draw)]
+     ["Tags Gained" #(-> (s) :gain :tag)]
+     ["Runs Made" #(-> (s) :runs :started)]
+     ["Cards Accessed" #(-> (s) :access :cards)]]))
 
 (defn show-stat
   "Determines statistic counter and if it should be shown"
@@ -1334,6 +1334,7 @@
 
       :else
       (str ") wins by scoring agenda points on turn "  (:turn @game-state)))]
+   [:div "Time taken: " (-> @game-state :stats :time :elapsed) " minutes"]
    [:br]
    (build-game-stats)
    [:button.win-right {:on-click #(swap! app-state assoc :win-shown true) :type "button"} "✘"]])

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -1279,23 +1279,25 @@
     (om/set-state! owner :sfx-last-played {:gameid gameid :id sfx-current-id})))
 
 (def corp-stats
-  [["Clicks Gained" #(-> @game-state :stats :corp :gain :click)]
-   ["Credits Gained" #(-> @game-state :stats :corp :gain :credit)]
-   ["Credits Lost" #(-> @game-state :stats :corp :click :credit)]
-   ["Credits by Click" #(-> @game-state :stats :corp :click :credit)]
-   ["Cards Drawn" #(-> @game-state :stats :corp :gain :card)]
-   ["Cards Drawn by Click" #(-> @game-state :corp :stats :click :draw)]])
+  (let [s (-> @game-state :stats :corp)]
+    [["Clicks Gained" #(-> s :gain :click)]
+     ["Credits Gained" #(-> s :gain :credit)]
+     ["Credits Lost" #(-> s :lose :credit)]
+     ["Credits by Click" #(-> s :click :credit)]
+     ["Cards Drawn" #(-> s :gain :card)]
+     ["Cards Drawn by Click" #(-> s :click :draw)]]))
 
 (def runner-stats
-  [["Clicks Gained" #(-> @game-state :stats :runner :gain :click)]
-   ["Credits Gained" #(-> @game-state :stats :runner :gain :credit)]
-   ["Credits Lost" #(-> @game-state :stats :runner :click :credit)]
-   ["Credits by Click" #(-> @game-state :stats :runner :click :credit)]
-   ["Cards Drawn" #(-> @game-state :stats :runner :gain :card)]
-   ["Cards Drawn by Click" #(-> @game-state :stats :runner :click :draw)]
-   ["Tags Gained" #(-> @game-state :stats :runner :gain :tag)]
-   ["Runs Made" #(-> @game-state :stats :runner :runs :started)]
-   ["Cards Accessed" #(-> @game-state :stats :runner :access :cards)]])
+  (let [s (-> @game-state :stats :runner)]
+    [["Clicks Gained" #(-> s :gain :click)]
+     ["Credits Gained" #(-> s :gain :credit)]
+     ["Credits Lost" #(-> s :lose :credit)]
+     ["Credits by Click" #(-> s :click :credit)]
+     ["Cards Drawn" #(-> s :gain :card)]
+     ["Cards Drawn by Click" #(-> s :click :draw)]
+     ["Tags Gained" #(-> s :gain :tag)]
+     ["Runs Made" #(-> s :runs :started)]
+     ["Cards Accessed" #(-> s :access :cards)]]))
 
 (defn show-stat
   "Determines statistic counter and if it should be shown"

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -1330,7 +1330,10 @@
       (str ") wins due to the Corp being decked on turn " (:turn @game-state))
 
       (= "Flatline" (@game-state :reason capitalize))
-      (str ") wins by flatlining the Runner on turn " (:turn @game-state))
+      (str ") wins by flatline on turn " (:turn @game-state))
+
+      (= "Concede" (@game-state :reason capitalize))
+      (str ") wins by concession on turn " (:turn @game-state))
 
       :else
       (str ") wins by scoring agenda points on turn "  (:turn @game-state)))]

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -1285,7 +1285,9 @@
      ["Credits Lost" #(-> (s) :lose :credit)]
      ["Credits by Click" #(-> (s) :click :credit)]
      ["Cards Drawn" #(-> (s) :gain :card)]
-     ["Cards Drawn by Click" #(-> (s) :click :draw)]]))
+     ["Cards Drawn by Click" #(-> (s) :click :draw)]
+     ["Damage Done" #(-> (s) :damage :all)]
+     ["Cards Rezzed" #(-> (s) :cards :rezzed)]]))
 
 (def runner-stats
   (let [s #(-> @game-state :stats :runner)]

--- a/src/cljs/netrunner/utils.cljs
+++ b/src/cljs/netrunner/utils.cljs
@@ -65,3 +65,10 @@
           "hideMethod" "fadeOut"
           "tapToDismiss" (:tap-to-dismiss options true)))
 
+(defn map-longest
+  [f default & colls]
+  (lazy-seq
+    (when (some seq colls)
+      (cons
+        (apply f (map #(if (seq %) (first %) default) colls))
+        (apply map-longest f default (map rest colls))))))

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -514,6 +514,7 @@ nav ul
   padding: 15px
   border: 1px solid #ffa500
   z-index: 2
+  border-radius: 4px
 
 .win-right
   position: absolute
@@ -526,6 +527,7 @@ nav ul
   height: 15px
   width: 15px
   background-color: transparent
+  border-radius: 1px
 
   &:hover
     background-color: transparent-orange

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -506,13 +506,14 @@ nav ul
 .win.centered
   position: fixed
   top: 30%
-  left: 45%
+  left: 35%
+  width: 40%
+  text-align: center
   margin-top: -50px
   margin-left: -100px
   padding: 15px
   border: 1px solid #ffa500
   z-index: 2
-
 
 .win-right
   position: absolute
@@ -529,6 +530,15 @@ nav ul
   &:hover
     background-color: transparent-orange
     border-color: orange
+
+.win.table
+  border: 1px solid #ffa500
+  width: 100%
+  text-align: left
+
+.win.th
+  border-bottom: 1px solid #ffa500
+//
 
 #stats
   .content-page


### PR DESCRIPTION
The first iteration of this.  Lots more to be added I am sure.
I tried to make the stats code easier to augment, and then map the corp and runner stats together for the table view.

Also includes a game duration not shown as added later.

<img width="602" alt="screen shot 2018-05-10 at 5 57 04 pm" src="https://user-images.githubusercontent.com/11830223/39863519-3a20adca-548a-11e8-9df8-c0d61a99f790.png">

Corp counters included and displayed:
- Clicks Gained
- Credits Gained
- Credits Lost
- Credits by Click
- Cards Drawn
- Cards Drawn by Click
- Damage Done  (all damage, per type is instrumented by not shown)
- Cards Rezzed

Runner counters included and displayed
- Clicks Gained
- Credits Gained
- Credits Lost
- Credits by Click
- Cards Drawn
- Cards Drawn by Click
- Tags gained
- Runs Made
- Cards Accessed

<img width="588" alt="screen shot 2018-05-11 at 5 29 00 pm" src="https://user-images.githubusercontent.com/11830223/39912080-dbdfda1c-5540-11e8-9774-e7155d14a1da.png">


