### PR TITLE
FIX: Better handling for costs in access prompts

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -133,7 +133,8 @@
                 trash-cost-str (when can-pay
                                  [(str "Pay " trash-cost "[Credits] to trash")])
                 ;; If the runner is forced to trash this card (Neutralize All Threats)
-                forced-to-trash? (and can-pay
+                forced-to-trash? (and (or can-pay
+                                          (seq trash-ab-cards))
                                       (or (get-in @state [:runner :register :force-trash])
                                           (card-flag-fn? state side card :must-trash true)))
                 trash-msg (when can-pay

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -254,9 +254,9 @@
                                       (.contains target "Pay")
                                       (if (> n 1)
                                         ;; Use the better function for multiple costs
-                                        (resolve-ability state :runner
-                                                         (steal-pay-choice state :runner cost-strs '() n c)
-                                                         c nil)
+                                        (continue-ability state :runner
+                                                          (steal-pay-choice state :runner cost-strs '() n c)
+                                                          c nil)
                                         ;; Otherwise, just handle everything right friggin here
                                         (when-completed (pay-sync state side nil cost {:action :steal-cost})
                                                         (do (system-msg state side

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -1054,8 +1054,6 @@
         (take-credits state :corp)
         (core/lose state :runner :credit (:credit (get-runner)) :click 3)
         (run-empty-server state :remote1)
-        (run-successful state)
-        (prompt-choice :runner "2 [Credits]")
         (prompt-choice :runner "No action")
         (is (= 0 (:credit (get-runner))) "Runner couldn't afford to steal, so no credits spent")
         (is (= 0 (count (:scored (get-runner)))) "Runner could not steal Ikawah Project"))
@@ -1064,8 +1062,6 @@
         (take-credits state :corp)
         (core/lose state :runner :credit (:credit (get-runner)) :click 3)
         (run-empty-server state :remote1)
-        (run-successful state)
-        (prompt-choice :runner "[Click]")
         (prompt-choice :runner "No action")
         (is (= 0 (:click (get-runner))) "Runner couldn't afford to steal, so no clicks spent")
         (is (= 0 (count (:scored (get-runner)))) "Runner could not steal Ikawah Project"))
@@ -1077,6 +1073,7 @@
         (is (= 5 (:credit (get-runner))) "Runner should be reset to 5 credits")
         (is (= 4 (:click (get-runner))) "Runner should be reset to 4 clicks")
         (run-empty-server state :remote1)
+        (prompt-choice-partial :runner "Pay")
         (prompt-choice :runner "[Click]")
         (prompt-choice :runner "2 [Credits]")
         (is (= 2 (:click (get-runner))) "Runner should lose 1 click to steal")
@@ -1092,10 +1089,10 @@
       (starting-hand state :corp ["Ikawah Project"])
       (run-empty-server state "R&D")
       (prompt-choice :runner "No action")
-      (is (not (last-log-contains? state "not to pay to steal Ikawah Project")) "Ikawah Project should not be mentioned")
+      (is (not (last-log-contains? state "Ikawah Project")) "Ikawah Project should not be mentioned")
       (run-empty-server state "HQ")
       (prompt-choice :runner "No action")
-      (is (last-log-contains? state "not to pay to steal Ikawah Project") "Ikawah Project should be mentioned"))))
+      (is (last-log-contains? state "Ikawah Project") "Ikawah Project should be mentioned"))))
 
 (deftest illicit-sales
   ;; Illicit Sales

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -647,8 +647,8 @@
     (play-from-hand state :corp "Crisium Grid" "R&D")
     (core/rez state :corp (get-content state :rd 0))
     (take-credits state :corp)
-
     (starting-hand state :runner ["Obelus"])
+    (core/gain state :runner :credit 5)
     (play-from-hand state :runner "Obelus")
     (is (empty? (:hand (get-runner))) "No cards in hand")
     (run-empty-server state "R&D")
@@ -657,7 +657,6 @@
     (prompt-choice-partial :runner "Card")
     (prompt-choice-partial :runner "No")
     (is (empty? (:hand (get-runner))) "Crisium Grid blocked successful run")
-
     (run-empty-server state "R&D")
     (prompt-choice-partial :runner "No")
     (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run")))

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -447,8 +447,9 @@
     (do-game
       (new-game (default-corp [(qty "Dedicated Response Team" 1)])
                 (make-deck "Freedom Khumalo: Crypto-Anarchist"
-                           [(qty "Cache" 1) (qty "Imp" 1)]))
+                           [(qty "Sure Gamble" 1) (qty "Cache" 1) (qty "Imp" 1)]))
       (take-credits state :corp)
+      (play-from-hand state :runner "Sure Gamble")
       (play-from-hand state :runner "Cache")
       (play-from-hand state :runner "Imp")
       (run-empty-server state "HQ")
@@ -1149,6 +1150,7 @@
       (prompt-choice :runner 0)
       (is (empty? (:prompt (get-runner))) "Forger can't avoid the tag")
       (is (= 1 (:tag (get-runner))) "Runner took 1 unpreventable tag")
+      (core/gain state :runner :credit 2)
       (run-empty-server state "Server 2")
       (prompt-choice-partial :runner "Pay")
       (is (empty? (:prompt (get-corp))) "No trace chance on 2nd trashed card of turn")))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1043,7 +1043,7 @@
     (play-from-hand state :corp "Crisium Grid" "HQ")
     (core/rez state :corp (get-content state :hq 0))
     (take-credits state :corp)
