### PR TITLE
Marilyn Campaign and Standoff interaction

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1116,11 +1116,12 @@
                                     (do (system-msg state :corp "declines to trash a card from Standoff")
                                         (clear-wait-prompt state :runner)
                                         (effect-completed state :corp eid))))
-              :effect (req (do (system-msg state side (str "trashes " (card-str state target) " due to Standoff"))
-                               (clear-wait-prompt state (other-side side))
-                               (trash state side target {:unpreventable true})
-                               (show-wait-prompt state side (str (side-str (other-side side)) " to trash a card for Standoff"))
-                               (continue-ability state (other-side side) (stand (other-side side)) card nil)))})]
+              :effect (req (when-completed (trash state side target {:unpreventable true})
+                                           (do
+                                             (system-msg state side (str "trashes " (card-str state target) " due to Standoff"))
+                                             (clear-wait-prompt state (other-side side))
+                                             (show-wait-prompt state side (str (side-str (other-side side)) " to trash a card for Standoff"))
+                                             (continue-ability state (other-side side) (stand (other-side side)) card nil))))})]
      {:interactive (req true)
       :delayed-completion true
       :effect (effect (show-wait-prompt (str (side-str (other-side side)) " to trash a card for Standoff"))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -873,9 +873,11 @@
                   :once :per-turn
                   :req (req (:corp-phase-12 @state))
                   :label (str "Gain 2 [Credits] (start of turn)")
+                  :delayed-completion true
                   :effect (req (gain state :corp :credit 2)
-                               (when (zero? (get-in card [:counter :credit]))
-                                 (trash state :corp card)))}]
+                               (if (zero? (get-in card [:counter :credit]))
+                                 (trash state :corp eid card)
+                                 (effect-completed state :corp eid)))}]
      {:effect (effect (add-counter card :credit 8))
       :flags {:corp-phase-12 (req (= 2 (get-in card [:counter :credit])))}
       :derezzed-events {:runner-turn-ends corp-rez-toast}
@@ -887,6 +889,7 @@
                                      (continue-ability :corp
                                        {:optional
                                         {:prompt "Shuffle Marilyn Campaign into R&D?"
+                                         :priority 1
                                          :player :corp
                                          :yes-ability {:msg "shuffle it back into R&D"
                                                        :effect (req (move state :corp card :deck)


### PR DESCRIPTION
If the Corp choses to trash a rezzed `Marilyn Campaign` during a `Standoff`, the runner wait prompt covers up the `Marilyn` shuffle prompt.

Made both `Standoff` and `Marilyn Campaign` more `delayed-completion` aware and bumped the `:priority` of the Marilyn prompt.