### PR TITLE
FIX: Move successful traces to :successful

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -793,11 +793,11 @@
 
    "Paper Trail"
    {:trace {:base 6
-            :msg "trash all connection and job resources"
-            :effect (req (doseq [resource (filter #(or (has-subtype? % "Job")
-                                                       (has-subtype? % "Connection"))
-                                                  (all-active-installed state :runner))]
-                                   (trash state side resource)))}}
+            :successful {:msg "trash all connection and job resources"
+                         :effect (req (doseq [resource (filter #(or (has-subtype? % "Job")
+                                                                    (has-subtype? % "Connection"))
+                                                               (all-active-installed state :runner))]
+                                        (trash state side resource)))}}}
 
    "Personality Profiles"
    (let [pp {:req (req (pos? (count (:hand runner))))
@@ -1046,9 +1046,9 @@
    "Restructured Datapool"
    {:abilities [{:cost [:click 1]
                  :trace {:base 2
-                         :msg "give the Runner 1 tag"
-                         :delayed-completion true
-                         :effect (effect (tag-runner :runner eid 1))}}]}
+                         :successful {:msg "give the Runner 1 tag"
+                                      :delayed-completion true
+                                      :effect (effect (tag-runner :runner eid 1))}}}]}
 
    "Self-Destruct Chips"
    {:silent (req true)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -131,17 +131,21 @@
                  :msg (msg "swap " (:advance-counter card 0) " cards in HQ and Archives")}]}
 
    "Amani Senai"
-   (let [get-last-stolen-pts (fn [state] (advancement-cost state :corp (last (get-in @state [:runner :scored]))))
-         get-last-scored-pts (fn [state] (advancement-cost state :corp (last (get-in @state [:corp :scored]))))
+   (let [get-last-stolen-pts (fn [state]
+                               (advancement-cost state :corp (last (get-in @state [:runner :scored]))))
+         get-last-scored-pts (fn [state]
+                               (advancement-cost state :corp (last (get-in @state [:corp :scored]))))
          senai-ability (fn [trace-base-func]
                          {:interactive (req true)
-                          :optional {:prompt "Trace with Amani Senai?" :player :corp
+                          :optional {:prompt "Trace with Amani Senai?"
+                                     :player :corp
                                      :yes-ability {:trace {:base (req (trace-base-func state))
-                                                           :choices {:req #(and (installed? %)
-                                                                                (card-is? % :side :runner))}
-                                                           :label "add an installed card to the Grip"
-                                                           :msg (msg "add " (:title target) " to the Runner's Grip")
-                                                           :effect (effect (move :runner target :hand true))}}}})]
+                                                           :successful
+                                                           {:choices {:req #(and (installed? %)
+                                                                                 (card-is? % :side :runner))}
+                                                            :label "add an installed card to the Grip"
+                                                            :msg (msg "add " (:title target) " to the Runner's Grip")
+                                                            :effect (effect (move :runner target :hand true))}}}}})]
      {:events {:agenda-scored (senai-ability get-last-scored-pts)
                :agenda-stolen (senai-ability get-last-stolen-pts)}})
 
@@ -220,8 +224,8 @@
    "Broadcast Square"
    {:events {:pre-bad-publicity {:delayed-completion true
                                  :trace {:base 3
-                                         :msg "prevents all bad publicity"
-                                         :effect (effect (bad-publicity-prevent Integer/MAX_VALUE))}}}}
+                                         :successful {:msg "prevents all bad publicity"
+                                                      :effect (effect (bad-publicity-prevent Integer/MAX_VALUE))}}}}}
 
    "Capital Investors"
    {:abilities [{:cost [:click 1] :effect (effect (gain :credit 2)) :msg "gain 2 [Credits]"}]}