-    (core/gain state :runner :click 2)
+    (core/gain state :runner :click 2 :credit 2)
     (play-from-hand state :runner "John Masanori")
     (is (= 4 (count (:hand (get-runner)))))
     (run-empty-server state "HQ")

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -814,7 +814,31 @@
         (is (= "Mumbad Virtual Tour" (:title (first (:discard (get-corp))))) "MVT trashed with Imp")
         ;; Trash Imp to reset :slow-trash flag
         (core/move state :runner (refresh imp) :discard)
-        (is (not (core/any-flag-fn? state :runner :slow-trash true)))))))
+        (is (not (core/any-flag-fn? state :runner :slow-trash true))))))
+  (testing "not forced to trash when credits below 5"
+    (do-game
+      (new-game (default-corp [(qty "Mumbad Virtual Tour" 3)])
+                (default-runner ["Imp"]))
+      (play-from-hand state :corp "Mumbad Virtual Tour" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Imp")
+      (is (= 3 (:credit (get-runner))) "Runner paid install costs")
+      (run-empty-server state "Server 1")
+      (is (= 2 (->> (get-runner) :prompt first :choices count)) "Should have Imp and no action options")
+      (prompt-choice-partial :runner "Imp")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Mumbad Virtual Tour" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 2")
+      (is (= 2 (->> (get-runner) :prompt first :choices count)) "Should have Imp and no action options")
+      (prompt-choice-partial :runner "Imp")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Mumbad Virtual Tour" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 3")
+      (is (= 1 (->> (get-runner) :prompt first :choices count)) "Should only have no action option")
+      (prompt-choice :runner "No action")
+      (is (= 2 (->> (get-corp) :discard count)) "Runner was not forced to trash MVT"))))
 
 (deftest mwanza-city-grid
   ;; Mwanza City Grid - runner accesses 3 additional cards, gain 2C for each card accessed

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -835,8 +835,7 @@
       (play-from-hand state :corp "Mumbad Virtual Tour" "New remote")
       (take-credits state :corp)
       (run-empty-server state "Server 2")
-      (is (= #{"[Imp]: Trash card" "No action"}
-             (->> (get-runner) :prompt first :choices (into #{}))) "Should have Imp and no action options")
+      (is (= ["[Imp]: Trash card"] (->> (get-runner) :prompt first :choices)) "Should only have Imp option")
       (prompt-choice-partial :runner "Imp")
       (take-credits state :runner)
       (core/lose state :runner :credit (:credit (get-runner)))

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -112,6 +112,7 @@
         ;; prompt should be asking for the net damage costs
         (is (= "Obokata Protocol" (:title (:card (first (:prompt (get-runner))))))
             "Prompt to pay steal costs")
+        (prompt-choice-partial :runner "Pay")
         (prompt-choice :runner "2 net damage")
         (is (= 2 (count (:discard (get-runner)))) "Runner took 2 net damage")
         (is (= 0 (count (:scored (get-runner)))) "No scored agendas")
@@ -134,6 +135,7 @@
         ;; prompt should be asking for the net damage costs
         (is (= "Fetal AI" (:title (:card (first (:prompt (get-runner))))))
             "Prompt to pay steal costs")
+        (prompt-choice-partial :runner "Pay")
         (prompt-choice :runner "2 [Credits]")
         (is (= 3 (:credit (get-runner))) "Runner paid 2 credits")
         (is (= 0 (count (:scored (get-runner)))) "No scored agendas")

--- a/test/clj/game_test/rules.clj
+++ b/test/clj/game_test/rules.clj
@@ -31,6 +31,7 @@
     (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
     (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
     (run-empty-server state :remote1)
+    (prompt-choice-partial :runner "Pay")
     (prompt-choice :runner "[Click]")
     (prompt-choice :runner "2 [Credits]")
     (is (= 2 (:click (get-runner))) "Runner should lose 1 click to steal")


### PR DESCRIPTION
Fixes bug where Mumbad Virtual Tour would force trash when Runner had < 5 credits. Also fixes bug with not showing trash ability choices on agenda access prompts with multiple steal costs.

Fixes #3471, #2469 