### PR TITLE
Changes order of trigger-event info/req checking AND MORE

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1422,8 +1422,10 @@
     :abilities [ability]
     :events {:corp-turn-begins ability
              :corp-install {:req (req (ice? target))
-                            :effect (effect (trash card)
-                                            (system-msg "trashes Server Diagnostics"))}}})
+                            :delayed-completion true
+                            :effect (req (when-completed (trash state side card nil)
+                                                         (do (system-msg state :runner "trashes Server Diagnostics")
+                                                             (effect-completed state side eid card))))}}})
 
    "Shannon Claire"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -55,7 +55,8 @@
    "Astrolabe"
    {:in-play [:memory 1]
     :events {:server-created {:msg "draw 1 card"
-                              :effect (effect (draw :runner))}}}
+                              :delayed-completion true
+                              :effect (effect (draw :runner eid 1 nil))}}}
 
    "Autoscripter"
    {:events {:runner-install {:silent (req true)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -670,9 +670,9 @@
     :leave-play (req (remove-watch state :obelus)
                      (lose state :runner :hand-size {:mod (:tag runner)}))
     :events {:successful-run-ends {:once :per-turn
-                                   :req (req (let [successes (turn-events state side :successful-run-ends)]
-                                               (and (#{[:rd] [:hq]} (:server target))
-                                                    (not-any? #(some #{:rd :hq} (:server (first %))) successes))))
+                                   :req (req (and (#{:rd :hq} (first (:server target)))
+                                               (first-event? state side :successful-run-ends
+                                                             #(#{:rd :hq} (first (:server (first %)))))))
                                    :msg (msg "draw " (:cards-accessed target 0) " cards")
                                    :effect (effect (draw (:cards-accessed target 0)))}}}
 

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -152,16 +152,19 @@
   (let [install-prompt {:req (req (and (= (:zone card) [:discard])
                                        (rezzed? current-ice)
                                        (has-subtype? current-ice type)
-                                       (not (install-locked? state side))
-                                       (not (some #(= title (:title %)) (all-active-installed state :runner)))
-                                       (not (get-in @state [:run :register :conspiracy (:cid current-ice)]))))
-                        :optional {:player :runner
-                                   :prompt (str "Install " title "?")
-                                   :yes-ability {:effect (effect (unregister-events card)
-                                                                 (runner-install :runner card))}
-                                   :no-ability {:effect (req  ;; Add a register to note that the player was already asked about installing,
-                                                              ;; to prevent multiple copies from prompting multiple times.
-                                                              (swap! state assoc-in [:run :register :conspiracy (:cid current-ice)] true))}}}
+                                       (not (install-locked? state side))))
+                        :delayed-completion true
+                        :effect (effect (continue-ability
+                                          {:optional {:req (req (and (not (some #(= title (:title %)) (all-active-installed state :runner)))
+                                                                     (not (get-in @state [:run :register :conspiracy (:cid current-ice)]))))
+                                                      :player :runner
+                                                      :prompt (str "Install " title "?")
+                                                      :yes-ability {:effect (effect (unregister-events card)
+                                                                                    (runner-install :runner card))}
+                                                      :no-ability {:effect (req  ;; Add a register to note that the player was already asked about installing,
+                                                                                ;; to prevent multiple copies from prompting multiple times.
+                                                                                (swap! state assoc-in [:run :register :conspiracy (:cid current-ice)] true))}}}
+                                          card targets))}
         heap-event (req (when (= (:zone card) [:discard])
                           (unregister-events state side card)
                           (register-events state side

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -658,10 +658,7 @@
 
    "Ken \"Express\" Tenma: Disappeared Clone"
    {:events {:play-event {:req (req (and (has-subtype? target "Run")
-                                         (empty? (filter #(has-subtype? % "Run")
-                                                         ;; have to flatten because each element is a list containing
-                                                         ;; the Event card that was played
-                                                         (flatten (turn-events state :runner :play-event))))))
+                                         (first-event? state :runner :play-event #(has-subtype? (first %) "Run"))))
                           :msg "gain 1 [Credits]"
                           :effect (effect (gain :credit 1))}}}
 
@@ -686,8 +683,7 @@
      {:delayed-completion true
       :interactive (req true)
       :req (req (and (is-central? (:server run))
-                     (empty? (let [successes (turn-events state side :successful-run)]
-                               (filter #(is-central? %) successes)))))
+                     (first-event? state side :successful-run #(is-central? %))))
       :effect (effect (continue-ability
                         {:optional
                          {:prompt "Force the Corp to draw a card?"
@@ -939,8 +935,7 @@
    "Spark Agency: Worldswide Reach"
    {:events
     {:rez {:req (req (and (has-subtype? target "Advertisement")
-                          (empty? (filter #(has-subtype? % "Advertisement")
-                                          (flatten (turn-events state :corp :rez))))))
+                          (first-event? state :corp :rez #(has-subtype? (first %) "Advertisement"))))
            :effect (effect (lose :runner :credit 1))
            :msg (msg "make the Runner lose 1 [Credits] by rezzing an Advertisement")}}}
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -171,7 +171,6 @@
                                                "non-agenda"
                                                "piece of ice")
                                              " in HQ to install with Asa Group: Security Through Vigilance (optional)")
-                                :delayed-completion true
                                 :choices {:req #(and (in-hand? %)
                                                      (= (:side %) "Corp")
                                                      (corp-installable-type? %)
@@ -773,7 +772,8 @@
    "Near-Earth Hub: Broadcast Center"
    {:events {:server-created {:req (req (first-event? state :corp :server-created))
                               :msg "draw 1 card"
-                              :effect (effect (draw 1))}}}
+                              :delayed-completion true
+                              :effect (effect (draw :corp eid 1 nil))}}}
 
    "Nero Severn: Information Broker"
    {:abilities [{:req (req (has-subtype? current-ice "Sentry"))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1280,7 +1280,6 @@
 
    "Shipment from MirrorMorph"
    (let [shelper (fn sh [n] {:prompt "Select a card to install with Shipment from MirrorMorph"
-                             :priority -1
                              :delayed-completion true
                              :choices {:req #(and (= (:side %) "Corp")
                                                   (not (is-type? % "Operation"))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -813,9 +813,8 @@
                                                 (effect-completed state side eid))
                                               (effect-completed state side eid)))}
              :post-access-card {:effect (effect (update! (assoc-in card [:special :rng-guess] nil)))}
-             :successful-run {:req (req (let [first-hq (first-successful-run-on-server? state :hq)
-                                              first-rd (first-successful-run-on-server? state :rd)]
-                                          (and first-hq first-rd (or (= target :hq) (= target :rd)))))
+             :successful-run {:req (req (and (or (= target :hq) (= target :rd))
+                                             (first-event? state :runner :successful-run #{[:hq] [:rd]})))
                               :optional {:prompt "Fire RNG Key?"
                                          :yes-ability {:prompt "Guess a number"
                                                        :choices {:number (req 20)}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -43,19 +43,22 @@
 
    "Activist Support"
    {:events
-    {:corp-turn-begins {:req (req (= 0 (:tag runner)))
-                        :msg "take 1 tag"
+    {:corp-turn-begins {:msg "take 1 tag"
                         :delayed-completion true
-                        :effect (effect (tag-runner :runner eid 1))}
-     :runner-turn-begins {:req (req (not has-bad-pub))
-                          :msg "give the Corp 1 bad publicity"
-                          :effect (effect (gain-bad-publicity :corp 1))}}}
+                        :effect (req (if (= 0 (:tag runner))
+                                       (tag-runner state :runner eid 1)
+                                       (effect-completed state :runner eid card)))}
+     :runner-turn-begins {:msg "give the Corp 1 bad publicity"
+                          :delayed-completion true
+                          :effect (req (if (not has-bad-pub)
+                                         (gain-bad-publicity state :corp eid 1)
+                                         (effect-completed state :runner eid card)))}}}
 
    "Adjusted Chronotype"
    {:events {:runner-loss {:req (req (and (some #{:click} target)
-                                          (let [click-losses (filter #(= :click %) (mapcat first (turn-events state side :runner-loss)))]
-                                            (or (empty? click-losses)
-                                                (and (= (count click-losses) 1)
+                                          (let [click-losses (count (filter #(= :click %) (mapcat first (turn-events state side :runner-loss))))]
+                                            (or (= 1 click-losses)
+                                                (and (= 2 click-losses)
                                                      (has-flag? state side :persistent :genetics-trigger-twice))))))
                            :msg "gain [Click]" :effect (effect (gain :runner :click 1))}}}
 
@@ -1487,9 +1490,11 @@
 
    "Safety First"
    {:in-play [:hand-size {:mod -2}]
-    :events {:runner-turn-ends {:req (req (< (count (:hand runner)) (hand-size state :runner)))
-                                :msg (msg "draw a card")
-                                :effect (effect (draw 1))}}}
+    :events {:runner-turn-ends {:msg (msg "draw a card")
+                                :delayed-completion true
+                                :effect (req (if (< (count (:hand runner)) (hand-size state :runner)) 
+                                               (draw state :runner eid 1 nil)
+                                               (effect-completed state :runner eid card)))}}}
 
    "Salvaged Vanadis Armory"
    {:events {:damage
@@ -1869,8 +1874,8 @@
    (let [ability {:label "Gain 1 [Credits] (start of turn)"
                   :msg "gain 1 [Credits]"
                   :once :per-turn
-                  :req (req (and (>= (:link runner) 2) (:runner-phase-12 @state)))
-                  :effect (effect (gain :credit 1))}]
+                  :effect (req (when (and (>= (:link runner) 2) (:runner-phase-12 @state))
+                                 (gain state :runner :credit 1)))}]
    {:flags {:drip-economy true}
     :abilities [ability]
     :events {:runner-turn-begins ability}})

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -95,7 +95,6 @@
                         (if (= 1 (count non-silent)) (first non-silent) (first handlers))
                         ab (dissoc (:ability to-resolve) :req)
                         c (:card to-resolve)
-                        persistent (when (:persistent ab) ((:persistent ab) state side eid c event-targets))
                         others (if (= 1 (count non-silent))
                                  (remove-once #(= (get-cid to-resolve) (get-cid %)) handlers)
                                  (next handlers))]

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -169,11 +169,12 @@
     (if (and (#{"Asset" "Agenda"} (:type card))
              prev-card
              (not (:host card)))
-      (resolve-ability state side eid {:prompt (str "The " (:title prev-card) " in " server " will now be trashed.")
-                                       :choices ["OK"]
-                                       :effect (req (system-msg state :corp (str "trashes " (card-str state prev-card)))
-                                                    (when (get-card state prev-card) ; make sure they didn't trash the card themselves
-                                                    (trash state :corp prev-card {:keep-server-alive true})))}
+      (continue-ability state side {:prompt (str "The " (:title prev-card) " in " server " will now be trashed.")
+                                    :choices ["OK"]
+                                    :delayed-completion true
+                                    :effect (req (system-msg state :corp (str "trashes " (card-str state prev-card)))
+                                                 (when (get-card state prev-card) ; make sure they didn't trash the card themselves
+                                                   (trash state :corp eid prev-card {:keep-server-alive true})))}
                        nil nil)
       (effect-completed state side eid))))
 

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -267,7 +267,7 @@
         end-cost (if no-install-cost 0 (install-cost state side card all-cost))]
     (if-let [cost-str (and (corp-can-install? state side card dest-zone)
                            (not (install-locked? state :corp))
-                           (pay state side card end-cost {action action}))]
+                           (pay state side card end-cost {:action action}))]
       (if (= server "New remote")
         (when-completed (trigger-event-sync state side :server-created card)
                         (corp-install-continue state side eid card server args slot cost-str))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -373,8 +373,10 @@
    {:keys [unpreventable cause keep-server-alive suppress-event host-trashed] :as args}]
   (let [cdef (card-def card)
         moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
-    (when-let [trash-effect (:trash-effect cdef)]
-      (when (and (not disabled)
+    (swap! state update-in [:per-turn] dissoc (:cid moved-card))
+    (swap! state update-in [:trash :trash-list] dissoc oid)
+    (if-let [trash-effect (:trash-effect cdef)]
+      (if (and (not disabled)
                  (or (and (= (:side card) "Runner")
                           (:installed card)
                           (not (:facedown card)))
@@ -382,10 +384,10 @@
                           (not host-trashed))
                      (and (:when-inactive trash-effect)
                           (not host-trashed))))
-        (resolve-ability state side trash-effect moved-card (list cause))))
-    (swap! state update-in [:per-turn] dissoc (:cid moved-card))
-    (swap! state update-in [:trash :trash-list] dissoc oid)
-    (effect-completed state side eid))))
+        (when-completed (resolve-ability state side trash-effect moved-card (list cause))
+                        (effect-completed state side eid))
+        (effect-completed state side eid))
+      (effect-completed state side eid)))))
 
 (defn- resolve-trash
   ([state side eid card args] (resolve-trash state side eid card eid args))

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -615,7 +615,7 @@
   ;; Asa Group - don't allow installation of agendas
   (do-game
     (new-game
-      (make-deck "Asa Group: Security Through Vigilance" [(qty "Pup") (qty "Project Vitruvius") (qty "Urban Renewal")])
+      (make-deck "Asa Group: Security Through Vigilance" [(qty "Pup" 1) (qty "Project Vitruvius" 1) (qty "Urban Renewal" 1)])
       (default-runner))
     (play-from-hand state :corp "Pup" "New remote")
     (prompt-select :corp (find-card "Project Vitruvius" (:hand (get-corp))))
@@ -627,11 +627,11 @@
   ;; Checks that asa group and mirrormorph prompts appear in the correct order
   (do-game
     (new-game
-      (make-deck "Asa Group: Security Through Vigilance" [(qty "Shipment from MirrorMorph")
-                                                          (qty "Pup")
-                                                          (qty "Red Herrings")
-                                                          (qty "Marilyn Campaign")
-                                                          (qty "Project Vitruvius")])
+      (make-deck "Asa Group: Security Through Vigilance" [(qty "Shipment from MirrorMorph" 1)
+                                                          (qty "Pup" 1)
+                                                          (qty "Red Herrings" 1)
+                                                          (qty "Marilyn Campaign" 1)
+                                                          (qty "Project Vitruvius" 1)])
       (default-runner))
     (let  [marilyn (find-card "Marilyn Campaign" (:hand (get-corp)))
            pup (find-card "Pup" (:hand (get-corp)))

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -599,7 +599,7 @@
     (prompt-select :corp (get-ice state :hq 0))
     (is (= 3 (:credit (get-corp))) "Corp not charged for Architects of Tomorrow rez of Eli 1.0")))
 
-(deftest haas-bioroid-asa-group
+(deftest haas-bioroid-asa-group-operation-install
   ;; Asa Group - don't allow installation of operations
   (do-game
     (new-game
@@ -610,6 +610,45 @@
     (is (empty? (get-content state :remote1)) "Asa Group installed an event in a server")
     (prompt-select :corp (find-card "Urban Renewal" (:hand (get-corp))))
     (is (= "Urban Renewal" (:title (get-content state :remote1 0))) "Asa Group can install an asset in a remote")))
+
+(deftest haas-bioroid-asa-group-agenda-install
+  ;; Asa Group - don't allow installation of agendas
+  (do-game
+    (new-game
+      (make-deck "Asa Group: Security Through Vigilance" [(qty "Pup") (qty "Project Vitruvius") (qty "Urban Renewal")])
+      (default-runner))
+    (play-from-hand state :corp "Pup" "New remote")
+    (prompt-select :corp (find-card "Project Vitruvius" (:hand (get-corp))))
+    (is (empty? (get-content state :remote1)) "Asa Group did not install Agenda with its ability")
+    (prompt-select :corp (find-card "Urban Renewal" (:hand (get-corp))))
+    (is (= "Urban Renewal" (:title (get-content state :remote1 0))) "Asa Group can install an asset in a remote")))
+
+(deftest haas-bioroid-asa-group-mirrormorph
+  ;; Checks that asa group and mirrormorph prompts appear in the correct order
+  (do-game
+    (new-game
+      (make-deck "Asa Group: Security Through Vigilance" [(qty "Shipment from MirrorMorph")
+                                                          (qty "Pup")
+                                                          (qty "Red Herrings")
+                                                          (qty "Marilyn Campaign")
+                                                          (qty "Project Vitruvius")])
+      (default-runner))
+    (let  [marilyn (find-card "Marilyn Campaign" (:hand (get-corp)))
+           pup (find-card "Pup" (:hand (get-corp)))
+           herrings (find-card "Red Herrings" (:hand (get-corp)))
+           vitruvius (find-card "Project Vitruvius" (:hand (get-corp)))]
+      (play-from-hand state :corp "Shipment from MirrorMorph")
+      (prompt-select :corp marilyn)
+      (prompt-choice :corp "New remote")
+      (is (= (:cid marilyn) (:cid (get-content state :remote1 0))) "Marilyn is installed as first card")
+      (prompt-select :corp herrings) ;; This should be the Asa prompt, should be automatically installed in remote1
+      (is (= (:cid herrings) (:cid (get-content state :remote1 1))) "Red Herrings is installed in Server 1")
+      (prompt-select :corp vitruvius)
+      (prompt-choice :corp "New remote")
+      (prompt-select :corp pup)
+      (prompt-choice :corp "New remote")
+      (is (empty? (:prompt (get-corp))) "No more prompts")
+      (is (= 6 (count (:servers (get-corp)))) "There are six servers, including centrals"))))
 
 (deftest haas-bioroid-engineering-the-future-employee-strike
   ;; EtF - interaction with Employee Strike


### PR DESCRIPTION
This PR does the following:

- Makes `trigger-event`, `trigger-event-sync` and `trigger-event-simult` swap in the event as happened as it's first order of business
- Changes `first-event?` to handle this change correctly (and fixes all bugs with this I could find, hopefully all)
- Makes `trigger-event-sync` and `trigger-event-simult` check their requirements *only* when the event is triggered, so they do not take into account changes to game state. The cards Activist Support, Underworld Contact and System Outage if-tests moved to inside the effect, to reflect this.
- Makes corp-install use `trigger-event-sync` instead of `trigger-event` to fix problem with Asa. This also fixes some other problems.
- While I was at it, makes `corp-install` check that `:pre-corp-install` and `:server-created` are actually done before continuing. None of these do anything that should be less than instant, but you never know, some of them might do something requiring prompts in the future.
- Made test for the Asa + MirrorMorph thing.

Closes #3495 #3409 #3393 and maybe more???