### PR TITLE
Protect against nil run position

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -492,7 +492,7 @@
       (when-completed (trigger-event-sync state side :pass-ice cur-ice)
                       (do (update-ice-in-server
                             state side (get-in @state (concat [:corp :servers] (get-in @state [:run :server]))))
-                          (swap! state update-in [:run :position] dec)
+                          (swap! state update-in [:run :position] (fnil dec 1))
                           (swap! state assoc-in [:run :no-action] false)
                           (system-msg state side "continues the run")
                           (when cur-ice


### PR DESCRIPTION
This is a crash that appears often in the production log. It does not address the root cause of the run position being unset, but perhaps this will expose a more useful crash location.