### PR TITLE
FIX: Disallow trash abilities on accessing agendas in archives

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -221,7 +221,7 @@
         trash-ab-cards (when (not= (:zone c) [:discard])
                          (->> (concat (all-active state :runner)
                                       (get-in @state [:runner :play-area]))
-                              (filter #(can-trigger? state :runner (:trash-ability (:interactions (card-def %))) % [c]))))
+                              (filter #(can-trigger? state :runner (->> % card-def :interactions :trash-ability) % [c]))))
         ability-strs (map #(->> (card-def %) :interactions :trash-ability :label) trash-ab-cards)
         ;; strs
         steal-str (when (and can-steal-this? can-pay-costs?)

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -221,7 +221,7 @@
         trash-ab-cards (when (not= (:zone c) [:discard])
                          (->> (concat (all-active state :runner)
                                       (get-in @state [:runner :play-area]))
-                              (filter #(can-trigger? state :runner (->> % card-def :interactions :trash-ability) % [c]))))
+                              (filter #(can-trigger? state :runner (get-in (card-def %) [:interactions :trash-ability]) % [c]))))
         ability-strs (map #(->> (card-def %) :interactions :trash-ability :label) trash-ab-cards)
         ;; strs
         steal-str (when (and can-steal-this? can-pay-costs?)

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -218,9 +218,10 @@
         cost-as-symbol (when (= 1 (count cost-strs)) (costs-to-symbol cost))
         ;; any trash abilities
         can-steal-this? (can-steal? state side c)
-        trash-ab-cards (->> (concat (all-active state :runner)
-                                    (get-in @state [:runner :play-area]))
-                            (filter #(can-trigger? state :runner (:trash-ability (:interactions (card-def %))) % [c])))
+        trash-ab-cards (when (not= (:zone c) [:discard])
+                         (->> (concat (all-active state :runner)
+                                      (get-in @state [:runner :play-area]))
+                              (filter #(can-trigger? state :runner (:trash-ability (:interactions (card-def %))) % [c]))))
         ability-strs (map #(->> (card-def %) :interactions :trash-ability :label) trash-ab-cards)
         ;; strs
         steal-str (when (and can-steal-this? can-pay-costs?)

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -388,7 +388,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Imp")
       (run-empty-server state "Archives")
-      (is (= ["Steal"] (->> (get-runner) :prompt first :choices)) "Should only get the option to steal"))))
+      (is (= ["Steal"] (->> (get-runner) :prompt first :choices)) "Should only get the option to steal Hostile on access in Archives"))))
 
 (deftest incubator-transfer-virus-counters
   ;; Incubator - Gain 1 virus counter per turn; trash to move them to an installed virus program

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -379,7 +379,16 @@
         ;; Fail psi game
         (prompt-choice-partial :runner "Imp")
         (is (= "The Future Perfect" (get-in @state [:corp :discard 0 :title])) "TFP trashed")
-        (is (= 0 (:agenda-point (get-runner))) "Runner did not steal TFP")))))
+        (is (= 0 (:agenda-point (get-runner))) "Runner did not steal TFP"))))
+  (testing "vs cards in Archives"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover"])
+                (default-runner ["Imp"]))
+      (core/move state :corp (find-card "Hostile Takeover" (:hand (get-corp))) :discard)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Imp")
+      (run-empty-server state "Archives")
+      (is (= ["Steal"] (->> (get-runner) :prompt first :choices)) "Should only get the option to steal"))))
 
 (deftest incubator-transfer-virus-counters
   ;; Incubator - Gain 1 virus counter per turn; trash to move them to an installed virus program


### PR DESCRIPTION
Missed this when building the Access prompts.