@@ -771,10 +775,10 @@
 
    "Kuwinda K4H1U3"
    (let [ability {:trace {:base (req (get-in card [:counter :power] 0))
-                          :delayed-completion true
-                          :effect (effect (damage :runner eid :brain 1 {:card card})
-                                          (trash card))
-                          :msg "do 1 brain damage"
+                          :successful {:delayed-completion true
+                                       :msg "do 1 brain damage"
+                                       :effect (effect (damage :runner eid :brain 1 {:card card})
+                                                       (trash card))}
                           :unsuccessful {:effect (effect (add-counter card :power 1)
                                                          (system-msg "adds 1 power counter to Kuwinda K4H1U3"))}}}]
      {:derezzed-events {:runner-turn-ends corp-rez-toast}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -516,7 +516,8 @@
               (run :hq {:req (req (= target :hq))
                         :replace-access
                         {:mandatory true
-                         :msg (msg "reveal 2 cards from HQ and trash all " target "s") ;should maybe lower-case target
+                         :msg (msg "reveal 2 cards from HQ and trash all "
+                                   target (when (not= "ICE" (:type target)) "s"))
                          :prompt "Choose a card type"
                          :choices ["Asset" "Upgrade" "Operation" "ICE"]
                          :effect (req (let [chosen-type target

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1940,7 +1940,8 @@
    (letfn [(finish-choice [choices]
              (let [choices (filter #(not= "None" %) choices)]
                (when (not-empty choices)
-                {:effect (req (doseq [c choices] (move state :corp c :deck))
+                {:effect (req (doseq [c choices]
+                                (move state :corp c :deck))
                               (shuffle! state :corp :deck))
                  :msg (str "shuffle " (join ", " (map :title choices)) " into R&D")})))
            (choose-cards [hand chosen]
@@ -1949,7 +1950,8 @@
               :choices (conj (vec (clojure.set/difference hand chosen))
                              "None")
               :delayed-completion true
-              :effect (req (if (and (empty? chosen) (not= "None" target))
+              :effect (req (if (and (empty? chosen)
+                                    (not= "None" target))
                              (continue-ability state side (choose-cards hand (conj chosen target)) card nil)
                              (continue-ability state side (finish-choice (conj chosen target)) card nil)))})]
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -35,9 +35,10 @@
    "Another Day, Another Paycheck"
    {:events {:agenda-stolen
              {:trace {:base 0
-                      :unsuccessful {:effect (effect (gain :runner :credit
-                                                           (+ (:agenda-point runner) (:agenda-point corp))))
-                                     :msg (msg (str "gain " (+ (:agenda-point runner) (:agenda-point corp)) " [Credits]"))}}}}}
+                      :unsuccessful
+                      {:effect (effect (gain :runner :credit
+                                             (+ (:agenda-point runner) (:agenda-point corp))))
+                       :msg (msg (str "gain " (+ (:agenda-point runner) (:agenda-point corp)) " [Credits]"))}}}}}
 
    "Apocalypse"
    (let [corp-trash {:delayed-completion true
@@ -1952,9 +1953,10 @@
                              (continue-ability state side (finish-choice (conj chosen target)) card nil)))})]
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
     :trace {:base 3
-            :unsuccessful {:delayed-completion true
-                           :msg "reveal all cards in HQ"
-                           :effect (effect (continue-ability :runner (choose-cards (set (:hand corp)) #{}) card nil))}}})
+            :unsuccessful
+            {:delayed-completion true
+             :msg "reveal all cards in HQ"
+             :effect (effect (continue-ability :runner (choose-cards (set (:hand corp)) #{}) card nil))}}})
 
    "Windfall"
    {:effect (effect (shuffle! :deck)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -905,14 +905,17 @@
                               (trash state side (get-card state card) {:cause :ability-cost}))}]}
 
    "Security Nexus"
-   {:in-play [:memory 1 :link 1]
+   {:implementation "Bypass is manual"
+    :in-play [:memory 1 :link 1]
     :abilities [{:req (req (:run @state))
                  :once :per-turn
                  :delayed-completion true
                  :msg "force the Corp to initiate a trace"
                  :label "Trace 5 - Give the Runner 1 tag and end the run"
-                 :trace {:base 5 :msg "give the Runner 1 tag and end the run"
-                         :effect (effect (tag-runner :runner eid 1) (end-run))
+                 :trace {:base 5
+                         :successful {:msg "give the Runner 1 tag and end the run"
+                                      :effect (effect (tag-runner :runner eid 1)
+                                                      (end-run))}
                          :unsuccessful {:msg "bypass the current ICE"}}}]}
 
    "Severnius Stim Implant"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -55,9 +55,15 @@
 (defn trace-ability
   "Run a trace with specified base strength.
    If successful trigger specified ability"
-  [base ability]
-  {:label (str "Trace " base " - " (:label ability))
-   :trace (assoc ability :base base)})
+  ([base {:keys [label] :as ability}]
+   {:label (str "Trace " base " - " label)
+    :trace {:base base
+            :successful ability}})
+  ([base {:keys [label] :as ability} {:keys [un-label] :as un-ability}]
+   {:label (str "Trace " base " - " label " / " un-label)
+    :trace {:base base
+            :successful ability
+            :unsuccessful un-ability}}))
 
 (defn tag-trace
   "Trace ability for giving a tag, at specified base strength"
@@ -208,7 +214,7 @@
 (defn constellation-ice
   "Generates map for Constellation ICE with specified effect."
   [ability]
-  {:subroutines [(trace-ability 2 (assoc ability :kicker (assoc ability :min 5)))]})
+  {:subroutines [(assoc-in (trace-ability 2 ability) [:trace :kicker] (assoc ability :min 5))]})
 
 ;;; Helper function for adding implementation notes to ICE defined with functions
 (defn- implementation-note
@@ -515,8 +521,9 @@
     :events {:successful-run nil :run-ends nil}}
 
    "Chetana"
-   {:subroutines [{:msg "make each player gain 2 [Credits]" :effect (effect (gain :runner :credit 2)
-                                                                            (gain :corp :credit 2))}
+   {:subroutines [{:msg "make each player gain 2 [Credits]"
+                   :effect (effect (gain :runner :credit 2)
+                                   (gain :corp :credit 2))}
                   (do-psi {:label "Do 1 net damage for each card in the Runner's grip"
                            :effect (effect (damage eid :net (count (get-in @state [:runner :hand])) {:card card}))
                            :msg (msg (str "do " (count (get-in @state [:runner :hand])) " net damage"))})]}
@@ -1789,12 +1796,7 @@
 
    "Searchlight"
    {:advanceable :always
-    ;; Could replace this with (tag-trace advance-counters).
-    :subroutines [{:label "Trace X - Give the Runner 1 tag"
-                   :trace {:base advance-counters
-                           :delayed-completion true
-                           :effect (effect (tag-runner :runner eid 1))
-                           :msg "give the Runner 1 tag"}}]}
+    :subroutines [(tag-trace advance-counters)]}
 
    "Seidr Adaptive Barrier"
    {:effect (req (let [srv (second (:zone card))]
@@ -1825,21 +1827,21 @@
    "Sherlock 1.0"
    {:subroutines [{:label "Trace 4 - Add an installed program to the top of the Runner's Stack"
                    :trace {:base 4
-                           :choices {:req #(and (installed? %)
-                                                (is-type? % "Program"))}
-                           :msg (msg "add " (:title target) " to the top of the Runner's Stack")
-                           :effect (effect (move :runner target :deck {:front true}))}}]
+                           :successful {:choices {:req #(and (installed? %)
+                                                             (is-type? % "Program"))}
+                                        :msg (msg "add " (:title target) " to the top of the Runner's Stack")
+                                        :effect (effect (move :runner target :deck {:front true}))}}}]
     :runner-abilities [(runner-break [:click 1] 1)]}
 
    "Sherlock 2.0"
    {:subroutines [{:label "Trace 4 - Add an installed program to the bottom of the Runner's Stack"
                    :trace {:base 4
-                           :choices {:req #(and (installed? %)
-                                                (is-type? % "Program"))}
-                           :msg     (msg "add " (:title target) " to the bottom of the Runner's Stack")
-                           :effect  (effect (move :runner target :deck))}}
-                  {:label  "Give the Runner 1 tag"
-                   :msg    "give the Runner 1 tag"
+                           :successful {:choices {:req #(and (installed? %)
+                                                             (is-type? % "Program"))}
+                                        :msg (msg "add " (:title target) " to the bottom of the Runner's Stack")
+                                        :effect (effect (move :runner target :deck))}}}
+                  {:label "Give the Runner 1 tag"
+                   :msg "give the Runner 1 tag"
                    :delayed-completion true
                    :effect (effect (tag-runner :runner eid 1))}]
     :runner-abilities [(runner-break [:click 2] 2)]}
@@ -1850,7 +1852,8 @@
                   (trace-ability 2 (do-net-damage 2))
                   (trace-ability 3 {:label "Do 3 net damage and end the run"
                                     :msg "do 3 net damage and end the run"
-                                    :effect (effect (damage eid :net 3 {:card card}) (end-run))})]}
+                                    :effect (effect (damage eid :net 3 {:card card})
+                                                    (end-run))})]}
 
    "Shiro"
    {:subroutines [{:label "Rearrange the top 3 cards of R&D"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -737,12 +737,11 @@
                              {:optional
                               {:prompt "Trace the Runner with NBN: Controlling the Message?"
                                :yes-ability {:trace {:base 4
-                                                     :msg "give the Runner 1 tag"
-                                                     :delayed-completion true
-                                                     :effect (effect (tag-runner :runner eid 1 {:unpreventable true})
-                                                                     (clear-wait-prompt :runner))
-                                                     :unsuccessful {:effect (effect (clear-wait-prompt :runner))}}}
-                               :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
+                                                     :successful
+                                                     {:msg "give the Runner 1 tag"
+                                                      :delayed-completion true
+                                                      :effect (effect (tag-runner :runner eid 1 {:unpreventable true}))}}}
+                               :end-effect (effect (clear-wait-prompt :runner))}}
                              card nil))}}})
 
    "NBN: Making News"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -363,12 +363,15 @@
 
    "Door to Door"
    {:events {:runner-turn-begins
-             {:trace {:base 1 :msg (msg (if tagged "do 1 meat damage" "give the Runner 1 tag"))
+             {:trace {:base 1
                       :label "Do 1 meat damage if Runner is tagged, or give the Runner 1 tag"
-                      :delayed-completion true
-                      :effect (req (if tagged
-                                     (damage state side eid :meat 1 {:card card})
-                                     (tag-runner state :runner eid 1)))}}}}
+                      :successful {:msg (msg (if tagged
+                                               "do 1 meat damage"
+                                               "give the Runner 1 tag"))
+                                   :delayed-completion true
+                                   :effect (req (if tagged
+                                                  (damage state side eid :meat 1 {:card card})
+                                                  (tag-runner state :runner eid 1)))}}}}}
 
    "Economic Warfare"
    {:req (req (and (last-turn? state :runner :successful-run)
@@ -379,8 +382,8 @@
    "Election Day"
    {:req (req (->> (get-in @state [:corp :hand])
                    (filter #(not (= (:cid %) (:cid card))))
-                   (count)
-                   (pos?)))
+                   count
+                   pos?))
     :delayed-completion true
     :msg (msg "trash all cards in HQ and draw 5 cards")
     :effect (effect (trash-cards (get-in @state [:corp :hand]))
@@ -394,15 +397,18 @@
    "Enforcing Loyalty"
    {:trace {:base 3
             :label "Trash a card not matching the faction of the Runner's identity"
-            :delayed-completion true
-            :effect (req (let [f (:faction (:identity runner))]
-                           (continue-ability
-                             state side
-                             {:prompt "Select an installed card not matching the faction of the Runner's identity"
-                              :choices {:req #(and (installed? %) (not= f (:faction %)) (card-is? % :side :runner))}
-                              :msg (msg "trash " (:title target))
-                              :effect (effect (trash target))}
-                            card nil)))}}
+            :successful
+            {:delayed-completion true
+             :effect (req (let [f (:faction (:identity runner))]
+                            (continue-ability
+                              state side
+                              {:prompt "Select an installed card not matching the faction of the Runner's identity"
+                               :choices {:req #(and (installed? %)
+                                                    (not= f (:faction %))
+                                                    (card-is? % :side :runner))}
+                               :msg (msg "trash " (:title target))
+                               :effect (effect (trash target))}
+                              card nil)))}}}
 
    "Enhanced Login Protocol"
    (letfn [(elp-activated [state]
@@ -492,13 +498,14 @@
 
    "Foxfire"
    {:trace {:base 7
-            :prompt "Select 1 card to trash"
-            :not-distinct true
-            :choices {:req #(and (installed? %)
-                                 (or (has-subtype? % "Virtual")
-                                     (has-subtype? % "Link")))}
-            :msg "trash 1 virtual resource or link"
-            :effect (effect (trash target) (system-msg (str "trashes " (:title target))))}}
+            :successful {:prompt "Select 1 card to trash"
+                         :not-distinct true
+                         :choices {:req #(and (installed? %)
+                                              (or (has-subtype? % "Virtual")
+                                                  (has-subtype? % "Link")))}
+                         :msg "trash 1 virtual resource or link"
+                         :effect (effect (trash target)
+                                         (system-msg (str "trashes " (:title target))))}}}
 
    "Freelancer"
    {:req (req tagged)
@@ -541,10 +548,10 @@
    "Hard-Hitting News"
    {:req (req (last-turn? state :runner :made-run))
     :trace {:base 4
-            :delayed-completion true
-            :msg "give the Runner 4 tags"
             :label "Give the Runner 4 tags"
-            :effect (effect (tag-runner :runner eid 4))}}
+            :successful {:delayed-completion true
+                         :msg "give the Runner 4 tags"
+                         :effect (effect (tag-runner :runner eid 4))}}}
 
    "Hasty Relocation"
    (letfn [(hr-final [chosen original]
@@ -576,11 +583,11 @@
 
    "Hatchet Job"
    {:trace {:base 5
-            :choices {:req #(and (installed? %)
-                                 (card-is? % :side :runner)
-                                 (not (has-subtype? % "Virtual")))}
-            :msg "add an installed non-virtual card to the Runner's grip"
-            :effect (effect (move :runner target :hand true))}}
+            :successful {:choices {:req #(and (installed? %)
+                                              (card-is? % :side :runner)
+                                              (not (has-subtype? % "Virtual")))}
+                         :msg "add an installed non-virtual card to the Runner's grip"
+                         :effect (effect (move :runner target :hand true))}}}
 
    "Hedge Fund"
    {:msg "gain 9 [Credits]" :effect (effect (gain :credit 9))}
