### PR TITLE
Hivemind interaction with Consume and Trypano

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -150,7 +150,7 @@
                             :req (req (some #(card-is? % :side :corp) targets))
                             :effect (req (let [amt-trashed (count (filter #(card-is? % :side :corp) targets))
                                                auto-ab {:effect (effect (add-counter :runner card :virus amt-trashed))
-                                                        :msg "place " (quantify amt-trashed "virus counter") "on Consume"}
+                                                        :msg (str "place " (quantify amt-trashed "virus counter") " on Consume")}
                                                sing-ab {:optional {:prompt "Place a virus counter on Consume?"
                                                                    :yes-ability {:effect (effect (add-counter :runner card :virus 1))
                                                                                  :msg "place 1 virus counter on Consume"}}}
@@ -171,17 +171,17 @@
                               (when-let [hiveminds (filter #(= "Hivemind" (:title %)) (all-active-installed state :runner))]
                                         (doseq [h hiveminds]
                                                (update! state side (assoc-in h [:counter :virus] 0)))))
-                 :msg (msg (let [local-virus (get-in card [:counter :virus])
+                 :msg (msg (let [local-virus (get-in card [:counter :virus] 0)
                                  global-virus (get-virus-counters state side card)
                                  hivemind-virus (- global-virus local-virus)]
-                             (str "gain " (* 2 global-virus) " [Credits], removing " local-virus " virus counter(s) from Consume"
+                             (str "gain " (* 2 global-virus) " [Credits], removing " (quantify local-virus "virus counter") " from Consume"
                              (when (pos? hivemind-virus)
                                    (str " (and " hivemind-virus " from Hivemind)")))))}
                 {:effect (effect (update! (update-in card [:special :auto-accept] #(not %)))
                                  (toast (str "Consume will now "
                                              (if (get-in card [:special :auto-accept]) "no longer " "")
                                              "automatically add counters.") "info"))
-                 :label "Toggle auomatically adding virus counters"}]}
+                 :label "Toggle automatically adding virus counters"}]}
 
    "D4v1d"
    {:implementation "Does not check that ICE strength is 5 or greater"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1022,7 +1022,6 @@
                              :yes-ability {:msg (msg "place a virus counter on Trypano")
                                            :effect (req (add-counter state side card :virus 1))}}}
                  :counter-added {:delayed-completion true
-                                 :req (req (= (:cid card) (:cid target)))
                                  :effect trash-if-5}
                  :card-moved {:effect trash-if-5
                               :delayed-completion true}

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1138,7 +1138,29 @@
       (play-from-hand state :runner "Hivemind") ; now Hivemind makes both Trypanos have 5 counters
       (is (= 0 (count (get-in @state [:corp :servers :rd :ices]))) "Unrezzed Archiect was trashed")
       (is (= 1 (count (get-in @state [:corp :servers :hq :ices]))) "Rezzed Archiect was not trashed")
-      (is (= 1 (count (:discard (get-runner)))) "Trypano went to discard"))))
+      (is (= 1 (count (:discard (get-runner)))) "Trypano went to discard")))
+  (testing "Fire when Hivemind gains counters"
+    (do-game
+      (new-game (default-corp ["Architect"])
+                (default-runner ["Trypano" "Hivemind" (qty "Surge" 2)]))
+      (play-from-hand state :corp "Architect" "R&D")
+      (let [architect-unrezzed (get-ice state :rd 0)]
+        (take-credits state :corp)
+        (play-from-hand state :runner "Trypano")
+        (prompt-select :runner architect-unrezzed)
+        (is (= 0 (count (:discard (get-runner)))) "Trypano not in discard yet")
+        (is (= 1 (count (get-in @state [:corp :servers :rd :ices]))) "Unrezzed Architect is not trashed")
+        (play-from-hand state :runner "Hivemind")
+        (let [hive (get-program state 0)]
+          (is (= 1 (get-counters (refresh hive) :virus)) "Hivemind starts with 1 virus counter")
+          (play-from-hand state :runner "Surge")
+          (prompt-select :runner (refresh hive))
+          (is (= 3 (get-counters (refresh hive) :virus)) "Hivemind gains 2 virus counters")
+          (play-from-hand state :runner "Surge")
+          (prompt-select :runner (refresh hive))
+          (is (= 5 (get-counters (refresh hive) :virus)) "Hivemind gains 2 virus counters (now at 5)")
+          (is (= 0 (count (get-in @state [:corp :servers :rd :ices]))) "Unrezzed Architect was trashed")
+          (is (= 3 (count (:discard (get-runner)))) "Trypano went to discard"))))))
 
 (deftest upya
   (do-game


### PR DESCRIPTION
Handle `Consume` gain ability with no local virus counters.
Make `Trypano` watch for counter updates on all cards (in case a `Hivemind` gains virus counters).

Fixes #3549 
Fixes #3550 