### PR TITLE
FIX: Aumakua shouldn't gain counters from using trash abilities

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -266,6 +266,8 @@
                                               cdef (-> (card-def trash-ab-card)
                                                        :interactions
                                                        :trash-ability)]
+                                          (when (:run @state)
+                                            (swap! state assoc-in [:run :did-trash] true))
                                           (when-completed (resolve-ability state side cdef trash-ab-card [c])
                                                           (do (trigger-event state side :no-steal c)
                                                               (access-end state side eid c))))))})

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -169,8 +169,8 @@
                                     cdef (-> (card-def trash-ab-card)
                                              :interactions
                                              :trash-ability)]
-                                  (when (:run @state)
-                                    (swap! state assoc-in [:run :did-trash] true))
+                                (when (:run @state)
+                                  (swap! state assoc-in [:run :did-trash] true))
                                 (when-completed (resolve-ability state side cdef trash-ab-card [card])
                                                 (access-end state side eid c)))))}
               card nil)))))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -169,6 +169,8 @@
                                     cdef (-> (card-def trash-ab-card)
                                              :interactions
                                              :trash-ability)]
+                                  (when (:run @state)
+                                    (swap! state assoc-in [:run :did-trash] true))
                                 (when-completed (resolve-ability state side cdef trash-ab-card [card])
                                                 (access-end state side eid c)))))}
               card nil)))))

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -494,7 +494,7 @@
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (is (= 1 (count (:discard (get-corp)))) "Ice Wall should be discarded now")
-      (is (nil? (->> (get-program state 1) :counter :virus)) "Aumakua oesn't gain any virus counters from trash ability.")
+      (is (nil? (->> (get-program state 1) :counter :virus)) "Aumakua doesn't gain any virus counters from trash ability.")
       (is (not (:run @state)) "Run ended"))))
 
 (deftest gabriel-santiago

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -481,6 +481,20 @@
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")
+      (is (not (:run @state)) "Run ended")))
+  (testing "Shouldn't give Aumakua additional counters on trash. #3479"
+    (do-game
+      (new-game (default-corp [(qty "Ice Wall" 10)])
+                (make-deck "Freedom Khumalo: Crypto-Anarchist" ["Cache" "Aumakua"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Cache")
+      (play-from-hand state :runner "Aumakua")
+      (run-empty-server state "R&D")
+      (is (nil? (->> (get-program state 1) :counter :virus)) "Shouldn't have any virus counters yet.")
+      (prompt-choice-partial :runner "Freedom")
+      (prompt-select :runner (get-program state 0))
+      (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")
+      (is (nil? (->> (get-program state 1) :counter :virus)) "Doesn't gain any virus counters from trash ability.")
       (is (not (:run @state)) "Run ended"))))
 
 (deftest gabriel-santiago

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -490,11 +490,11 @@
       (play-from-hand state :runner "Cache")
       (play-from-hand state :runner "Aumakua")
       (run-empty-server state "R&D")
-      (is (nil? (->> (get-program state 1) :counter :virus)) "Shouldn't have any virus counters yet.")
+      (is (nil? (->> (get-program state 1) :counter :virus)) "Aumakuma shouldn't have any virus counters yet.")
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
-      (is (= 1 (count (:discard (get-corp)))) "Card should be discarded now")
-      (is (nil? (->> (get-program state 1) :counter :virus)) "Doesn't gain any virus counters from trash ability.")
+      (is (= 1 (count (:discard (get-corp)))) "Ice Wall should be discarded now")
+      (is (nil? (->> (get-program state 1) :counter :virus)) "Aumakuma oesn't gain any virus counters from trash ability.")
       (is (not (:run @state)) "Run ended"))))
 
 (deftest gabriel-santiago

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -494,7 +494,7 @@
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (is (= 1 (count (:discard (get-corp)))) "Ice Wall should be discarded now")
-      (is (nil? (->> (get-program state 1) :counter :virus)) "Aumakuma oesn't gain any virus counters from trash ability.")
+      (is (nil? (->> (get-program state 1) :counter :virus)) "Aumakua oesn't gain any virus counters from trash ability.")
       (is (not (:run @state)) "Run ended"))))
 
 (deftest gabriel-santiago


### PR DESCRIPTION
The trash ability wasn't setting `@state [:run :did-trash]`, so Aumakua triggered on it's usage. This corrects that miss.

Fixes #3479, #3347