### PR TITLE
Updates RNG Key to not pay out when first access is an installed card

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -795,18 +795,22 @@
                                :delayed-completion true
                                :msg (msg "to reveal " (:title target))
                                :effect (req (if-let [guess (get-in card [:special :rng-guess])]
-                                              (if (or (= guess (:cost target))
-                                                      (= guess (:advancementcost target)))
-                                                (continue-ability state side
-                                                                  {:prompt "Choose RNG Key award"
-                                                                   :choices ["Gain 3 [Credits]" "Draw 2 cards"]
-                                                                   :effect (req (if (= target "Draw 2 cards")
-                                                                                  (do (draw state :runner 2)
-                                                                                      (system-msg state :runner "uses RNG Key to draw 2 cards"))
-                                                                                  (do (gain state :runner :credit 3)
-                                                                                      (system-msg state :runner "uses RNG Key to gain 3 [Credits]"))))}
-                                                                  card nil)
-                                                (effect-completed state side eid))
+                                              (if (installed? target)
+                                                ;; Do not trigger on installed cards (can't "reveal" an installed card per UFAQ)
+                                                (do (toast state :runner "Installed cards cannot be revealed, so RNG Key does not pay out." "info")
+                                                    (effect-completed state side eid))
+                                                (if (or (= guess (:cost target))
+                                                        (= guess (:advancementcost target)))
+                                                  (continue-ability state side
+                                                                    {:prompt "Choose RNG Key award"
+                                                                     :choices ["Gain 3 [Credits]" "Draw 2 cards"]
+                                                                     :effect (req (if (= target "Draw 2 cards")
+                                                                                    (do (draw state :runner 2)
+                                                                                        (system-msg state :runner "uses RNG Key to draw 2 cards"))
+                                                                                    (do (gain state :runner :credit 3)
+                                                                                        (system-msg state :runner "uses RNG Key to gain 3 [Credits]"))))}
+                                                                    card nil)
+                                                  (effect-completed state side eid)))
                                               (effect-completed state side eid)))}
              :post-access-card {:effect (effect (update! (assoc-in card [:special :rng-guess] nil)))}
              :successful-run {:req (req (let [first-hq (first-successful-run-on-server? state :hq)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -62,7 +62,9 @@
    "Aeneas Informant"
    {:events {:no-trash {:req (req (and (:trash target) (not= (first (:zone target)) :discard)))
                         :optional {:prompt (msg "Use Aeneas Informant?")
-                                   :yes-ability {:msg (msg (str "gain 1 [Credits] and reveal " (:title target)))
+                                   :yes-ability {:msg (msg (str "gain 1 [Credits]"
+                                                                (when-not (installed? target)
+                                                                  (str " and reveal "  (:title target)))))
                                                  :effect (effect (gain :credit 1))}}}}}
 
    "Aesops Pawnshop"

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -877,7 +877,6 @@
         (prompt-choice :runner "Yes")
         (prompt-choice :runner 2)
         (prompt-choice :runner "Unrezzed upgrade in HQ")
-        (clojure.pprint/pprint (:prompt (get-runner)))
         (is (= "You accessed Hokusai Grid." (:msg (:prompt (get-runner)))) "No RNG Key prompt, straight to access prompt")
         (is (= 5 (:credit (get-runner))) "Gained no credits")))))
 

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -877,7 +877,8 @@
         (prompt-choice :runner "Yes")
         (prompt-choice :runner 2)
         (prompt-choice :runner "Unrezzed upgrade in HQ")
-        (is (= "You accessed Hokusai Grid." (:msg (:prompt (get-runner)))) "No RNG Key prompt, straight to access prompt")
+        (is (= "You accessed Hokusai Grid." (-> (get-runner) :prompt first :msg))
+            "No RNG Key prompt, straight to access prompt")
         (is (= 5 (:credit (get-runner))) "Gained no credits")))))
 
 (deftest scheherazade


### PR DESCRIPTION
Also update Aeneas to not "reveal" installed cards.

Fixes #3150