### PR TITLE
Mumbad City Grid fixes

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -548,7 +548,10 @@
                                        (move state side c :hand)))} card nil)))}]}
 
    "Mumbad City Grid"
-   {:abilities [{:req (req this-server)
+   {:abilities [{:req (req (let [num-ice (count run-ices)]
+                             (and this-server
+                                  (>= num-ice 2)
+                                  (< (:position run 0) num-ice))))
                  :label "Swap the ICE just passed with another piece of ICE protecting this server"
                  :effect (req (let [passed-ice (nth (get-in @state (vec (concat [:corp :servers] (:server run) [:ices])))
                                                                                 (:position run))
@@ -565,9 +568,11 @@
                                                    (swap! state update-in (cons :corp ice-zone)
                                                           #(assoc % sndx fnew))
                                                    (update-ice-strength state side fnew)
-                                                   (update-ice-strength state side snew)))} card nil)
-                                 (system-msg state side (str "uses Mumbad City Grid to swap " (card-str state passed-ice)
-                                                             " with " (card-str state target)))))}]}
+                                                   (update-ice-strength state side snew)
+                                                   (system-msg state side (str "uses Mumbad City Grid to swap "
+                                                                               (card-str state passed-ice)
+                                                                               " with " (card-str state target)))))}
+                                                  card nil)))}]}
 
    "Mumbad Virtual Tour"
    {:implementation "Only forces trash if runner has no Imps and enough credits in the credit pool"

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -779,6 +779,53 @@
       (is (prompt-is-card? :corp sn) "Corp prompt is on Security Nexus")
       (is (prompt-is-type? :runner :waiting) "Runner prompt is waiting for Corp"))))
 
+(deftest mumbad-city-grid
+  ;; Mumbad City Grid - when runner passes a piece of ice, swap that ice with another from this server
+  (testing "1 ice"
+    (do-game
+      (new-game (default-corp ["Mumbad City Grid" "Quandary"])
+                (default-runner))
+      (play-from-hand state :corp "Mumbad City Grid" "New remote")
+      (play-from-hand state :corp "Quandary" "Server 1")
+      (let [mcg (get-content state :remote1 0)]
+        (core/rez state :corp mcg)
+        (take-credits state :corp)
+        (run-on state "Server 1")
+        (is (= 1 (count (get-in @state [:corp :servers :remote1 :ices]))) "1 ice on server")
+        (card-ability state :corp (refresh mcg) 0)
+        (prompt-choice-partial :corp "No")
+        (prompt-choice-partial :runner "Continue")
+        (card-ability state :corp (refresh mcg) 0)
+        (prompt-choice-partial :corp "No")
+        (prompt-choice-partial :runner "Jack")
+        (is (= 1 (count (get-in @state [:corp :servers :remote1 :ices]))) "Still 1 ice on server"))))
+  (testing "fire before pass"
+    (do-game
+      (new-game (default-corp ["Mumbad City Grid" "Quandary" "Ice Wall"])
+                (default-runner))
+      (play-from-hand state :corp "Mumbad City Grid" "New remote")
+      (play-from-hand state :corp "Quandary" "Server 1")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (let [mcg (get-content state :remote1 0)]
+        (core/rez state :corp mcg)
+        (take-credits state :corp)
+        (run-on state "Server 1")
+        (is (= 2 (:position (:run @state))) "Runner at position 2")
+        (is (= 2 (count (get-in @state [:corp :servers :remote1 :ices]))) "2 ice on server")
+        (is (= "Quandary" (:title (first (get-in @state [:corp :servers :remote1 :ices])))) "Quandary inner ice")
+        (is (= "Ice Wall" (:title (second (get-in @state [:corp :servers :remote1 :ices])))) "Ice Wall outer ice")
+        (card-ability state :corp (refresh mcg) 0)
+        (run-continue state)
+        (is (= 1 (:position (:run @state))) "Runner at position 1")
+        (card-ability state :corp (refresh mcg) 0)
+        (prompt-select :corp (get-ice state :remote1 0))
+        (is (= 1 (:position (:run @state))) "Runner at position 1")
+        (is (= "Quandary" (:title (second (get-in @state [:corp :servers :remote1 :ices])))) "Quandary outer ice")
+        (is (= "Ice Wall" (:title (first (get-in @state [:corp :servers :remote1 :ices])))) "Ice Wall inner ice")
+        (prompt-choice-partial :corp "No")
+        (prompt-choice-partial :runner "Jack")
+        (is (= 2 (count (get-in @state [:corp :servers :remote1 :ices]))) "Still 2 ice on server")))))
+
 (deftest mumbad-virtual-tour
   ;; Tests that Mumbad Virtual Tour forces trash when no :slow-trash
   (do-game


### PR DESCRIPTION
`Mumbad City Grid` would crash if fired on a server with one ice or if fired when approaching the outermost ice on a server.

Also fixed message printing.

Added tests.