@@ -588,26 +595,28 @@
    "Hellion Alpha Test"
    {:req (req (last-turn? state :runner :installed-resource))
     :trace {:base 2
-            :choices {:req #(and (installed? %)
-                                 (is-type? % "Resource"))}
-            :msg "add a Resource to the top of the Stack"
-            :effect (effect (move :runner target :deck {:front true})
-                            (system-msg (str "adds " (:title target) " to the top of the Stack")))
+            :successful {:msg "add a Resource to the top of the Stack"
+                         :choices {:req #(and (installed? %)
+                                              (is-type? % "Resource"))}
+                         :effect (effect (move :runner target :deck {:front true})
+                                         (system-msg (str "adds " (:title target) " to the top of the Stack")))}
             :unsuccessful {:msg "take 1 bad publicity"
                            :effect (effect (gain-bad-publicity :corp 1))}}}
 
    "Hellion Beta Test"
    {:req (req (last-turn? state :runner :trashed-card))
     :trace {:base 2
-            :label "Trash 2 installed non-program cards"
-            :choices {:max (req (min 2 (count (filter #(or (:facedown %) (not (is-type? % "Program"))) (concat (all-installed state :corp)
-                                                                                            (all-installed state :runner))))))
-                      :all true
-                      :req #(and (installed? %)
-                                 (not (is-type? % "Program")))}
-            :msg (msg "trash " (join ", " (map :title (sort-by :title targets))))
-            :effect (req (doseq [c targets]
-                           (trash state side c)))
+            :label "Trace 2 - Trash 2 installed non-program cards or take 1 bad publicity"
+            :successful {:choices {:max (req (min 2 (count (filter #(or (:facedown %)
+                                                                        (not (is-type? % "Program")))
+                                                                   (concat (all-installed state :corp)
+                                                                           (all-installed state :runner))))))
+                                   :all true
+                                   :req #(and (installed? %)
+                                              (not (is-type? % "Program")))}
+                         :msg (msg "trash " (join ", " (map :title (sort-by :title targets))))
+                         :effect (req (doseq [c targets]
+                                        (trash state side c)))}
             :unsuccessful {:msg "take 1 bad publicity"
                            :effect (effect (gain-bad-publicity :corp 1))}}}
 
@@ -659,25 +668,33 @@
    "Invasion of Privacy"
    (letfn [(iop [x]
              {:delayed-completion true
-              :req (req (pos? (count (filter #(or (is-type? % "Resource")
-                                                  (is-type? % "Event")) (:hand runner)))))
+              :req (req (->> (:hand runner)
+                             (filter #(or (is-type? % "Resource")
+                                          (is-type? % "Event")))
+                             count
+                             pos?))
               :prompt "Choose a resource or event to trash"
               :msg (msg "trash " (:title target))
               :choices (req (cancellable
                               (filter #(or (is-type? % "Resource")
-                                           (is-type? % "Event")) (:hand runner)) :sorted))
+                                           (is-type? % "Event"))
+                                      (:hand runner))
+                              :sorted))
               :effect (req (trash state side target)
                            (if (pos? x)
                              (continue-ability state side (iop (dec x)) card nil)
                              (effect-completed state side eid card)))})]
-     {:trace {:base 2 :msg "reveal the Runner's Grip and trash up to X resources or events"
-              :effect (req (let [x (- target (second targets))]
-                             (system-msg state :corp
-                                         (str "reveals the Runner's Grip ( "
-                                              (join ", " (map :title (sort-by :title (:hand runner))))
-                                              " ) and can trash up to " x " resources or events"))
-                             (continue-ability state side (iop (dec x)) card nil)))
-              :unsuccessful {:msg "take 1 bad publicity" :effect (effect (gain-bad-publicity :corp 1))}}})
+     {:trace {:base 2
+              :successful {:msg "reveal the Runner's Grip and trash up to X resources or events"
+                           :effect (req (let [x (- target (second targets))]
+                                          (system-msg
+                                            state :corp
+                                            (str "reveals the Runner's Grip ( "
+                                                 (join ", " (map :title (sort-by :title (:hand runner))))
+                                                 " ) and can trash up to " x " resources or events"))
+                                          (continue-ability state side (iop (dec x)) card nil)))}
+              :unsuccessful {:msg "take 1 bad publicity"
+                             :effect (effect (gain-bad-publicity :corp 1))}}})
 
    "IPO"
    {:msg "gain 13 [Credits]" :effect (effect (gain :credit 13))}
@@ -685,9 +702,9 @@
    "Kill Switch"
    (let [trace-for-brain-damage {:msg (msg "reveal that they accessed " (:title target))
                                  :trace {:base 3
-                                         :msg "do 1 brain damage"
-                                         :delayed-completion true
-                                         :effect (effect (damage :runner eid :brain 1 {:card card}))}}]
+                                         :successful {:msg "do 1 brain damage"
+                                                      :delayed-completion true
+                                                      :effect (effect (damage :runner eid :brain 1 {:card card}))}}}]
      {:events {:access (assoc trace-for-brain-damage :req (req (is-type? target "Agenda"))
                                                      :interactive (req (is-type? target "Agenda")))
                :agenda-scored trace-for-brain-damage}})
@@ -752,9 +769,10 @@
    "Manhunt"
    {:events {:successful-run {:interactive (req true)
                               :req (req (first-event? state side :successful-run))
-                              :trace {:base 2 :msg "give the Runner 1 tag"
-                                      :delayed-completion true
-                                      :effect (effect (tag-runner :runner eid 1))}}}}
+                              :trace {:base 2
+                                      :successful {:msg "give the Runner 1 tag"
+                                                   :delayed-completion true
+                                                   :effect (effect (tag-runner :runner eid 1))}}}}}
 
    "Market Forces"
    (letfn [(credit-diff [runner]
@@ -791,11 +809,12 @@
    "Midseason Replacements"
    {:req (req (last-turn? state :runner :stole-agenda))
     :trace {:base 6
-            :msg "give the Runner X tags"
-            :label "Give the Runner X tags"
-            :delayed-completion true
-            :effect (effect (system-msg (str "gives the Runner " (- target (second targets)) " tags"))
-                            (tag-runner :runner eid (- target (second targets))))}}
+            :label "Trace 6 - Give the Runner X tags"
+            :successful {:msg "give the Runner X tags"
+                         :delayed-completion true
+                         :effect (effect (system-msg
+                                           (str "gives the Runner " (- target (second targets)) " tags"))
+                                         (tag-runner :runner eid (- target (second targets))))}}}
 
    "Mushin No Shin"
    {:prompt "Select a card to install from HQ"
@@ -910,16 +929,20 @@
    "Power Grid Overload"
    {:req (req (last-turn? state :runner :made-run))
     :trace {:base 2
-            :msg "trash 1 piece of hardware"
-            :delayed-completion true
-            :effect (req (let [max-cost (- target (second targets))]
-                           (continue-ability state side
-                                             {:choices {:req #(and (is-type? % "Hardware")
-                                                                   (<= (:cost %) max-cost))}
-                                              :msg (msg "trash " (:title target))
-                                              :effect (effect (trash target))}
-                                             card nil))
-                         (system-msg state :corp (str "trashes 1 piece of hardware with install cost less than or equal to " (- target (second targets)))))}}
+            :successful {:msg "trash 1 piece of hardware"
+                         :delayed-completion true
+                         :effect (req (let [max-cost (- target (second targets))]
+                                        (continue-ability
+                                          state side
+                                          {:choices {:req #(and (is-type? % "Hardware")
+                                                                (<= (:cost %) max-cost))}
+                                           :msg (msg "trash " (:title target))
+                                           :effect (effect (trash target))}
+                                          card nil))
+                                      (system-msg
+                                        state :corp
+                                        (str "trashes 1 piece of hardware with install cost less than or equal to "
+                                             (- target (second targets)))))}}}
 
    "Power Shutdown"
    {:req (req (last-turn? state :runner :made-run))
@@ -1019,9 +1042,9 @@
 
    "Punitive Counterstrike"
    {:trace {:base 5
-            :delayed-completion true
-            :msg (msg "do " (:stole-agenda runner-reg-last 0) " meat damage")
-            :effect (effect (damage eid :meat (:stole-agenda runner-reg-last 0) {:card card}))}}
+            :successful {:delayed-completion true
+                         :msg (msg "do " (:stole-agenda runner-reg-last 0) " meat damage")
+                         :effect (effect (damage eid :meat (:stole-agenda runner-reg-last 0) {:card card}))}}}
 
    "Reclamation Order"
    {:prompt "Select a card from Archives"
@@ -1237,10 +1260,10 @@
    "SEA Source"
    {:req (req (last-turn? state :runner :successful-run))
     :trace {:base 3
-            :msg "give the Runner 1 tag"
-            :label "Give the Runner 1 tag"
-            :delayed-completion true
-            :effect (effect (tag-runner :runner eid 1))}}
+            :label "Trace 3 - Give the Runner 1 tag"
+            :successful {:msg "give the Runner 1 tag"
+                         :delayed-completion true
+                         :effect (effect (tag-runner :runner eid 1))}}}
 
    "Self-Growth Program"
    {:req (req tagged)
@@ -1325,29 +1348,31 @@
                  (effect-completed state side eid card))}
 
    "Snatch and Grab"
