### PR TITLE
Wrong number of args to is-scored?

### DIFF
--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -132,7 +132,7 @@
                         value (if-let [n (string->num (first args))] n 0)
                         counter-type (cond (= 1 (count existing)) (first (keys existing))
                                      (can-be-advanced? target) :advance-counter
-                                     (and (is-type? target "Agenda") (is-scored? target)) :agenda
+                                     (and (is-type? target "Agenda") (is-scored? state side target)) :agenda
                                      (and (card-is? target :side :runner) (has-subtype? target "Virus")) :virus)
                         advance (= :advance-counter counter-type)]
                     (cond

--- a/test/clj/game_test/rules.clj
+++ b/test/clj/game_test/rules.clj
@@ -456,6 +456,29 @@
       (is (= 4 (:agenda-point (get-corp)))) ; PS2 should get scored
       (is (= 12 (:credit (get-corp))))))))
 
+(deftest counter-manipulation-commands-smart
+  ;; Test interactions of smart counter advancement command
+  (do-game
+    (new-game (default-corp [(qty "House of Knives" 1)])
+              (default-runner))
+    (play-from-hand state :corp "House of Knives" "New remote")
+    (let [hok (get-content state :remote1 0)]
+      (core/command-counter state :corp [3])
+      (prompt-select :corp (refresh hok))
+      (is (= 3 (:advance-counter (refresh hok))))
+      (core/score state :corp (refresh hok)))
+    (let [hok-scored (get-scored state :corp)]
+      (is (= 3 (get-counters (refresh hok-scored) :agenda)) "House of Knives should start with 3 counters")
+      (core/command-counter state :corp ["virus" 2])
+      (prompt-select :corp (refresh hok-scored))
+      (is (= 3 (get-counters (refresh hok-scored) :agenda)) "House of Knives should stay at 3 counters")
+      (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters")
+      (core/command-counter state :corp [4])
+      (prompt-select :corp (refresh hok-scored)) ;; doesn't crash with unknown counter type
+      (is (empty? (:prompt (get-corp))) "Counter prompt closed")
+      (is (= 4 (get-counters (refresh hok-scored) :agenda)) "House of Knives should have 4 agenda counters")
+      (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters"))))
+
 (deftest run-bad-publicity-credits
   ;; Should not lose BP credits until a run is completely over. Issue #1721.
   (do-game


### PR DESCRIPTION
Crash when using `/counter 1` on a scored agenda with both agenda and virus counters already present.