### PR TITLE
Only allow a user to be in a game once

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -1,6 +1,6 @@
 (ns web.game
   (:require [web.ws :as ws]
-            [web.lobby :refer [all-games old-states] :as lobby]
+            [web.lobby :refer [all-games old-states already-in-game?] :as lobby]
             [web.utils :refer [response]]
             [web.stats :as stats]
             [game.main :as main]
@@ -187,8 +187,9 @@
     (when (and user game (lobby/allowed-in-game game user) state @state)
       (if-not started
         false ; don't handle this message, let lobby/handle-game-watch.
-        (if (or (empty? game-password)
-                (bcrypt/check password game-password))
+        (if (and (not (already-in-game? user game))
+                 (or (empty? game-password)
+                     (bcrypt/check password game-password)))
           (let [{:keys [spect-state]} (main/public-states state)]
             ;; Add as a spectator, inform the client that this is the active game,
             ;; add a chat message, then send full states to all players.

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -265,6 +265,12 @@
                         :games/diff
                         {:diff {:update {gameid (game-public-view (game-for-id gameid))}}}))))
 
+(defn already-in-game?
+  "Checks if a user with the given database id (:_id) is already in the game"
+  [{:keys [_id] :as user} {:keys [players spectators] :as game}]
+  (or (some #(= _id (:_id %)) (map :user players))
+      (some #(= _id (:_id %)) (map :user spectators))))
+
 (defn handle-lobby-join
   [{{{:keys [username] :as user} :user} :ring-req
     client-id                           :client-id
@@ -273,8 +279,9 @@
     :as                                 msg}]
   (if-let [{game-password :password :as game} (@all-games gameid)]
     (when (and user game (allowed-in-game game user))
-      (if (or (empty? game-password)
-              (bcrypt/check password game-password))
+      (if (and (not (already-in-game? user game))
+               (or (empty? game-password)
+                   (bcrypt/check password game-password)))
         (do (join-game user client-id gameid)
             (ws/broadcast-to! (lobby-clients gameid)
                               :lobby/message
@@ -297,8 +304,9 @@
     (when (and user game (allowed-in-game game user))
       (if started
         false                                               ; don't handle this message, let game/handle-game-watch.
-        (if (or (empty? game-password)
-                (bcrypt/check password game-password))
+        (if (and (not (already-in-game? user game))
+                 (or (empty? game-password)
+                     (bcrypt/check password game-password)))
           (do (spectate-game user client-id gameid)
 
               (ws/broadcast-to! (lobby-clients gameid)


### PR DESCRIPTION
To further encourage the use of smurf accounts.

Any of our internal data structures that use the database id to identify a player cannot handle the case of a player as both `Runner` and `Corp` (or `Spectator`). This attempts to block you from joining or watching a game which you are already participating.