-   {:trace {:msg "trash a connection"
-            :base 3
-            :choices {:req #(has-subtype? % "Connection")}
-            :delayed-completion true
-            :effect (req (let [c target]
-                           (show-wait-prompt state :corp "Runner to decide if they will take 1 tag")
-                           (continue-ability
-                             state side
-                             {:prompt (msg "Take 1 tag to prevent " (:title c) " from being trashed?")
-                              :choices ["Yes" "No"] :player :runner
-                              :delayed-completion true
-                              :effect (effect (clear-wait-prompt :corp)
-                                              (continue-ability
-                                                (if (= target "Yes")
-                                                  {:msg (msg "take 1 tag to prevent " (:title c)
-                                                             " from being trashed")
-                                                   :delayed-completion true
-                                                   :effect (effect (tag-runner eid 1 {:unpreventable true}))}
-                                                  {:delayed-completion true
-                                                   :effect (effect (trash :corp eid c nil))
-                                                   :msg (msg "trash " (:title c))})
-                                                card nil))}
-                             card nil)))}}
+   {:trace {:base 3
+            :successful
+            {:msg "trash a connection"
+             :choices {:req #(has-subtype? % "Connection")}
+             :delayed-completion true
+             :effect (req (let [c target]
+                            (show-wait-prompt state :corp "Runner to decide if they will take 1 tag")
+                            (continue-ability
+                              state side
+                              {:player :runner
+                               :prompt (msg "Take 1 tag to prevent " (:title c) " from being trashed?")
+                               :choices ["Yes" "No"]
+                               :delayed-completion true
+                               :effect (effect (clear-wait-prompt :corp)
+                                               (continue-ability
+                                                 (if (= target "Yes")
+                                                   {:msg (msg "take 1 tag to prevent " (:title c)
+                                                              " from being trashed")
+                                                    :delayed-completion true
+                                                    :effect (effect (tag-runner eid 1 {:unpreventable true}))}
+                                                   {:delayed-completion true
+                                                    :effect (effect (trash :corp eid c nil))
+                                                    :msg (msg "trash " (:title c))})
+                                                 card nil))}
+                              card nil)))}}}
 
    "Special Report"
    {:prompt "Select any number of cards in HQ to shuffle into R&D"
@@ -1526,14 +1551,19 @@
 
    "Threat Level Alpha"
    {:trace {:base 1
-            :label "Give the Runner X tags"
-            :delayed-completion true
-            :effect (req (let [tags (-> @state :runner :tag)]
-                           (if (pos? tags)
-                             (do (tag-runner state :runner eid tags)
-                                 (system-msg state side (str "uses Threat Level Alpha to give the Runner " tags " tags")))
-                             (do (tag-runner state :runner eid 1)
-                                 (system-msg state side "uses Threat Level Alpha to give the Runner a tag")))))}}
+            :successful
+            {:label "Give the Runner X tags"
+             :delayed-completion true
+             :effect (req (let [tags (-> @state :runner :tag)]
+                            (if (pos? tags)
+                              (do (tag-runner state :runner eid tags)
+                                  (system-msg
+                                    state side
+                                    (str "uses Threat Level Alpha to give the Runner " tags " tags")))
+                              (do (tag-runner state :runner eid 1)
+                                  (system-msg
+                                    state side
+                                    "uses Threat Level Alpha to give the Runner a tag")))))}}}
 
    "Too Big to Fail"
    {:req (req (< (:credit corp) 10))
@@ -1587,18 +1617,19 @@
    {:req (req (:accessed-cards runner-reg))
     :trace {:base 4
             :label "Trace 4 - Trash a program"
-            :delayed-completion true
-            :effect (req (let [exceed (- target (second targets))]
-                           (continue-ability
-                             state side
-                             {:delayed-completion true
-                              :prompt (str "Select a program with an install cost of no more than " exceed "[Credits]")
-                              :choices {:req #(and (is-type? % "Program")
-                                                   (installed? %)
-                                                   (>= exceed (:cost %)))}
-                              :msg (msg "trash " (card-str state target))
-                              :effect (effect (trash eid target nil))}
-                             card nil)))}}
+            :successful {:delayed-completion true
+                         :effect (req (let [exceed (- target (second targets))]
+                                        (continue-ability
+                                          state side
+                                          {:delayed-completion true
+                                           :prompt (str "Select a program with an install cost of no more than "
+                                                        exceed "[Credits]")
+                                           :choices {:req #(and (is-type? % "Program")
+                                                                (installed? %)
+                                                                (>= exceed (:cost %)))}
+                                           :msg (msg "trash " (card-str state target))
+                                           :effect (effect (trash eid target nil))}
+                                          card nil)))}}}
 
    "Ultraviolet Clearance"
    {:delayed-completion true

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -354,8 +354,9 @@
              {:req (req (pos? (:tag runner)))
               :msg "force the Corp to initiate a trace"
               :label "Trace 1 - If unsuccessful, Runner removes 1 tag"
-              :trace {:base 1 :unsuccessful {:effect (effect (lose :runner :tag 1))
-                                             :msg "remove 1 tag"}}}}}
+              :trace {:base 1
+                      :unsuccessful {:msg "remove 1 tag"
+                                     :effect (effect (lose :runner :tag 1))}}}}}
 
    "Clan Vengeance"
    {:events {:pre-resolve-damage {:req (req (pos? (last targets)))
@@ -1207,6 +1208,7 @@
                                   :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}
              :pre-resolve-tag {:silent (req true)
                                :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}}})
+
    "Off-Campus Apartment"
    {:flags {:runner-install-draw true}
     :abilities [{:label "Install and host a connection on Off-Campus Apartment"
@@ -1378,11 +1380,14 @@
                                 (swap! state update-in [:bonus] dissoc :trash)))}]}
 
    "Power Tap"
-   {:events {:trace {:msg "gain 1 [Credits]" :effect (effect (gain :runner :credit 1))}}}
+   {:events {:trace {:successful {:msg "gain 1 [Credits]"
+                                  :effect (effect (gain :runner :credit 1))}}}}
 
    "Professional Contacts"
-   {:abilities [{:cost [:click 1] :effect (effect (gain :credit 1) (draw))
-                 :msg "gain 1 [Credits] and draw 1 card"}]}
+   {:abilities [{:cost [:click 1]
+                 :msg "gain 1 [Credits] and draw 1 card"
+                 :effect (effect (gain :credit 1)
+                                 (draw))}]}
 
    "Public Sympathy"
    {:in-play [:hand-size 2]}
