### PR TITLE
Only check :_id when looking up players on the server-side

### DIFF
--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -58,8 +58,7 @@
 (defn not-spectator?
   "Returns true if the specified user in the specified state is not a spectator"
   [state user]
-  (and state (#{(get-in @state [:corp :user]) (get-in @state [:runner :user])} user)))
-
+  (and state (#{(get-in @state [:corp :user :_id]) (get-in @state [:runner :user :_id])} (:_id user))))
 
 (defn- private-card-vector [state side cards]
   (vec (map (fn [card]


### PR DESCRIPTION
Another case where we were comparing the entire `user` struct (which contains stats and alt art selections) when looking up players in a game. Could be the cause of some games locking up because the client and server user state diverges and the game think the player is a spectator.