### PR TITLE
Fixed Mutate

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -820,29 +820,32 @@
                          true)))))}
 
    "Mutate"
-   {:additional-cost [:ice 1]
-    :effect (effect (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
-
-    :events {:corp-trash {:effect (req (let [i (ice-index state target)
+   {:req (req (some #(and (ice? %) (rezzed? %)) (all-installed state :corp)))
+    :prompt "Select a rezzed piece of ice to trash"
+    :choices {:req #(and (ice? %) (rezzed? %))}
+    :delayed-completion true
+    :effect (req (let [i (ice-index state target)
                        [reveal r] (split-with (complement ice?) (get-in @state [:corp :deck]))
                        titles (->> (conj (vec reveal) (first r)) (filter identity) (map :title))]
-                                           (system-msg state side (str "uses Mutate to trash " (:title target)))
-                                           (when (seq titles)
-                                             (system-msg state side (str "reveals " (clojure.string/join ", " titles) " from R&D")))
-                                           (if-let [ice (first r)]
-                                             (let [newice (assoc ice :zone (:zone target) :rezzed true)
-                                                   ices (get-in @state (cons :corp (:zone target)))
-                                                   newices (apply conj (subvec ices 0 i) newice (subvec ices i))]
-                                               (swap! state assoc-in (cons :corp (:zone target)) newices)
-                                               (swap! state update-in [:corp :deck] (fn [coll] (remove-once #(= (:cid %) (:cid newice)) coll)))
-                                               (trigger-event state side :corp-install newice)
-                                               (card-init state side newice {:resolve-effect false})
-                                               (system-msg state side (str "uses Mutate to install and rez " (:title newice) " from R&D at no cost"))
-                                               (trigger-event state side :rez newice))
-                                             (system-msg state side (str "does not find any ICE to install from R&D")))
-                                           (shuffle! state :corp :deck)
-                                           (effect-completed state side eid card)
-                                           (unregister-events state side card)))}}}
+                   (when-completed (trash state :corp target nil)
+                                   (do
+                                     (system-msg state side (str "uses Mutate to trash " (:title target)))
+                                     (when (seq titles)
+                                       (system-msg state side (str "reveals " (clojure.string/join ", " titles) " from R&D")))
+                                     (if-let [ice (first r)]
+                                       (let [newice (assoc ice :zone (:zone target) :rezzed true)
+                                             ices (get-in @state (cons :corp (:zone target)))
+                                             newices (apply conj (subvec ices 0 i) newice (subvec ices i))]
+                                         (swap! state assoc-in (cons :corp (:zone target)) newices)
+                                         (swap! state update-in [:corp :deck] (fn [coll] (remove-once #(= (:cid %) (:cid newice)) coll)))
+                                         (trigger-event state side :corp-install newice)
+                                         (card-init state side newice {:resolve-effect false
+                                                                       :init-data true})
+                                         (system-msg state side (str "uses Mutate to install and rez " (:title newice) " from R&D at no cost"))
+                                         (trigger-event state side :rez newice))
+                                       (system-msg state side (str "does not find any ICE to install from R&D")))
+                                     (shuffle! state :corp :deck)
+                                     (effect-completed state side eid card)))))}
 
    "Neural EMP"
    {:req (req (last-turn? state :runner :made-run))

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -1045,6 +1045,39 @@
         (prompt-choice :corp "0")
         (is (= 1 (:agenda-point (get-corp))) "Profiteering was able to be scored")))))
 
+(deftest mutate
+  ;; Mutate - trash a rezzed piece of ice, install and rez one from R&D
+  (testing "Basic operation"
+    (do-game
+      (new-game (default-corp ["Mutate" "Ice Wall" "Enigma" "Hedge Fund"])
+                (default-runner))
+      (core/move state :corp (find-card "Hedge Fund" (:hand (get-corp))) :deck)
+      (core/move state :corp (find-card "Enigma" (:hand (get-corp))) :deck)
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (is (= 1 (count (get-ice state :hq))) "1 ice installed")
+      (is (= "Ice Wall" (:title (get-ice state :hq 0))) "Ice Wall is installed")
+      (play-from-hand state :corp "Mutate")
+      (prompt-select :corp (get-ice state :hq 0))
+      (is (= 1 (count (get-ice state :hq))) "1 ice installed")
+      (is (= "Enigma" (:title (get-ice state :hq 0))) "Enigma is installed")
+      (is (:rezzed (get-ice state :hq 0)) "Enigma is rezzed")
+      (is (second-last-log-contains? state "Hedge Fund") "Skipped card name was logged")
+      (is (second-last-log-contains? state "Enigma") "Installed card name was logged")))
+  (testing "No ice in R&D"
+    (do-game
+      (new-game (default-corp ["Mutate" "Ice Wall" "Enigma" "Hedge Fund"])
+                (default-runner))
+      (core/move state :corp (find-card "Hedge Fund" (:hand (get-corp))) :deck)
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (is (= 1 (count (get-ice state :hq))) "1 ice installed")
+      (is (= "Ice Wall" (:title (get-ice state :hq 0))) "Ice Wall is installed")
+      (play-from-hand state :corp "Mutate")
+      (prompt-select :corp (get-ice state :hq 0))
+      (is (empty? (get-ice state :hq)) "No ice installed")
+      (is (second-last-log-contains? state "Hedge Fund") "Skipped card name was logged"))))
+
 (deftest neural-emp
   ;; Neural EMP - Play if Runner made a run the previous turn to do 1 net damage
   (do-game

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -78,9 +78,11 @@
                                      :subroutine ability :targets targets})))
 
 (defn get-ice
-  "Get installed ice protecting server by position."
-  [state server pos]
-  (get-in @state [:corp :servers server :ices pos]))
+  "Get installed ice protecting server by position. If no pos, get all ice on the server."
+  ([state server]
+   (get-in @state [:corp :servers server :ices]))
+  ([state server pos]
+   (get-in @state [:corp :servers server :ices pos])))
 
 (defn get-content
   "Get card in a server by position. If no pos, get all cards in the server."


### PR DESCRIPTION
Instead of relying on the corp trash event, we provide a prompt to select rezzed ice and handle the result.

Fixes #3488 