@@ -1735,8 +1740,9 @@
                              :msg "force the Corp to initiate a trace"
                              :label "Trace 1 - If unsuccessful, take 1 bad publicity"
                              :trace {:base 1
-                                     :unsuccessful {:effect (effect (gain-bad-publicity :corp 1)
-                                                                    (system-msg :corp (str "takes 1 bad publicity")))}}}}}
+                                     :unsuccessful
+                                     {:effect (effect (gain-bad-publicity :corp 1)
+                                                      (system-msg :corp (str "takes 1 bad publicity")))}}}}}
 
    "The Black File"
    {:msg "prevent the Corp from winning the game unless they are flatlined"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -18,14 +18,16 @@
    {:events {:successful-run {:interactive (req true)
                               :req (req this-server)
                               :trace {:base 4
-                                      :effect (req (max-access state side 0)
-                                                   (when-not (:replace-access (get-in @state [:run :run-effect]))
-                                                     (let [ash card]
-                                                       (swap! state update-in [:run :run-effect]
-                                                              #(assoc % :replace-access
-                                                                        {:mandatory true
-                                                                         :effect (effect (access-card ash)) :card ash})))))
-                                      :msg "prevent the Runner from accessing cards other than Ash 2X3ZB9CY"}}}}
+                                      :successful
+                                      {:msg "prevent the Runner from accessing cards other than Ash 2X3ZB9CY"
+                                       :effect (req (max-access state side 0)
+                                                    (when-not (:replace-access (get-in @state [:run :run-effect]))
+                                                      (let [ash card]
+                                                        (swap! state update-in [:run :run-effect]
+                                                               #(assoc % :replace-access
+                                                                       {:mandatory true
+                                                                        :effect (effect (access-card ash))
+                                                                        :card ash})))))}}}}}
 
    "Awakening Center"
    {:can-host (req (is-type? target "ICE"))
@@ -97,11 +99,13 @@
    "Bernice Mai"
    {:events {:successful-run {:interactive (req true)
                               :req (req this-server)
-                              :trace {:base 5 :msg "give the Runner 1 tag"
-                                      :delayed-completion true
-                                      :effect (effect (tag-runner :runner eid 1))
-                                      :unsuccessful {:effect (effect (system-msg "trashes Bernice Mai from the unsuccessful trace")
-                                                                     (trash card))}}}}}
+                              :trace {:base 5
+                                      :successful {:msg "give the Runner 1 tag"
+                                                   :delayed-completion true
+                                                   :effect (effect (tag-runner :runner eid 1))}
+                                      :unsuccessful
+                                      {:effect (effect (system-msg "trashes Bernice Mai from the unsuccessful trace")
+                                                       (trash card))}}}}}
 
   "Bio Vault"
   {:implementation "Installation restriction not enforced"
@@ -297,8 +301,10 @@
    {:events {:run {:req (req (and this-server tagged))
                    :delayed-completion true
                    :trace {:base 3
-                           :msg "do 1 meat damage"
-                           :effect (effect (damage eid :meat 1 {:card card :unpreventable true}))}}}}
+                           :successful
+                           {:msg "do 1 meat damage"
+                            :effect (effect (damage eid :meat 1 {:card card
+                                                                 :unpreventable true}))}}}}}
 
    "Experiential Data"
    {:effect (req (update-ice-in-server state side (card->server state card)))
@@ -324,9 +330,9 @@
     :access {:req (req (not= (first (:zone card)) :discard))
              :interactive (req true)
              :trace {:base 3
-                     :msg "give the Runner 2 tags"
-                     :delayed-completion true
-                     :effect (effect (tag-runner :runner eid 2))}}}
+                     :successful {:msg "give the Runner 2 tags"
+                                  :delayed-completion true
+                                  :effect (effect (tag-runner :runner eid 2))}}}}
 
    "Fractal Threat Matrix"
    {:implementation "Manual trigger each time all subs are broken"
@@ -401,24 +407,23 @@
              :interactive (req true)
              :trace {:base 4
                      :label "add an installed program or virtual resource to the Grip"
-                     :delayed-completion true
-                     :effect (req (show-wait-prompt state :runner "Corp to resolve Intake")
-                                  (continue-ability
-                                    state :corp
-                                    {:prompt "Select a program or virtual resource"
-                                     :player :corp
-                                     :choices {:req #(and (installed? %)
-                                                          (or (program? %)
-                                                              (and (resource? %)
-                                                                   (has-subtype? % "Virtual"))))}
-                                     :delayed-completion true
-                                     :msg (msg "move " (:title target) " to the Grip")
-                                     :cancel-effect (effect (clear-wait-prompt :runner)
-                                                            (effect-completed eid))
-                                     :effect (req (move state :runner target :hand)
-                                                  (clear-wait-prompt state :runner)
-                                                  (effect-completed state side eid))}
-                                    card nil))}}}
+                     :successful
+                     {:delayed-completion true
+                      :effect (req (show-wait-prompt state :runner "Corp to resolve Intake")
+                                   (continue-ability
+                                     state :corp
+                                     {:prompt "Select a program or virtual resource"
+                                      :player :corp
+                                      :choices {:req #(and (installed? %)
+                                                           (or (program? %)
+                                                               (and (resource? %)
+                                                                    (has-subtype? % "Virtual"))))}
+                                      :delayed-completion true
+                                      :msg (msg "move " (:title target) " to the Grip")
+                                      :effect (effect (move :runner target :hand))
+                                      :end-effect (effect (clear-wait-prompt :runner)
+                                                          (effect-completed eid))}
+                                     card nil))}}}}
 
    "Jinja City Grid"
    (letfn [(install-ice [ice ices grids server]
@@ -835,12 +840,14 @@
                  :effect (req (let [serv (card->server state card)
                                     cards (concat (:ices serv) (:content serv))]
                                 (trash state side card)
-                                (doseq [c cards] (trash state side c))
+                                (doseq [c cards]
+                                  (trash state side c))
                                 (resolve-ability
                                   state side
                                   {:trace {:base (req (dec (count cards)))
-                                           :effect (effect (damage eid :net 3 {:card card}))
-                                           :msg "do 3 net damage"}} card nil)))}]}
+                                           :successful {:msg "do 3 net damage"
+                                                        :effect (effect (damage eid :net 3 {:card card}))}}}
+                                  card nil)))}]}
 
    "Shell Corporation"
    {:abilities
@@ -910,31 +917,33 @@
              :effect (req (when (= (first (:zone card)) :deck)
                             (system-msg state :runner (str "accesses Tempus"))))
              :trace {:base 3
-                     :msg "make the Runner choose between losing [Click][Click] or suffering 1 brain damage"
-                     :delayed-completion true
-                     :effect (req (let [tempus card]
-                                    (if (< (:click runner) 2)
-                                      (do
-                                        (system-msg state side "suffers 1 brain damage")
-                                        (damage state side eid :brain 1 {:card tempus}))
-                                      (do
-                                        (show-wait-prompt state :corp "Runner to resolve Tempus")
-                                        (continue-ability
-                                          state :runner
-                                          {:prompt "Lose [Click][Click] or take 1 brain damage?"
-                                           :player :runner
-                                           :choices ["Lose [Click][Click]" "Take 1 brain damage"]
-                                           :delayed-completion true
-                                           :effect (req (clear-wait-prompt state :corp)
-                                                        (if (.startsWith target "Take")
-                                                          (do
-                                                            (system-msg state side (str "chooses to take 1 brain damage"))
-                                                            (damage state side eid :brain 1 {:card tempus}))
-                                                          (do
-                                                            (system-msg state side "chooses to lose [Click][Click]")
-                                                            (lose state :runner :click 2)
-                                                            (effect-completed state side eid))))}
-                                          card nil)))))}}}
+                     :successful
+                     {:msg "make the Runner choose between losing [Click][Click] or suffering 1 brain damage"
+                      :delayed-completion true
+                      :effect (req (let [tempus card]
+                                     (if (< (:click runner) 2)
+                                       (do
+                                         (system-msg state side "suffers 1 brain damage")
+                                         (damage state side eid :brain 1 {:card tempus}))
+                                       (do
+                                         (show-wait-prompt state :corp "Runner to resolve Tempus")
+                                         (continue-ability
+                                           state :runner
+                                           {:prompt "Lose [Click][Click] or take 1 brain damage?"
+                                            :player :runner
+                                            :choices ["Lose [Click][Click]" "Take 1 brain damage"]
+                                            :delayed-completion true
+                                            :effect
+                                            (req (clear-wait-prompt state :corp)
+                                                 (if (.startsWith target "Take")
+                                                   (do
+                                                     (system-msg state side (str "chooses to take 1 brain damage"))
+                                                     (damage state side eid :brain 1 {:card tempus}))
+                                                   (do
+                                                     (system-msg state side "chooses to lose [Click][Click]")
+                                                     (lose state :runner :click 2)
+                                                     (effect-completed state side eid))))}
+                                           card nil)))))}}}}
 
    "The Twins"
    {:abilities [{:label "Reveal and trash a copy of the ICE just passed from HQ"
@@ -985,8 +994,8 @@
                                   (ice? target)))
                    :interactive (req true)
                    :trace {:base 2
-                           :msg "gain 1 [Credits]"
-                           :effect (effect (gain :credit 1))}}}}
+                           :successful {:msg "gain 1 [Credits]"
+                                        :effect (effect (gain :credit 1))}}}}}
 
    "Tyrs Hand"
    {:abilities [{:label "[Trash]: Prevent a subroutine on a piece of Bioroid ICE from being broken"
@@ -1043,12 +1052,20 @@
     :events {:runner-trash {:delayed-completion true
                             :req (req (= (-> card :zone second) (-> target :zone second)))
                             :trace {:base 4
-                                    :effect (req (let [n (count (all-installed state :runner))
-                                                       n (if (> n 2) 2 n)]
-                                                   (if (pos? n) (do (system-msg state side (str "uses Warroid Tracker to force the runner to trash " n " installed card(s)"))
-                                                                    (show-wait-prompt state :corp "Runner to choose cards to trash")
-                                                                    (resolve-ability state side (wt card n 1) card nil))
-                                                                (system-msg state side (str "uses Warroid Tracker but there are no installed cards to trash")))))}}}})
+                                    :successful
+                                    {:effect
+                                     (req (let [n (count (all-installed state :runner))
+                                                n (if (> n 2) 2 n)]
+                                            (if (pos? n)
+                                              (do (system-msg
+                                                    state side
+                                                    (str "uses Warroid Tracker to force the runner to trash "
+                                                         n " installed card(s)"))
+                                                  (show-wait-prompt state :corp "Runner to choose cards to trash")
+                                                  (resolve-ability state side (wt card n 1) card nil))
+                                              (system-msg
+                                                state side
+                                                (str "uses Warroid Tracker but there are no installed cards to trash")))))}}}}})
 
    "Will-o-the-Wisp"
    {:events

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -403,7 +403,8 @@
                  :effect (effect (gain :credit 2))}]}
 
    "Hokusai Grid"
