### PR TITLE
Ensure necessary info for breaker auto-pump

### DIFF
--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -13,10 +13,14 @@
                                                               (not= % "credit"))
                                                         (:cost pumpabi))))
               current-ice (when-not (get-in @state [:run :ending]) (get-card state current-ice))
-              strdif (when current-ice (max 0 (- (or (:current-strength current-ice)
-                                                     (:strength current-ice))
-                                                 (or (:current-strength card)
-                                                     (:strength card)))))
+              strdif (when (and (or (:current-strength current-ice)
+                                    (:strength current-ice))
+                                (or (:current-strength card)
+                                    (:strength card)))
+                       (max 0 (- (or (:current-strength current-ice)
+                                     (:strength current-ice))
+                                 (or (:current-strength card)
+                                     (:strength card)))))
               pumpnum (when strdif (int (Math/ceil (/ strdif (:pump pumpabi)))))]
           (update! state side
                    (assoc card :abilities


### PR DESCRIPTION
Catching another `Null Pointer Exception` from the production logs