### PR TITLE
Deckbuilder cleanup

### DIFF
--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -167,7 +167,8 @@
 
 (defn load-decks [decks]
   (swap! app-state assoc :decks decks)
-  (put! select-channel (first (sort-by :date > decks)))
+  (when-let [selected-deck (first (sort-by :date > decks))]
+    (put! select-channel selected-deck))
   (swap! app-state assoc :decks-loaded true))
 
 (defn process-decks
@@ -616,8 +617,13 @@
          [:div.viewport {:ref "viewport"}
           [:div.decks
            [:div.button-bar
-            [:button {:on-click #(new-deck "Corp" owner)} "New Corp deck"]
-            [:button {:on-click #(new-deck "Runner" owner)} "New Runner deck"]]
+            (if (:user @app-state)
+              (list
+                [:button {:on-click #(new-deck "Corp" owner)} "New Corp deck"]
+                [:button {:on-click #(new-deck "Runner" owner)} "New Runner deck"])
+              (list
+                [:button {:class "disabled"} "New Corp deck"]
+                [:button {:class "disabled"} "New Runner deck"]))]
            [:div.deck-collection
             (when-not (:edit state)
               (om/build deck-collection {:sets sets :decks decks :decks-loaded decks-loaded :active-deck (om/get-state owner :deck)}))

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -278,9 +278,9 @@
 (defn new-deck [side owner]
   (let [old-deck (om/get-state owner :deck)
         id (->> side
-             side-identities
-             (sort-by :title)
-             first)]
+                side-identities
+                (sort-by :title)
+                first)]
     (om/set-state! owner :deck {:name "New deck" :cards [] :identity id})
     (try (js/ga "send" "event" "deckbuilder" "new" side) (catch js/Error e))
     (edit-deck owner)

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -276,8 +276,12 @@
          (end-delete owner))))))
 
 (defn new-deck [side owner]
-  (let [old-deck (om/get-state owner :deck)]
-    (om/set-state! owner :deck {:name "New deck" :cards [] :identity (-> side side-identities first)})
+  (let [old-deck (om/get-state owner :deck)
+        id (->> side
+             side-identities
+             (sort-by :title)
+             first)]
+    (om/set-state! owner :deck {:name "New deck" :cards [] :identity id})
     (try (js/ga "send" "event" "deckbuilder" "new" side) (catch js/Error e))
     (edit-deck owner)
     (om/set-state! owner :old-deck old-deck)))


### PR DESCRIPTION
Better handling of not logged in users.
Select the first ID (alphabetically) when creating a new deck.