-   {:events {:successful-run {:req (req this-server) :msg "do 1 net damage"
+   {:events {:successful-run {:req (req this-server)
+                              :msg "do 1 net damage"
                               :delayed-completion true
                               :effect (effect (damage eid :net 1 {:card card}))}}}
 

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -526,7 +526,10 @@
                                                    corp-strength)))
     (clear-wait-prompt state player)
     (let [successful (> corp-strength runner-strength)
-          which-ability (assoc (if successful trace (:unsuccessful trace)) :eid (make-eid state))]
+          which-ability (assoc (if successful
+                                 (:successful trace)
+                                 (:unsuccessful trace))
+                               :eid (make-eid state))]
       (system-say state side (str "The trace was " (when-not successful "un") "successful."))
       (when-completed (trigger-event-sync state :corp (if successful :successful-trace :unsuccessful-trace)
                                           {:runner-spent (if (corp-start? trace)
@@ -552,7 +555,8 @@
                                   " strength to " strength))
     (clear-wait-prompt state other)
     (show-wait-prompt state player
-                      (str (if (corp-start? trace) "Runner" "Corp") " to boost " other-type " strength")
+                      (str (if (corp-start? trace) "Runner" "Corp")
+                           " to boost " other-type " strength")
                       {:priority priority})
     (show-trace-prompt state other card (str "Boost " other-type " strength?")
                        #(resolve-trace state side card trace %)
@@ -571,7 +575,8 @@
                          (if (corp-start? trace) "trace" "link")
                          " strength")
                     {:priority priority})
-  (show-trace-prompt state player card (str "Boost " (if (corp-start? trace) "trace" "link") " strength?")
+  (show-trace-prompt state player card
+                     (str "Boost " (if (corp-start? trace) "trace" "link") " strength?")
                      #(trace-reply state side card trace %)
                      trace))
 

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -98,7 +98,7 @@
       (is (= 0 (count (get-in @state [:corp :servers :remote2 :content]))) "Agenda was stolen")
       (prompt-choice :corp "Medical Breakthrough") ;simult. effect resolution
       (prompt-choice :corp "Yes")
-      (prompt-choice :corp 0)  ;; Corp doesn't pump trace
+      (prompt-choice :corp 0)
       (is (= 3 (-> (get-runner) :prompt first :strength)) "Trace base strength is 3 after stealing first Breakthrough")
       (prompt-choice :runner 0)
       (let [n (count (get-in @state [:runner :hand]))]

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -101,11 +101,11 @@
       (prompt-choice :corp 0)
       (is (= 3 (-> (get-runner) :prompt first :strength)) "Trace base strength is 3 after stealing first Breakthrough")
       (prompt-choice :runner 0)
-      (let [n (count (get-in @state [:runner :hand]))]
-        (is (= 1 (count (get-in @state [:runner :rig :program]))) "There is an Analog Dreamers installed")
-        (prompt-select :corp (first (get-in @state [:runner :rig :program])))
-        (is (= 0 (count (get-in @state [:runner :rig :program]))) "Analog Dreamers was uninstalled")
-        (is (= (+ n 1) (count (get-in @state [:runner :hand]))) "Analog Dreamers was added to hand"))
+      (let [n (count (:hand (get-runner)))]
+        (is (= 1 (count (get-program state))) "There is an Analog Dreamers installed")
+        (prompt-select :corp (get-program state 0))
+        (is (zero? (count (get-program state))) "Analog Dreamers was uninstalled")
+        (is (= (+ n 1) (count (:hand (get-runner)))) "Analog Dreamers was added to hand"))
       (take-credits state :runner)
       (score-agenda state :corp breakthrough)
       ;; (prompt-choice :corp "Medical Breakthrough") ; there is no simult. effect resolution on score for some reason

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2590,4 +2590,16 @@
 
 (deftest white-hat
   ;; White Hat
-  )
+  (do-game
+    (new-game (default-corp ["Ice Wall" "Fire Wall" "Enigma"])
+              (default-runner ["White Hat"]))
+    (take-credits state :corp)
+    (run-empty-server state :rd)
+    (play-from-hand state :runner "White Hat")
+    (is (= :waiting (-> (get-runner) :prompt first :prompt-type)) "Runner is waiting for Corp to boost")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 4)
+    (prompt-card :runner (find-card "Ice Wall" (:hand (get-corp))))
+    (prompt-card :runner (find-card "Enigma" (:hand (get-corp))))
+    (is (= #{"Ice Wall" "Enigma"} (->> (get-corp) :deck (map :title) (into #{}))))
+  ))

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2587,3 +2587,7 @@
       (take-credits state :corp 1)
       (is (not (get-in (refresh crypsis) [:added-virus-counter]))
           "Counter flag was cleared on Crypsis"))))
+
+(deftest white-hat
+  ;; White Hat
+  )

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -936,8 +936,34 @@
        (is (= 2 (:click (get-runner))) "Spent 1 click")
        (is (= 1 (:credit (get-runner))) "Spent 1c")))))
 
+(deftest security-nexus
+  ;; Security Nexus
+  (do-game
+    (new-game (default-corp ["Ice Wall"])
+              (default-runner ["Security Nexus"]))
+    (play-from-hand state :corp "Ice Wall" "R&D")
+    (take-credits state :corp)
+    (core/gain state :runner :credit 100)
+    (play-from-hand state :runner "Security Nexus")
+    (let [nexus (get-hardware state 0)]
+      (run-on state :rd)
+      (card-ability state :runner nexus 0)
+      (is (zero? (:tag (get-runner))) "Runner should have no tags to start")
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (not (:run @state)) "Run should end from losing Security Nexus trace")
+      (is (= 1 (:tag (get-runner))) "Runner should take 1 tag from losing Security Nexus trace")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (run-on state :rd)
+      (card-ability state :runner nexus 0)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 10)
+      (is (:run @state) "Run should still be going on from winning Security Nexus trace")
+      (is (= 1 (:tag (get-runner))) "Runner should still only have 1 tag"))))
+
 (deftest sifr
-  ;; Once per turn drop encountered ICE to zero strenght
+  ;; Sifr - Once per turn drop encountered ICE to zero strenght
   ;; Also handle archangel then re-install sifr should not break the game #2576
   (do-game
     (new-game (default-corp [(qty "Archangel" 1) (qty "IP Block" 1) (qty "Hedge Fund" 1)])

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1265,7 +1265,6 @@
         (is (= :waiting (-> (get-runner) :prompt first :prompt-type)) "Runner waits for Corp to boost first")
         (prompt-choice :corp 0)
         (prompt-choice :runner 0)
-        (is (= :waiting (-> (get-corp) :prompt first :prompt-type)) "Runner waits for Runner to choose option")
         (prompt-choice :runner "End the run")
         (is (not (:run @state)) "Run is ended")))))
 

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1370,28 +1370,27 @@
           "Tithonium hosting OAI as a condition"))))
 
 (deftest tmi
-  ;; TMI ICE test
-  (do-game
-    (new-game (default-corp [(qty "TMI" 3)])
-              (default-runner))
-    (play-from-hand state :corp "TMI" "HQ")
-    (let [tmi (get-ice state :hq 0)]
-      (core/rez state :corp tmi)
-      (prompt-choice :corp 0)
-      (prompt-choice :runner 0)
-      (is (get-in (refresh tmi) [:rezzed])))))
-
-(deftest tmi-derez
-  ;; TMI ICE trace derez
-  (do-game
-    (new-game (default-corp [(qty "TMI" 3)])
-              (make-deck "Sunny Lebeau: Security Specialist" [(qty "Blackmail" 3)]))
-    (play-from-hand state :corp "TMI" "HQ")
-    (let [tmi (get-ice state :hq 0)]
-      (core/rez state :corp tmi)
-      (prompt-choice :corp 0)
-      (prompt-choice :runner 0)
-      (is (not (get-in (refresh tmi) [:rezzed]))))))
+  ;; TMI
+  (testing "basic test"
+    (do-game
+      (new-game (default-corp ["TMI"])
+                (default-runner))
+      (play-from-hand state :corp "TMI" "HQ")
+      (let [tmi (get-ice state :hq 0)]
+        (core/rez state :corp tmi)
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (:rezzed (refresh tmi))))))
+  (testing "trace derez"
+    (do-game
+      (new-game (default-corp ["TMI"])
+                (make-deck "Sunny Lebeau: Security Specialist" [(qty "Blackmail" 3)]))
+      (play-from-hand state :corp "TMI" "HQ")
+      (let [tmi (get-ice state :hq 0)]
+        (core/rez state :corp tmi)
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (not (:rezzed (refresh tmi))))))))
 
 (deftest troll
   ;; Troll
@@ -1411,7 +1410,7 @@
         (prompt-choice :runner "End the run")
         (is (not (:run @state)) "Run is ended")))))
 
-(deftest turing-positional-strength
+(deftest turing
   ;; Turing - Strength boosted when protecting a remote server
   (do-game
     (new-game (default-corp [(qty "Turing" 2) "Hedge Fund"])

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1062,22 +1062,41 @@
       (take-credits state :corp 2)
       (is (= 2 (:current-strength (refresh sacw))) "Self-Adapting Code Wall strength increased"))))
 
-(deftest sherlock
+(deftest sherlock-1-0
   ;; Sherlock 1.0 - Trace to add an installed program to the top of Runner's Stack
   (do-game
     (new-game (default-corp [(qty "Sherlock 1.0" 1)])
               (default-runner [(qty "Gordian Blade" 3) (qty "Sure Gamble" 3)]))
     (play-from-hand state :corp "Sherlock 1.0" "HQ")
     (take-credits state :corp)
-    (play-from-hand state :runner "Gordian Blade")
-    (run-on state :hq)
-    (core/rez state :corp (get-ice state :hq 0))
-    (card-subroutine state :corp (get-ice state :hq 0) 0)
-    (prompt-choice :corp 0)
-    (prompt-choice :runner 0)
-    (prompt-select :corp (get-in @state [:runner :rig :program 0]))
-    (is (empty? (get-in @state [:runner :rig :program])) "Gordian uninstalled")
-    (is (= "Gordian Blade" (:title (first (:deck (get-runner))))) "Gordian on top of Stack")))
+    (let [sherlock (get-ice state :hq 0)]
+      (play-from-hand state :runner "Gordian Blade")
+      (run-on state :hq)
+      (core/rez state :corp sherlock)
+      (card-subroutine state :corp sherlock 0)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (prompt-select :corp (get-program state 0))
+      (is (empty? (get-program state)) "Gordian uninstalled")
+      (is (= "Gordian Blade" (:title (first (:deck (get-runner))))) "Gordian on top of Stack"))))
+
+(deftest sherlock-2.0
+  ;; Sherlock 2.0 - Trace to add an installed program to the bottom of Runner's Stack
+  (do-game
+    (new-game (default-corp [(qty "Sherlock 2.0" 1)])
+              (default-runner [(qty "Gordian Blade" 3) (qty "Sure Gamble" 3)]))
+    (play-from-hand state :corp "Sherlock 2.0" "HQ")
+    (take-credits state :corp)
+    (let [sherlock (get-ice state :hq 0)]
+      (play-from-hand state :runner "Gordian Blade")
+      (run-on state :hq)
+      (core/rez state :corp sherlock)
+      (card-subroutine state :corp sherlock 0)
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (prompt-select :corp (get-program state 0))
+      (is (empty? (get-program state)) "Gordian uninstalled")
+      (is (= "Gordian Blade" (:title (last (:deck (get-runner))))) "Gordian on bottom of Stack"))))
 
 (deftest shiro
   ;; Shiro - Full test

--- a/test/clj/game_test/cards/icebreakers.clj
+++ b/test/clj/game_test/cards/icebreakers.clj
@@ -106,7 +106,6 @@
       (play-from-hand state :runner "Aumakua")
       (run-empty-server state :archives)
       (is (= 1 (get-counters (get-program state 0) :virus)) "Aumakua gains virus counter from accessing empty Archives")))
-
   (testing "Neutralize All Threats interaction"
     (do-game
       (new-game (default-corp [(qty "PAD Campaign" 3)])

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -219,38 +219,37 @@
   (do-game
     (new-game (default-corp [(qty "Cerebral Cast" 1)])
               (default-runner))
-	    (play-from-hand state :corp "Cerebral Cast")
-	    (is (= 3 (:click (get-corp))) "Cerebral Cast precondition not met; card not played")
-	    (take-credits state :corp)
-	    (run-empty-server state "Archives")
-	    (take-credits state :runner)
-	    (play-from-hand state :corp "Cerebral Cast")
-        (prompt-choice :corp "0 [Credits]")
-        (prompt-choice :runner "0 [Credits]")
-	    (is (= 0 (count (:discard (get-runner)))) "Runner took no damage")
-		(is (= 0 (:tag (get-runner))) "Runner took no tags")))
+    (play-from-hand state :corp "Cerebral Cast")
+    (is (= 3 (:click (get-corp))) "Cerebral Cast precondition not met; card not played")
+    (take-credits state :corp)
+    (run-empty-server state "Archives")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Cerebral Cast")
+    (prompt-choice :corp "0 [Credits]")
+    (prompt-choice :runner "0 [Credits]")
+    (is (= 0 (count (:discard (get-runner)))) "Runner took no damage")
+    (is (= 0 (:tag (get-runner))) "Runner took no tags")))
 
 (deftest cerebral-cast-corp-wins
   ;; Cerebral Cast: if the runner succefully ran last turn, psi game to give runner choice of tag or BD
   (do-game
     (new-game (default-corp [(qty "Cerebral Cast" 2)])
               (default-runner))
-	    (take-credits state :corp)
-	    (run-empty-server state "Archives")
-	    (take-credits state :runner)
-	    (play-from-hand state :corp "Cerebral Cast")
-        (prompt-choice :corp "0 [Credits]")
-        (prompt-choice :runner "1 [Credits]")
-		(prompt-choice :runner "1 brain damage")
-	    (is (= 1 (count (:discard (get-runner)))) "Runner took a brain damage")
-		(is (= 0 (:tag (get-runner))) "Runner took no tags from brain damage choice")
-	    (play-from-hand state :corp "Cerebral Cast")
-        (prompt-choice :corp "0 [Credits]")
-        (prompt-choice :runner "1 [Credits]")
-		(prompt-choice :runner "1 tag")
-	    (is (= 1 (count (:discard (get-runner)))) "Runner took no additional damage")
-		(is (= 1 (:tag (get-runner))) "Runner took a tag from Cerebral Cast choice")))
-
+    (take-credits state :corp)
+    (run-empty-server state "Archives")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Cerebral Cast")
+    (prompt-choice :corp "0 [Credits]")
+    (prompt-choice :runner "1 [Credits]")
+    (prompt-choice :runner "1 brain damage")
+    (is (= 1 (count (:discard (get-runner)))) "Runner took a brain damage")
+    (is (= 0 (:tag (get-runner))) "Runner took no tags from brain damage choice")
+    (play-from-hand state :corp "Cerebral Cast")
+    (prompt-choice :corp "0 [Credits]")
+    (prompt-choice :runner "1 [Credits]")
+    (prompt-choice :runner "1 tag")
+    (is (= 1 (count (:discard (get-runner)))) "Runner took no additional damage")
+    (is (= 1 (:tag (get-runner))) "Runner took a tag from Cerebral Cast choice")))
 
 (deftest cerebral-static-chaos-theory
   ;; Cerebral Static - vs Chaos Theory
@@ -427,6 +426,26 @@
     (play-from-hand state :corp "PAD Campaign" "New remote")
     (play-from-hand state :corp "Diversified Portfolio")
     (is (= 7 (:credit (get-corp))) "Ignored remote with ICE but no server contents")))
+
+(deftest door-to-door
+  ;; Door to Door
+  (do-game
+    (new-game (default-corp ["Door to Door"])
+              (default-runner))
+    (play-from-hand state :corp "Door to Door")
+    (take-credits state :corp)
+    (is (zero? (:tag (get-runner))) "Runner should start with 0 tags")
+    (is (= 3 (-> (get-runner) :hand count)) "Runner should start with 3 cards in hand")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 1 (:tag (get-runner))) "Runner should gain 1 tag from Door to Door")
+    (is (= 3 (-> (get-runner) :hand count)) "Runner should start with 3 cards in hand")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 1 (:tag (get-runner))) "Runner should still have 1 tag")
+    (is (= 2 (-> (get-runner) :hand count)) "Runner should take 1 meat damage from Door to Door")))
 
 (deftest economic-warfare
   ;; Economic Warfare - If successful run last turn, make the runner lose 4 credits if able
@@ -623,26 +642,20 @@
                              (qty "Project Beale" 1)
                              (qty "Explode-a-palooza" 1)])
               (default-runner))
-
       (score-agenda state :corp (find-card "Market Research" (:hand (get-corp))))
       (score-agenda state :corp (find-card "Breaking News" (:hand (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner gained 2 tags")
       (take-credits state :corp)
       (is (= 0 (:tag (get-runner))) "Runner lost 2 tags")
-
       (core/steal state :runner (find-card "Project Beale" (:hand (get-corp))))
       (core/steal state :runner (find-card "Explode-a-palooza" (:hand (get-corp))))
       (take-credits state :runner)
-
       (is (= 4 (:agenda-point (get-runner))))
       (is (= 3 (:agenda-point (get-corp))))
-
       (core/gain state :runner :tag 1)
       (play-from-hand state :corp "Exchange of Information")
-
       (prompt-select :corp (find-card "Project Beale" (:scored (get-runner))))
       (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
-
       (is (= 3 (:agenda-point (get-runner))))
       (is (= 4 (:agenda-point (get-corp))))))
 
@@ -655,21 +668,16 @@
                              (qty "Project Beale" 1)
                              (qty "Explode-a-palooza" 1)])
               (default-runner))
-
       (take-credits state :corp)
-
       (core/steal state :runner (find-card "Project Beale" (:hand (get-corp))))
       (core/steal state :runner (find-card "Explode-a-palooza" (:hand (get-corp))))
       (take-credits state :runner)
-
       (score-agenda state :corp (find-card "Breaking News" (:hand (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner gained 2 tags")
       (play-from-hand state :corp "Exchange of Information")
-
       (prompt-select :corp (find-card "Project Beale" (:scored (get-runner))))
       (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 2 (:tag (get-runner))) "Still has tags after swap and before end of turn")
-
       (take-credits state :corp)
       (is (= 3 (:agenda-point (get-runner))))
       (is (= 2 (:agenda-point (get-corp))))
@@ -753,6 +761,43 @@
     (is (= 3 (:click (get-corp))))
     (is (= 3 (:click-per-turn (get-corp))))))
 
+(deftest foxfire
+  ;; Foxfire
+  (do-game
+    (new-game (default-corp [(qty "Foxfire" 2)])
+              (default-runner ["Dyson Mem Chip" "Ice Carver"]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 100)
+    (play-from-hand state :runner "Dyson Mem Chip")
+    (play-from-hand state :runner "Ice Carver")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Foxfire")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (prompt-select :corp (get-hardware state 0))
+    (is (= 1 (-> (get-runner) :discard count)) "Corp should trash Dyson Mem Chip from winning Foxfire trace")
+    (play-from-hand state :corp "Foxfire")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (prompt-select :corp (get-resource state 0))
+    (is (= 2 (-> (get-runner) :discard count)) "Corp should trash Ice Carver from winning Foxfire trace")))
+
+(deftest hard-hitting-news
+  ;; Hard-Hitting News
+  (do-game
+    (new-game (default-corp ["Hard-Hitting News"])
+              (default-runner))
+    (take-credits state :corp)
+    (run-empty-server state :rd)
+    (take-credits state :runner)
+    (is (= 3 (:click (get-corp))) "Corp should start with 3 clicks")
+    (play-from-hand state :corp "Hard-Hitting News")
+    (is (zero? (:click (get-corp))) "Playing Hard-Hitting News should lose all remaining clicks")
+    (is (zero? (:tag (get-runner))) "Runner should start with 0 tags")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 4 (:tag (get-runner))) "Runner should gain 4 tags from losing Hard-Hitting News trace")))
+
 (deftest hatchet-job
   ;; Hatchet Job - Win trace to add installed non-virtual to grip
   (do-game
@@ -786,7 +831,6 @@
      (play-from-hand state :corp "High-Profile Target")
      (is (= 3 (:click (get-corp))) "Corp not charged a click")
      (is (= 5 (count (:hand (get-runner)))) "Runner did not take damage")))
-
   (testing "when the runner has one tag"
     (do-game
      (new-game (default-corp [(qty "High-Profile Target" 6)])
@@ -794,7 +838,6 @@
      (core/gain state :runner :tag 1)
      (play-from-hand state :corp "High-Profile Target")
      (is (= 3 (count (:hand (get-runner)))) "Runner has 3 cards in hand")))
-
   (testing "when the runner has two tags"
     (do-game
      (new-game (default-corp [(qty "High-Profile Target" 6)])
@@ -802,7 +845,6 @@
      (core/gain state :runner :tag 2)
      (play-from-hand state :corp "High-Profile Target")
      (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")))
-
   (testing "when the runner has enough tags to die"
     (do-game
      (new-game (default-corp [(qty "High-Profile Target" 6)])
@@ -884,8 +926,8 @@
     (take-credits state :corp)
     (take-credits state :runner)
     (play-from-hand state :corp "IPO")
-	(is (= 13 (:credit (get-corp))))
-	(is (= 0 (:click (get-corp))) "Terminal ends turns")))
+    (is (= 13 (:credit (get-corp))))
+    (is (= 0 (:click (get-corp))) "Terminal ends turns")))
 
 (deftest lag-time
   (do-game
@@ -899,7 +941,7 @@
     (core/rez state :corp (get-ice state :hq 0))
     (core/rez state :corp (get-ice state :rd 0))
     (is (= 1 (:current-strength (get-ice state :hq 0))) "Vanilla at 1 strength")
-	(is (= 5 (:current-strength (get-ice state :rd 0))) "Lotus Field at 5 strength")))
+    (is (= 5 (:current-strength (get-ice state :rd 0))) "Lotus Field at 5 strength")))
 
 (deftest lateral-growth
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -910,7 +910,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Sneakdoor Beta")
       (is (= 1 (:credit (get-runner))) "Sneakdoor cost 4 credits")
-      (let [sb (get-in @state [:runner :rig :program 0])
+      (let [sb (get-program state 0)
             ash (get-content state :hq 0)]
         (core/rez state :corp ash)
         (card-ability state :runner sb 0)

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -2247,15 +2247,31 @@
   (do-game
     (new-game (default-corp)
               (default-runner ["Tech Trader" "Fall Guy"]))
-
     (take-credits state :corp)
     (play-from-hand state :runner "Tech Trader")
     (play-from-hand state :runner "Fall Guy")
     (is (= 4 (:credit (get-runner))))
-
     (let [fall (get-in @state [:runner :rig :resource 1])]
       (card-ability state :runner fall 1)
       (is (= 7 (:credit (get-runner)))))))
+
+(deftest the-archivist
+  ;; The Archivist
+  (do-game
+    (new-game (default-corp ["Global Food Initiative" "Private Security Force"])
+              (default-runner ["The Archivist"]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "The Archivist")
+    (is (zero? (:bad-publicity (get-corp))) "Corp should start with 0 bad publicity")
+    (take-credits state :runner)
+    (play-and-score state "Global Food Initiative")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 1 (:bad-publicity (get-corp))) "Corp should get 1 bad publicity from The Archivist")
+    (play-and-score state "Private Security Force")
+    (prompt-choice :corp 0)
+    (prompt-choice :runner 0)
+    (is (= 2 (:bad-publicity (get-corp))) "Corp should get 1 bad publicity from The Archivist")))
 
 (deftest the-black-file
   ;; The Black File - Prevent Corp from winning by agenda points

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1794,7 +1794,7 @@
               (default-runner ["Corroder" "Dyson Mem Chip"]))
     (play-from-hand state :corp "Warroid Tracker" "New remote")
     (take-credits state :corp)
-    (core/gain state :runner :credit 100)
+    (core/gain state :runner :credit 10)
     (play-from-hand state :runner "Corroder")
     (play-from-hand state :runner "Dyson Mem Chip")
     (let [war (get-content state :remote1 0)


### PR DESCRIPTION
Because Trace maps defaulted to successful, any abilities that presented options to the runner would trigger "runner boosts first" (Surveillance Sweep PR). To fix that, I moved all successful trace abilities to `:successful`, now mirroring `:unsuccessful`. I also modified how `:kicker` is added to the `:trace` maps so it stays at the base level, as it happens regardless of trace success.

Notes:
* I refactored Searchlight to use the existing `tag-trace` and `advance-counters`, as per the comment.
* I refactored Controlling the Message to use `end-effect` instead of `no-ability` for `clear-wait-prompt`.

Fixes #5335

Tests for all cards I touched are ~~forthcoming~~ completed. I want NO REGRESSIONS this time.