### PR TITLE
Card test coverage task

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,8 @@
 
   :aliases {"fetch" ["run" "-m" "tasks.fetch/fetch"]
             "add-art" ["run" "-m" "tasks.altart/add-art"]
-            "delete-duplicate-users" ["run" "-m" "tasks.db/delete-duplicate-users"]}
+            "delete-duplicate-users" ["run" "-m" "tasks.db/delete-duplicate-users"]
+            "card-coverage" ["run" "-m" "tasks.cards/test-coverage"]}
 
   ;; Compilation.
   :source-paths ["src/clj" "src/cljs" "src/cljc"]

--- a/src/clj/tasks/cards.clj
+++ b/src/clj/tasks/cards.clj
@@ -4,17 +4,17 @@
             [monger.collection :as mc]
             [clojure.data :refer [diff]]
             [clojure.string :as s]
-            [game-test.cards.agendas :as agendas]
-            [game-test.cards.assets :as assets]
-            [game-test.cards.events :as events]
-            [game-test.cards.hardware :as hardware]
-            [game-test.cards.ice :as ice]
-            [game-test.cards.icebreakers :as icebreakers]
-            [game-test.cards.identities :as identities]
-            [game-test.cards.operations :as operations]
-            [game-test.cards.programs :as programs]
-            [game-test.cards.resources :as resources]
-            [game-test.cards.upgrades :as upgrades]))
+            [game-test.cards.agendas]
+            [game-test.cards.assets]
+            [game-test.cards.events]
+            [game-test.cards.hardware]
+            [game-test.cards.ice]
+            [game-test.cards.icebreakers]
+            [game-test.cards.identities]
+            [game-test.cards.operations]
+            [game-test.cards.programs]
+            [game-test.cards.resources]
+            [game-test.cards.upgrades]))
 
 (defn- get-card-by-type
   "Get the normalized title (as a symbol) for cards of a specific type in the database"

--- a/src/clj/tasks/cards.clj
+++ b/src/clj/tasks/cards.clj
@@ -19,10 +19,21 @@
 (defn- get-card-by-type
   "Get the normalized title (as a symbol) for cards of a specific type in the database"
   [t]
-  (->> (mc/find-maps db "cards" {:type t} [:normalizedtitle])
-    (map :normalizedtitle)
-    (map #(s/replace % #"\s+" "-"))
-    (map symbol)))
+  (let [card-type (if (= "Icebreaker" t) "Program" t)
+        f (case t
+            "Icebreaker" filter
+            "Program" remove
+            nil)
+        func (fn [coll]
+               (if f
+                 (f #(and (:subtype %)
+                          (> (.indexOf (:subtype %) "Icebreaker") -1)) coll)
+                 coll))]
+    (->> (mc/find-maps db "cards" {:type card-type} [:normalizedtitle :subtype])
+      func
+      (map :normalizedtitle)
+      (map #(s/replace % #"\s+" "-"))
+      (map symbol))))
 
 (defn- get-tests
   "Returns the names of all tests in a namespace"
@@ -83,9 +94,10 @@
                    "Event" '(game-test.cards.events)
                    "Hardware" '(game-test.cards.hardware)
                    "ICE" '(game-test.cards.ice)
+                   "Icebreaker" '(game-test.cards.icebreakers)
                    "Identity" '(game-test.cards.identities)
                    "Operation" '(game-test.cards.operations)
-                   "Program" '(game-test.cards.icebreakers game-test.cards.programs)
+                   "Program"  '(game-test.cards.programs)
                    "Resource" '(game-test.cards.resources)
                    "Upgrade" '(game-test.cards.upgrades)}
           filtered-nspaces (if only

--- a/src/clj/tasks/cards.clj
+++ b/src/clj/tasks/cards.clj
@@ -1,0 +1,103 @@
+(ns tasks.cards
+  "Utilities for card tests"
+  (:require [web.db :refer [db] :as webdb]
+            [monger.collection :as mc]
+            [clojure.data :refer [diff]]
+            [clojure.string :as s]
+            [game-test.cards.agendas :as agendas]
+            [game-test.cards.assets :as assets]
+            [game-test.cards.events :as events]
+            [game-test.cards.hardware :as hardware]
+            [game-test.cards.ice :as ice]
+            [game-test.cards.icebreakers :as icebreakers]
+            [game-test.cards.identities :as identities]
+            [game-test.cards.operations :as operations]
+            [game-test.cards.programs :as programs]
+            [game-test.cards.resources :as resources]
+            [game-test.cards.upgrades :as upgrades]))
+
+(defn- get-card-by-type
+  "Get the normalized title (as a symbol) for cards of a specific type in the database"
+  [t]
+  (->> (mc/find-maps db "cards" {:type t} [:normalizedtitle])
+    (map :normalizedtitle)
+    (map #(s/replace % #"\s+" "-"))
+    (map symbol)))
+
+(defn- get-tests
+  "Returns the names of all tests in a namespace"
+  [nspace]
+  (->> nspace
+    (ns-publics)
+    (filter (fn [[k v]] (contains? (meta v) :test)))
+    (remove (fn [[k v]] (:skip-card-coverage (meta v))))
+    (map (fn [[k v]] (if-let [title (:card-title (meta v))]
+                       (symbol title) k)))))
+
+(def ansi-esc "\u001B")
+(def ansi-reset "\u001B[0m")
+(def ansi-bold "[1m")
+(def ansi-red "[1;31m")
+(def ansi-green "[1;32m")
+(def ansi-blue "[1;34m")
+
+(defn- format-output
+  [s cnt color]
+  (str ansi-esc color s ansi-reset ansi-esc ansi-bold cnt ansi-reset))
+
+(defn- compare-tests
+  [[k v] show-all show-none]
+  (let [cards (get-card-by-type k)
+        tests (->> v
+                (map get-tests)
+                (flatten))
+        [cards-wo tests-wo both] (diff (set cards)
+                                       (set tests))]
+    (println (str ansi-esc ansi-blue k ansi-reset))
+    (println "\tUnique cards in db:" (count (set cards)))
+    (println "\tTests:" (count tests))
+    (println (format-output "\tCards with tests: " (count both) ansi-green))
+    (when (and show-all (not show-none))
+      (doseq [c (sort both)]
+        (println "\t\t" c)))
+    (println (format-output "\tCards without tests: " (count cards-wo) ansi-red))
+    (when (not show-none)
+      (doseq [c (sort cards-wo)]
+        (println "\t\t" c)))
+    (println (format-output "\tTests without cards: " (count tests-wo) ansi-red))
+    (when (not show-none)
+      (doseq [c (sort tests-wo)]
+        (println "\t\t" c)))))
+
+(defn test-coverage
+  "Determine which cards have tests written for them. Takes an `--only <Type>` argument to limit output to a specific card type."
+  [& args]
+  (webdb/connect)
+  (try
+    (let [only (some #{"--only"} args)
+          card-type (first (remove #(s/starts-with? % "--") args))
+          show-all (some #{"--show-all"} args)
+          show-none (some #{"--show-none"} args)
+          nspaces {"Agenda" '(game-test.cards.agendas)
+                   "Asset" '(game-test.cards.assets)
+                   "Event" '(game-test.cards.events)
+                   "Hardware" '(game-test.cards.hardware)
+                   "ICE" '(game-test.cards.ice)
+                   "Identity" '(game-test.cards.identities)
+                   "Operation" '(game-test.cards.operations)
+                   "Program" '(game-test.cards.icebreakers game-test.cards.programs)
+                   "Resource" '(game-test.cards.resources)
+                   "Upgrade" '(game-test.cards.upgrades)}
+          filtered-nspaces (if only
+                             (select-keys nspaces [card-type])
+                             (into (sorted-map) nspaces))]
+      (when only
+        (println "Only checking cards of type" (str ansi-esc ansi-blue card-type ansi-reset)))
+      (doseq [ct filtered-nspaces]
+        (compare-tests ct show-all show-none)
+        (println)))
+    (catch Exception e
+      (do
+        (println "Card test coverage failed: " (.getMessage e))
+        (.printStackTrace e)))
+    (finally (webdb/disconnect))))

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -7,7 +7,7 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "agendas"))
 
-(deftest fifteen-minutes
+(deftest ^{:card-title "15-minutes"} fifteen-minutes
   ;; 15 Minutes - check if it works correctly from both sides
   (do-game
     (new-game (default-corp ["15 Minutes"])
@@ -519,7 +519,7 @@
         (is (empty? (get-in (get-runner)  [:rig :facedown])) "Degree Mill didn't remove facedown cards")
         (is (= 2 (count (:deck (get-runner)))) "Degree Mill didn't put cards back in deck")))))
 
-(deftest director-haas-pet-project
+(deftest ^{:card-title "director-haas'-pet-project"} director-haas-pet-project
   ;; Director Haas' Pet Project
   (do-game
     (new-game (default-corp ["Director Haas' Pet Project"

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -7,7 +7,8 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "agendas"))
 
-(deftest ^{:card-title "15-minutes"} fifteen-minutes
+(deftest ^{:card-title "15-minutes"}
+  fifteen-minutes
   ;; 15 Minutes - check if it works correctly from both sides
   (do-game
     (new-game (default-corp ["15 Minutes"])
@@ -165,7 +166,7 @@
       (card-ability state :corp as-scored 0)
       (is (last-log-contains? state "make the Runner trash") "Should only write to log"))))
 
-(deftest astro-script-token
+(deftest astroscript-pilot-program
   ;; AstroScript token placement
   (do-game
     (new-game (default-corp [(qty "AstroScript Pilot Program" 3) (qty "Ice Wall" 2)])
@@ -286,7 +287,7 @@
       (is (= 19 (:credit (get-corp))) "Should gain 7 credits from 12 to 19")
       (is (= 2 (:bad-publicity (get-corp))) "Should gain 1 bad publicity"))))
 
-(deftest brainrewiring
+(deftest brain-rewiring
   ;; Brain Rewiring
   (do-game
     (new-game (default-corp ["Brain Rewiring"])
@@ -519,7 +520,7 @@
         (is (empty? (get-in (get-runner)  [:rig :facedown])) "Degree Mill didn't remove facedown cards")
         (is (= 2 (count (:deck (get-runner)))) "Degree Mill didn't put cards back in deck")))))
 
-(deftest ^{:card-title "director-haas'-pet-project"} director-haas-pet-project
+(deftest director-haas'-pet-project
   ;; Director Haas' Pet Project
   (do-game
     (new-game (default-corp ["Director Haas' Pet Project"
@@ -696,41 +697,40 @@
 
 (deftest explode-a-palooza
   ;; Explode-a-palooza
-  (do-game
-    (new-game (default-corp ["Explode-a-palooza"])
-              (default-runner))
-    (play-from-hand state :corp "Explode-a-palooza" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state :remote1)
-    (prompt-choice :runner "Access")
-    (prompt-choice :runner "Steal")
-    (prompt-choice :corp "Yes")
-    (is (= 12 (:credit (get-corp))) "Gained 5 credits")))
-
-(deftest explode-ttw
-  ;; Explode-a-palooza - Interaction with The Turning Wheel. Issue #1717.
-  (do-game
-    (new-game (default-corp [(qty "Explode-a-palooza" 3)])
-              (default-runner ["The Turning Wheel"]))
-    (starting-hand state :corp ["Explode-a-palooza" "Explode-a-palooza"])
-    (play-from-hand state :corp "Explode-a-palooza" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "The Turning Wheel")
-    (run-empty-server state :remote1)
-    (prompt-choice :runner "Access")
-    (prompt-choice :corp "Yes")
-    (prompt-choice :runner "Steal")
-    (let [ttw (get-resource state 0)]
-      (is (= 0 (get-counters (refresh ttw) :power)) "TTW did not gain counters")
-      (is (= 1 (count (:scored (get-runner)))) "Runner stole Explodapalooza")
-      (is (= 12 (:credit (get-corp))) "Gained 5 credits")
-      (run-empty-server state :rd)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Explode-a-palooza"])
+                (default-runner))
+      (play-from-hand state :corp "Explode-a-palooza" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state :remote1)
+      (prompt-choice :runner "Access")
+      (prompt-choice :runner "Steal")
+      (prompt-choice :corp "Yes")
+      (is (= 12 (:credit (get-corp))) "Gained 5 credits")))
+  (testing "Interaction with The Turning Wheel. Issue #1717."
+    (do-game
+      (new-game (default-corp [(qty "Explode-a-palooza" 3)])
+                (default-runner ["The Turning Wheel"]))
+      (starting-hand state :corp ["Explode-a-palooza" "Explode-a-palooza"])
+      (play-from-hand state :corp "Explode-a-palooza" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Turning Wheel")
+      (run-empty-server state :remote1)
       (prompt-choice :runner "Access")
       (prompt-choice :corp "Yes")
       (prompt-choice :runner "Steal")
-      (is (= 0 (get-counters (refresh ttw) :power)) "TTW did not gain counters")
-      (is (= 2 (count (:scored (get-runner)))) "Runner stole Explodapalooza")
-      (is (= 17 (:credit (get-corp))) "Gained 5 credits"))))
+      (let [ttw (get-resource state 0)]
+        (is (= 0 (get-counters (refresh ttw) :power)) "TTW did not gain counters")
+        (is (= 1 (count (:scored (get-runner)))) "Runner stole Explodapalooza")
+        (is (= 12 (:credit (get-corp))) "Gained 5 credits")
+        (run-empty-server state :rd)
+        (prompt-choice :runner "Access")
+        (prompt-choice :corp "Yes")
+        (prompt-choice :runner "Steal")
+        (is (= 0 (get-counters (refresh ttw) :power)) "TTW did not gain counters")
+        (is (= 2 (count (:scored (get-runner)))) "Runner stole Explodapalooza")
+        (is (= 17 (:credit (get-corp))) "Gained 5 credits")))))
 
 (deftest false-lead
   ;; False Lead
@@ -744,7 +744,7 @@
     (card-ability state :corp (get-scored state :corp) 0)
     (is (= 2 (:click (get-runner))) "Runner should lose 2 clicks from False Lead")))
 
-(deftest fetal-ai-damage
+(deftest fetal-ai
   ;; Fetal AI
   (testing "basic test"
     (do-game
@@ -1495,7 +1495,7 @@
     (prompt-choice :corp "Yes")
     (is (= 1 (:brain-damage (get-runner))) "Runner should gain 1 brain damage")))
 
-(deftest nisei-mk-ii-step-43
+(deftest nisei-mk-ii
   ;; Nisei MK II - Remove hosted counter to ETR, check this works in 4.3
   (do-game
     (new-game (default-corp ["Nisei MK II"])

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -934,18 +934,40 @@
 
 (deftest ghost-branch
   ;; Ghost Branch - Advanceable; give the Runner tags equal to advancements when accessed
-  (do-game
-    (new-game (default-corp ["Ghost Branch"])
-              (default-runner))
-    (play-from-hand state :corp "Ghost Branch" "New remote")
-    (let [gb (get-content state :remote1 0)]
-      (core/advance state :corp {:card (refresh gb)})
-      (core/advance state :corp {:card (refresh gb)})
-      (is (= 2 (get-in (refresh gb) [:advance-counter])))
-      (take-credits state :corp)
-      (run-empty-server state "Server 1")
-      (prompt-choice :corp "Yes") ; choose to do the optional ability
-      (is (= 2 (:tag (get-runner))) "Runner given 2 tags"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Ghost Branch"])
+                (default-runner))
+      (play-from-hand state :corp "Ghost Branch" "New remote")
+      (let [gb (get-content state :remote1 0)]
+        (core/advance state :corp {:card (refresh gb)})
+        (core/advance state :corp {:card (refresh gb)})
+        (is (= 2 (get-in (refresh gb) [:advance-counter])))
+        (take-credits state :corp)
+        (run-empty-server state "Server 1")
+        (prompt-choice :corp "Yes") ; choose to do the optional ability
+        (is (= 2 (:tag (get-runner))) "Runner given 2 tags"))))
+  (testing "with Dedicated Response Team"
+    (do-game
+      (new-game (default-corp ["Ghost Branch" "Dedicated Response Team"])
+                (default-runner))
+      (play-from-hand state :corp "Ghost Branch" "New remote")
+      (play-from-hand state :corp "Dedicated Response Team" "New remote")
+      (core/gain state :corp :click 1)
+      (let [gb (get-content state :remote1 0)
+            drt (get-content state :remote2 0)]
+        (core/advance state :corp {:card gb})
+        (core/advance state :corp {:card (refresh gb)})
+        (is (= 2 (:advance-counter (refresh gb))) "Ghost Branch advanced twice")
+        (take-credits state :corp)
+        (run-on state "Server 1")
+        (core/rez state :corp drt)
+        (run-successful state)
+        (is (prompt-is-type? :runner :waiting) "Runner has prompt to wait for Ghost Branch")
+        (prompt-choice :corp "Yes")
+        (is (= 2 (:tag (get-runner))) "Runner has 2 tags")
+        (prompt-choice-partial :runner "Pay")
+        (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage")))))
 
 (deftest haas-arcology-ai
   ;; Haas Arcology AI - Click and advancement to gain 2 clicks, once per turn

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -7,57 +7,58 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "events"))
 
-(deftest account-siphon-ability
-  ;; Account Siphon - Use ability
-  (do-game
-    (new-game (default-corp) (default-runner [(qty "Account Siphon" 3)]))
-    (take-credits state :corp)
-    (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
-    ;; play Account Siphon, use ability
-    (play-run-event state (first (:hand (get-runner))) :hq)
-    (prompt-choice :runner "Replacement effect")
-    (is (= 2 (:tag (get-runner))) "Runner took 2 tags")
-    (is (= 15 (:credit (get-runner))) "Runner gained 10 credits")
-    (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))
-
-(deftest account-siphon-access
-  ;; Account Siphon - Access
-  (do-game
-    (new-game (default-corp) (default-runner [(qty "Account Siphon" 3)]))
-    (take-credits state :corp) ; pass to runner's turn by taking credits
-    (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
-    ;; play another Siphon, do not use ability
-    (play-run-event state (first (get-in @state [:runner :hand])) :hq)
-    (prompt-choice :runner "Access")
-    (is (= 0 (:tag (get-runner))) "Runner did not take any tags")
-    (is (= 5 (:credit (get-runner))) "Runner did not gain any credits")
-    (is (= 8 (:credit (get-corp))) "Corp did not lose any credits")))
-
-(deftest account-siphon-nach-interaction
-  ;; Account Siphon - Access
-  (do-game
-    (new-game (default-corp) (default-runner ["Account Siphon"
-                                              "New Angeles City Hall"]))
-    (core/gain state :corp :bad-publicity 1)
-    (is (= 1 (:bad-publicity (get-corp))) "Corp has 1 bad publicity")
-    (core/lose state :runner :credit 1)
-    (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
-    (take-credits state :corp) ; pass to runner's turn by taking credits
-    (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
-    (play-from-hand state :runner "New Angeles City Hall")
-    (is (= 3 (:credit (get-runner))) "Runner has 3 credits")
-    (let [nach (get-in @state [:runner :rig :resource 0])]
-      (play-run-event state (first (get-in @state [:runner :hand])) :hq)
+(deftest account-siphon
+  ;; Account Siphon
+  (testing "Use ability"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Account Siphon" 3)]))
+      (take-credits state :corp)
+      (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
+      ;; play Account Siphon, use ability
+      (play-run-event state (first (:hand (get-runner))) :hq)
       (prompt-choice :runner "Replacement effect")
-      (is (= 4 (:credit (get-runner))) "Runner still has 4 credits due to BP")
-      (card-ability state :runner nach 0)
-      (is (= 2 (:credit (get-runner))) "Runner has 2 credits left")
-      (card-ability state :runner nach 0)
-      (is (= 0 (:credit (get-runner))) "Runner has no credits left")
-      (prompt-choice :runner "Done"))
-    (is (= 0 (:tag (get-runner))) "Runner did not take any tags")
-    (is (= 10 (:credit (get-runner))) "Runner gained 10 credits")
-    (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))
+      (is (= 2 (:tag (get-runner))) "Runner took 2 tags")
+      (is (= 15 (:credit (get-runner))) "Runner gained 10 credits")
+      (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))
+  (testing "Access"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Account Siphon" 3)]))
+      (take-credits state :corp) ; pass to runner's turn by taking credits
+      (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
+      ;; play another Siphon, do not use ability
+      (play-run-event state (first (get-in @state [:runner :hand])) :hq)
+      (prompt-choice :runner "Access")
+      (is (= 0 (:tag (get-runner))) "Runner did not take any tags")
+      (is (= 5 (:credit (get-runner))) "Runner did not gain any credits")
+      (is (= 8 (:credit (get-corp))) "Corp did not lose any credits")))
+  (testing "New Angeles City Hall interaction"
+    ;; Account Siphon - Access
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Account Siphon"
+                                 "New Angeles City Hall"]))
+      (core/gain state :corp :bad-publicity 1)
+      (is (= 1 (:bad-publicity (get-corp))) "Corp has 1 bad publicity")
+      (core/lose state :runner :credit 1)
+      (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
+      (take-credits state :corp) ; pass to runner's turn by taking credits
+      (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
+      (play-from-hand state :runner "New Angeles City Hall")
+      (is (= 3 (:credit (get-runner))) "Runner has 3 credits")
+      (let [nach (get-in @state [:runner :rig :resource 0])]
+        (play-run-event state (first (get-in @state [:runner :hand])) :hq)
+        (prompt-choice :runner "Replacement effect")
+        (is (= 4 (:credit (get-runner))) "Runner still has 4 credits due to BP")
+        (card-ability state :runner nach 0)
+        (is (= 2 (:credit (get-runner))) "Runner has 2 credits left")
+        (card-ability state :runner nach 0)
+        (is (= 0 (:credit (get-runner))) "Runner has no credits left")
+        (prompt-choice :runner "Done"))
+      (is (= 0 (:tag (get-runner))) "Runner did not take any tags")
+      (is (= 10 (:credit (get-runner))) "Runner gained 10 credits")
+      (is (= 3 (:credit (get-corp))) "Corp lost 5 credits"))))
 
 (deftest amped-up
   ;; Amped Up - Gain 3 clicks and take 1 unpreventable brain damage
@@ -76,7 +77,8 @@
     (is (= 4 (core/hand-size state :runner)) "Runner handsize decreased by 1")
     (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")))
 
-(deftest another-day-another-paycheck
+(deftest ^{:card-title "another-day,-another-paycheck"}
+  another-day-another-paycheck
   ;; Another Day, Another Paycheck
   (do-game
     (new-game
@@ -98,123 +100,116 @@
     ;; 4 credits after trace, gain 6
     (is (= 10 (:credit (get-runner))) "Runner gained 6 credits")))
 
-(deftest apocalypse-hosting
-  ;; Apocalypse - Ensure MU is correct and no duplicate cards in heap
-  (do-game
-    (new-game (default-corp [(qty "Launch Campaign" 2) "Ice Wall"])
-              (default-runner ["Scheherazade" "Corroder" "Hivemind" (qty "Apocalypse" 2)]))
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Launch Campaign" "New remote")
-    (play-from-hand state :corp "Launch Campaign" "New remote")
-    (take-credits state :corp)
-    (core/gain state :runner :click 3)
-    (core/gain state :runner :credit 2)
-    (play-from-hand state :runner "Scheherazade")
-    (let [scheherazade (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner scheherazade 0)
-      (prompt-select :runner (find-card "Corroder" (:hand (get-runner))))
-      (is (= 3 (core/available-mu state)) "Memory at 3 (-1 from Corroder)"))
-    (play-from-hand state :runner "Hivemind")
-    (is (= 1 (core/available-mu state)) "Memory at 1 (-1 from Corroder, -2 from Hivemind)")
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (run-empty-server state "HQ")
-    (play-from-hand state :runner "Apocalypse")
-    (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
-    (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
-    (is (= 0 (count (core/all-active-installed state :runner))) "No active installed runner cards")
-    (let [facedowns (filter :facedown (core/all-installed state :runner))
-          scheherazade (find-card "Scheherazade" facedowns)
-          corroder (find-card "Corroder" facedowns)
-          hivemind (find-card "Hivemind" facedowns)]
-      (is scheherazade "Scheherazade facedown")
-      (is corroder "Corroder facedown")
-      (is hivemind "Hivemind facedown")
-      (is (= 3 (count facedowns)) "No other cards facedown")
-      (is (= corroder (first (:hosted scheherazade))) "Corroder is still hosted on Scheherazade")
-      (is (= 1 (get-in hivemind [:counter :virus])) "Hivemind still has a virus counters"))
-    (is (find-card "Apocalypse" (:discard (get-runner))) "Apocalypse is in the heap")
-    (is (= 1 (count (:discard (get-runner)))) "Only Apocalypse is in the heap")
-    (is (= 4 (core/available-mu state)) "Memory back to 4")))
-
-(deftest apocalype-full-immersion-recstudio
-  ;; Apocalypse with Full Immersion - no duplicate cards in heap #2606
-  (do-game
-    (new-game
-      (default-corp ["Full Immersion RecStudio" "Sandburg"
-                     "Oaktown Renovation"])
-      (default-runner  ["Apocalypse"]))
-    (play-from-hand state :corp "Full Immersion RecStudio" "New remote")
-    (let [fir (get-content state :remote1 0)]
-      (core/rez state :corp fir)
-      (card-ability state :corp fir 0)
-      (prompt-select :corp (find-card "Sandburg" (:hand (get-corp))))
-      (card-ability state :corp fir 0)
-      (prompt-select :corp (find-card "Oaktown Renovation" (:hand (get-corp))))
+(deftest apocalypse
+  ;; Apocalypse
+  (testing "Ensure MU is correct and no duplicate cards in heap"
+    (do-game
+      (new-game (default-corp [(qty "Launch Campaign" 2) "Ice Wall"])
+                (default-runner ["Scheherazade" "Corroder" "Hivemind" (qty "Apocalypse" 2)]))
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Launch Campaign" "New remote")
+      (play-from-hand state :corp "Launch Campaign" "New remote")
       (take-credits state :corp)
+      (core/gain state :runner :click 3)
+      (core/gain state :runner :credit 2)
+      (play-from-hand state :runner "Scheherazade")
+      (let [scheherazade (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner scheherazade 0)
+        (prompt-select :runner (find-card "Corroder" (:hand (get-runner))))
+        (is (= 3 (core/available-mu state)) "Memory at 3 (-1 from Corroder)"))
+      (play-from-hand state :runner "Hivemind")
+      (is (= 1 (core/available-mu state)) "Memory at 1 (-1 from Corroder, -2 from Hivemind)")
       (run-empty-server state "Archives")
       (run-empty-server state "R&D")
       (run-empty-server state "HQ")
       (play-from-hand state :runner "Apocalypse")
       (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
       (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
-      (is (= 1 (count (:discard (get-runner)))) "Only Apocalypse is in the heap"))))
-
-(deftest apocalypse-hostile-infrastructure
-  ;; Apocalypse with Hostile Infrastructure - should take damage equal to 2x cards on the table
-  (do-game
-    (new-game
-      (default-corp [(qty "Hostile Infrastructure" 2) (qty "Ice Wall" 2)])
-      (default-runner ["Apocalypse" (qty "Sure Gamble" 9)]))
-    (core/gain state :corp :click 1)
-    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
-    (core/rez state :corp (get-content state :remote1 0) {:ignore-cost true})
-    (core/rez state :corp (get-content state :remote4 0) {:ignore-cost true})
-    (take-credits state :corp)
-    (core/draw state :runner 5)
-    (is (= 10 (count (:hand (get-runner)))) "Runner has 9 cards in hand")
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (run-empty-server state "HQ")
-    (play-from-hand state :runner "Apocalypse")
-    (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
-    (is (= 4 (count (:discard (get-corp)))) "4 Corp cards in Archives")
-    (is (= 1 (count (:hand (get-runner)))) "Runner has one card in hand")
-    (is (= 9 (count (:discard (get-runner)))) "There are 9 cards in heap")))
-
-(deftest apocalypse-in-play-ability
-  ;; Apocalypse - Turn Runner cards facedown and reduce memory and hand-size gains
-  (do-game
-    (new-game (default-corp [(qty "Launch Campaign" 2) "Ice Wall"])
-              (default-runner ["Logos" "Apocalypse" (qty "Origami" 2)]))
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Launch Campaign" "New remote")
-    (play-from-hand state :corp "Launch Campaign" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Logos")
-    (is (= 1 (get-in (get-runner) [:hand-size :mod])) "Hand-size increased from Logos")
-    (is (= 5 (core/available-mu state)) "Memory increased from Logos")
-    (play-from-hand state :runner "Origami")
-    (play-from-hand state :runner "Origami")
-    (is (= 5 (get-in (get-runner) [:hand-size :mod])) "Hand-size increased from Logos and Origami")
-    (is (= 3 (core/available-mu state)) "Memory decreased from Origamis")
-    (core/gain state :runner :click 3 :credit 2)
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (run-empty-server state "HQ")
-    (play-from-hand state :runner "Apocalypse")
-    (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
-    (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
-    (let [logos (find-card "Logos" (get-in (get-runner) [:rig :facedown]))]
-      (is (:facedown (refresh logos)) "Logos is facedown")
-      (is (= 0 (get-in (get-runner) [:hand-size :mod])) "Hand-size reset with Logos and Origami facedown")
-      (is (= 4 (core/available-mu state)) "Memory reset with Logos and Origami facedown"))))
-
-(deftest apocalypse-turn-facedown
-  ;; Apocalypse - Turn Runner cards facedown without firing their trash effects
+      (is (= 0 (count (core/all-active-installed state :runner))) "No active installed runner cards")
+      (let [facedowns (filter :facedown (core/all-installed state :runner))
+            scheherazade (find-card "Scheherazade" facedowns)
+            corroder (find-card "Corroder" facedowns)
+            hivemind (find-card "Hivemind" facedowns)]
+        (is scheherazade "Scheherazade facedown")
+        (is corroder "Corroder facedown")
+        (is hivemind "Hivemind facedown")
+        (is (= 3 (count facedowns)) "No other cards facedown")
+        (is (= corroder (first (:hosted scheherazade))) "Corroder is still hosted on Scheherazade")
+        (is (= 1 (get-in hivemind [:counter :virus])) "Hivemind still has a virus counters"))
+      (is (find-card "Apocalypse" (:discard (get-runner))) "Apocalypse is in the heap")
+      (is (= 1 (count (:discard (get-runner)))) "Only Apocalypse is in the heap")
+      (is (= 4 (core/available-mu state)) "Memory back to 4")))
+  (testing "with Full Immersion - no duplicate cards in heap #2606"
+    (do-game
+      (new-game
+        (default-corp ["Full Immersion RecStudio" "Sandburg"
+                       "Oaktown Renovation"])
+        (default-runner  ["Apocalypse"]))
+      (play-from-hand state :corp "Full Immersion RecStudio" "New remote")
+      (let [fir (get-content state :remote1 0)]
+        (core/rez state :corp fir)
+        (card-ability state :corp fir 0)
+        (prompt-select :corp (find-card "Sandburg" (:hand (get-corp))))
+        (card-ability state :corp fir 0)
+        (prompt-select :corp (find-card "Oaktown Renovation" (:hand (get-corp))))
+        (take-credits state :corp)
+        (run-empty-server state "Archives")
+        (run-empty-server state "R&D")
+        (run-empty-server state "HQ")
+        (play-from-hand state :runner "Apocalypse")
+        (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
+        (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
+        (is (= 1 (count (:discard (get-runner)))) "Only Apocalypse is in the heap"))))
+  (testing "with Hostile Infrastructure - should take damage equal to 2x cards on the table"
+    (do-game
+      (new-game
+        (default-corp [(qty "Hostile Infrastructure" 2) (qty "Ice Wall" 2)])
+        (default-runner ["Apocalypse" (qty "Sure Gamble" 9)]))
+      (core/gain state :corp :click 1)
+      (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+      (core/rez state :corp (get-content state :remote1 0) {:ignore-cost true})
+      (core/rez state :corp (get-content state :remote4 0) {:ignore-cost true})
+      (take-credits state :corp)
+      (core/draw state :runner 5)
+      (is (= 10 (count (:hand (get-runner)))) "Runner has 9 cards in hand")
+      (run-empty-server state "Archives")
+      (run-empty-server state "R&D")
+      (run-empty-server state "HQ")
+      (play-from-hand state :runner "Apocalypse")
+      (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
+      (is (= 4 (count (:discard (get-corp)))) "4 Corp cards in Archives")
+      (is (= 1 (count (:hand (get-runner)))) "Runner has one card in hand")
+      (is (= 9 (count (:discard (get-runner)))) "There are 9 cards in heap")))
+  (testing "Turn Runner cards facedown and reduce memory and hand-size gains"
+    (do-game
+      (new-game (default-corp [(qty "Launch Campaign" 2) "Ice Wall"])
+                (default-runner ["Logos" "Apocalypse" (qty "Origami" 2)]))
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Launch Campaign" "New remote")
+      (play-from-hand state :corp "Launch Campaign" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Logos")
+      (is (= 1 (get-in (get-runner) [:hand-size :mod])) "Hand-size increased from Logos")
+      (is (= 5 (core/available-mu state)) "Memory increased from Logos")
+      (play-from-hand state :runner "Origami")
+      (play-from-hand state :runner "Origami")
+      (is (= 5 (get-in (get-runner) [:hand-size :mod])) "Hand-size increased from Logos and Origami")
+      (is (= 3 (core/available-mu state)) "Memory decreased from Origamis")
+      (core/gain state :runner :click 3 :credit 2)
+      (run-empty-server state "Archives")
+      (run-empty-server state "R&D")
+      (run-empty-server state "HQ")
+      (play-from-hand state :runner "Apocalypse")
+      (is (= 0 (count (core/all-installed state :corp))) "All installed Corp cards trashed")
+      (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
+      (let [logos (find-card "Logos" (get-in (get-runner) [:rig :facedown]))]
+        (is (:facedown (refresh logos)) "Logos is facedown")
+        (is (= 0 (get-in (get-runner) [:hand-size :mod])) "Hand-size reset with Logos and Origami facedown")
+        (is (= 4 (core/available-mu state)) "Memory reset with Logos and Origami facedown"))))
+(testing "Turn Runner cards facedown without firing their trash effects"
   (do-game
     (new-game (default-corp [(qty "Launch Campaign" 2) "Ice Wall"])
               (default-runner [(qty "Tri-maf Contact" 3) (qty "Apocalypse" 3)]))
@@ -236,7 +231,7 @@
           "No meat damage dealt by Tri-maf's leave play effect")
       (core/trash state :runner tmc)
       (is (= 3 (count (:hand (get-runner))))
-          "No meat damage dealt by trashing facedown Tri-maf"))))
+          "No meat damage dealt by trashing facedown Tri-maf")))))
 
 (deftest because-i-can
   ;; make a successful run on a remote to shuffle its contents into R&D
@@ -275,49 +270,88 @@
       (is (= (+ n 1) (count (get-in @state [:corp :deck]))) "1 card was shuffled into R&D")
       (is (= 0 (count (get-in @state [:corp :servers :remote3 :content]))) "No cards left in server 3"))))
 
+(deftest black-hat
+  ;; Black Hat
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Hedge Fund" 10)])
+                (default-runner [(qty "Black Hat" 3)]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Black Hat")
+      (prompt-choice  :corp 0)
+      (prompt-choice  :runner 4)
+      (run-on state :rd)
+      (run-successful state)
+      (prompt-choice :runner "Card from deck")
+      (prompt-choice :runner "No action")
+      (prompt-choice :runner "Card from deck")
+      (prompt-choice :runner "No action")
+      (prompt-choice :runner "Card from deck")))
+  (testing "Kitsune interaction"
+    (do-game
+     (new-game (default-corp [(qty "Kitsune" 10)])
+               (default-runner [(qty "Black Hat" 3)]))
+      (starting-hand state :corp ["Kitsune" "Kitsune" "Kitsune" "Kitsune" "Kitsune"])
+      (play-from-hand state :corp "Kitsune" "R&D")
+      (let [kitsune (get-ice state :rd 0)]
+        (core/rez state :corp kitsune)
+        (take-credits state :corp)
+        (core/gain state :runner :credit 10)
+        (play-from-hand state :runner "Black Hat")
+        (prompt-choice  :corp 0)
+        (prompt-choice :runner 4)
+        (run-on state :rd)
+        (card-subroutine state :corp kitsune 0)
+        (prompt-select :corp (find-card "Kitsune" (:hand (get-corp))))
+        (prompt-choice :runner "No action")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "No action")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "No action")))))
+
 (deftest blackmail
   ;; Prevent rezzing of ice for one run
-  (do-game
-    (new-game
-      (default-corp [(qty "Ice Wall" 3)])
-      (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Blackmail" 3)]))
-    (is (= 1 (get-in @state [:corp :bad-publicity])) "Corp has 1 bad-publicity")
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Blackmail")
-    (prompt-choice :runner "HQ")
-    (let [iwall1 (get-ice state :hq 0)
-          iwall2 (get-ice state :hq 1)]
-      (core/rez state :corp iwall1)
-      (is (not (get-in (refresh iwall1) [:rezzed])) "First Ice Wall is not rezzed")
-      (run-continue state)
-      (core/rez state :corp iwall2)
-      (is (not (get-in (refresh iwall2) [:rezzed])) "Second Ice Wall is not rezzed")
-      (core/jack-out state :runner nil)
-      ;; Do another run, where the ice should rez
-      (run-on state "HQ")
-      (core/rez state :corp iwall1)
-      (is (get-in (refresh iwall1) [:rezzed]) "First Ice Wall is rezzed"))))
-
-(deftest blackmail-tmi-interaction
-  ;; Regression test for a rezzed tmi breaking game state on a blackmail run
-  (do-game
-    (new-game (default-corp [(qty "TMI" 3)])
-              (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Blackmail" 3)]))
-    (is (= 1 (get-in @state [:corp :bad-publicity])) "Corp has 1 bad-publicity")
-    (play-from-hand state :corp "TMI" "HQ")
-    (let [tmi (get-ice state :hq 0)]
-      (core/rez state :corp tmi)
-      (prompt-choice :corp 0)
-      (prompt-choice :runner 0)
-      (is (get-in (refresh tmi) [:rezzed]) "TMI is rezzed")
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (default-corp [(qty "Ice Wall" 3)])
+        (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Blackmail" 3)]))
+      (is (= 1 (get-in @state [:corp :bad-publicity])) "Corp has 1 bad-publicity")
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Ice Wall" "HQ")
       (take-credits state :corp)
       (play-from-hand state :runner "Blackmail")
       (prompt-choice :runner "HQ")
-      (run-continue state)
-      (run-jack-out state)
-      (run-on state "Archives"))))
+      (let [iwall1 (get-ice state :hq 0)
+            iwall2 (get-ice state :hq 1)]
+        (core/rez state :corp iwall1)
+        (is (not (get-in (refresh iwall1) [:rezzed])) "First Ice Wall is not rezzed")
+        (run-continue state)
+        (core/rez state :corp iwall2)
+        (is (not (get-in (refresh iwall2) [:rezzed])) "Second Ice Wall is not rezzed")
+        (core/jack-out state :runner nil)
+        ;; Do another run, where the ice should rez
+        (run-on state "HQ")
+        (core/rez state :corp iwall1)
+        (is (get-in (refresh iwall1) [:rezzed]) "First Ice Wall is rezzed"))))
+  (testing "Regression test for a rezzed tmi breaking game state on a blackmail run"
+    (do-game
+      (new-game (default-corp [(qty "TMI" 3)])
+                (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Blackmail" 3)]))
+      (is (= 1 (get-in @state [:corp :bad-publicity])) "Corp has 1 bad-publicity")
+      (play-from-hand state :corp "TMI" "HQ")
+      (let [tmi (get-ice state :hq 0)]
+        (core/rez state :corp tmi)
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (get-in (refresh tmi) [:rezzed]) "TMI is rezzed")
+        (take-credits state :corp)
+        (play-from-hand state :runner "Blackmail")
+        (prompt-choice :runner "HQ")
+        (run-continue state)
+        (run-jack-out state)
+        (run-on state "Archives")))))
 
 (deftest by-any-means
   ;; By Any Means
@@ -481,14 +515,14 @@
       (is (= 4 (:rec-counter (find-card "Cold Read" (get-in @state [:runner :play-area])))) "Cold Read has 4 counters")
       (run-successful state))))
 
-(deftest compile-test
+(deftest ^{:card-title "compile"}
+  compile-test
   ;; Compile - Make a run, and install a program for free which is shuffled back into stack
   ;; test name is weird because clojure.core/compile exists - can't see it being
   ;; a problem, but I got a warning
   (do-game
    (new-game (default-corp)
-              (default-runner ["Compile"
-                               "Clone Chip"
+              (default-runner ["Compile" "Clone Chip"
                                (qty "Self-modifying Code" 3)]))
     (starting-hand state :runner ["Compile" "Clone Chip"] )
     (take-credits state :corp)
@@ -625,50 +659,49 @@
 
 (deftest data-breach
   ;; Data Breach
-  (do-game
-    (new-game
-      (default-corp)
-      (default-runner [(qty "Data Breach" 3)]))
-    (starting-hand state :corp ["Hedge Fund"])
-    (take-credits state :corp)
-    (play-from-hand state :runner "Data Breach")
-    (core/no-action state :corp nil)
-    (run-successful state)
-    (prompt-choice :runner "No action")
-    (prompt-choice :runner "Yes")
-    (is (= [:rd] (get-in @state [:run :server])) "Second run on R&D triggered")
-    (core/no-action state :corp nil)
-    (run-successful state)
-    (prompt-choice :runner "No action")
-    (is (empty? (:prompt (get-runner))) "No prompt to run a third time")
-    (is (not (:run @state)) "Run is over")
-    (play-from-hand state :runner "Data Breach")
-    (run-jack-out state)
-    (is (empty? (:prompt (get-runner))) "No option to run again on unsuccessful run")))
-
-(deftest data-breach-doppelganger
-  ;; FAQ 4.1 - ensure runner gets choice of activation order
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Doppelgänger" (qty "Data Breach" 3)]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Doppelgänger")
-    (play-from-hand state :runner "Data Breach")
-    (core/no-action state :corp nil)
-    (run-successful state)
-    (prompt-choice :runner "No action")
-    (prompt-choice :runner "Doppelgänger")
-    (prompt-choice :runner "Yes")
-    (prompt-choice :runner "HQ")
-    (is (:run @state) "New run started")
-    (is (= [:hq] (:server (:run @state))) "Running on HQ via Doppelgänger")
-    (core/no-action state :corp nil)
-    (run-successful state)
-    (prompt-choice :runner "No action")
-    (prompt-choice :runner "Yes")
-    (is (= [:rd] (get-in @state [:run :server])) "Second Data Breach run on R&D triggered")
-    (core/no-action state :corp nil)
-    (run-successful state)))
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (default-corp)
+        (default-runner [(qty "Data Breach" 3)]))
+      (starting-hand state :corp ["Hedge Fund"])
+      (take-credits state :corp)
+      (play-from-hand state :runner "Data Breach")
+      (core/no-action state :corp nil)
+      (run-successful state)
+      (prompt-choice :runner "No action")
+      (prompt-choice :runner "Yes")
+      (is (= [:rd] (get-in @state [:run :server])) "Second run on R&D triggered")
+      (core/no-action state :corp nil)
+      (run-successful state)
+      (prompt-choice :runner "No action")
+      (is (empty? (:prompt (get-runner))) "No prompt to run a third time")
+      (is (not (:run @state)) "Run is over")
+      (play-from-hand state :runner "Data Breach")
+      (run-jack-out state)
+      (is (empty? (:prompt (get-runner))) "No option to run again on unsuccessful run")))
+  (testing "FAQ 4.1 - ensure runner gets choice of activation order"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Doppelgänger" (qty "Data Breach" 3)]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Doppelgänger")
+      (play-from-hand state :runner "Data Breach")
+      (core/no-action state :corp nil)
+      (run-successful state)
+      (prompt-choice :runner "No action")
+      (prompt-choice :runner "Doppelgänger")
+      (prompt-choice :runner "Yes")
+      (prompt-choice :runner "HQ")
+      (is (:run @state) "New run started")
+      (is (= [:hq] (:server (:run @state))) "Running on HQ via Doppelgänger")
+      (core/no-action state :corp nil)
+      (run-successful state)
+      (prompt-choice :runner "No action")
+      (prompt-choice :runner "Yes")
+      (is (= [:rd] (get-in @state [:run :server])) "Second Data Breach run on R&D triggered")
+      (core/no-action state :corp nil)
+      (run-successful state))))
 
 (deftest deja-vu
   ;; Deja Vu - recur one non-virus or two virus cards
@@ -764,80 +797,78 @@
     (run-jack-out state)
     (is (= 6 (:credit (get-runner))) "Run unsuccessful; gained no credits")))
 
-(deftest diversion-of-funds-ability
-  ;; Diversion of Funds - Use ability
-  (do-game
-   (new-game (default-corp) (default-runner [(qty "Diversion of Funds" 3)]))
-   (take-credits state :corp)
-   (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
-   ;; play Diversion of Funds, use ability
-   (play-run-event state (first (:hand (get-runner))) :hq)
-   (prompt-choice :runner "Replacement effect")
-   (is (= 9 (:credit (get-runner))) "Runner netted 4 credits")
-   (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))
-
-(deftest diversion-of-funds-access
-  ;; Diversion of Funds - Access
-  (do-game
-   (new-game (default-corp) (default-runner [(qty "Diversion of Funds" 3)]))
-   (take-credits state :corp) ; pass to runner's turn by taking credits
-   (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
-   ;; play Diversion, do not use ability
-   (play-run-event state (first (get-in @state [:runner :hand])) :hq)
-   (prompt-choice :runner "Access")
-   (is (= 0 (:tag (get-runner))) "Runner did not take any tags")
-   (is (= 4 (:credit (get-runner))) "Runner is down a credit")
-   (is (= 8 (:credit (get-corp))) "Corp did not lose any credits")))
+(deftest diversion-of-funds
+  ;; Diversion of Funds
+  (testing "Use ability"
+    (do-game
+      (new-game (default-corp) (default-runner [(qty "Diversion of Funds" 3)]))
+      (take-credits state :corp)
+      (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
+      ;; play Diversion of Funds, use ability
+      (play-run-event state (first (:hand (get-runner))) :hq)
+      (prompt-choice :runner "Replacement effect")
+      (is (= 9 (:credit (get-runner))) "Runner netted 4 credits")
+      (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))
+  (testing "Access"
+    (do-game
+      (new-game (default-corp) (default-runner [(qty "Diversion of Funds" 3)]))
+      (take-credits state :corp) ; pass to runner's turn by taking credits
+      (is (= 8 (:credit (get-corp))) "Corp has 8 credits")
+      ;; play Diversion, do not use ability
+      (play-run-event state (first (get-in @state [:runner :hand])) :hq)
+      (prompt-choice :runner "Access")
+      (is (= 0 (:tag (get-runner))) "Runner did not take any tags")
+      (is (= 4 (:credit (get-runner))) "Runner is down a credit")
+      (is (= 8 (:credit (get-corp))) "Corp did not lose any credits"))))
 
 (deftest drive-by
   ;; Drive By - Expose card in remote server and trash if asset or upgrade
-  (do-game
-    (new-game (default-corp [(qty "Eve Campaign" 2)
-                             "Product Placement"
-                             "Project Atlas"])
-              (default-runner [(qty "Drive By" 2)]))
-    (core/gain state :corp :click 1)
-    (play-from-hand state :corp "Eve Campaign" "New remote")
-    (play-from-hand state :corp "Eve Campaign" "New remote")
-    (play-from-hand state :corp "Project Atlas" "New remote")
-    (play-from-hand state :corp "Product Placement" "HQ")
-    (take-credits state :corp)
-    (let [eve1 (get-content state :remote1 0)
-          eve2 (get-content state :remote2 0)
-          atl (get-content state :remote3 0)
-          pp (get-content state :hq 0)]
-      (core/rez state :corp eve1)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Eve Campaign" 2)
+                               "Product Placement"
+                               "Project Atlas"])
+                (default-runner [(qty "Drive By" 2)]))
+      (core/gain state :corp :click 1)
+      (play-from-hand state :corp "Eve Campaign" "New remote")
+      (play-from-hand state :corp "Eve Campaign" "New remote")
+      (play-from-hand state :corp "Project Atlas" "New remote")
+      (play-from-hand state :corp "Product Placement" "HQ")
+      (take-credits state :corp)
+      (let [eve1 (get-content state :remote1 0)
+            eve2 (get-content state :remote2 0)
+            atl (get-content state :remote3 0)
+            pp (get-content state :hq 0)]
+        (core/rez state :corp eve1)
+        (play-from-hand state :runner "Drive By")
+        (prompt-select :runner pp)
+        (is (= 1 (count (get-in @state [:corp :servers :hq :content])))
+            "Upgrades in root of central servers can't be targeted")
+        (prompt-select :runner (refresh eve1))
+        (is (= 1 (count (get-in @state [:corp :servers :remote1 :content])))
+            "Rezzed cards can't be targeted")
+        (prompt-select :runner eve2)
+        (is (= 2 (:click (get-runner))) "Spent 2 clicks")
+        (is (and (= 1 (count (:discard (get-corp))))
+                 (= 5 (:credit (get-runner))))
+            "Eve trashed at no cost")
+        (is (nil? (get-in @state [:corp :servers :remote2 :content])) "Server 2 no longer exists")
+        (play-from-hand state :runner "Drive By")
+        (prompt-select :runner atl)
+        (is (= 0 (:click (get-runner))) "Runner has 0 clicks left")
+        (is (= 1 (count (get-in @state [:corp :servers :remote3 :content])))
+            "Project Atlas not trashed from Server 3"))))
+  (testing "Psychic Field trashed after psi game. Issue #2127."
+    (do-game
+      (new-game (default-corp ["Psychic Field"])
+                (default-runner [(qty "Drive By" 3)]))
+      (play-from-hand state :corp "Psychic Field" "New remote")
+      (take-credits state :corp)
       (play-from-hand state :runner "Drive By")
-      (prompt-select :runner pp)
-      (is (= 1 (count (get-in @state [:corp :servers :hq :content])))
-          "Upgrades in root of central servers can't be targeted")
-      (prompt-select :runner (refresh eve1))
-      (is (= 1 (count (get-in @state [:corp :servers :remote1 :content])))
-          "Rezzed cards can't be targeted")
-      (prompt-select :runner eve2)
-      (is (= 2 (:click (get-runner))) "Spent 2 clicks")
-      (is (and (= 1 (count (:discard (get-corp))))
-               (= 5 (:credit (get-runner))))
-          "Eve trashed at no cost")
-      (is (nil? (get-in @state [:corp :servers :remote2 :content])) "Server 2 no longer exists")
-      (play-from-hand state :runner "Drive By")
-      (prompt-select :runner atl)
-      (is (= 0 (:click (get-runner))) "Runner has 0 clicks left")
-      (is (= 1 (count (get-in @state [:corp :servers :remote3 :content])))
-          "Project Atlas not trashed from Server 3"))))
-
-(deftest drive-by-psychic-field
-  ;; Drive By - Psychic Field trashed after psi game. Issue #2127.
-  (do-game
-    (new-game (default-corp ["Psychic Field"])
-              (default-runner [(qty "Drive By" 3)]))
-    (play-from-hand state :corp "Psychic Field" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Drive By")
-    (prompt-select :runner (get-content state :remote1 0))
-    (prompt-choice :corp "0 [Credits]")
-    (prompt-choice :runner "1 [Credits]")
-    (is (empty? (get-content state :remote1)) "Psychic Field trashed")))
+      (prompt-select :runner (get-content state :remote1 0))
+      (prompt-choice :corp "0 [Credits]")
+      (prompt-choice :runner "1 [Credits]")
+      (is (empty? (get-content state :remote1)) "Psychic Field trashed"))))
 
 (deftest early-bird
   ;; Early Bird - Priority, make a run and gain a click
@@ -886,7 +917,6 @@
                                "Heartbeat" "Gordian Blade" "Test Run"]))
     (starting-hand state :runner ["Emergent Creativity" "Heartbeat" "Gordian Blade" "Test Run"])
     (take-credits state :corp)
-
     (play-from-hand state :runner "Emergent Creativity")
     (prompt-select :runner (find-card "Heartbeat" (:hand (get-runner))))
     (prompt-select :runner (find-card "Gordian Blade" (:hand (get-runner))))
@@ -897,73 +927,72 @@
     (is (= 3 (count (:discard (get-runner)))) "Discard is 3 cards - EC, Heartbeat, GB")
     (is (= 2 (:click (get-runner))) "Emergent Creativity is a Double event")))
 
-(deftest employee-strike-blue-sun
-  ;; Employee Strike - vs Blue Sun, suppress Step 1.2
-  (do-game
-    (new-game (make-deck "Blue Sun: Powering the Future" ["Ice Wall"])
-              (default-runner ["Employee Strike" "Scrubbed"]))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Employee Strike")
-    (take-credits state :runner)
-    (is (not (:corp-phase-12 @state)) "Employee Strike suppressed Blue Sun step 1.2")))
-
-(deftest employee-strike-pu-philotic
-  ;; Employee Strike - vs PU/Philotic - test for #2688
-  (do-game
-    (new-game (make-deck "Jinteki: Potential Unleashed" ["Philotic Entanglement" (qty "Braintrust" 2)])
-              (default-runner [(qty "Employee Strike" 10)]))
-    (play-from-hand state :corp "Braintrust" "New remote")
-    (play-from-hand state :corp "Braintrust" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state "Server 1")
-    (prompt-choice :runner "Steal")
-    (run-empty-server state "Server 2")
-    (prompt-choice :runner "Steal")
-    (play-from-hand state :runner "Employee Strike")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Philotic Entanglement" "New remote")
-    (score-agenda state :corp (get-content state :remote3 0))
-    (is (= 3 (count (:discard (get-runner)))) "Discard is 3 cards - 2 from Philotic, 1 EStrike.  Nothing from PU mill")))
+(deftest employee-strike
+  ;; Employee Strike
+  (testing "vs Blue Sun, suppress Step 1.2"
+    (do-game
+      (new-game (make-deck "Blue Sun: Powering the Future" ["Ice Wall"])
+                (default-runner ["Employee Strike" "Scrubbed"]))
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Employee Strike")
+      (take-credits state :runner)
+      (is (not (:corp-phase-12 @state)) "Employee Strike suppressed Blue Sun step 1.2")))
+  (testing "vs PU/Philotic - test for #2688"
+    (do-game
+      (new-game (make-deck "Jinteki: Potential Unleashed" ["Philotic Entanglement" (qty "Braintrust" 2)])
+                (default-runner [(qty "Employee Strike" 10)]))
+      (play-from-hand state :corp "Braintrust" "New remote")
+      (play-from-hand state :corp "Braintrust" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (prompt-choice :runner "Steal")
+      (run-empty-server state "Server 2")
+      (prompt-choice :runner "Steal")
+      (play-from-hand state :runner "Employee Strike")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Philotic Entanglement" "New remote")
+      (score-agenda state :corp (get-content state :remote3 0))
+      (is (= 3 (count (:discard (get-runner))))
+          "Discard is 3 cards - 2 from Philotic, 1 EStrike.  Nothing from PU mill"))))
 
 (deftest encore
   ;; Encore - Run all 3 central servers successfully to take another turn.  Remove Encore from game.
-  (do-game
-    (new-game (default-corp ["Hedge Fund"])
-              (default-runner ["Encore"]))
-    (play-from-hand state :corp "Hedge Fund")
-    (take-credits state :corp)
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (run-empty-server state "HQ")
-    (play-from-hand state :runner "Encore")
-    (is (= 1 (count (:rfg (get-runner)))) "Encore removed from game")
-    (take-credits state :runner)
-    (take-credits state :runner)
-    ; only get one extra turn
-    (take-credits state :runner)
-    (is (= 9 (:credit (get-runner))))))
-
-(deftest encore-stacking
-  ;; Encore - 2 encores in a 5 click turn results in 2 extra turns
-  (do-game
-    (new-game (default-corp ["Hedge Fund"])
-              (default-runner [(qty "Encore" 2)]))
-    (play-from-hand state :corp "Hedge Fund")
-    (take-credits state :corp)
-    (core/gain state :runner :click 1)
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (run-empty-server state "HQ")
-    (play-from-hand state :runner "Encore")
-    (play-from-hand state :runner "Encore")
-    (is (= 2 (count (:rfg (get-runner)))) "2 Encores removed from game")
-    (take-credits state :runner)
-    (take-credits state :runner)
-    ;; Two extra turns
-    (take-credits state :runner)
-    (is (= 13 (:credit (get-runner))))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Hedge Fund"])
+                (default-runner ["Encore"]))
+      (play-from-hand state :corp "Hedge Fund")
+      (take-credits state :corp)
+      (run-empty-server state "Archives")
+      (run-empty-server state "R&D")
+      (run-empty-server state "HQ")
+      (play-from-hand state :runner "Encore")
+      (is (= 1 (count (:rfg (get-runner)))) "Encore removed from game")
+      (take-credits state :runner)
+      (take-credits state :runner)
+      ; only get one extra turn
+      (take-credits state :runner)
+      (is (= 9 (:credit (get-runner))))))
+  (testing "2 encores in a 5 click turn results in 2 extra turns"
+    (do-game
+      (new-game (default-corp ["Hedge Fund"])
+                (default-runner [(qty "Encore" 2)]))
+      (play-from-hand state :corp "Hedge Fund")
+      (take-credits state :corp)
+      (core/gain state :runner :click 1)
+      (run-empty-server state "Archives")
+      (run-empty-server state "R&D")
+      (run-empty-server state "HQ")
+      (play-from-hand state :runner "Encore")
+      (play-from-hand state :runner "Encore")
+      (is (= 2 (count (:rfg (get-runner)))) "2 Encores removed from game")
+      (take-credits state :runner)
+      (take-credits state :runner)
+      ;; Two extra turns
+      (take-credits state :runner)
+      (is (= 13 (:credit (get-runner)))))))
 
 (deftest eureka!
   ;; Eureka! - Install the program but trash the event
@@ -984,108 +1013,103 @@
 
 (deftest exploratory-romp
   ;; Exploratory Romp - Remove advancements from card instead of accessing
-  (do-game
-    (new-game (default-corp ["TGTBT"])
-              (default-runner ["Exploratory Romp"]))
-    (play-from-hand state :corp "TGTBT" "New remote")
-    (let [tg (get-content state :remote1 0)]
-      (advance state tg 2)
-      (take-credits state :corp)
-      (play-from-hand state :runner "Exploratory Romp")
-      (prompt-choice :runner "Server 1")
-      (run-successful state)
-      (prompt-choice :runner "Replacement effect")
-      (prompt-choice :runner "2")
-      (prompt-select :runner (refresh tg))
-      (is (= 0 (:tag (get-runner))) "No tags, didn't access TGTBT")
-      (is (= 0 (:advance-counter (refresh tg))) "Advancements removed"))))
-
-(deftest exploratory-romp-negative
-  ;; Exploratory Romp - Don't remove more than the existing number of advancement tokens
-  (do-game
-    (new-game (default-corp ["TGTBT"])
-              (default-runner ["Exploratory Romp"]))
-    (play-from-hand state :corp "TGTBT" "New remote")
-    (let [tg (get-content state :remote1 0)]
-      (advance state tg 2)
-      (take-credits state :corp)
-      (play-from-hand state :runner "Exploratory Romp")
-      (prompt-choice :runner "Server 1")
-      (run-successful state)
-      (prompt-choice :runner "Replacement effect")
-      (prompt-choice :runner "3")
-      (prompt-select :runner (refresh tg))
-      (is (= 0 (:tag (get-runner))) "No tags, didn't access TGTBT")
-      (is (= 0 (:advance-counter (refresh tg))) "Advancements removed"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["TGTBT"])
+                (default-runner ["Exploratory Romp"]))
+      (play-from-hand state :corp "TGTBT" "New remote")
+      (let [tg (get-content state :remote1 0)]
+        (advance state tg 2)
+        (take-credits state :corp)
+        (play-from-hand state :runner "Exploratory Romp")
+        (prompt-choice :runner "Server 1")
+        (run-successful state)
+        (prompt-choice :runner "Replacement effect")
+        (prompt-choice :runner "2")
+        (prompt-select :runner (refresh tg))
+        (is (= 0 (:tag (get-runner))) "No tags, didn't access TGTBT")
+        (is (= 0 (:advance-counter (refresh tg))) "Advancements removed"))))
+  (testing "Don't remove more than the existing number of advancement tokens"
+    (do-game
+      (new-game (default-corp ["TGTBT"])
+                (default-runner ["Exploratory Romp"]))
+      (play-from-hand state :corp "TGTBT" "New remote")
+      (let [tg (get-content state :remote1 0)]
+        (advance state tg 2)
+        (take-credits state :corp)
+        (play-from-hand state :runner "Exploratory Romp")
+        (prompt-choice :runner "Server 1")
+        (run-successful state)
+        (prompt-choice :runner "Replacement effect")
+        (prompt-choice :runner "3")
+        (prompt-select :runner (refresh tg))
+        (is (= 0 (:tag (get-runner))) "No tags, didn't access TGTBT")
+        (is (= 0 (:advance-counter (refresh tg))) "Advancements removed")))))
 
 (deftest falsified-credentials
   ;; Falsified Credentials - Expose card in remote
   ;; server and correctly guess its type to gain 5 creds
-  (do-game
-    (new-game (default-corp [(qty "Eve Campaign" 2)
-                             (qty "Product Placement" 2)
-                             "Project Atlas"])
-              (default-runner [(qty "Falsified Credentials" 3)]))
-    (core/gain state :corp :click 2)
-    (play-from-hand state :corp "Eve Campaign" "New remote")
-    (play-from-hand state :corp "Eve Campaign" "New remote")
-    (play-from-hand state :corp "Project Atlas" "New remote")
-    (play-from-hand state :corp "Product Placement" "HQ")
-    (play-from-hand state :corp "Product Placement" "Server 3")
-    (take-credits state :corp)
-    (let [eve1 (get-content state :remote1 0)
-          eve2 (get-content state :remote2 0)
-          atl (get-content state :remote3 0)
-          pp1 (get-content state :hq 0)
-          pp2 (get-content state :remote3 1)]
-      (core/rez state :corp eve1)
-      (play-from-hand state :runner "Falsified Credentials")
-      (prompt-choice :runner "Asset")
-      (prompt-select :runner (refresh eve1))
-      (is (= 4 (:credit (get-runner)))
-          "Rezzed cards can't be targeted")
-      (prompt-select :runner eve2)
-      (is (= 3 (:click (get-runner))) "Spent 1 click")
-      (is (= 9 (:credit (get-runner))) "Gained 5 creds for guessing asset correctly")
-      (play-from-hand state :runner "Falsified Credentials")
-      (prompt-choice :runner "Upgrade")
-      (prompt-select :runner pp1)
-      (is (= 8 (:credit (get-runner))) "Can't target cards in centrals")
-      (prompt-select :runner pp2)
-      (is (= 13 (:credit (get-runner)))
-          "Gained 5 creds for guessing upgrade correctly, even if server contains non-upgrade as well")
-      (core/rez state :corp pp2)
-      (play-from-hand state :runner "Falsified Credentials")
-      (prompt-choice :runner "Agenda")
-      (prompt-select :runner atl)
-      (is (= 17 (:credit (get-runner)))
-          "Gained 5 credits for guessing agenda correctly, even with rezzed card in server"))))
-
-(deftest falsified-credentials-zaibatsu-loyalty
-  ;; If Falsified Credentials fails to expose, it grants no credits.
-  (do-game
-   (new-game (default-corp ["Zaibatsu Loyalty"
-                            "Project Atlas"])
-             (default-runner [(qty "Falsified Credentials" 2)]))
-
-    (play-from-hand state :corp "Project Atlas" "New remote")
-    (play-from-hand state :corp "Zaibatsu Loyalty" "New remote")
-    (take-credits state :corp)
-    (let [atl (get-content state :remote1 0)
-          zaibatsu (get-content state :remote2 0)]
-      (core/rez state :corp zaibatsu)
-      (play-from-hand state :runner "Falsified Credentials")
-      (prompt-choice :runner "Agenda")
-      (prompt-select :runner atl)
-      (prompt-choice :corp "Done")
-      (is (= 9 (:credit (get-runner))) "An unprevented expose gets credits")
-
-      (play-from-hand state :runner "Falsified Credentials")
-      (prompt-choice :runner "Agenda")
-      (prompt-select :runner atl)
-      (card-ability state :corp (refresh zaibatsu) 0) ; prevent the expose!
-      (prompt-choice :corp "Done")
-      (is (= 8 (:credit (get-runner))) "A prevented expose does not"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Eve Campaign" 2)
+                               (qty "Product Placement" 2)
+                               "Project Atlas"])
+                (default-runner [(qty "Falsified Credentials" 3)]))
+      (core/gain state :corp :click 2)
+      (play-from-hand state :corp "Eve Campaign" "New remote")
+      (play-from-hand state :corp "Eve Campaign" "New remote")
+      (play-from-hand state :corp "Project Atlas" "New remote")
+      (play-from-hand state :corp "Product Placement" "HQ")
+      (play-from-hand state :corp "Product Placement" "Server 3")
+      (take-credits state :corp)
+      (let [eve1 (get-content state :remote1 0)
+            eve2 (get-content state :remote2 0)
+            atl (get-content state :remote3 0)
+            pp1 (get-content state :hq 0)
+            pp2 (get-content state :remote3 1)]
+        (core/rez state :corp eve1)
+        (play-from-hand state :runner "Falsified Credentials")
+        (prompt-choice :runner "Asset")
+        (prompt-select :runner (refresh eve1))
+        (is (= 4 (:credit (get-runner)))
+            "Rezzed cards can't be targeted")
+        (prompt-select :runner eve2)
+        (is (= 3 (:click (get-runner))) "Spent 1 click")
+        (is (= 9 (:credit (get-runner))) "Gained 5 creds for guessing asset correctly")
+        (play-from-hand state :runner "Falsified Credentials")
+        (prompt-choice :runner "Upgrade")
+        (prompt-select :runner pp1)
+        (is (= 8 (:credit (get-runner))) "Can't target cards in centrals")
+        (prompt-select :runner pp2)
+        (is (= 13 (:credit (get-runner)))
+            "Gained 5 creds for guessing upgrade correctly, even if server contains non-upgrade as well")
+        (core/rez state :corp pp2)
+        (play-from-hand state :runner "Falsified Credentials")
+        (prompt-choice :runner "Agenda")
+        (prompt-select :runner atl)
+        (is (= 17 (:credit (get-runner)))
+            "Gained 5 credits for guessing agenda correctly, even with rezzed card in server"))))
+  (testing "vs Zaibatsu Loyalty. If Falsified Credentials fails to expose, it grants no credits."
+    (do-game
+      (new-game (default-corp ["Zaibatsu Loyalty" "Project Atlas"])
+                (default-runner [(qty "Falsified Credentials" 2)]))
+      (play-from-hand state :corp "Project Atlas" "New remote")
+      (play-from-hand state :corp "Zaibatsu Loyalty" "New remote")
+      (take-credits state :corp)
+      (let [atl (get-content state :remote1 0)
+            zaibatsu (get-content state :remote2 0)]
+        (core/rez state :corp zaibatsu)
+        (play-from-hand state :runner "Falsified Credentials")
+        (prompt-choice :runner "Agenda")
+        (prompt-select :runner atl)
+        (prompt-choice :corp "Done")
+        (is (= 9 (:credit (get-runner))) "An unprevented expose gets credits")
+        (play-from-hand state :runner "Falsified Credentials")
+        (prompt-choice :runner "Agenda")
+        (prompt-select :runner atl)
+        (card-ability state :corp (refresh zaibatsu) 0) ; prevent the expose!
+        (prompt-choice :corp "Done")
+        (is (= 8 (:credit (get-runner))) "A prevented expose does not")))))
 
 (deftest feint
   ;; Feint - bypass 2 pieces of ice on HQ, but access no cards
@@ -1098,47 +1122,47 @@
     (prompt-choice :runner "Ok")
     (is (not (:run @state)) "Run is over")))
 
-(deftest frantic-coding-install
+(deftest frantic-coding
   ;; Frantic Coding - Install 1 program, other 9 cards are trashed
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Frantic Coding" "Torch" "Corroder"
-                               "Magnum Opus" (qty "Daily Casts" 2) (qty "Sure Gamble" 2)
-                               "John Masanori" "Amped Up" "Wanton Destruction"]))
-    (starting-hand state :runner ["Frantic Coding"])
-    (take-credits state :corp)
-    (play-from-hand state :runner "Frantic Coding")
-    (prompt-choice :runner "No action")
-    (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
-          prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
-      (is (= (list "Corroder" "Magnum Opus" nil) (prompt-names)) "No Torch in list because can't afford")
-      (is (= 2 (:credit (get-runner))))
-      (is (= 1 (count (:discard (get-runner)))))
-      (prompt-card :runner (find-card "Magnum Opus" (:deck (get-runner))))
-      (is (= 1 (count (get-in @state [:runner :rig :program]))))
-      (is (= 2 (:credit (get-runner))) "Magnum Opus installed for free")
-      (is (= 10 (count (:discard (get-runner))))))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Frantic Coding" "Torch" "Corroder"
+                                 "Magnum Opus" (qty "Daily Casts" 2) (qty "Sure Gamble" 2)
+                                 "John Masanori" "Amped Up" "Wanton Destruction"]))
+      (starting-hand state :runner ["Frantic Coding"])
+      (take-credits state :corp)
+      (play-from-hand state :runner "Frantic Coding")
+      (prompt-choice :runner "No action")
+      (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
+            prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
+        (is (= (list "Corroder" "Magnum Opus" nil) (prompt-names)) "No Torch in list because can't afford")
+        (is (= 2 (:credit (get-runner))))
+        (is (= 1 (count (:discard (get-runner)))))
+        (prompt-card :runner (find-card "Magnum Opus" (:deck (get-runner))))
+        (is (= 1 (count (get-in @state [:runner :rig :program]))))
+        (is (= 2 (:credit (get-runner))) "Magnum Opus installed for free")
+        (is (= 10 (count (:discard (get-runner))))))))
+  (testing "Don't install anything, all 10 cards are trashed"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Frantic Coding" "Torch" "Corroder"
+                                 "Magnum Opus" (qty "Daily Casts" 2) (qty "Sure Gamble" 2)
+                                 "John Masanori" "Amped Up" "Wanton Destruction"]))
+      (starting-hand state :runner ["Frantic Coding"])
+      (take-credits state :corp)
+      (play-from-hand state :runner "Frantic Coding")
+      (prompt-choice :runner "No action")
+      (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
+            prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
+        (is (= (list "Corroder" "Magnum Opus" nil) (prompt-names)) "No Torch in list because can't afford")
+        (is (= 1 (count (:discard (get-runner)))))
+        (prompt-choice :runner "No install")
+        (is (= 0 (count (get-in @state [:runner :rig :program]))))
+        (is (= 11 (count (:discard (get-runner)))))))))
 
-(deftest frantic-coding-noinstall
-  ;; Frantic Coding - Don't install anything, all 10 cards are trashed
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Frantic Coding" "Torch" "Corroder"
-                               "Magnum Opus" (qty "Daily Casts" 2) (qty "Sure Gamble" 2)
-                               "John Masanori" "Amped Up" "Wanton Destruction"]))
-    (starting-hand state :runner ["Frantic Coding"])
-    (take-credits state :corp)
-    (play-from-hand state :runner "Frantic Coding")
-    (prompt-choice :runner "No action")
-    (let [get-prompt (fn [] (first (#(get-in @state [:runner :prompt]))))
-          prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
-      (is (= (list "Corroder" "Magnum Opus" nil) (prompt-names)) "No Torch in list because can't afford")
-      (is (= 1 (count (:discard (get-runner)))))
-      (prompt-choice :runner "No install")
-      (is (= 0 (count (get-in @state [:runner :rig :program]))))
-      (is (= 11 (count (:discard (get-runner))))))))
-
-(deftest freedom-through-equality
+(deftest ^{:card-title "\"freedom-through-equality\""}
+  freedom-through-equality
   ;; Move Freedom Through Equality to runner score on another steal
   ;; Check only one current used
   (do-game
@@ -1170,9 +1194,7 @@
   (do-game
     (new-game (default-corp)
               (default-runner ["Freelance Coding Contract"
-                               "Paricia"
-                               "Cloak"
-                               "Inti"]))
+                               "Paricia" "Cloak" "Inti"]))
     (take-credits state :corp)
     (play-from-hand state :runner "Freelance Coding Contract")
     (prompt-select :runner (find-card "Cloak" (:hand (get-runner))))
@@ -1202,32 +1224,24 @@
 
 (deftest glut-cipher
   (do-game
-    (new-game (default-corp [(qty "Ice Wall" 3)
-                              (qty "Wraparound" 2)
-                              "Hedge Fund"
-                              ])
+    (new-game (default-corp [(qty "Ice Wall" 3) (qty "Wraparound" 2) "Hedge Fund"])
               (default-runner [(qty "Glut Cipher" 3)]))
     (take-credits state :corp)
     (trash-from-hand state :corp "Ice Wall")
     (trash-from-hand state :corp "Ice Wall")
     (trash-from-hand state :corp "Hedge Fund")
     (is (= 3 (count (:discard (get-corp)))) "There are 3 cards in Archives")
-
-
     (play-from-hand state :runner "Glut Cipher")
     (is (= 3 (count (:discard (get-corp)))) "Glut Cipher did not fire when < 5 cards")
     (is (= 0 (count (filter :seen (:discard (get-corp))))) "There are no faceup cards in Archives")
-
     (run-on state :archives)
     (run-successful state)
     (is (= 3 (count (filter :seen (:discard (get-corp))))) "There are 3 faceup cards in Archives")
-
     (trash-from-hand state :corp "Wraparound")
     (trash-from-hand state :corp "Wraparound")
     (trash-from-hand state :corp "Ice Wall")
     (is (= 3 (count (filter :seen (:discard (get-corp))))) "There are 3 faceup cards in Archives")
     (is (= 6 (count (:discard (get-corp)))) "There are 6 cards in Archives")
-
     (play-run-event state "Glut Cipher" :archives)
     (prompt-select :corp (get-discarded state :corp 0))
     (prompt-select :corp (get-discarded state :corp 1))
@@ -1270,15 +1284,11 @@
   (do-game
     (new-game
       (default-corp)
-      (make-deck "Apex: Invasive Predator" ["Neutralize All Threats"
-                                            (qty "Independent Thinking" 2)
-                                            (qty "Fan Site" 3)
-                                            (qty "Street Magic" 3)]))
-    (starting-hand state :runner ["Fan Site"
-                                  "Fan Site"
-                                  "Neutralize All Threats"
-                                  "Independent Thinking"
-                                  "Independent Thinking"])
+      (make-deck "Apex: Invasive Predator"
+                 ["Neutralize All Threats" (qty "Independent Thinking" 2)
+                  (qty "Fan Site" 3) (qty "Street Magic" 3)]))
+    (starting-hand state :runner ["Fan Site" "Fan Site" "Neutralize All Threats"
+                                  "Independent Thinking" "Independent Thinking"])
     (take-credits state :corp)
     (core/end-phase-12 state :runner nil)
     (prompt-select :runner (find-card "Neutralize All Threats" (:hand (get-runner))))
@@ -1435,44 +1445,44 @@
       (core/rez state :corp jackson)
       (is (not (get-in (refresh jackson) [:rezzed])) "Jackson is not rezzed"))))
 
-(deftest ive-had-worse
+(deftest ^{:card-title "i've-had-worse"}
+  ive-had-worse
   ;; I've Had Worse - Draw 3 cards when lost to net/meat damage; don't trigger if flatlined
-  (do-game
-    (new-game (default-corp [(qty "Scorched Earth" 3) (qty "Pup" 3)])
-              (default-runner [(qty "I've Had Worse" 2) (qty "Sure Gamble" 3) (qty "Imp" 2)]))
-    (core/gain state :runner :tag 1)
-    (core/gain state :corp :credit 5)
-    (starting-hand state :runner ["I've Had Worse"])
-    (play-from-hand state :corp "Pup" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (card-subroutine state :corp (get-ice state :hq 0) 0)
-    (is (= 1 (count (:discard (get-runner)))))
-    (is (= 3 (count (:hand (get-runner)))) "I've Had Worse triggered and drew 3 cards")
-    (starting-hand state :runner ["I've Had Worse" "Imp" "Imp"])
-    (play-from-hand state :corp "Scorched Earth")
-    (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
-    (is (= :corp (:winner @state)) "Corp wins")
-    (is (= "Flatline" (:reason @state)) "Win condition reports flatline")
-    (is (= 4 (count (:discard (get-runner)))) "All 3 cards in Grip trashed by Scorched Earth")
-    (is (= 3 (count (:deck (get-runner)))) "No cards drawn from I've Had Worse")))
-
-(deftest ive-had-worse-apocalypse-hostile-infrastructure
-  ;; I've Had Worse - Will save you if you apocalypse away a lot of cards vs Hostile Infrastructure
-  (do-game
-    (new-game (default-corp ["Hostile Infrastructure" (qty "Ice Wall" 2)])
-              (default-runner [(qty "I've Had Worse" 3) (qty "Sure Gamble" 3) (qty "Apocalypse" 2)]))
-    (starting-hand state :runner ["I've Had Worse" "Apocalypse"])
-    (starting-hand state :corp ["Hostile Infrastructure" "Ice Wall" "Ice Wall"])
-    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (core/rez state :corp (get-content state :remote1 0))
-    (take-credits state :corp)
-    (run-empty-server state "HQ")
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (play-from-hand state :runner "Apocalypse")
-    (is (not (= "Flatline" (:reason @state))) "Win condition does not report flatline")))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Scorched Earth" 3) (qty "Pup" 3)])
+                (default-runner [(qty "I've Had Worse" 2) (qty "Sure Gamble" 3) (qty "Imp" 2)]))
+      (core/gain state :runner :tag 1)
+      (core/gain state :corp :credit 5)
+      (starting-hand state :runner ["I've Had Worse"])
+      (play-from-hand state :corp "Pup" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (card-subroutine state :corp (get-ice state :hq 0) 0)
+      (is (= 1 (count (:discard (get-runner)))))
+      (is (= 3 (count (:hand (get-runner)))) "I've Had Worse triggered and drew 3 cards")
+      (starting-hand state :runner ["I've Had Worse" "Imp" "Imp"])
+      (play-from-hand state :corp "Scorched Earth")
+      (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+      (is (= :corp (:winner @state)) "Corp wins")
+      (is (= "Flatline" (:reason @state)) "Win condition reports flatline")
+      (is (= 4 (count (:discard (get-runner)))) "All 3 cards in Grip trashed by Scorched Earth")
+      (is (= 3 (count (:deck (get-runner)))) "No cards drawn from I've Had Worse")))
+  (testing "Will save you if you apocalypse away a lot of cards vs Hostile Infrastructure"
+    (do-game
+      (new-game (default-corp ["Hostile Infrastructure" (qty "Ice Wall" 2)])
+                (default-runner [(qty "I've Had Worse" 3) (qty "Sure Gamble" 3) (qty "Apocalypse" 2)]))
+      (starting-hand state :runner ["I've Had Worse" "Apocalypse"])
+      (starting-hand state :corp ["Hostile Infrastructure" "Ice Wall" "Ice Wall"])
+      (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (run-empty-server state "HQ")
+      (run-empty-server state "Archives")
+      (run-empty-server state "R&D")
+      (play-from-hand state :runner "Apocalypse")
+      (is (not (= "Flatline" (:reason @state))) "Win condition does not report flatline"))))
 
 (deftest lawyer-up
   ;; Lawyer Up - Lose 2 tags and draw 3 cards
@@ -1491,35 +1501,34 @@
 
 (deftest leave-no-trace
   ;; Leave No Trace should derez ICE that was rezzed during the run
-  (do-game
-    (new-game (default-corp [(qty "Ice Wall" 2)])
-              (default-runner ["Leave No Trace"]))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/rez state :corp (get-ice state :hq 1))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Leave No Trace")
-    (prompt-choice :runner "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (run-successful state)
-    (is (not (:rezzed (get-ice state :hq 0))) "Inner Ice Wall should not be rezzed")
-    (is (:rezzed (get-ice state :hq 1)) "Outer Ice Wall should be rezzed still")))
-
-(deftest leave-no-trace-does-not-derez-modified-ice
-  ;; Leave No Trace should not derez ICE that has changed during a run
-  (do-game
-    (new-game (default-corp ["Ice Wall"])
-              (default-runner ["Leave No Trace"]))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (is (:rezzed (get-ice state :hq 0)) "Ice Wall should be rezzed initially")
-    (play-from-hand state :runner "Leave No Trace")
-    (prompt-choice :runner "Server 1")
-    (core/add-counter state :corp (get-ice state :hq 0) :advance-counter 1)
-    (run-successful state)
-    (is (= 1 (get-counters (get-ice state :hq 0) :advance-counter)))
-    (is (:rezzed (get-ice state :hq 0)) "Ice Wall should still be rezzed")))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Ice Wall" 2)])
+                (default-runner ["Leave No Trace"]))
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 1))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Leave No Trace")
+      (prompt-choice :runner "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (run-successful state)
+      (is (not (:rezzed (get-ice state :hq 0))) "Inner Ice Wall should not be rezzed")
+      (is (:rezzed (get-ice state :hq 1)) "Outer Ice Wall should be rezzed still")))
+  (testing "should not derez ICE that has changed during a run"
+    (do-game
+      (new-game (default-corp ["Ice Wall"])
+                (default-runner ["Leave No Trace"]))
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (is (:rezzed (get-ice state :hq 0)) "Ice Wall should be rezzed initially")
+      (play-from-hand state :runner "Leave No Trace")
+      (prompt-choice :runner "Server 1")
+      (core/add-counter state :corp (get-ice state :hq 0) :advance-counter 1)
+      (run-successful state)
+      (is (= 1 (get-counters (get-ice state :hq 0) :advance-counter)))
+      (is (:rezzed (get-ice state :hq 0)) "Ice Wall should still be rezzed"))))
 
 (deftest mad-dash
   ;; Mad Dash - Make a run. Move to score pile as 1 point if steal agenda.  Take 1 meat if not
@@ -1652,19 +1661,15 @@
     (let [hand-count #(count (:hand (get-runner)))]
       (starting-hand state :runner ["The Noble Path" "Sure Gamble"])
       (take-credits state :corp)
-
       ;; Play The Noble Path and confirm it trashes remaining cards in hand
       (is (= 2 (hand-count)) "Start with 2 cards")
       (play-from-hand state :runner "The Noble Path")
       (is (= 0 (hand-count)) "Playing Noble Path trashes the remaining cards in hand")
-
       ;; Put a card into hand so I can confirm it's not discarded by damage
       ;; Don't want to dealing with checking damage on a zero card hand
       (starting-hand state :runner ["Sure Gamble"])
-
       (core/damage state :runner :net 1)
       (is (= 1 (hand-count)) "Damage was prevented")
-
       ;; Finish the run and check that damage works again
       (prompt-choice :runner "HQ")
       (run-successful state)
@@ -1731,53 +1736,51 @@
 
 (deftest political-graffiti
   ;; Political Graffiti - swapping with Turntable works / purging viruses restores points
-  (do-game
-    (new-game (default-corp ["Breaking News" "Chronos Project"])
-              (default-runner ["Turntable" "Political Graffiti"]))
-    (play-from-hand state :corp "Breaking News" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (is (= 1 (:agenda-point (get-corp))))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Political Graffiti")
-    (is (= [:archives] (get-in @state [:run :server])) "Run initiated on Archives")
-    (run-successful state)
-    (prompt-choice :runner "Replacement effect")
-    (prompt-select :runner (find-card "Breaking News" (:scored (get-corp))))
-    (is (= 0 (:agenda-point (get-corp))) "Political Dealings lowered agenda points by 1")
-    (play-from-hand state :runner "Turntable")
-    (run-empty-server state "HQ")
-    (prompt-choice :runner "Steal")
-    (let [tt (get-in @state [:runner :rig :hardware 0])]
-      (prompt-choice :runner "Yes")
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Breaking News" "Chronos Project"])
+                (default-runner ["Turntable" "Political Graffiti"]))
+      (play-from-hand state :corp "Breaking News" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      (is (= 1 (:agenda-point (get-corp))))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Political Graffiti")
+      (is (= [:archives] (get-in @state [:run :server])) "Run initiated on Archives")
+      (run-successful state)
+      (prompt-choice :runner "Replacement effect")
       (prompt-select :runner (find-card "Breaking News" (:scored (get-corp))))
+      (is (= 0 (:agenda-point (get-corp))) "Political Dealings lowered agenda points by 1")
+      (play-from-hand state :runner "Turntable")
+      (run-empty-server state "HQ")
+      (prompt-choice :runner "Steal")
+      (let [tt (get-in @state [:runner :rig :hardware 0])]
+        (prompt-choice :runner "Yes")
+        (prompt-select :runner (find-card "Breaking News" (:scored (get-corp))))
+        (is (= 1 (:agenda-point (get-corp))))
+        (is (= 0 (:agenda-point (get-runner))))
+        (take-credits state :runner)
+        (core/purge state :corp)
+        (is (= 1 (:agenda-point (get-corp))))
+        (is (= 1 (:agenda-point (get-runner)))))))
+  (testing "forfeiting agenda with Political Graffiti does not refund double points. Issue #2765"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover" "Sacrifice"])
+                (default-runner ["Political Graffiti"]))
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
       (is (= 1 (:agenda-point (get-corp))))
-      (is (= 0 (:agenda-point (get-runner))))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Political Graffiti")
+      (is (= [:archives] (get-in @state [:run :server])) "Run initiated on Archives")
+      (run-successful state)
+      (prompt-choice :runner "Replacement effect")
+      (prompt-select :runner (find-card "Hostile Takeover" (:scored (get-corp))))
+      (is (= 0 (:agenda-point (get-corp))) "Political Dealings lowered agenda points by 1")
       (take-credits state :runner)
-      (core/purge state :corp)
-      (is (= 1 (:agenda-point (get-corp))))
-      (is (= 1 (:agenda-point (get-runner)))))))
-
-(deftest political-graffiti-forfeit
-  ;; Political Graffiti - forfeiting agenda with Political Graffiti does not refund double points
-  ;; Regression test for issue #2765
-  (do-game
-    (new-game (default-corp ["Hostile Takeover" "Sacrifice"])
-              (default-runner ["Political Graffiti"]))
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (is (= 1 (:agenda-point (get-corp))))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Political Graffiti")
-    (is (= [:archives] (get-in @state [:run :server])) "Run initiated on Archives")
-    (run-successful state)
-    (prompt-choice :runner "Replacement effect")
-    (prompt-select :runner (find-card "Hostile Takeover" (:scored (get-corp))))
-    (is (= 0 (:agenda-point (get-corp))) "Political Dealings lowered agenda points by 1")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Sacrifice")
-    (prompt-select :corp (get-scored state :corp 0))
-    (is (= 0 (:agenda-point (get-corp))) "Forfeiting agenda did not refund extra agenda points ")
-    (is (= 1 (count (:discard (get-runner)))) "Political Graffiti is in the Heap")))
+      (play-from-hand state :corp "Sacrifice")
+      (prompt-select :corp (get-scored state :corp 0))
+      (is (= 0 (:agenda-point (get-corp))) "Forfeiting agenda did not refund extra agenda points ")
+      (is (= 1 (count (:discard (get-runner)))) "Political Graffiti is in the Heap"))))
 
 (deftest power-to-the-people
   ;; Power to the People - Gain 7c the first time you access an agenda
@@ -1799,27 +1802,26 @@
       (prompt-choice :runner "Steal")
       (is (= 6 (:credit (get-runner))) "No credits gained from 2nd agenda access"))))
 
-(deftest push-your-luck-correct-guess
-  ;; Push Your Luck - Corp guesses correctly
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Push Your Luck"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Push Your Luck")
-    (prompt-choice :corp "Odd")
-    (prompt-choice :runner 3)
-    (is (= 0 (:credit (get-runner))) "Corp guessed correctly")))
-
-(deftest push-your-luck-incorrect-guess
-  ;; Push Your Luck - Corp guesses incorrectly
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Push Your Luck"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Push Your Luck")
-    (prompt-choice :corp "Even")
-    (prompt-choice :runner 3)
-    (is (= 6 (:credit (get-runner))) "Corp guessed incorrectly")))
+(deftest push-your-luck
+  ;; Push Your Luck
+  (testing "Corp guesses correctly"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Push Your Luck"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Push Your Luck")
+      (prompt-choice :corp "Odd")
+      (prompt-choice :runner 3)
+      (is (= 0 (:credit (get-runner))) "Corp guessed correctly")))
+  (testing "Corp guesses incorrectly"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Push Your Luck"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Push Your Luck")
+      (prompt-choice :corp "Even")
+      (prompt-choice :runner 3)
+      (is (= 6 (:credit (get-runner))) "Corp guessed incorrectly"))))
 
 (deftest pushing-the-envelope
   ;; Run. Add 2 strength to each installer breaker.
@@ -1853,7 +1855,8 @@
       (is (= 0 (:current-strength (refresh atman))) "Atman 0 current strength")
       (is (= 2 (:current-strength (refresh corr))) "Corroder 2 current strength"))))
 
-(deftest queens-gambit
+(deftest ^{:card-title "queen's-gambit"}
+  queens-gambit
   ;; Check that Queen's Gambit prevents access of card #1542
   (do-game
     (new-game (default-corp [(qty "PAD Campaign" 2)])
@@ -1883,10 +1886,10 @@
       (is (= (- runner-creds 4) (:credit (get-runner))) "Paid 4 credits to trash PAD Campaign"))))
 
 ;; Rebirth
-(let [choose-runner (fn [name state prompt-map]
-                      (let [kate-choice (some #(when (= name (:title %)) %) (:choices (prompt-map :runner)))]
-                        (core/resolve-prompt state :runner {:card kate-choice})))
-
+(let [choose-runner
+      (fn [id-name state prompt-map]
+        (let [kate-choice (some #(when (= id-name (:title %)) %) (:choices (prompt-map :runner)))]
+          (core/resolve-prompt state :runner {:card kate-choice})))
       akiko "Akiko Nisei: Head Case"
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"
       kit "Rielle \"Kit\" Peddler: Transhuman"
@@ -1895,85 +1898,70 @@
       chaos "Chaos Theory: Wünderkind"
       whizzard "Whizzard: Master Gamer"
       reina "Reina Roja: Freedom Fighter"]
-
-  (deftest rebirth-kate
+  (deftest rebirth
     ;; Rebirth - Kate's discount applies after rebirth
-    (do-game
-      (new-game (default-corp) (default-runner ["Magnum Opus" "Rebirth"]) {:start-as :runner})
-
-      (play-from-hand state :runner "Rebirth")
-      (is (= (first (prompt-titles :runner)) akiko) "List is sorted")
-      (is (every?   #(some #{%} (prompt-titles :runner))
+    (testing "Kate"
+      (do-game
+        (new-game (default-corp)
+                  (default-runner ["Magnum Opus" "Rebirth"])
+                  {:start-as :runner})
+        (play-from-hand state :runner "Rebirth")
+        (is (= (first (prompt-titles :runner)) akiko) "List is sorted")
+        (is (every? #(some #{%} (prompt-titles :runner))
                     [kate kit]))
-      (is (not-any? #(some #{%} (prompt-titles :runner))
-                    [professor whizzard jamie]))
-
-      (choose-runner kate state prompt-map)
-
-      (is (= kate (-> (get-runner) :identity :title)))
-      (is (= 1 (:link (get-runner))) "1 link")
-
-      (is (empty? (:discard (get-runner))))
-      (is (= "Rebirth" (-> (get-runner) :rfg first :title)))
-
-      (is (changes-credits (get-runner) -4
-        (play-from-hand state :runner "Magnum Opus")))))
-
+        (is (not-any? #(some #{%} (prompt-titles :runner))
+                      [professor whizzard jamie]))
+        (choose-runner kate state prompt-map)
+        (is (= kate (-> (get-runner) :identity :title)))
+        (is (= 1 (:link (get-runner))) "1 link")
+        (is (empty? (:discard (get-runner))))
+        (is (= "Rebirth" (-> (get-runner) :rfg first :title)))
+        (is (changes-credits (get-runner) -4
+                             (play-from-hand state :runner "Magnum Opus")))))
+    (testing "Whizzard works after rebirth"
+      (do-game
+        (new-game (default-corp ["Ice Wall"]) (make-deck reina ["Rebirth"]))
+        (play-from-hand state :corp "Ice Wall" "R&D")
+        (take-credits state :corp)
+        (play-from-hand state :runner "Rebirth")
+        (choose-runner whizzard state prompt-map)
+        (card-ability state :runner (:identity (get-runner)) 0)
+        (is (= 6 (:credit (get-runner))) "Took a Whizzard credit")
+        (is (changes-credits (get-corp) -1
+                             (core/rez state :corp (get-ice state :rd 0)))
+            "Reina is no longer active")))
+    (testing "Lose link from ID"
+      (do-game
+        (new-game (default-corp)
+                  (make-deck kate ["Rebirth" "Access to Globalsec"])
+                  {:start-as :runner})
+        (play-from-hand state :runner "Access to Globalsec")
+        (is (= 2 (:link (get-runner))) "2 link before rebirth")
+        (play-from-hand state :runner "Rebirth")
+        (choose-runner chaos state prompt-map)
+        (is (= 1 (:link (get-runner))) "1 link after rebirth")))
+    (testing "Gain link from ID"
+      (do-game
+        (new-game (default-corp)
+                  (default-runner ["Rebirth" "Access to Globalsec"])
+                  {:start-as :runner})
+        (play-from-hand state :runner "Access to Globalsec")
+        (is (= 1 (:link (get-runner))) "1 link before rebirth")
+        (play-from-hand state :runner "Rebirth")
+        (choose-runner kate state prompt-map)
+        (is (= 2 (:link (get-runner))) "2 link after rebirth"))))
   (deftest-pending rebirth-kate-twice
     ;; Rebirth - Kate's discount does not after rebirth if something already installed
     (do-game
-      (new-game (default-corp) (default-runner ["Akamatsu Mem Chip" "Rebirth" "Clone Chip"]) {:start-as :runner})
-
+      (new-game (default-corp)
+                (default-runner ["Akamatsu Mem Chip" "Rebirth" "Clone Chip"])
+                {:start-as :runner})
       (play-from-hand state :runner "Clone Chip")
       (play-from-hand state :runner "Rebirth")
       (choose-runner kate state prompt-map)
-
       (is (changes-credits (get-corp) -1
-        (play-from-hand state :runner "Akamatsu Mem Chip"))
-        "Discount not applied for 2nd install")))
-
-  (deftest rebirth-whizzard
-    ;; Rebirth - Whizzard works after rebirth
-    (do-game
-      (new-game (default-corp ["Ice Wall"]) (make-deck reina ["Rebirth"]))
-      (play-from-hand state :corp "Ice Wall" "R&D")
-      (take-credits state :corp)
-
-      (play-from-hand state :runner "Rebirth")
-      (choose-runner whizzard state prompt-map)
-
-      (card-ability state :runner (:identity (get-runner)) 0)
-      (is (= 6 (:credit (get-runner))) "Took a Whizzard credit")
-
-      (is (changes-credits (get-corp) -1
-        (core/rez state :corp (get-ice state :rd 0)))
-        "Reina is no longer active")))
-
-  (deftest rebirth-lose-link
-    ;; Rebirth - Lose link from ID
-    (do-game
-      (new-game (default-corp)
-                (make-deck kate ["Rebirth" "Access to Globalsec"])
-                {:start-as :runner})
-      (play-from-hand state :runner "Access to Globalsec")
-      (is (= 2 (:link (get-runner))) "2 link before rebirth")
-
-      (play-from-hand state :runner "Rebirth")
-      (choose-runner chaos state prompt-map)
-      (is (= 1 (:link (get-runner))) "1 link after rebirth")))
-
-  (deftest rebirth-gain-link
-    ;; Rebirth - Gain link from ID
-    (do-game
-      (new-game (default-corp)
-                (default-runner ["Rebirth" "Access to Globalsec"])
-                {:start-as :runner})
-      (play-from-hand state :runner "Access to Globalsec")
-      (is (= 1 (:link (get-runner))) "1 link before rebirth")
-
-      (play-from-hand state :runner "Rebirth")
-      (choose-runner kate state prompt-map)
-      (is (= 2 (:link (get-runner))) "2 link after rebirth"))))
+                           (play-from-hand state :runner "Akamatsu Mem Chip"))
+          "Discount not applied for 2nd install"))))
 
 (deftest reshape
   ;; Reshape - Swap 2 pieces of unrezzed ICE
@@ -2033,129 +2021,114 @@
 
 (deftest rip-deal
   ;; Rip Deal - replaces number of HQ accesses with heap retrieval
-  (do-game
-    (new-game (default-corp [(qty "Crisium Grid" 2)(qty "Vanilla" 2)])
-              (default-runner ["The Gauntlet" "Rip Deal" (qty "Easy Mark" 2)]))
-    (trash-from-hand state :runner "Easy Mark")
-    (trash-from-hand state :runner "Easy Mark")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Rip Deal")
-    (run-successful state)
-    (prompt-choice :runner "Replacement effect")
-    (is (= "Choose 1 card(s) to move from the Heap to your Grip" (-> (get-runner) :prompt first :msg)))))
-
-(deftest rip-deal-gauntlet
-  ;; Rip Deal with Gauntlet #2942
-  (do-game
-    (new-game (default-corp [(qty "Crisium Grid" 2)(qty "Vanilla" 2)])
-              (default-runner ["The Gauntlet" "Rip Deal" (qty "Easy Mark" 2)]))
-    (trash-from-hand state :runner "Easy Mark")
-    (trash-from-hand state :runner "Easy Mark")
-    (play-from-hand state :corp "Vanilla" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (core/gain state :runner :credit 4)
-    (play-from-hand state :runner "The Gauntlet")
-    (play-from-hand state :runner "Rip Deal")
-    (run-successful state)
-    (prompt-choice :runner 1)
-    (prompt-choice :runner "Replacement effect")
-    (is (= "Choose 2 card(s) to move from the Heap to your Grip" (-> (get-runner) :prompt first :msg)))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Crisium Grid" 2)(qty "Vanilla" 2)])
+                (default-runner ["The Gauntlet" "Rip Deal" (qty "Easy Mark" 2)]))
+      (trash-from-hand state :runner "Easy Mark")
+      (trash-from-hand state :runner "Easy Mark")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Rip Deal")
+      (run-successful state)
+      (prompt-choice :runner "Replacement effect")
+      (is (= "Choose 1 card(s) to move from the Heap to your Grip" (-> (get-runner) :prompt first :msg)))))
+  (testing "with Gauntlet #2942"
+    (do-game
+      (new-game (default-corp [(qty "Crisium Grid" 2)(qty "Vanilla" 2)])
+                (default-runner ["The Gauntlet" "Rip Deal" (qty "Easy Mark" 2)]))
+      (trash-from-hand state :runner "Easy Mark")
+      (trash-from-hand state :runner "Easy Mark")
+      (play-from-hand state :corp "Vanilla" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 4)
+      (play-from-hand state :runner "The Gauntlet")
+      (play-from-hand state :runner "Rip Deal")
+      (run-successful state)
+      (prompt-choice :runner 1)
+      (prompt-choice :runner "Replacement effect")
+      (is (= "Choose 2 card(s) to move from the Heap to your Grip" (-> (get-runner) :prompt first :msg))))))
 
 (deftest rumor-mill
   ;; Rumor Mill - interactions with rez effects, additional costs, general event handlers, and trash-effects
-  (do-game
-    (new-game
-      (default-corp [(qty "Project Atlas" 2)
-                     "Caprice Nisei" "Chairman Hiro" "Cybernetics Court"
-                     "Elizabeth Mills"
-                     "Ibrahim Salem"
-                     "Housekeeping"
-                     "Director Haas"
-                     "Oberth Protocol"])
-      (default-runner ["Rumor Mill"]))
-    (core/gain state :corp :credit 100 :click 100 :bad-publicity 1)
-    (core/draw state :corp 100)
-    (play-from-hand state :corp "Caprice Nisei" "New remote")
-    (play-from-hand state :corp "Chairman Hiro" "New remote")
-    (play-from-hand state :corp "Cybernetics Court" "New remote")
-    (play-from-hand state :corp "Elizabeth Mills" "New remote")
-    (play-from-hand state :corp "Project Atlas" "New remote")
-    (play-from-hand state :corp "Ibrahim Salem" "New remote")
-    (play-from-hand state :corp "Oberth Protocol" "New remote")
-    (core/move state :corp (find-card "Director Haas" (:hand (get-corp))) :deck)
-    (core/rez state :corp (get-content state :remote2 0))
-    (core/rez state :corp (get-content state :remote3 0))
-    (score-agenda state :corp (get-content state :remote5 0))
-    (take-credits state :corp)
-    (core/gain state :runner :credit 100 :click 100)
-    (is (= 4 (get-in (get-corp) [:hand-size :mod])) "Corp has +4 hand size")
-    (is (= -2 (get-in (get-runner) [:hand-size :mod])) "Runner has -2 hand size")
-
-    (play-from-hand state :runner "Rumor Mill")
-
-    ;; Additional costs to rez should NOT be applied
-    (core/rez state :corp (get-content state :remote6 0))
-    (is (= 1 (count (:scored (get-corp)))) "No agenda was auto-forfeit to rez Ibrahim Salem")
-
-    ;; In-play effects
-    (is (= 0 (get-in (get-corp) [:hand-size :mod])) "Corp has original hand size")
-    (is (= 0 (get-in (get-runner) [:hand-size :mod])) "Runner has original hand size")
-
-    ;; "When you rez" effects should not apply
-    (core/rez state :corp (get-content state :remote4 0))
-    (is (= 1 (:bad-publicity (get-corp))) "Corp still has 1 bad publicity")
-
-    ;; Run events (Caprice)
-    ;; Make sure Rumor Mill applies even if card is rezzed after RM is put in play.
-    (core/rez state :corp (get-content state :remote1 0))
-    (run-on state :remote1)
-    (run-continue state)
-    (is (empty? (:prompt (get-corp))) "Caprice prompt is not showing")
-    (run-jack-out state)
-
-    ;; Trashable execs
-    (run-empty-server state :remote2)
-    (prompt-choice :runner "Yes")
-    (is (empty? (:scored (get-runner))) "Chairman Hiro not added to runner's score area")
-    (run-jack-out state)
-    (run-on state "R&D")
-    (run-successful state)
-    (prompt-choice :runner "Yes")
-    (is (empty? (:scored (get-runner))) "Director Haas not added to runner's score area")
-    (take-credits state :runner)
-
-    ;; Trash RM, make sure everything works again
-    (play-from-hand state :corp "Housekeeping")
-    (is (= 4 (get-in (get-corp) [:hand-size :mod])) "Corp has +4 hand size")
-    (is (= 0 (get-in (get-runner) [:hand-size :mod])) "Runner has +0 hand size")
-
-    ;; Additional costs to rez should now be applied again
-    (core/rez state :corp (get-content state :remote7 0))
-    (prompt-select :corp (get-in (get-corp) [:scored 0]))
-    (is (zero? (count (:scored (get-corp)))) "Agenda was auto-forfeit to rez Oberth")
-
-    (core/derez state :corp (get-content state :remote4 0))
-    (core/rez state :corp (get-content state :remote4 0))
-    (is (= 0 (:bad-publicity (get-corp))) "Corp has 0 bad publicity")
-    (card-ability state :corp (get-content state :remote4 0) 0) ; Elizabeth Mills, should show a prompt
-    (is (:prompt (get-corp)) "Elizabeth Mills ability allowed")))
-
-(deftest rumor-mill-street-peddler
-  ;; Make sure Rumor Mill is not active when hosted on Peddler
-  (do-game
-    (new-game (default-corp ["Jeeves Model Bioroids"])
-              (default-runner ["Street Peddler"
-                               (qty "Rumor Mill" 3)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler"])
-    (play-from-hand state :runner "Street Peddler")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Jeeves Model Bioroids" "New remote")
-    (let [jeeves (get-content state :remote1 0)]
-      (core/rez state :corp jeeves)
-      (card-ability state :corp jeeves 0)
-      (is (= 3 (:click (get-corp))) "Corp has 3 clicks - Jeeves working ok"))))
+  (testing "Full test"
+    (do-game
+      (new-game
+        (default-corp [(qty "Project Atlas" 2)
+                       "Caprice Nisei" "Chairman Hiro" "Cybernetics Court"
+                       "Elizabeth Mills" "Ibrahim Salem"
+                       "Housekeeping" "Director Haas" "Oberth Protocol"])
+        (default-runner ["Rumor Mill"]))
+      (core/gain state :corp :credit 100 :click 100 :bad-publicity 1)
+      (core/draw state :corp 100)
+      (play-from-hand state :corp "Caprice Nisei" "New remote")
+      (play-from-hand state :corp "Chairman Hiro" "New remote")
+      (play-from-hand state :corp "Cybernetics Court" "New remote")
+      (play-from-hand state :corp "Elizabeth Mills" "New remote")
+      (play-from-hand state :corp "Project Atlas" "New remote")
+      (play-from-hand state :corp "Ibrahim Salem" "New remote")
+      (play-from-hand state :corp "Oberth Protocol" "New remote")
+      (core/move state :corp (find-card "Director Haas" (:hand (get-corp))) :deck)
+      (core/rez state :corp (get-content state :remote2 0))
+      (core/rez state :corp (get-content state :remote3 0))
+      (score-agenda state :corp (get-content state :remote5 0))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 100 :click 100)
+      (is (= 4 (get-in (get-corp) [:hand-size :mod])) "Corp has +4 hand size")
+      (is (= -2 (get-in (get-runner) [:hand-size :mod])) "Runner has -2 hand size")
+      (play-from-hand state :runner "Rumor Mill")
+      ;; Additional costs to rez should NOT be applied
+      (core/rez state :corp (get-content state :remote6 0))
+      (is (= 1 (count (:scored (get-corp)))) "No agenda was auto-forfeit to rez Ibrahim Salem")
+      ;; In-play effects
+      (is (= 0 (get-in (get-corp) [:hand-size :mod])) "Corp has original hand size")
+      (is (= 0 (get-in (get-runner) [:hand-size :mod])) "Runner has original hand size")
+      ;; "When you rez" effects should not apply
+      (core/rez state :corp (get-content state :remote4 0))
+      (is (= 1 (:bad-publicity (get-corp))) "Corp still has 1 bad publicity")
+      ;; Run events (Caprice)
+      ;; Make sure Rumor Mill applies even if card is rezzed after RM is put in play.
+      (core/rez state :corp (get-content state :remote1 0))
+      (run-on state :remote1)
+      (run-continue state)
+      (is (empty? (:prompt (get-corp))) "Caprice prompt is not showing")
+      (run-jack-out state)
+      ;; Trashable execs
+      (run-empty-server state :remote2)
+      (prompt-choice :runner "Yes")
+      (is (empty? (:scored (get-runner))) "Chairman Hiro not added to runner's score area")
+      (run-jack-out state)
+      (run-on state "R&D")
+      (run-successful state)
+      (prompt-choice :runner "Yes")
+      (is (empty? (:scored (get-runner))) "Director Haas not added to runner's score area")
+      (take-credits state :runner)
+      ;; Trash RM, make sure everything works again
+      (play-from-hand state :corp "Housekeeping")
+      (is (= 4 (get-in (get-corp) [:hand-size :mod])) "Corp has +4 hand size")
+      (is (= 0 (get-in (get-runner) [:hand-size :mod])) "Runner has +0 hand size")
+      ;; Additional costs to rez should now be applied again
+      (core/rez state :corp (get-content state :remote7 0))
+      (prompt-select :corp (get-in (get-corp) [:scored 0]))
+      (is (zero? (count (:scored (get-corp)))) "Agenda was auto-forfeit to rez Oberth")
+      (core/derez state :corp (get-content state :remote4 0))
+      (core/rez state :corp (get-content state :remote4 0))
+      (is (= 0 (:bad-publicity (get-corp))) "Corp has 0 bad publicity")
+      (card-ability state :corp (get-content state :remote4 0) 0) ; Elizabeth Mills, should show a prompt
+      (is (:prompt (get-corp)) "Elizabeth Mills ability allowed")))
+  (testing "Make sure Rumor Mill is not active when hosted on Peddler"
+    (do-game
+      (new-game (default-corp ["Jeeves Model Bioroids"])
+                (default-runner ["Street Peddler" (qty "Rumor Mill" 3)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler"])
+      (play-from-hand state :runner "Street Peddler")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Jeeves Model Bioroids" "New remote")
+      (let [jeeves (get-content state :remote1 0)]
+        (core/rez state :corp jeeves)
+        (card-ability state :corp jeeves 0)
+        (is (= 3 (:click (get-corp))) "Corp has 3 clicks - Jeeves working ok")))))
 
 (deftest scrubbed
   ;; First piece of ice encountered each turn has -2 Strength for remainder of the run
@@ -2229,64 +2202,57 @@
     (play-from-hand state :runner "Sure Gamble")
     (is (= 9 (:credit (get-runner))))))
 
-;; Surge and virus counter flag tests
-(deftest surge-valid-target
-  ;; Add counters if target is a virus and had a counter added this turn
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Imp" "Surge"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Imp")
-    (let [imp (get-in @state [:runner :rig :program 0])]
-      (is (= 2 (get-counters imp :virus)) "Imp has 2 counters after install")
-      (play-from-hand state :runner "Surge")
-      (prompt-select :runner imp)
-      (is (= 4 (get-counters (refresh imp) :virus)) "Imp has 4 counters after surge"))))
-
-(deftest surge-target-not-virus
-  ;; Don't fire surge if target is not a virus
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Security Testing" "Surge"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Security Testing")
-    (let [st (get-in @state [:runner :rig :resource 0])]
-      (play-from-hand state :runner "Surge")
-      (prompt-select :runner st)
-      (is (not (contains? st :counter)) "Surge does not fire on Security Testing"))))
-
-(deftest surge-target-no-token-this-turn
-  ;; Don't fire surge if target does not have virus counter flag set
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Imp" "Surge"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Imp")
-    (let [imp (get-in @state [:runner :rig :program 0])]
-      (is (= 2 (get-counters imp :virus)) "Imp has 2 counters after install")
-      (take-credits state :runner 3)
+(deftest surge
+  ;; Surge - Add counters if target is a virus and had a counter added this turn
+  (testing "Valid target"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Imp" "Surge"]))
       (take-credits state :corp)
-      (play-from-hand state :runner "Surge")
-      (prompt-select :runner imp)
-      (is (= 2 (get-counters (refresh imp) :virus))
-          "Surge does not fire on Imp turn after install"))))
-
-(deftest surge-target-gorman-drip
-  ;; Don't allow surging Gorman Drip, since it happens on the corp turn
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Gorman Drip v1" "Surge"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Gorman Drip v1")
-    (let [gd (get-in @state [:runner :rig :program 0])]
-      (is (= 0 (get-counters gd :virus)) "Gorman Drip starts without counters")
-      (take-credits state :runner 3)
+      (play-from-hand state :runner "Imp")
+      (let [imp (get-in @state [:runner :rig :program 0])]
+        (is (= 2 (get-counters imp :virus)) "Imp has 2 counters after install")
+        (play-from-hand state :runner "Surge")
+        (prompt-select :runner imp)
+        (is (= 4 (get-counters (refresh imp) :virus)) "Imp has 4 counters after surge"))))
+  (testing "Don't fire surge if target is not a virus"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Security Testing" "Surge"]))
       (take-credits state :corp)
-      (is (= 3 (get-counters (refresh gd) :virus))
-          "Gorman Drip gains 3 counters after Corp clicks 3 times for credits")
-      (play-from-hand state :runner "Surge")
-      (prompt-select :runner gd)
-      (is (= 3 (get-counters (refresh gd) :virus)) "Surge does not trigger on Gorman Drip"))))
+      (play-from-hand state :runner "Security Testing")
+      (let [st (get-in @state [:runner :rig :resource 0])]
+        (play-from-hand state :runner "Surge")
+        (prompt-select :runner st)
+        (is (not (contains? st :counter)) "Surge does not fire on Security Testing"))))
+  (testing "Don't fire surge if target does not have virus counter flag set"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Imp" "Surge"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Imp")
+      (let [imp (get-in @state [:runner :rig :program 0])]
+        (is (= 2 (get-counters imp :virus)) "Imp has 2 counters after install")
+        (take-credits state :runner 3)
+        (take-credits state :corp)
+        (play-from-hand state :runner "Surge")
+        (prompt-select :runner imp)
+        (is (= 2 (get-counters (refresh imp) :virus)) "Surge does not fire on Imp turn after install"))))
+  (testing "Don't allow surging Gorman Drip, since it happens on the corp turn"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Gorman Drip v1" "Surge"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Gorman Drip v1")
+      (let [gd (get-in @state [:runner :rig :program 0])]
+        (is (= 0 (get-counters gd :virus)) "Gorman Drip starts without counters")
+        (take-credits state :runner 3)
+        (take-credits state :corp)
+        (is (= 3 (get-counters (refresh gd) :virus))
+            "Gorman Drip gains 3 counters after Corp clicks 3 times for credits")
+        (play-from-hand state :runner "Surge")
+        (prompt-select :runner gd)
+        (is (= 3 (get-counters (refresh gd) :virus)) "Surge does not trigger on Gorman Drip")))))
 
 (deftest system-outage
   ;; When Corp draws 1+ cards, it loses 1 if it is not the first time he or she has drawn cards this turn
@@ -2327,7 +2293,6 @@
     (let [c1 (get-program state 0)
           c2  (get-program state 1)]
       (run-empty-server state "R&D") ;; Check that System Seizure triggers even if another run has been made
-
       (run-on state "HQ") ;; Check that System Seizure only keeps strength on one of the breakers
       (is (= 2 (core/breaker-strength state :runner (core/get-card state c1))) "Corroder 1 has 2 strength")
       (is (= 2 (core/breaker-strength state :runner (core/get-card state c2))) "Corroder 2 has 2 strength")
@@ -2341,7 +2306,6 @@
       (run-successful state)
       (is (= 2 (core/breaker-strength state :runner (core/get-card state c1))) "Corroder 1 has 2 strength")
       (is (= 2 (core/breaker-strength state :runner (core/get-card state c2))) "Corroder 2 has 2 strength")
-
       (run-on state "HQ") ;; Check that System Seizure does not keep strength on 2nd run
       (is (= 2 (core/breaker-strength state :runner (core/get-card state c1))) "Corroder 1 has 2 strength")
       (is (= 2 (core/breaker-strength state :runner (core/get-card state c2))) "Corroder 2 has 2 strength")
@@ -2393,26 +2357,27 @@
               (take-credits state :runner)
               (is (= "Knight" (:title (first (:deck (get-runner))))) "Knight returned to Stack from host ICE"))))))))
 
-(deftest test-run-scavenge
-  ;; Test Run - Make sure program remains installed if Scavenged
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Test Run" "Morning Star"
-                               "Scavenge" "Inti"]))
-    (take-credits state :corp)
-    (core/move state :runner (find-card "Morning Star" (:hand (get-runner))) :discard)
-    (play-from-hand state :runner "Test Run")
-    (let [ms (find-card "Morning Star" (:discard (get-runner)))]
-      (prompt-choice :runner "Heap")
-      (prompt-choice :runner ms)
-      (is (= 2 (:credit (get-runner))) "Program installed for free")
-      (let [ms (get-in @state [:runner :rig :program 0])]
-        (play-from-hand state :runner "Scavenge")
-        (prompt-select :runner ms)
-        (prompt-select :runner (find-card "Morning Star" (:discard (get-runner))))
-        (take-credits state :runner)
-        (is (empty? (:deck (get-runner))) "Morning Star not returned to Stack")
-        (is (= "Morning Star" (:title (get-in @state [:runner :rig :program 0]))) "Morning Star still installed")))))
+(deftest test-run
+  ;; Test Run
+  (testing "Make sure program remains installed if Scavenged"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Test Run" "Morning Star"
+                                 "Scavenge" "Inti"]))
+      (take-credits state :corp)
+      (core/move state :runner (find-card "Morning Star" (:hand (get-runner))) :discard)
+      (play-from-hand state :runner "Test Run")
+      (let [ms (find-card "Morning Star" (:discard (get-runner)))]
+        (prompt-choice :runner "Heap")
+        (prompt-choice :runner ms)
+        (is (= 2 (:credit (get-runner))) "Program installed for free")
+        (let [ms (get-in @state [:runner :rig :program 0])]
+          (play-from-hand state :runner "Scavenge")
+          (prompt-select :runner ms)
+          (prompt-select :runner (find-card "Morning Star" (:discard (get-runner))))
+          (take-credits state :runner)
+          (is (empty? (:deck (get-runner))) "Morning Star not returned to Stack")
+          (is (= "Morning Star" (:title (get-in @state [:runner :rig :program 0]))) "Morning Star still installed"))))))
 
 (deftest the-makers-eye
   (do-game
@@ -2551,79 +2516,36 @@
     (is (= 5 (:credit (get-runner))) "Paid 8 credits")
     (is (= 0 (:credit (get-corp))) "Corp lost all 8 credits")))
 
-(deftest virus-counter-flag-on-enter
-  ;; Set counter flag when virus card enters play with counters
-  (do-game
-    (new-game (default-corp) (default-runner ["Surge" "Imp" "Crypsis"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Imp")
-    (let [imp (get-in @state [:runner :rig :program 0])]
-      (is (get-in imp [:added-virus-counter]) "Counter flag was not set on Imp"))))
-
-(deftest virus-counter-flag-on-add-prop
-  ;; Set counter flag when add-prop is called on a virus
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Crypsis"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Crypsis")
-    (let [crypsis (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner crypsis 2) ;click to add a virus counter
-      (is (= 1 (get-counters (refresh crypsis) :virus)) "Crypsis added a virus token")
-      (is (get-in (refresh crypsis) [:added-virus-counter])
-          "Counter flag was set on Crypsis"))))
-
-(deftest virus-counter-flag-clear-on-end-turn
-  ;; Clear the virus counter flag at the end of each turn
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Crypsis"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Crypsis")
-    (let [crypsis (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner crypsis 2) ; click to add a virus counter
-      (take-credits state :runner 2)
-      (take-credits state :corp 1)
-      (is (not (get-in (refresh crypsis) [:added-virus-counter]))
-          "Counter flag was cleared on Crypsis"))))
-
-(deftest black-hat
-  ;; Black Hat
-  (testing "Basic test"
+(deftest virus-counter-flags
+  ^:skip-card-coverage
+  (testing "Set counter flag when virus card enters play with counters"
     (do-game
-      (new-game (default-corp [(qty "Hedge Fund" 10)])
-                (default-runner [(qty "Black Hat" 3)]))
+      (new-game (default-corp)
+                (default-runner ["Surge" "Imp" "Crypsis"]))
       (take-credits state :corp)
-      (core/gain state :runner :credit 10)
-      (play-from-hand state :runner "Black Hat")
-      (prompt-choice  :corp 0)
-      (prompt-choice  :runner 4)
-      (run-on state :rd)
-      (run-successful state)
-      (prompt-choice :runner "Card from deck")
-      (prompt-choice :runner "No action")
-      (prompt-choice :runner "Card from deck")
-      (prompt-choice :runner "No action")
-      (prompt-choice :runner "Card from deck")))
-  
-  (testing "Kitsune interaction"
+      (play-from-hand state :runner "Imp")
+      (let [imp (get-in @state [:runner :rig :program 0])]
+        (is (get-in imp [:added-virus-counter]) "Counter flag was set on Imp"))))
+  (testing "Set counter flag when add-prop is called on a virus"
     (do-game
-     (new-game (default-corp [(qty "Kitsune" 10)])
-               (default-runner [(qty "Black Hat" 3)]))
-      (starting-hand state :corp ["Kitsune" "Kitsune" "Kitsune" "Kitsune" "Kitsune"])
-      (play-from-hand state :corp "Kitsune" "R&D")
-      (let [kitsune (get-ice state :rd 0)]
-        (core/rez state :corp kitsune)
-        (take-credits state :corp)
-        (core/gain state :runner :credit 10)
-        (play-from-hand state :runner "Black Hat")
-        (prompt-choice  :corp 0)
-        (prompt-choice :runner 4)
-        (run-on state :rd)
-        (card-subroutine state :corp kitsune 0)
-        (prompt-select :corp (find-card "Kitsune" (:hand (get-corp))))
-        (prompt-choice :runner "No action")
-        (prompt-choice :runner "Card from hand")
-        (prompt-choice :runner "No action")
-        (prompt-choice :runner "Card from hand")
-        (prompt-choice :runner "No action")))))
+      (new-game (default-corp)
+                (default-runner ["Crypsis"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Crypsis")
+      (let [crypsis (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner crypsis 2) ;click to add a virus counter
+        (is (= 1 (get-counters (refresh crypsis) :virus)) "Crypsis added a virus token")
+        (is (get-in (refresh crypsis) [:added-virus-counter])
+            "Counter flag was set on Crypsis"))))
+  (testing "Clear the virus counter flag at the end of each turn"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Crypsis"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Crypsis")
+      (let [crypsis (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner crypsis 2) ; click to add a virus counter
+        (take-credits state :runner 2)
+        (take-credits state :corp 1)
+        (is (not (get-in (refresh crypsis) [:added-virus-counter]))
+            "Counter flag was cleared on Crypsis")))))

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -25,7 +25,7 @@
     (is (= 9 (:credit (get-runner))) "Runner gained 9 credits")
     (is (= 1 (count (:discard (get-runner)))) "Acacia has trashed")))
 
-(deftest akamatsu-mem
+(deftest akamatsu-mem-chip
   ;; Akamatsu Mem Chip - Gain 1 memory
   (do-game
     (new-game (default-corp)
@@ -49,22 +49,14 @@
     (is (= "Shock!" (:title (first (:rfg (get-corp))))) "Shock! removed from game")
     (is (empty? (:discard (get-runner))) "Didn't access Shock!, no net damage taken")))
 
-(deftest astrolabe-memory
-  ;; Astrolabe - Gain 1 memory
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Astrolabe" 3)]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Astrolabe")
-    (is (= 5 (core/available-mu state)) "Gain 1 memory")))
-
-(deftest astrolabe-draw
+(deftest astrolabe
   ;; Astrolabe - Draw on new server install
   (do-game
     (new-game (default-corp [(qty "Snare!" 3)])
               (default-runner [(qty "Astrolabe" 3) (qty "Sure Gamble" 3) "Cloak"]))
     (take-credits state :corp)
     (play-from-hand state :runner "Astrolabe")
+    (is (= 5 (core/available-mu state)) "Gain 1 memory")
     (take-credits state :runner 3)
     ;; corp's turn. install something from HQ to trigger Astrolabe draw
     (play-from-hand state :corp "Snare!" "New remote")
@@ -121,44 +113,43 @@
 
 (deftest clone-chip
   ;; Test clone chip usage- outside and during run
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Datasucker" (qty "Clone Chip" 2)]))
-    (take-credits state :corp)
-    (trash-from-hand state :runner "Datasucker")
-    (play-from-hand state :runner "Clone Chip")
-    (let [chip (get-in @state [:runner :rig :hardware 0])]
-      (card-ability state :runner chip 0)
-      (prompt-select :runner (find-card "Datasucker" (:discard (get-runner))))
-      (let [ds (get-in @state [:runner :rig :program 0])]
-        (is (not (nil? ds)))
-        (is (= (:title ds) "Datasucker"))))))
-
-(deftest clone-chip-dont-install-choices-runner-cant-afford
-  ;; Test clone chip usage - dont show inavalid choices
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Inti" "Magnum Opus" "Clone Chip"]))
-    (take-credits state :corp)
-    (trash-from-hand state :runner "Inti")
-    (trash-from-hand state :runner "Magnum Opus")
-    (play-from-hand state :runner "Clone Chip")
-    (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left")
-    (let [chip (get-in @state [:runner :rig :hardware 0])]
-      (card-ability state :runner chip 0)
-      (prompt-select :runner (find-card "Magnum Opus" (:discard (get-runner))))
-      (is (nil? (get-in @state [:runner :rig :program 0])) "No program was installed"))
-    (let [chip (get-in @state [:runner :rig :hardware 0])]
-      (is (not (nil? chip)) "Clone Chip is still installed")
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Datasucker" (qty "Clone Chip" 2)]))
+      (take-credits state :corp)
+      (trash-from-hand state :runner "Datasucker")
+      (play-from-hand state :runner "Clone Chip")
+      (let [chip (get-in @state [:runner :rig :hardware 0])]
+        (card-ability state :runner chip 0)
+        (prompt-select :runner (find-card "Datasucker" (:discard (get-runner))))
+        (let [ds (get-in @state [:runner :rig :program 0])]
+          (is (not (nil? ds)))
+          (is (= (:title ds) "Datasucker"))))))
+  (testing "don't show inavalid choices"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Inti" "Magnum Opus" "Clone Chip"]))
+      (take-credits state :corp)
+      (trash-from-hand state :runner "Inti")
+      (trash-from-hand state :runner "Magnum Opus")
+      (play-from-hand state :runner "Clone Chip")
       (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left")
-      (card-ability state :runner chip 0)
-      (prompt-select :runner (find-card "Inti" (:discard (get-runner))))
-      (let [inti (get-in @state [:runner :rig :program 0])]
-        (is (not (nil? inti)) "Program was installed")
-        (is (= (:title inti) "Inti") "Program is Inti")
-        (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left")))))
+      (let [chip (get-in @state [:runner :rig :hardware 0])]
+        (card-ability state :runner chip 0)
+        (prompt-select :runner (find-card "Magnum Opus" (:discard (get-runner))))
+        (is (nil? (get-in @state [:runner :rig :program 0])) "No program was installed"))
+      (let [chip (get-in @state [:runner :rig :hardware 0])]
+        (is (not (nil? chip)) "Clone Chip is still installed")
+        (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left")
+        (card-ability state :runner chip 0)
+        (prompt-select :runner (find-card "Inti" (:discard (get-runner))))
+        (let [inti (get-in @state [:runner :rig :program 0])]
+          (is (not (nil? inti)) "Program was installed")
+          (is (= (:title inti) "Inti") "Program is Inti")
+          (is (= (get-in @state [:runner :click]) 3) "Runner has 3 clicks left"))))))
 
-(deftest comet-event-play
+(deftest comet
   ;; Comet - Play event without spending a click after first event played
   (do-game
     (new-game (default-corp)
@@ -232,6 +223,7 @@
     (is (= 3 (:credit (get-runner))) "Got 1c for successful run on Desperado")))
 
 (deftest dinosaurus
+  ;; Dinosaurus
   (testing "Hosting a breaker with strength based on unused MU should calculate correctly"
     (do-game
       (new-game (default-corp)
@@ -304,8 +296,7 @@
           "Runner has prompt to wait for Snare!")
       (prompt-choice :corp "Yes")
       (is (= 0 (:tag (get-runner))) "Runner has 0 tags")
-      (is (= 3 (get-counters (refresh dorm) :power))))
-      ))
+      (is (= 3 (get-counters (refresh dorm) :power))))))
 
 (deftest feedback-filter
   ;; Feedback Filter - Prevent net and brain damage
@@ -520,7 +511,6 @@
     (prompt-choice :runner "No action")
     (is (empty? (:prompt (get-runner))) "No prompt if not virus program installed")
     (take-credits state :runner)
-
     (take-credits state :corp)
     (play-from-hand state :runner "Hivemind")
     (let [hv (find-card "Hivemind" (get-in @state [:runner :rig :program]))]
@@ -617,55 +607,54 @@
 
 (deftest maya
   ;; Maya - Move accessed card to bottom of R&D
-  (do-game
-    (new-game (default-corp [(qty "Hedge Fund" 2) (qty "Snare!" 2) "Hostile Takeover" "Scorched Earth"])
-              (default-runner ["Maya" (qty "Sure Gamble" 3)]))
-    (core/move state :corp (find-card "Hostile Takeover" (:hand (get-corp))) :deck)
-    (core/move state :corp (find-card "Snare!" (:hand (get-corp))) :deck)
-    (take-credits state :corp)
-    (play-from-hand state :runner "Maya")
-    (let [maya (get-in @state [:runner :rig :hardware 0])
-          accessed (first (:deck (get-corp)))]
-      (run-empty-server state :rd)
-      (is (= (:cid accessed) (:cid (:card (first (:prompt (get-runner)))))) "Accessing the top card of R&D")
-      (card-ability state :runner maya 0)
-      (is (empty? (:prompt (get-runner))) "No more prompts for runner")
-      (is (not (:run @state)) "Run is ended")
-      (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")
-      (take-credits state :runner)
-      (core/draw state :corp)
-      (take-credits state :corp)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Hedge Fund" 2) (qty "Snare!" 2) "Hostile Takeover" "Scorched Earth"])
+                (default-runner ["Maya" (qty "Sure Gamble" 3)]))
+      (core/move state :corp (find-card "Hostile Takeover" (:hand (get-corp))) :deck)
       (core/move state :corp (find-card "Snare!" (:hand (get-corp))) :deck)
-      (core/move state :corp (find-card "Scorched Earth" (:hand (get-corp))) :deck)
-      (let [accessed (first (:deck (get-corp)))]
+      (take-credits state :corp)
+      (play-from-hand state :runner "Maya")
+      (let [maya (get-in @state [:runner :rig :hardware 0])
+            accessed (first (:deck (get-corp)))]
         (run-empty-server state :rd)
-        (prompt-choice :corp "Yes")
-        (is (= 0 (count (:hand (get-runner)))) "Runner took Snare! net damage")
         (is (= (:cid accessed) (:cid (:card (first (:prompt (get-runner)))))) "Accessing the top card of R&D")
         (card-ability state :runner maya 0)
         (is (empty? (:prompt (get-runner))) "No more prompts for runner")
         (is (not (:run @state)) "Run is ended")
-        (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")))))
-
-(deftest maya-multi-access
-  ;; Maya - Does not interrupt multi-access.
-  (do-game
-    (new-game (default-corp [(qty "Hedge Fund" 2) (qty "Scorched Earth" 2) (qty "Snare!" 2)])
-              (default-runner ["Maya" (qty "Sure Gamble" 3) "R&D Interface"]))
-    (core/move state :corp (find-card "Scorched Earth" (:hand (get-corp))) :deck)
-    (core/move state :corp (find-card "Snare!" (:hand (get-corp))) :deck)
-    (take-credits state :corp)
-    (core/gain state :runner :credit 10)
-    (play-from-hand state :runner "Maya")
-    (play-from-hand state :runner "R&D Interface")
-    (let [maya (get-in @state [:runner :rig :hardware 0])
-          accessed (first (:deck (get-corp)))]
-      (run-empty-server state :rd)
-      (prompt-choice :runner "Card from deck")
-      (is (= (:cid accessed) (:cid (:card (first (:prompt (get-runner)))))) "Accessing the top card of R&D")
-      (card-ability state :runner maya 0)
-      (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")
-      (is (:prompt (get-runner)) "Runner has next access prompt"))))
+        (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")
+        (take-credits state :runner)
+        (core/draw state :corp)
+        (take-credits state :corp)
+        (core/move state :corp (find-card "Snare!" (:hand (get-corp))) :deck)
+        (core/move state :corp (find-card "Scorched Earth" (:hand (get-corp))) :deck)
+        (let [accessed (first (:deck (get-corp)))]
+          (run-empty-server state :rd)
+          (prompt-choice :corp "Yes")
+          (is (= 0 (count (:hand (get-runner)))) "Runner took Snare! net damage")
+          (is (= (:cid accessed) (:cid (:card (first (:prompt (get-runner)))))) "Accessing the top card of R&D")
+          (card-ability state :runner maya 0)
+          (is (empty? (:prompt (get-runner))) "No more prompts for runner")
+          (is (not (:run @state)) "Run is ended")
+          (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")))))
+  (testing "Does not interrupt multi-access"
+    (do-game
+      (new-game (default-corp [(qty "Hedge Fund" 2) (qty "Scorched Earth" 2) (qty "Snare!" 2)])
+                (default-runner ["Maya" (qty "Sure Gamble" 3) "R&D Interface"]))
+      (core/move state :corp (find-card "Scorched Earth" (:hand (get-corp))) :deck)
+      (core/move state :corp (find-card "Snare!" (:hand (get-corp))) :deck)
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Maya")
+      (play-from-hand state :runner "R&D Interface")
+      (let [maya (get-in @state [:runner :rig :hardware 0])
+            accessed (first (:deck (get-corp)))]
+        (run-empty-server state :rd)
+        (prompt-choice :runner "Card from deck")
+        (is (= (:cid accessed) (:cid (:card (first (:prompt (get-runner)))))) "Accessing the top card of R&D")
+        (card-ability state :runner maya 0)
+        (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")
+        (is (:prompt (get-runner)) "Runner has next access prompt")))))
 
 (deftest net-ready-eyes
   ;; Net-Ready Eyes
@@ -688,106 +677,99 @@
 
 (deftest obelus
   ;; Obelus - Increase max hand size with tags, draw cards on first successful HQ/R&D run
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Obelus" "Nerve Agent"
-                               (qty "Sure Gamble" 3) (qty "Cache" 3)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Obelus" "Nerve Agent"])
-    (core/gain state :runner :credit 10 :click 3)
-    (play-from-hand state :runner "Nerve Agent")
-    (let [nerve (get-in @state [:runner :rig :program 0])]
-      (run-empty-server state :hq)
-      (is (= 1 (get-counters (refresh nerve) :virus)) "1 virus counter on Nerve Agent")
-      (prompt-choice :runner "No action")
-      (play-from-hand state :runner "Obelus")
-      (core/gain state :runner :tag 1)
-      (is (= 6 (core/hand-size state :runner)) "Max hand size is 6")
-      (core/lose state :runner :tag 1)
-      (is (= 5 (core/hand-size state :runner)) "Max hand size is 5")
-      (run-empty-server state :hq)
-      (is (= 2 (get-counters (refresh nerve) :virus)) "2 virus counters on Nerve Agent")
-      (prompt-choice :runner 1)
-      (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "No action")
-      (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "No action")
-      (is (empty? (:hand (get-runner))) "No cards drawn by Obelus, already had successful HQ run")
-      (take-credits state :runner)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Obelus" "Nerve Agent"
+                                 (qty "Sure Gamble" 3) (qty "Cache" 3)]))
       (take-credits state :corp)
-      (run-empty-server state :hq)
-      (is (= 3 (get-counters (refresh nerve) :virus)) "3 virus counters on Nerve Agent")
-      (prompt-choice :runner 2)
-      (prompt-choice :runner "Card from hand")
+      (starting-hand state :runner ["Obelus" "Nerve Agent"])
+      (core/gain state :runner :credit 10 :click 3)
+      (play-from-hand state :runner "Nerve Agent")
+      (let [nerve (get-in @state [:runner :rig :program 0])]
+        (run-empty-server state :hq)
+        (is (= 1 (get-counters (refresh nerve) :virus)) "1 virus counter on Nerve Agent")
+        (prompt-choice :runner "No action")
+        (play-from-hand state :runner "Obelus")
+        (core/gain state :runner :tag 1)
+        (is (= 6 (core/hand-size state :runner)) "Max hand size is 6")
+        (core/lose state :runner :tag 1)
+        (is (= 5 (core/hand-size state :runner)) "Max hand size is 5")
+        (run-empty-server state :hq)
+        (is (= 2 (get-counters (refresh nerve) :virus)) "2 virus counters on Nerve Agent")
+        (prompt-choice :runner 1)
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "No action")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "No action")
+        (is (empty? (:hand (get-runner))) "No cards drawn by Obelus, already had successful HQ run")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (run-empty-server state :hq)
+        (is (= 3 (get-counters (refresh nerve) :virus)) "3 virus counters on Nerve Agent")
+        (prompt-choice :runner 2)
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "No action")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "No action")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "No action")
+        (is (= 3 (count (:hand (get-runner)))) "Obelus drew 3 cards"))))
+  (testing "running and trashing Crisium Grid makes run neither successful/unsuccessful"
+    (do-game
+      (new-game (default-corp ["Hedge Fund" "Crisium Grid"])
+                (default-runner ["Obelus" (qty "Sure Gamble" 3)]))
+      (starting-hand state :corp ["Crisium Grid"])
+      (play-from-hand state :corp "Crisium Grid" "R&D")
+      (core/rez state :corp (get-content state :rd 0))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Obelus"])
+      (core/gain state :runner :credit 5)
+      (play-from-hand state :runner "Obelus")
+      (is (empty? (:hand (get-runner))) "No cards in hand")
+      (run-empty-server state "R&D")
+      (prompt-choice :runner "Crisium Grid")
+      (prompt-choice-partial :runner "Pay")
+      (prompt-choice-partial :runner "Card")
+      (prompt-choice-partial :runner "No")
+      (is (empty? (:hand (get-runner))) "Crisium Grid blocked successful run")
+      (run-empty-server state "R&D")
+      (prompt-choice-partial :runner "No")
+      (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run")))
+  (testing "using Hades Shard during run to increase draw"
+    (do-game
+      (new-game (default-corp [(qty "Hedge Fund" 3) (qty "Restructure" 3)])
+                (default-runner ["Obelus" "Hades Shard"
+                                 (qty "Sure Gamble" 3) (qty "Cache" 3)]))
+      (starting-hand state :corp ["Hedge Fund" "Hedge Fund"])
+      (trash-from-hand state :corp "Hedge Fund")
+      (trash-from-hand state :corp "Hedge Fund")
+      (take-credits state :corp)
+      (starting-hand state :runner ["Obelus" "Hades Shard"])
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Obelus")
+      (play-from-hand state :runner "Hades Shard")
+      (run-empty-server state "R&D")
+      (card-ability state :runner (get-resource state 0) 0)
       (prompt-choice :runner "No action")
-      (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "No action")
-      (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "No action")
-      (is (= 3 (count (:hand (get-runner)))) "Obelus drew 3 cards"))))
+      (is (= 3 (count (:hand (get-runner)))) "Obelus drew 3 cards")))
+  (testing "running a remote server first doesn't block card draw"
+    (do-game
+      (new-game (default-corp ["Urban Renewal" "Hedge Fund"])
+                (default-runner ["Obelus" (qty "Sure Gamble" 3)]))
+      (starting-hand state :corp ["Urban Renewal"])
+      (play-from-hand state :corp "Urban Renewal" "New remote")
+      (take-credits state :corp)
+      (starting-hand state :runner ["Obelus"])
+      (play-from-hand state :runner "Obelus")
+      (is (empty? (:hand (get-runner))) "No cards in hand")
+      (run-empty-server state "Server 1")
+      (prompt-choice-partial :runner "No")
+      (run-empty-server state "R&D")
+      (prompt-choice-partial :runner "No")
+      (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run"))))
 
-(deftest obelus-crisium
-  ;; Obelus - running and trashing Crisium Grid makes run neither successful/unsuccessful
-  (do-game
-    (new-game (default-corp ["Hedge Fund" "Crisium Grid"])
-              (default-runner ["Obelus" (qty "Sure Gamble" 3)]))
-    (starting-hand state :corp ["Crisium Grid"])
-    (play-from-hand state :corp "Crisium Grid" "R&D")
-    (core/rez state :corp (get-content state :rd 0))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Obelus"])
-    (core/gain state :runner :credit 5)
-    (play-from-hand state :runner "Obelus")
-    (is (empty? (:hand (get-runner))) "No cards in hand")
-    (run-empty-server state "R&D")
-    (prompt-choice :runner "Crisium Grid")
-    (prompt-choice-partial :runner "Pay")
-    (prompt-choice-partial :runner "Card")
-    (prompt-choice-partial :runner "No")
-    (is (empty? (:hand (get-runner))) "Crisium Grid blocked successful run")
-    (run-empty-server state "R&D")
-    (prompt-choice-partial :runner "No")
-    (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run")))
-
-(deftest obelus-hades-shard
-  ;; Obelus - using Hades Shard during run to increase draw
-  (do-game
-    (new-game (default-corp [(qty "Hedge Fund" 3) (qty "Restructure" 3)])
-              (default-runner ["Obelus" "Hades Shard"
-                               (qty "Sure Gamble" 3) (qty "Cache" 3)]))
-    (starting-hand state :corp ["Hedge Fund" "Hedge Fund"])
-    (trash-from-hand state :corp "Hedge Fund")
-    (trash-from-hand state :corp "Hedge Fund")
-    (take-credits state :corp)
-    (starting-hand state :runner ["Obelus" "Hades Shard"])
-    (core/gain state :runner :credit 10)
-    (play-from-hand state :runner "Obelus")
-    (play-from-hand state :runner "Hades Shard")
-    (run-empty-server state "R&D")
-    (card-ability state :runner (get-resource state 0) 0)
-    (prompt-choice :runner "No action")
-    (is (= 3 (count (:hand (get-runner)))) "Obelus drew 3 cards")))
-
-(deftest obelus-remote-server
-  ;; Obelus - running a remote server first doesn't block card draw
-  (do-game
-    (new-game (default-corp ["Urban Renewal" "Hedge Fund"])
-              (default-runner ["Obelus" (qty "Sure Gamble" 3)]))
-    (starting-hand state :corp ["Urban Renewal"])
-    (play-from-hand state :corp "Urban Renewal" "New remote")
-    (take-credits state :corp)
-
-    (starting-hand state :runner ["Obelus"])
-    (play-from-hand state :runner "Obelus")
-    (is (empty? (:hand (get-runner))) "No cards in hand")
-    (run-empty-server state "Server 1")
-    (prompt-choice-partial :runner "No")
-
-    (run-empty-server state "R&D")
-    (prompt-choice-partial :runner "No")
-    (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run")))
-
-(deftest plascrete
+(deftest plascrete-carapace
   ;; Plascrete Carapace - Prevent meat damage
   (do-game
     (new-game (default-corp ["Scorched Earth"])
@@ -825,61 +807,60 @@
     (is (= 2 (:click (get-runner))) "Clickless installs of extra 2 copies")
     (is (= 3 (:credit (get-runner))) "Paid 2c for each of 3 copies")))
 
-(deftest ramujan-reliant
+(deftest ramujan-reliant-550-bmi
   ;; Prevent up to X net or brain damage.
-  (do-game
-    (new-game (default-corp ["Data Mine"
-                             "Snare!"])
-              (default-runner [(qty "Ramujan-reliant 550 BMI" 4) (qty "Sure Gamble" 6)]))
-    (starting-hand state :runner
-                   ["Ramujan-reliant 550 BMI" "Ramujan-reliant 550 BMI" "Ramujan-reliant 550 BMI" "Ramujan-reliant 550 BMI" "Sure Gamble"])
-    (play-from-hand state :corp "Data Mine" "Server 1")
-    (play-from-hand state :corp "Snare!" "Server 1")
-    (let [sn (get-content state :remote1 0)
-          dm (get-ice state :remote1 0)]
-      (take-credits state :corp)
-      (play-from-hand state :runner "Ramujan-reliant 550 BMI")
-      (play-from-hand state :runner "Ramujan-reliant 550 BMI")
-      (play-from-hand state :runner "Ramujan-reliant 550 BMI")
-      (let [rr1 (get-in @state [:runner :rig :hardware 0])
-            rr2 (get-in @state [:runner :rig :hardware 1])
-            rr3 (get-in @state [:runner :rig :hardware 2])]
-        (run-on state "Server 1")
-        (core/rez state :corp dm)
-        (card-subroutine state :corp dm 0)
-        (card-ability state :runner rr1 0)
-        (prompt-choice :runner 1)
-        (is (last-log-contains? state "Sure Gamble")
-            "Ramujan did log trashed card names")
-        (is (= 2 (count (:hand (get-runner)))) "1 net damage prevented")
-        (run-successful state)
-        (take-credits state :runner)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Data Mine" "Snare!"])
+                (default-runner [(qty "Ramujan-reliant 550 BMI" 4)
+                                 (qty "Sure Gamble" 6)]))
+      (starting-hand state :runner
+                     ["Ramujan-reliant 550 BMI" "Ramujan-reliant 550 BMI" "Ramujan-reliant 550 BMI" "Ramujan-reliant 550 BMI" "Sure Gamble"])
+      (play-from-hand state :corp "Data Mine" "Server 1")
+      (play-from-hand state :corp "Snare!" "Server 1")
+      (let [sn (get-content state :remote1 0)
+            dm (get-ice state :remote1 0)]
         (take-credits state :corp)
         (play-from-hand state :runner "Ramujan-reliant 550 BMI")
-        (run-empty-server state "Server 1")
-        (prompt-choice :corp "Yes")
-        (card-ability state :runner rr2 0)
-        (prompt-choice :runner 3)
-        (is (last-log-contains? state "Sure Gamble, Sure Gamble, Sure Gamble")
-            "Ramujan did log trashed card names")
-        (is (= 1 (count (:hand (get-runner)))) "3 net damage prevented")))))
-
-(deftest ramujan-reliant-empty
-  ;; Prevent up to X net or brain damage. Empty stack
-  (do-game
-    (new-game (default-corp ["Data Mine"])
-              (default-runner ["Ramujan-reliant 550 BMI" "Sure Gamble"]))
-    (play-from-hand state :corp "Data Mine" "Server 1")
-    (let [dm (get-ice state :remote1 0)]
-      (take-credits state :corp)
-      (play-from-hand state :runner "Ramujan-reliant 550 BMI")
-      (let [rr1 (get-in @state [:runner :rig :hardware 0])]
-        (run-on state "Server 1")
-        (core/rez state :corp dm)
-        (card-subroutine state :corp dm 0)
-        (card-ability state :runner rr1 0)
-        (prompt-choice :runner 1)
-        (is (= 0 (count (:hand (get-runner)))) "Not enough cards in Stack for Ramujan to work")))))
+        (play-from-hand state :runner "Ramujan-reliant 550 BMI")
+        (play-from-hand state :runner "Ramujan-reliant 550 BMI")
+        (let [rr1 (get-in @state [:runner :rig :hardware 0])
+              rr2 (get-in @state [:runner :rig :hardware 1])
+              rr3 (get-in @state [:runner :rig :hardware 2])]
+          (run-on state "Server 1")
+          (core/rez state :corp dm)
+          (card-subroutine state :corp dm 0)
+          (card-ability state :runner rr1 0)
+          (prompt-choice :runner 1)
+          (is (last-log-contains? state "Sure Gamble")
+              "Ramujan did log trashed card names")
+          (is (= 2 (count (:hand (get-runner)))) "1 net damage prevented")
+          (run-successful state)
+          (take-credits state :runner)
+          (take-credits state :corp)
+          (play-from-hand state :runner "Ramujan-reliant 550 BMI")
+          (run-empty-server state "Server 1")
+          (prompt-choice :corp "Yes")
+          (card-ability state :runner rr2 0)
+          (prompt-choice :runner 3)
+          (is (last-log-contains? state "Sure Gamble, Sure Gamble, Sure Gamble")
+              "Ramujan did log trashed card names")
+          (is (= 1 (count (:hand (get-runner)))) "3 net damage prevented")))))
+  (testing "Prevent up to X net or brain damage. Empty stack"
+    (do-game
+      (new-game (default-corp ["Data Mine"])
+                (default-runner ["Ramujan-reliant 550 BMI" "Sure Gamble"]))
+      (play-from-hand state :corp "Data Mine" "Server 1")
+      (let [dm (get-ice state :remote1 0)]
+        (take-credits state :corp)
+        (play-from-hand state :runner "Ramujan-reliant 550 BMI")
+        (let [rr1 (get-in @state [:runner :rig :hardware 0])]
+          (run-on state "Server 1")
+          (core/rez state :corp dm)
+          (card-subroutine state :corp dm 0)
+          (card-ability state :runner rr1 0)
+          (prompt-choice :runner 1)
+          (is (= 0 (count (:hand (get-runner)))) "Not enough cards in Stack for Ramujan to work"))))))
 
 (deftest recon-drone
   ;; trash and pay X to prevent that much damage from a card you are accessing
@@ -960,48 +941,46 @@
       (prompt-choice :runner "Done")
       (is (= 2 (count (:hand (get-runner)))) "Runner took no brain damage"))))
 
-(deftest replicator-bazaar
-  ;; Replicator - interaction with Bazaar. Issue #1511.
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Replicator" "Bazaar" (qty "Spy Camera" 6)]))
-    (letfn [(count-spy [n] (= n (count (filter #(= "Spy Camera" (:title %)) (-> (get-runner) :rig :hardware)))))]
+(deftest replicator
+  ;; Replicator
+  (testing "interaction with Bazaar. Issue #1511"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Replicator" "Bazaar" (qty "Spy Camera" 6)]))
+      (letfn [(count-spy [n] (= n (count (filter #(= "Spy Camera" (:title %)) (-> (get-runner) :rig :hardware)))))]
+        (take-credits state :corp)
+        (starting-hand state :runner ["Replicator" "Bazaar" "Spy Camera"])
+        (play-from-hand state :runner "Replicator")
+        (play-from-hand state :runner "Bazaar")
+        (play-from-hand state :runner "Spy Camera") ; 1 installed
+        (is (count-spy 1) "1 Spy Cameras installed")
+        (prompt-choice :runner "Yes") ; for now, choosing Replicator then shows its optional Yes/No
+        (prompt-choice :runner "Yes") ; Bazaar triggers, 2 installed
+        (is (count-spy 2) "2 Spy Cameras installed")
+        (prompt-choice :runner "Yes")
+        (prompt-choice :runner "Yes")  ; 3 installed
+        (is (count-spy 3) "3 Spy Cameras installed")
+        (prompt-choice :runner "Yes")
+        (prompt-choice :runner "Yes")  ; 4 installed
+        (is (count-spy 4) "4 Spy Cameras installed")
+        (prompt-choice :runner "Yes")
+        (prompt-choice :runner "Yes")  ; 5 installed
+        (is (count-spy 5) "5 Spy Cameras installed")
+        (prompt-choice :runner "Yes")
+        (prompt-choice :runner "Yes")  ; 6 installed
+        (is (count-spy 6) "6 Spy Cameras installed")))))
+
+(deftest respirocytes
+  (testing "Should draw multiple cards when multiple respirocytes are in play"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Respirocytes" 3) (qty "Sure Gamble" 3)]))
       (take-credits state :corp)
-      (starting-hand state :runner ["Replicator" "Bazaar" "Spy Camera"])
-      (play-from-hand state :runner "Replicator")
-      (play-from-hand state :runner "Bazaar")
-      (play-from-hand state :runner "Spy Camera") ; 1 installed
-      (is (count-spy 1) "1 Spy Cameras installed")
-      (prompt-choice :runner "Yes") ; for now, choosing Replicator then shows its optional Yes/No
-      (prompt-choice :runner "Yes") ; Bazaar triggers, 2 installed
-      (is (count-spy 2) "2 Spy Cameras installed")
-      (prompt-choice :runner "Yes")
-      (prompt-choice :runner "Yes")  ; 3 installed
-      (is (count-spy 3) "3 Spy Cameras installed")
-
-      (prompt-choice :runner "Yes")
-      (prompt-choice :runner "Yes")  ; 4 installed
-      (is (count-spy 4) "4 Spy Cameras installed")
-
-      (prompt-choice :runner "Yes")
-      (prompt-choice :runner "Yes")  ; 5 installed
-      (is (count-spy 5) "5 Spy Cameras installed")
-
-      (prompt-choice :runner "Yes")
-      (prompt-choice :runner "Yes")  ; 6 installed
-      (is (count-spy 6) "6 Spy Cameras installed"))))
-
-(deftest respirocytes-multiple
-  ;; Should draw multiple cards when multiple respirocytes are in play
-  (do-game
-   (new-game (default-corp)
-             (default-runner [(qty "Respirocytes" 3) (qty "Sure Gamble" 3)]))
-   (take-credits state :corp)
-   (starting-hand state :runner ["Respirocytes" "Respirocytes" "Respirocytes" "Sure Gamble"])
-   (dotimes [_ 2]
-     (play-from-hand state :runner "Respirocytes"))
-   (is (= 2 (count (:discard (get-runner)))) "2 damage done")
-   (is (= 2 (count (:hand (get-runner)))) "Drew 2 cards")))
+      (starting-hand state :runner ["Respirocytes" "Respirocytes" "Respirocytes" "Sure Gamble"])
+      (dotimes [_ 2]
+        (play-from-hand state :runner "Respirocytes"))
+      (is (= 2 (count (:discard (get-runner)))) "2 damage done")
+      (is (= 2 (count (:hand (get-runner)))) "Drew 2 cards"))))
 
 (deftest rubicon-switch
   ;; Rubicon Switch
@@ -1157,26 +1136,25 @@
         (is (= "The top card of R&D is Hedge Fund" topcard)))
       (is (= 1 (count (:discard (get-runner))))))))
 
-(deftest the-gauntlet-not-with-gang-sign
-  ;; Access additional cards on run on HQ, not with Gang Sign
-  ;; Issue #2749
-  (do-game
-    (new-game (default-corp ["Hostile Takeover"
-                             (qty "Hedge Fund" 3)])
-              (default-runner ["The Gauntlet"
-                               "Gang Sign"]))
-    (take-credits state :corp)
-    (core/gain state :runner :credit 5)
-    (play-from-hand state :runner "Gang Sign")
-    (play-from-hand state :runner "The Gauntlet")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    ;; Gang Sign should trigger, without The Gauntlet pop-up
-    (let [gs (get-resource state 0)]
-      (prompt-is-card? :runner gs))
-    ;; This will throw error if The Gauntlet triggers.
-    (prompt-choice :runner "Card from hand")))
+(deftest the-gauntlet
+  (testing "Access additional cards on run on HQ, not with Gang Sign. Issue #2749"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover"
+                               (qty "Hedge Fund" 3)])
+                (default-runner ["The Gauntlet"
+                                 "Gang Sign"]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 5)
+      (play-from-hand state :runner "Gang Sign")
+      (play-from-hand state :runner "The Gauntlet")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      ;; Gang Sign should trigger, without The Gauntlet pop-up
+      (let [gs (get-resource state 0)]
+        (prompt-is-card? :runner gs))
+      ;; This will throw error if The Gauntlet triggers.
+      (prompt-choice :runner "Card from hand"))))
 
 (deftest the-personal-touch
   ;; The Personal Touch - Give +1 strength to an icebreaker
@@ -1230,51 +1208,51 @@
         (prompt-choice :corp kati) ; Chronos Protocol takes precedence over Ribs on Corp turn
         (is (= 2 (count (:discard (get-runner)))) "Card chosen by Corp for first net damage")))))
 
-(deftest turntable-swap
+(deftest turntable
   ;; Turntable - Swap a stolen agenda for a scored agenda
-  (do-game
-    (new-game (default-corp ["Domestic Sleepers" "Project Vitruvius"])
-              (default-runner ["Turntable"]))
-    (play-from-hand state :corp "Project Vitruvius" "New remote")
-    (let [ag1 (get-content state :remote1 0)]
-      (score-agenda state :corp ag1)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Domestic Sleepers" "Project Vitruvius"])
+                (default-runner ["Turntable"]))
+      (play-from-hand state :corp "Project Vitruvius" "New remote")
+      (let [ag1 (get-content state :remote1 0)]
+        (score-agenda state :corp ag1)
+        (take-credits state :corp)
+        (play-from-hand state :runner "Turntable")
+        (is (= 3 (:credit (get-runner))))
+        (let [tt (get-in @state [:runner :rig :hardware 0])]
+          (run-empty-server state "HQ")
+          (prompt-choice :runner "Steal")
+          (is (= 0 (:agenda-point (get-runner))) "Stole Domestic Sleepers")
+          (is (prompt-is-card? :runner tt))
+          (prompt-choice :runner "Yes")
+          (prompt-select :runner (find-card "Project Vitruvius" (:scored (get-corp))))
+          (is (= 2 (:agenda-point (get-runner))) "Took Project Vitruvius from Corp")
+          (is (= 0 (:agenda-point (get-corp))) "Swapped Domestic Sleepers to Corp")))))
+  (testing "vs Mandatory Upgrades"
+    ;; Turntable - Swap a Mandatory Upgrades away from the Corp reduces Corp clicks per turn
+    ;;           - Corp doesn't gain a click on the Runner's turn when it receives a Mandatory Upgrades
+    (do-game
+      (new-game (default-corp [(qty "Mandatory Upgrades" 2) "Project Vitruvius"])
+                (default-runner ["Turntable"]))
+      (score-agenda state :corp (find-card "Mandatory Upgrades" (:hand (get-corp))))
+      (is (= 4 (:click-per-turn (get-corp))) "Up to 4 clicks per turn")
       (take-credits state :corp)
       (play-from-hand state :runner "Turntable")
-      (is (= 3 (:credit (get-runner))))
       (let [tt (get-in @state [:runner :rig :hardware 0])]
-        (run-empty-server state "HQ")
-        (prompt-choice :runner "Steal")
-        (is (= 0 (:agenda-point (get-runner))) "Stole Domestic Sleepers")
+        ;; steal Project Vitruvius and swap for Mandatory Upgrades
+        (core/steal state :runner (find-card "Project Vitruvius" (:hand (get-corp))))
+        (is (prompt-is-card? :runner tt))
+        (prompt-choice :runner "Yes")
+        (prompt-select :runner (find-card "Mandatory Upgrades" (:scored (get-corp))))
+        (is (= 3 (:click-per-turn (get-corp))) "Back down to 3 clicks per turn")
+        ;; steal second Mandatory Upgrades and swap for Project Vitruvius
+        (core/steal state :runner (find-card "Mandatory Upgrades" (:hand (get-corp))))
         (is (prompt-is-card? :runner tt))
         (prompt-choice :runner "Yes")
         (prompt-select :runner (find-card "Project Vitruvius" (:scored (get-corp))))
-        (is (= 2 (:agenda-point (get-runner))) "Took Project Vitruvius from Corp")
-        (is (= 0 (:agenda-point (get-corp))) "Swapped Domestic Sleepers to Corp")))))
-
-(deftest turntable-mandatory-upgrades
-  ;; Turntable - Swap a Mandatory Upgrades away from the Corp reduces Corp clicks per turn
-  ;;           - Corp doesn't gain a click on the Runner's turn when it receives a Mandatory Upgrades
-  (do-game
-    (new-game (default-corp [(qty "Mandatory Upgrades" 2) "Project Vitruvius"])
-              (default-runner ["Turntable"]))
-    (score-agenda state :corp (find-card "Mandatory Upgrades" (:hand (get-corp))))
-    (is (= 4 (:click-per-turn (get-corp))) "Up to 4 clicks per turn")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Turntable")
-    (let [tt (get-in @state [:runner :rig :hardware 0])]
-      ;; steal Project Vitruvius and swap for Mandatory Upgrades
-      (core/steal state :runner (find-card "Project Vitruvius" (:hand (get-corp))))
-      (is (prompt-is-card? :runner tt))
-      (prompt-choice :runner "Yes")
-      (prompt-select :runner (find-card "Mandatory Upgrades" (:scored (get-corp))))
-      (is (= 3 (:click-per-turn (get-corp))) "Back down to 3 clicks per turn")
-      ;; steal second Mandatory Upgrades and swap for Project Vitruvius
-      (core/steal state :runner (find-card "Mandatory Upgrades" (:hand (get-corp))))
-      (is (prompt-is-card? :runner tt))
-      (prompt-choice :runner "Yes")
-      (prompt-select :runner (find-card "Project Vitruvius" (:scored (get-corp))))
-      (is (= 0 (:click (get-corp))) "Corp doesn't gain a click on Runner's turn")
-      (is (= 4 (:click-per-turn (get-corp)))))))
+        (is (= 0 (:click (get-corp))) "Corp doesn't gain a click on Runner's turn")
+        (is (= 4 (:click-per-turn (get-corp))))))))
 
 (deftest vigil
   ;; Vigil - Draw 1 card when turn begins if Corp HQ is filled to max hand size

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -8,7 +8,7 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "ice"))
 
-(deftest end-the-run-test
+(deftest ^:skip-card-coverage end-the-run-test
   ;; Since all ETR ice share a common ability, we only need one test
   (do-game
     (new-game (default-corp [(qty "Ice Wall" 3) (qty "Hedge Fund" 3) (qty "Restructure" 2)])

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -8,7 +8,8 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "ice"))
 
-(deftest ^:skip-card-coverage end-the-run-test
+(deftest ^:skip-card-coverage
+  end-the-run-test
   ;; Since all ETR ice share a common ability, we only need one test
   (do-game
     (new-game (default-corp [(qty "Ice Wall" 3) (qty "Hedge Fund" 3) (qty "Restructure" 2)])
@@ -57,22 +58,22 @@
     (prompt-choice :runner "No action")
     (is (not (:run @state)) "Run ended")))
 
-(deftest architect-untrashable
-  ;; Architect is untrashable while installed and rezzed, but trashable if derezzed or from HQ
-  (do-game
-    (new-game (default-corp [(qty "Architect" 3)])
-              (default-runner))
-    (play-from-hand state :corp "Architect" "HQ")
-    (let [architect (get-ice state :hq 0)]
-      (core/rez state :corp architect)
-      (core/trash state :corp (refresh architect))
-      (is (not= nil (get-ice state :hq 0)) "Architect was trashed, but should be untrashable")
-      (core/derez state :corp (refresh architect))
-      (core/trash state :corp (refresh architect))
-      (is (= nil (get-ice state :hq 0)) "Architect was not trashed, but should be trashable")
-      (core/trash state :corp (get-in @state [:corp :hand 0]))
-      (is (= (get-in @state [:corp :discard 0 :title]) "Architect"))
-      (is (= (get-in @state [:corp :discard 1 :title]) "Architect")))))
+(deftest architect
+  (testing "Architect is untrashable while installed and rezzed, but trashable if derezzed or from HQ"
+    (do-game
+      (new-game (default-corp [(qty "Architect" 3)])
+                (default-runner))
+      (play-from-hand state :corp "Architect" "HQ")
+      (let [architect (get-ice state :hq 0)]
+        (core/rez state :corp architect)
+        (core/trash state :corp (refresh architect))
+        (is (not= nil (get-ice state :hq 0)) "Architect was trashed, but should be untrashable")
+        (core/derez state :corp (refresh architect))
+        (core/trash state :corp (refresh architect))
+        (is (= nil (get-ice state :hq 0)) "Architect was not trashed, but should be trashable")
+        (core/trash state :corp (get-in @state [:corp :hand 0]))
+        (is (= (get-in @state [:corp :discard 0 :title]) "Architect"))
+        (is (= (get-in @state [:corp :discard 1 :title]) "Architect"))))))
 
 (deftest asteroid-belt
   ;; Asteroid Belt - Space ICE rez cost reduced by 3 credits per advancement
@@ -401,43 +402,42 @@
 
 (deftest gemini
   ;; Gemini - Successfully trace to do 1 net damage; do 1 net damage if trace strength is 5 or more regardless of success
-  (do-game
-    (new-game (default-corp ["Gemini" (qty "Hedge Fund" 2)])
-              (default-runner [(qty "Sure Gamble" 3) (qty "Dirty Laundry" 2)]))
-    (play-from-hand state :corp "Gemini" "HQ")
-    (play-from-hand state :corp "Hedge Fund")
-    (play-from-hand state :corp "Hedge Fund")
-    (take-credits state :corp)
-    (let [gem (get-ice state :hq 0)]
-      (run-on state "HQ")
-      (core/rez state :corp gem)
-      (card-subroutine state :corp gem 0)
-      (prompt-choice :corp 3) ; boost to trace strength 5
-      (prompt-choice :runner 0)
-      (is (= 2 (count (:discard (get-runner)))) "Did 2 net damage")
-      (card-subroutine state :corp gem 0)
-      (prompt-choice :corp 3) ; boost to trace strength 5
-      (prompt-choice :runner 5) ; match trace
-      (is (= 3 (count (:discard (get-runner)))) "Did only 1 net damage for having trace strength 5 or more"))))
-
-(deftest gemini-chronos-protocol
-  ;; Gemini - Interaction with Chronos Protocol and kicker
-  (do-game
-    (new-game (make-deck "Chronos Protocol: Selective Mind-mapping" ["Gemini" (qty "Hedge Fund" 2)])
-              (default-runner ["Sure Gamble" (qty "Dirty Laundry" 2)]))
-    (play-from-hand state :corp "Gemini" "HQ")
-    (play-from-hand state :corp "Hedge Fund")
-    (play-from-hand state :corp "Hedge Fund")
-    (take-credits state :corp)
-    (let [gem (get-ice state :hq 0)]
-      (run-on state "HQ")
-      (core/rez state :corp gem)
-      (card-subroutine state :corp gem 0)
-      (prompt-choice :corp 3) ; boost to trace strength 5
-      (prompt-choice :runner 0)
-      (prompt-choice :corp "Yes")
-      (prompt-card :corp (find-card "Sure Gamble" (:hand (get-runner))))
-      (is (= 2 (count (:discard (get-runner)))) "Did 2 net damage"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Gemini" (qty "Hedge Fund" 2)])
+                (default-runner [(qty "Sure Gamble" 3) (qty "Dirty Laundry" 2)]))
+      (play-from-hand state :corp "Gemini" "HQ")
+      (play-from-hand state :corp "Hedge Fund")
+      (play-from-hand state :corp "Hedge Fund")
+      (take-credits state :corp)
+      (let [gem (get-ice state :hq 0)]
+        (run-on state "HQ")
+        (core/rez state :corp gem)
+        (card-subroutine state :corp gem 0)
+        (prompt-choice :corp 3) ; boost to trace strength 5
+        (prompt-choice :runner 0)
+        (is (= 2 (count (:discard (get-runner)))) "Did 2 net damage")
+        (card-subroutine state :corp gem 0)
+        (prompt-choice :corp 3) ; boost to trace strength 5
+        (prompt-choice :runner 5) ; match trace
+        (is (= 3 (count (:discard (get-runner)))) "Did only 1 net damage for having trace strength 5 or more"))))
+  (testing "Interaction with Chronos Protocol and kicker"
+    (do-game
+      (new-game (make-deck "Chronos Protocol: Selective Mind-mapping" ["Gemini" (qty "Hedge Fund" 2)])
+                (default-runner ["Sure Gamble" (qty "Dirty Laundry" 2)]))
+      (play-from-hand state :corp "Gemini" "HQ")
+      (play-from-hand state :corp "Hedge Fund")
+      (play-from-hand state :corp "Hedge Fund")
+      (take-credits state :corp)
+      (let [gem (get-ice state :hq 0)]
+        (run-on state "HQ")
+        (core/rez state :corp gem)
+        (card-subroutine state :corp gem 0)
+        (prompt-choice :corp 3) ; boost to trace strength 5
+        (prompt-choice :runner 0)
+        (prompt-choice :corp "Yes")
+        (prompt-card :corp (find-card "Sure Gamble" (:hand (get-runner))))
+        (is (= 2 (count (:discard (get-runner)))) "Did 2 net damage")))))
 
 (deftest holmegaard
   ;; Holmegaard - Stop Runner from accessing cards if win trace
@@ -486,7 +486,8 @@
                  (= 3 (:current-strength (refresh iq2)))
                  (= 2 (:credit (get-corp)))) "3 cards in HQ: paid 3 to rez, both have 3 strength")))))
 
-(deftest its-a-trap
+(deftest ^{:card-title "it's-a-trap!"}
+  its-a-trap
   ;; It's a Trap! - 2 net dmg on expose, self-trash and make Runner trash installed card
   (do-game
     (new-game (default-corp ["It's a Trap!"])
@@ -506,79 +507,75 @@
       (is (= 4 (count (:discard (get-runner)))) "Cache trashed")
       (is (= 1 (count (:discard (get-corp)))) "It's a Trap trashed"))))
 
-(deftest jua-encounter
-  ;; Jua (encounter effect) - Prevent Runner from installing cards for the rest of the turn
-  (do-game
-    (new-game (default-corp ["Jua"])
-              (default-runner ["Desperado" "Sure Gamble"]))
-    (play-from-hand state :corp "Jua" "HQ")
-    (take-credits state :corp)
-    (let [jua (get-ice state :hq 0)]
-      (run-on state "HQ")
-      (core/rez state :corp jua)
-      (card-ability state :corp (refresh jua) 0)
-      (run-successful state)
-      (is (= 2 (count (:hand (get-runner)))) "Runner starts with 2 cards in hand")
-      (play-from-hand state :runner "Desperado")
-      (is (= 2 (count (:hand (get-runner)))) "No cards installed")
-      (play-from-hand state :runner "Sure Gamble")
-      (is (= 1 (count (:hand (get-runner)))) "Can play events")
-      (take-credits state :runner)
+(deftest jua
+  (testing "Encounter effect - Prevent Runner from installing cards for the rest of the turn"
+    (do-game
+      (new-game (default-corp ["Jua"])
+                (default-runner ["Desperado" "Sure Gamble"]))
+      (play-from-hand state :corp "Jua" "HQ")
       (take-credits state :corp)
-      (is (= 1 (count (:hand (get-runner)))) "Runner starts with 1 cards in hand")
-      (play-from-hand state :runner "Desperado")
-      (is (= 0 (count (:hand (get-runner)))) "Card installed"))))
+      (let [jua (get-ice state :hq 0)]
+        (run-on state "HQ")
+        (core/rez state :corp jua)
+        (card-ability state :corp (refresh jua) 0)
+        (run-successful state)
+        (is (= 2 (count (:hand (get-runner)))) "Runner starts with 2 cards in hand")
+        (play-from-hand state :runner "Desperado")
+        (is (= 2 (count (:hand (get-runner)))) "No cards installed")
+        (play-from-hand state :runner "Sure Gamble")
+        (is (= 1 (count (:hand (get-runner)))) "Can play events")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 1 (count (:hand (get-runner)))) "Runner starts with 1 cards in hand")
+        (play-from-hand state :runner "Desperado")
+        (is (= 0 (count (:hand (get-runner)))) "Card installed"))))
+  (testing "Subroutine effect - Select 2 runner cards, runner moves one to the stack"
+    (do-game
+      (new-game (default-corp ["Jua"])
+                (default-runner ["Desperado" "Gordian Blade"]))
+      (play-from-hand state :corp "Jua" "HQ")
+      (take-credits state :corp)
+      (let [jua (get-ice state :hq 0)]
+        (core/gain state :runner :credit 10)
+        (play-from-hand state :runner "Desperado")
+        (run-on state "HQ")
+        (core/rez state :corp jua)
+        (card-subroutine state :corp (refresh jua) 0)
+        (is (empty? (:prompt (get-corp))) "Can't fire for 1 installed card")
+        (run-successful state)
+        (play-from-hand state :runner "Gordian Blade")
+        (run-on state "HQ")
+        (card-subroutine state :corp (refresh jua) 0)
+        (prompt-select :corp (get-program state 0))
+        (prompt-select :corp (get-hardware state 0))
+        (prompt-card :runner (get-program state 0))
+        (is (nil? (get-program state 0)) "Card is uninstalled")
+        (is (= 1 (count (:deck (get-runner)))) "Runner puts card in deck")))))
 
-(deftest jua-sub
-  ;; Jua (subroutine effect) - Select 2 runner cards, runner moves one to the stack
-  (do-game
-    (new-game (default-corp ["Jua"])
-              (default-runner ["Desperado" "Gordian Blade"]))
-    (play-from-hand state :corp "Jua" "HQ")
-    (take-credits state :corp)
-    (let [jua (get-ice state :hq 0)]
-      (core/gain state :runner :credit 10)
-      (play-from-hand state :runner "Desperado")
-      (run-on state "HQ")
-      (core/rez state :corp jua)
-      (card-subroutine state :corp (refresh jua) 0)
-      (is (empty? (:prompt (get-corp))) "Can't fire for 1 installed card")
-      (run-successful state)
-      (play-from-hand state :runner "Gordian Blade")
-      (run-on state "HQ")
-      (card-subroutine state :corp (refresh jua) 0)
-      (prompt-select :corp (get-program state 0))
-      (prompt-select :corp (get-hardware state 0))
-      (prompt-card :runner (get-program state 0))
-      (is (nil? (get-program state 0)) "Card is uninstalled")
-      (is (= 1 (count (:deck (get-runner)))) "Runner puts card in deck"))))
+(deftest kakugo
+  ;; Kakugo
+  (testing "ability continues to work when ice is swapped"
+    (do-game
+      (new-game (default-corp ["Kakugo"
+                               "Ice Wall"])
+                (default-runner))
+      (play-from-hand state :corp "Kakugo" "R&D")
+      (play-from-hand state :corp "Ice Wall" "Archives")
+      (take-credits state :corp)
+      (let [kakugo   (get-ice state :rd 0)
+            ice-wall (get-ice state :archives 0)]
+        (run-on state "R&D")
+        (core/rez state :corp kakugo)
+        (run-continue state)
+        (run-jack-out state)
+        (is (= 2 (count (:hand (get-runner)))) "Runner took damage before swap")
+        (core/swap-ice state :corp (refresh kakugo) (refresh ice-wall))
+        (run-on state "Archives")
+        (run-continue state)
+        (run-jack-out state)
+        (is (= 1 (count (:hand (get-runner)))) "Runner took damage after swap")))))
 
-(deftest kakugo-swap
-  ;; Kakugo - ability continues to work when ice is swapped
-  (do-game
-   (new-game (default-corp ["Kakugo"
-                            "Ice Wall"])
-             (default-runner))
-   (play-from-hand state :corp "Kakugo" "R&D")
-   (play-from-hand state :corp "Ice Wall" "Archives")
-   (take-credits state :corp)
-
-   (let [kakugo   (get-ice state :rd 0)
-         ice-wall (get-ice state :archives 0)]
-     (run-on state "R&D")
-     (core/rez state :corp kakugo)
-     (run-continue state)
-     (run-jack-out state)
-     (is (= 2 (count (:hand (get-runner)))) "Runner took damage before swap")
-
-     (core/swap-ice state :corp (refresh kakugo) (refresh ice-wall))
-
-     (run-on state "Archives")
-     (run-continue state)
-     (run-jack-out state)
-     (is (= 1 (count (:hand (get-runner)))) "Runner took damage after swap"))))
-
-(deftest kamali
+(deftest kamali-1.0
   ;; Kamali 1.0
   (do-game
     (new-game (default-corp ["Kamali 1.0"])
@@ -586,27 +583,22 @@
                                "Cache" "Hedge Fund"]))
     (play-from-hand state :corp "Kamali 1.0" "HQ")
     (take-credits state :corp)
-
     (play-from-hand state :runner "Astrolabe")
     (play-from-hand state :runner "Decoy")
     (play-from-hand state :runner "Cache")
-
    (let [kamali (get-ice state :hq 0)]
      (run-on state "HQ")
      (core/rez state :corp kamali)
-
      (card-subroutine state :corp kamali 0)
      (is (zero? (:brain-damage (get-runner))) "Runner starts with 0 brain damage")
      (prompt-choice :runner "Take 1 brain damage")
      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")
-
      (card-subroutine state :corp kamali 1)
      (is (empty? (:discard (get-runner))) "Runner starts with no discarded cards")
      (prompt-choice :runner "Trash an installed piece of hardware")
      (prompt-select :runner (get-hardware state 0))
      (is (empty? (get-in @state [:runner :rig :hardware])) "Astrolabe trashed")
      (is (= 1 (count (:discard (get-runner)))) "Runner trashed 1 card")
-
      (card-subroutine state :corp kamali 2)
      (is (= 1 (count (:discard (get-runner)))) "Runner starts with 1 discarded card")
      (prompt-choice :runner "Trash an installed program")
@@ -655,7 +647,7 @@
       (is (= 3 (count (:hand (get-runner))))
           "New turn ends prevention; remaining 3 cards drawn from Stack"))))
 
-(deftest lotus-field-unlowerable
+(deftest lotus-field
   ;; Lotus Field strength cannot be lowered
   (do-game
     (new-game (default-corp ["Lotus Field" "Lag Time"])
@@ -897,32 +889,6 @@
       (is (= 3 (count (:discard (get-runner)))) "Runner trashed 2 cards")
       (is (empty? (:deck (get-runner))) "Runner trashed card from stack"))))
 
-(deftest morph-ice-subtype-changing
-  ;; Morph ice gain and lose subtypes from normal advancements and placed advancements
-  (do-game
-    (new-game (default-corp ["Wendigo"
-                             "Shipment from SanSan"
-                             "Superior Cyberwalls"])
-              (default-runner))
-    (core/gain state :corp :click 2)
-    (play-from-hand state :corp "Superior Cyberwalls" "New remote")
-    (let [sc (get-content state :remote1 0)]
-      (score-agenda state :corp sc)
-      (play-from-hand state :corp "Wendigo" "HQ")
-      (let [wend (get-ice state :hq 0)]
-        (core/rez state :corp wend)
-        (is (= 4 (:current-strength (refresh wend))) "Wendigo at normal 4 strength")
-        (core/advance state :corp {:card (refresh wend)})
-        (is (= true (has? (refresh wend) :subtype "Barrier")) "Wendigo gained Barrier")
-        (is (= false (has? (refresh wend) :subtype "Code Gate")) "Wendigo lost Code Gate")
-        (is (= 5 (:current-strength (refresh wend))) "Wendigo boosted to 5 strength by scored Superior Cyberwalls")
-        (play-from-hand state :corp "Shipment from SanSan")
-        (prompt-choice :corp "1")
-        (prompt-select :corp wend)
-        (is (= false (has? (refresh wend) :subtype "Barrier")) "Wendigo lost Barrier")
-        (is (= true (has? (refresh wend) :subtype "Code Gate")) "Wendigo gained Code Gate")
-        (is (= 4 (:current-strength (refresh wend))) "Wendigo returned to normal 4 strength")))))
-
 (deftest mother-goddess
   ;; Mother Goddess - Gains other ice subtypes
   (do-game
@@ -1049,9 +1015,7 @@
       (card-ability state :corp (refresh odu) 1)
       (prompt-select :corp (refresh eni))
       (is (= 3 (:advance-counter (refresh odu))))
-      (is (= 6 (:advance-counter (refresh eni))))
-      )))
-
+      (is (= 6 (:advance-counter (refresh eni)))))))
 
 (deftest resistor
   ;; Resistor - Strength equal to Runner tags, lose strength when Runner removes a tag
@@ -1069,61 +1033,60 @@
       (core/remove-tag state :runner 1)
       (is (= 1 (:current-strength (refresh resistor))) "Runner removed 1 tag; down to 1 strength"))))
 
-(deftest sadaka-sub1
-  ;; Sadaka - Look at the top 3 cards of R&D, arrange those or shuffle R&D. You may draw 1 card.
-  (do-game
-    (new-game (default-corp ["Sadaka" (qty "Enigma" 3)])
-              (default-runner))
-    (starting-hand state :corp ["Sadaka"])
-    (play-from-hand state :corp "Sadaka" "Archives")
-    (let [sadaka (get-ice state :archives 0)]
-      (take-credits state :corp)
-      (run-on state "archives")
-      (core/rez state :corp sadaka)
-      (is (= 0 (count (:hand (get-corp)))) "Corp starts with empty hand")
-      (card-subroutine state :corp (refresh sadaka) 0)
-      (prompt-choice :corp "Shuffle R&D")
-      (prompt-choice :corp "Yes")
-      (is (= 1 (count (:hand (get-corp)))) "Corp draws a card")
-      (card-subroutine state :corp (refresh sadaka) 0)
-      (prompt-choice :corp "Shuffle R&D")
-      (prompt-choice :corp "No")
-      (is (= 1 (count (:hand (get-corp)))) "Corp doesn't draw a card"))))
-
-(deftest sadaka-sub2
-  ;; Sadaka - You may trash 1 card in HQ. If you do, trash 1 resource. Trash Sadaka.
-  (do-game
-    (new-game (default-corp [(qty "Sadaka" 2) (qty "Enigma" 3)])
-              (default-runner ["Bank Job"]))
-    (play-from-hand state :corp "Sadaka" "Archives")
-    (play-from-hand state :corp "Sadaka" "HQ")
-    (let [sadaka (get-ice state :archives 0)
-          sadakaHQ (get-ice state :hq 0)]
-      (take-credits state :corp)
-      (play-from-hand state :runner "Bank Job")
-      (run-on state "archives")
-      (core/rez state :corp sadaka)
-      (is (= 3 (count (:hand (get-corp)))) "Corp starts with 3 cards in hand")
-      (is (= 0 (count (:discard (get-corp)))) "Corps starts with 0 cards in archives")
-      (card-subroutine state :corp (refresh sadaka) 1)
-      (prompt-card :corp (find-card "Enigma" (:hand (get-corp))))
-      (is (= 2 (count (:hand (get-corp)))) "Corp discards 1 card")
-      (is (= 1 (count (:discard (get-corp)))) "1 card trashed")
-      (prompt-choice :corp "Done")
-      (is (= 2 (count (:discard (get-corp)))) "Sadaka trashed")
-      (run-jack-out state)
-      (run-on state "archives")
-      (core/rez state :corp sadakaHQ)
-      (is (= 2 (count (:hand (get-corp)))) "Corp starts with 2 cards in hand")
-      (is (= 2 (count (:discard (get-corp)))) "Corps starts with 2 cards in archives")
-      (is (= 0 (count (:discard (get-runner)))) "Runner starts with 0 cards in discard")
-      (card-subroutine state :corp (refresh sadakaHQ) 1)
-      (prompt-card :corp (find-card "Enigma" (:hand (get-corp))))
-      (is (= 1 (count (:hand (get-corp)))) "Corp discards 1 card")
-      (is (= 3 (count (:discard (get-corp)))) "1 card trashed")
-      (prompt-select :corp (get-resource state 0))
-      (is (= 1 (count (:discard (get-runner)))) "Runner resource trashed")
-      (is (= 4 (count (:discard (get-corp)))) "sadakaHQ trashed"))))
+(deftest sadaka
+  ;; Sadaka
+  (testing "Sub 1 - Look at the top 3 cards of R&D, arrange those or shuffle R&D. You may draw 1 card"
+    (do-game
+      (new-game (default-corp ["Sadaka" (qty "Enigma" 3)])
+                (default-runner))
+      (starting-hand state :corp ["Sadaka"])
+      (play-from-hand state :corp "Sadaka" "Archives")
+      (let [sadaka (get-ice state :archives 0)]
+        (take-credits state :corp)
+        (run-on state "archives")
+        (core/rez state :corp sadaka)
+        (is (= 0 (count (:hand (get-corp)))) "Corp starts with empty hand")
+        (card-subroutine state :corp (refresh sadaka) 0)
+        (prompt-choice :corp "Shuffle R&D")
+        (prompt-choice :corp "Yes")
+        (is (= 1 (count (:hand (get-corp)))) "Corp draws a card")
+        (card-subroutine state :corp (refresh sadaka) 0)
+        (prompt-choice :corp "Shuffle R&D")
+        (prompt-choice :corp "No")
+        (is (= 1 (count (:hand (get-corp)))) "Corp doesn't draw a card"))))
+  (testing "Sub 2 - You may trash 1 card in HQ. If you do, trash 1 resource. Trash Sadaka."
+    (do-game
+      (new-game (default-corp [(qty "Sadaka" 2) (qty "Enigma" 3)])
+                (default-runner ["Bank Job"]))
+      (play-from-hand state :corp "Sadaka" "Archives")
+      (play-from-hand state :corp "Sadaka" "HQ")
+      (let [sadaka (get-ice state :archives 0)
+            sadakaHQ (get-ice state :hq 0)]
+        (take-credits state :corp)
+        (play-from-hand state :runner "Bank Job")
+        (run-on state "archives")
+        (core/rez state :corp sadaka)
+        (is (= 3 (count (:hand (get-corp)))) "Corp starts with 3 cards in hand")
+        (is (= 0 (count (:discard (get-corp)))) "Corps starts with 0 cards in archives")
+        (card-subroutine state :corp (refresh sadaka) 1)
+        (prompt-card :corp (find-card "Enigma" (:hand (get-corp))))
+        (is (= 2 (count (:hand (get-corp)))) "Corp discards 1 card")
+        (is (= 1 (count (:discard (get-corp)))) "1 card trashed")
+        (prompt-choice :corp "Done")
+        (is (= 2 (count (:discard (get-corp)))) "Sadaka trashed")
+        (run-jack-out state)
+        (run-on state "archives")
+        (core/rez state :corp sadakaHQ)
+        (is (= 2 (count (:hand (get-corp)))) "Corp starts with 2 cards in hand")
+        (is (= 2 (count (:discard (get-corp)))) "Corps starts with 2 cards in archives")
+        (is (= 0 (count (:discard (get-runner)))) "Runner starts with 0 cards in discard")
+        (card-subroutine state :corp (refresh sadakaHQ) 1)
+        (prompt-card :corp (find-card "Enigma" (:hand (get-corp))))
+        (is (= 1 (count (:hand (get-corp)))) "Corp discards 1 card")
+        (is (= 3 (count (:discard (get-corp)))) "1 card trashed")
+        (prompt-select :corp (get-resource state 0))
+        (is (= 1 (count (:discard (get-runner)))) "Runner resource trashed")
+        (is (= 4 (count (:discard (get-corp)))) "sadakaHQ trashed")))))
 
 (deftest sandman
   ;; Sandman - add an installed runner card to the grip
@@ -1132,7 +1095,6 @@
               (default-runner ["Inti" "Scrubber"]))
     (play-from-hand state :corp "Sandman" "HQ")
     (take-credits state :corp)
-
     (play-from-hand state :runner "Inti")
     (play-from-hand state :runner "Scrubber")
     (is (zero? (count (:hand (get-runner)))) "Runner's hand is empty")
@@ -1181,8 +1143,8 @@
       (play-from-hand state :corp "Ice Wall" "HQ")
       (is (= 5 (:current-strength (refresh sab))) "+3 strength for 3 pieces of ICE"))))
 
-(deftest self-adapting-code-wall-unlowerable
-  ;; self-adapting code wall strength cannot be lowered
+(deftest self-adapting-code-wall
+  ;; Self-Adapting Code Wall
   (do-game
     (new-game (default-corp ["Self-Adapting Code Wall" "Lag Time"])
               (default-runner ["Ice Carver" "Parasite"]))
@@ -1208,7 +1170,7 @@
       (take-credits state :corp 2)
       (is (= 2 (:current-strength (refresh sacw))) "Self-Adapting Code Wall strength increased"))))
 
-(deftest sherlock
+(deftest sherlock-1.0
   ;; Sherlock 1.0 - Trace to add an installed program to the top of Runner's Stack
   (do-game
     (new-game (default-corp ["Sherlock 1.0"])
@@ -1277,7 +1239,7 @@
       (prompt-choice :runner "1 [Credits]")
       (is (not (:run @state)) "Run ended"))))
 
-(deftest special-offer-trash-ice-during-run
+(deftest special-offer
   ;; Special Offer trashes itself and updates the run position
   (do-game
     (new-game (default-corp ["Ice Wall" "Special Offer"])
@@ -1295,8 +1257,7 @@
       (is (= 1 (:position (get-in @state [:run])))
           "Run position updated; now approaching Ice Wall"))))
 
-
-(deftest sand-storm-alone
+(deftest sand-storm
   ;; Sand Storm should not end the run if protecting an otherwise empty/naked server
   (do-game
     (new-game (default-corp ["Sand Storm" "PAD Campaign"])
@@ -1313,90 +1274,88 @@
 
 (deftest tithonium
   ;; Forfeit option as rez cost, can have hosted condition counters
-  (do-game
-    (new-game (default-corp ["Hostile Takeover" "Tithonium" "Patch"])
-              (default-runner ["Pawn" "Wasteland"]))
-    (core/gain state :corp :click 10)
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (play-from-hand state :corp "Tithonium" "HQ")
-    (let [ht (get-content state :remote1 0)
-          ti (get-ice state :hq 0)]
-      (score-agenda state :corp ht)
-      (is (= 1 (count (:scored (get-corp)))) "Agenda scored")
-      (is (= 12 (:credit (get-corp))) "Gained 7 credits")
-      (core/rez state :corp ti)
-      (prompt-choice :corp "No") ; don't use alternative cost
-      (is (= 3 (:credit (get-corp))) "Spent 9 to Rez")
-      (core/derez state :corp (refresh ti))
-      (core/rez state :corp ti)
-      (prompt-choice :corp "Yes") ; use alternative cost
-      (prompt-select :corp (get-in (get-corp) [:scored 0]))
-      (is (= 3 (:credit (get-corp))) "Still on 3c")
-      (is (= 0 (count (:scored (get-corp)))) "Agenda forfeited")
-      ;; Can Host Conditions Counters
-      (play-from-hand state :corp "Patch")
-      (prompt-select :corp (refresh ti))
-      (is (= 1 (count (:hosted (refresh ti)))) "1 card on Tithonium")
-      (take-credits state :corp)
-      (core/derez state :corp (refresh ti))
-      (is (= 1 (count (:hosted (refresh ti)))) "1 card on Tithonium")
-      (play-from-hand state :runner "Pawn")
-      (play-from-hand state :runner "Wasteland")
-      (let [pawn (get-program state 0)
-            wast (get-resource state 0)]
-        (card-ability state :runner (refresh pawn) 0)
-        (prompt-select :runner (refresh ti))
-        (is (= 2 (count (:hosted (refresh ti)))) "2 cards on Tithonium")
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover" "Tithonium" "Patch"])
+                (default-runner ["Pawn" "Wasteland"]))
+      (core/gain state :corp :click 10)
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (play-from-hand state :corp "Tithonium" "HQ")
+      (let [ht (get-content state :remote1 0)
+            ti (get-ice state :hq 0)]
+        (score-agenda state :corp ht)
+        (is (= 1 (count (:scored (get-corp)))) "Agenda scored")
+        (is (= 12 (:credit (get-corp))) "Gained 7 credits")
+        (core/rez state :corp ti)
+        (prompt-choice :corp "No") ; don't use alternative cost
+        (is (= 3 (:credit (get-corp))) "Spent 9 to Rez")
         (core/derez state :corp (refresh ti))
-        (is (= 2 (count (:hosted (refresh ti)))) "2 cards on Tithonium")
-        (run-on state "HQ")
-        (card-subroutine state :corp ti 2)
-        (prompt-select :corp (refresh wast))
-        (is (= 1 (count (:discard (get-runner)))) "1 card trashed")
-        (card-subroutine state :corp ti 1)
-        (is (not (:run @state)) "Run ended")))))
-
-(deftest tithonium-oversight-ai
-  ;; Do not prompt for alt cost #2734
-  (do-game
-    (new-game (default-corp ["Hostile Takeover" "Oversight AI" "Tithonium"])
-              (default-runner))
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (play-from-hand state :corp "Tithonium" "R&D")
-    (let [ht (get-content state :remote1 0)
-          ti (get-ice state :rd 0)]
-      (score-agenda state :corp ht)
-      (play-from-hand state :corp "Oversight AI")
-      (prompt-select :corp ti)
-      (is (get-in (refresh ti) [:rezzed]))
-      (is (= "Oversight AI" (:title (first (:hosted (refresh ti)))))
-          "Tithonium hosting OAI as a condition"))))
+        (core/rez state :corp ti)
+        (prompt-choice :corp "Yes") ; use alternative cost
+        (prompt-select :corp (get-in (get-corp) [:scored 0]))
+        (is (= 3 (:credit (get-corp))) "Still on 3c")
+        (is (= 0 (count (:scored (get-corp)))) "Agenda forfeited")
+        ;; Can Host Conditions Counters
+        (play-from-hand state :corp "Patch")
+        (prompt-select :corp (refresh ti))
+        (is (= 1 (count (:hosted (refresh ti)))) "1 card on Tithonium")
+        (take-credits state :corp)
+        (core/derez state :corp (refresh ti))
+        (is (= 1 (count (:hosted (refresh ti)))) "1 card on Tithonium")
+        (play-from-hand state :runner "Pawn")
+        (play-from-hand state :runner "Wasteland")
+        (let [pawn (get-program state 0)
+              wast (get-resource state 0)]
+          (card-ability state :runner (refresh pawn) 0)
+          (prompt-select :runner (refresh ti))
+          (is (= 2 (count (:hosted (refresh ti)))) "2 cards on Tithonium")
+          (core/derez state :corp (refresh ti))
+          (is (= 2 (count (:hosted (refresh ti)))) "2 cards on Tithonium")
+          (run-on state "HQ")
+          (card-subroutine state :corp ti 2)
+          (prompt-select :corp (refresh wast))
+          (is (= 1 (count (:discard (get-runner)))) "1 card trashed")
+          (card-subroutine state :corp ti 1)
+          (is (not (:run @state)) "Run ended")))))
+  (testing "Do not prompt for alt cost #2734"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover" "Oversight AI" "Tithonium"])
+                (default-runner))
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (play-from-hand state :corp "Tithonium" "R&D")
+      (let [ht (get-content state :remote1 0)
+            ti (get-ice state :rd 0)]
+        (score-agenda state :corp ht)
+        (play-from-hand state :corp "Oversight AI")
+        (prompt-select :corp ti)
+        (is (get-in (refresh ti) [:rezzed]))
+        (is (= "Oversight AI" (:title (first (:hosted (refresh ti)))))
+            "Tithonium hosting OAI as a condition")))))
 
 (deftest tmi
   ;; TMI ICE test
-  (do-game
-    (new-game (default-corp [(qty "TMI" 3)])
-              (default-runner))
-    (play-from-hand state :corp "TMI" "HQ")
-    (let [tmi (get-ice state :hq 0)]
-      (core/rez state :corp tmi)
-      (prompt-choice :corp 0)
-      (prompt-choice :runner 0)
-      (is (get-in (refresh tmi) [:rezzed])))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "TMI" 3)])
+                (default-runner))
+      (play-from-hand state :corp "TMI" "HQ")
+      (let [tmi (get-ice state :hq 0)]
+        (core/rez state :corp tmi)
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (get-in (refresh tmi) [:rezzed])))))
+  (testing "Losing trace derezzes TMI"
+    (do-game
+      (new-game (default-corp [(qty "TMI" 3)])
+                (make-deck "Sunny Lebeau: Security Specialist" [(qty "Blackmail" 3)]))
+      (play-from-hand state :corp "TMI" "HQ")
+      (let [tmi (get-ice state :hq 0)]
+        (core/rez state :corp tmi)
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (not (get-in (refresh tmi) [:rezzed])))))))
 
-(deftest tmi-derez
-  ;; TMI ICE trace derez
-  (do-game
-    (new-game (default-corp [(qty "TMI" 3)])
-              (make-deck "Sunny Lebeau: Security Specialist" [(qty "Blackmail" 3)]))
-    (play-from-hand state :corp "TMI" "HQ")
-    (let [tmi (get-ice state :hq 0)]
-      (core/rez state :corp tmi)
-      (prompt-choice :corp 0)
-      (prompt-choice :runner 0)
-      (is (not (get-in (refresh tmi) [:rezzed]))))))
-
-(deftest turing-positional-strength
+(deftest turing
   ;; Turing - Strength boosted when protecting a remote server
   (do-game
     (new-game (default-corp [(qty "Turing" 2) "Hedge Fund"])
@@ -1427,6 +1386,31 @@
       (is (empty? (filter #(= "Ubax" (:title %)) (:discard (get-runner)))) "Ubax not trashed")
       (is (empty? (filter #(= "Caldera" (:title %)) (:discard (get-runner)))) "Caldera not trashed")
       (is (= 2 (count (:discard (get-runner)))) "2 cards trashed"))))
+
+(deftest wendigo
+  ;; Morph ice gain and lose subtypes from normal advancements and placed advancements
+  (do-game
+    (new-game (default-corp ["Wendigo" "Shipment from SanSan"
+                             "Superior Cyberwalls"])
+              (default-runner))
+    (core/gain state :corp :click 2)
+    (play-from-hand state :corp "Superior Cyberwalls" "New remote")
+    (let [sc (get-content state :remote1 0)]
+      (score-agenda state :corp sc)
+      (play-from-hand state :corp "Wendigo" "HQ")
+      (let [wend (get-ice state :hq 0)]
+        (core/rez state :corp wend)
+        (is (= 4 (:current-strength (refresh wend))) "Wendigo at normal 4 strength")
+        (core/advance state :corp {:card (refresh wend)})
+        (is (= true (has? (refresh wend) :subtype "Barrier")) "Wendigo gained Barrier")
+        (is (= false (has? (refresh wend) :subtype "Code Gate")) "Wendigo lost Code Gate")
+        (is (= 5 (:current-strength (refresh wend))) "Wendigo boosted to 5 strength by scored Superior Cyberwalls")
+        (play-from-hand state :corp "Shipment from SanSan")
+        (prompt-choice :corp "1")
+        (prompt-select :corp wend)
+        (is (= false (has? (refresh wend) :subtype "Barrier")) "Wendigo lost Barrier")
+        (is (= true (has? (refresh wend) :subtype "Code Gate")) "Wendigo gained Code Gate")
+        (is (= 4 (:current-strength (refresh wend))) "Wendigo returned to normal 4 strength")))))
 
 (deftest wraparound
   ;; Wraparound - Strength boosted when no fracter is installed

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -8,7 +8,7 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "ice"))
 
-(deftest end-the-run
+(deftest end-the-run-test
   ;; Since all ETR ice share a common ability, we only need one test
   (do-game
     (new-game (default-corp [(qty "Ice Wall" 3) (qty "Hedge Fund" 3) (qty "Restructure" 2)])

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -7,7 +7,8 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "identities"))
 
-(deftest FourHundredAndNineTeen-amoral-scammer
+(deftest ^{:card-title "419:-amoral-scammer"}
+  FourHundredAndNineTeen-amoral-scammer
   ;; 419
   (testing "basic test: Amoral Scammer - expose first installed card unless corp pays 1 credit"
     (do-game
@@ -75,7 +76,7 @@
         (is (= 1 (- corp-credits (:credit (get-corp)))) "Should lose 1 credit from 419 ability")
         (is (= 0 (- runner-credits (:credit (get-runner)))) "Should not gain any credits from Ixodidae")))))
 
-(deftest adam
+(deftest adam:-compulsive-hacker
   ;; Adam
   (testing "Allow runner to choose directives"
     (do-game
@@ -128,37 +129,34 @@
       (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")
       (is (= 1 (count (:discard (get-corp)))) "1 card in archives"))))
 
-(deftest andromeda
+(deftest andromeda:-dispossessed-ristie
   ;; Andromeda - 9 card starting hand, 1 link
-  (do-game
-    (new-game
-      (default-corp)
-      (make-deck "Andromeda: Dispossessed Ristie" [(qty "Sure Gamble" 3) (qty "Desperado" 3)
-                                                   (qty "Security Testing" 3) (qty "Bank Job" 3)]))
-    (is (= 1 (:link (get-runner))) "1 link")
-    (is (= 9 (count (:hand (get-runner)))) "9 cards in Andromeda starting hand")))
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (default-corp)
+        (make-deck "Andromeda: Dispossessed Ristie" [(qty "Sure Gamble" 3) (qty "Desperado" 3)
+                                                     (qty "Security Testing" 3) (qty "Bank Job" 3)]))
+      (is (= 1 (:link (get-runner))) "1 link")
+      (is (= 9 (count (:hand (get-runner)))) "9 cards in Andromeda starting hand")))
+  (testing "9 card starting hand after mulligan"
+    (do-game
+      (new-game
+        (default-corp)
+        (make-deck "Andromeda: Dispossessed Ristie" [(qty "Sure Gamble" 3) (qty "Desperado" 3)
+                                                     (qty "Security Testing" 3) (qty "Bank Job" 3)])
+        {:mulligan :runner})
+      (is (= 1 (:link (get-runner))) "1 link")
+      (is (= 9 (count (:hand (get-runner)))) "9 cards in Andromeda starting hand")))
+  (testing "should not grant Palana credits"
+    (do-game
+      (new-game
+        (make-deck "Pālanā Foods: Sustainable Growth" [(qty "Hedge Fund" 3)])
+        (make-deck "Andromeda: Dispossessed Ristie" [(qty "Sure Gamble" 3) (qty "Desperado" 3)
+                                                     (qty "Security Testing" 3) (qty "Bank Job" 3)]))
+      (is (= 5 (:credit (get-corp))) "Palana does not gain credit from Andromeda's starting hand"))))
 
-(deftest andromeda-mulligan
-  ;; Andromeda - 9 card starting hand after mulligan
-  (do-game
-    (new-game
-      (default-corp)
-      (make-deck "Andromeda: Dispossessed Ristie" [(qty "Sure Gamble" 3) (qty "Desperado" 3)
-                                                   (qty "Security Testing" 3) (qty "Bank Job" 3)])
-      {:mulligan :runner})
-    (is (= 1 (:link (get-runner))) "1 link")
-    (is (= 9 (count (:hand (get-runner)))) "9 cards in Andromeda starting hand")))
-
-(deftest andromeda-palana
-  ;; Andromeda - should not grant Palana credits.
-  (do-game
-    (new-game
-      (make-deck "Pālanā Foods: Sustainable Growth" [(qty "Hedge Fund" 3)])
-      (make-deck "Andromeda: Dispossessed Ristie" [(qty "Sure Gamble" 3) (qty "Desperado" 3)
-                                                   (qty "Security Testing" 3) (qty "Bank Job" 3)]))
-    (is (= 5 (:credit (get-corp))) "Palana does not gain credit from Andromeda's starting hand")))
-
-(deftest apex-facedown-console
+(deftest apex:-invasive-predator
   ;; Apex - Allow facedown install of a second console. Issue #1326
   (do-game
     (new-game
@@ -175,7 +173,7 @@
     (prompt-select :runner (find-card "Heartbeat" (:hand (get-runner))))
     (is (= 1 (count (get-in @state [:runner :rig :facedown]))) "2nd console installed facedown")))
 
-(deftest asa-group
+(deftest asa-group:-security-through-vigilance
   (testing "Asa Group should not allow installing operations"
     (do-game
       (new-game
@@ -220,9 +218,20 @@
         (prompt-select :corp pup)
         (prompt-choice :corp "New remote")
         (is (empty? (:prompt (get-corp))) "No more prompts")
-        (is (= 6 (count (:servers (get-corp)))) "There are six servers, including centrals")))))
+        (is (= 6 (count (:servers (get-corp)))) "There are six servers, including centrals"))))
+  (testing "don't allow installation of operations"
+    (do-game
+      (new-game
+        (make-deck "Asa Group: Security Through Vigilance" ["Pup" "BOOM!" "Urban Renewal"])
+        (default-runner))
+      (play-from-hand state :corp "Pup" "New remote")
+      (prompt-select :corp (find-card "BOOM!" (:hand (get-corp))))
+      (is (empty? (get-content state :remote1)) "Asa Group installed an event in a server")
+      (prompt-select :corp (find-card "Urban Renewal" (:hand (get-corp))))
+      (is (= "Urban Renewal" (:title (get-content state :remote1 0))) "Asa Group can install an asset in a remote"))))
 
-(deftest ayla
+(deftest ^{:card-title "ayla-\"bios\"-rahim:-simulant-specialist"}
+  ayla
   ;; Ayla - choose & use cards for NVRAM
   (do-game
     (new-game
@@ -247,7 +256,7 @@
     (prompt-card :runner (find-card "Bank Job" (:hosted (:identity (get-runner)))))
     (is (= 3 (count (get-in @state [:runner :hand]))) "There are 3 cards in the runner's Grip")))
 
-(deftest cerebral-imaging-max-hand-size
+(deftest cerebral-imaging:-infinite-frontiers
   ;; Cerebral Imaging - Maximum hand size equal to credits
   (do-game
     (new-game
@@ -258,83 +267,80 @@
     (is (= 13 (:credit (get-corp))) "Has 13 credits")
     (is (= 13 (core/hand-size state :corp)) "Max hand size is 13")))
 
-(deftest chaos-theory
+(deftest chaos-theory:-wunderkind
   ;; Chaos Theory, start with +1 MU
   (do-game
     (new-game (default-corp)
               (make-deck "Chaos Theory: Wünderkind" []))
     (is (= 5 (core/available-mu state)) "Chaos Theory starts the game with +1 MU")))
 
-(deftest chronos-protocol
+(deftest chronos-protocol:-selective-mind-mapping
   ;; Chronos Protocol - Choose Runner discard for first net damage of a turn
-  (do-game
-    (new-game
-      (make-deck "Chronos Protocol: Selective Mind-mapping" ["Pup" (qty "Neural EMP" 2)])
-      (default-runner [(qty "Imp" 3)]))
-    (play-from-hand state :corp "Pup" "HQ")
-    (take-credits state :corp)
-    (run-on state :hq)
-    (let [pup (get-ice state :hq 0)]
-      (core/rez state :corp pup)
-      (card-subroutine state :corp pup 0)
-      (prompt-choice :corp "Yes")
-      (let [imp (find-card "Imp" (:hand (get-runner)))]
-        (prompt-choice :corp imp)
-        (is (= 1 (count (:discard (get-runner)))))
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (make-deck "Chronos Protocol: Selective Mind-mapping" ["Pup" (qty "Neural EMP" 2)])
+        (default-runner [(qty "Imp" 3)]))
+      (play-from-hand state :corp "Pup" "HQ")
+      (take-credits state :corp)
+      (run-on state :hq)
+      (let [pup (get-ice state :hq 0)]
+        (core/rez state :corp pup)
         (card-subroutine state :corp pup 0)
-        (is (empty? (:prompt (get-corp))) "No choice on second net damage")
+        (prompt-choice :corp "Yes")
+        (let [imp (find-card "Imp" (:hand (get-runner)))]
+          (prompt-choice :corp imp)
+          (is (= 1 (count (:discard (get-runner)))))
+          (card-subroutine state :corp pup 0)
+          (is (empty? (:prompt (get-corp))) "No choice on second net damage")
+          (is (= 2 (count (:discard (get-runner)))))
+          (run-jack-out state)
+          (take-credits state :runner)
+          (core/move state :runner (find-card "Imp" (:discard (get-runner))) :hand)
+          (play-from-hand state :corp "Neural EMP")
+          (prompt-choice :corp "No")
+          (is (= 2 (count (:discard (get-runner)))) "Damage dealt after declining ability")
+          (play-from-hand state :corp "Neural EMP")
+          (is (empty? (:prompt (get-corp))) "No choice after declining on first damage")
+          (is (= 3 (count (:discard (get-runner)))))))))
+  (testing "with Obokata: Pay 4 net damage to steal.  Only 3 damage left after Chronos.  No trigger of damage prevent."
+    (do-game
+      (new-game (make-deck "Chronos Protocol: Selective Mind-mapping" [(qty "Obokata Protocol" 5)])
+                (default-runner [(qty "Sure Gamble" 3) "Inti" "Feedback Filter"]))
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :corp "Obokata Protocol" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Feedback Filter")
+      (run-empty-server state "Server 1")
+      (prompt-choice-partial :runner "Pay")
+      (prompt-choice :corp "Yes")
+      (prompt-card :corp (find-card "Inti" (:hand (get-runner))))
+      (is (empty? (:prompt (get-runner))) "Feedback Filter net damage prevention opportunity not given")
+      (is (= 4 (count (:discard (get-runner)))) "Runner paid 4 net damage")))
+  (testing "vs Employee Strike. Issue #1958"
+    (do-game
+      (new-game
+        (make-deck "Chronos Protocol: Selective Mind-mapping" ["Pup"])
+        (default-runner ["Employee Strike" (qty "Scrubbed" 3) "Sure Gamble"]))
+      (play-from-hand state :corp "Pup" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Employee Strike")
+      (run-on state :hq)
+      (let [pup (get-ice state :hq 0)]
+        (core/rez state :corp pup)
+        (card-subroutine state :corp pup 0)
+        (is (empty? (:prompt (get-corp))) "No choice because of Employee Strike")
+        (card-subroutine state :corp pup 0)
         (is (= 2 (count (:discard (get-runner)))))
         (run-jack-out state)
         (take-credits state :runner)
-        (core/move state :runner (find-card "Imp" (:discard (get-runner))) :hand)
-        (play-from-hand state :corp "Neural EMP")
-        (prompt-choice :corp "No")
-        (is (= 2 (count (:discard (get-runner)))) "Damage dealt after declining ability")
-        (play-from-hand state :corp "Neural EMP")
-        (is (empty? (:prompt (get-corp))) "No choice after declining on first damage")
-        (is (= 3 (count (:discard (get-runner)))))))))
+        (take-credits state :corp)
+        (play-from-hand state :runner "Scrubbed")
+        (run-on state :hq)
+        (card-subroutine state :corp pup 0)
+        (is (not (empty? (:prompt (get-corp)))) "Employee Strike out of play - Ability turned on correctly")))))
 
-(deftest chronos-protocol-obokata-protocol
-  ;; Pay 4 net damage to steal.  Only 3 damage left after Chronos.  No trigger of damage prevent.
-  (do-game
-    (new-game (make-deck "Chronos Protocol: Selective Mind-mapping" [(qty "Obokata Protocol" 5)])
-              (default-runner [(qty "Sure Gamble" 3) "Inti" "Feedback Filter"]))
-    (core/gain state :runner :credit 10)
-    (play-from-hand state :corp "Obokata Protocol" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Feedback Filter")
-    (run-empty-server state "Server 1")
-    (prompt-choice-partial :runner "Pay")
-    (prompt-choice :corp "Yes")
-    (prompt-card :corp (find-card "Inti" (:hand (get-runner))))
-    (is (empty? (:prompt (get-runner))) "Feedback Filter net damage prevention opportunity not given")
-    (is (= 4 (count (:discard (get-runner)))) "Runner paid 4 net damage")))
-
-(deftest chronos-protocol-employee-strike
-  ;; Chronos Protocol - Issue #1958 also affects Chronos Protocol
-  (do-game
-    (new-game
-      (make-deck "Chronos Protocol: Selective Mind-mapping" ["Pup"])
-      (default-runner ["Employee Strike" (qty "Scrubbed" 3) "Sure Gamble"]))
-    (play-from-hand state :corp "Pup" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Employee Strike")
-    (run-on state :hq)
-    (let [pup (get-ice state :hq 0)]
-      (core/rez state :corp pup)
-      (card-subroutine state :corp pup 0)
-      (is (empty? (:prompt (get-corp))) "No choice because of Employee Strike")
-      (card-subroutine state :corp pup 0)
-      (is (= 2 (count (:discard (get-runner)))))
-      (run-jack-out state)
-      (take-credits state :runner)
-      (take-credits state :corp)
-      (play-from-hand state :runner "Scrubbed")
-      (run-on state :hq)
-      (card-subroutine state :corp pup 0)
-      (is (not (empty? (:prompt (get-corp)))) "Employee Strike out of play - Ability turned on correctly"))))
-
-(deftest edward-kim
+(deftest edward-kim:-humanity's-hammer
   ;; Edward Kim
   (testing "Trash first operation accessed each turn, but not if first one was in Archives"
     (do-game
@@ -380,7 +386,7 @@
       (prompt-choice :runner "No action")
       (is (= 2 (count (:discard (get-corp)))) "One more card trashed from HQ, by Maw"))))
 
-(deftest exile
+(deftest exile:-streethawk
   ;; Exile
   (testing "Simultaneous-resolution prompt shown for interaction with Customized Secretary"
     (do-game
@@ -399,7 +405,7 @@
       (prompt-choice :runner "Exile: Streethawk")
       (is (= 1 (count (:hand (get-runner)))) "Exile drew a card"))))
 
-(deftest freedom-khumalo
+(deftest freedom-khumalo:-crypto-anarchist
   ;; Freedom Khumalo - Can spend virus counters from other cards to trash accessed cards with play/rez costs
   (testing "Only works with Assets, ICE, Operations, and Upgrades"
     (letfn [(fk-test [card]
@@ -550,7 +556,7 @@
       (is (nil? (->> (get-program state 1) :counter :virus)) "Aumakua doesn't gain any virus counters from trash ability.")
       (is (not (:run @state)) "Run ended"))))
 
-(deftest gabriel-santiago
+(deftest gabriel-santiago:-consummate-professional
   ;; Gabriel Santiago - Gain 2c on first successful HQ run each turn
   (do-game
     (new-game
@@ -564,7 +570,7 @@
     (run-empty-server state :hq)
     (is (= 7 (:credit (get-runner))) "No credits gained")))
 
-(deftest gagarin
+(deftest gagarin-deep-space:-expanding-the-horizon
   ;; Gagarin - pay 1c to access each card in remote
   (do-game
     (new-game
@@ -588,25 +594,24 @@
     (prompt-choice :runner "No") ; Dismiss trash prompt
     (is (last-log-contains? state "Caprice") "Accessed card name was logged")))
 
-(deftest grndl-power-unleashed
+(deftest grndl:-power-unleashed
   ;; GRNDL: Power Unleashed - start game with 10 credits and 1 bad pub.
-  (do-game
-    (new-game
-      (make-deck "GRNDL: Power Unleashed" [(qty "Hedge Fund" 3)])
-      (default-runner))
-    (is (= 10 (:credit (get-corp))) "GRNDL starts with 10 credits")
-    (is (= 1 (:bad-publicity (get-corp))) "GRNDL starts with 1 bad publicity")))
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (make-deck "GRNDL: Power Unleashed" [(qty "Hedge Fund" 3)])
+        (default-runner))
+      (is (= 10 (:credit (get-corp))) "GRNDL starts with 10 credits")
+      (is (= 1 (:bad-publicity (get-corp))) "GRNDL starts with 1 bad publicity")))
+  (testing "vs Valencia - only 1 bad pub at start"
+    (do-game
+      (new-game
+        (make-deck "GRNDL: Power Unleashed" [(qty "Hedge Fund" 3)])
+        (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Sure Gamble" 3)]))
+      (is (= 10 (:credit (get-corp))) "GRNDL starts with 10 credits")
+      (is (= 1 (:bad-publicity (get-corp))) "GRNDL starts with 1 bad publicity"))))
 
-(deftest grndl-valencia
-  ;; GRNDL vs Valencia - only 1 bad pub at start
-  (do-game
-    (new-game
-      (make-deck "GRNDL: Power Unleashed" [(qty "Hedge Fund" 3)])
-      (make-deck "Valencia Estevez: The Angel of Cayambe" [(qty "Sure Gamble" 3)]))
-    (is (= 10 (:credit (get-corp))) "GRNDL starts with 10 credits")
-    (is (= 1 (:bad-publicity (get-corp))) "GRNDL starts with 1 bad publicity")))
-
-(deftest haarpsichord-studios
+(deftest haarpsichord-studios:-entertainment-unleashed
   ;; Haarpsichord Studios
   (testing "Prevent stealing more than 1 agenda per turn"
     (do-game
@@ -646,7 +651,7 @@
       (prompt-choice :runner "No action")
       (is (= 2 (:agenda-point (get-runner))) "Third steal prevented"))))
 
-(deftest haas-bioroid-architects-of-tomorrow
+(deftest haas-bioroid:-architects-of-tomorrow
   ;; Architects of Tomorrow - prompt to rez after passing bioroid
   (do-game
     (new-game
@@ -666,39 +671,28 @@
     (prompt-select :corp (get-ice state :hq 0))
     (is (= 3 (:credit (get-corp))) "Corp not charged for Architects of Tomorrow rez of Eli 1.0")))
 
-(deftest haas-bioroid-asa-group
-  ;; Asa Group - don't allow installation of operations
-  (do-game
-    (new-game
-      (make-deck "Asa Group: Security Through Vigilance" ["Pup" "BOOM!" "Urban Renewal"])
-      (default-runner))
-    (play-from-hand state :corp "Pup" "New remote")
-    (prompt-select :corp (find-card "BOOM!" (:hand (get-corp))))
-    (is (empty? (get-content state :remote1)) "Asa Group installed an event in a server")
-    (prompt-select :corp (find-card "Urban Renewal" (:hand (get-corp))))
-    (is (= "Urban Renewal" (:title (get-content state :remote1 0))) "Asa Group can install an asset in a remote")))
+(deftest haas-bioroid:-engineering-the-future
+  ;; Engineereing the Future
+  (testing "interaction with Employee Strike"
+    (do-game
+      (new-game
+        (make-deck "Haas-Bioroid: Engineering the Future" [(qty "Eli 1.0" 3) "Paywall Implementation"])
+        (default-runner ["Employee Strike"]))
+      (take-credits state :corp)
+      (is (= 8 (:credit (get-corp))) "Corp has 8 credits at turn end")
+      (play-from-hand state :runner "Employee Strike")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Eli 1.0" "New remote")
+      (is (= 8 (:credit (get-corp))) "Corp did not gain 1cr from EtF")
+      (play-from-hand state :corp "Paywall Implementation")
+      (play-from-hand state :corp "Eli 1.0" "New remote")
+      (is (= 8 (:credit (get-corp))) "Corp did not gain 1cr from EtF")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (play-from-hand state :corp "Eli 1.0" "New remote")
+      (is (= 9 (:credit (get-corp))) "Corp gained 1cr from EtF"))))
 
-(deftest haas-bioroid-engineering-the-future-employee-strike
-  ;; EtF - interaction with Employee Strike
-  (do-game
-    (new-game
-      (make-deck "Haas-Bioroid: Engineering the Future" [(qty "Eli 1.0" 3) "Paywall Implementation"])
-      (default-runner ["Employee Strike"]))
-    (take-credits state :corp)
-    (is (= 8 (:credit (get-corp))) "Corp has 8 credits at turn end")
-    (play-from-hand state :runner "Employee Strike")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Eli 1.0" "New remote")
-    (is (= 8 (:credit (get-corp))) "Corp did not gain 1cr from EtF")
-    (play-from-hand state :corp "Paywall Implementation")
-    (play-from-hand state :corp "Eli 1.0" "New remote")
-    (is (= 8 (:credit (get-corp))) "Corp did not gain 1cr from EtF")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (play-from-hand state :corp "Eli 1.0" "New remote")
-    (is (= 9 (:credit (get-corp))) "Corp gained 1cr from EtF")))
-
-(deftest haas-bioroid-stronger-together
+(deftest haas-bioroid:-stronger-together
   ;; Stronger Together - +1 strength for Bioroid ice
   (do-game
     (new-game
@@ -709,7 +703,7 @@
       (core/rez state :corp eli)
       (is (= 5 (:current-strength (refresh eli))) "Eli 1.0 at 5 strength"))))
 
-(deftest iain-stirling-credits
+(deftest iain-stirling:-retired-spook
   ;; Iain Stirling - Gain 2 credits when behind
   (do-game
     (new-game
@@ -725,7 +719,7 @@
       (take-credits state :runner 1)
       (is (= 8 (:credit (get-runner))) "Gained 2 credits from being behind on points"))))
 
-(deftest industrial-genomics-trash-cost
+(deftest industrial-genomics:-growing-solutions
   ;; Industrial Genomics - Increase trash cost
   (do-game
     (new-game
@@ -743,151 +737,143 @@
       (run-empty-server state "Server 1")
       (is (= 8 (core/trash-cost state :runner (refresh pad)))))))
 
-(deftest jemison-astronautics
+(deftest jemison-astronautics:-sacrifice.-audacity.-success.
   ;; Jemison Astronautics - Place advancements when forfeiting agendas
-  (do-game
-    (new-game
-      (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success." ["Enforcer 1.0" "Hostile Takeover"
-                                                                        "Ice Wall" "Global Food Initiative"])
-      (default-runner ["Data Dealer"]))
-    (play-from-hand state :corp "Enforcer 1.0" "HQ")
-    (play-from-hand state :corp "Ice Wall" "R&D")
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (let [enf (get-ice state :hq 0)
-          iwall (get-ice state :rd 0)]
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success." ["Enforcer 1.0" "Hostile Takeover"
+                                                                          "Ice Wall" "Global Food Initiative"])
+        (default-runner ["Data Dealer"]))
+      (play-from-hand state :corp "Enforcer 1.0" "HQ")
+      (play-from-hand state :corp "Ice Wall" "R&D")
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (let [enf (get-ice state :hq 0)
+            iwall (get-ice state :rd 0)]
+        (take-credits state :corp)
+        (play-from-hand state :runner "Data Dealer")
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "Steal")
+        (let [dd (get-resource state 0)]
+          (card-ability state :runner dd 0)
+          (prompt-select :runner (get-in (get-runner) [:scored 0]))
+          (is (empty? (:prompt (get-corp))) "No Jemison prompt for Runner forfeit")
+          (take-credits state :runner)
+          (play-from-hand state :corp "Global Food Initiative" "New remote")
+          (score-agenda state :corp (get-content state :remote2 0))
+          (core/rez state :corp enf)
+          (prompt-select :corp (get-in (get-corp) [:scored 0]))
+          (prompt-select :corp iwall)
+          (is (= 4 (:advance-counter (refresh iwall))) "Jemison placed 4 advancements")))))
+  (testing "24/7 - Armed Intimidation combination"
+    ;; Expected result: 24/7 causes Forfeit, Jemison places counters, AI triggers
+    (do-game
+      (new-game
+        (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success."
+                   ["Armed Intimidation" "Hostile Takeover"
+                    "24/7 News Cycle" "Ice Wall"])
+        (default-runner))
+      (play-and-score state "Hostile Takeover")
+      (is (= 1 (:agenda-point (get-corp))) "Corp has 1 agenda points from Hostile Takeover")
+      (is (= 12 (:credit (get-corp))) "Corp has 12 credits after scoring Hostile Takeover with play-score")
+      (play-and-score state "Armed Intimidation")
+      (prompt-choice :runner "Take 2 tags")
+      (is (= 3 (:agenda-point (get-corp))) "Corp has 3 agenda points from HT + Armed Intimidation")
+      (is (= 2 (:tag (get-runner))) "Runner took 2 tags from AI")
+      (play-from-hand state :corp "Ice Wall" "HQ")
       (take-credits state :corp)
-      (play-from-hand state :runner "Data Dealer")
-      (run-empty-server state "Server 1")
-      (prompt-choice :runner "Steal")
-      (let [dd (get-resource state 0)]
-        (card-ability state :runner dd 0)
-        (prompt-select :runner (get-in (get-runner) [:scored 0]))
-        (is (empty? (:prompt (get-corp))) "No Jemison prompt for Runner forfeit")
-        (take-credits state :runner)
-        (play-from-hand state :corp "Global Food Initiative" "New remote")
-        (score-agenda state :corp (get-content state :remote2 0))
-        (core/rez state :corp enf)
-        (prompt-select :corp (get-in (get-corp) [:scored 0]))
-        (prompt-select :corp iwall)
-        (is (= 4 (:advance-counter (refresh iwall))) "Jemison placed 4 advancements")))))
-
-(deftest jemison-24-intimidation
-  ;; Test Jemison - 24/7 - Armed Intimidation combination
-  ;; Expected result: 24/7 causes Forfeit, Jemison places counters, AI triggers
-  (do-game
-    (new-game
-      (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success."
-                 ["Armed Intimidation" "Hostile Takeover"
-                  "24/7 News Cycle" "Ice Wall"])
-      (default-runner))
-    (play-and-score state "Hostile Takeover")
-    (is (= 1 (:agenda-point (get-corp))) "Corp has 1 agenda points from Hostile Takeover")
-    (is (= 12 (:credit (get-corp))) "Corp has 12 credits after scoring Hostile Takeover with play-score")
-    (play-and-score state "Armed Intimidation")
-    (prompt-choice :runner "Take 2 tags")
-    (is (= 3 (:agenda-point (get-corp))) "Corp has 3 agenda points from HT + Armed Intimidation")
-    (is (= 2 (:tag (get-runner))) "Runner took 2 tags from AI")
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
-    (take-credits state :runner)
-
-    (play-from-hand state :corp "24/7 News Cycle")
-    (prompt-select :corp (get-scored state :corp 0))        ; select HT to forfeit
-
-    (let [ice-wall (get-ice state :hq 0)]
-      (prompt-select :corp ice-wall)                        ; The Jemison forfeit triggers
-      (is (= 2 (:advance-counter (refresh ice-wall))) "Ice Wall has 2 advancement counters from HT forfeit"))
-
-    (prompt-select :corp (get-scored state :corp 0))        ; select AI to trigger
-    (prompt-choice :runner "Take 2 tags")                   ; First runner has prompt
-    (is (= 4 (:tag (get-runner))) "Runner took 2 more tags from AI -- happens at the end of all the delayed-completion")))
-
-(deftest jesminder-sareen-ability
-  ;; Jesminder Sareen - avoid tags only during a run
-  (do-game
-    (new-game (default-corp ["SEA Source" "Data Raven"])
-              (make-deck "Jesminder Sareen: Girl Behind the Curtain" [(qty "Sure Gamble" 3)]))
-    (play-from-hand state :corp "Data Raven" "Archives")
-    (take-credits state :corp)
-    (let [dr (-> @state :corp :servers :archives :ices first)]
-      (core/rez state :corp dr)
-      (core/click-run state :runner {:server "Archives"})
-      (card-ability state :corp dr 0)
-      (is (= 0 (:tag (get-runner))) "Jesminder avoided first tag during the run")
-      (card-ability state :corp dr 0)
-      (is (= 1 (:tag (get-runner))) "Jesminder did not avoid the second tag during the run")
-      (core/no-action state :corp nil)
-      (core/continue state :runner nil)
-      (core/no-action state :corp nil)
-      (core/successful-run state :runner nil)
-      (run-empty-server state "R&D") ; clear per-run buffer
       (take-credits state :runner)
-      (play-from-hand state :corp "SEA Source")
-      (prompt-choice :corp 0)
-      (prompt-choice :runner 0)
-      (is (= 2 (:tag (get-runner))) "Jesminder did not avoid the tag outside of a run"))))
+      (play-from-hand state :corp "24/7 News Cycle")
+      (prompt-select :corp (get-scored state :corp 0))        ; select HT to forfeit
+      (let [ice-wall (get-ice state :hq 0)]
+        (prompt-select :corp ice-wall)                        ; The Jemison forfeit triggers
+        (is (= 2 (:advance-counter (refresh ice-wall))) "Ice Wall has 2 advancement counters from HT forfeit"))
+      (prompt-select :corp (get-scored state :corp 0))        ; select AI to trigger
+      (prompt-choice :runner "Take 2 tags")                   ; First runner has prompt
+      (is (= 4 (:tag (get-runner))) "Runner took 2 more tags from AI -- happens at the end of all the delayed-completion"))))
 
-(deftest jesminder-john-masanori
-  ;; Jesminder Sareen - don't avoid John Masanori tag
-  (do-game
-    (new-game (default-corp)
-              (make-deck "Jesminder Sareen: Girl Behind the Curtain" ["John Masanori"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "John Masanori")
-    (run-on state "HQ")
-    (core/jack-out state :runner nil)
-    (is (= 1 (:tag (get-runner))) "Jesminder did not avoid John Masanori tag")))
+(deftest jesminder-sareen:-girl-behind-the-curtain
+  ;; Jesminder Sareen - avoid tags only during a run
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["SEA Source" "Data Raven"])
+                (make-deck "Jesminder Sareen: Girl Behind the Curtain" [(qty "Sure Gamble" 3)]))
+      (play-from-hand state :corp "Data Raven" "Archives")
+      (take-credits state :corp)
+      (let [dr (-> @state :corp :servers :archives :ices first)]
+        (core/rez state :corp dr)
+        (core/click-run state :runner {:server "Archives"})
+        (card-ability state :corp dr 0)
+        (is (= 0 (:tag (get-runner))) "Jesminder avoided first tag during the run")
+        (card-ability state :corp dr 0)
+        (is (= 1 (:tag (get-runner))) "Jesminder did not avoid the second tag during the run")
+        (core/no-action state :corp nil)
+        (core/continue state :runner nil)
+        (core/no-action state :corp nil)
+        (core/successful-run state :runner nil)
+        (run-empty-server state "R&D") ; clear per-run buffer
+        (take-credits state :runner)
+        (play-from-hand state :corp "SEA Source")
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (= 2 (:tag (get-runner))) "Jesminder did not avoid the tag outside of a run"))))
+  (testing "don't avoid John Masanori tag"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "Jesminder Sareen: Girl Behind the Curtain" ["John Masanori"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "John Masanori")
+      (run-on state "HQ")
+      (core/jack-out state :runner nil)
+      (is (= 1 (:tag (get-runner))) "Jesminder did not avoid John Masanori tag"))))
 
-(deftest jinteki-biotech-brewery
-  ;; Jinteki Biotech - Brewery net damage
-  (do-game
-    (new-game
-      (make-deck "Jinteki Biotech: Life Imagined" ["Braintrust"])
-      (default-runner)
-      {:dont-start-turn true})
-    (prompt-choice :corp "The Brewery")
-    (core/start-turn state :corp nil)
-    (card-ability state :corp (:identity (get-corp)) 1)
-    (is (= 1 (count (:hand (get-runner)))) "Runner took 2 net damage from Brewery flip")))
-
-(deftest jinteki-biotech-greenhouse
-  ;; Jinteki Biotech - Greenhouse four advancement tokens
-  (do-game
-    (new-game
-      (make-deck "Jinteki Biotech: Life Imagined" ["Braintrust"])
-      (default-runner)
-      {:dont-start-turn true})
-    (prompt-choice :corp "The Greenhouse")
-    (core/start-turn state :corp nil)
-    (play-from-hand state :corp "Braintrust" "New remote")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (let [bt (get-content state :remote1 0)]
-      (is (nil? (:advance-counter (refresh bt))) "No advancement counters on agenda")
+(deftest jinteki-biotech:-life-imagined
+  ;; Jinteki Biotech
+  (testing "Brewery net damage"
+    (do-game
+      (new-game
+        (make-deck "Jinteki Biotech: Life Imagined" ["Braintrust"])
+        (default-runner)
+        {:dont-start-turn true})
+      (prompt-choice :corp "The Brewery")
+      (core/start-turn state :corp nil)
       (card-ability state :corp (:identity (get-corp)) 1)
-      (prompt-select :corp (refresh bt))
-      (is (= 4 (:advance-counter (refresh bt))) "Four advancement counters on agenda"))))
+      (is (= 1 (count (:hand (get-runner)))) "Runner took 2 net damage from Brewery flip")))
+  (testing "Greenhouse four advancement tokens"
+    (do-game
+      (new-game
+        (make-deck "Jinteki Biotech: Life Imagined" ["Braintrust"])
+        (default-runner)
+        {:dont-start-turn true})
+      (prompt-choice :corp "The Greenhouse")
+      (core/start-turn state :corp nil)
+      (play-from-hand state :corp "Braintrust" "New remote")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (let [bt (get-content state :remote1 0)]
+        (is (nil? (:advance-counter (refresh bt))) "No advancement counters on agenda")
+        (card-ability state :corp (:identity (get-corp)) 1)
+        (prompt-select :corp (refresh bt))
+        (is (= 4 (:advance-counter (refresh bt))) "Four advancement counters on agenda"))))
+  (testing "Tank shuffle Archives into R&D"
+    (do-game
+      (new-game
+        (make-deck "Jinteki Biotech: Life Imagined" [(qty "Hedge Fund" 3)])
+        (default-runner)
+        {:dont-start-turn true})
+      (prompt-choice :corp "The Tank")
+      (core/start-turn state :corp nil)
+      (play-from-hand state :corp "Hedge Fund")
+      (play-from-hand state :corp "Hedge Fund")
+      (play-from-hand state :corp "Hedge Fund")
+      (take-credits state :runner)
+      (is (= 3 (count (:discard (get-corp)))) "Archives started with 3 cards")
+      (is (= 0 (count (:deck (get-corp)))) "R&D started empty")
+      (card-ability state :corp (:identity (get-corp)) 1)
+      (is (= 0 (count (:discard (get-corp)))) "Archives ended empty")
+      (is (= 3 (count (:deck (get-corp)))) "R&D ended with 3 cards"))))
 
-(deftest jinteki-biotech-tank
-  ;; Jinteki Biotech - Tank shuffle Archives into R&D
-  (do-game
-    (new-game
-      (make-deck "Jinteki Biotech: Life Imagined" [(qty "Hedge Fund" 3)])
-      (default-runner)
-      {:dont-start-turn true})
-    (prompt-choice :corp "The Tank")
-    (core/start-turn state :corp nil)
-    (play-from-hand state :corp "Hedge Fund")
-    (play-from-hand state :corp "Hedge Fund")
-    (play-from-hand state :corp "Hedge Fund")
-    (take-credits state :runner)
-    (is (= 3 (count (:discard (get-corp)))) "Archives started with 3 cards")
-    (is (= 0 (count (:deck (get-corp)))) "R&D started empty")
-    (card-ability state :corp (:identity (get-corp)) 1)
-    (is (= 0 (count (:discard (get-corp)))) "Archives ended empty")
-    (is (= 3 (count (:deck (get-corp)))) "R&D ended with 3 cards")))
-
-(deftest jinteki-personal-evolution
+(deftest jinteki:-personal-evolution
   ;; Personal Evolution - Prevent runner from running on remotes unless they first run on a central
   (do-game
     (new-game
@@ -899,8 +885,8 @@
     (prompt-choice :runner "Steal")
     (is (= 2 (count (:hand (get-runner)))) "Runner took 1 net damage from steal")))
 
-(deftest jinteki-potential-unleashed
-  ;; PU - when the runner takes at least one net damage, mill 1 from their deck
+(deftest jinteki:-potential-unleashed
+  ;; Potential Unleashed - when the runner takes at least one net damage, mill 1 from their deck
   (do-game
     (new-game (make-deck "Jinteki: Potential Unleashed" ["Philotic Entanglement" "Neural EMP" (qty "Braintrust" 3)])
               (default-runner [(qty "Employee Strike" 10)]))
@@ -918,66 +904,64 @@
     (play-from-hand state :corp "Neural EMP")
     (is (= 5 (count (:discard (get-runner)))))))
 
-(deftest jinteki-replicating-perfection
+(deftest jinteki:-replicating-perfection
   ;; Replicating Perfection - Prevent runner from running on remotes unless they first run on a central
-  (do-game
-    (new-game
-      (make-deck "Jinteki: Replicating Perfection" [(qty "Mental Health Clinic" 3)])
-      (default-runner))
-    (play-from-hand state :corp "Mental Health Clinic" "New remote")
-    (take-credits state :corp)
-    (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
-    (run-empty-server state "HQ")
-    (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")))
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (make-deck "Jinteki: Replicating Perfection" [(qty "Mental Health Clinic" 3)])
+        (default-runner))
+      (play-from-hand state :corp "Mental Health Clinic" "New remote")
+      (take-credits state :corp)
+      (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
+      (run-empty-server state "HQ")
+      (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")))
+  (testing "interaction with Employee Strike. Issue #1313 and #1956."
+    (do-game
+      (new-game
+        (make-deck "Jinteki: Replicating Perfection" [(qty "Mental Health Clinic" 3)])
+        (default-runner ["Employee Strike" "Scrubbed"]))
+      (play-from-hand state :corp "Mental Health Clinic" "New remote")
+      (take-credits state :corp)
+      (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
+      (play-from-hand state :runner "Employee Strike")
+      (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")
+      (play-from-hand state :runner "Scrubbed")
+      (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals"))))
 
-(deftest jinteki-replicating-perfection-employee-strike
-  ;; Replicating Perfection - interaction with Employee Strike. Issue #1313 and #1956.
-  (do-game
-    (new-game
-      (make-deck "Jinteki: Replicating Perfection" [(qty "Mental Health Clinic" 3)])
-      (default-runner ["Employee Strike" "Scrubbed"]))
-    (play-from-hand state :corp "Mental Health Clinic" "New remote")
-    (take-credits state :corp)
-    (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
-    (play-from-hand state :runner "Employee Strike")
-    (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")
-    (play-from-hand state :runner "Scrubbed")
-    (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")))
+(deftest ^{:card-title "kate-\"mac\"-mccaffrey:-digital-tinker"}
+  kate
+  ;; Kate 'Mac' McCaffrey
+  (testing "Install discount"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" ["Magnum Opus"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Magnum Opus")
+      (is (= 1 (:credit (get-runner))) "Installed Magnum Opus for 4 credits")))
+  (testing "No discount for 0 cost"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker"
+                           ["Magnum Opus"
+                            "Self-modifying Code"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Self-modifying Code")
+      (play-from-hand state :runner "Magnum Opus")
+      (is (= 0 (:credit (get-runner))) "No Kate discount on second program install")))
+  (testing "Can afford only with the discount"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" ["Magnum Opus"]))
+      (take-credits state :corp)
+      (core/lose state :runner :credit 1)
+      (is (= 4 (:credit (get-runner))))
+      (play-from-hand state :runner "Magnum Opus")
+      (is (= 1 (count (get-in @state [:runner :rig :program]))) "Magnum Opus installed")
+      (is (= 0 (:credit (get-runner))) "Installed Magnum Opus for 4 credits"))))
 
-(deftest kate-mac-mccaffrey-discount
-  ;; Kate 'Mac' McCaffrey - Install discount
-  (do-game
-    (new-game (default-corp)
-              (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" ["Magnum Opus"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Magnum Opus")
-    (is (= 1 (:credit (get-runner))) "Installed Magnum Opus for 4 credits")))
-
-(deftest kate-mac-mccaffrey-no-discount
-  ;; Kate 'Mac' McCaffrey - No discount for 0 cost
-  (do-game
-    (new-game (default-corp)
-              (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker"
-                         ["Magnum Opus"
-                          "Self-modifying Code"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Self-modifying Code")
-    (play-from-hand state :runner "Magnum Opus")
-    (is (= 0 (:credit (get-runner))) "No Kate discount on second program install")))
-
-(deftest kate-mac-mccaffrey-discount-cant-afford
-  ;; Kate 'Mac' McCaffrey - Can Only Afford With the Discount
-  (do-game
-    (new-game (default-corp)
-              (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" ["Magnum Opus"]))
-    (take-credits state :corp)
-    (core/lose state :runner :credit 1)
-    (is (= 4 (:credit (get-runner))))
-    (play-from-hand state :runner "Magnum Opus")
-    (is (= 1 (count (get-in @state [:runner :rig :program]))) "Magnum Opus installed")
-    (is (= 0 (:credit (get-runner))) "Installed Magnum Opus for 4 credits")))
-
-(deftest ken-tenma-run-event-credit
+(deftest ^{:card-title "ken-\"express\"-tenma:-disappeared-clone"}
+  ken
   ;; Ken 'Express' Tenma - Gain 1 credit when first Run event played
   (do-game
     (new-game (default-corp)
@@ -989,177 +973,174 @@
     (play-run-event state (first (:hand (get-runner))) :hq)
     (is (= 16 (:credit (get-runner))) "No credit gained for second Run event")))
 
-(deftest khan-vs-caprice
-  ;; Khan - proper order of events when vs. Caprice
-  (do-game
-    (new-game
-      (default-corp ["Eli 1.0" "Caprice Nisei"])
-      (make-deck "Khan: Savvy Skiptracer" ["Corroder"]))
-    (play-from-hand state :corp "Eli 1.0" "Archives")
-    (play-from-hand state :corp "Caprice Nisei" "Archives")
-    (core/rez state :corp (get-content state :archives 0))
-    (take-credits state :corp)
-    (run-on state "Archives")
-    (run-continue state)
-    (is (and (empty? (:prompt (get-corp)))
-             (= 1 (count (:prompt (get-runner))))
-             (= "Khan: Savvy Skiptracer" (-> (get-runner) :prompt first :card :title)))
-        "Only Khan prompt showing")
-    (prompt-select :runner (first (:hand (get-runner))))
-    (is (find-card "Corroder" (-> (get-runner) :rig :program)) "Corroder installed")
-    (is (= 4 (:credit (get-runner))) "1cr discount from Khan")
-    (is (= "Caprice Nisei" (-> (get-runner) :prompt first :card :title)) "Caprice prompt showing")
-    (prompt-choice :runner "0 [Credits]")
-    (prompt-choice :corp "1 [Credits]")
-    (is (not (:run @state)) "Run ended")))
+(deftest khan:-savvy-skiptracer
+  ;; Khan
+  (testing "proper order of events when vs. Caprice"
+    (do-game
+      (new-game
+        (default-corp ["Eli 1.0" "Caprice Nisei"])
+        (make-deck "Khan: Savvy Skiptracer" ["Corroder"]))
+      (play-from-hand state :corp "Eli 1.0" "Archives")
+      (play-from-hand state :corp "Caprice Nisei" "Archives")
+      (core/rez state :corp (get-content state :archives 0))
+      (take-credits state :corp)
+      (run-on state "Archives")
+      (run-continue state)
+      (is (and (empty? (:prompt (get-corp)))
+               (= 1 (count (:prompt (get-runner))))
+               (= "Khan: Savvy Skiptracer" (-> (get-runner) :prompt first :card :title)))
+          "Only Khan prompt showing")
+      (prompt-select :runner (first (:hand (get-runner))))
+      (is (find-card "Corroder" (-> (get-runner) :rig :program)) "Corroder installed")
+      (is (= 4 (:credit (get-runner))) "1cr discount from Khan")
+      (is (= "Caprice Nisei" (-> (get-runner) :prompt first :card :title)) "Caprice prompt showing")
+      (prompt-choice :runner "0 [Credits]")
+      (prompt-choice :corp "1 [Credits]")
+      (is (not (:run @state)) "Run ended"))))
 
-(deftest laramy-fisk-shards
-  ;; Laramy Fisk - installing a Shard should still give option to force Corp draw.
-  (do-game
-    (new-game
-      (default-corp [(qty "Hedge Fund" 3) (qty "Eli 1.0" 3)])
-      (make-deck "Laramy Fisk: Savvy Investor" ["Eden Shard"]))
-    (starting-hand state :corp ["Hedge Fund" "Hedge Fund" "Hedge Fund" "Eli 1.0" "Eli 1.0"])
-    (take-credits state :corp)
-    (run-on state "R&D")
-    (core/no-action state :corp nil)
-    ;; at Successful Run stage -- click Eden Shard to install
-    (play-from-hand state :runner "Eden Shard")
-    (is (= 5 (:credit (get-runner))) "Eden Shard install was free")
-    (is (= "Eden Shard" (:title (get-resource state 0))) "Eden Shard installed")
-    (is (= "Identity" (-> (get-runner) :prompt first :card :type)) "Fisk prompt showing")
-    (prompt-choice :runner "Yes")
-    (is (not (:run @state)) "Run ended")
-    (is (= 6 (count (:hand (get-corp)))) "Corp forced to draw")))
+(deftest laramy-fisk:-savvy-investor
+  ;; Laramy Fisk
+  (testing "installing a Shard should still give option to force Corp draw"
+    (do-game
+      (new-game
+        (default-corp [(qty "Hedge Fund" 3) (qty "Eli 1.0" 3)])
+        (make-deck "Laramy Fisk: Savvy Investor" ["Eden Shard"]))
+      (starting-hand state :corp ["Hedge Fund" "Hedge Fund" "Hedge Fund" "Eli 1.0" "Eli 1.0"])
+      (take-credits state :corp)
+      (run-on state "R&D")
+      (core/no-action state :corp nil)
+      ;; at Successful Run stage -- click Eden Shard to install
+      (play-from-hand state :runner "Eden Shard")
+      (is (= 5 (:credit (get-runner))) "Eden Shard install was free")
+      (is (= "Eden Shard" (:title (get-resource state 0))) "Eden Shard installed")
+      (is (= "Identity" (-> (get-runner) :prompt first :card :type)) "Fisk prompt showing")
+      (prompt-choice :runner "Yes")
+      (is (not (:run @state)) "Run ended")
+      (is (= 6 (count (:hand (get-corp)))) "Corp forced to draw"))))
 
-(deftest leela-gang-sign-complicated
-  ;; Leela Patel - complicated interaction with mutiple Gang Sign
-  (do-game
-    (new-game
-      (make-deck "Titan Transnational: Investing In Your Future" ["Project Atlas"
-                                                                  "Hostile Takeover"
-                                                                  "Geothermal Fracking"])
-      (make-deck "Leela Patel: Trained Pragmatist" [(qty "Gang Sign" 2)]))
-    (play-from-hand state :corp "Project Atlas" "New remote")
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (play-from-hand state :corp "Geothermal Fracking" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Gang Sign")
-    (play-from-hand state :runner "Gang Sign")
-    (take-credits state :runner)
-    (score-agenda state :corp (get-content state :remote1 0))
-    (prompt-choice :runner "Leela Patel: Trained Pragmatist")
-    (prompt-select :runner (get-content state :remote2 0))
-    (is (find-card "Hostile Takeover" (:hand (get-corp))) "Hostile Takeover returned to hand")
-    (prompt-choice :runner "Gang Sign")
-    (prompt-choice :runner "Card from hand")
-    (prompt-choice :runner "Steal")
-    (is (find-card "Hostile Takeover" (:scored (get-runner))) "Hostile Takeover stolen with Gang Sign")
-    (prompt-select :runner (get-content state :remote3 0))
-    (is (find-card "Geothermal Fracking" (:hand (get-corp))) "Geothermal Fracking returned to hand")
-    (prompt-choice :runner "Card from hand")
-    (prompt-choice :runner "Steal")
-    (is (find-card "Hostile Takeover" (:scored (get-runner))) "Geothermal Fracking stolen with Gang Sign")
-    (prompt-choice :runner "Done")))
+(deftest leela-patel:-trained-pragmatist
+  ;; Leela Patel
+  (testing "complicated interaction with mutiple Gang Sign"
+    (do-game
+      (new-game
+        (make-deck "Titan Transnational: Investing In Your Future" ["Project Atlas"
+                                                                    "Hostile Takeover"
+                                                                    "Geothermal Fracking"])
+        (make-deck "Leela Patel: Trained Pragmatist" [(qty "Gang Sign" 2)]))
+      (play-from-hand state :corp "Project Atlas" "New remote")
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (play-from-hand state :corp "Geothermal Fracking" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Gang Sign")
+      (play-from-hand state :runner "Gang Sign")
+      (take-credits state :runner)
+      (score-agenda state :corp (get-content state :remote1 0))
+      (prompt-choice :runner "Leela Patel: Trained Pragmatist")
+      (prompt-select :runner (get-content state :remote2 0))
+      (is (find-card "Hostile Takeover" (:hand (get-corp))) "Hostile Takeover returned to hand")
+      (prompt-choice :runner "Gang Sign")
+      (prompt-choice :runner "Card from hand")
+      (prompt-choice :runner "Steal")
+      (is (find-card "Hostile Takeover" (:scored (get-runner))) "Hostile Takeover stolen with Gang Sign")
+      (prompt-select :runner (get-content state :remote3 0))
+      (is (find-card "Geothermal Fracking" (:hand (get-corp))) "Geothermal Fracking returned to hand")
+      (prompt-choice :runner "Card from hand")
+      (prompt-choice :runner "Steal")
+      (is (find-card "Hostile Takeover" (:scored (get-runner))) "Geothermal Fracking stolen with Gang Sign")
+      (prompt-choice :runner "Done")))
+  (testing "issues with lingering successful run prompt"
+    (do-game
+      (new-game
+        (make-deck "NBN: Making News" ["Breaking News" "SanSan City Grid"])
+        (make-deck "Leela Patel: Trained Pragmatist" []))
+      (starting-hand state :corp ["SanSan City Grid"])
+      (play-from-hand state :corp "SanSan City Grid" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state :rd)
+      (prompt-choice :runner "Steal")
+      (prompt-select :runner (get-content state :remote1 0))
+      (is (not (:run @state)) "Run is over")))
+  (testing "upgrades returned to hand in the middle of a run do not break the run. Issue #2008"
+    (do-game
+      (new-game (default-corp [(qty "Crisium Grid" 3) (qty "Project Atlas" 3) "Shock!"])
+                (make-deck "Leela Patel: Trained Pragmatist" ["Sure Gamble"]))
+      (starting-hand state :corp ["Crisium Grid" "Crisium Grid" "Crisium Grid" "Project Atlas" "Shock!" "Project Atlas"])
+      (play-from-hand state :corp "Crisium Grid" "HQ")
+      (play-from-hand state :corp "Crisium Grid" "Archives")
+      (play-from-hand state :corp "Crisium Grid" "R&D")
+      (trash-from-hand state :corp "Project Atlas")
+      (trash-from-hand state :corp "Shock!")
+      (take-credits state :corp)
+      (run-empty-server state "HQ")
+      (prompt-choice :runner "Card from hand")
+      (prompt-choice :runner "Steal")
+      (prompt-select :runner (get-content state :hq 0))
+      (is (not (get-content state :hq 0)) "Upgrade returned to hand")
+      (is (not (:run @state)) "Run ended, no more accesses")
+      (run-empty-server state "R&D")
+      (prompt-choice :runner "Card from deck")
+      (prompt-choice :runner "Steal")
+      (prompt-select :runner (get-content state :rd 0))
+      (is (not (get-content state :rd 0)) "Upgrade returned to hand")
+      (is (not (:run @state)) "Run ended, no more accesses")
+      (run-empty-server state "Archives")
+      (prompt-choice :runner "Shock!")
+      (prompt-choice :runner "Project Atlas")
+      (prompt-choice :runner "Steal")
+      (prompt-select :runner (get-content state :archives 0))
+      (is (not (get-content state :archives 0)) "Upgrade returned to hand")
+      (is (not (:run @state)) "Run ended, no more accesses"))))
 
-(deftest leela-lingering-successful-run-prompt
-  ;; Leela Patel - issues with lingering successful run prompt
-  (do-game
-    (new-game
-      (make-deck "NBN: Making News" ["Breaking News" "SanSan City Grid"])
-      (make-deck "Leela Patel: Trained Pragmatist" []))
-    (starting-hand state :corp ["SanSan City Grid"])
-    (play-from-hand state :corp "SanSan City Grid" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state :rd)
-    (prompt-choice :runner "Steal")
-    (prompt-select :runner (get-content state :remote1 0))
-    (is (not (:run @state)) "Run is over")))
+(deftest maxx:-maximum-punk-rock
+  ;; MaxX
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "MaxX: Maximum Punk Rock" [(qty "Wyldside" 3)
+                                                      "Eater"]))
+      (starting-hand state :runner ["Eater"])
+      (take-credits state :corp)
+      (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
+      (is (last-log-contains? state "Wyldside, Wyldside")
+          "Maxx did log trashed card names")))
+  (testing "with Dummy Box. Check that mills don't trigger trash prevention #3246"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "MaxX: Maximum Punk Rock" [(qty "Dummy Box" 30)]))
+      (take-credits state :corp)
+      (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
+      (play-from-hand state :runner "Dummy Box")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (empty? (:prompt (get-runner))) "Dummy Box not fired from mill")))
+  (testing "with Wyldside - using Wyldside during Step 1.2 should lose 1 click"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "MaxX: Maximum Punk Rock" [(qty "Wyldside" 3)
+                                                      (qty "Sure Gamble" 3)
+                                                      (qty "Infiltration" 3)
+                                                      (qty "Corroder" 3)
+                                                      (qty "Eater" 3)]))
+      (take-credits state :corp)
+      (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
+      (starting-hand state :runner ["Wyldside"])
+      (play-from-hand state :runner "Wyldside")
+      (take-credits state :runner 3)
+      (is (= 5 (:credit (get-runner))) "Runner has 5 credits at end of first turn")
+      (is (find-card "Wyldside" (get-in @state [:runner :rig :resource])) "Wyldside was installed")
+      (take-credits state :corp)
+      (is (= 0 (:click (get-runner))) "Runner has 0 clicks")
+      (is (:runner-phase-12 @state) "Runner is in Step 1.2")
+      (let [maxx (get-in @state [:runner :identity])
+            wyld (find-card "Wyldside" (get-in @state [:runner :rig :resource]))]
+        (card-ability state :runner maxx 0)
+        (card-ability state :runner wyld 0)
+        (core/end-phase-12 state :runner nil)
+        (is (= 4 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
+        (is (= 3 (:click (get-runner))) "Wyldside caused 1 click to be lost")
+        (is (= 3 (count (:hand (get-runner)))) "3 cards drawn total")))))
 
-(deftest leela-upgrades
-  ;; Leela Patel - upgrades returned to hand in the middle of a run do not break the run. Issue #2008.
-  (do-game
-    (new-game (default-corp [(qty "Crisium Grid" 3) (qty "Project Atlas" 3) "Shock!"])
-              (make-deck "Leela Patel: Trained Pragmatist" ["Sure Gamble"]))
-    (starting-hand state :corp ["Crisium Grid" "Crisium Grid" "Crisium Grid" "Project Atlas" "Shock!" "Project Atlas"])
-    (play-from-hand state :corp "Crisium Grid" "HQ")
-    (play-from-hand state :corp "Crisium Grid" "Archives")
-    (play-from-hand state :corp "Crisium Grid" "R&D")
-    (trash-from-hand state :corp "Project Atlas")
-    (trash-from-hand state :corp "Shock!")
-    (take-credits state :corp)
-    (run-empty-server state "HQ")
-    (prompt-choice :runner "Card from hand")
-    (prompt-choice :runner "Steal")
-    (prompt-select :runner (get-content state :hq 0))
-    (is (not (get-content state :hq 0)) "Upgrade returned to hand")
-    (is (not (:run @state)) "Run ended, no more accesses")
-    (run-empty-server state "R&D")
-    (prompt-choice :runner "Card from deck")
-    (prompt-choice :runner "Steal")
-    (prompt-select :runner (get-content state :rd 0))
-    (is (not (get-content state :rd 0)) "Upgrade returned to hand")
-    (is (not (:run @state)) "Run ended, no more accesses")
-    (run-empty-server state "Archives")
-    (prompt-choice :runner "Shock!")
-    (prompt-choice :runner "Project Atlas")
-    (prompt-choice :runner "Steal")
-    (prompt-select :runner (get-content state :archives 0))
-    (is (not (get-content state :archives 0)) "Upgrade returned to hand")
-    (is (not (:run @state)) "Run ended, no more accesses")))
-
-(deftest maxx
-  (do-game
-    (new-game (default-corp)
-              (make-deck "MaxX: Maximum Punk Rock" [(qty "Wyldside" 3)
-                                                    "Eater"]))
-    (starting-hand state :runner ["Eater"])
-    (take-credits state :corp)
-    (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
-    (is (last-log-contains? state "Wyldside, Wyldside")
-        "Maxx did log trashed card names")))
-
-(deftest maxx-dummy-box
-  ; Check that mills don't trigger trash prevention #3246
-  (do-game
-    (new-game (default-corp)
-              (make-deck "MaxX: Maximum Punk Rock" [(qty "Dummy Box" 30)]))
-    (take-credits state :corp)
-    (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
-    (play-from-hand state :runner "Dummy Box")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (is (empty? (:prompt (get-runner))) "Dummy Box not fired from mill")))
-
-(deftest maxx-wyldside-start-of-turn
-  ;; MaxX and Wyldside - using Wyldside during Step 1.2 should lose 1 click
-  (do-game
-    (new-game (default-corp)
-              (make-deck "MaxX: Maximum Punk Rock" [(qty "Wyldside" 3)
-                                                     (qty "Sure Gamble" 3)
-                                                     (qty "Infiltration" 3)
-                                                     (qty "Corroder" 3)
-                                                     (qty "Eater" 3)]))
-    (take-credits state :corp)
-    (is (= 2 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
-    (starting-hand state :runner ["Wyldside"])
-    (play-from-hand state :runner "Wyldside")
-    (take-credits state :runner 3)
-    (is (= 5 (:credit (get-runner))) "Runner has 5 credits at end of first turn")
-    (is (find-card "Wyldside" (get-in @state [:runner :rig :resource])) "Wyldside was installed")
-    (take-credits state :corp)
-    (is (= 0 (:click (get-runner))) "Runner has 0 clicks")
-    (is (:runner-phase-12 @state) "Runner is in Step 1.2")
-    (let [maxx (get-in @state [:runner :identity])
-          wyld (find-card "Wyldside" (get-in @state [:runner :rig :resource]))]
-      (card-ability state :runner maxx 0)
-      (card-ability state :runner wyld 0)
-      (core/end-phase-12 state :runner nil)
-      (is (= 4 (count (:discard (get-runner)))) "MaxX discarded 2 cards at start of turn")
-      (is (= 3 (:click (get-runner))) "Wyldside caused 1 click to be lost")
-      (is (= 3 (count (:hand (get-runner)))) "3 cards drawn total"))))
-
-(deftest mti
+(deftest mti-mwekundu:-life-improved
   ;; Mti Mwekundu: Life Improved - when server is approached, install ice from HQ at the innermost position
   (testing "No ice"
     (do-game
@@ -1190,43 +1171,40 @@
       (is (= "Enigma" (:title (get-ice state :rd 0))) "Enigma was installed")
       (is (empty? (:hand (get-corp))) "Enigma removed from HQ"))))
 
-(deftest nasir-ability-basic
-  ;; Nasir Ability - Basic
-  (do-game
-    (new-game
-      (default-corp [(qty "Ice Wall" 3)])
-      (make-deck "Nasir Meidan: Cyber Explorer" []))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
+(deftest nasir-meidan:-cyber-explorer
+  ;; Nasir
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (default-corp [(qty "Ice Wall" 3)])
+        (make-deck "Nasir Meidan: Cyber Explorer" []))
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (let [iwall (get-ice state :hq 0)
+            nasir (get-in @state [:runner :identity])]
+        (core/rez state :corp iwall)
+        (is (= 5 (:credit (get-runner))) "Nasir Ability does not trigger automatically")
+        (card-ability state :runner nasir 0)
+        (is (= 1 (:credit (get-runner))) "Credits at 1 after Nasir ability trigger"))))
+  (testing "with Xanadu"
+    (do-game
+      (new-game
+        (default-corp ["Ice Wall"])
+        (make-deck "Nasir Meidan: Cyber Explorer" ["Xanadu"]))
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (swap! state assoc-in [:runner :credit] 6)
+      (play-from-hand state :runner "Xanadu")
+      (run-on state "HQ")
+      (let [iwall (get-in @state [:corp :servers :hq :ices 0])
+            nasir (get-in @state [:runner :identity])]
+        (core/rez state :corp iwall)
+        (is (= 3 (:credit (get-runner))) "Pay 3 to install Xanadu")
+        (card-ability state :runner nasir 0)
+        (is (= 2 (:credit (get-runner))) "Gain 1 more credit due to Xanadu")))))
 
-    (run-on state "HQ")
-    (let [iwall (get-ice state :hq 0)
-          nasir (get-in @state [:runner :identity])]
-      (core/rez state :corp iwall)
-      (is (= 5 (:credit (get-runner))) "Nasir Ability does not trigger automatically")
-      (card-ability state :runner nasir 0)
-      (is (= 1 (:credit (get-runner))) "Credits at 1 after Nasir ability trigger"))))
-
-(deftest nasir-ability-xanadu
-  ;; Nasir Ability - Xanadu
-  (do-game
-    (new-game
-      (default-corp ["Ice Wall"])
-      (make-deck "Nasir Meidan: Cyber Explorer" ["Xanadu"]))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
-
-    (swap! state assoc-in [:runner :credit] 6)
-    (play-from-hand state :runner "Xanadu")
-    (run-on state "HQ")
-    (let [iwall (get-in @state [:corp :servers :hq :ices 0])
-          nasir (get-in @state [:runner :identity])]
-      (core/rez state :corp iwall)
-      (is (= 3 (:credit (get-runner))) "Pay 3 to install Xanadu")
-      (card-ability state :runner nasir 0)
-      (is (= 2 (:credit (get-runner))) "Gain 1 more credit due to Xanadu"))))
-
-(deftest nbn-controlling-the-message
+(deftest nbn:-controlling-the-message
   ;; NBN: Controlling the Message
   (testing "Trace to tag Runner when first installed Corp card is trashed"
     (do-game
@@ -1268,7 +1246,7 @@
       (is (= 1 (:tag (get-runner))) "Runner took 1 unpreventable tag")
       (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage from DRT"))))
 
-(deftest new-angeles-sol-on-steal
+(deftest new-angeles-sol:-your-news
   ;; New Angeles Sol - interaction with runner stealing agendas
   (do-game
     (new-game
@@ -1287,7 +1265,7 @@
     (is (not (:run @state)) "Run ended")
     (is (find-card "Paywall Implementation" (:current (get-corp))) "Paywall back in play")))
 
-(deftest next-design
+(deftest next-design:-guarding-the-net
   ;; Next Design.  Install up to 3 ICE before game starts, one per server max, and re-draw to 5
   (do-game
     (new-game
@@ -1304,7 +1282,7 @@
     (card-ability state :corp (get-in @state [:corp :identity]) 0)
     (is (= 5 (count (:hand (get-corp)))) "Corp should start with 5 cards in hand")))
 
-(deftest nisei-division
+(deftest nisei-division:-the-next-generation
   ;; Nisei Division - Gain 1 credit from every psi game
   (do-game
     (new-game
@@ -1330,8 +1308,8 @@
       (prompt-choice :runner "1 [Credits]")
       (is (= 5 (:credit (get-corp))) "Gained 1 credit from psi game"))))
 
-(deftest noise-ability
-  ;; Noise: Hacker Extraordinaire - Ability
+(deftest noise:-hacker-extraordinaire
+  ;; Noise: Hacker Extraordinaire
   (do-game
     (new-game
       (default-corp [(qty "Hedge Fund" 3) (qty "Restructure" 3) (qty "PAD Campaign" 3) (qty "Beanstalk Royalties" 2)])
@@ -1370,57 +1348,56 @@
         (is (= (:title ss) "Sharpshooter"))))
     (is (= 2 (count (:discard (get-corp)))) "Playing non-virus via Clone Chip on corp's turn should not trigger Noise ability")))
 
-(deftest null-ability
-  ;; Null ability - once per turn
-  (do-game
-    (new-game
-      (default-corp [(qty "Wraparound" 3)])
-      (make-deck "Null: Whistleblower" [(qty "Sure Gamble" 3)]))
-    (play-from-hand state :corp "Wraparound" "HQ")
-    (play-from-hand state :corp "Wraparound" "HQ")
-    (take-credits state :corp)
-    (run-on state "HQ")
-    (let [null (get-in @state [:runner :identity])
-          wrap1 (get-ice state :hq 0)
-          wrap2 (get-ice state :hq 1)]
-      (card-ability state :runner null 0)
-      (is (empty? (:prompt (get-runner))) "Ability won't work on unrezzed ICE")
-      (core/rez state :corp wrap2)
-      (card-ability state :runner null 0)
-      (prompt-select :runner (find-card "Sure Gamble" (:hand (get-runner))))
-      (is (= 5 (:current-strength (refresh wrap2))) "Wraparound reduced to 5 strength")
-      (run-continue state)
-      (core/rez state :corp wrap1)
-      (card-ability state :runner null 0)
-      (is (empty? (:prompt (get-runner))) "Ability already used this turn")
-      (run-jack-out state)
-      (is (= 7 (:current-strength (refresh wrap2))) "Outer Wraparound back to 7 strength"))))
-
-(deftest null-trashed
-  ;; Null ability - does not affect next ice when current is trashed. Issue #1788.
-  (do-game
-    (new-game
-      (default-corp ["Wraparound" "Spiderweb"])
-      (make-deck "Null: Whistleblower" [(qty "Parasite" 3)]))
-    (play-from-hand state :corp "Spiderweb" "HQ")
-    (play-from-hand state :corp "Wraparound" "HQ")
-    (take-credits state :corp)
-    (core/gain state :corp :credit 10)
-    (let [null (get-in @state [:runner :identity])
-          spider (get-ice state :hq 0)
-          wrap (get-ice state :hq 1)]
-      (core/rez state :corp spider)
-      (core/rez state :corp wrap)
-      (play-from-hand state :runner "Parasite")
-      (prompt-select :runner (refresh spider))
+(deftest null:-whistleblower
+  ;; Null
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (default-corp [(qty "Wraparound" 3)])
+        (make-deck "Null: Whistleblower" [(qty "Sure Gamble" 3)]))
+      (play-from-hand state :corp "Wraparound" "HQ")
+      (play-from-hand state :corp "Wraparound" "HQ")
+      (take-credits state :corp)
       (run-on state "HQ")
-      (run-continue state)
-      (card-ability state :runner null 0)
-      (prompt-select :runner (first (:hand (get-runner))))
-      (is (find-card "Spiderweb" (:discard (get-corp))) "Spiderweb trashed by Parasite + Null")
-      (is (= 7 (:current-strength (refresh wrap))) "Wraparound not reduced by Null"))))
+      (let [null (get-in @state [:runner :identity])
+            wrap1 (get-ice state :hq 0)
+            wrap2 (get-ice state :hq 1)]
+        (card-ability state :runner null 0)
+        (is (empty? (:prompt (get-runner))) "Ability won't work on unrezzed ICE")
+        (core/rez state :corp wrap2)
+        (card-ability state :runner null 0)
+        (prompt-select :runner (find-card "Sure Gamble" (:hand (get-runner))))
+        (is (= 5 (:current-strength (refresh wrap2))) "Wraparound reduced to 5 strength")
+        (run-continue state)
+        (core/rez state :corp wrap1)
+        (card-ability state :runner null 0)
+        (is (empty? (:prompt (get-runner))) "Ability already used this turn")
+        (run-jack-out state)
+        (is (= 7 (:current-strength (refresh wrap2))) "Outer Wraparound back to 7 strength"))))
+  (testing "does not affect next ice when current is trashed. Issue #1788."
+    (do-game
+      (new-game
+        (default-corp ["Wraparound" "Spiderweb"])
+        (make-deck "Null: Whistleblower" [(qty "Parasite" 3)]))
+      (play-from-hand state :corp "Spiderweb" "HQ")
+      (play-from-hand state :corp "Wraparound" "HQ")
+      (take-credits state :corp)
+      (core/gain state :corp :credit 10)
+      (let [null (get-in @state [:runner :identity])
+            spider (get-ice state :hq 0)
+            wrap (get-ice state :hq 1)]
+        (core/rez state :corp spider)
+        (core/rez state :corp wrap)
+        (play-from-hand state :runner "Parasite")
+        (prompt-select :runner (refresh spider))
+        (run-on state "HQ")
+        (run-continue state)
+        (card-ability state :runner null 0)
+        (prompt-select :runner (first (:hand (get-runner))))
+        (is (find-card "Spiderweb" (:discard (get-corp))) "Spiderweb trashed by Parasite + Null")
+        (is (= 7 (:current-strength (refresh wrap))) "Wraparound not reduced by Null")))))
 
-(deftest omar
+(deftest omar-keung:-conspiracy-theorist
   ;; Omar Keung
   (testing "Make a successful run on the chosen server once per turn"
     (do-game
@@ -1505,7 +1482,7 @@
         (prompt-choice :runner "HQ")
         (is (= 1 (get-counters (refresh nerve) :virus)))))))
 
-(deftest quetzal
+(deftest quetzal:-free-spirit
   ;; Quetzal
   (do-game
     (new-game
@@ -1535,7 +1512,7 @@
       (is (last-log-contains? state qmsg) "Quetzal ability did trigger")
       (core/jack-out state :runner nil))))
 
-(deftest reina-rez
+(deftest reina-roja:-freedom-fighter
   ;; Reina Roja - Increase cost of first rezzed ICE
   (do-game
     (new-game
@@ -1549,7 +1526,8 @@
       (core/rez state :corp quan)
       (is (= 5 (:credit (get-corp))) "Rez cost increased by 1"))))
 
-(deftest rielle-kit-peddler
+(deftest ^{:card-title "rielle-\"kit\"-peddler:-transhuman"}
+  kit
   ;; Rielle "Kit" Peddler - Give ICE Code Gate
   (do-game
     (new-game (default-corp [(qty "Ice Wall" 2)])
@@ -1564,7 +1542,7 @@
       (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
       (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has Code Gate"))))
 
-(deftest skorpios
+(deftest skorpios-defense-systems:-persuasive-power
   ; Remove a card from game when it moves to discard once per round
   (do-game
     (new-game (make-deck "Skorpios Defense Systems: Persuasive Power" ["Hedge Fund" (qty "Quandary" 4)])
@@ -1596,7 +1574,7 @@
     (card-ability state :corp (get-in @state [:corp :identity]) 0)
     (is (empty? (:prompt (get-corp))) "Cannot use Skorpios twice")))
 
-(deftest silhouette
+(deftest silhouette:-stealth-operative
   ;; Silhouette
   (testing "Expose trigger ability resolves completely before access. Issue #2173"
     (do-game
@@ -1656,7 +1634,7 @@
       (is (= 12 (:credit (get-runner))) "Gained 4cr")
       (is (= 12 (get-counters (get-resource state 0) :credit)) "12 cr on Temujin"))))
 
-(deftest spark-advertisements
+(deftest spark-agency:-worldswide-reach
   ;; Spark Agency - Rezzing advertisements
   (do-game
     (new-game
@@ -1680,7 +1658,7 @@
       (is (= 3 (:credit (get-runner)))
           "Runner lost 1 credit from rez of advertisement (Runner turn)"))))
 
-(deftest sso-industries-fueling-innovation
+(deftest sso-industries:-fueling-innovation
   ;; SSO Industries: Fueling Innovation - add advancement tokens on ice for faceup agendas
   (do-game
     (new-game
@@ -1717,8 +1695,8 @@
       (take-credits state :corp)
       (is (empty? (:prompt (get-corp))) "Not prompted when all ice advanced"))))
 
-(deftest strategic-innovations-future-forward
-  ;; Strategic Innovations: Future Forward - Ability
+(deftest strategic-innovations:-future-forward
+  ;; Strategic Innovations: Future Forward
   (do-game
     (new-game
       (make-deck "Strategic Innovations: Future Forward"
@@ -1743,7 +1721,7 @@
       (is (= 0 (count (:prompt (get-corp))))
           "Corp not prompted to trigger Strategic Innovations"))))
 
-(deftest the-foundry
+(deftest the-foundry:-refining-the-process
   ;; The Foundry
   (testing "interaction with Accelerated Beta Test"
     (do-game
@@ -1759,7 +1737,7 @@
       (prompt-choice :corp "Yes")
       (is (empty? (:play-area (get-corp))) "Play area shuffled into R&D"))))
 
-(deftest the-outfit
+(deftest the-outfit:-family-owned-and-operated
   ;; The Outfit - Gain 3 whenever you take at least 1 bad publicity
   (testing "basic test"
     (do-game
@@ -1797,7 +1775,7 @@
       (is (= 2 (:bad-publicity (get-corp))) "Take 1 bad publicity")
       (is (= 18 (:credit (get-corp))) "Gain 7 from Hostile Takeover + 3 from The Outfit"))))
 
-(deftest titan-transnational
+(deftest titan-transnational:-investing-in-your-future
   ;; Titan Transnational
   (testing "Add a counter to a scored agenda"
     (do-game
@@ -1841,7 +1819,7 @@
           (is (= 0 (get-counters (refresh scored) :agenda)) "No agenda counter used by Mark Yale")
           (is (= 10 (get-counters (refresh scored) :credit)) "Credits not used by Mark Yale"))))))
 
-(deftest weyland-builder-of-nations
+(deftest weyland-consortium:-builder-of-nations
   ;; Builder of Nations
   (testing "1 meat damage per turn at most"
     (do-game
@@ -1871,23 +1849,21 @@
           (prompt-choice :corp "Yes")
           (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage from BoN/Cleaners combo"))))))
 
-(deftest whizzard
+(deftest whizzard:-master-gamer
   ;; Whizzard - Recurring credits
   (do-game
-    (new-game (default-corp) (make-deck "Whizzard: Master Gamer" ["Sure Gamble"]))
-
+    (new-game (default-corp)
+              (make-deck "Whizzard: Master Gamer" ["Sure Gamble"]))
     (let [click-whizzard (fn [n] (dotimes [i n] (card-ability state :runner (:identity (get-runner)) 0)))]
       (is (changes-credits (get-runner) 1 (click-whizzard 1)))
       (is (changes-credits (get-runner) 2 (click-whizzard 5)) "Can't take more than 3 Whizzard credits")
-
       (take-credits state :corp)
       (is (changes-credits (get-runner) 3 (click-whizzard 3)) "Credits reset at start of Runner's turn")
-
       (take-credits state :runner)
       (is (changes-credits (get-runner) 0 (click-whizzard 1)) "Credits don't reset at start of Corp's turn"))))
 
-(deftest wyvern-chemically-enhanced
-  ;; Wyvern: Chemically Enhanced - Ability
+(deftest wyvern:-chemically-enhanced
+  ;; Wyvern: Chemically Enhanced
   (do-game
     (new-game (default-corp [(qty "Launch Campaign" 3)])
               (make-deck "Wyvern: Chemically Enhanced"

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -7,137 +7,132 @@
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "operations"))
 
-(deftest twenty-four-seven-news-cycle-breaking-news
-  ;; 24/7 News Cycle - Breaking News interaction
-  (do-game
-    (new-game (default-corp [(qty "Breaking News" 2) (qty "24/7 News Cycle" 3)])
-              (default-runner))
-    (play-from-hand state :corp "Breaking News" "New remote")
-    (play-from-hand state :corp "Breaking News" "New remote")
-    (let [ag1 (get-content state :remote1 0)
-          ag2 (get-content state :remote2 0)]
-      (score-agenda state :corp ag1)
-      (score-agenda state :corp ag2)
+(deftest ^{:card-title "24/7-news-cycle"}
+  twenty-four-seven-news
+  ;; 24/7 News Cycle
+  (testing "Breaking News interaction"
+    (do-game
+      (new-game (default-corp [(qty "Breaking News" 2) (qty "24/7 News Cycle" 3)])
+                (default-runner))
+      (play-from-hand state :corp "Breaking News" "New remote")
+      (play-from-hand state :corp "Breaking News" "New remote")
+      (let [ag1 (get-content state :remote1 0)
+            ag2 (get-content state :remote2 0)]
+        (score-agenda state :corp ag1)
+        (score-agenda state :corp ag2)
+        (take-credits state :corp)
+        (is (= 0 (:tag (get-runner)))) ; tags cleared
+        (take-credits state :runner)
+        (play-from-hand state :corp "24/7 News Cycle")
+        (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
+        (is (= 1 (:agenda-point (get-corp))) "Forfeited Breaking News")
+        (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
+        (is (= 2 (:tag (get-runner))) "Runner given 2 tags")
+        (take-credits state :corp 2)
+        (is (= 2 (:tag (get-runner))) "Tags remained after Corp ended turn"))))
+  (testing "Posted Bounty interaction -- Issue #1043"
+    (do-game
+      (new-game (default-corp [(qty "Posted Bounty" 2) (qty "24/7 News Cycle" 3)])
+                (default-runner))
+      (play-from-hand state :corp "Posted Bounty" "New remote")
+      (play-from-hand state :corp "Posted Bounty" "New remote")
+      (let [ag1 (get-content state :remote1 0)
+            ag2 (get-content state :remote2 0)]
+        (score-agenda state :corp ag1)
+        (prompt-choice :corp "No")
+        (score-agenda state :corp ag2)
+        (prompt-choice :corp "No")
+        (play-from-hand state :corp "24/7 News Cycle")
+        (prompt-select :corp (find-card "Posted Bounty" (:scored (get-corp))))
+        (is (= 1 (:agenda-point (get-corp))) "Forfeited Posted Bounty")
+        (prompt-select :corp (find-card "Posted Bounty" (:scored (get-corp))))
+        (prompt-choice :corp "Yes") ; "Forfeit Posted Bounty to give 1 tag?"
+        (is (= 1 (:tag (get-runner))) "Runner given 1 tag")
+        (is (= 1 (:bad-publicity (get-corp))) "Corp has 1 bad publicity")
+        (is (= 0 (:agenda-point (get-corp))) "Forfeited Posted Bounty to 24/7 News Cycle"))))
+  (testing "Swapped agendas are able to be used. #1555"
+    (do-game
+      (new-game (default-corp ["24/7 News Cycle" "Chronos Project"
+                               "Philotic Entanglement" "Profiteering"])
+                (default-runner [(qty "Turntable" 3)]))
+      (score-agenda state :corp (find-card "Chronos Project" (:hand (get-corp))))
+      (score-agenda state :corp (find-card "Philotic Entanglement" (:hand (get-corp))))
       (take-credits state :corp)
-      (is (= 0 (:tag (get-runner)))) ; tags cleared
+      (play-from-hand state :runner "Turntable")
+      (core/steal state :runner (find-card "Profiteering" (:hand (get-corp))))
+      (prompt-choice :runner "Yes")
+      (prompt-select :runner (find-card "Philotic Entanglement" (:scored (get-corp))))
+      (is (= 2 (:agenda-point (get-corp))))
+      (is (= 2 (:agenda-point (get-runner))))
       (take-credits state :runner)
       (play-from-hand state :corp "24/7 News Cycle")
-      (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
-      (is (= 1 (:agenda-point (get-corp))) "Forfeited Breaking News")
-      (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
-      (is (= 2 (:tag (get-runner))) "Runner given 2 tags")
-      (take-credits state :corp 2)
-      (is (= 2 (:tag (get-runner))) "Tags remained after Corp ended turn"))))
-
-(deftest twenty-four-seven-news-cycle-posted-bounty
-  ;; 24/7 News Cycle and Posted Bounty interaction -- Issue #1043
-  (do-game
-    (new-game (default-corp [(qty "Posted Bounty" 2) (qty "24/7 News Cycle" 3)])
-              (default-runner))
-    (play-from-hand state :corp "Posted Bounty" "New remote")
-    (play-from-hand state :corp "Posted Bounty" "New remote")
-    (let [ag1 (get-content state :remote1 0)
-          ag2 (get-content state :remote2 0)]
-      (score-agenda state :corp ag1)
-      (prompt-choice :corp "No")
-      (score-agenda state :corp ag2)
-      (prompt-choice :corp "No")
-      (play-from-hand state :corp "24/7 News Cycle")
-      (prompt-select :corp (find-card "Posted Bounty" (:scored (get-corp))))
-      (is (= 1 (:agenda-point (get-corp))) "Forfeited Posted Bounty")
-      (prompt-select :corp (find-card "Posted Bounty" (:scored (get-corp))))
-      (prompt-choice :corp "Yes") ; "Forfeit Posted Bounty to give 1 tag?"
-      (is (= 1 (:tag (get-runner))) "Runner given 1 tag")
-      (is (= 1 (:bad-publicity (get-corp))) "Corp has 1 bad publicity")
-      (is (= 0 (:agenda-point (get-corp))) "Forfeited Posted Bounty to 24/7 News Cycle"))))
-
-(deftest twenty-four-seven-news-cycle-swaps
-  ;; 24/7 News Cycle - Swapped agendas are able to be used. #1555
-  (do-game
-    (new-game (default-corp ["24/7 News Cycle" "Chronos Project"
-                             "Philotic Entanglement" "Profiteering"])
-              (default-runner [(qty "Turntable" 3)]))
-    (score-agenda state :corp (find-card "Chronos Project" (:hand (get-corp))))
-    (score-agenda state :corp (find-card "Philotic Entanglement" (:hand (get-corp))))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Turntable")
-    (core/steal state :runner (find-card "Profiteering" (:hand (get-corp))))
-    (prompt-choice :runner "Yes")
-    (prompt-select :runner (find-card "Philotic Entanglement" (:scored (get-corp))))
-    (is (= 2 (:agenda-point (get-corp))))
-    (is (= 2 (:agenda-point (get-runner))))
-    (take-credits state :runner)
-    (play-from-hand state :corp "24/7 News Cycle")
-    (prompt-select :corp (find-card "Chronos Project" (:scored (get-corp))))
-    (is (= "Chronos Project" (:title (first (:rfg (get-corp))))))
-    ;; shouldn't work on an agenda in the Runner's scored area
-    (is (= 2 (count (:hand (get-runner)))))
-    (prompt-select :corp (find-card "Philotic Entanglement" (:scored (get-runner))))
-    (is (= 2 (count (:hand (get-runner)))))
-    ;; resolve 'when scored' ability on swapped Profiteering
-    (is (= 8 (:credit (get-corp))))
-    (prompt-select :corp (find-card "Profiteering" (:scored (get-corp))))
-    (prompt-choice :corp "3")
-    (is (= 1 (:agenda-point (get-corp))))
-    (is (= 3 (:bad-publicity (get-corp))))
-    (is (= 23 (:credit (get-corp))) "Gained 15 credits")))
+      (prompt-select :corp (find-card "Chronos Project" (:scored (get-corp))))
+      (is (= "Chronos Project" (:title (first (:rfg (get-corp))))))
+      ;; shouldn't work on an agenda in the Runner's scored area
+      (is (= 2 (count (:hand (get-runner)))))
+      (prompt-select :corp (find-card "Philotic Entanglement" (:scored (get-runner))))
+      (is (= 2 (count (:hand (get-runner)))))
+      ;; resolve 'when scored' ability on swapped Profiteering
+      (is (= 8 (:credit (get-corp))))
+      (prompt-select :corp (find-card "Profiteering" (:scored (get-corp))))
+      (prompt-choice :corp "3")
+      (is (= 1 (:agenda-point (get-corp))))
+      (is (= 3 (:bad-publicity (get-corp))))
+      (is (= 23 (:credit (get-corp))) "Gained 15 credits"))))
 
 (deftest accelerated-diagnostics
   ;; Accelerated Diagnostics - Interaction with prompt effects, like Shipment from SanSan
-  (do-game
-    (new-game (default-corp ["Accelerated Diagnostics" "Cerebral Overwriter" "Shipment from SanSan"
-                             "Hedge Fund" "Back Channels"])
-              (default-runner))
-    (starting-hand state :corp ["Accelerated Diagnostics" "Cerebral Overwriter"])
-    (play-from-hand state :corp "Cerebral Overwriter" "New remote")
-    (core/gain state :corp :credit 1)
-    (play-from-hand state :corp "Accelerated Diagnostics")
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Accelerated Diagnostics" "Cerebral Overwriter" "Shipment from SanSan"
+                               "Hedge Fund" "Back Channels"])
+                (default-runner))
+      (starting-hand state :corp ["Accelerated Diagnostics" "Cerebral Overwriter"])
+      (play-from-hand state :corp "Cerebral Overwriter" "New remote")
+      (core/gain state :corp :credit 1)
+      (play-from-hand state :corp "Accelerated Diagnostics")
+      (let [playarea (get-in @state [:corp :play-area])
+            hf (find-card "Hedge Fund" playarea)
+            ss (find-card "Shipment from SanSan" playarea)
+            bc (find-card "Back Channels" playarea)
+            co (get-content state :remote1 0)]
+        (is (= 3 (count playarea)) "3 cards in play area")
+        (prompt-select :corp ss)
+        (prompt-choice :corp "2")
+        (prompt-select :corp co)
+        (is (= 2 (:advance-counter (refresh co))) "Cerebral Overwriter gained 2 advancements")
+        (prompt-select :corp hf)
+        (is (= 9 (:credit (get-corp))) "Corp gained credits from Hedge Fund")
+        (prompt-select :corp bc)
+        (prompt-select :corp (refresh co))
+        (is (= 15 (:credit (get-corp))) "Corp gained 6 credits for Back Channels"))))
+  (testing "Interaction with Current"
+    (do-game
+      (new-game (default-corp ["Accelerated Diagnostics" "Cerebral Overwriter"
+                               "Enhanced Login Protocol" "Shipment from SanSan"
+                               "Hedge Fund"])
+                (default-runner))
+      (starting-hand state :corp ["Accelerated Diagnostics" "Cerebral Overwriter"])
+      (play-from-hand state :corp "Cerebral Overwriter" "New remote")
+      (core/gain state :corp :credit 3)
+      (play-from-hand state :corp "Accelerated Diagnostics")
+      (let [playarea (get-in @state [:corp :play-area])
+            hf (find-card "Hedge Fund" playarea)
+            ss (find-card "Shipment from SanSan" playarea)
+            elp (find-card "Enhanced Login Protocol" playarea)
+            co (get-content state :remote1 0)]
+        (is (= 3 (count playarea)) "3 cards in play area")
+        (prompt-select :corp elp)
+        (is (= "Enhanced Login Protocol" (:title (first (get-in @state [:corp :current]))))
+            "Enhanced Login Protocol active in Current area")
+        (prompt-select :corp ss)
+        (prompt-choice :corp "2")
+        (prompt-select :corp co)
+        (is (= 2 (:advance-counter (refresh co))) "Cerebral Overwriter gained 2 advancements")
+        (prompt-select :corp hf)
+        (is (= 9 (:credit (get-corp))) "Corp gained credits from Hedge Fund")))))
 
-    (let [playarea (get-in @state [:corp :play-area])
-          hf (find-card "Hedge Fund" playarea)
-          ss (find-card "Shipment from SanSan" playarea)
-          bc (find-card "Back Channels" playarea)
-          co (get-content state :remote1 0)]
-      (is (= 3 (count playarea)) "3 cards in play area")
-      (prompt-select :corp ss)
-      (prompt-choice :corp "2")
-      (prompt-select :corp co)
-      (is (= 2 (:advance-counter (refresh co))) "Cerebral Overwriter gained 2 advancements")
-      (prompt-select :corp hf)
-      (is (= 9 (:credit (get-corp))) "Corp gained credits from Hedge Fund")
-      (prompt-select :corp bc)
-      (prompt-select :corp (refresh co))
-      (is (= 15 (:credit (get-corp))) "Corp gained 6 credits for Back Channels"))))
-
-(deftest accelerated-diagnostics-with-current
-  ;; Accelerated Diagnostics - Interaction with Current
-  (do-game
-    (new-game (default-corp ["Accelerated Diagnostics" "Cerebral Overwriter"
-                             "Enhanced Login Protocol" "Shipment from SanSan"
-                             "Hedge Fund"])
-              (default-runner))
-    (starting-hand state :corp ["Accelerated Diagnostics" "Cerebral Overwriter"])
-    (play-from-hand state :corp "Cerebral Overwriter" "New remote")
-    (core/gain state :corp :credit 3)
-    (play-from-hand state :corp "Accelerated Diagnostics")
-
-    (let [playarea (get-in @state [:corp :play-area])
-          hf (find-card "Hedge Fund" playarea)
-          ss (find-card "Shipment from SanSan" playarea)
-          elp (find-card "Enhanced Login Protocol" playarea)
-          co (get-content state :remote1 0)]
-      (is (= 3 (count playarea)) "3 cards in play area")
-      (prompt-select :corp elp)
-      (is (= "Enhanced Login Protocol" (:title (first (get-in @state [:corp :current]))))
-        "Enhanced Login Protocol active in Current area")
-      (prompt-select :corp ss)
-      (prompt-choice :corp "2")
-      (prompt-select :corp co)
-      (is (= 2 (:advance-counter (refresh co))) "Cerebral Overwriter gained 2 advancements")
-      (prompt-select :corp hf)
-      (is (= 9 (:credit (get-corp))) "Corp gained credits from Hedge Fund"))))
-
-(deftest an-offer-you-cant-refuse
+(deftest an-offer-you-can't-refuse
   ;; An Offer You Can't Refuse - exact card added to score area, not the last discarded one
   (do-game
     (new-game (default-corp ["Celebrity Gift" "An Offer You Can't Refuse"])
@@ -214,54 +209,53 @@
           (prompt-choice :runner "Steal")
           (is (= 2 (:tag (get-runner))) "Runner took 2 tags from accessing agenda with Casting Call hosted on it"))))))
 
-(deftest cerebral-cast-runner-wins
-  ;; Cerebral Cast: if the runner succefully ran last turn, psi game to give runner choice of tag or BD
-  (do-game
-    (new-game (default-corp ["Cerebral Cast"])
-              (default-runner))
-    (play-from-hand state :corp "Cerebral Cast")
-    (is (= 3 (:click (get-corp))) "Cerebral Cast precondition not met; card not played")
-    (take-credits state :corp)
-    (run-empty-server state "Archives")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Cerebral Cast")
-    (prompt-choice :corp "0 [Credits]")
-    (prompt-choice :runner "0 [Credits]")
-    (is (= 0 (count (:discard (get-runner)))) "Runner took no damage")
-    (is (= 0 (:tag (get-runner))) "Runner took no tags")))
+(deftest cerebral-cast
+  ;; Cerebral Cast
+  (testing "Runner wins"
+    (do-game
+      (new-game (default-corp ["Cerebral Cast"])
+                (default-runner))
+      (play-from-hand state :corp "Cerebral Cast")
+      (is (= 3 (:click (get-corp))) "Cerebral Cast precondition not met; card not played")
+      (take-credits state :corp)
+      (run-empty-server state "Archives")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Cerebral Cast")
+      (prompt-choice :corp "0 [Credits]")
+      (prompt-choice :runner "0 [Credits]")
+      (is (= 0 (count (:discard (get-runner)))) "Runner took no damage")
+      (is (= 0 (:tag (get-runner))) "Runner took no tags")))
+  (testing "Corp wins"
+    (do-game
+      (new-game (default-corp [(qty "Cerebral Cast" 2)])
+                (default-runner))
+      (take-credits state :corp)
+      (run-empty-server state "Archives")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Cerebral Cast")
+      (prompt-choice :corp "0 [Credits]")
+      (prompt-choice :runner "1 [Credits]")
+      (prompt-choice :runner "1 brain damage")
+      (is (= 1 (count (:discard (get-runner)))) "Runner took a brain damage")
+      (is (= 0 (:tag (get-runner))) "Runner took no tags from brain damage choice")
+      (play-from-hand state :corp "Cerebral Cast")
+      (prompt-choice :corp "0 [Credits]")
+      (prompt-choice :runner "1 [Credits]")
+      (prompt-choice :runner "1 tag")
+      (is (= 1 (count (:discard (get-runner)))) "Runner took no additional damage")
+      (is (= 1 (:tag (get-runner))) "Runner took a tag from Cerebral Cast choice"))))
 
-(deftest cerebral-cast-corp-wins
-  ;; Cerebral Cast: if the runner succefully ran last turn, psi game to give runner choice of tag or BD
-  (do-game
-    (new-game (default-corp [(qty "Cerebral Cast" 2)])
-              (default-runner))
-    (take-credits state :corp)
-    (run-empty-server state "Archives")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Cerebral Cast")
-    (prompt-choice :corp "0 [Credits]")
-    (prompt-choice :runner "1 [Credits]")
-    (prompt-choice :runner "1 brain damage")
-    (is (= 1 (count (:discard (get-runner)))) "Runner took a brain damage")
-    (is (= 0 (:tag (get-runner))) "Runner took no tags from brain damage choice")
-    (play-from-hand state :corp "Cerebral Cast")
-    (prompt-choice :corp "0 [Credits]")
-    (prompt-choice :runner "1 [Credits]")
-    (prompt-choice :runner "1 tag")
-    (is (= 1 (count (:discard (get-runner)))) "Runner took no additional damage")
-    (is (= 1 (:tag (get-runner))) "Runner took a tag from Cerebral Cast choice")))
-
-
-(deftest cerebral-static-chaos-theory
-  ;; Cerebral Static - vs Chaos Theory
-  (do-game
-    (new-game (default-corp ["Cerebral Static" "Lag Time"])
-              (make-deck "Chaos Theory: Wünderkind" [(qty "Sure Gamble" 3)]))
-    (is (= 5 (core/available-mu state)) "CT starts with 5 memory")
-    (play-from-hand state :corp "Cerebral Static")
-    (is (= 4 (core/available-mu state)) "Cerebral Static causes CT to have 4 memory")
-    (play-from-hand state :corp "Lag Time")
-    (is (= 5 (core/available-mu state)) "CT 5 memory restored")))
+(deftest cerebral-static
+  ;; Cerebral Static
+  (testing "vs Chaos Theory"
+    (do-game
+      (new-game (default-corp ["Cerebral Static" "Lag Time"])
+                (make-deck "Chaos Theory: Wünderkind" [(qty "Sure Gamble" 3)]))
+      (is (= 5 (core/available-mu state)) "CT starts with 5 memory")
+      (play-from-hand state :corp "Cerebral Static")
+      (is (= 4 (core/available-mu state)) "Cerebral Static causes CT to have 4 memory")
+      (play-from-hand state :corp "Lag Time")
+      (is (= 5 (core/available-mu state)) "CT 5 memory restored"))))
 
 (deftest closed-accounts
   ;; Closed Accounts - Play if Runner is tagged to make Runner lose all credits
@@ -276,78 +270,70 @@
     (play-from-hand state :corp "Closed Accounts")
     (is (= 0 (:credit (get-runner))) "Runner lost all credits")))
 
-(deftest commercialization-single-advancement
-  ;; Commercialization - Single advancement token
-  (do-game
-    (new-game (default-corp ["Commercialization"
-                             "Ice Wall"])
-              (default-runner))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/add-counter state :corp (refresh (get-ice state :hq 0)) :advancement 1)
-    (play-from-hand state :corp "Commercialization")
-    (prompt-select :corp (refresh (get-ice state :hq 0)))
-    (is (= 6 (:credit (get-corp))) "Gained 1 for single advanced ice from Commercialization")))
-
-(deftest commercialization-double-advancement
-  ;; Commercialization - Two advancement tokens
-  (do-game
-    (new-game (default-corp ["Commercialization"
-                             "Ice Wall"])
-              (default-runner))
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/add-counter state :corp (refresh (get-ice state :hq 0)) :advancement 2)
-    (play-from-hand state :corp "Commercialization")
-    (prompt-select :corp (refresh (get-ice state :hq 0)))
-    (is (= 7 (:credit (get-corp))) "Gained 2 for double advanced ice from Commercialization")))
+(deftest commercialization
+  ;; Commercialization
+  (testing "Single advancement token"
+    (do-game
+      (new-game (default-corp ["Commercialization"
+                               "Ice Wall"])
+                (default-runner))
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/add-counter state :corp (refresh (get-ice state :hq 0)) :advancement 1)
+      (play-from-hand state :corp "Commercialization")
+      (prompt-select :corp (refresh (get-ice state :hq 0)))
+      (is (= 6 (:credit (get-corp))) "Gained 1 for single advanced ice from Commercialization")))
+  (testing "Two advancement tokens"
+    (do-game
+      (new-game (default-corp ["Commercialization"
+                               "Ice Wall"])
+                (default-runner))
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/add-counter state :corp (refresh (get-ice state :hq 0)) :advancement 2)
+      (play-from-hand state :corp "Commercialization")
+      (prompt-select :corp (refresh (get-ice state :hq 0)))
+      (is (= 7 (:credit (get-corp))) "Gained 2 for double advanced ice from Commercialization"))))
 
 (deftest consulting-visit
   ;; Consulting Visit - Only show single copies of operations corp can afford as choices. Play chosen operation
-  (do-game
-    (new-game (default-corp ["Consulting Visit"
-                             (qty "Beanstalk Royalties" 2)
-                             "Green Level Clearance"
-                             "Breaking News"
-                             "Hedge Fund"])
-              (default-runner))
-    (is (= 5 (:credit (get-corp))))
-    (starting-hand state :corp ["Consulting Visit"])
-    (play-from-hand state :corp "Consulting Visit")
-
-    (let [get-prompt (fn [] (first (#(get-in @state [:corp :prompt]))))
-          prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
-
-      (is (= (list "Beanstalk Royalties" "Green Level Clearance" nil) (prompt-names)))
-      (prompt-card :corp (find-card "Beanstalk Royalties" (:deck (get-corp))))
-      (is (= 6 (:credit (get-corp)))))))
-
-(deftest consulting-visit-mumbad
-  ;; Consulting Visit - Works properly when played with Mumbad City Hall
-  (do-game
-    (new-game (default-corp ["Mumbad City Hall"
-                             "Beanstalk Royalties"
-                             "Green Level Clearance"
-                             "Breaking News"
-                             "Hedge Fund"
-                             "Consulting Visit"
-                             "Mumba Temple"])
-              (default-runner))
-    (is (= 5 (:credit (get-corp))))
-    (starting-hand state :corp ["Mumbad City Hall"])
-    (play-from-hand state :corp "Mumbad City Hall" "New remote")
-
-    (let [hall (get-content state :remote1 0)
-          get-prompt (fn [] (first (#(get-in @state [:corp :prompt]))))
-          prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
-
-      (card-ability state :corp hall 0)
-      (is (= (list "Consulting Visit" "Mumba Temple" nil) (prompt-names)))
-
-      (prompt-card :corp (find-card "Consulting Visit" (:deck (get-corp))))
-      (is (= 3 (:credit (get-corp))))
-      (is (= (list "Beanstalk Royalties" "Green Level Clearance" nil) (prompt-names)))
-
-      (prompt-card :corp (find-card "Green Level Clearance" (:deck (get-corp))))
-      (is (= 5 (:credit (get-corp)))))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Consulting Visit"
+                               (qty "Beanstalk Royalties" 2)
+                               "Green Level Clearance"
+                               "Breaking News"
+                               "Hedge Fund"])
+                (default-runner))
+      (is (= 5 (:credit (get-corp))))
+      (starting-hand state :corp ["Consulting Visit"])
+      (play-from-hand state :corp "Consulting Visit")
+      (let [get-prompt (fn [] (first (#(get-in @state [:corp :prompt]))))
+            prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
+        (is (= (list "Beanstalk Royalties" "Green Level Clearance" nil) (prompt-names)))
+        (prompt-card :corp (find-card "Beanstalk Royalties" (:deck (get-corp))))
+        (is (= 6 (:credit (get-corp)))))))
+  (testing "Works properly when played with Mumbad City Hall"
+    (do-game
+      (new-game (default-corp ["Mumbad City Hall"
+                               "Beanstalk Royalties"
+                               "Green Level Clearance"
+                               "Breaking News"
+                               "Hedge Fund"
+                               "Consulting Visit"
+                               "Mumba Temple"])
+                (default-runner))
+      (is (= 5 (:credit (get-corp))))
+      (starting-hand state :corp ["Mumbad City Hall"])
+      (play-from-hand state :corp "Mumbad City Hall" "New remote")
+      (let [hall (get-content state :remote1 0)
+            get-prompt (fn [] (first (#(get-in @state [:corp :prompt]))))
+            prompt-names (fn [] (map #(:title %) (:choices (get-prompt))))]
+        (card-ability state :corp hall 0)
+        (is (= (list "Consulting Visit" "Mumba Temple" nil) (prompt-names)))
+        (prompt-card :corp (find-card "Consulting Visit" (:deck (get-corp))))
+        (is (= 3 (:credit (get-corp))))
+        (is (= (list "Beanstalk Royalties" "Green Level Clearance" nil) (prompt-names)))
+        (prompt-card :corp (find-card "Green Level Clearance" (:deck (get-corp))))
+        (is (= 5 (:credit (get-corp))))))))
 
 (deftest death-and-taxes
   ;; Death and Taxes gain credit on runner install, runner trash installed card
@@ -437,20 +423,16 @@
     (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
     (is (= 3 (count (:hand (get-corp)))) "Corp still has 3 cards")
     (take-credits state :corp)
-
     (run-on state :archives)
     (run-successful state)
     (take-credits state :runner)
-
     (play-from-hand state :corp "Economic Warfare")
     (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
     (play-from-hand state :corp "Economic Warfare")
     (is (= 0 (:credit (get-runner))) "Runner has 0 credits")
     (take-credits state :corp)
-
     (run-on state :archives)
     (take-credits state :runner)
-
     (play-from-hand state :corp "Economic Warfare")
     (is (= 3 (:credit (get-runner))) "Runner has 3 credits")))
 
@@ -615,143 +597,127 @@
     (is (= 1 (:click (get-runner))) "Runner doesn't spend 1 additional click to make a run"))))
 
 (deftest exchange-of-information
-  ;; Exchange of Information - Swapping agendas works correctly
-  (do-game
-    (new-game (default-corp ["Exchange of Information"
-                             "Market Research"
-                             "Breaking News"
-                             "Project Beale"
-                             "Explode-a-palooza"])
-              (default-runner))
-
+  ;; Exchange of Information
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Exchange of Information"
+                               "Market Research"
+                               "Breaking News"
+                               "Project Beale"
+                               "Explode-a-palooza"])
+                (default-runner))
       (score-agenda state :corp (find-card "Market Research" (:hand (get-corp))))
       (score-agenda state :corp (find-card "Breaking News" (:hand (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner gained 2 tags")
       (take-credits state :corp)
       (is (= 0 (:tag (get-runner))) "Runner lost 2 tags")
-
       (core/steal state :runner (find-card "Project Beale" (:hand (get-corp))))
       (core/steal state :runner (find-card "Explode-a-palooza" (:hand (get-corp))))
       (take-credits state :runner)
-
       (is (= 4 (:agenda-point (get-runner))))
       (is (= 3 (:agenda-point (get-corp))))
-
       (core/gain state :runner :tag 1)
       (play-from-hand state :corp "Exchange of Information")
-
       (prompt-select :corp (find-card "Project Beale" (:scored (get-runner))))
       (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
-
       (is (= 3 (:agenda-point (get-runner))))
       (is (= 4 (:agenda-point (get-corp))))))
-
-(deftest exchange-of-information-breaking-news
-  ;; Exchange of Information - Swapping a just scored Breaking News keeps the tags
-  (do-game
-    (new-game (default-corp ["Exchange of Information"
-                             "Market Research"
-                             "Breaking News"
-                             "Project Beale"
-                             "Explode-a-palooza"])
-              (default-runner))
-
+  (testing "Swapping a just scored Breaking News keeps the tags"
+    (do-game
+      (new-game (default-corp ["Exchange of Information"
+                               "Market Research"
+                               "Breaking News"
+                               "Project Beale"
+                               "Explode-a-palooza"])
+                (default-runner))
       (take-credits state :corp)
-
       (core/steal state :runner (find-card "Project Beale" (:hand (get-corp))))
       (core/steal state :runner (find-card "Explode-a-palooza" (:hand (get-corp))))
       (take-credits state :runner)
-
       (score-agenda state :corp (find-card "Breaking News" (:hand (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner gained 2 tags")
       (play-from-hand state :corp "Exchange of Information")
-
       (prompt-select :corp (find-card "Project Beale" (:scored (get-runner))))
       (prompt-select :corp (find-card "Breaking News" (:scored (get-corp))))
       (is (= 2 (:tag (get-runner))) "Still has tags after swap and before end of turn")
-
       (take-credits state :corp)
       (is (= 3 (:agenda-point (get-runner))))
       (is (= 2 (:agenda-point (get-corp))))
       (is (= 2 (:tag (get-runner))) "Runner does not lose tags at end of turn")))
-
-(deftest exchange-of-information-fifteen-minutes
-  ;; Exchange of Information - Swapping a 15 Minutes still keeps the ability. #1783
-  (do-game
-    (new-game (default-corp [(qty "Exchange of Information" 2) "15 Minutes"
-                             "Project Beale"])
-              (default-runner))
-    (score-agenda state :corp (find-card "15 Minutes" (:hand (get-corp))))
-    (take-credits state :corp)
-    (core/gain state :runner :tag 1)
-    (core/steal state :runner (find-card "Project Beale" (:hand (get-corp))))
-    (take-credits state :runner)
-    (is (= 1 (:agenda-point (get-corp))))
-    (is (= 2 (:agenda-point (get-runner))))
-    (play-from-hand state :corp "Exchange of Information")
-    (prompt-select :corp (find-card "Project Beale" (:scored (get-runner))))
-    (prompt-select :corp (find-card "15 Minutes" (:scored (get-corp))))
-    (is (= 2 (:agenda-point (get-corp))))
-    (is (= 1 (:agenda-point (get-runner))))
-    (is (= 0 (count (:deck (get-corp)))))
-    ;; shuffle back into R&D from runner's scored area
-    (let [fifm (get-in @state [:runner :scored 0])]
-      (card-ability state :corp fifm 0))
-    (is (= 2 (:agenda-point (get-corp))))
-    (is (= 0 (:agenda-point (get-runner))))
-    (is (= "15 Minutes" (:title (first (:deck (get-corp))))))
-    (take-credits state :corp)
-    (core/steal state :runner (find-card "15 Minutes" (:deck (get-corp))))
-    (take-credits state :runner)
-    (is (= 2 (:agenda-point (get-corp))))
-    (is (= 1 (:agenda-point (get-runner))))
-    (play-from-hand state :corp "Exchange of Information")
-    (prompt-select :corp (find-card "15 Minutes" (:scored (get-runner))))
-    (prompt-select :corp (find-card "Project Beale" (:scored (get-corp))))
-    (is (= 1 (:agenda-point (get-corp))))
-    (is (= 2 (:agenda-point (get-runner))))
-    ;; shuffle back into R&D from corp's scored area
-    (let [fifm (get-in @state [:corp :scored 0])]
-      (card-ability state :corp fifm 0))
-    (is (= "15 Minutes" (:title (first (:deck (get-corp))))))))
-
-(deftest exchange-of-information-mandatory-upgrades
-  ;; Exchange of Information - Swapping a Mandatory Upgrades gives the Corp an additional click per turn. #1687
-  (do-game
-    (new-game (default-corp [(qty "Exchange of Information" 2) "Mandatory Upgrades"
-                             "Global Food Initiative"])
-              (default-runner))
-    (score-agenda state :corp (find-card "Global Food Initiative" (:hand (get-corp))))
-    (take-credits state :corp)
-    (core/gain state :runner :tag 1)
-    (core/steal state :runner (find-card "Mandatory Upgrades" (:hand (get-corp))))
-    (take-credits state :runner)
-    (is (= 3 (:agenda-point (get-corp))))
-    (is (= 2 (:agenda-point (get-runner))))
-    (is (= 3 (:click (get-corp))))
-    (is (= 3 (:click-per-turn (get-corp))))
-    (play-from-hand state :corp "Exchange of Information")
-    (prompt-select :corp (find-card "Mandatory Upgrades" (:scored (get-runner))))
-    (prompt-select :corp (find-card "Global Food Initiative" (:scored (get-corp))))
-    (is (= 2 (:agenda-point (get-corp))))
-    (is (= 2 (:agenda-point (get-runner))))
-    (is (= 3 (:click (get-corp))))
-    (is (= 4 (:click-per-turn (get-corp))))
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (is (= 4 (:click (get-corp))))
-    (is (= 4 (:click-per-turn (get-corp))))
-    (play-from-hand state :corp "Exchange of Information")
-    (prompt-select :corp (find-card "Global Food Initiative" (:scored (get-runner))))
-    (prompt-select :corp (find-card "Mandatory Upgrades" (:scored (get-corp))))
-    (is (= 3 (:agenda-point (get-corp))))
-    (is (= 2 (:agenda-point (get-runner))))
-    (is (= 2 (:click (get-corp))))
-    (is (= 3 (:click-per-turn (get-corp))))
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (is (= 3 (:click (get-corp))))
-    (is (= 3 (:click-per-turn (get-corp))))))
+  (testing "Swapping a 15 Minutes still keeps the ability. #1783"
+    (do-game
+      (new-game (default-corp [(qty "Exchange of Information" 2) "15 Minutes"
+                               "Project Beale"])
+                (default-runner))
+      (score-agenda state :corp (find-card "15 Minutes" (:hand (get-corp))))
+      (take-credits state :corp)
+      (core/gain state :runner :tag 1)
+      (core/steal state :runner (find-card "Project Beale" (:hand (get-corp))))
+      (take-credits state :runner)
+      (is (= 1 (:agenda-point (get-corp))))
+      (is (= 2 (:agenda-point (get-runner))))
+      (play-from-hand state :corp "Exchange of Information")
+      (prompt-select :corp (find-card "Project Beale" (:scored (get-runner))))
+      (prompt-select :corp (find-card "15 Minutes" (:scored (get-corp))))
+      (is (= 2 (:agenda-point (get-corp))))
+      (is (= 1 (:agenda-point (get-runner))))
+      (is (= 0 (count (:deck (get-corp)))))
+      ;; shuffle back into R&D from runner's scored area
+      (let [fifm (get-in @state [:runner :scored 0])]
+        (card-ability state :corp fifm 0))
+      (is (= 2 (:agenda-point (get-corp))))
+      (is (= 0 (:agenda-point (get-runner))))
+      (is (= "15 Minutes" (:title (first (:deck (get-corp))))))
+      (take-credits state :corp)
+      (core/steal state :runner (find-card "15 Minutes" (:deck (get-corp))))
+      (take-credits state :runner)
+      (is (= 2 (:agenda-point (get-corp))))
+      (is (= 1 (:agenda-point (get-runner))))
+      (play-from-hand state :corp "Exchange of Information")
+      (prompt-select :corp (find-card "15 Minutes" (:scored (get-runner))))
+      (prompt-select :corp (find-card "Project Beale" (:scored (get-corp))))
+      (is (= 1 (:agenda-point (get-corp))))
+      (is (= 2 (:agenda-point (get-runner))))
+      ;; shuffle back into R&D from corp's scored area
+      (let [fifm (get-in @state [:corp :scored 0])]
+        (card-ability state :corp fifm 0))
+      (is (= "15 Minutes" (:title (first (:deck (get-corp))))))))
+  (testing "Swapping a Mandatory Upgrades gives the Corp an additional click per turn. #1687"
+    (do-game
+      (new-game (default-corp [(qty "Exchange of Information" 2) "Mandatory Upgrades"
+                               "Global Food Initiative"])
+                (default-runner))
+      (score-agenda state :corp (find-card "Global Food Initiative" (:hand (get-corp))))
+      (take-credits state :corp)
+      (core/gain state :runner :tag 1)
+      (core/steal state :runner (find-card "Mandatory Upgrades" (:hand (get-corp))))
+      (take-credits state :runner)
+      (is (= 3 (:agenda-point (get-corp))))
+      (is (= 2 (:agenda-point (get-runner))))
+      (is (= 3 (:click (get-corp))))
+      (is (= 3 (:click-per-turn (get-corp))))
+      (play-from-hand state :corp "Exchange of Information")
+      (prompt-select :corp (find-card "Mandatory Upgrades" (:scored (get-runner))))
+      (prompt-select :corp (find-card "Global Food Initiative" (:scored (get-corp))))
+      (is (= 2 (:agenda-point (get-corp))))
+      (is (= 2 (:agenda-point (get-runner))))
+      (is (= 3 (:click (get-corp))))
+      (is (= 4 (:click-per-turn (get-corp))))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (= 4 (:click (get-corp))))
+      (is (= 4 (:click-per-turn (get-corp))))
+      (play-from-hand state :corp "Exchange of Information")
+      (prompt-select :corp (find-card "Global Food Initiative" (:scored (get-runner))))
+      (prompt-select :corp (find-card "Mandatory Upgrades" (:scored (get-corp))))
+      (is (= 3 (:agenda-point (get-corp))))
+      (is (= 2 (:agenda-point (get-runner))))
+      (is (= 2 (:click (get-corp))))
+      (is (= 3 (:click-per-turn (get-corp))))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (= 3 (:click (get-corp))))
+      (is (= 3 (:click-per-turn (get-corp)))))))
 
 (deftest hatchet-job
   ;; Hatchet Job - Win trace to add installed non-virtual to grip
@@ -781,48 +747,34 @@
 (deftest high-profile-target
   (testing "when the runner has no tags"
     (do-game
-     (new-game (default-corp [(qty "High-Profile Target" 6)])
-               (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
-     (play-from-hand state :corp "High-Profile Target")
-     (is (= 3 (:click (get-corp))) "Corp not charged a click")
-     (is (= 5 (count (:hand (get-runner)))) "Runner did not take damage")))
-
+      (new-game (default-corp [(qty "High-Profile Target" 6)])
+                (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
+      (play-from-hand state :corp "High-Profile Target")
+      (is (= 3 (:click (get-corp))) "Corp not charged a click")
+      (is (= 5 (count (:hand (get-runner)))) "Runner did not take damage")))
   (testing "when the runner has one tag"
     (do-game
-     (new-game (default-corp [(qty "High-Profile Target" 6)])
-               (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
-     (core/gain state :runner :tag 1)
-     (play-from-hand state :corp "High-Profile Target")
-     (is (= 3 (count (:hand (get-runner)))) "Runner has 3 cards in hand")))
-
+      (new-game (default-corp [(qty "High-Profile Target" 6)])
+                (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
+      (core/gain state :runner :tag 1)
+      (play-from-hand state :corp "High-Profile Target")
+      (is (= 3 (count (:hand (get-runner)))) "Runner has 3 cards in hand")))
   (testing "when the runner has two tags"
     (do-game
-     (new-game (default-corp [(qty "High-Profile Target" 6)])
-               (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
-     (core/gain state :runner :tag 2)
-     (play-from-hand state :corp "High-Profile Target")
-     (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")))
-
-  (testing "when the runner has enough tags to die"
+      (new-game (default-corp [(qty "High-Profile Target" 6)])
+                (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
+      (core/gain state :runner :tag 2)
+      (play-from-hand state :corp "High-Profile Target")
+      (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")))
+  (testing "When the runner has three tags, gg"
     (do-game
-     (new-game (default-corp [(qty "High-Profile Target" 6)])
-               (default-runner))
-     (core/gain state :runner :tag 3)
-     (play-from-hand state :corp "High-Profile Target")
-     (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
-     (is (= :corp (:winner @state)) "Corp wins")
-     (is (= "Flatline" (:reason @state)) "Win condition reports flatline"))))
-
-(deftest high-profile-target-flatline
-  ;; High-Profile Target - three tags, gg
-  (do-game
-   (new-game (default-corp [(qty "High-Profile Target" 10)])
-             (default-runner))
-   (core/gain state :runner :tag 3)
-   (play-from-hand state :corp "High-Profile Target")
-   (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
-   (is (= :corp (:winner @state)) "Corp wins")
-   (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
+      (new-game (default-corp [(qty "High-Profile Target" 10)])
+                (default-runner))
+      (core/gain state :runner :tag 3)
+      (play-from-hand state :corp "High-Profile Target")
+      (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+      (is (= :corp (:winner @state)) "Corp wins")
+      (is (= "Flatline" (:reason @state)) "Win condition reports flatline"))))
 
 (deftest housekeeping
   ;; Housekeeping - Runner must trash a card from Grip on first install of a turn
@@ -875,7 +827,7 @@
     (prompt-choice :runner 2) ; Runner matches
     (is (= 1 (:bad-publicity (get-corp))))))
 
-(deftest ipo-terminal
+(deftest ipo
   ;; IPO - credits with Terminal operations
   (do-game
     (new-game
@@ -913,7 +865,7 @@
       "Breaking News installed by Lateral Growth")
     (is (= 7 (:credit (get-corp))))))
 
-(deftest manhunt-every-run
+(deftest manhunt
   ;; Manhunt - only fires once per turn. Unreported issue.
   (do-game
     (new-game (default-corp ["Manhunt" (qty "Hedge Fund" 3)])
@@ -933,37 +885,21 @@
     (is (not (:run @state)) "Run ended")))
 
 (deftest market-forces
-  (testing "when the runner is not tagged"
-    (do-game
-     (new-game (default-corp [(qty "Market Forces" 6)])
-               (default-runner))
-
-     (play-from-hand state :corp "Market Forces")
-
-     (is (= 6 (count (:hand (get-corp))))
-         "Market Forces is not played")
-     (is (= 3 (:click (get-corp)))
-         "the corp does not spend a click")
-     (is (= 5 (:credit (get-corp)) (:credit (get-runner)))
-         "credits are unaffected")))
-
+  (testing "Full test"
     (letfn [(market-forces-credit-test
               [{:keys [tag-count runner-creds expected-credit-diff]}]
               (testing (str "when the runner has " tag-count " tags and " runner-creds " credits")
                 (do-game
-                 (new-game (default-corp [(qty "Market Forces" 6)])
-                           (default-runner))
-
-                 (swap! state assoc-in [:corp :credit] 0)
-                 (swap! state assoc-in [:runner :credit] runner-creds)
-                 (core/gain state :runner :tag tag-count)
-
-                 (play-from-hand state :corp "Market Forces")
-
-                 (is (= expected-credit-diff (:credit (get-corp)))
-                     (str "the corp gains " expected-credit-diff " credits"))
-                 (is (= expected-credit-diff (- runner-creds (:credit (get-runner))))
-                     (str "the runner loses " expected-credit-diff " credits")))))]
+                  (new-game (default-corp [(qty "Market Forces" 6)])
+                            (default-runner))
+                  (swap! state assoc-in [:corp :credit] 0)
+                  (swap! state assoc-in [:runner :credit] runner-creds)
+                  (core/gain state :runner :tag tag-count)
+                  (play-from-hand state :corp "Market Forces")
+                  (is (= expected-credit-diff (:credit (get-corp)))
+                      (str "the corp gains " expected-credit-diff " credits"))
+                  (is (= expected-credit-diff (- runner-creds (:credit (get-runner))))
+                      (str "the runner loses " expected-credit-diff " credits")))))]
       (doall (map market-forces-credit-test
                   [{:tag-count            1
                     :runner-creds         10
@@ -980,6 +916,17 @@
                    {:tag-count            3
                     :runner-creds         5
                     :expected-credit-diff 5}]))))
+  (testing "when the runner is not tagged"
+    (do-game
+      (new-game (default-corp [(qty "Market Forces" 6)])
+                (default-runner))
+      (play-from-hand state :corp "Market Forces")
+      (is (= 6 (count (:hand (get-corp))))
+          "Market Forces is not played")
+      (is (= 3 (:click (get-corp)))
+          "the corp does not spend a click")
+      (is (= 5 (:credit (get-corp)) (:credit (get-runner)))
+          "credits are unaffected"))))
 
 (deftest mass-commercialization
   ;; Mass Commercialization
@@ -1200,48 +1147,45 @@
 
 (deftest preemptive-action
   ;; Preemptive Action - Shuffles cards into R&D and removes itself from game
-  (do-game
-    (new-game (default-corp [(qty "Subliminal Messaging" 3)
-                             "Preemptive Action"])
-              (default-runner))
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Preemptive Action")
-    (prompt-select :corp (first (:discard (get-corp))))
-    (prompt-select :corp (second (:discard (get-corp))))
-    (prompt-select :corp (last (:discard (get-corp))))
-    (is (= 0 (count (:discard (get-corp)))))
-    (is (= 1 (count (:rfg (get-corp)))))))
-
-(deftest preemptive-action-must-take-three
-  ;; Preemptive Action - Shuffles cards into R&D, forcing you to take 3 if there are three, and removes itself from game
-  (do-game
-    (new-game (default-corp [(qty "Subliminal Messaging" 3)
-                             (qty "Preemptive Action" 1)])
-              (default-runner))
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Preemptive Action")
-    (prompt-select :corp (first (:discard (get-corp))))
-    (prompt-select :corp (last (:discard (get-corp))))
-    (is (= 3 (count (:discard (get-corp)))))
-    (is (= 1 (count (:rfg (get-corp)))))))
-
-(deftest preemptive-action-small-archives
-  ;; Preemptive Action - Shuffles all archives cards into R&D if Archives has less than 3 cards, and removes itself from game
-  (do-game
-    (new-game (default-corp [(qty "Subliminal Messaging" 2)
-                             (qty "Preemptive Action" 1)])
-              (default-runner))
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Preemptive Action")
-    (prompt-select :corp (first (:discard (get-corp))))
-    (prompt-select :corp (last (:discard (get-corp))))
-    (is (= 0 (count (:discard (get-corp)))))
-    (is (= 1 (count (:rfg (get-corp)))))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Subliminal Messaging" 3)
+                               "Preemptive Action"])
+                (default-runner))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Preemptive Action")
+      (prompt-select :corp (first (:discard (get-corp))))
+      (prompt-select :corp (second (:discard (get-corp))))
+      (prompt-select :corp (last (:discard (get-corp))))
+      (is (= 0 (count (:discard (get-corp)))))
+      (is (= 1 (count (:rfg (get-corp)))))))
+  (testing "forces you to take 3 if there are three, and removes itself from game"
+    (do-game
+      (new-game (default-corp [(qty "Subliminal Messaging" 3)
+                               (qty "Preemptive Action" 1)])
+                (default-runner))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Preemptive Action")
+      (prompt-select :corp (first (:discard (get-corp))))
+      (prompt-select :corp (last (:discard (get-corp))))
+      (is (= 3 (count (:discard (get-corp)))))
+      (is (= 1 (count (:rfg (get-corp)))))))
+  (testing "Shuffles all archives cards into R&D if Archives has less than 3 cards, and removes itself from game"
+    (do-game
+      (new-game (default-corp [(qty "Subliminal Messaging" 2)
+                               (qty "Preemptive Action" 1)])
+                (default-runner))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Preemptive Action")
+      (prompt-select :corp (first (:discard (get-corp))))
+      (prompt-select :corp (last (:discard (get-corp))))
+      (is (= 0 (count (:discard (get-corp)))))
+      (is (= 1 (count (:rfg (get-corp))))))))
 
 (deftest psychographics
   ;; Psychographics - Place advancements up to the number of Runner tags on a card
@@ -1391,7 +1335,7 @@
     (play-from-hand state :runner "Easy Mark")
     (is (= 12 (:credit (get-runner))) "Easy Mark netted 3c after Brownout trashed")))
 
-(deftest salems-hospitality
+(deftest salem's-hospitality
   ;; Salem's Hospitality - Full test
   (do-game
     (new-game (default-corp [(qty "Salem's Hospitality" 3)])
@@ -1406,33 +1350,30 @@
     (is (= 2 (count (:hand (get-runner)))))))
 
 (deftest scorched-earth
-  ;; Scorched Earth - burn 'em
-  (do-game
-    (new-game (default-corp ["Scorched Earth"])
-              (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
-    (core/gain state :runner :tag 1)
-    (play-from-hand state :corp "Scorched Earth")
-    (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")))
-
-(deftest scorched-earth-no-tag
-  ;; Scorched Earth - not tagged
-  (do-game
-    (new-game (default-corp ["Scorched Earth"])
-              (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
-    (play-from-hand state :corp "Scorched Earth")
-    (is (= 3 (:click (get-corp))) "Corp not charged a click")
-    (is (= 5 (count (:hand (get-runner)))) "Runner did not take damage")))
-
-(deftest scorched-earth-flatline
-  ;; Scorched Earth - murderize 'em
-  (do-game
-    (new-game (default-corp [(qty "Scorched Earth" 10)])
-              (default-runner))
-    (core/gain state :runner :tag 1)
-    (play-from-hand state :corp "Scorched Earth")
-    (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
-    (is (= :corp (:winner @state)) "Corp wins")
-    (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
+  ;; Scorched Earth
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Scorched Earth"])
+                (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
+      (core/gain state :runner :tag 1)
+      (play-from-hand state :corp "Scorched Earth")
+      (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")))
+  (testing "not tagged"
+    (do-game
+      (new-game (default-corp ["Scorched Earth"])
+                (default-runner [(qty "Sure Gamble" 3) (qty "Lucky Find" 3)]))
+      (play-from-hand state :corp "Scorched Earth")
+      (is (= 3 (:click (get-corp))) "Corp not charged a click")
+      (is (= 5 (count (:hand (get-runner)))) "Runner did not take damage")))
+  (testing "flatline"
+    (do-game
+      (new-game (default-corp [(qty "Scorched Earth" 10)])
+                (default-runner))
+      (core/gain state :runner :tag 1)
+      (play-from-hand state :corp "Scorched Earth")
+      (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+      (is (= :corp (:winner @state)) "Corp wins")
+      (is (= "Flatline" (:reason @state)) "Win condition reports flatline"))))
 
 (deftest self-growth-program
   ;; Self-Growth Program - Add 2 installed cards to grip if runner is tagged
@@ -1457,148 +1398,122 @@
     (is (= 0 (count (get-in @state [:runner :rig :hardware]))) "No hardware installed")))
 
 (deftest service-outage
-  ;; Service Outage - First click run each turn costs a credit
-  (do-game
-    (new-game (default-corp ["Service Outage"])
-              (default-runner ["Employee Strike"]))
-    (play-from-hand state :corp "Service Outage")
-    (take-credits state :corp)
-
-    (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
-    (run-on state :archives)
-    (is (= 4 (:credit (get-runner)))
-        "Runner spends 1 credit to make the first run")
-    (run-successful state)
-
-    (run-on state :archives)
-    (is (= 4 (:credit (get-runner)))
-        "Runner doesn't spend 1 credit to make the second run")
-    (run-successful state)
-
-    (take-credits state :runner)
-    (take-credits state :corp)
-
-    (core/lose state :runner :credit 6)
-    (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
-    (is (= 0 (:credit (get-runner))) "Runner has 0 credits")
-    (run-on state :archives)
-    (is (not (:run @state)) "No run was initiated")
-    (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
-    (is (= 0 (:credit (get-runner))) "Runner has 0 credits")
-
-    (take-credits state :runner)
-    (take-credits state :corp)
-
-    (core/lose state :runner :credit 2)
-    (play-from-hand state :runner "Employee Strike")
-    (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
-
-    (run-on state :archives)
-    (is (= 1 (:credit (get-runner)))
-        "Runner doesn't spend 1 credit to make a run")))
-
-(deftest service-outage-card-ability
-  ;; Service Outage - First card ability run each turn costs an additional credit
-  (do-game
-    (new-game (default-corp ["Service Outage"])
-              (default-runner ["Sneakdoor Beta"]))
-    (play-from-hand state :corp "Service Outage")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Sneakdoor Beta")
-    (take-credits state :runner 1)
-
-    (is (= 2 (:credit (get-runner))) "Runner has 2 credits")
-    (let [sneakdoor (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner sneakdoor 0)
-      (is (= 1 (:credit (get-runner)))
-          "Runner spends 1 additional credit to run with a card ability")
-      (run-successful state)
-
+  ;; Service Outage
+  (testing "First click run each turn costs a credit"
+    (do-game
+      (new-game (default-corp ["Service Outage"])
+                (default-runner ["Employee Strike"]))
+      (play-from-hand state :corp "Service Outage")
+      (take-credits state :corp)
+      (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
       (run-on state :archives)
-      (is (= 1 (:credit (get-runner)))
-          "Runner doesn't spend 1 credit to make a run")
+      (is (= 4 (:credit (get-runner)))
+          "Runner spends 1 credit to make the first run")
       (run-successful state)
-
+      (run-on state :archives)
+      (is (= 4 (:credit (get-runner)))
+          "Runner doesn't spend 1 credit to make the second run")
+      (run-successful state)
       (take-credits state :runner)
       (take-credits state :corp)
-
-      (core/lose state :runner :credit 1)
+      (core/lose state :runner :credit 6)
       (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
       (is (= 0 (:credit (get-runner))) "Runner has 0 credits")
-      (card-ability state :runner sneakdoor 0)
+      (run-on state :archives)
       (is (not (:run @state)) "No run was initiated")
       (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
-      (is (= 0 (:credit (get-runner))) "Runner has 0 credits"))))
-
-(deftest service-outage-run-events
-  ;; Service Outage - First run event each turn costs an additional credit
-  (do-game
-    (new-game (default-corp ["Service Outage"])
-              (default-runner [(qty "Out of the Ashes" 2)]))
-    (play-from-hand state :corp "Service Outage")
-    (take-credits state :corp)
-
-    (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
-    (play-from-hand state :runner "Out of the Ashes")
-    (is (= 3 (:credit (get-runner)))
-        "Runner spends 1 additional credit to run with a run event")
-    (prompt-choice :runner "Archives")
-    (run-successful state)
-
-    (run-on state :archives)
-    (is (= 3 (:credit (get-runner)))
-        "Runner doesn't spend 1 credit to make a run")
-    (run-successful state)
-
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (prompt-choice :runner "No") ; Out of the Ashes prompt
-
-    (core/lose state :runner :credit 4)
-    (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
-    (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
-    (play-from-hand state :runner "Out of the Ashes")
-    (is (empty? (get-in @state [:runner :prompt]))
-        "Out of the Ashes was not played")
-    (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
-    (is (= 1 (:credit (get-runner))) "Runner has 1 credit")))
-
-(deftest service-outage-runner-turn-first-run
-  ;; Service Outage - Works when played on the runner's turn
+      (is (= 0 (:credit (get-runner))) "Runner has 0 credits")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (core/lose state :runner :credit 2)
+      (play-from-hand state :runner "Employee Strike")
+      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
+      (run-on state :archives)
+      (is (= 1 (:credit (get-runner)))
+          "Runner doesn't spend 1 credit to make a run")))
+  (testing "First card ability run each turn costs an additional credit"
+    (do-game
+      (new-game (default-corp ["Service Outage"])
+                (default-runner ["Sneakdoor Beta"]))
+      (play-from-hand state :corp "Service Outage")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Sneakdoor Beta")
+      (take-credits state :runner 1)
+      (is (= 2 (:credit (get-runner))) "Runner has 2 credits")
+      (let [sneakdoor (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner sneakdoor 0)
+        (is (= 1 (:credit (get-runner)))
+            "Runner spends 1 additional credit to run with a card ability")
+        (run-successful state)
+        (run-on state :archives)
+        (is (= 1 (:credit (get-runner)))
+            "Runner doesn't spend 1 credit to make a run")
+        (run-successful state)
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (core/lose state :runner :credit 1)
+        (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
+        (is (= 0 (:credit (get-runner))) "Runner has 0 credits")
+        (card-ability state :runner sneakdoor 0)
+        (is (not (:run @state)) "No run was initiated")
+        (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
+        (is (= 0 (:credit (get-runner))) "Runner has 0 credits"))))
+  (testing "First run event each turn costs an additional credit"
+    (do-game
+      (new-game (default-corp ["Service Outage"])
+                (default-runner [(qty "Out of the Ashes" 2)]))
+      (play-from-hand state :corp "Service Outage")
+      (take-credits state :corp)
+      (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
+      (play-from-hand state :runner "Out of the Ashes")
+      (is (= 3 (:credit (get-runner)))
+          "Runner spends 1 additional credit to run with a run event")
+      (prompt-choice :runner "Archives")
+      (run-successful state)
+      (run-on state :archives)
+      (is (= 3 (:credit (get-runner)))
+          "Runner doesn't spend 1 credit to make a run")
+      (run-successful state)
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (prompt-choice :runner "No") ; Out of the Ashes prompt
+      (core/lose state :runner :credit 4)
+      (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
+      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
+      (play-from-hand state :runner "Out of the Ashes")
+      (is (empty? (get-in @state [:runner :prompt]))
+          "Out of the Ashes was not played")
+      (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
+      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")))
+  (testing "Works when played on the runner's turn"
+    (do-game
+      (new-game (make-deck "New Angeles Sol: Your News" ["Service Outage"
+                                                         "Breaking News"])
+                (default-runner ["Hades Shard"]))
+      (trash-from-hand state :corp "Breaking News")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 3)
+      (play-from-hand state :runner "Hades Shard")
+      (card-ability state :runner (get-in @state [:runner :rig :resource 0]) 0)
+      (prompt-choice :runner "Steal")
+      (prompt-choice :corp "Yes")
+      (prompt-select :corp (find-card "Service Outage" (:hand (get-corp))))
+      (is (find-card "Service Outage" (:current (get-corp)))
+          "Service Outage is in play")
+      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
+      (run-on state :archives)
+      (is (= 0 (:credit (get-runner)))
+          "Runner spends 1 additional credit to make a run")))
+(testing "Doesn't fire if already run when played on the runner's turn"
   (do-game
     (new-game (make-deck "New Angeles Sol: Your News" ["Service Outage"
                                                        "Breaking News"])
               (default-runner ["Hades Shard"]))
     (trash-from-hand state :corp "Breaking News")
     (take-credits state :corp)
-
-    (core/gain state :runner :credit 3)
-    (play-from-hand state :runner "Hades Shard")
-    (card-ability state :runner (get-in @state [:runner :rig :resource 0]) 0)
-    (prompt-choice :runner "Steal")
-    (prompt-choice :corp "Yes")
-    (prompt-select :corp (find-card "Service Outage" (:hand (get-corp))))
-    (is (find-card "Service Outage" (:current (get-corp)))
-        "Service Outage is in play")
-
-    (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
-    (run-on state :archives)
-    (is (= 0 (:credit (get-runner)))
-        "Runner spends 1 additional credit to make a run")))
-
-(deftest service-outage-runner-turn-second-run
-  ;; Service Outage - Doesn't fire if already run when played on the runner's turn
-  (do-game
-    (new-game (make-deck "New Angeles Sol: Your News" ["Service Outage"
-                                                       "Breaking News"])
-              (default-runner ["Hades Shard"]))
-    (trash-from-hand state :corp "Breaking News")
-    (take-credits state :corp)
-
     (run-on state :hq)
     (run-successful state)
     (prompt-choice :runner "No action")
-
     (core/gain state :runner :credit 3)
     (play-from-hand state :runner "Hades Shard")
     (card-ability state :runner (get-in @state [:runner :rig :resource 0]) 0)
@@ -1607,14 +1522,11 @@
     (prompt-select :corp (find-card "Service Outage" (:hand (get-corp))))
     (is (find-card "Service Outage" (:current (get-corp)))
         "Service Outage is in play")
-
     (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
     (run-on state :archives)
     (is (= 1 (:credit (get-runner)))
         "Runner doesn't spend 1 additional credit to make a run")))
-
-(deftest service-outage-new-angeles-sol
-  ;; Service Outage trashed and reinstalled on steal doesn't double remove penalty
+(testing "trashed and reinstalled on steal doesn't double remove penalty"
   (do-game
     (new-game
       (make-deck "New Angeles Sol: Your News" ["Service Outage"
@@ -1623,23 +1535,16 @@
     (play-from-hand state :corp "Breaking News" "New remote")
     (play-from-hand state :corp "Service Outage")
     (take-credits state :corp)
-
     (run-on state :remote1)
     (run-successful state)
     (prompt-choice :runner "Steal")
-
     (prompt-choice :corp "Yes")
-    (prompt-select :corp (find-card "Service Outage"
-                                    (:discard (get-corp))))
-
+    (prompt-select :corp (find-card "Service Outage" (:discard (get-corp))))
     (take-credits state :runner)
-
     (take-credits state :corp)
-
     (is (= 7 (:credit (get-runner))) "Runner has 7 credits")
     (run-on state :archives)
-    (is (= 6 (:credit (get-runner)))
-        "Runner spends 1 credit to make a run")))
+    (is (= 6 (:credit (get-runner))) "Runner spends 1 credit to make a run"))))
 
 (deftest shipment-from-sansan
   ;; Shipment from SanSan - placing advancements
@@ -1687,229 +1592,218 @@
       (is (core/has-subtype? (refresh qu) "Barrier") "Quandary ICE Barrier")
       (is (= 2 (count (:subroutines (refresh qu)))) "Quandry gains a subroutine"))))
 
-(deftest subcontract-scorched
-  ;; Subcontract - Don't allow second operation until damage prevention completes
-  (do-game
-    (new-game (default-corp [(qty "Scorched Earth" 2) "Subcontract"])
-              (default-runner ["Plascrete Carapace"]))
-    (take-credits state :corp)
-    (core/gain state :runner :tag 1)
-    (play-from-hand state :runner "Plascrete Carapace")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Subcontract")
-    (prompt-select :corp (find-card "Scorched Earth" (:hand (get-corp))))
-    (is (and (= 1 (count (:prompt (get-corp)))) (= :waiting (-> (get-corp) :prompt first :prompt-type)))
-        "Corp does not have Subcontract prompt until damage prevention completes")
-    (prompt-choice :runner "Done")
-    (is (not-empty (:prompt (get-corp))) "Corp can now play second Subcontract operation")))
-
-(deftest subcontract-terminal
-  ;; Subcontract - interaction with Terminal operations
-  (do-game
-    (new-game
-      (default-corp [(qty "Hard-Hitting News" 2) "Subcontract"])
-      (default-runner))
-    (core/gain state :runner :tag 1)
-    (take-credits state :corp)
-    (run-empty-server state :archives)
-    (take-credits state :runner)
-    (play-from-hand state :corp "Subcontract")
-    (prompt-select :corp (find-card "Hard-Hitting News" (:hand (get-corp))))
-    (prompt-choice :corp 0)
-    (prompt-choice :runner 0)
-    (is (= 5 (:tag (get-runner))) "Runner has 5 tags")
-    (is (empty? (:prompt (get-corp))) "Corp does not have a second Subcontract selection prompt")))
+(deftest subcontract
+  ;; Subcontract
+  (testing "Don't allow second operation until damage prevention completes"
+    (do-game
+      (new-game (default-corp [(qty "Scorched Earth" 2) "Subcontract"])
+                (default-runner ["Plascrete Carapace"]))
+      (take-credits state :corp)
+      (core/gain state :runner :tag 1)
+      (play-from-hand state :runner "Plascrete Carapace")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Subcontract")
+      (prompt-select :corp (find-card "Scorched Earth" (:hand (get-corp))))
+      (is (and (= 1 (count (:prompt (get-corp)))) (= :waiting (-> (get-corp) :prompt first :prompt-type)))
+          "Corp does not have Subcontract prompt until damage prevention completes")
+      (prompt-choice :runner "Done")
+      (is (not-empty (:prompt (get-corp))) "Corp can now play second Subcontract operation")))
+  (testing "interaction with Terminal operations"
+    (do-game
+      (new-game
+        (default-corp [(qty "Hard-Hitting News" 2) "Subcontract"])
+        (default-runner))
+      (core/gain state :runner :tag 1)
+      (take-credits state :corp)
+      (run-empty-server state :archives)
+      (take-credits state :runner)
+      (play-from-hand state :corp "Subcontract")
+      (prompt-select :corp (find-card "Hard-Hitting News" (:hand (get-corp))))
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (= 5 (:tag (get-runner))) "Runner has 5 tags")
+      (is (empty? (:prompt (get-corp))) "Corp does not have a second Subcontract selection prompt"))))
 
 (deftest subliminal-messaging
   ;; Subliminal Messaging - Playing/trashing/milling will all prompt returning to hand
-  (do-game
-    (new-game (default-corp [(qty "Subliminal Messaging" 3)])
-              (make-deck "Noise: Hacker Extraordinaire" [(qty "Cache" 3) "Utopia Shard"]))
-    (play-from-hand state :corp "Subliminal Messaging")
-    (is (= 6 (:credit (get-corp))))
-    (is (= 3 (:click (get-corp))) "First Subliminal Messaging gains 1 click")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (is (= 7 (:credit (get-corp))))
-    (is (= 2 (:click (get-corp))) "Second Subliminal Messaging does not gain 1 click")
-    (trash-from-hand state :corp "Subliminal Messaging")
-    (is (= 0 (count (:hand (get-corp)))))
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (prompt-choice :corp "Yes")
-    (prompt-choice :corp "Yes")
-    (prompt-choice :corp "Yes")
-    (is (= 3 (count (:hand (get-corp)))) "All 3 Subliminals returned to HQ")
-    (core/move state :corp (find-card "Subliminal Messaging" (:hand (get-corp))) :deck)
-    (take-credits state :corp)
-    (play-from-hand state :runner "Cache")
-    (play-from-hand state :runner "Utopia Shard")
-    (let [utopia (get-in @state [:runner :rig :resource 0])]
-      (card-ability state :runner utopia 0))
-    (take-credits state :runner)
-    (prompt-choice :corp "Yes")
-    (prompt-choice :corp "Yes")
-    (prompt-choice :corp "Yes")
-    (is (= 3 (count (:hand (get-corp)))) "All 3 Subliminals returned to HQ")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (take-credits state :corp)
-    (run-on state "R&D")
-    (run-jack-out state)
-    (take-credits state :runner)
-    (is (empty? (get-in @state [:corp :prompt])) "No prompt here because runner made a run last turn")
-    (take-credits state :corp)
-    (is (= 2 (count (:hand (get-corp)))))
-    (is (= 1 (count (:discard (get-corp)))) "1 Subliminal not returned because runner made a run last turn")))
-
-(deftest subliminal-messaging-archived
-  ;; Subliminal Messaging - Scenario involving Subliminal being added to HQ with Archived Memories
-  (do-game
-    (new-game (default-corp [(qty "Subliminal Messaging" 2) "Archived Memories"])
-              (default-runner))
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Archived Memories")
-    (prompt-select :corp (find-card "Subliminal Messaging" (:discard (get-corp))))
-    (is (= 2 (count (:discard (get-corp)))))
-    (is (= 1 (count (:hand (get-corp)))))
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (prompt-choice :corp "No")
-    (is (empty? (get-in @state [:corp :prompt])) "Only 1 Subliminal prompt")
-    (play-from-hand state :corp "Subliminal Messaging")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (prompt-choice :corp "Yes")
-    (prompt-choice :corp "Yes")
-    (is (empty? (get-in @state [:corp :prompt]))
-        "Only 2 Subliminal prompts - there will be a third if flag not cleared")))
-
-(deftest subliminal-messaging-jackson
-  ;; Subliminal Messaging - Scenario involving Subliminal being reshuffled into R&D with Jackson
-  (do-game
-    (new-game (default-corp ["Subliminal Messaging" "Jackson Howard"])
-              (default-runner))
-    (play-from-hand state :corp "Subliminal Messaging")
-    (play-from-hand state :corp "Jackson Howard" "New remote")
-    (take-credits state :corp)
-    (let [jhow (get-content state :remote1 0)]
-      (core/rez state :corp jhow)
-      (card-ability state :corp jhow 1)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Subliminal Messaging" 3)])
+                (make-deck "Noise: Hacker Extraordinaire" [(qty "Cache" 3) "Utopia Shard"]))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (is (= 6 (:credit (get-corp))))
+      (is (= 3 (:click (get-corp))) "First Subliminal Messaging gains 1 click")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (is (= 7 (:credit (get-corp))))
+      (is (= 2 (:click (get-corp))) "Second Subliminal Messaging does not gain 1 click")
+      (trash-from-hand state :corp "Subliminal Messaging")
+      (is (= 0 (count (:hand (get-corp)))))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp "Yes")
+      (is (= 3 (count (:hand (get-corp)))) "All 3 Subliminals returned to HQ")
+      (core/move state :corp (find-card "Subliminal Messaging" (:hand (get-corp))) :deck)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Cache")
+      (play-from-hand state :runner "Utopia Shard")
+      (let [utopia (get-in @state [:runner :rig :resource 0])]
+        (card-ability state :runner utopia 0))
+      (take-credits state :runner)
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp "Yes")
+      (is (= 3 (count (:hand (get-corp)))) "All 3 Subliminals returned to HQ")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (take-credits state :corp)
+      (run-on state "R&D")
+      (run-jack-out state)
+      (take-credits state :runner)
+      (is (empty? (get-in @state [:corp :prompt])) "No prompt here because runner made a run last turn")
+      (take-credits state :corp)
+      (is (= 2 (count (:hand (get-corp)))))
+      (is (= 1 (count (:discard (get-corp)))) "1 Subliminal not returned because runner made a run last turn")))
+  (testing "Scenario involving Subliminal being added to HQ with Archived Memories"
+    (do-game
+      (new-game (default-corp [(qty "Subliminal Messaging" 2) "Archived Memories"])
+                (default-runner))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Archived Memories")
       (prompt-select :corp (find-card "Subliminal Messaging" (:discard (get-corp))))
-      (prompt-choice :corp "Done")
-      (is (= 0 (count (:discard (get-corp)))))
-      (is (= 1 (count (:rfg (get-corp))))))
-    (take-credits state :runner)
-    (play-from-hand state :corp "Subliminal Messaging")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (prompt-choice :corp "Yes")
-    (is (= 1 (count (:hand (get-corp)))) "Subliminal returned to HQ")
-    (is (empty? (get-in @state [:corp :prompt]))
-        "Subliminal prompt cleared - there will be a second prompt if flag not cleared")))
+      (is (= 2 (count (:discard (get-corp)))))
+      (is (= 1 (count (:hand (get-corp)))))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (prompt-choice :corp "No")
+      (is (empty? (get-in @state [:corp :prompt])) "Only 1 Subliminal prompt")
+      (play-from-hand state :corp "Subliminal Messaging")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp "Yes")
+      (is (empty? (get-in @state [:corp :prompt]))
+          "Only 2 Subliminal prompts - there will be a third if flag not cleared")))
+  (testing "Scenario involving Subliminal being reshuffled into R&D with Jackson"
+    (do-game
+      (new-game (default-corp ["Subliminal Messaging" "Jackson Howard"])
+                (default-runner))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (play-from-hand state :corp "Jackson Howard" "New remote")
+      (take-credits state :corp)
+      (let [jhow (get-content state :remote1 0)]
+        (core/rez state :corp jhow)
+        (card-ability state :corp jhow 1)
+        (prompt-select :corp (find-card "Subliminal Messaging" (:discard (get-corp))))
+        (prompt-choice :corp "Done")
+        (is (= 0 (count (:discard (get-corp)))))
+        (is (= 1 (count (:rfg (get-corp))))))
+      (take-credits state :runner)
+      (play-from-hand state :corp "Subliminal Messaging")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (prompt-choice :corp "Yes")
+      (is (= 1 (count (:hand (get-corp)))) "Subliminal returned to HQ")
+      (is (empty? (get-in @state [:corp :prompt]))
+          "Subliminal prompt cleared - there will be a second prompt if flag not cleared")))
+  (testing "Runner made run, ensure game asks again next turn"
+    (do-game
+      (new-game (default-corp [(qty "Subliminal Messaging" 2)])
+                (default-runner))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (trash-from-hand state :corp "Subliminal Messaging")
+      (take-credits state :corp)
+      (run-on state "R&D")
+      (run-jack-out state)
+      (take-credits state :runner)
+      (is (empty? (get-in @state [:corp :prompt])) "No prompt here because runner made a run last turn")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp "Yes")
+      (is (= 2 (count (:hand (get-corp)))) "Both Subliminals returned to HQ")
+      (is (= 0 (count (:discard (get-corp)))) "No Subliminals in Archives")))
+  (testing "User declines to return to hand, ensure game asks again next turn"
+    (do-game
+      (new-game (default-corp [(qty "Subliminal Messaging" 2)])
+                (default-runner))
+      (play-from-hand state :corp "Subliminal Messaging")
+      (trash-from-hand state :corp "Subliminal Messaging")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (prompt-choice :corp "No")
+      (prompt-choice :corp "No")
+      (is (= 0 (count (:hand (get-corp)))) "Neither Subliminal returned to HQ")
+      (is (= 2 (count (:discard (get-corp)))) "Both Subliminals in Archives")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (prompt-choice :corp "Yes")
+      (prompt-choice :corp "Yes")
+      (is (= 2 (count (:hand (get-corp)))) "Both Subliminals returned to HQ")
+      (is (= 0 (count (:discard (get-corp)))) "No Subliminals in Archives"))))
 
-(deftest subliminal-messaging-made-run
-  ;; Subliminal Messaging - Runner made run, ensure game asks again next turn
-  (do-game
-    (new-game (default-corp [(qty "Subliminal Messaging" 2)])
-              (default-runner))
-  (play-from-hand state :corp "Subliminal Messaging")
-  (trash-from-hand state :corp "Subliminal Messaging")
-  (take-credits state :corp)
-  (run-on state "R&D")
-  (run-jack-out state)
-  (take-credits state :runner)
-  (is (empty? (get-in @state [:corp :prompt])) "No prompt here because runner made a run last turn")
-  (take-credits state :corp)
-  (take-credits state :runner)
-  (prompt-choice :corp "Yes")
-  (prompt-choice :corp "Yes")
-  (is (= 2 (count (:hand (get-corp)))) "Both Subliminals returned to HQ")
-  (is (= 0 (count (:discard (get-corp)))) "No Subliminals in Archives")))
-
-(deftest subliminal-messaging-no
-  ;; Subliminal Messaging - User declines to return to hand, ensure game asks again next turn
-  (do-game
-    (new-game (default-corp [(qty "Subliminal Messaging" 2)])
-              (default-runner))
-    (play-from-hand state :corp "Subliminal Messaging")
-    (trash-from-hand state :corp "Subliminal Messaging")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (prompt-choice :corp "No")
-    (prompt-choice :corp "No")
-    (is (= 0 (count (:hand (get-corp)))) "Neither Subliminal returned to HQ")
-    (is (= 2 (count (:discard (get-corp)))) "Both Subliminals in Archives")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (prompt-choice :corp "Yes")
-    (prompt-choice :corp "Yes")
-    (is (= 2 (count (:hand (get-corp)))) "Both Subliminals returned to HQ")
-    (is (= 0 (count (:discard (get-corp)))) "No Subliminals in Archives")))
-
-(deftest success-bad-publicity
-  ;; Success - Works with bad publicity
-  (do-game
-    (new-game (default-corp ["NAPD Contract" "Project Beale" "Success"])
-              (default-runner))
-    (play-from-hand state :corp "NAPD Contract" "New remote")
-    (play-from-hand state :corp "Project Beale" "New remote")
-    (core/gain state :corp :bad-publicity 9)
-    (core/gain state :corp :credit 8)
-    (core/gain state :corp :click 15)
-    (let [napd (get-content state :remote1 0)
-          beale (get-content state :remote2 0)]
-      (dotimes [_ 13] (core/advance state :corp {:card (refresh napd)}))
-      (is (= 13 (:advance-counter (refresh napd))))
-      (core/score state :corp {:card (refresh napd)})
-      (is (= 2 (:agenda-point (get-corp))))
+(deftest success
+  ;; Success
+  (testing "Works with bad publicity"
+    (do-game
+      (new-game (default-corp ["NAPD Contract" "Project Beale" "Success"])
+                (default-runner))
+      (play-from-hand state :corp "NAPD Contract" "New remote")
+      (play-from-hand state :corp "Project Beale" "New remote")
+      (core/gain state :corp :bad-publicity 9)
+      (core/gain state :corp :credit 8)
+      (core/gain state :corp :click 15)
+      (let [napd (get-content state :remote1 0)
+            beale (get-content state :remote2 0)]
+        (dotimes [_ 13] (core/advance state :corp {:card (refresh napd)}))
+        (is (= 13 (:advance-counter (refresh napd))))
+        (core/score state :corp {:card (refresh napd)})
+        (is (= 2 (:agenda-point (get-corp))))
+        (play-from-hand state :corp "Success")
+        (prompt-select :corp (get-scored state :corp 0))
+        (is (= "NAPD Contract" (:title (first (:rfg (get-corp))))))
+        (prompt-select :corp (refresh beale))
+        (is (= 13 (:advance-counter (refresh beale))))
+        (core/score state :corp {:card (refresh beale)})
+        (is (= 7 (:agenda-point (get-corp)))))))
+  (testing "Works with public agendas"
+    (do-game
+      (new-game (default-corp ["Oaktown Renovation" "Vanity Project" "Success"])
+                (default-runner))
+      (core/gain state :corp :click 1)
+      (score-agenda state :corp (find-card "Vanity Project" (:hand (get-corp))))
+      (is (= 4 (:agenda-point (get-corp))))
+      (play-from-hand state :corp "Oaktown Renovation" "New remote")
+      (is (= 5 (:credit (get-corp))))
       (play-from-hand state :corp "Success")
-      (prompt-select :corp (get-scored state :corp 0))
-      (is (= "NAPD Contract" (:title (first (:rfg (get-corp))))))
-      (prompt-select :corp (refresh beale))
-      (is (= 13 (:advance-counter (refresh beale))))
-      (core/score state :corp {:card (refresh beale)})
-      (is (= 7 (:agenda-point (get-corp)))))))
-
-(deftest success-public-agenda
-  ;; Success - Works with public agendas
-  (do-game
-    (new-game (default-corp ["Oaktown Renovation" "Vanity Project" "Success"])
-              (default-runner))
-    (core/gain state :corp :click 1)
-    (score-agenda state :corp (find-card "Vanity Project" (:hand (get-corp))))
-    (is (= 4 (:agenda-point (get-corp))))
-    (play-from-hand state :corp "Oaktown Renovation" "New remote")
-    (is (= 5 (:credit (get-corp))))
-    (play-from-hand state :corp "Success")
-    (prompt-select :corp (get-scored state :corp))
-    (is (= "Vanity Project" (:title (first (:rfg (get-corp))))))
-    (let [oaktown (get-content state :remote1 0)]
-      (prompt-select :corp (refresh oaktown))
-      (is (= 6 (:advance-counter (refresh oaktown))))
-      (is (= 19 (:credit (get-corp))) "Gain 2 + 2 + 2 + 2 + 3 + 3 = 14 credits for advancing Oaktown")
-      (core/score state :corp {:card (refresh oaktown)})
-      (is (= 2 (:agenda-point (get-corp)))))))
-
-(deftest success-jemison
-  ;; Success interaction with Jemison, regression test for issue #2704
-  (do-game
-    (new-game (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success."
-                         ["Success"
-                          "High-Risk Investment"
-                          "Government Takeover"])
-              (default-runner))
-    (core/gain state :corp :click 1)
-    (score-agenda state :corp (find-card "High-Risk Investment" (:hand (get-corp))))
-    (play-from-hand state :corp "Government Takeover" "New remote")
-    (play-from-hand state :corp "Success")
-    (prompt-select :corp (get-in (get-corp) [:scored 0]))
-    (let [gto (get-content state :remote1 0)]
-      ;; Prompt for Jemison
-      (prompt-select :corp (refresh gto))
-      (is (= 4 (:advance-counter (refresh gto))) "Added 4 counters from Jemison trigger")
-      ;; Prompt for Success
-      (prompt-select :corp (refresh gto))
-      (is (= (+ 4 5) (:advance-counter (refresh gto))) "Advance 5 times from Success"))))
+      (prompt-select :corp (get-scored state :corp))
+      (is (= "Vanity Project" (:title (first (:rfg (get-corp))))))
+      (let [oaktown (get-content state :remote1 0)]
+        (prompt-select :corp (refresh oaktown))
+        (is (= 6 (:advance-counter (refresh oaktown))))
+        (is (= 19 (:credit (get-corp))) "Gain 2 + 2 + 2 + 2 + 3 + 3 = 14 credits for advancing Oaktown")
+        (core/score state :corp {:card (refresh oaktown)})
+        (is (= 2 (:agenda-point (get-corp)))))))
+  (testing "interaction with Jemison, regression test for issue #2704"
+    (do-game
+      (new-game (make-deck "Jemison Astronautics: Sacrifice. Audacity. Success."
+                           ["Success"
+                            "High-Risk Investment"
+                            "Government Takeover"])
+                (default-runner))
+      (core/gain state :corp :click 1)
+      (score-agenda state :corp (find-card "High-Risk Investment" (:hand (get-corp))))
+      (play-from-hand state :corp "Government Takeover" "New remote")
+      (play-from-hand state :corp "Success")
+      (prompt-select :corp (get-in (get-corp) [:scored 0]))
+      (let [gto (get-content state :remote1 0)]
+        ;; Prompt for Jemison
+        (prompt-select :corp (refresh gto))
+        (is (= 4 (:advance-counter (refresh gto))) "Added 4 counters from Jemison trigger")
+        ;; Prompt for Success
+        (prompt-select :corp (refresh gto))
+        (is (= (+ 4 5) (:advance-counter (refresh gto))) "Advance 5 times from Success")))))
 
 (deftest successful-demonstration
   ;; Successful Demonstration - Play if only Runner made unsuccessful run last turn; gain 7 credits
@@ -1990,76 +1884,72 @@
         (prompt-select :runner fc)
         (is (not= :waiting (-> (get-corp) :prompt first :prompt-type)) "After steal, Surveillance Sweep leaves play and Runner waits on Corp")))))
 
-(deftest the-all-seeing-i-prevent-trash
-  ;; Counts number of cards if one card is prevented trashed with fall guy
-  (do-game
-    (new-game (default-corp ["The All-Seeing I"])
-              (default-runner ["Fall Guy" (qty "Same Old Thing" 2)]))
-    (letfn [(res [] (count (get-in (get-runner) [:rig :resource])))]
+(deftest the-all-seeing-i
+  (testing "Counts number of cards if one card is prevented trashed with fall guy"
+    (do-game
+      (new-game (default-corp ["The All-Seeing I"])
+                (default-runner ["Fall Guy" (qty "Same Old Thing" 2)]))
+      (letfn [(res [] (count (get-in (get-runner) [:rig :resource])))]
+        (take-credits state :corp)
+        (play-from-hand state :runner "Same Old Thing")
+        (play-from-hand state :runner "Fall Guy")
+        (play-from-hand state :runner "Same Old Thing")
+        (take-credits state :runner)
+        (play-from-hand state :corp "The All-Seeing I")
+        (is (= 1 (count (:hand (get-corp)))) "Corp could not play All Seeing I when runner was not tagged")
+        (core/gain state :runner :tag 1)
+        (play-from-hand state :corp "The All-Seeing I")
+        (let [fall-guy (get-resource state 1)]
+          (card-ability state :runner fall-guy 0))
+        (prompt-choice :runner "Done")
+        (is (= 1 (res)) "One installed resource saved by Fall Guy")
+        (is (= 2 (count (:discard (get-runner)))) "Two cards in heap"))))
+  (testing "Checks that All-seeing I does not double-trash hosted cards, trashes hosted cards"
+    (do-game
+      (new-game (default-corp ["The All-Seeing I"])
+                (default-runner [(qty "Fall Guy" 2) "Off-Campus Apartment"]))
       (take-credits state :corp)
-      (play-from-hand state :runner "Same Old Thing")
-      (play-from-hand state :runner "Fall Guy")
-      (play-from-hand state :runner "Same Old Thing")
-      (take-credits state :runner)
-      (play-from-hand state :corp "The All-Seeing I")
-      (is (= 1 (count (:hand (get-corp)))) "Corp could not play All Seeing I when runner was not tagged")
+      (play-from-hand state :runner "Off-Campus Apartment")
+      (let [oca (get-resource state 0)
+            fg1 (get-in (get-runner) [:hand 0])
+            fg2 (get-in (get-runner) [:hand 1])]
+        (card-ability state :runner oca 0)
+        (prompt-select :runner fg1)
+        (card-ability state :runner oca 0)
+        (prompt-select :runner fg2))
       (core/gain state :runner :tag 1)
+      (take-credits state :runner)
       (play-from-hand state :corp "The All-Seeing I")
-      (let [fall-guy (get-resource state 1)]
-        (card-ability state :runner fall-guy 0))
       (prompt-choice :runner "Done")
-      (is (= 1 (res)) "One installed resource saved by Fall Guy")
-      (is (= 2 (count (:discard (get-runner)))) "Two cards in heap"))))
-
-(deftest the-all-seeing-i-hosted-cards
-  ;; Checks that All-seeing I does not double-trash hosted cards, trashes hosted cards
-  (do-game
-    (new-game (default-corp ["The All-Seeing I"])
-              (default-runner [(qty "Fall Guy" 2) "Off-Campus Apartment"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Off-Campus Apartment")
-    (let [oca (get-resource state 0)
-          fg1 (get-in (get-runner) [:hand 0])
-          fg2 (get-in (get-runner) [:hand 1])]
-      (card-ability state :runner oca 0)
-      (prompt-select :runner fg1)
-      (card-ability state :runner oca 0)
-      (prompt-select :runner fg2))
-    (core/gain state :runner :tag 1)
-    (take-credits state :runner)
-    (play-from-hand state :corp "The All-Seeing I")
-    (prompt-choice :runner "Done")
-    (prompt-choice :runner "Done")
-    (let  [fall-guy (find-card "Fall Guy" (core/all-active-installed state :runner))]
-      (card-ability state :runner fall-guy 0))
-    (prompt-choice :runner "Done") ;; This assumes hosted cards get put in trash-list before host
-    (is (= 1 (count (core/all-active-installed state :runner))) "One installed card (Off-Campus)")
-    (is  (= 2 (count (:discard (get-runner)))) "Two cards in heap")))
-
-(deftest the-all-seeing-i-jarogniew-mercs
-  ;; The All-Seeing I should not trash Jarogniew Mercs if there are other installed resources
-  (do-game
-    (new-game (default-corp [(qty "The All-Seeing I" 4)])
-              (default-runner [(qty "Jarogniew Mercs" 2) (qty "Same Old Thing" 2)]))
-    (letfn [(res [] (count (get-in (get-runner) [:rig :resource])))]
-      (take-credits state :corp)
-      (play-from-hand state :runner "Same Old Thing")
-      (play-from-hand state :runner "Jarogniew Mercs")
-      (take-credits state :runner)
-      (is (= 2 (res)) "There are two installed resources")
-      (play-from-hand state :corp "The All-Seeing I")
-      (is (= 1 (res)) "Jarogniew Mercs still installed")
-      (play-from-hand state :corp "The All-Seeing I")
-      (is (= 0 (res)) "There are no installed resources")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Jarogniew Mercs") ;; Testing if order matters
-      (play-from-hand state :runner "Same Old Thing")
-      (take-credits state :runner)
-      (is (= 2 (res)) "There are two installed resources")
-      (play-from-hand state :corp "The All-Seeing I")
-      (is (= 1 (res)) "Jarogniew Mercs still installed")
-      (play-from-hand state :corp "The All-Seeing I")
-      (is (= 0 (res)) "There are no installed resources"))))
+      (prompt-choice :runner "Done")
+      (let  [fall-guy (find-card "Fall Guy" (core/all-active-installed state :runner))]
+        (card-ability state :runner fall-guy 0))
+      (prompt-choice :runner "Done") ;; This assumes hosted cards get put in trash-list before host
+      (is (= 1 (count (core/all-active-installed state :runner))) "One installed card (Off-Campus)")
+      (is  (= 2 (count (:discard (get-runner)))) "Two cards in heap")))
+  (testing "should not trash Jarogniew Mercs if there are other installed resources"
+    (do-game
+      (new-game (default-corp [(qty "The All-Seeing I" 4)])
+                (default-runner [(qty "Jarogniew Mercs" 2) (qty "Same Old Thing" 2)]))
+      (letfn [(res [] (count (get-in (get-runner) [:rig :resource])))]
+        (take-credits state :corp)
+        (play-from-hand state :runner "Same Old Thing")
+        (play-from-hand state :runner "Jarogniew Mercs")
+        (take-credits state :runner)
+        (is (= 2 (res)) "There are two installed resources")
+        (play-from-hand state :corp "The All-Seeing I")
+        (is (= 1 (res)) "Jarogniew Mercs still installed")
+        (play-from-hand state :corp "The All-Seeing I")
+        (is (= 0 (res)) "There are no installed resources")
+        (take-credits state :corp)
+        (play-from-hand state :runner "Jarogniew Mercs") ;; Testing if order matters
+        (play-from-hand state :runner "Same Old Thing")
+        (take-credits state :runner)
+        (is (= 2 (res)) "There are two installed resources")
+        (play-from-hand state :corp "The All-Seeing I")
+        (is (= 1 (res)) "Jarogniew Mercs still installed")
+        (play-from-hand state :corp "The All-Seeing I")
+        (is (= 0 (res)) "There are no installed resources")))))
 
 (deftest threat-assessment
   ;; Threat Assessment - play only if runner trashed a card last turn, move a card to the stack or take 2 tags
@@ -2148,30 +2038,29 @@
       (core/advance state :corp {:card (refresh atlas)})
       (is (= 5 (:credit (get-corp))) "Transparency initiative didn't fire"))))
 
-(deftest wake-up-call-en-passant
-  ;; Wake Up Call - should fire after using En Passant to trash ice
-  (do-game
-    (new-game (default-corp ["Enigma" "Wake Up Call"])
-              (default-runner ["En Passant" "Maya"]))
-    (play-from-hand state :corp "Enigma" "HQ")
-    (take-credits state :corp)
-
-    (play-from-hand state :runner "Maya")
-    (run-on state :hq)
-    (run-successful state)
-    (prompt-choice :runner "No action")
-    (is (= 0 (count (:discard (get-corp)))) "Corp starts with no discards")
-    (play-from-hand state :runner "En Passant")
-    (prompt-select :runner (get-ice state :hq 0))
-    (is (= 1 (count (:discard (get-corp)))) "Corp trashes installed ice")
-    (take-credits state :runner)
-
-    (is (= 1 (count (:discard (get-runner)))) "Runner starts with 1 trashed card (En Passant)")
-    (play-from-hand state :corp "Wake Up Call")
-    (prompt-select :corp (get-in @state [:runner :rig :hardware 0]))
-    (prompt-choice :runner "Trash Maya")
-    (is (= 2 (count (:discard (get-runner)))) "Maya is trashed")
-    (is (= 1 (count (:rfg (get-corp)))) "Wake Up Call is removed from the game")))
+(deftest wake-up-call
+  ;; Wake Up Call
+  (testing "should fire after using En Passant to trash ice"
+    (do-game
+      (new-game (default-corp ["Enigma" "Wake Up Call"])
+                (default-runner ["En Passant" "Maya"]))
+      (play-from-hand state :corp "Enigma" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Maya")
+      (run-on state :hq)
+      (run-successful state)
+      (prompt-choice :runner "No action")
+      (is (= 0 (count (:discard (get-corp)))) "Corp starts with no discards")
+      (play-from-hand state :runner "En Passant")
+      (prompt-select :runner (get-ice state :hq 0))
+      (is (= 1 (count (:discard (get-corp)))) "Corp trashes installed ice")
+      (take-credits state :runner)
+      (is (= 1 (count (:discard (get-runner)))) "Runner starts with 1 trashed card (En Passant)")
+      (play-from-hand state :corp "Wake Up Call")
+      (prompt-select :corp (get-in @state [:runner :rig :hardware 0]))
+      (prompt-choice :runner "Trash Maya")
+      (is (= 2 (count (:discard (get-runner)))) "Maya is trashed")
+      (is (= 1 (count (:rfg (get-corp)))) "Wake Up Call is removed from the game"))))
 
 (deftest wetwork-refit
   ;; Wetwork Refit - Only works on Bioroid ICE and adds a subroutine
@@ -2190,12 +2079,10 @@
       (is (not-any? #{"Eli 1.0"} (get-in @state [:corp :prompt :choices]))
           "Unrezzed Eli 1.0 is not a choice to host Wetwork Refit")
       (prompt-choice :corp "Done")
-
       (take-credits state :corp)
       (take-credits state :runner)
       (core/rez state :corp (refresh eli))
       (core/rez state :corp (refresh vanilla))
-
       (play-from-hand state :corp "Wetwork Refit")
       (prompt-select :corp (refresh eli))
       (is (= "Wetwork Refit" (:title (first (:hosted (refresh eli)))))
@@ -2204,14 +2091,12 @@
           "Eli 1.0 has 2 different subroutines")
       (is (= "[Wetwork Refit] Do 1 brain damage" (:label (first (:subroutines (refresh eli)))))
           "Eli 1.0 has a brain damage subroutine as his first subroutine")
-
       (core/move state :corp (first (:hosted (refresh eli))) :hand)
       (is (empty? (:hosted (refresh eli))) "No cards are hosted on Eli 1.0")
       (is (= 1 (count (:subroutines (refresh eli))))
           "Eli 1.0 has 1 different subroutine")
       (is (= "End the run" (:label (first (:subroutines (refresh eli)))))
           "Eli 1.0 has an end the run subroutine as his first subroutine")
-
       (play-from-hand state :corp "Wetwork Refit")
       (prompt-select :corp (refresh vanilla))
       (is (not= "Wetwork Refit" (:title (first (:hosted (refresh vanilla)))))

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -11,7 +11,8 @@
 (deftest au-revoir
   ;; Au Revoir - Gain 1 credit every time you jack out
   (do-game
-    (new-game (default-corp) (default-runner [(qty "Au Revoir" 2)]))
+    (new-game (default-corp)
+              (default-runner [(qty "Au Revoir" 2)]))
     (take-credits state :corp)
     (play-from-hand state :runner "Au Revoir")
     (run-on state "Archives")
@@ -106,62 +107,60 @@
 
 (deftest datasucker
   ;; Datasucker - Reduce strength of encountered ICE
-  (do-game
-    (new-game (default-corp ["Fire Wall"])
-              (default-runner ["Datasucker"]))
-    (play-from-hand state :corp "Fire Wall" "New remote")
-    (take-credits state :corp)
-    (core/gain state :runner :click 3)
-    (play-from-hand state :runner "Datasucker")
-    (let [ds (get-in @state [:runner :rig :program 0])
-          fw (get-ice state :remote1 0)]
-      (run-empty-server state "Archives")
-      (is (= 1 (get-counters (refresh ds) :virus)))
-      (run-empty-server state "Archives")
-      (is (= 2 (get-counters (refresh ds) :virus)))
-      (run-on state "Server 1")
-      (run-continue state)
-      (run-successful state)
-      (is (= 2 (get-counters (refresh ds) :virus)) "No counter gained, not a central server")
-      (run-on state "Server 1")
-      (core/rez state :corp fw)
-      (is (= 5 (:current-strength (refresh fw))))
-      (card-ability state :runner ds 0)
-      (is (= 1 (get-counters (refresh ds) :virus)) "1 counter spent from Datasucker")
-      (is (= 4 (:current-strength (refresh fw))) "Fire Wall strength lowered by 1"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Fire Wall"])
+                (default-runner ["Datasucker"]))
+      (play-from-hand state :corp "Fire Wall" "New remote")
+      (take-credits state :corp)
+      (core/gain state :runner :click 3)
+      (play-from-hand state :runner "Datasucker")
+      (let [ds (get-in @state [:runner :rig :program 0])
+            fw (get-ice state :remote1 0)]
+        (run-empty-server state "Archives")
+        (is (= 1 (get-counters (refresh ds) :virus)))
+        (run-empty-server state "Archives")
+        (is (= 2 (get-counters (refresh ds) :virus)))
+        (run-on state "Server 1")
+        (run-continue state)
+        (run-successful state)
+        (is (= 2 (get-counters (refresh ds) :virus)) "No counter gained, not a central server")
+        (run-on state "Server 1")
+        (core/rez state :corp fw)
+        (is (= 5 (:current-strength (refresh fw))))
+        (card-ability state :runner ds 0)
+        (is (= 1 (get-counters (refresh ds) :virus)) "1 counter spent from Datasucker")
+        (is (= 4 (:current-strength (refresh fw))) "Fire Wall strength lowered by 1"))))
+  (testing "does not affect next ice when current is trashed. Issue #1788"
+    (do-game
+      (new-game
+        (default-corp ["Wraparound" "Spiderweb"])
+        (default-corp ["Datasucker" "Parasite"]))
+      (play-from-hand state :corp "Spiderweb" "HQ")
+      (play-from-hand state :corp "Wraparound" "HQ")
+      (take-credits state :corp)
+      (core/gain state :corp :credit 10)
+      (play-from-hand state :runner "Datasucker")
+      (let [sucker (get-program state 0)
+            spider (get-ice state :hq 0)
+            wrap (get-ice state :hq 1)]
+        (core/add-counter state :runner sucker :virus 2)
+        (core/rez state :corp spider)
+        (core/rez state :corp wrap)
+        (play-from-hand state :runner "Parasite")
+        (prompt-select :runner (refresh spider))
+        (run-on state "HQ")
+        (run-continue state)
+        (card-ability state :runner (refresh sucker) 0)
+        (card-ability state :runner (refresh sucker) 0)
+        (is (find-card "Spiderweb" (:discard (get-corp))) "Spiderweb trashed by Parasite + Datasucker")
+        (is (= 7 (:current-strength (refresh wrap))) "Wraparound not reduced by Datasucker")))))
 
-(deftest datasucker-trashed
-  ;; Datasucker - does not affect next ice when current is trashed. Issue #1788.
-  (do-game
-    (new-game
-      (default-corp ["Wraparound" "Spiderweb"])
-      (default-corp ["Datasucker" "Parasite"]))
-    (play-from-hand state :corp "Spiderweb" "HQ")
-    (play-from-hand state :corp "Wraparound" "HQ")
-    (take-credits state :corp)
-    (core/gain state :corp :credit 10)
-    (play-from-hand state :runner "Datasucker")
-    (let [sucker (get-program state 0)
-          spider (get-ice state :hq 0)
-          wrap (get-ice state :hq 1)]
-      (core/add-counter state :runner sucker :virus 2)
-      (core/rez state :corp spider)
-      (core/rez state :corp wrap)
-      (play-from-hand state :runner "Parasite")
-      (prompt-select :runner (refresh spider))
-      (run-on state "HQ")
-      (run-continue state)
-      (card-ability state :runner (refresh sucker) 0)
-      (card-ability state :runner (refresh sucker) 0)
-      (is (find-card "Spiderweb" (:discard (get-corp))) "Spiderweb trashed by Parasite + Datasucker")
-      (is (= 7 (:current-strength (refresh wrap))) "Wraparound not reduced by Datasucker"))))
-
-(deftest dhegdheer-adept
+(deftest dhegdheer
   ;; Dheghdheer - hosting a breaker with strength based on unused MU should calculate correctly
   (do-game
     (new-game (default-corp)
-              (default-runner ["Adept"
-                               "Dhegdheer"]))
+              (default-runner ["Adept" "Dhegdheer"]))
     (take-credits state :corp)
     (core/gain state :runner :credit 5)
     (play-from-hand state :runner "Dhegdheer")
@@ -204,57 +203,54 @@
     (is (= "Diwan" (-> (get-runner) :discard first :title)) "Diwan was trashed from purge")
     (is (= 3 (:credit (get-corp))) "No charge for installs after Diwan purged")))
 
-(deftest djinn-host-chakana
-  ;; Djinn - Hosted Chakana does not disable advancing agendas. Issue #750
-  (do-game
-    (new-game (default-corp ["Priority Requisition"])
-              (default-runner ["Djinn" "Chakana"]))
-    (play-from-hand state :corp "Priority Requisition" "New remote")
-    (take-credits state :corp 2)
-    (play-from-hand state :runner "Djinn")
-    (let [djinn (get-in @state [:runner :rig :program 0])
-          agenda (get-content state :remote1 0)]
-      (is agenda "Agenda was installed")
-      (card-ability state :runner djinn 1)
-      (prompt-select :runner (find-card "Chakana" (:hand (get-runner))))
-      (let [chak (first (:hosted (refresh djinn)))]
-        (is (= "Chakana" (:title chak)) "Djinn has a hosted Chakana")
-        ;; manually add 3 counters
-        (core/add-counter state :runner (first (:hosted (refresh djinn))) :virus 3)
-        (take-credits state :runner 2)
-        (core/advance state :corp {:card agenda})
-        (is (= 1 (:advance-counter (refresh agenda))) "Agenda was advanced")))))
-
-(deftest djinn-host-program
-  ;; Djinn - Host a non-icebreaker program
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Djinn" "Chakana"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Djinn")
-    (is (= 3 (core/available-mu state)))
-    (let [djinn (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner djinn 1)
-      (prompt-select :runner (find-card "Chakana" (:hand (get-runner))))
-      (is (= 3 (core/available-mu state)) "No memory used to host on Djinn")
-      (is (= "Chakana" (:title (first (:hosted (refresh djinn))))) "Djinn has a hosted Chakana")
-      (is (= 1 (:credit (get-runner))) "Full cost to host on Djinn"))))
-
-(deftest djinn-tutor-virus
-  ;; Djinn - Tutor a virus program
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Djinn" "Parasite"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Djinn")
-    (core/move state :runner (find-card "Parasite" (:hand (get-runner))) :deck)
-    (is (zero? (count (:hand (get-runner)))) "No cards in hand after moving Parasite to deck")
-    (let [djinn (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner djinn 0)
-      (prompt-card :runner (find-card "Parasite" (:deck (get-runner))))
-      (is (= "Parasite" (:title (first (:hand (get-runner))))) "Djinn moved Parasite to hand")
-      (is (= 2 (:credit (get-runner))) "1cr to use Djinn ability")
-      (is (= 2 (:click (get-runner))) "1click to use Djinn ability"))))
+(deftest djinn
+  ;; Djinn
+  (testing "Hosted Chakana does not disable advancing agendas. Issue #750"
+    (do-game
+      (new-game (default-corp ["Priority Requisition"])
+                (default-runner ["Djinn" "Chakana"]))
+      (play-from-hand state :corp "Priority Requisition" "New remote")
+      (take-credits state :corp 2)
+      (play-from-hand state :runner "Djinn")
+      (let [djinn (get-in @state [:runner :rig :program 0])
+            agenda (get-content state :remote1 0)]
+        (is agenda "Agenda was installed")
+        (card-ability state :runner djinn 1)
+        (prompt-select :runner (find-card "Chakana" (:hand (get-runner))))
+        (let [chak (first (:hosted (refresh djinn)))]
+          (is (= "Chakana" (:title chak)) "Djinn has a hosted Chakana")
+          ;; manually add 3 counters
+          (core/add-counter state :runner (first (:hosted (refresh djinn))) :virus 3)
+          (take-credits state :runner 2)
+          (core/advance state :corp {:card agenda})
+          (is (= 1 (:advance-counter (refresh agenda))) "Agenda was advanced")))))
+  (testing "Host a non-icebreaker program"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Djinn" "Chakana"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Djinn")
+      (is (= 3 (core/available-mu state)))
+      (let [djinn (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner djinn 1)
+        (prompt-select :runner (find-card "Chakana" (:hand (get-runner))))
+        (is (= 3 (core/available-mu state)) "No memory used to host on Djinn")
+        (is (= "Chakana" (:title (first (:hosted (refresh djinn))))) "Djinn has a hosted Chakana")
+        (is (= 1 (:credit (get-runner))) "Full cost to host on Djinn"))))
+  (testing "Tutor a virus program"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Djinn" "Parasite"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Djinn")
+      (core/move state :runner (find-card "Parasite" (:hand (get-runner))) :deck)
+      (is (zero? (count (:hand (get-runner)))) "No cards in hand after moving Parasite to deck")
+      (let [djinn (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner djinn 0)
+        (prompt-card :runner (find-card "Parasite" (:deck (get-runner))))
+        (is (= "Parasite" (:title (first (:hand (get-runner))))) "Djinn moved Parasite to hand")
+        (is (= 2 (:credit (get-runner))) "1cr to use Djinn ability")
+        (is (= 2 (:click (get-runner))) "1click to use Djinn ability")))))
 
 (deftest equivocation
   ;; Equivocation - interactions with other successful-run events.
@@ -324,58 +320,57 @@
       (is (= 1 (count (:deck (get-corp)))))
       (is (= 3 (count (:discard (get-corp)))) "Milled 1 card from R&D"))))
 
-(deftest harbinger-blacklist
-  ;; Harbinger - install facedown when Blacklist installed
-  (do-game
-    (new-game (default-corp ["Blacklist"])
-              (default-runner ["Harbinger"]))
-    (play-from-hand state :corp "Blacklist" "New remote")
-    (core/rez state :corp (get-content state :remote1 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Harbinger")
-    (core/trash state :runner (-> (get-runner) :rig :program first))
-    (is (= 0 (count (:discard (get-runner)))) "Harbinger not in heap")
-    (is (-> (get-runner) :rig :facedown first :facedown) "Harbinger installed facedown")))
+(deftest harbinger
+  ;; Harbinger
+  (testing "install facedown when Blacklist installed"
+    (do-game
+      (new-game (default-corp ["Blacklist"])
+                (default-runner ["Harbinger"]))
+      (play-from-hand state :corp "Blacklist" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Harbinger")
+      (core/trash state :runner (-> (get-runner) :rig :program first))
+      (is (= 0 (count (:discard (get-runner)))) "Harbinger not in heap")
+      (is (-> (get-runner) :rig :facedown first :facedown) "Harbinger installed facedown"))))
 
 (deftest hyperdriver
   ;; Hyperdriver - Remove from game to gain 3 clicks
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Hyperdriver"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Hyperdriver")
-    (is (= 1 (core/available-mu state)) "3 MU used")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (is (:runner-phase-12 @state) "Runner in Step 1.2")
-    (let [hyp (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner hyp 0)
-      (core/end-phase-12 state :runner nil)
-      (is (= 7 (:click (get-runner))) "Gained 3 clicks")
-      (is (= 1 (count (:rfg (get-runner)))) "Hyperdriver removed from game"))))
-
-(deftest hyperdriver-dhegdheer
-  ;; triggering a Dhegdeered Hyperdriver should not grant +3 MU
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Hyperdriver"
-                               "Dhegdheer"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Dhegdheer")
-    (let [dheg (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner dheg 0)
-      (prompt-select :runner (find-card "Hyperdriver" (:hand (get-runner))))
-      (is (= 4 (core/available-mu state)) "0 MU used by Hyperdriver hosted on Dhegdheer")
-      (is (= 2 (:click (get-runner))) "2 clicks used")
-      (is (= 3 (:credit (get-runner))) "2 credits used")
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Hyperdriver"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Hyperdriver")
+      (is (= 1 (core/available-mu state)) "3 MU used")
       (take-credits state :runner)
       (take-credits state :corp)
       (is (:runner-phase-12 @state) "Runner in Step 1.2")
-      (let [hyp (first (:hosted (refresh dheg)))]
+      (let [hyp (get-in @state [:runner :rig :program 0])]
         (card-ability state :runner hyp 0)
         (core/end-phase-12 state :runner nil)
-        (is (= 7 (:click (get-runner))) "Used Hyperdriver")
-        (is (= 4 (core/available-mu state)) "Still 0 MU used after Hyperdriver removed from game")))))
+        (is (= 7 (:click (get-runner))) "Gained 3 clicks")
+        (is (= 1 (count (:rfg (get-runner)))) "Hyperdriver removed from game"))))
+  (testing "triggering a Dhegdeered Hyperdriver should not grant +3 MU"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Hyperdriver" "Dhegdheer"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Dhegdheer")
+      (let [dheg (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner dheg 0)
+        (prompt-select :runner (find-card "Hyperdriver" (:hand (get-runner))))
+        (is (= 4 (core/available-mu state)) "0 MU used by Hyperdriver hosted on Dhegdheer")
+        (is (= 2 (:click (get-runner))) "2 clicks used")
+        (is (= 3 (:credit (get-runner))) "2 credits used")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (:runner-phase-12 @state) "Runner in Step 1.2")
+        (let [hyp (first (:hosted (refresh dheg)))]
+          (card-ability state :runner hyp 0)
+          (core/end-phase-12 state :runner nil)
+          (is (= 7 (:click (get-runner))) "Used Hyperdriver")
+          (is (= 4 (core/available-mu state)) "Still 0 MU used after Hyperdriver removed from game"))))))
 
 (deftest imp
   ;; Imp
@@ -451,7 +446,7 @@
       (run-empty-server state "Archives")
       (is (= ["Steal"] (->> (get-runner) :prompt first :choices)) "Should only get the option to steal Hostile on access in Archives"))))
 
-(deftest incubator-transfer-virus-counters
+(deftest incubator
   ;; Incubator - Gain 1 virus counter per turn; trash to move them to an installed virus program
   (do-game
     (new-game (default-corp)
@@ -519,51 +514,49 @@
       (core/purge state :corp)
       (is (empty? (get-in @state [:runner :rig :program])) "Lamprey trashed by purge"))))
 
-(deftest leprechaun-adept
+(deftest leprechaun
   ;; Leprechaun - hosting a breaker with strength based on unused MU should calculate correctly
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Adept"
-                               "Leprechaun"]))
-    (take-credits state :corp)
-    (core/gain state :runner :credit 5)
-    (play-from-hand state :runner "Leprechaun")
-    (play-from-hand state :runner "Adept")
-    (is (= 1 (core/available-mu state)) "3 MU used")
-    (let [lep (get-program state 0)
-          adpt (get-program state 1)]
-      (is (= 3 (:current-strength (refresh adpt))) "Adept at 3 strength individually")
-      (card-ability state :runner lep 1)
-      (prompt-select :runner (refresh adpt))
-      (let [hosted-adpt (first (:hosted (refresh lep)))]
-        (is (= 3 (core/available-mu state)) "1 MU used")
-        (is (= 5 (:current-strength (refresh hosted-adpt))) "Adept at 5 strength hosted")))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Adept" "Leprechaun"]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 5)
+      (play-from-hand state :runner "Leprechaun")
+      (play-from-hand state :runner "Adept")
+      (is (= 1 (core/available-mu state)) "3 MU used")
+      (let [lep (get-program state 0)
+            adpt (get-program state 1)]
+        (is (= 3 (:current-strength (refresh adpt))) "Adept at 3 strength individually")
+        (card-ability state :runner lep 1)
+        (prompt-select :runner (refresh adpt))
+        (let [hosted-adpt (first (:hosted (refresh lep)))]
+          (is (= 3 (core/available-mu state)) "1 MU used")
+          (is (= 5 (:current-strength (refresh hosted-adpt))) "Adept at 5 strength hosted")))))
+  (testing "Keep MU the same when hosting or trashing hosted programs"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Leprechaun" "Hyperdriver" "Imp"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Leprechaun")
+      (let [lep (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner lep 0)
+        (prompt-select :runner (find-card "Hyperdriver" (:hand (get-runner))))
+        (is (= 2 (:click (get-runner))))
+        (is (= 2 (:credit (get-runner))))
+        (is (= 3 (core/available-mu state)) "Hyperdriver 3 MU not deducted from available MU")
+        (card-ability state :runner lep 0)
+        (prompt-select :runner (find-card "Imp" (:hand (get-runner))))
+        (is (= 1 (:click (get-runner))))
+        (is (= 0 (:credit (get-runner))))
+        (is (= 3 (core/available-mu state)) "Imp 1 MU not deducted from available MU")
+        ;; Trash Hyperdriver
+        (core/move state :runner (find-card "Hyperdriver" (:hosted (refresh lep))) :discard)
+        (is (= 3 (core/available-mu state)) "Hyperdriver 3 MU not added to available MU")
+        (core/move state :runner (find-card "Imp" (:hosted (refresh lep))) :discard) ; trash Imp
+        (is (= 3 (core/available-mu state)) "Imp 1 MU not added to available MU")))))
 
-(deftest leprechaun-mu-savings
-  ;; Leprechaun - Keep MU the same when hosting or trashing hosted programs
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Leprechaun" "Hyperdriver" "Imp"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Leprechaun")
-    (let [lep (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner lep 0)
-      (prompt-select :runner (find-card "Hyperdriver" (:hand (get-runner))))
-      (is (= 2 (:click (get-runner))))
-      (is (= 2 (:credit (get-runner))))
-      (is (= 3 (core/available-mu state)) "Hyperdriver 3 MU not deducted from available MU")
-      (card-ability state :runner lep 0)
-      (prompt-select :runner (find-card "Imp" (:hand (get-runner))))
-      (is (= 1 (:click (get-runner))))
-      (is (= 0 (:credit (get-runner))))
-      (is (= 3 (core/available-mu state)) "Imp 1 MU not deducted from available MU")
-      ;; Trash Hyperdriver
-      (core/move state :runner (find-card "Hyperdriver" (:hosted (refresh lep))) :discard)
-      (is (= 3 (core/available-mu state)) "Hyperdriver 3 MU not added to available MU")
-      (core/move state :runner (find-card "Imp" (:hosted (refresh lep))) :discard) ; trash Imp
-      (is (= 3 (core/available-mu state)) "Imp 1 MU not added to available MU"))))
-
-(deftest magnum-opus-click
+(deftest magnum-opus
   ;; Magnum Opus - Gain 2 cr
   (do-game
     (new-game (default-corp)
@@ -742,13 +735,12 @@
           (is (= 1 (count (:discard (get-corp)))) "Enigma trashed")
           (is (= 1 (count (:discard (get-runner)))) "Parasite trashed when Enigma was trashed"))))))
 
-(deftest pheromones-no-counters
+(deftest pheromones
   ;; Pheromones ability shouldn't have a NullPointerException when fired with 0 virus counter
   (do-game
     (new-game (default-corp)
               (default-runner ["Pheromones"]))
     (take-credits state :corp)
-
     (play-from-hand state :runner "Pheromones")
     (let [ph (get-in @state [:runner :rig :program 0])]
       (card-ability state :runner (refresh ph) 0)
@@ -775,90 +767,88 @@
       (run-empty-server state "Archives")
       (is (= 4 (get-counters (refresh plague) :virus)) "Plague did not gain counters"))))
 
-(deftest progenitor-host-hivemind
-  ;; Progenitor - Hosting Hivemind, using Virus Breeding Ground. Issue #738
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Progenitor" "Virus Breeding Ground" "Hivemind"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Progenitor")
-    (play-from-hand state :runner "Virus Breeding Ground")
-    (is (= 4 (core/available-mu state)))
-    (let [prog (get-in @state [:runner :rig :program 0])
-          vbg (get-in @state [:runner :rig :resource 0])]
-      (card-ability state :runner prog 0)
-      (prompt-select :runner (find-card "Hivemind" (:hand (get-runner))))
-      (is (= 4 (core/available-mu state)) "No memory used to host on Progenitor")
-      (let [hive (first (:hosted (refresh prog)))]
-        (is (= "Hivemind" (:title hive)) "Hivemind is hosted on Progenitor")
-        (is (= 1 (get-counters hive :virus)) "Hivemind has 1 counter")
-        (is (= 0 (:credit (get-runner))) "Full cost to host on Progenitor")
-        (take-credits state :runner 1)
-        (take-credits state :corp)
-        (card-ability state :runner vbg 0) ; use VBG to transfer 1 token to Hivemind
-        (prompt-select :runner hive)
-        (is (= 2 (get-counters (refresh hive) :virus)) "Hivemind gained 1 counter")
-        (is (= 0 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter")))))
-
-(deftest progenitor-mu-savings
-  ;; Progenitor - Keep MU the same when hosting or trashing hosted programs
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Progenitor" "Hivemind"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Progenitor")
-    (let [pro (get-in @state [:runner :rig :program 0])]
-      (card-ability state :runner pro 0)
-      (prompt-select :runner (find-card "Hivemind" (:hand (get-runner))))
-      (is (= 2 (:click (get-runner))))
-      (is (= 2 (:credit (get-runner))))
-      (is (= 4 (core/available-mu state)) "Hivemind 2 MU not deducted from available MU")
-      ;; Trash Hivemind
-      (core/move state :runner (find-card "Hivemind" (:hosted (refresh pro))) :discard)
-      (is (= 4 (core/available-mu state)) "Hivemind 2 MU not added to available MU"))))
+(deftest progenitor
+  ;; Progenitor
+  (testing "Hosting Hivemind, using Virus Breeding Ground. Issue #738"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Progenitor" "Virus Breeding Ground" "Hivemind"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Progenitor")
+      (play-from-hand state :runner "Virus Breeding Ground")
+      (is (= 4 (core/available-mu state)))
+      (let [prog (get-in @state [:runner :rig :program 0])
+            vbg (get-in @state [:runner :rig :resource 0])]
+        (card-ability state :runner prog 0)
+        (prompt-select :runner (find-card "Hivemind" (:hand (get-runner))))
+        (is (= 4 (core/available-mu state)) "No memory used to host on Progenitor")
+        (let [hive (first (:hosted (refresh prog)))]
+          (is (= "Hivemind" (:title hive)) "Hivemind is hosted on Progenitor")
+          (is (= 1 (get-counters hive :virus)) "Hivemind has 1 counter")
+          (is (= 0 (:credit (get-runner))) "Full cost to host on Progenitor")
+          (take-credits state :runner 1)
+          (take-credits state :corp)
+          (card-ability state :runner vbg 0) ; use VBG to transfer 1 token to Hivemind
+          (prompt-select :runner hive)
+          (is (= 2 (get-counters (refresh hive) :virus)) "Hivemind gained 1 counter")
+          (is (= 0 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter")))))
+  (testing "Keep MU the same when hosting or trashing hosted programs"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Progenitor" "Hivemind"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Progenitor")
+      (let [pro (get-in @state [:runner :rig :program 0])]
+        (card-ability state :runner pro 0)
+        (prompt-select :runner (find-card "Hivemind" (:hand (get-runner))))
+        (is (= 2 (:click (get-runner))))
+        (is (= 2 (:credit (get-runner))))
+        (is (= 4 (core/available-mu state)) "Hivemind 2 MU not deducted from available MU")
+        ;; Trash Hivemind
+        (core/move state :runner (find-card "Hivemind" (:hosted (refresh pro))) :discard)
+        (is (= 4 (core/available-mu state)) "Hivemind 2 MU not added to available MU")))))
 
 (deftest reaver
   ;; Reaver - Draw a card the first time you trash an installed card each turn
-  (do-game
-    (new-game (default-corp ["PAD Campaign"])
-              (default-runner ["Reaver" (qty "Fall Guy" 5)]))
-    (starting-hand state :runner ["Reaver" "Fall Guy"])
-    (play-from-hand state :corp "PAD Campaign" "New remote")
-    (take-credits state :corp)
-    (core/gain state :runner :credit 10)
-    (core/gain state :runner :click 1)
-    (play-from-hand state :runner "Reaver")
-    (is (= 1 (count (:hand (get-runner)))) "One card in hand")
-    (run-empty-server state "Server 1")
-    (prompt-choice-partial :runner "Pay") ; Trash PAD campaign
-    (is (= 2 (count (:hand (get-runner)))) "Drew a card from trash of corp card")
-    (play-from-hand state :runner "Fall Guy")
-    (play-from-hand state :runner "Fall Guy")
-    (is (= 0 (count (:hand (get-runner)))) "No cards in hand")
-    ; No draw from Fall Guy trash as Reaver already fired this turn
-    (card-ability state :runner (get-resource state 0) 1)
-    (is (= 0 (count (:hand (get-runner)))) "No cards in hand")
-    (take-credits state :runner)
-    ; Draw from Fall Guy trash on corp turn
-    (card-ability state :runner (get-resource state 0) 1)
-    (is (= 1 (count (:hand (get-runner)))) "One card in hand")))
-
-(deftest reaver-fcc
-  ;; Reaver / Freelance Coding Construct - should not draw when trash from hand #2671
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Reaver" 9) "Imp" "Snitch" "Freelance Coding Contract"]))
-    (starting-hand state :runner ["Reaver" "Imp" "Snitch" "Freelance Coding Contract"])
-    (take-credits state :corp)
-    (play-from-hand state :runner "Reaver")
-    (is (= 3 (count (:hand (get-runner)))) "Four cards in hand")
-    (is (= 3 (:credit (get-runner))) "3 credits")
-    (play-from-hand state :runner "Freelance Coding Contract")
-    (prompt-select :runner (find-card "Snitch" (:hand (get-runner))))
-    (prompt-select :runner (find-card "Imp" (:hand (get-runner))))
-    (prompt-choice :runner "Done")
-    (is (= 7 (:credit (get-runner))) "7 credits - FCC fired")
-    (is (= 0 (count (:hand (get-runner)))) "No cards in hand")))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["PAD Campaign"])
+                (default-runner ["Reaver" (qty "Fall Guy" 5)]))
+      (starting-hand state :runner ["Reaver" "Fall Guy"])
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (core/gain state :runner :click 1)
+      (play-from-hand state :runner "Reaver")
+      (is (= 1 (count (:hand (get-runner)))) "One card in hand")
+      (run-empty-server state "Server 1")
+      (prompt-choice-partial :runner "Pay") ; Trash PAD campaign
+      (is (= 2 (count (:hand (get-runner)))) "Drew a card from trash of corp card")
+      (play-from-hand state :runner "Fall Guy")
+      (play-from-hand state :runner "Fall Guy")
+      (is (= 0 (count (:hand (get-runner)))) "No cards in hand")
+      ; No draw from Fall Guy trash as Reaver already fired this turn
+      (card-ability state :runner (get-resource state 0) 1)
+      (is (= 0 (count (:hand (get-runner)))) "No cards in hand")
+      (take-credits state :runner)
+      ; Draw from Fall Guy trash on corp turn
+      (card-ability state :runner (get-resource state 0) 1)
+      (is (= 1 (count (:hand (get-runner)))) "One card in hand")))
+  (testing "with Freelance Coding Construct - should not draw when trash from hand #2671"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Reaver" 9) "Imp" "Snitch" "Freelance Coding Contract"]))
+      (starting-hand state :runner ["Reaver" "Imp" "Snitch" "Freelance Coding Contract"])
+      (take-credits state :corp)
+      (play-from-hand state :runner "Reaver")
+      (is (= 3 (count (:hand (get-runner)))) "Four cards in hand")
+      (is (= 3 (:credit (get-runner))) "3 credits")
+      (play-from-hand state :runner "Freelance Coding Contract")
+      (prompt-select :runner (find-card "Snitch" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Imp" (:hand (get-runner))))
+      (prompt-choice :runner "Done")
+      (is (= 7 (:credit (get-runner))) "7 credits - FCC fired")
+      (is (= 0 (count (:hand (get-runner)))) "No cards in hand"))))
 
 (deftest rng-key
   ;; RNG Key - first successful run on RD/HQ, guess a number, gain credits or cards if number matches card cost
@@ -879,14 +869,12 @@
         (prompt-choice :runner "Gain 3 [Credits]")
         (is (= 8 (:credit (get-runner))) "Gained 3 credits")
         (prompt-choice :runner "No action"))
-
       (testing "Do not trigger on second successful run"
         (run-on state "R&D")
         (run-successful state)
         (prompt-choice :runner "No action")
         (take-credits state :runner)
         (take-credits state :corp))
-
       (testing "Do not trigger on archives"
         (run-on state "Archives")
         (run-successful state))
@@ -900,17 +888,14 @@
       (prompt-choice :runner "No action")
       (take-credits state :runner)
       (take-credits state :corp)
-
       (testing "Do not gain credits / cards if guess incorrect"
         (run-on state "R&D")
         (run-successful state)
         (prompt-choice :runner "Yes")
         (prompt-choice :runner 2)
         (prompt-choice :runner "No action"))
-
       (take-credits state :runner)
       (take-credits state :corp)
-
       (testing "Gain 2 cards"
         (is (= 0 (count (:hand (get-runner)))) "Started with 0 cards")
         (run-on state "R&D")
@@ -921,14 +906,12 @@
         (prompt-choice :runner "No action")
         (is (= 2 (count (:hand (get-runner)))) "Gained 2 cards")
         (is (= 0 (count (:deck (get-runner)))) "Cards came from stack"))))
-
   (testing "Do not pay out if accessing an upgrade first -- regression test for #3150"
     (do-game
       (new-game (default-corp ["Hokusai Grid" "Hedge Fund"])
                 (default-runner ["RNG Key"]))
       (play-from-hand state :corp "Hokusai Grid" "HQ")
       (take-credits state :corp)
-
       (testing "Gain 3 credits"
         (play-from-hand state :runner "RNG Key")
         (is (= 5 (:credit (get-runner))) "Starts at 5 credits")
@@ -1106,7 +1089,6 @@
               (default-runner ["Takobi" "Corroder" "Faust"]))
     (play-from-hand state :corp "Enigma" "HQ")
     (take-credits state :corp)
-
     (core/gain state :runner :credit 10)
     (play-from-hand state :runner "Takobi")
     (play-from-hand state :runner "Corroder")
@@ -1117,7 +1099,6 @@
       (dotimes [_ 3]
         (card-ability state :runner tako 0))
       (is (= 3 (get-counters (refresh tako) :power)) "3 counters on Takobi")
-
       (run-on state "HQ")
       (card-ability state :runner tako 1)
       (is (empty? (:prompt (get-runner))) "No prompt for un-rezzed ice")
@@ -1227,4 +1208,3 @@
     (prompt-select :runner (get-ice state :rd 0))
     (is (= 1 (count (:discard (get-runner)))) "Wari in heap")
     (is (not (empty? (get-in @state [:runner :prompt]))) "Runner is currently accessing Ice Wall")))
-

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -27,62 +27,59 @@
 
 (deftest adjusted-chronotype
   ;; Ensure adjusted chronotype gains only 1 click when 2 clicks are lost
-  (do-game
-   (new-game (default-corp)
-             (default-runner ["Adjusted Chronotype" (qty "Beach Party" 2)]))
-   (take-credits state :corp)
-   (play-from-hand state :runner "Adjusted Chronotype")
-   (play-from-hand state :runner "Beach Party")
-   (take-credits state :runner)
-   (take-credits state :corp)
-   (is (= 4 (:click (get-runner))) "Should have lost 1 click and gained 1 click")
-   (play-from-hand state :runner "Beach Party")
-   (take-credits state :runner)
-   (take-credits state :corp)
-   (is (= 3 (:click (get-runner))) "Should have lost 2 clicks and gained 1 click")))
-
-(deftest adjusted-chronotype-mca
-  ;; Chronotype to cancel out MCA click loss
-  (do-game
-    (new-game
-      (default-corp ["MCA Austerity Policy"])
-      (default-runner ["Adjusted Chronotype"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Adjusted Chronotype")
-    (take-credits state :runner)
-    (play-from-hand state :corp "MCA Austerity Policy" "New remote")
-    (let [mca (get-content state :remote1 0)]
-      (core/rez state :corp mca)
-      (card-ability state :corp mca 0)
-      (is (= 1 (get-counters (refresh mca) :power)))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Adjusted Chronotype" (qty "Beach Party" 2)]))
       (take-credits state :corp)
-      ; runner does not lose a click
-      (is (= 4 (:click (get-runner)))))))
+      (play-from-hand state :runner "Adjusted Chronotype")
+      (play-from-hand state :runner "Beach Party")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (= 4 (:click (get-runner))) "Should have lost 1 click and gained 1 click")
+      (play-from-hand state :runner "Beach Party")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (= 3 (:click (get-runner))) "Should have lost 2 clicks and gained 1 click")))
+  (testing "Chronotype to cancel out MCA click loss"
+    (do-game
+      (new-game
+        (default-corp ["MCA Austerity Policy"])
+        (default-runner ["Adjusted Chronotype"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Adjusted Chronotype")
+      (take-credits state :runner)
+      (play-from-hand state :corp "MCA Austerity Policy" "New remote")
+      (let [mca (get-content state :remote1 0)]
+        (core/rez state :corp mca)
+        (card-ability state :corp mca 0)
+        (is (= 1 (get-counters (refresh mca) :power)))
+        (take-credits state :corp)
+        ; runner does not lose a click
+        (is (= 4 (:click (get-runner)))))))
+  (testing "Ensure adjusted chronotype gains 2 clicks when 2 clicks are lost and GCS is installed"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Adjusted Chronotype"
+                                 (qty "Beach Party" 3)
+                                 "Gene Conditioning Shoppe"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Adjusted Chronotype")
+      (play-from-hand state :runner "Beach Party")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (= 4 (:click (get-runner))) "Should have lost 1 click and gained 1 click")
+      (play-from-hand state :runner "Beach Party")
+      (play-from-hand state :runner "Gene Conditioning Shoppe")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (= 4 (:click (get-runner))) "Should have lost 2 clicks and gained 2 clicks")
+      (play-from-hand state :runner "Beach Party")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (= 3 (:click (get-runner))) "Should have lost 3 clicks and gained 2 clicks"))))
 
-(deftest adjusted-chronotype-gcs
-  ;; Ensure adjusted chronotype gains 2 clicks when 2 clicks are lost and GCS is installed
-  (do-game
-   (new-game (default-corp)
-             (default-runner ["Adjusted Chronotype"
-                              (qty "Beach Party" 3)
-                              "Gene Conditioning Shoppe"]))
-   (take-credits state :corp)
-   (play-from-hand state :runner "Adjusted Chronotype")
-   (play-from-hand state :runner "Beach Party")
-   (take-credits state :runner)
-   (take-credits state :corp)
-   (is (= 4 (:click (get-runner))) "Should have lost 1 click and gained 1 click")
-   (play-from-hand state :runner "Beach Party")
-   (play-from-hand state :runner "Gene Conditioning Shoppe")
-   (take-credits state :runner)
-   (take-credits state :corp)
-   (is (= 4 (:click (get-runner))) "Should have lost 2 clicks and gained 2 clicks")
-   (play-from-hand state :runner "Beach Party")
-   (take-credits state :runner)
-   (take-credits state :corp)
-   (is (= 3 (:click (get-runner))) "Should have lost 3 clicks and gained 2 clicks")))
-
-(deftest aesops-pawnshop
+(deftest aesop's-pawnshop
   ;; Tests use cases for Aesop's Pawnshop
   (do-game
     (new-game (default-corp)
@@ -115,65 +112,62 @@
     (is (= 4 (:click (get-runner))) "Spent 1 click; gained 2 clicks")
     (is (= 1 (count (:discard (get-runner)))) "All-nighter is trashed")))
 
-(deftest bank-job-manhunt
-  ;; Bank Job - Manhunt trace happens first
-  (do-game
-    (new-game (default-corp ["Manhunt" "PAD Campaign"])
-              (default-runner ["Bank Job"]))
-    (play-from-hand state :corp "Manhunt")
-    (play-from-hand state :corp "PAD Campaign" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Bank Job")
-    (run-empty-server state "Server 1")
-    (prompt-choice :corp 2) ; Manhunt trace active
-    (prompt-choice :runner 0)
-    (prompt-choice :runner "Replacement effect")
-    (is (= "Bank Job" (:title (:card (first (get-in @state [:runner :prompt])))))
-        "Bank Job prompt active")
-    (prompt-choice :runner 8)
-    (is (empty? (get-in @state [:runner :rig :resource])) "Bank Job trashed after all credits taken")
-    (is (= 1 (count (:discard (get-runner)))))))
-
-(deftest bank-job-multiple-copies
-  ;; Bank Job - Choose which to use when 2+ copies are installed
-  (do-game
-    (new-game (default-corp ["PAD Campaign"])
-              (default-runner [(qty "Bank Job" 2)]))
-    (play-from-hand state :corp "PAD Campaign" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Bank Job")
-    (run-empty-server state "Server 1")
-    (prompt-choice :runner "Replacement effect")
-    (prompt-choice :runner 4)
-    (play-from-hand state :runner "Bank Job")
-    (let [bj1 (get-resource state 0)
-          bj2 (get-resource state 1)]
-      (is (= 4 (get-counters (refresh bj1) :credit)) "4 credits remaining on 1st copy")
+(deftest bank-job
+  ;; Bank Job
+  (testing "Manhunt trace happens first"
+    (do-game
+      (new-game (default-corp ["Manhunt" "PAD Campaign"])
+                (default-runner ["Bank Job"]))
+      (play-from-hand state :corp "Manhunt")
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Bank Job")
+      (run-empty-server state "Server 1")
+      (prompt-choice :corp 2) ; Manhunt trace active
+      (prompt-choice :runner 0)
+      (prompt-choice :runner "Replacement effect")
+      (is (= "Bank Job" (:title (:card (first (get-in @state [:runner :prompt])))))
+          "Bank Job prompt active")
+      (prompt-choice :runner 8)
+      (is (empty? (get-in @state [:runner :rig :resource])) "Bank Job trashed after all credits taken")
+      (is (= 1 (count (:discard (get-runner)))))))
+  (testing "Choose which to use when 2+ copies are installed"
+    (do-game
+      (new-game (default-corp ["PAD Campaign"])
+                (default-runner [(qty "Bank Job" 2)]))
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Bank Job")
       (run-empty-server state "Server 1")
       (prompt-choice :runner "Replacement effect")
-      (prompt-select :runner bj2)
-      (prompt-choice :runner 6)
-      (is (= 13 (:credit (get-runner))))
-      (is (= 2 (get-counters (refresh bj2) :credit)) "2 credits remaining on 2nd copy"))))
+      (prompt-choice :runner 4)
+      (play-from-hand state :runner "Bank Job")
+      (let [bj1 (get-resource state 0)
+            bj2 (get-resource state 1)]
+        (is (= 4 (get-counters (refresh bj1) :credit)) "4 credits remaining on 1st copy")
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "Replacement effect")
+        (prompt-select :runner bj2)
+        (prompt-choice :runner 6)
+        (is (= 13 (:credit (get-runner))))
+        (is (= 2 (get-counters (refresh bj2) :credit)) "2 credits remaining on 2nd copy"))))
+  (testing "Security Testing takes priority"
+    (do-game
+      (new-game (default-corp ["PAD Campaign"])
+                (default-runner ["Bank Job" "Security Testing"]))
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Security Testing")
+      (play-from-hand state :runner "Bank Job")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (prompt-choice :runner "Server 1")
+      (is (= 6 (:credit (get-runner))))
+      (run-empty-server state "Server 1")
+      (is (empty? (:prompt (get-runner))) "No Bank Job replacement choice")
+      (is (= 8 (:credit (get-runner))) "Security Testing paid 2c"))))
 
-(deftest bank-job-sectesting
-  ;; Bank Job - Security Testing takes priority
-  (do-game
-    (new-game (default-corp ["PAD Campaign"])
-              (default-runner ["Bank Job" "Security Testing"]))
-    (play-from-hand state :corp "PAD Campaign" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Security Testing")
-    (play-from-hand state :runner "Bank Job")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (prompt-choice :runner "Server 1")
-    (is (= 6 (:credit (get-runner))))
-    (run-empty-server state "Server 1")
-    (is (empty? (:prompt (get-runner))) "No Bank Job replacement choice")
-    (is (= 8 (:credit (get-runner))) "Security Testing paid 2c")))
-
-(deftest bazaar-grip-only
+(deftest bazaar
   ;; Bazaar - Only triggers when installing from Grip
   (do-game
     (new-game (default-corp)
@@ -279,6 +273,28 @@
       (core/rez state :corp (refresh jesus))
       (is (core/rezzed? (refresh jesus)) "Jackson Howard can be rezzed next turn"))))
 
+(deftest-pending councilman-zone-change
+  ;; Rezz no longer prevented when card changes zone (issues #1571)
+  (do-game
+    (new-game (default-corp ["Jackson Howard"])
+              (default-runner ["Councilman"]))
+    (play-from-hand state :corp "Jackson Howard" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Councilman")
+    (take-credits state :runner)
+    (let [jesus (get-content state :remote1 0)
+          judas (get-resource state 0)]
+      (core/rez state :corp jesus)
+      ;; Runner triggers Councilman
+      (card-ability state :runner judas 0)
+      (prompt-select :runner jesus)
+      (is (not (core/rezzed? (refresh jesus))) "Jackson Howard no longer rezzed")
+      (core/move state :corp (refresh jesus) :hand))
+    (play-from-hand state :corp "Jackson Howard" "New remote")
+    (let [jesus (get-content state :remote2 0)]
+      (core/rez state :corp jesus)
+      (is (core/rezzed? (refresh jesus)) "Jackson Howard can be rezzed after changing zone"))))
+
 (deftest counter-surveillance
   ;; Counter-Surveillance
   (testing "Trash to run, on successful run access cards equal to Tags and pay that amount in credits"
@@ -330,28 +346,6 @@
         (is (= 2 (count (:hand (get-runner)))) "Runner did draw cards from Obelus after all accesses are done")
         (is (= 1 (count (:discard (get-runner)))) "Counter Surveillance trashed")
         (is (zero? (:credit (get-runner))) "Runner has no credits")))))
-
-(deftest-pending councilman-zone-change
-  ;; Rezz no longer prevented when card changes zone (issues #1571)
-  (do-game
-    (new-game (default-corp ["Jackson Howard"])
-              (default-runner ["Councilman"]))
-    (play-from-hand state :corp "Jackson Howard" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Councilman")
-    (take-credits state :runner)
-    (let [jesus (get-content state :remote1 0)
-          judas (get-resource state 0)]
-      (core/rez state :corp jesus)
-      ;; Runner triggers Councilman
-      (card-ability state :runner judas 0)
-      (prompt-select :runner jesus)
-      (is (not (core/rezzed? (refresh jesus))) "Jackson Howard no longer rezzed")
-      (core/move state :corp (refresh jesus) :hand))
-    (play-from-hand state :corp "Jackson Howard" "New remote")
-    (let [jesus (get-content state :remote2 0)]
-      (core/rez state :corp jesus)
-      (is (core/rezzed? (refresh jesus)) "Jackson Howard can be rezzed after changing zone"))))
 
 (deftest daily-casts
   ;; Play and tick through all turns of daily casts
@@ -460,7 +454,7 @@
       reina "Reina Roja: Freedom Fighter"
       maxx "MaxX: Maximum Punk Rock"]
 
-  (deftest dj-fenris-chaos
+  (deftest dj-fenris
     ;; DJ Fenris - host 1 g-mod id not in faction on DJ Fenris
     (testing "Hosting Chaos Theory"
       ;; Ensure +1 MU is handled correctly
@@ -542,122 +536,113 @@
 
 (deftest dummy-box
   ;; Dummy Box - trash a card from hand to prevent corp trashing installed card
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Dummy Box" 1) (qty "Cache" 1) (qty "Clot" 1)]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Dummy Box")
-    (play-from-hand state :runner "Cache")
-    (take-credits state :runner)
-    (core/trash state :runner (get-program state 0))
-    (is (not-empty (:prompt (get-runner))) "Dummy Box prompting to prevent program trash")
-    (card-ability state :runner (get-resource state 0) 2)
-    (prompt-select :runner (find-card "Clot" (:hand (get-runner))))
-    (prompt-choice :runner "Done")
-    (is (= 1 (count (:discard (get-runner)))) "Clot trashed")
-    (is (empty? (:hand (get-runner))) "Card trashed from hand")
-    (is (= 1 (count (get-in @state [:runner :rig :program]))) "Cache still installed")
-    (is (= 1 (count (get-in @state [:runner :rig :resource]))) "Dummy Box still installed")))
-
-(deftest dummy-box-purge
-  ;; Dummy Box - doesn't prevent program deletion during purge
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Dummy Box" 1) (qty "Cache" 1) (qty "Clot" 1)]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Dummy Box")
-    (play-from-hand state :runner "Clot")
-    (take-credits state :runner)
-    (core/purge state :corp)
-    (is (empty? (:prompt (get-runner))) "Dummy Box not prompting to prevent purge trash")))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Dummy Box" 1) (qty "Cache" 1) (qty "Clot" 1)]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Dummy Box")
+      (play-from-hand state :runner "Cache")
+      (take-credits state :runner)
+      (core/trash state :runner (get-program state 0))
+      (is (not-empty (:prompt (get-runner))) "Dummy Box prompting to prevent program trash")
+      (card-ability state :runner (get-resource state 0) 2)
+      (prompt-select :runner (find-card "Clot" (:hand (get-runner))))
+      (prompt-choice :runner "Done")
+      (is (= 1 (count (:discard (get-runner)))) "Clot trashed")
+      (is (empty? (:hand (get-runner))) "Card trashed from hand")
+      (is (= 1 (count (get-in @state [:runner :rig :program]))) "Cache still installed")
+      (is (= 1 (count (get-in @state [:runner :rig :resource]))) "Dummy Box still installed")))
+  (testing "doesn't prevent program deletion during purge"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Dummy Box" 1) (qty "Cache" 1) (qty "Clot" 1)]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Dummy Box")
+      (play-from-hand state :runner "Clot")
+      (take-credits state :runner)
+      (core/purge state :corp)
+      (is (empty? (:prompt (get-runner))) "Dummy Box not prompting to prevent purge trash"))))
 
 (deftest eden-shard
   ;; Eden Shard - Install from Grip in lieu of accessing R&D; trash to make Corp draw 2
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Eden Shard"]))
-    (starting-hand state :corp ["Hedge Fund"])
-    (take-credits state :corp)
-    (is (= 1 (count (:hand (get-corp)))))
-    (run-on state :rd)
-    (core/no-action state :corp nil)
-    (play-from-hand state :runner "Eden Shard")
-    (is (= 5 (:credit (get-runner))) "Eden Shard installed for 0c")
-    (is (not (:run @state)) "Run is over")
-    (card-ability state :runner (get-resource state 0) 0)
-    (is (= 3 (count (:hand (get-corp)))) "Corp drew 2 cards")
-    (is (= 1 (count (:discard (get-runner)))) "Eden Shard trashed")))
-
-(deftest eden-shard-no-install-on-access
-  ;; Eden Shard - Do not install when accessing cards
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Eden Shard"]))
-    (starting-hand state :corp ["Hedge Fund"])
-    (take-credits state :corp)
-    (is (= 1 (count (:hand (get-corp)))))
-    (run-empty-server state :rd)
-    (play-from-hand state :runner "Eden Shard")
-    (is (not (get-resource state 0)) "Eden Shard not installed")
-    (is (= 1 (count (:hand (get-runner)))) "Eden Shard not installed")))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Eden Shard"]))
+      (starting-hand state :corp ["Hedge Fund"])
+      (take-credits state :corp)
+      (is (= 1 (count (:hand (get-corp)))))
+      (run-on state :rd)
+      (core/no-action state :corp nil)
+      (play-from-hand state :runner "Eden Shard")
+      (is (= 5 (:credit (get-runner))) "Eden Shard installed for 0c")
+      (is (not (:run @state)) "Run is over")
+      (card-ability state :runner (get-resource state 0) 0)
+      (is (= 3 (count (:hand (get-corp)))) "Corp drew 2 cards")
+      (is (= 1 (count (:discard (get-runner)))) "Eden Shard trashed")))
+  (testing "Do not install when accessing cards"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Eden Shard"]))
+      (starting-hand state :corp ["Hedge Fund"])
+      (take-credits state :corp)
+      (is (= 1 (count (:hand (get-corp)))))
+      (run-empty-server state :rd)
+      (play-from-hand state :runner "Eden Shard")
+      (is (not (get-resource state 0)) "Eden Shard not installed")
+      (is (= 1 (count (:hand (get-runner)))) "Eden Shard not installed"))))
 
 (deftest fan-site
   ;; Fan Site - Add to score area as 0 points when Corp scores an agenda
-  (do-game
-    (new-game (default-corp ["Hostile Takeover"])
-              (default-runner ["Fan Site"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Fan Site")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (is (= 0 (:agenda-point (get-runner))))
-    (is (= 1 (count (:scored (get-runner)))) "Fan Site added to Runner score area")))
-
-(deftest fan-site-eoi
-  ;; Fan Site - Don't trigger after swap with Exchange of Information. Issue #1824
-  (do-game
-    (new-game (default-corp [(qty "Hostile Takeover" 2) "Exchange of Information"])
-              (default-runner ["Fan Site"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Fan Site")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (core/tag-runner state :runner 1)
-
-    (play-from-hand state :corp "Exchange of Information")
-
-    (prompt-select :corp (find-card "Fan Site" (:scored (get-runner))))
-    (prompt-select :corp (find-card "Hostile Takeover" (:scored (get-corp))))
-
-    (is (= 1 (:agenda-point (get-runner))))
-    (is (= 0 (:agenda-point (get-corp))))
-
-    (is (find-card "Fan Site" (:scored (get-corp))) "Fan Site swapped into Corp score area")
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (score-agenda state :corp (get-content state :remote2 0))
-    (is (find-card "Fan Site" (:scored (get-corp))) "Fan Site not removed from Corp score area")))
-
-(deftest fan-site-forfeit
-  ;; Fan Site - Runner can forfeit Fan Site
-  (do-game
-    (new-game (default-corp ["Hostile Takeover"])
-              (default-runner ["Fan Site" "Data Dealer"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Fan Site")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (is (= 0 (:agenda-point (get-runner))))
-    (is (= 1 (count (:scored (get-runner)))) "Fan Site added to Runner score area")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Data Dealer")
-    (let [credits (:credit (get-runner))]
-      (card-ability state :runner (get-resource state 0) 0)
-      (prompt-select :runner (get-scored state :runner 0))
-      (is (= 0 (count (:scored (get-runner)))) "Fan Site successfully forfeit to Data Dealer")
-      (is (= (+ credits 9) (:credit (get-runner))) "Gained 9 credits from Data Dealer"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover"])
+                (default-runner ["Fan Site"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Fan Site")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      (is (= 0 (:agenda-point (get-runner))))
+      (is (= 1 (count (:scored (get-runner)))) "Fan Site added to Runner score area")))
+  (testing "Don't trigger after swap with Exchange of Information. Issue #1824"
+    (do-game
+      (new-game (default-corp [(qty "Hostile Takeover" 2) "Exchange of Information"])
+                (default-runner ["Fan Site"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Fan Site")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      (core/tag-runner state :runner 1)
+      (play-from-hand state :corp "Exchange of Information")
+      (prompt-select :corp (find-card "Fan Site" (:scored (get-runner))))
+      (prompt-select :corp (find-card "Hostile Takeover" (:scored (get-corp))))
+      (is (= 1 (:agenda-point (get-runner))))
+      (is (= 0 (:agenda-point (get-corp))))
+      (is (find-card "Fan Site" (:scored (get-corp))) "Fan Site swapped into Corp score area")
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (score-agenda state :corp (get-content state :remote2 0))
+      (is (find-card "Fan Site" (:scored (get-corp))) "Fan Site not removed from Corp score area")))
+  (testing "Runner can forfeit Fan Site"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover"])
+                (default-runner ["Fan Site" "Data Dealer"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Fan Site")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      (is (= 0 (:agenda-point (get-runner))))
+      (is (= 1 (count (:scored (get-runner)))) "Fan Site added to Runner score area")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Data Dealer")
+      (let [credits (:credit (get-runner))]
+        (card-ability state :runner (get-resource state 0) 0)
+        (prompt-select :runner (get-scored state :runner 0))
+        (is (= 0 (count (:scored (get-runner)))) "Fan Site successfully forfeit to Data Dealer")
+        (is (= (+ credits 9) (:credit (get-runner))) "Gained 9 credits from Data Dealer")))))
 
 (deftest fester
   ;; Fester - Corp loses 2c (if able) when purging viruses
@@ -675,79 +660,74 @@
     (core/purge state :corp)
     (is (= 1 (:credit (get-corp))) "Lost no credits when purging, only had 1c")))
 
-(deftest film-critic-discarded-executives
-  ;; Film Critic - Prevent Corp-trashed execs going to Runner scored. Issues #1181/#1042
-  (do-game
-    (new-game (default-corp [(qty "Director Haas" 3) (qty "Project Vitruvius" 3) "Hedge Fund"])
-              (default-runner ["Film Critic"]))
-    (play-from-hand state :corp "Project Vitruvius" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Film Critic")
-    (let [fc (first (get-in @state [:runner :rig :resource]))]
-      (run-empty-server state "Server 1")
-      (prompt-choice :runner "Yes")
-      (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
-      (take-credits state :runner)
-      (trash-from-hand state :corp "Director Haas")
-      (is (= 1 (count (:discard (get-corp)))) "Director Haas stayed in Archives")
-      (is (= 0 (:agenda-point (get-runner))) "No points gained by Runner")
-      (is (empty? (:scored (get-runner))) "Nothing in Runner scored"))))
-
-(deftest film-critic-fetal-ai
-  ;; Film Critic - Fetal AI interaction
-  (do-game
-    (new-game (default-corp [(qty "Fetal AI" 3)])
-              (default-runner ["Film Critic" (qty "Sure Gamble" 3)]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Film Critic")
-    (let [fc (first (get-in @state [:runner :rig :resource]))]
-      (run-empty-server state "HQ")
-      ;; should not have taken damage yet
-      (is (= 3 (count (:hand (get-runner)))) "No damage dealt yet")
-      (prompt-choice :runner "Yes")
-      (is (= 3 (count (:hand (get-runner)))) "No damage dealt")
-      (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
-      (card-ability state :runner fc 0)
-      (is (= 1 (count (:scored (get-runner)))) "Agenda added to runner scored")
-      (is (= 3 (count (:hand (get-runner)))) "No damage dealt"))))
-
-(deftest film-critic-hostile-infrastructure
-  ;; Do not take a net damage when a hosted agenda is trashed due to film critic trash #2382
-  (do-game
-    (new-game (default-corp [(qty "Hostile Infrastructure" 3) "Project Vitruvius"])
-              (default-runner ["Film Critic" (qty "Sure Gamble" 3)]))
-    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
-    (play-from-hand state :corp "Project Vitruvius" "New remote")
-    (core/rez state :corp (get-content state :remote1 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Film Critic")
-    (let [fc (first (get-in @state [:runner :rig :resource]))]
-      (run-empty-server state :remote2)
-      (prompt-choice :runner "Yes")
-      (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
-      (take-credits state :runner)
-      (core/gain state :corp :credit 10)
-      (core/trash-resource state :corp nil)
-      (prompt-select :corp fc)
-      (is (= 1 (count (:discard (get-runner)))) "FC trashed")
-      (is (= 1 (count (:discard (get-corp)))) "Agenda trashed")
-      (is (= 3 (count (:hand (get-runner)))) "No damage dealt"))))
-
-(deftest film-critic-mca-informant
-  ;; Film Critic - required hosted cards to be an agenda before firing ability
-  (do-game
-    (new-game (default-corp ["MCA Informant"])
-              (default-runner ["Film Critic"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Film Critic")
-    (let [fc (first (get-in @state [:runner :rig :resource]))]
-      (take-credits state :runner)
-      (play-from-hand state :corp "MCA Informant")
-      (prompt-select :corp fc)
-      (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant hosted on FC")
+(deftest film-critic
+  ;; Film Critic
+  (testing "Prevent Corp-trashed execs going to Runner scored. Issues #1181/#1042"
+    (do-game
+      (new-game (default-corp [(qty "Director Haas" 3) (qty "Project Vitruvius" 3) "Hedge Fund"])
+                (default-runner ["Film Critic"]))
+      (play-from-hand state :corp "Project Vitruvius" "New remote")
       (take-credits state :corp)
-      (card-ability state :runner fc 0)
-      (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant still hosted on FC"))))
+      (play-from-hand state :runner "Film Critic")
+      (let [fc (first (get-in @state [:runner :rig :resource]))]
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "Yes")
+        (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+        (take-credits state :runner)
+        (trash-from-hand state :corp "Director Haas")
+        (is (= 1 (count (:discard (get-corp)))) "Director Haas stayed in Archives")
+        (is (= 0 (:agenda-point (get-runner))) "No points gained by Runner")
+        (is (empty? (:scored (get-runner))) "Nothing in Runner scored"))))
+  (testing "Fetal AI interaction"
+    (do-game
+      (new-game (default-corp [(qty "Fetal AI" 3)])
+                (default-runner ["Film Critic" (qty "Sure Gamble" 3)]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Film Critic")
+      (let [fc (first (get-in @state [:runner :rig :resource]))]
+        (run-empty-server state "HQ")
+        ;; should not have taken damage yet
+        (is (= 3 (count (:hand (get-runner)))) "No damage dealt yet")
+        (prompt-choice :runner "Yes")
+        (is (= 3 (count (:hand (get-runner)))) "No damage dealt")
+        (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+        (card-ability state :runner fc 0)
+        (is (= 1 (count (:scored (get-runner)))) "Agenda added to runner scored")
+        (is (= 3 (count (:hand (get-runner)))) "No damage dealt"))))
+  (testing "Do not take a net damage when a hosted agenda is trashed due to film critic trash #2382"
+    (do-game
+      (new-game (default-corp [(qty "Hostile Infrastructure" 3) "Project Vitruvius"])
+                (default-runner ["Film Critic" (qty "Sure Gamble" 3)]))
+      (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+      (play-from-hand state :corp "Project Vitruvius" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Film Critic")
+      (let [fc (first (get-in @state [:runner :rig :resource]))]
+        (run-empty-server state :remote2)
+        (prompt-choice :runner "Yes")
+        (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+        (take-credits state :runner)
+        (core/gain state :corp :credit 10)
+        (core/trash-resource state :corp nil)
+        (prompt-select :corp fc)
+        (is (= 1 (count (:discard (get-runner)))) "FC trashed")
+        (is (= 1 (count (:discard (get-corp)))) "Agenda trashed")
+        (is (= 3 (count (:hand (get-runner)))) "No damage dealt"))))
+  (testing "required hosted cards to be an agenda before firing ability"
+    (do-game
+      (new-game (default-corp ["MCA Informant"])
+                (default-runner ["Film Critic"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Film Critic")
+      (let [fc (first (get-in @state [:runner :rig :resource]))]
+        (take-credits state :runner)
+        (play-from-hand state :corp "MCA Informant")
+        (prompt-select :corp fc)
+        (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant hosted on FC")
+        (take-credits state :corp)
+        (card-ability state :runner fc 0)
+        (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant still hosted on FC")))))
 
 (deftest find-the-truth
   ;; Find the Truth
@@ -807,83 +787,81 @@
       (is (= 2 (:credit (get-runner)))) #_ trashed_marilyn)))
 
 (deftest gang-sign
-  ;; Gang Sign - accessing from HQ, not including root. Issue #2113.
-  (do-game
-    (new-game (default-corp [(qty "Hostile Takeover" 3) (qty "Braintrust" 2) "Crisium Grid"])
-              (default-runner [(qty "Gang Sign" 2) "HQ Interface"]))
-    (play-from-hand state :corp "Crisium Grid" "HQ")
-    (take-credits state :corp)
-    (core/gain state :runner :credit 100)
-    (play-from-hand state :runner "Gang Sign")
-    (play-from-hand state :runner "Gang Sign")
-    (play-from-hand state :runner "HQ Interface")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (prompt-choice :runner "Gang Sign") ; simultaneous effect resolution
-    (let [gs1 (-> (get-runner) :prompt first)]
-      (is (= (:choices gs1) ["Card from hand"]) "Gang Sign does not let Runner access upgrade in HQ root")
+  ;; Gang Sign
+  (testing "accessing from HQ, not including root. Issue #2113"
+    (do-game
+      (new-game (default-corp [(qty "Hostile Takeover" 3) (qty "Braintrust" 2) "Crisium Grid"])
+                (default-runner [(qty "Gang Sign" 2) "HQ Interface"]))
+      (play-from-hand state :corp "Crisium Grid" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 100)
+      (play-from-hand state :runner "Gang Sign")
+      (play-from-hand state :runner "Gang Sign")
+      (play-from-hand state :runner "HQ Interface")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      (prompt-choice :runner "Gang Sign") ; simultaneous effect resolution
+      (let [gs1 (-> (get-runner) :prompt first)]
+        (is (= (:choices gs1) ["Card from hand"]) "Gang Sign does not let Runner access upgrade in HQ root")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "Steal")
+        (is (= (:card gs1) (-> (get-runner) :prompt first :card)) "Second access from first Gang Sign triggered")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "Steal")
+        (is (not= (:card gs1) (-> (get-runner) :prompt first :card)) "First access from second Gang Sign triggered")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "Steal")
+        (prompt-choice :runner "Card from hand")
+        (prompt-choice :runner "Steal"))))
+  (testing "accessing from HQ, not including root. Issue #2113"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover" "Snare!"])
+                (default-runner ["Gang Sign"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Gang Sign")
+      (take-credits state :runner)
+      (play-and-score state "Hostile Takeover")
       (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "Steal")
-      (is (= (:card gs1) (-> (get-runner) :prompt first :card)) "Second access from first Gang Sign triggered")
-      (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "Steal")
-      (is (not= (:card gs1) (-> (get-runner) :prompt first :card)) "First access from second Gang Sign triggered")
-      (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "Steal")
-      (prompt-choice :runner "Card from hand")
-      (prompt-choice :runner "Steal"))))
-
-(deftest gang-sign-correct-prompts
-  ;; Gang Sign - accessing from HQ, not including root. Issue #2113.
-  (do-game
-    (new-game (default-corp ["Hostile Takeover" "Snare!"])
-              (default-runner ["Gang Sign"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Gang Sign")
-    (take-credits state :runner)
-    (play-and-score state "Hostile Takeover")
-    (prompt-choice :runner "Card from hand")
-    ;; Runner has "wait for Snare, wait for on-access" prompts.
-    (is (= 2 (count (:prompt (get-runner)))) "Runner only has the Waiting prompt, not Snare!'s pay-prompt")
-    ;; Core has "pay for Snare, wait for agenda-scored" prompts.
-    (is (= 2 (count (:prompt (get-corp)))) "Corp has the prompt to use Snare!")))
+      ;; Runner has "wait for Snare, wait for on-access" prompts.
+      (is (= 2 (count (:prompt (get-runner)))) "Runner only has the Waiting prompt, not Snare!'s pay-prompt")
+      ;; Core has "pay for Snare, wait for agenda-scored" prompts.
+      (is (= 2 (count (:prompt (get-corp)))) "Corp has the prompt to use Snare!"))))
 
 (deftest gene-conditioning-shoppe
   ;; Gene Conditioning Shoppe - set :genetics-trigger-twice flag
-  (do-game
-   (new-game (default-corp [(qty "Hedge Fund" 3)])
-             (default-runner ["Gene Conditioning Shoppe"
-                              "Adjusted Chronotype"]))
-   (take-credits state :corp)
-   (play-from-hand state :runner "Adjusted Chronotype")
-   (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice)))
-   (play-from-hand state :runner "Gene Conditioning Shoppe")
-   (is (core/has-flag? state :runner :persistent :genetics-trigger-twice))
-   (core/trash state :runner (get-in @state [:runner :rig :resource 1]))
-   (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice)))))
-
-(deftest gene-conditioning-shoppe-redundancy
-  ;; Gene Conditioning Shoppe - set :genetics-trigger-twice flag - ensure redundant copies work
-  (do-game
-   (new-game (default-corp [(qty "Hedge Fund" 3)])
-             (default-runner [(qty "Gene Conditioning Shoppe" 2)
-                              "Adjusted Chronotype"]))
-   (take-credits state :corp)
-   (take-credits state :runner)
-   (take-credits state :corp)
-   (play-from-hand state :runner "Adjusted Chronotype")
-   (let [adjusted-chronotype (get-in @state [:runner :rig :resource 0])]
-     (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice)))
-     (play-from-hand state :runner "Gene Conditioning Shoppe")
-     (play-from-hand state :runner "Gene Conditioning Shoppe")
-     (let [gcs1 (get-in @state [:runner :rig :resource 1])
-           gcs2 (get-in @state [:runner :rig :resource 2])]
-       (is (core/has-flag? state :runner :persistent :genetics-trigger-twice))
-       (core/trash state :runner gcs1)
-       (is (core/has-flag? state :runner :persistent :genetics-trigger-twice))
-       (core/trash state :runner gcs2)
-       (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice)))))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Hedge Fund" 3)])
+                (default-runner ["Gene Conditioning Shoppe"
+                                 "Adjusted Chronotype"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Adjusted Chronotype")
+      (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice)))
+      (play-from-hand state :runner "Gene Conditioning Shoppe")
+      (is (core/has-flag? state :runner :persistent :genetics-trigger-twice))
+      (core/trash state :runner (get-in @state [:runner :rig :resource 1]))
+      (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice)))))
+  (testing "set :genetics-trigger-twice flag - ensure redundant copies work"
+    (do-game
+      (new-game (default-corp [(qty "Hedge Fund" 3)])
+                (default-runner [(qty "Gene Conditioning Shoppe" 2)
+                                 "Adjusted Chronotype"]))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Adjusted Chronotype")
+      (let [adjusted-chronotype (get-in @state [:runner :rig :resource 0])]
+        (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice)))
+        (play-from-hand state :runner "Gene Conditioning Shoppe")
+        (play-from-hand state :runner "Gene Conditioning Shoppe")
+        (let [gcs1 (get-in @state [:runner :rig :resource 1])
+              gcs2 (get-in @state [:runner :rig :resource 2])]
+          (is (core/has-flag? state :runner :persistent :genetics-trigger-twice))
+          (core/trash state :runner gcs1)
+          (is (core/has-flag? state :runner :persistent :genetics-trigger-twice))
+          (core/trash state :runner gcs2)
+          (is (not (core/has-flag? state :runner :persistent :genetics-trigger-twice))))))))
 
 (deftest globalsec-security-clearance
   ;; Globalsec Security Clearance - Ability, click lost on use
@@ -921,31 +899,30 @@
 
 (deftest guru-davinder
   ;; Guru Davinder - no prompt/trash for 'preventing' 0 damage
-  (do-game
-    (new-game (default-corp ["Punitive Counterstrike"])
-              (default-runner ["Guru Davinder"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Guru Davinder")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Punitive Counterstrike")
-    (prompt-choice :corp 0)
-    (prompt-choice :runner 0)
-    (is (empty? (get-in @state [:runner :prompt]))
-        "There is no prompt for 0 damage")))
-
-(deftest guru-davinder-obokata-protocol
-  ;; Guru Davinder - cannot steal Obokata while installed
-  (do-game
-    (new-game (make-deck "Jinteki: Personal Evolution" [(qty "Obokata Protocol" 10)])
-              (default-runner ["Guru Davinder" (qty "Sure Gamble" 4)]))
-    (play-from-hand state :corp "Obokata Protocol" "New remote")
-    (take-credits state :corp)
-    (core/gain state :runner :agenda-point 6)
-    (play-from-hand state :runner "Guru Davinder")
-    (run-empty-server state "Server 1")
-    (prompt-choice :runner "No action")
-    (is (= 0 (count (:discard (get-runner)))) "Runner did not pay damage")
-    (is (not= :runner (:winner @state)) "Runner has not won")))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Punitive Counterstrike"])
+                (default-runner ["Guru Davinder"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Guru Davinder")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Punitive Counterstrike")
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (empty? (get-in @state [:runner :prompt]))
+          "There is no prompt for 0 damage")))
+  (testing "cannot steal Obokata while installed"
+    (do-game
+      (new-game (make-deck "Jinteki: Personal Evolution" [(qty "Obokata Protocol" 10)])
+                (default-runner ["Guru Davinder" (qty "Sure Gamble" 4)]))
+      (play-from-hand state :corp "Obokata Protocol" "New remote")
+      (take-credits state :corp)
+      (core/gain state :runner :agenda-point 6)
+      (play-from-hand state :runner "Guru Davinder")
+      (run-empty-server state "Server 1")
+      (prompt-choice :runner "No action")
+      (is (= 0 (count (:discard (get-runner)))) "Runner did not pay damage")
+      (is (not= :runner (:winner @state)) "Runner has not won"))))
 
 (deftest hard-at-work
   ;; Hard at Work - Gain 2c and lose 1 click when turn begins
@@ -991,93 +968,91 @@
     (is (= 1 (count (:discard (get-runner)))) "IJ is trashed")
     (is (= 2 (:bad-publicity (get-corp))) "Corp took 1 bad publicity")))
 
-(deftest jackpot
+(deftest jackpot!
   ;; Jackpot! - whenever a card enters your score area, trash Jackpot to pull off credits
-  (do-game
-    (new-game (default-corp ["Braintrust"])
-              (default-runner ["Jackpot!"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Jackpot!")
-    (let [jak (get-resource state 0)]
-      (is (zero? (get-counters (refresh jak) :credit)) "Jackpot! starts with 0 credits")
-      (take-credits state :runner)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Braintrust"])
+                (default-runner ["Jackpot!"]))
       (take-credits state :corp)
-      (is (= 1 (get-counters (refresh jak) :credit)) "Jackpot! gains 1 credit per turn")
-      (take-credits state :runner)
+      (play-from-hand state :runner "Jackpot!")
+      (let [jak (get-resource state 0)]
+        (is (zero? (get-counters (refresh jak) :credit)) "Jackpot! starts with 0 credits")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 1 (get-counters (refresh jak) :credit)) "Jackpot! gains 1 credit per turn")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 2 (get-counters (refresh jak) :credit)) "Jackpot! gains 1 credit per turn (2nd turn)")
+        (run-empty-server state "HQ")
+        (prompt-choice :runner "Steal")
+        (is (= 2 (:agenda-point (get-runner))) "Runner steals Braintrust")
+        (prompt-choice :runner "Yes")
+        (is (= 12 (:credit (get-runner))) "Runner starts with 12 credits")
+        (prompt-choice :runner 2)
+        (is (= 14 (:credit (get-runner))) "Runner gains 2 credits")
+        (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed"))))
+  (testing "should fire when moving agendas from Film Critic to scored area"
+    (do-game
+      (new-game (default-corp ["Project Vitruvius"])
+                (default-runner ["Jackpot!" "Film Critic"]))
+      (play-from-hand state :corp "Project Vitruvius" "New remote")
       (take-credits state :corp)
-      (is (= 2 (get-counters (refresh jak) :credit)) "Jackpot! gains 1 credit per turn (2nd turn)")
-      (run-empty-server state "HQ")
-      (prompt-choice :runner "Steal")
-      (is (= 2 (:agenda-point (get-runner))) "Runner steals Braintrust")
-      (prompt-choice :runner "Yes")
-      (is (= 12 (:credit (get-runner))) "Runner starts with 12 credits")
-      (prompt-choice :runner 2)
-      (is (= 14 (:credit (get-runner))) "Runner gains 2 credits")
-      (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed"))))
+      (play-from-hand state :runner "Film Critic")
+      (play-from-hand state :runner "Jackpot!")
+      (let [fc (get-resource state 0)
+            jak (get-resource state 1)]
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "Yes")
+        (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (card-ability state :runner fc 0)
+        (prompt-choice :runner "Yes")
+        (prompt-choice :runner 1)
+        (is (= 1 (count (:scored (get-runner)))) "Moved agenda to scored area")
+        (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed")
+        (is (empty? (:hosted (refresh fc))) "Removed agenda hosted on FC"))))
+  (testing "should fire when trashing Chairman Hiro"
+    (do-game
+      (new-game (default-corp ["Chairman Hiro"])
+                (default-runner ["Jackpot!"]))
+      (play-from-hand state :corp "Chairman Hiro" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Jackpot!")
+      (let [jak (get-resource state 0)]
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 1 (get-counters (refresh jak) :credit)) "Jackpot! gains 1 credit per turn")
+        (run-empty-server state "Server 1")
+        (prompt-choice-partial :runner "Pay") ;trash CH
+        (prompt-choice :runner "Yes") ;trash Jackpot!
+        (prompt-choice :runner 1)
+        (is (= 3 (:credit (get-runner))) "Runner gains 1 credit")
+        (is (= 1 (count (:scored (get-runner)))) "Chairman Hiro in score area")
+        (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed")))))
 
-(deftest jackpot-film-critic
-  ;; Jackpot! should fire when moving agendas from Film Critic to scored area
-  (do-game
-    (new-game (default-corp ["Project Vitruvius"])
-              (default-runner ["Jackpot!" "Film Critic"]))
-    (play-from-hand state :corp "Project Vitruvius" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Film Critic")
-    (play-from-hand state :runner "Jackpot!")
-    (let [fc (get-resource state 0)
-          jak (get-resource state 1)]
-      (run-empty-server state "Server 1")
-      (prompt-choice :runner "Yes")
-      (is (= 1 (count (:hosted (refresh fc)))) "Agenda hosted on FC")
+(deftest jak-sinclair
+  ;; Jak Sinclair
+  (testing "Lost clicks carry through to when turn starts fully #1764"
+    (do-game
+      (new-game (default-corp [(qty "Enigma" 3)])
+                (default-runner [(qty "Jak Sinclair" 3)]))
+      (play-from-hand state :corp "Enigma" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Jak Sinclair")
       (take-credits state :runner)
       (take-credits state :corp)
-      (card-ability state :runner fc 0)
-      (prompt-choice :runner "Yes")
-      (prompt-choice :runner 1)
-      (is (= 1 (count (:scored (get-runner)))) "Moved agenda to scored area")
-      (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed")
-      (is (empty? (:hosted (refresh fc))) "Removed agenda hosted on FC"))))
-
-(deftest jackpot-hiro
-  ;; Jackpot! - should fire when trashing Chairman Hiro
-  (do-game
-    (new-game (default-corp ["Chairman Hiro"])
-              (default-runner ["Jackpot!"]))
-    (play-from-hand state :corp "Chairman Hiro" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Jackpot!")
-    (let [jak (get-resource state 0)]
-      (take-credits state :runner)
-      (take-credits state :corp)
-      (is (= 1 (get-counters (refresh jak) :credit)) "Jackpot! gains 1 credit per turn")
-      (run-empty-server state "Server 1")
-      (prompt-choice-partial :runner "Pay") ;trash CH
-      (prompt-choice :runner "Yes") ;trash Jackpot!
-      (prompt-choice :runner 1)
-      (is (= 3 (:credit (get-runner))) "Runner gains 1 credit")
-      (is (= 1 (count (:scored (get-runner)))) "Chairman Hiro in score area")
-      (is (= 1 (count (:discard (get-runner)))) "Jackpot! trashed"))))
-
-(deftest jak-sinclair-enigma
-  ;; Lost clicks carry through to when turn starts fully #1764
-  (do-game
-    (new-game (default-corp [(qty "Enigma" 3)])
-              (default-runner [(qty "Jak Sinclair" 3)]))
-    (play-from-hand state :corp "Enigma" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Jak Sinclair")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (let [eni (get-ice state :hq 0)
-          jak (get-resource state 0)]
-      (core/rez state :corp eni)
-      (is (:runner-phase-12 @state) "Runner in Step 1.2")
-      (card-ability state :runner jak 0)
-      (prompt-choice :runner "HQ")
-      (card-subroutine state :corp (refresh eni) 0)
-      (run-successful state)
-      (core/end-phase-12 state :runner nil)
-      (is (= 3 (:click (get-runner))) "Enigma took a click"))))
+      (let [eni (get-ice state :hq 0)
+            jak (get-resource state 0)]
+        (core/rez state :corp eni)
+        (is (:runner-phase-12 @state) "Runner in Step 1.2")
+        (card-ability state :runner jak 0)
+        (prompt-choice :runner "HQ")
+        (card-subroutine state :corp (refresh eni) 0)
+        (run-successful state)
+        (core/end-phase-12 state :runner nil)
+        (is (= 3 (:click (get-runner))) "Enigma took a click")))))
 
 (deftest john-masanori
   ;; John Masanori - Draw 1 card on first successful run, take 1 tag on first unsuccessful run
@@ -1105,7 +1080,7 @@
     (run-jack-out state)
     (is (= 1 (:tag (get-runner))) "No tag taken from second unsuccessful run")))
 
-(deftest joshua-b
+(deftest joshua-b.
   ;; Joshua B. - Take 1 tag at turn end if you choose to gain the extra click
   (do-game
     (new-game (default-corp)
@@ -1258,54 +1233,51 @@
       (is (= 2 (count (:hand (get-runner)))) "Darwin never got played, Chameleon returned to hand")
       (is (= 2 (count (:discard (get-runner)))) "Femme Fatale and Study Guide trashed"))))
 
-(deftest muertos-trashed
+(deftest muertos-gang-member
   ;; Muertos Gang Member - Install and Trash
-  (do-game
-    (new-game (default-corp ["Tollbooth" "Ice Wall"])
-              (default-runner [(qty "Hedge Fund" 3) "Muertos Gang Member"]))
-    (play-from-hand state :corp "Tollbooth" "HQ")
-    (play-from-hand state :corp "Ice Wall" "Archives")
-    (take-credits state :corp)
-    (let [toll (get-ice state :hq 0)
-          iw (get-ice state :archives 0)]
-      (core/rez state :corp iw)
-      (core/move state :runner (find-card "Hedge Fund" (:hand (get-runner))) :deck)
-
-      (play-from-hand state :runner "Muertos Gang Member")
-      (prompt-select :corp (refresh iw))
-      (is (not (:rezzed (refresh iw))) "Ice Wall derezzed")
-      (is (= 2 (count (:hand (get-runner)))) "2 cards in Runner's hand")
-      (let [muer (get-in @state [:runner :rig :resource 0])]
-        (card-ability state :runner muer 0)
-        (is (= 3 (count (:hand (get-runner)))) "Runner drew a card from Muertos")
-        (prompt-select :corp toll)
-        (is (:rezzed (refresh toll)) "Tollbooth was rezzed")))))
-
-(deftest muertos-reina
-  ;; Muertos Gang Member - Account for Reina interaction, #1098.
-  (do-game
-    (new-game (default-corp ["Tollbooth" "Ice Wall"])
-              (make-deck "Reina Roja: Freedom Fighter" [(qty "Hedge Fund" 3)
-                                                        "Muertos Gang Member"]))
-    (play-from-hand state :corp "Tollbooth" "HQ")
-    (play-from-hand state :corp "Ice Wall" "Archives")
-    (let [toll (get-ice state :hq 0)
-          iw (get-ice state :archives 0)]
-      (core/rez state :corp iw)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Tollbooth" "Ice Wall"])
+                (default-runner [(qty "Hedge Fund" 3) "Muertos Gang Member"]))
+      (play-from-hand state :corp "Tollbooth" "HQ")
+      (play-from-hand state :corp "Ice Wall" "Archives")
       (take-credits state :corp)
-      (core/lose state :corp :credit 100)
-      (core/move state :runner (find-card "Hedge Fund" (:hand (get-runner))) :deck)
-
-      (play-from-hand state :runner "Muertos Gang Member")
-      (prompt-select :corp (refresh iw))
-      (is (not (:rezzed (refresh iw))) "Ice Wall derezzed")
-      (is (= 2 (count (:hand (get-runner)))) "2 cards in Runner's hand")
-      (let [muer (get-in @state [:runner :rig :resource 0])]
-        (card-ability state :runner muer 0)
-        (is (= 3 (count (:hand (get-runner)))) "Runner drew a card from Muertos")
-        (prompt-select :corp toll)
-        (is (:rezzed (refresh toll)) "Tollbooth was rezzed")
-        (is (= 0 (:credit (get-corp))) "Corp has 0 credits")))))
+      (let [toll (get-ice state :hq 0)
+            iw (get-ice state :archives 0)]
+        (core/rez state :corp iw)
+        (core/move state :runner (find-card "Hedge Fund" (:hand (get-runner))) :deck)
+        (play-from-hand state :runner "Muertos Gang Member")
+        (prompt-select :corp (refresh iw))
+        (is (not (:rezzed (refresh iw))) "Ice Wall derezzed")
+        (is (= 2 (count (:hand (get-runner)))) "2 cards in Runner's hand")
+        (let [muer (get-in @state [:runner :rig :resource 0])]
+          (card-ability state :runner muer 0)
+          (is (= 3 (count (:hand (get-runner)))) "Runner drew a card from Muertos")
+          (prompt-select :corp toll)
+          (is (:rezzed (refresh toll)) "Tollbooth was rezzed")))))
+  (testing "Account for Reina interaction, #1098"
+    (do-game
+      (new-game (default-corp ["Tollbooth" "Ice Wall"])
+                (make-deck "Reina Roja: Freedom Fighter" [(qty "Hedge Fund" 3)
+                                                          "Muertos Gang Member"]))
+      (play-from-hand state :corp "Tollbooth" "HQ")
+      (play-from-hand state :corp "Ice Wall" "Archives")
+      (let [toll (get-ice state :hq 0)
+            iw (get-ice state :archives 0)]
+        (core/rez state :corp iw)
+        (take-credits state :corp)
+        (core/lose state :corp :credit 100)
+        (core/move state :runner (find-card "Hedge Fund" (:hand (get-runner))) :deck)
+        (play-from-hand state :runner "Muertos Gang Member")
+        (prompt-select :corp (refresh iw))
+        (is (not (:rezzed (refresh iw))) "Ice Wall derezzed")
+        (is (= 2 (count (:hand (get-runner)))) "2 cards in Runner's hand")
+        (let [muer (get-in @state [:runner :rig :resource 0])]
+          (card-ability state :runner muer 0)
+          (is (= 3 (count (:hand (get-runner)))) "Runner drew a card from Muertos")
+          (prompt-select :corp toll)
+          (is (:rezzed (refresh toll)) "Tollbooth was rezzed")
+          (is (= 0 (:credit (get-corp))) "Corp has 0 credits"))))))
 
 (deftest net-mercur
   ;; Net Mercur - Gains 1 credit or draw 1 card when a stealth credit is used
@@ -1337,36 +1309,35 @@
 
 (deftest network-exchange
   ;; ICE install costs 1 more except for inner most
-  (do-game
-    (new-game (default-corp [(qty "Paper Wall" 3)])
-              (default-runner ["Network Exchange"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Network Exchange")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Paper Wall" "HQ")
-    (is (= 8 (:credit (get-corp))) "Paid 0 to install Paper Wall")
-    (play-from-hand state :corp "Paper Wall" "HQ")
-    (is (= 6 (:credit (get-corp))) "Paid 1 extra  to install Paper Wall")
-    (play-from-hand state :corp "Paper Wall" "HQ")
-    (is (= 3 (:credit (get-corp))) "Paid 1 extra  to install Paper Wall")))
-
-(deftest network-exchange-architect
-  ;; Architect 1st sub should ignore additional install cose
-  (do-game
-    (new-game (default-corp [(qty "Architect" 3)])
-              (default-runner ["Network Exchange"]))
-    (play-from-hand state :corp "Architect" "HQ")
-    (take-credits state :corp) ; corp has 7 credits
-    (play-from-hand state :runner "Network Exchange")
-    (take-credits state :runner)
-    (let [architect (get-ice state :hq 0)]
-      (core/rez state :corp architect)
-      (is (= 3 (:credit (get-corp))) "Corp has 3 credits after rez")
-      (core/move state :corp (find-card "Architect" (:hand (get-corp))) :deck)
-      (card-subroutine state :corp architect 0)
-      (prompt-card :corp (find-card "Architect" (:deck (get-corp))))
-      (prompt-choice :corp "HQ")
-      (is (= 3 (:credit (get-corp))) "Corp has 7 credits"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Paper Wall" 3)])
+                (default-runner ["Network Exchange"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Network Exchange")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Paper Wall" "HQ")
+      (is (= 8 (:credit (get-corp))) "Paid 0 to install Paper Wall")
+      (play-from-hand state :corp "Paper Wall" "HQ")
+      (is (= 6 (:credit (get-corp))) "Paid 1 extra  to install Paper Wall")
+      (play-from-hand state :corp "Paper Wall" "HQ")
+      (is (= 3 (:credit (get-corp))) "Paid 1 extra  to install Paper Wall")))
+  (testing "Architect 1st sub should ignore additional install cost"
+    (do-game
+      (new-game (default-corp [(qty "Architect" 3)])
+                (default-runner ["Network Exchange"]))
+      (play-from-hand state :corp "Architect" "HQ")
+      (take-credits state :corp) ; corp has 7 credits
+      (play-from-hand state :runner "Network Exchange")
+      (take-credits state :runner)
+      (let [architect (get-ice state :hq 0)]
+        (core/rez state :corp architect)
+        (is (= 3 (:credit (get-corp))) "Corp has 3 credits after rez")
+        (core/move state :corp (find-card "Architect" (:hand (get-corp))) :deck)
+        (card-subroutine state :corp architect 0)
+        (prompt-card :corp (find-card "Architect" (:deck (get-corp))))
+        (prompt-choice :corp "HQ")
+        (is (= 3 (:credit (get-corp))) "Corp has 7 credits")))))
 
 (deftest neutralize-all-threats
   ;; Neutralize All Threats - Access 2 cards from HQ, force trash first accessed card with a trash cost
@@ -1391,46 +1362,45 @@
 
 (deftest new-angeles-city-hall
   ;; New Angeles City Hall - Avoid tags; trash when agenda is stolen
-  (do-game
-    (new-game (default-corp ["SEA Source" "Breaking News"])
-              (default-runner ["New Angeles City Hall"]))
-    (play-from-hand state :corp "Breaking News" "New remote")
-    (take-credits state :corp 2)
-    (play-from-hand state :runner "New Angeles City Hall")
-    (let [nach (get-in @state [:runner :rig :resource 0])]
-      (run-empty-server state "Archives")
-      (take-credits state :runner)
-      (is (= 6 (:credit (get-runner))))
-      (play-from-hand state :corp "SEA Source")
-      (prompt-choice :corp 0) ; default trace
-      (prompt-choice :runner 0) ; Runner won't match
-      (card-ability state :runner nach 0)
-      (prompt-choice :runner "Done")
-      (is (= 0 (:tag (get-runner))) "Avoided SEA Source tag")
-      (is (= 4 (:credit (get-runner))) "Paid 2 credits")
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["SEA Source" "Breaking News"])
+                (default-runner ["New Angeles City Hall"]))
+      (play-from-hand state :corp "Breaking News" "New remote")
+      (take-credits state :corp 2)
+      (play-from-hand state :runner "New Angeles City Hall")
+      (let [nach (get-in @state [:runner :rig :resource 0])]
+        (run-empty-server state "Archives")
+        (take-credits state :runner)
+        (is (= 6 (:credit (get-runner))))
+        (play-from-hand state :corp "SEA Source")
+        (prompt-choice :corp 0) ; default trace
+        (prompt-choice :runner 0) ; Runner won't match
+        (card-ability state :runner nach 0)
+        (prompt-choice :runner "Done")
+        (is (= 0 (:tag (get-runner))) "Avoided SEA Source tag")
+        (is (= 4 (:credit (get-runner))) "Paid 2 credits")
+        (take-credits state :corp)
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "Steal")
+        (is (= 1 (:agenda-point (get-runner))))
+        (is (empty? (get-in @state [:runner :rig :resource])) "NACH trashed by agenda steal"))))
+  (testing "don't gain Siphon credits until opportunity to avoid tags has passed"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Account Siphon" "New Angeles City Hall"]))
       (take-credits state :corp)
-      (run-empty-server state "Server 1")
-      (prompt-choice :runner "Steal")
-      (is (= 1 (:agenda-point (get-runner))))
-      (is (empty? (get-in @state [:runner :rig :resource])) "NACH trashed by agenda steal"))))
-
-(deftest new-angeles-city-hall-siphon
-  ;; New Angeles City Hall - don't gain Siphon credits until opportunity to avoid tags has passed
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Account Siphon" "New Angeles City Hall"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "New Angeles City Hall")
-    (play-run-event state (first (:hand (get-runner))) :hq)
-    (prompt-choice :runner "Replacement effect")
-    (let [nach (get-in @state [:runner :rig :resource 0])]
-      (is (= 4 (:credit (get-runner))) "Have not gained Account Siphon credits until tag avoidance window closes")
-      (card-ability state :runner nach 0)
-      (card-ability state :runner nach 0)
-      (prompt-choice :runner "Done")
-      (is (= 0 (:tag (get-runner))) "Tags avoided")
-      (is (= 10 (:credit (get-runner))) "10 credits siphoned")
-      (is (= 3 (:credit (get-corp))) "Corp lost 5 credits"))))
+      (play-from-hand state :runner "New Angeles City Hall")
+      (play-run-event state (first (:hand (get-runner))) :hq)
+      (prompt-choice :runner "Replacement effect")
+      (let [nach (get-in @state [:runner :rig :resource 0])]
+        (is (= 4 (:credit (get-runner))) "Have not gained Account Siphon credits until tag avoidance window closes")
+        (card-ability state :runner nach 0)
+        (card-ability state :runner nach 0)
+        (prompt-choice :runner "Done")
+        (is (= 0 (:tag (get-runner))) "Tags avoided")
+        (is (= 10 (:credit (get-runner))) "10 credits siphoned")
+        (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))))
 
 (deftest no-one-home
   ;; Prevent first tag or net damage of the turn if you beat trace0, then trash
@@ -1463,49 +1433,48 @@
         (is (= 3 (count (:discard (get-runner)))) "Two NOH trashed, 1 gamble played")
         (is (= 0 (:tag (get-runner))) "Tags avoided")))))
 
-(deftest off-campus-apartment-simultaneous
-  ;; Off-Campus Apartment - ability shows a simultaneous resolution prompt when appropriate
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Street Peddler" "Off-Campus Apartment"
-                               "Underworld Contact" (qty "Spy Camera" 6)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler" "Off-Campus Apartment" "Underworld Contact"])
-    (play-from-hand state :runner "Off-Campus Apartment")
-    (let [oca (get-resource state 0)]
-      (card-ability state :runner oca 0)
-      (prompt-select :runner (find-card "Underworld Contact" (:hand (get-runner))))
-      (is (= 2 (count (:hand (get-runner)))) "Drew a card from OCA")
-      (card-ability state :runner oca 0)
-      (prompt-select :runner (find-card "Street Peddler" (:hand (get-runner))))
-      ;; Make sure the simultaneous-resolution prompt is showing with 2 choices
-      (is (= 2 (-> (get-runner) :prompt first :choices count)) "Simultaneous-resolution prompt is showing")
-      (prompt-choice :runner "Off-Campus Apartment")
-      (is (= 2 (count (:hand (get-runner)))) "Drew a card from OCA"))))
-
-(deftest off-campus-peddler
-  ;; Off-Campus Apartment - second ability does not break cards that are hosting others, e.g., Street Peddler
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Street Peddler" 2) "Off-Campus Apartment" (qty "Spy Camera" 6)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler" "Street Peddler" "Off-Campus Apartment"])
-    (core/move state :runner (find-card "Street Peddler" (:hand (get-runner))) :deck {:front true})
-    (play-from-hand state :runner "Off-Campus Apartment")
-    (let [oca (get-resource state 0)]
-      (card-ability state :runner oca 0)
-      (prompt-select :runner (find-card "Street Peddler" (:hand (get-runner))))
-      (prompt-choice :runner "Street Peddler")
-      (let [ped1 (first (:hosted (refresh oca)))]
-        (card-ability state :runner ped1 0)
-        (prompt-card :runner (-> (get-runner) :prompt first :choices second)) ; choose Street Peddler
-        (card-ability state :runner (refresh oca) 1)
-        (prompt-select :runner (get-resource state 1))
-        (let [ped2 (first (:hosted (refresh oca)))]
-          (card-ability state :runner ped2 0)
-          (prompt-card :runner (-> (get-runner) :prompt first :choices first)) ; choose Spy Camera
-          ;; the fact that we got this far means the bug is fixed
-          (is (= 1 (count (get-hardware state))) "Spy Camera installed"))))))
+(deftest off-campus-apartment
+  ;; Off-Campus Apartment
+  (testing "ability shows a simultaneous resolution prompt when appropriate"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Street Peddler" "Off-Campus Apartment"
+                                 "Underworld Contact" (qty "Spy Camera" 6)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler" "Off-Campus Apartment" "Underworld Contact"])
+      (play-from-hand state :runner "Off-Campus Apartment")
+      (let [oca (get-resource state 0)]
+        (card-ability state :runner oca 0)
+        (prompt-select :runner (find-card "Underworld Contact" (:hand (get-runner))))
+        (is (= 2 (count (:hand (get-runner)))) "Drew a card from OCA")
+        (card-ability state :runner oca 0)
+        (prompt-select :runner (find-card "Street Peddler" (:hand (get-runner))))
+        ;; Make sure the simultaneous-resolution prompt is showing with 2 choices
+        (is (= 2 (-> (get-runner) :prompt first :choices count)) "Simultaneous-resolution prompt is showing")
+        (prompt-choice :runner "Off-Campus Apartment")
+        (is (= 2 (count (:hand (get-runner)))) "Drew a card from OCA"))))
+  (testing "second ability does not break cards that are hosting others, e.g., Street Peddler"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Street Peddler" 2) "Off-Campus Apartment" (qty "Spy Camera" 6)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler" "Street Peddler" "Off-Campus Apartment"])
+      (core/move state :runner (find-card "Street Peddler" (:hand (get-runner))) :deck {:front true})
+      (play-from-hand state :runner "Off-Campus Apartment")
+      (let [oca (get-resource state 0)]
+        (card-ability state :runner oca 0)
+        (prompt-select :runner (find-card "Street Peddler" (:hand (get-runner))))
+        (prompt-choice :runner "Street Peddler")
+        (let [ped1 (first (:hosted (refresh oca)))]
+          (card-ability state :runner ped1 0)
+          (prompt-card :runner (-> (get-runner) :prompt first :choices second)) ; choose Street Peddler
+          (card-ability state :runner (refresh oca) 1)
+          (prompt-select :runner (get-resource state 1))
+          (let [ped2 (first (:hosted (refresh oca)))]
+            (card-ability state :runner ped2 0)
+            (prompt-card :runner (-> (get-runner) :prompt first :choices first)) ; choose Spy Camera
+            ;; the fact that we got this far means the bug is fixed
+            (is (= 1 (count (get-hardware state))) "Spy Camera installed")))))))
 
 (deftest officer-frank
   ;; Officer Frank - meat damage to trash 2 from HQ
@@ -1535,81 +1504,81 @@
    (card-ability state :runner (get-resource state 0) 0)
    (is (= 2 (count (:discard (get-corp)))) "Two cards trashed from HQ")))
 
-(deftest paige-piper-frantic-coding
-  ;; Paige Piper - interaction with Frantic Coding. Issue #2190.
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Paige Piper" (qty "Frantic Coding" 2) (qty "Sure Gamble" 3)
-                               (qty "Gordian Blade" 2) "Ninja" (qty "Bank Job" 3) (qty "Indexing" 2)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Paige Piper" "Frantic Coding" "Frantic Coding"])
-    (play-from-hand state :runner "Paige Piper")
-    (prompt-choice :runner "No")
-    (take-credits state :runner) ; now 8 credits
-    (take-credits state :corp)
-    (play-from-hand state :runner "Frantic Coding")
-    (prompt-choice :runner "No action")
-    (prompt-card :runner (find-card "Gordian Blade" (:deck (get-runner))))
-    (is (= 1 (count (get-program state))) "Installed Gordian Blade")
-    (prompt-choice :runner "Yes")
-    (prompt-choice :runner "0")
-    (is (= 1 (count (:discard (get-runner)))) "Paige Piper intervention stopped Frantic Coding from trashing 9 cards")
-    (is (= 5 (:credit (get-runner))) "No charge to install Gordian")
-    ;; a second Frantic Coding will not trigger Paige (once per turn)
-    (play-from-hand state :runner "Frantic Coding")
-    (prompt-choice :runner "No action")
-    (prompt-card :runner (find-card "Ninja" (:deck (get-runner))))
-    (is (= 2 (count (get-program state))) "Installed Ninja")
-    (is (= 11 (count (:discard (get-runner)))) "11 cards in heap")
-    (is (= 2 (:credit (get-runner))) "No charge to install Ninja")))
+(deftest paige-piper
+  ;; Paige Piper
+  (testing "interaction with Frantic Coding. Issue #2190"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Paige Piper" (qty "Frantic Coding" 2) (qty "Sure Gamble" 3)
+                                 (qty "Gordian Blade" 2) "Ninja" (qty "Bank Job" 3) (qty "Indexing" 2)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Paige Piper" "Frantic Coding" "Frantic Coding"])
+      (play-from-hand state :runner "Paige Piper")
+      (prompt-choice :runner "No")
+      (take-credits state :runner) ; now 8 credits
+      (take-credits state :corp)
+      (play-from-hand state :runner "Frantic Coding")
+      (prompt-choice :runner "No action")
+      (prompt-card :runner (find-card "Gordian Blade" (:deck (get-runner))))
+      (is (= 1 (count (get-program state))) "Installed Gordian Blade")
+      (prompt-choice :runner "Yes")
+      (prompt-choice :runner "0")
+      (is (= 1 (count (:discard (get-runner)))) "Paige Piper intervention stopped Frantic Coding from trashing 9 cards")
+      (is (= 5 (:credit (get-runner))) "No charge to install Gordian")
+      ;; a second Frantic Coding will not trigger Paige (once per turn)
+      (play-from-hand state :runner "Frantic Coding")
+      (prompt-choice :runner "No action")
+      (prompt-card :runner (find-card "Ninja" (:deck (get-runner))))
+      (is (= 2 (count (get-program state))) "Installed Ninja")
+      (is (= 11 (count (:discard (get-runner)))) "11 cards in heap")
+      (is (= 2 (:credit (get-runner))) "No charge to install Ninja"))))
 
 (deftest patron
-  ;; Patron - Ability
-  (do-game
-    (new-game (default-corp ["Jackson Howard"])
-              (default-runner [(qty "Patron" 4) (qty "Easy Mark" 4)]))
-    (play-from-hand state :corp "Jackson Howard" "New remote")
-    (take-credits state :corp 2)
-    (play-from-hand state :runner "Patron")
-    (let [p (get-in @state [:runner :rig :resource 0])]
-      (take-credits state :runner 3)
+  ;; Patron
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Jackson Howard"])
+                (default-runner [(qty "Patron" 4) (qty "Easy Mark" 4)]))
+      (play-from-hand state :corp "Jackson Howard" "New remote")
+      (take-credits state :corp 2)
+      (play-from-hand state :runner "Patron")
+      (let [p (get-in @state [:runner :rig :resource 0])]
+        (take-credits state :runner 3)
+        (take-credits state :corp)
+        (prompt-choice :runner "Server 1")
+        (is (= 4 (count (:hand (get-runner)))) "Starts with 4 cards")
+        (run-empty-server state "Server 1")
+        (is (= 6 (count (:hand (get-runner)))) "Drew 2 cards")
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "No")
+        (is (= 6 (count (:hand (get-runner)))) "Drew no cards")
+        (play-from-hand state :runner "Easy Mark")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (prompt-choice :runner "Server 1")
+        (run-empty-server state "Archives")
+        (is (= 5 (count (:hand (get-runner)))) "Did not draw cards when running other server"))))
+  (testing "Manually selecting during Step 1.2 does not show a second prompt at start of turn. Issue #1744."
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Patron" 3) (qty "Jak Sinclair" 3)]))
       (take-credits state :corp)
-      (prompt-choice :runner "Server 1")
-      (is (= 4 (count (:hand (get-runner)))) "Starts with 4 cards")
-      (run-empty-server state "Server 1")
-      (is (= 6 (count (:hand (get-runner)))) "Drew 2 cards")
-      (run-empty-server state "Server 1")
-      (prompt-choice :runner "No")
-      (is (= 6 (count (:hand (get-runner)))) "Drew no cards")
-      (play-from-hand state :runner "Easy Mark")
+      (core/gain state :runner :credit 10)
+      (starting-hand state :runner ["Patron" "Jak Sinclair"])
+      (play-from-hand state :runner "Patron")
+      (play-from-hand state :runner "Jak Sinclair")
       (take-credits state :runner)
-      (take-credits state :corp)
-      (prompt-choice :runner "Server 1")
-      (run-empty-server state "Archives")
-      (is (= 5 (count (:hand (get-runner)))) "Did not draw cards when running other server"))))
-
-(deftest patron-manual
-  ;; Patron - Manually selecting during Step 1.2 does not show a second prompt at start of turn. Issue #1744.
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Patron" 3) (qty "Jak Sinclair" 3)]))
-    (take-credits state :corp)
-    (core/gain state :runner :credit 10)
-    (starting-hand state :runner ["Patron" "Jak Sinclair"])
-    (play-from-hand state :runner "Patron")
-    (play-from-hand state :runner "Jak Sinclair")
-    (take-credits state :runner)
-    (let [p (get-resource state 0)
-          j (get-resource state 1)]
-      (take-credits state :corp)
-      (is (:runner-phase-12 @state) "Runner in Step 1.2")
-      (card-ability state :runner p 0)
-      (prompt-choice :runner "Archives")
-      (card-ability state :runner j 0)
-      (prompt-choice :runner "Archives")
-      (run-successful state)
-      (core/end-phase-12 state :runner nil)
-      (is (empty? (:prompt (get-runner))) "No second prompt for Patron - used already"))))
+      (let [p (get-resource state 0)
+            j (get-resource state 1)]
+        (take-credits state :corp)
+        (is (:runner-phase-12 @state) "Runner in Step 1.2")
+        (card-ability state :runner p 0)
+        (prompt-choice :runner "Archives")
+        (card-ability state :runner j 0)
+        (prompt-choice :runner "Archives")
+        (run-successful state)
+        (core/end-phase-12 state :runner nil)
+        (is (empty? (:prompt (get-runner))) "No second prompt for Patron - used already")))))
 
 (deftest professional-contacts
   ;; Professional Contacts - Click to gain 1 credit and draw 1 card
@@ -1772,44 +1741,43 @@
       (is (not (= (:cid hostile2) (:cid (last (:rfg (get-corp)))))) "Did not remove card from game"))))
 
 (deftest security-testing
-  ;; Security Testing - Ability
-  (do-game
-    (new-game (default-corp ["Jackson Howard"])
-              (default-runner ["Security Testing"]))
-    (play-from-hand state :corp "Jackson Howard" "New remote")
-    (take-credits state :corp 2)
-    (play-from-hand state :runner "Security Testing")
-    (let [st (get-in @state [:runner :rig :resource 0])]
-      (take-credits state :runner 3)
+  ;; Security Testing
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Jackson Howard"])
+                (default-runner ["Security Testing"]))
+      (play-from-hand state :corp "Jackson Howard" "New remote")
+      (take-credits state :corp 2)
+      (play-from-hand state :runner "Security Testing")
+      (let [st (get-in @state [:runner :rig :resource 0])]
+        (take-credits state :runner 3)
+        (take-credits state :corp)
+        (prompt-choice :runner "Server 1")
+        (run-empty-server state "Server 1")
+        (is (= 10 (:credit (get-runner))) "Gained 2 credits from Security Testing")
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "No")
+        (is (= 10 (:credit (get-runner))) "Did not gain credits on second run")
+        (take-credits state :runner 2)
+        (take-credits state :corp)
+        (prompt-choice :runner "Server 1")
+        (run-empty-server state "Archives")
+        (is (= 12 (:credit (get-runner))) "Did not gain credits when running other server"))))
+  (testing "with multiple copies"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Security Testing" 2)]))
       (take-credits state :corp)
-      (prompt-choice :runner "Server 1")
-      (run-empty-server state "Server 1")
-      (is (= 10 (:credit (get-runner))) "Gained 2 credits from Security Testing")
-      (run-empty-server state "Server 1")
-      (prompt-choice :runner "No")
-      (is (= 10 (:credit (get-runner))) "Did not gain credits on second run")
-      (take-credits state :runner 2)
+      (play-from-hand state :runner "Security Testing")
+      (play-from-hand state :runner "Security Testing")
+      (take-credits state :runner)
       (take-credits state :corp)
-      (prompt-choice :runner "Server 1")
+      (prompt-choice :runner "Archives")
+      (prompt-choice :runner "R&D")
       (run-empty-server state "Archives")
-      (is (= 12 (:credit (get-runner))) "Did not gain credits when running other server"))))
-
-(deftest security-testing-multiple
-  ;; Security Testing - multiple copies
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Security Testing" 2)]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Security Testing")
-    (play-from-hand state :runner "Security Testing")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (prompt-choice :runner "Archives")
-    (prompt-choice :runner "R&D")
-    (run-empty-server state "Archives")
-    (is (= 9 (:credit (get-runner))) "Gained 2 credits")
-    (run-empty-server state "R&D")
-    (is (= 11 (:credit (get-runner))))))
+      (is (= 9 (:credit (get-runner))) "Gained 2 credits")
+      (run-empty-server state "R&D")
+      (is (= 11 (:credit (get-runner)))))))
 
 (deftest spoilers
   ;; Spoilers - Mill the Corp when it scores an agenda
@@ -1852,154 +1820,139 @@
       (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")
       (is (= 4 (:click (get-runner))) "Didn't gain extra click"))))
 
-(deftest street-peddler-ability
-  ;; Street Peddler - Ability
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Street Peddler"
-                               "Gordian Blade"
-                               "Torch"
-                               (qty "Sure Gamble" 2)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler" "Sure Gamble"])
-    (play-from-hand state :runner "Street Peddler")
-    (let [sp (get-in @state [:runner :rig :resource 0])]
-      (is (= 3 (count (:hosted sp))) "Street Peddler is hosting 3 cards")
-      (card-ability state :runner sp 0)
-      (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
-      (is (= "Gordian Blade" (:title (get-in @state [:runner :rig :program 0])))
-          "Gordian Blade was installed")
-      (is (= 3 (core/available-mu state)) "Gordian cost 1 mu"))))
-
-(deftest street-peddler-cant-afford
-  ;; Street Peddler - Can't afford install
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Street Peddler" (qty "Gordian Blade" 3)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler"])
-    (play-from-hand state :runner "Street Peddler")
-    (let [sp (get-in @state [:runner :rig :resource 0])]
-      (card-ability state :runner sp 0)
-      (core/lose state :runner :credit 3)
-      (is (= 2 (count (:choices (first (:prompt (get-runner))))))
-          "1 card and 1 cancel option on Street Peddler")
-      (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
-      (is (zero? (count (get-in @state [:runner :rig :program])))
-          "Gordian Blade was not installed")
-      (is (and (:installed (refresh sp)) (= 3 (count (:hosted (refresh sp))))
-               "Street Peddler still installed with 3 hosted cards")))))
-
-(deftest street-peddler-kate-discount
-  ;; Street Peddler - Interaction with Kate discount
-  (do-game
-    (new-game (default-corp)
-              (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" ["Street Peddler"
-                                                                   "Gordian Blade"
-                                                                   (qty "Sure Gamble" 2)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler"])
-    (play-from-hand state :runner "Street Peddler")
-    (let [sp (get-in @state [:runner :rig :resource 0])]
-      ;; should still be able to afford Gordian w/ Kate discount
-      (core/lose state :runner :credit 3)
-      (card-ability state :runner sp 0)
-      (is (= 2 (count (:choices (first (:prompt (get-runner))))))
-          "Only 1 choice (plus Cancel) to install off Peddler")
-      (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
-      (is (= "Gordian Blade" (:title (get-in @state [:runner :rig :program 0])))
-          "Gordian Blade was installed")
-      (is (= 3 (core/available-mu state)) "Gordian cost 1 mu"))))
-
-(deftest street-peddler-memory-units
-  ;; Street Peddler - Programs Should Cost Memory. Issue #708
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Street Peddler" (qty "Corroder" 3)]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler"])
-    (play-from-hand state :runner "Street Peddler")
-    (is (= 4 (core/available-mu state)) "No memory cost for hosting on Street Peddler")
-    (let [sp (get-in @state [:runner :rig :resource 0])]
-      (is (= "Corroder" (:title (first (:hosted sp)))) "Street Peddler is hosting Corroder")
-      (card-ability state :runner sp 0)
-      (prompt-card :runner (first (:hosted sp))) ; choose to install Gordian
-      (is (= "Corroder" (:title (get-in @state [:runner :rig :program 0])))
-          "Corroder was installed")
-      (is (= 3 (core/available-mu state)) "Corroder cost 1 mu"))))
-
-(deftest street-peddler-muertos-brain-chip
-  ;; Muertos/Brain Chip uninstall effect not fired when removed off peddler/hosting Issue #2294+#2358
-  (do-game
-    (new-game (default-corp ["Jackson Howard"])
-              (default-runner [(qty "Street Peddler" 2) "Muertos Gang Member" "Brain Chip"]))
-    (core/move state :runner (find-card "Muertos Gang Member" (:hand (get-runner))) :deck {:front true})
-    (core/move state :runner (find-card "Brain Chip" (:hand (get-runner))) :deck {:front true})
-    (core/move state :runner (find-card "Street Peddler" (:hand (get-runner))) :deck {:front true})
-    (play-from-hand state :corp "Jackson Howard" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Street Peddler")
-    (core/gain state :runner :agenda-point 1)
-    (let [jh (get-content state :remote1 0)
-          sp (get-in @state [:runner :rig :resource 0])]
-      (core/rez state :corp jh)
-      (card-ability state :runner sp 0)
-      (prompt-card :runner (find-card "Street Peddler" (:hosted sp))) ; choose to another Peddler
-      (is (empty? (:prompt (get-corp))) "Corp not prompted to rez Jackson")
-      (is (= 4 (core/available-mu state)) "Runner has 4 MU"))))
-
-(deftest street-peddler-in-play-effects
-  ;; Street Peddler - Trashing hardware should not reduce :in-play values
-  (do-game
-   (new-game (default-corp)
-             (default-runner ["Street Peddler" (qty "HQ Interface" 3)]))
-   (take-credits state :corp)
-   (starting-hand state :runner ["Street Peddler"])
-   (play-from-hand state :runner "Street Peddler")
-   (let [sp (get-in @state [:runner :rig :resource 0])]
-     (card-ability state :runner sp 0)
-     (prompt-card :runner (first (:hosted sp))) ; choose to install HQ Interface
-     (is (= 2 (:hq-access (get-runner)))
-         "HQ Access increased by 1 from installed HQI and not reduced by the 2 trashed ones"))))
-
-(deftest street-peddler-parasite-1cr
-  ;; Street Peddler - Installing Parasite with only 1cr. Issue #491.
-  (do-game
-    (new-game (default-corp [(qty "Pop-up Window" 3)])
-              (default-runner ["Street Peddler" (qty "Parasite" 3)]))
-    (play-from-hand state :corp "Pop-up Window" "HQ")
-    (take-credits state :corp 2)
-    (starting-hand state :runner ["Street Peddler"])
-    (core/lose state :runner :credit 4) ; go down to 1 credit
-    (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
-    (play-from-hand state :runner "Street Peddler")
-    (let [sp (get-in @state [:runner :rig :resource 0])
-          pu (get-ice state :hq 0)]
-      (core/rez state :corp pu)
-      (card-ability state :runner sp 0)
-      (prompt-card :runner (first (:hosted sp))) ; choose to install Parasite
-      (is (= "Parasite" (:title (:card (first (get-in @state [:runner :prompt])))))
-          "Parasite target prompt")
-      (prompt-select :runner pu)
-      (is (= 4 (count (:discard (get-runner)))) "3 Parasite, 1 Street Peddler in heap")
-      (is (= 1 (count (:discard (get-corp)))) "Pop-up Window in archives"))))
-
-(deftest street-peddler-tech-trader
-  ;; Street Peddler - Tech Trader install
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Street Peddler"
-                               "Tech Trader"]))
-    (take-credits state :corp)
-    (starting-hand state :runner ["Street Peddler"])
-    (play-from-hand state :runner "Street Peddler")
-    (let [sp (get-in @state [:runner :rig :resource 0])]
-      (is (= 1 (count (:hosted sp))) "Street Peddler is hosting 1 card")
-      (card-ability state :runner sp 0)
-      (prompt-card :runner (find-card "Tech Trader" (:hosted sp))) ; choose to install Tech Trader
-      (is (= "Tech Trader" (:title (get-in @state [:runner :rig :resource 0])))
-          "Tech Trader was installed")
-      (is (= 5 (:credit (get-runner))) "Did not gain 1cr from Tech Trader ability"))))
+(deftest street-peddler
+  ;; Street Peddler
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Street Peddler" "Gordian Blade"
+                                 "Torch" (qty "Sure Gamble" 2)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler" "Sure Gamble"])
+      (play-from-hand state :runner "Street Peddler")
+      (let [sp (get-in @state [:runner :rig :resource 0])]
+        (is (= 3 (count (:hosted sp))) "Street Peddler is hosting 3 cards")
+        (card-ability state :runner sp 0)
+        (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
+        (is (= "Gordian Blade" (:title (get-in @state [:runner :rig :program 0])))
+            "Gordian Blade was installed")
+        (is (= 3 (core/available-mu state)) "Gordian cost 1 mu"))))
+  (testing "Can't afford install"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Street Peddler" (qty "Gordian Blade" 3)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler"])
+      (play-from-hand state :runner "Street Peddler")
+      (let [sp (get-in @state [:runner :rig :resource 0])]
+        (card-ability state :runner sp 0)
+        (core/lose state :runner :credit 3)
+        (is (= 2 (count (:choices (first (:prompt (get-runner))))))
+            "1 card and 1 cancel option on Street Peddler")
+        (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
+        (is (zero? (count (get-in @state [:runner :rig :program])))
+            "Gordian Blade was not installed")
+        (is (and (:installed (refresh sp)) (= 3 (count (:hosted (refresh sp))))
+                 "Street Peddler still installed with 3 hosted cards")))))
+  (testing "Interaction with Kate discount"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker" ["Street Peddler"
+                                                                     "Gordian Blade"
+                                                                     (qty "Sure Gamble" 2)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler"])
+      (play-from-hand state :runner "Street Peddler")
+      (let [sp (get-in @state [:runner :rig :resource 0])]
+        ;; should still be able to afford Gordian w/ Kate discount
+        (core/lose state :runner :credit 3)
+        (card-ability state :runner sp 0)
+        (is (= 2 (count (:choices (first (:prompt (get-runner))))))
+            "Only 1 choice (plus Cancel) to install off Peddler")
+        (prompt-card :runner (find-card "Gordian Blade" (:hosted sp))) ; choose to install Gordian
+        (is (= "Gordian Blade" (:title (get-in @state [:runner :rig :program 0])))
+            "Gordian Blade was installed")
+        (is (= 3 (core/available-mu state)) "Gordian cost 1 mu"))))
+  (testing "Programs should cost memory. Issue #708"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Street Peddler" (qty "Corroder" 3)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler"])
+      (play-from-hand state :runner "Street Peddler")
+      (is (= 4 (core/available-mu state)) "No memory cost for hosting on Street Peddler")
+      (let [sp (get-in @state [:runner :rig :resource 0])]
+        (is (= "Corroder" (:title (first (:hosted sp)))) "Street Peddler is hosting Corroder")
+        (card-ability state :runner sp 0)
+        (prompt-card :runner (first (:hosted sp))) ; choose to install Gordian
+        (is (= "Corroder" (:title (get-in @state [:runner :rig :program 0])))
+            "Corroder was installed")
+        (is (= 3 (core/available-mu state)) "Corroder cost 1 mu"))))
+  (testing "Muertos/Brain Chip uninstall effect not fired when removed off peddler/hosting Issue #2294, #2358"
+    (do-game
+      (new-game (default-corp ["Jackson Howard"])
+                (default-runner [(qty "Street Peddler" 2) "Muertos Gang Member" "Brain Chip"]))
+      (core/move state :runner (find-card "Muertos Gang Member" (:hand (get-runner))) :deck {:front true})
+      (core/move state :runner (find-card "Brain Chip" (:hand (get-runner))) :deck {:front true})
+      (core/move state :runner (find-card "Street Peddler" (:hand (get-runner))) :deck {:front true})
+      (play-from-hand state :corp "Jackson Howard" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Street Peddler")
+      (core/gain state :runner :agenda-point 1)
+      (let [jh (get-content state :remote1 0)
+            sp (get-in @state [:runner :rig :resource 0])]
+        (core/rez state :corp jh)
+        (card-ability state :runner sp 0)
+        (prompt-card :runner (find-card "Street Peddler" (:hosted sp))) ; choose to another Peddler
+        (is (empty? (:prompt (get-corp))) "Corp not prompted to rez Jackson")
+        (is (= 4 (core/available-mu state)) "Runner has 4 MU"))))
+  (testing "Trashing hardware should not reduce :in-play values"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Street Peddler" (qty "HQ Interface" 3)]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler"])
+      (play-from-hand state :runner "Street Peddler")
+      (let [sp (get-in @state [:runner :rig :resource 0])]
+        (card-ability state :runner sp 0)
+        (prompt-card :runner (first (:hosted sp))) ; choose to install HQ Interface
+        (is (= 2 (:hq-access (get-runner)))
+            "HQ Access increased by 1 from installed HQI and not reduced by the 2 trashed ones"))))
+  (testing "Installing Parasite with only 1cr. Issue #491."
+    (do-game
+      (new-game (default-corp [(qty "Pop-up Window" 3)])
+                (default-runner ["Street Peddler" (qty "Parasite" 3)]))
+      (play-from-hand state :corp "Pop-up Window" "HQ")
+      (take-credits state :corp 2)
+      (starting-hand state :runner ["Street Peddler"])
+      (core/lose state :runner :credit 4) ; go down to 1 credit
+      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
+      (play-from-hand state :runner "Street Peddler")
+      (let [sp (get-in @state [:runner :rig :resource 0])
+            pu (get-ice state :hq 0)]
+        (core/rez state :corp pu)
+        (card-ability state :runner sp 0)
+        (prompt-card :runner (first (:hosted sp))) ; choose to install Parasite
+        (is (= "Parasite" (:title (:card (first (get-in @state [:runner :prompt])))))
+            "Parasite target prompt")
+        (prompt-select :runner pu)
+        (is (= 4 (count (:discard (get-runner)))) "3 Parasite, 1 Street Peddler in heap")
+        (is (= 1 (count (:discard (get-corp)))) "Pop-up Window in archives"))))
+  (testing "Tech Trader install"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Street Peddler"
+                                 "Tech Trader"]))
+      (take-credits state :corp)
+      (starting-hand state :runner ["Street Peddler"])
+      (play-from-hand state :runner "Street Peddler")
+      (let [sp (get-in @state [:runner :rig :resource 0])]
+        (is (= 1 (count (:hosted sp))) "Street Peddler is hosting 1 card")
+        (card-ability state :runner sp 0)
+        (prompt-card :runner (find-card "Tech Trader" (:hosted sp))) ; choose to install Tech Trader
+        (is (= "Tech Trader" (:title (get-in @state [:runner :rig :resource 0])))
+            "Tech Trader was installed")
+        (is (= 5 (:credit (get-runner))) "Did not gain 1cr from Tech Trader ability")))))
 
 (deftest-pending street-peddler-trash-while-choosing-card
   ;; Street Peddler - trashing Street Peddler while choosing which card to
@@ -2021,87 +1974,85 @@
 
 (deftest symmetrical-visage
   ;; Symmetrical Visage - Gain 1 credit the first time you click to draw each turn
-  (do-game
-    (new-game (default-corp)
-              (default-runner [(qty "Symmetrical Visage" 3)
-                               (qty "Sure Gamble" 3)
-                               "Fall Guy"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Symmetrical Visage")
-    (is (= 3 (:credit (get-runner))))
-    (core/click-draw state :runner nil)
-    (is (= 4 (:credit (get-runner))) "Gained 1 credit from first click spent to draw")
-    (core/click-draw state :runner nil)
-    (is (= 4 (:credit (get-runner))) "No credit gained from second click spent to draw")))
-
-(deftest symmetrical-visage-gcs
-  ;; Symmetrical Visage - Gain 1 credit the first and second time you click to draw each turn when GCS is installed
-  (do-game
-   (new-game (default-corp)
-             (default-runner [(qty "Symmetrical Visage" 3)
-                              (qty "Gene Conditioning Shoppe" 3)
-                              "Fall Guy"]))
-   (take-credits state :corp)
-   (core/gain state :runner :click 1)
-   (play-from-hand state :runner "Symmetrical Visage")
-   (is (= 3 (:credit (get-runner))))
-   (play-from-hand state :runner "Gene Conditioning Shoppe")
-   (is (= 1 (:credit (get-runner))))
-   (core/click-draw state :runner nil)
-   (is (= 2 (:credit (get-runner))) "Gained 1 credit from first click spent to draw")
-   (core/click-draw state :runner nil)
-   (is (= 3 (:credit (get-runner)))
-       "Gained 1 credit from second click spent to draw with Gene Conditioning Shoppe")
-   ;; Move Fall Guy back to deck
-   (core/move state :runner (find-card "Fall Guy" (:hand (get-runner))) :deck)
-   (core/click-draw state :runner nil)
-   (is (= 3 (:credit (get-runner)))
-       "No credit gained from third click spent to draw with Gene Conditioning Shoppe")))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Symmetrical Visage" 3)
+                                 (qty "Sure Gamble" 3)
+                                 "Fall Guy"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Symmetrical Visage")
+      (is (= 3 (:credit (get-runner))))
+      (core/click-draw state :runner nil)
+      (is (= 4 (:credit (get-runner))) "Gained 1 credit from first click spent to draw")
+      (core/click-draw state :runner nil)
+      (is (= 4 (:credit (get-runner))) "No credit gained from second click spent to draw")))
+  (testing "Gain 1 credit the first and second time you click to draw each turn when GCS is installed"
+    (do-game
+      (new-game (default-corp)
+                (default-runner [(qty "Symmetrical Visage" 3)
+                                 (qty "Gene Conditioning Shoppe" 3)
+                                 "Fall Guy"]))
+      (take-credits state :corp)
+      (core/gain state :runner :click 1)
+      (play-from-hand state :runner "Symmetrical Visage")
+      (is (= 3 (:credit (get-runner))))
+      (play-from-hand state :runner "Gene Conditioning Shoppe")
+      (is (= 1 (:credit (get-runner))))
+      (core/click-draw state :runner nil)
+      (is (= 2 (:credit (get-runner))) "Gained 1 credit from first click spent to draw")
+      (core/click-draw state :runner nil)
+      (is (= 3 (:credit (get-runner)))
+          "Gained 1 credit from second click spent to draw with Gene Conditioning Shoppe")
+      ;; Move Fall Guy back to deck
+      (core/move state :runner (find-card "Fall Guy" (:hand (get-runner))) :deck)
+      (core/click-draw state :runner nil)
+      (is (= 3 (:credit (get-runner)))
+          "No credit gained from third click spent to draw with Gene Conditioning Shoppe"))))
 
 (deftest synthetic-blood
   ;; Synthetic Blood - The first time you take damage each turn, draw one card
-  (do-game
-   (new-game (default-corp [(qty "Data Mine" 3) (qty "Hedge Fund" 3)])
-             (default-runner [(qty "Synthetic Blood" 3)
-                              (qty "Sure Gamble" 3)
-                              "Fall Guy"]))
-   (play-from-hand state :corp "Data Mine" "HQ")
-   (play-from-hand state :corp "Data Mine" "HQ")
-   (take-credits state :corp)
-   (let [first-dm (get-ice state :hq 1)
-         second-dm (get-ice state :hq 0)]
-     (play-from-hand state :runner "Synthetic Blood")
-     (run-on state "HQ")
-     (core/rez state :corp first-dm)
-     (card-subroutine state :corp first-dm 0)
-     (is (= 4 (count (:hand (get-runner)))) "1 card drawn when receiving damage (1st time)")
-     (run-continue state)
-     (core/rez state :corp second-dm)
-     (card-subroutine state :corp second-dm 0)
-     (is (= 3 (count (:hand (get-runner)))) "no card drawn when receiving damage (2nd time)"))))
-
-(deftest synthetic-blood-gcs
-  ;; Synthetic Blood - The first and second time you take damage each turn (with GCS installed), draw one card
-  (do-game
-   (new-game (default-corp [(qty "Data Mine" 3) (qty "Hedge Fund" 3)])
-             (default-runner [(qty "Synthetic Blood" 3)
-                              "Sure Gamble"
-                              (qty "Gene Conditioning Shoppe" 3)]))
-   (play-from-hand state :corp "Data Mine" "HQ")
-   (play-from-hand state :corp "Data Mine" "HQ")
-   (take-credits state :corp)
-   (let [first-dm (get-ice state :hq 1)
-         second-dm (get-ice state :hq 0)]
-     (play-from-hand state :runner "Synthetic Blood")
-     (play-from-hand state :runner "Gene Conditioning Shoppe")
-     (run-on state "HQ")
-     (core/rez state :corp first-dm)
-     (card-subroutine state :corp first-dm 0)
-     (is (= 3 (count (:hand (get-runner)))) "1 card drawn when receiving damage (1st time)")
-     (run-continue state)
-     (core/rez state :corp second-dm)
-     (card-subroutine state :corp second-dm 0)
-     (is (= 3 (count (:hand (get-runner)))) "1 card drawn when receiving damage (2nd time)"))))
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Data Mine" 3) (qty "Hedge Fund" 3)])
+                (default-runner [(qty "Synthetic Blood" 3)
+                                 (qty "Sure Gamble" 3)
+                                 "Fall Guy"]))
+      (play-from-hand state :corp "Data Mine" "HQ")
+      (play-from-hand state :corp "Data Mine" "HQ")
+      (take-credits state :corp)
+      (let [first-dm (get-ice state :hq 1)
+            second-dm (get-ice state :hq 0)]
+        (play-from-hand state :runner "Synthetic Blood")
+        (run-on state "HQ")
+        (core/rez state :corp first-dm)
+        (card-subroutine state :corp first-dm 0)
+        (is (= 4 (count (:hand (get-runner)))) "1 card drawn when receiving damage (1st time)")
+        (run-continue state)
+        (core/rez state :corp second-dm)
+        (card-subroutine state :corp second-dm 0)
+        (is (= 3 (count (:hand (get-runner)))) "no card drawn when receiving damage (2nd time)"))))
+  (testing "The first and second time you take damage each turn (with GCS installed), draw one card"
+    (do-game
+      (new-game (default-corp [(qty "Data Mine" 3) (qty "Hedge Fund" 3)])
+                (default-runner [(qty "Synthetic Blood" 3)
+                                 "Sure Gamble"
+                                 (qty "Gene Conditioning Shoppe" 3)]))
+      (play-from-hand state :corp "Data Mine" "HQ")
+      (play-from-hand state :corp "Data Mine" "HQ")
+      (take-credits state :corp)
+      (let [first-dm (get-ice state :hq 1)
+            second-dm (get-ice state :hq 0)]
+        (play-from-hand state :runner "Synthetic Blood")
+        (play-from-hand state :runner "Gene Conditioning Shoppe")
+        (run-on state "HQ")
+        (core/rez state :corp first-dm)
+        (card-subroutine state :corp first-dm 0)
+        (is (= 3 (count (:hand (get-runner)))) "1 card drawn when receiving damage (1st time)")
+        (run-continue state)
+        (core/rez state :corp second-dm)
+        (card-subroutine state :corp second-dm 0)
+        (is (= 3 (count (:hand (get-runner)))) "1 card drawn when receiving damage (2nd time)")))))
 
 (deftest technical-writer
   ;; Technical Writer - Gain 1c per program/hardware install; click/trash to take all credits
@@ -2171,152 +2122,147 @@
       (is (= 1 (:agenda-point (get-corp))) "Hostile Takeover scored with 3 adv")
       (is (= 3 (count (:discard (get-runner)))) "The Source is trashed"))))
 
-(deftest the-supplier-ability
-  ;; The Supplier - Ability
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["The Supplier"
-                               "Plascrete Carapace"
-                               "Utopia Shard"
-                               "Hedge Fund"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "The Supplier")
-    (let [ts (get-in @state [:runner :rig :resource 0])]
-      (card-ability state :runner ts 0)
-      (prompt-select :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
-      (card-ability state :runner ts 0)
-      (is (= 1 (count (-> @state :runner :prompt first :choices))))
-      (prompt-select :runner (find-card "Utopia Shard" (:hand (get-runner))))
-      (is (= 2 (count (:hosted (refresh ts)))) "The Supplier is hosting 2 cards")
-      (take-credits state :runner)
+(deftest the-supplier
+  ;; The Supplier
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["The Supplier"
+                                 "Plascrete Carapace"
+                                 "Utopia Shard"
+                                 "Hedge Fund"]))
       (take-credits state :corp)
-      ;; Utopia Shard cannot be afforded and should not be in the prompt
-      (prompt-select :runner (find-card "Plascrete Carapace" (:hosted (refresh ts))))
-      (is (= 2 (:credit (get-runner)))
-          "Runner charged 1 credit to install Plascrete off The Supplier")
-      (take-credits state :runner)
-      (is (= 6 (:credit (get-runner))) "Runner ends turn with 5 credits")
-      (is (= 1 (count (:hosted (refresh ts)))) "One card still on The Supplier"))))
-
-(deftest the-supplier-kate-discount
-  ;; The Supplier - Interaction with Kate discount. Issue #578.
-  (do-game
-    (new-game (default-corp)
-              (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker"
-                         ["The Supplier"
-                          "Plascrete Carapace"
-                          "Kati Jones"
-                          "Hedge Fund"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "The Supplier")
-    (let [ts (get-in @state [:runner :rig :resource 0])]
-      (card-ability state :runner ts 0)
-      (prompt-select :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
-      (core/lose state :runner :credit (:credit (get-runner)))
-      (core/end-turn state :runner nil)
+      (play-from-hand state :runner "The Supplier")
+      (let [ts (get-in @state [:runner :rig :resource 0])]
+        (card-ability state :runner ts 0)
+        (prompt-select :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
+        (card-ability state :runner ts 0)
+        (is (= 1 (count (-> @state :runner :prompt first :choices))))
+        (prompt-select :runner (find-card "Utopia Shard" (:hand (get-runner))))
+        (is (= 2 (count (:hosted (refresh ts)))) "The Supplier is hosting 2 cards")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        ;; Utopia Shard cannot be afforded and should not be in the prompt
+        (prompt-select :runner (find-card "Plascrete Carapace" (:hosted (refresh ts))))
+        (is (= 2 (:credit (get-runner)))
+            "Runner charged 1 credit to install Plascrete off The Supplier")
+        (take-credits state :runner)
+        (is (= 6 (:credit (get-runner))) "Runner ends turn with 5 credits")
+        (is (= 1 (count (:hosted (refresh ts)))) "One card still on The Supplier"))))
+  (testing "Interaction with Kate discount. Issue #578."
+    (do-game
+      (new-game (default-corp)
+                (make-deck "Kate \"Mac\" McCaffrey: Digital Tinker"
+                           ["The Supplier"
+                            "Plascrete Carapace"
+                            "Kati Jones"
+                            "Hedge Fund"]))
       (take-credits state :corp)
-      (prompt-select :runner (find-card "Plascrete Carapace" (:hosted (refresh ts))))
-      (is (= 0 (:credit (get-runner))) "Kate discount applied")
-      (is (= 1 (count (get-in @state [:runner :rig :resource]))) "Plascrete installed"))))
-
-(deftest the-supplier-trashed
-  ;; Issue #2358 Brain chip mem is deducted when it is hosted and Supplier is trashed
-  (do-game
-    (new-game (default-corp [(qty "Hostile Takeover" 2)])
-              (default-runner ["The Supplier"
-                               "Brain Chip"]))
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (take-credits state :corp)
-    (is (= 4 (core/available-mu state)) "Runner has 4 MU")
-    (play-from-hand state :runner "The Supplier")
-    (let [ts (get-resource state 0)]
-      (card-ability state :runner ts 0)
-      (prompt-select :runner (find-card "Brain Chip" (:hand (get-runner))))
+      (play-from-hand state :runner "The Supplier")
+      (let [ts (get-in @state [:runner :rig :resource 0])]
+        (card-ability state :runner ts 0)
+        (prompt-select :runner (find-card "Plascrete Carapace" (:hand (get-runner))))
+        (core/lose state :runner :credit (:credit (get-runner)))
+        (core/end-turn state :runner nil)
+        (take-credits state :corp)
+        (prompt-select :runner (find-card "Plascrete Carapace" (:hosted (refresh ts))))
+        (is (= 0 (:credit (get-runner))) "Kate discount applied")
+        (is (= 1 (count (get-in @state [:runner :rig :resource]))) "Plascrete installed"))))
+  (testing "Brain chip mem is deducted when it is hosted and Supplier is trashed. Issue #2358"
+    (do-game
+      (new-game (default-corp [(qty "Hostile Takeover" 2)])
+                (default-runner ["The Supplier"
+                                 "Brain Chip"]))
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (take-credits state :corp)
       (is (= 4 (core/available-mu state)) "Runner has 4 MU")
-      (run-empty-server state "Server 1")
-      (prompt-choice :runner "Steal")
-      (take-credits state :runner)
-      (core/gain state :runner :tag 1)
-      (core/trash-resource state :corp nil)
-      (prompt-select :corp (get-resource state 0))
-      (is (= 2 (count (:discard (get-runner)))))
-      (is (= 4 (core/available-mu state)) "Runner has 4 MU"))))
+      (play-from-hand state :runner "The Supplier")
+      (let [ts (get-resource state 0)]
+        (card-ability state :runner ts 0)
+        (prompt-select :runner (find-card "Brain Chip" (:hand (get-runner))))
+        (is (= 4 (core/available-mu state)) "Runner has 4 MU")
+        (run-empty-server state "Server 1")
+        (prompt-choice :runner "Steal")
+        (take-credits state :runner)
+        (core/gain state :runner :tag 1)
+        (core/trash-resource state :corp nil)
+        (prompt-select :corp (get-resource state 0))
+        (is (= 2 (count (:discard (get-runner)))))
+        (is (= 4 (core/available-mu state)) "Runner has 4 MU")))))
 
 (deftest tech-trader
   ;; Basic test
   (do-game
     (new-game (default-corp)
               (default-runner ["Tech Trader" "Fall Guy"]))
-
     (take-credits state :corp)
     (play-from-hand state :runner "Tech Trader")
     (play-from-hand state :runner "Fall Guy")
     (is (= 4 (:credit (get-runner))))
-
     (let [fall (get-in @state [:runner :rig :resource 1])]
       (card-ability state :runner fall 1)
       (is (= 7 (:credit (get-runner)))))))
 
 (deftest the-black-file
   ;; The Black File - Prevent Corp from winning by agenda points
-  (do-game
-    (new-game (default-corp [(qty "Vanity Project" 3) (qty "Sure Gamble" 3)])
-              (default-runner ["The Black File"]))
-    (starting-hand state :corp ["Vanity Project"])
-    (core/gain state :corp :agenda-point 3)
-    (take-credits state :corp)
-    (play-from-hand state :runner "The Black File")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Vanity Project" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (is (= 7 (:agenda-point (get-corp))))
-    (is (not (:winner @state)) "No registered Corp win")
-    (take-credits state :corp)
-    (let [bf (get-resource state 0)]
-      (is (= 1 (get-in (refresh bf) [:counter :power])) "1 power counter on The Black File")
-      (take-credits state :runner)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Vanity Project" 3) (qty "Sure Gamble" 3)])
+                (default-runner ["The Black File"]))
+      (starting-hand state :corp ["Vanity Project"])
+      (core/gain state :corp :agenda-point 3)
       (take-credits state :corp)
-      (is (= 2 (get-in (refresh bf) [:counter :power])) "2 power counters on The Black File")
+      (play-from-hand state :runner "The Black File")
       (take-credits state :runner)
+      (play-from-hand state :corp "Vanity Project" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      (is (= 7 (:agenda-point (get-corp))))
+      (is (not (:winner @state)) "No registered Corp win")
       (take-credits state :corp)
-      (is (= 1 (count (:rfg (get-runner)))) "The Black File removed from the game")
+      (let [bf (get-resource state 0)]
+        (is (= 1 (get-in (refresh bf) [:counter :power])) "1 power counter on The Black File")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 2 (get-in (refresh bf) [:counter :power])) "2 power counters on The Black File")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 1 (count (:rfg (get-runner)))) "The Black File removed from the game")
+        (is (= :corp (:winner @state)) "Corp wins")
+        (is (= "Agenda" (:reason @state)) "Win condition reports agendas"))))
+  (testing "Corp can still win by flatlining Runner"
+    (do-game
+      (new-game (default-corp [(qty "Vanity Project" 3) (qty "Scorched Earth" 3)])
+                (default-runner ["The Black File"]))
+      (starting-hand state :corp ["Vanity Project" "Scorched Earth"])
+      (core/gain state :corp :agenda-point 3)
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Black File")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Vanity Project" "New remote")
+      (score-agenda state :corp (get-content state :remote1 0))
+      (is (= 7 (:agenda-point (get-corp))))
+      (is (not (:winner @state)) "No registered Corp win")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (core/gain state :runner :tag 1)
+      (play-from-hand state :corp "Scorched Earth")
       (is (= :corp (:winner @state)) "Corp wins")
-      (is (= "Agenda" (:reason @state)) "Win condition reports agendas"))))
-
-(deftest the-black-file-flatline
-  ;; The Black File - Corp can still win by flatlining Runner
-  (do-game
-    (new-game (default-corp [(qty "Vanity Project" 3) (qty "Scorched Earth" 3)])
-              (default-runner ["The Black File"]))
-    (starting-hand state :corp ["Vanity Project" "Scorched Earth"])
-    (core/gain state :corp :agenda-point 3)
-    (take-credits state :corp)
-    (play-from-hand state :runner "The Black File")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Vanity Project" "New remote")
-    (score-agenda state :corp (get-content state :remote1 0))
-    (is (= 7 (:agenda-point (get-corp))))
-    (is (not (:winner @state)) "No registered Corp win")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (core/gain state :runner :tag 1)
-    (play-from-hand state :corp "Scorched Earth")
-    (is (= :corp (:winner @state)) "Corp wins")
-    (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
+      (is (= "Flatline" (:reason @state)) "Win condition reports flatline"))))
 
 (deftest temujin-contract
-  ;; Temüjin Contract - Multiple times in one turn. Issue #1952.
-  (do-game
-    (new-game (default-corp)
-              (make-deck "Silhouette: Stealth Operative" ["Temüjin Contract"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Temüjin Contract")
-    (prompt-choice :runner "Archives")
-    (run-empty-server state "Archives")
-    (is (= 5 (:credit (get-runner))) "Gained 4cr")
-    (run-empty-server state "Archives")
-    (is (= 9 (:credit (get-runner))) "Gained 4cr")
-    (is (= 12 (get-counters (get-resource state 0) :credit)) "Temjin has 12 credits remaining")))
+  ;; Temüjin Contract
+  (testing "Multiple times in one turn. Issue #1952"
+    (do-game
+      (new-game (default-corp)
+                (make-deck "Silhouette: Stealth Operative" ["Temüjin Contract"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Temüjin Contract")
+      (prompt-choice :runner "Archives")
+      (run-empty-server state "Archives")
+      (is (= 5 (:credit (get-runner))) "Gained 4cr")
+      (run-empty-server state "Archives")
+      (is (= 9 (:credit (get-runner))) "Gained 4cr")
+      (is (= 12 (get-counters (get-resource state 0) :credit)) "Temjin has 12 credits remaining"))))
 
 (deftest tri-maf-contact
   ;; Tri-maf Contact - Click for 2c once per turn; take 3 meat dmg when trashed
@@ -2340,91 +2286,85 @@
       (prompt-select :corp (get-resource state 0))
       (is (= 4 (count (:discard (get-runner)))) "Took 3 meat damage"))))
 
-(deftest virus-breeding-ground-gain
+(deftest virus-breeding-ground
   ;; Virus Breeding Ground - Gain counters
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Virus Breeding Ground"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Virus Breeding Ground")
-    (let [vbg (get-in @state [:runner :rig :resource 0])]
-      (is (zero? (get-counters vbg :virus)) "Virus Breeding Ground starts with 0 counters")
-      (take-credits state :runner 3)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Virus Breeding Ground"]))
       (take-credits state :corp)
-      (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
-      (take-credits state :runner 3)
+      (play-from-hand state :runner "Virus Breeding Ground")
+      (let [vbg (get-in @state [:runner :rig :resource 0])]
+        (is (zero? (get-counters vbg :virus)) "Virus Breeding Ground starts with 0 counters")
+        (take-credits state :runner 3)
+        (take-credits state :corp)
+        (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
+        (take-credits state :runner 3)
+        (take-credits state :corp)
+        (is (= 2 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn"))))
+  (testing "Can move to programs pumped by Hivemind"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Virus Breeding Ground" "Hivemind" "Aumakua"]))
       (take-credits state :corp)
-      (is (= 2 (get-counters (refresh vbg) :virus))
-          "Virus Breeding Ground gains 1 counter per turn"))))
-
-(deftest virus-breeding-hivemind
-  ;; Virus Breeding Ground - Can move to programs pumped by Hivemind
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Virus Breeding Ground" "Hivemind" "Aumakua"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Virus Breeding Ground")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (play-from-hand state :runner "Hivemind")
-    (play-from-hand state :runner "Aumakua")
-    (let [aum (get-in @state [:runner :rig :program 1])
-          vbg (get-in @state [:runner :rig :resource 0])]
-      (is (zero? (get-counters aum :virus)) "Aumakua starts with 0 counters (excluding Hivemind)")
-      (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
-      (card-ability state :runner vbg 0)
-      (prompt-select :runner aum)
-      (is (= 1 (get-counters (refresh aum) :virus)) "Aumakua gained 1 counter")
-      (is (zero? (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter"))))
-
-(deftest virus-breeding-ground-move
-  ;; Virus Breeding Ground - Move counters
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Virus Breeding Ground" "Hivemind"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Virus Breeding Ground")
-    (play-from-hand state :runner "Hivemind")
-    (let [hive (get-in @state [:runner :rig :program 0])
-          vbg (get-in @state [:runner :rig :resource 0])]
-      (is (= 1 (get-counters hive :virus)) "Hivemind starts with 1 counter")
-      (is (zero? (get-counters vbg :virus)) "Virus Breeding Ground starts with 0 counters")
-      (take-credits state :runner 3)
-      (take-credits state :corp)
-      (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
-      (card-ability state :runner vbg 0)
-      (prompt-select :runner hive)
-      (is (= 2 (get-counters (refresh hive) :virus)) "Hivemind gained 1 counter")
-      (is (zero? (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter"))))
-
-(deftest virus-breeding-ground-resource
-  ;; Virus Breeding Ground - Move counters to a non-virus resource
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Virus Breeding Ground" "Crypt"]))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Virus Breeding Ground")
-    (play-from-hand state :runner "Crypt")
-    (let [vbg (get-in @state [:runner :rig :resource 0])
-          crypt (get-in @state [:runner :rig :resource 1])]
-      (is (zero? (get-counters crypt :virus)) "Crypt starts with 0 counters")
-      (is (zero? (get-counters vbg :virus)) "Virus Breeding Ground starts with 0 counters")
+      (play-from-hand state :runner "Virus Breeding Ground")
       (take-credits state :runner)
       (take-credits state :corp)
-      (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
-      (card-ability state :runner (refresh vbg) 0)
-      (prompt-select :runner (refresh crypt))
-      (prompt-choice :runner "Done")
-      (is (zero? (get-counters (refresh crypt) :virus)) "Crypt doesn't gain a counter")
-      (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground doesn't lose a counter")
-      (run-on state "Archives")
-      (run-successful state)
-      (prompt-choice :runner "Yes")
-      (is (= 1 (get-counters (refresh crypt) :virus)) "Crypt gained a counter")
-      (card-ability state :runner (refresh vbg) 0)
-      (prompt-select :runner (refresh crypt))
-      (is (= 2 (get-counters (refresh crypt) :virus)) "Crypt gained 1 counter")
-      (is (zero? (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter"))))
+      (play-from-hand state :runner "Hivemind")
+      (play-from-hand state :runner "Aumakua")
+      (let [aum (get-in @state [:runner :rig :program 1])
+            vbg (get-in @state [:runner :rig :resource 0])]
+        (is (zero? (get-counters aum :virus)) "Aumakua starts with 0 counters (excluding Hivemind)")
+        (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
+        (card-ability state :runner vbg 0)
+        (prompt-select :runner aum)
+        (is (= 1 (get-counters (refresh aum) :virus)) "Aumakua gained 1 counter")
+        (is (zero? (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter"))))
+  (testing "Move counters"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Virus Breeding Ground" "Hivemind"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Virus Breeding Ground")
+      (play-from-hand state :runner "Hivemind")
+      (let [hive (get-in @state [:runner :rig :program 0])
+            vbg (get-in @state [:runner :rig :resource 0])]
+        (is (= 1 (get-counters hive :virus)) "Hivemind starts with 1 counter")
+        (is (zero? (get-counters vbg :virus)) "Virus Breeding Ground starts with 0 counters")
+        (take-credits state :runner 3)
+        (take-credits state :corp)
+        (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
+        (card-ability state :runner vbg 0)
+        (prompt-select :runner hive)
+        (is (= 2 (get-counters (refresh hive) :virus)) "Hivemind gained 1 counter")
+        (is (zero? (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter"))))
+  (testing "Move counters to a non-virus resource"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Virus Breeding Ground" "Crypt"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Virus Breeding Ground")
+      (play-from-hand state :runner "Crypt")
+      (let [vbg (get-in @state [:runner :rig :resource 0])
+            crypt (get-in @state [:runner :rig :resource 1])]
+        (is (zero? (get-counters crypt :virus)) "Crypt starts with 0 counters")
+        (is (zero? (get-counters vbg :virus)) "Virus Breeding Ground starts with 0 counters")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground gains 1 counter per turn")
+        (card-ability state :runner (refresh vbg) 0)
+        (prompt-select :runner (refresh crypt))
+        (prompt-choice :runner "Done")
+        (is (zero? (get-counters (refresh crypt) :virus)) "Crypt doesn't gain a counter")
+        (is (= 1 (get-counters (refresh vbg) :virus)) "Virus Breeding Ground doesn't lose a counter")
+        (run-on state "Archives")
+        (run-successful state)
+        (prompt-choice :runner "Yes")
+        (is (= 1 (get-counters (refresh crypt) :virus)) "Crypt gained a counter")
+        (card-ability state :runner (refresh vbg) 0)
+        (prompt-select :runner (refresh crypt))
+        (is (= 2 (get-counters (refresh crypt) :virus)) "Crypt gained 1 counter")
+        (is (zero? (get-counters (refresh vbg) :virus)) "Virus Breeding Ground lost 1 counter")))))
 
 (deftest wasteland
   ;; Wasteland - Gain 1c the first time you trash an installed card of yours each turn

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -197,7 +197,6 @@
               (default-runner))
     (play-from-hand state :corp "Bio Vault" "New remote")
     (take-credits state :corp)
-
     (let [bv (get-content state :remote1 0)]
       (run-on state "Server 1")
       (core/rez state :corp (refresh bv))
@@ -206,10 +205,8 @@
       (run-successful state)
       (prompt-choice :runner "No action")
       (take-credits state :runner)
-
       (advance state (refresh bv) 2)
       (take-credits state :corp)
-
       (run-on state "Server 1")
       (card-ability state :corp (refresh bv) 0)
       (is (not (:run @state)) "Bio Vault fires with 2 advancement tokens")
@@ -236,7 +233,7 @@
        (core/rez state :corp sbox)
        (is (= 1 (:credit (get-corp))) "Paid full 3 credits to rez Strongbox")))))
 
-(deftest bryan-stinson-current
+(deftest bryan-stinson
   ;; Bryan Stinson - play a transaction from archives and remove from game. Ensure Currents are RFG and not trashed.
   (do-game
    (new-game (default-corp ["Bryan Stinson" "Death and Taxes"
@@ -256,7 +253,6 @@
       (is (find-card "Death and Taxes" (:rfg (get-corp))) "Death and Taxes removed from game")
       (is (not= "Death and Taxes" (:title (first (:discard (get-corp))))) "Death and Taxes not moved to trash")
       (take-credits state :runner)
-
       (core/lose state :runner :credit 3)
       (trash-from-hand state :corp "Paywall Implementation")
       (card-ability state :corp (refresh bs) 0)
@@ -271,7 +267,6 @@
       (is (find-card "Paywall Implementation" (:rfg (get-corp))) "Paywall Implementation removed from game")
       (is (not= "Paywall Implementation" (:title (first (:discard (get-corp))))) "Paywall Implementation not moved to trash")
       (take-credits state :runner)
-
       (core/lose state :runner :credit 3)
       (card-ability state :corp (refresh bs) 0)
       (prompt-card :corp (find-card "IPO" (:discard (get-corp))))
@@ -545,29 +540,6 @@
     (prompt-choice-partial :runner "Pay") ; trash
     (is (= 2 (:tag (get-runner))) "Runner doesn't take tags when trace won")))
 
-(deftest ghost-branch-dedicated-response-team
-  ;; Ghost Branch - with Dedicated Response Team
-  (do-game
-    (new-game (default-corp ["Ghost Branch" "Dedicated Response Team"])
-              (default-runner))
-    (play-from-hand state :corp "Ghost Branch" "New remote")
-    (play-from-hand state :corp "Dedicated Response Team" "New remote")
-    (core/gain state :corp :click 1)
-    (let [gb (get-content state :remote1 0)
-          drt (get-content state :remote2 0)]
-      (core/advance state :corp {:card gb})
-      (core/advance state :corp {:card (refresh gb)})
-      (is (= 2 (:advance-counter (refresh gb))) "Ghost Branch advanced twice")
-      (take-credits state :corp)
-      (run-on state "Server 1")
-      (core/rez state :corp drt)
-      (run-successful state)
-      (is (prompt-is-type? :runner :waiting) "Runner has prompt to wait for Ghost Branch")
-      (prompt-choice :corp "Yes")
-      (is (= 2 (:tag (get-runner))) "Runner has 2 tags")
-      (prompt-choice-partial :runner "Pay")
-      (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage"))))
-
 (deftest georgia-emelyov
   ;; Georgia Emelyov
   (do-game
@@ -753,31 +725,32 @@
     (take-credits state :runner)
     (is (= 4 (:click (get-corp))) "Corp gained a click due to running last click")))
 
-(deftest marcus-batty-security-nexus
-  ;; Marcus Batty - Simultaneous Interaction with Security Nexus
-  (do-game
-    (new-game (default-corp ["Marcus Batty" "Enigma"])
-              (default-runner ["Security Nexus"]))
-    (play-from-hand state :corp "Marcus Batty" "HQ")
-    (play-from-hand state :corp "Enigma" "HQ")
-    (take-credits state :corp)
-    (core/gain state :runner :credit 8)
-    (play-from-hand state :runner "Security Nexus")
-    (let [mb (get-content state :hq 0)
-          en (get-ice state :hq 0)
-          sn (-> @state :runner :rig :hardware first)]
-      (run-on state "HQ")
-      (core/rez state :corp mb)
-      (core/rez state :corp en)
-      (card-ability state :corp mb 0)
-      (card-ability state :runner sn 0)
-      ;; both prompts should be on Batty
-      (is (prompt-is-card? :corp mb) "Corp prompt is on Marcus Batty")
-      (is (prompt-is-card? :runner mb) "Runner prompt is on Marcus Batty")
-      (prompt-choice :corp "0")
-      (prompt-choice :runner "0")
-      (is (prompt-is-card? :corp sn) "Corp prompt is on Security Nexus")
-      (is (prompt-is-type? :runner :waiting) "Runner prompt is waiting for Corp"))))
+(deftest marcus-batty
+  ;; Marcus Batty
+  (testing "Simultaneous Interaction with Security Nexus"
+    (do-game
+      (new-game (default-corp ["Marcus Batty" "Enigma"])
+                (default-runner ["Security Nexus"]))
+      (play-from-hand state :corp "Marcus Batty" "HQ")
+      (play-from-hand state :corp "Enigma" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 8)
+      (play-from-hand state :runner "Security Nexus")
+      (let [mb (get-content state :hq 0)
+            en (get-ice state :hq 0)
+            sn (-> @state :runner :rig :hardware first)]
+        (run-on state "HQ")
+        (core/rez state :corp mb)
+        (core/rez state :corp en)
+        (card-ability state :corp mb 0)
+        (card-ability state :runner sn 0)
+        ;; both prompts should be on Batty
+        (is (prompt-is-card? :corp mb) "Corp prompt is on Marcus Batty")
+        (is (prompt-is-card? :runner mb) "Runner prompt is on Marcus Batty")
+        (prompt-choice :corp "0")
+        (prompt-choice :runner "0")
+        (is (prompt-is-card? :corp sn) "Corp prompt is on Security Nexus")
+        (is (prompt-is-type? :runner :waiting) "Runner prompt is waiting for Corp")))))
 
 (deftest mumbad-city-grid
   ;; Mumbad City Grid - when runner passes a piece of ice, swap that ice with another from this server
@@ -1118,7 +1091,6 @@
         (prompt-select :runner (refresh pb))
         (prompt-choice-partial :runner "No")
         (is (empty? (:scored (get-runner))) "End with no stolen agendas")
-
         (run-empty-server state "Server 1")
         (prompt-choice-partial :runner "Steal")
         (is (= 1 (count (:scored (get-runner)))) "1 stolen agenda"))))
@@ -1600,89 +1572,86 @@
 
 (deftest tori-hanzo
   ;; Tori Hanzō - Pay to do 1 brain damage instead of net damage
-  (do-game
-    (new-game (default-corp ["Pup" "Tori Hanzō"])
-              (default-runner [(qty "Sure Gamble" 3) "Net Shield"]))
-    (core/gain state :corp :credit 10)
-    (play-from-hand state :corp "Pup" "HQ")
-    (play-from-hand state :corp "Tori Hanzō" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Net Shield")
-    (run-on state "HQ")
-    (let [pup (get-ice state :hq 0)
-          tori (get-content state :hq 0)
-          nshld (get-in @state [:runner :rig :program 0])]
-      (core/rez state :corp pup)
-      (core/rez state :corp tori)
-      (card-subroutine state :corp pup 0)
-      (card-ability state :runner nshld 0)
-      (prompt-choice :runner "Done")
-      (is (empty? (:discard (get-runner))) "1 net damage prevented")
-      (card-subroutine state :corp pup 0)
-      (prompt-choice :runner "Done") ; decline to prevent
-      (is (= 1 (count (:discard (get-runner)))) "1 net damage; previous prevention stopped Tori ability")
-      (run-jack-out state)
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Pup" "Tori Hanzō"])
+                (default-runner [(qty "Sure Gamble" 3) "Net Shield"]))
+      (core/gain state :corp :credit 10)
+      (play-from-hand state :corp "Pup" "HQ")
+      (play-from-hand state :corp "Tori Hanzō" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Net Shield")
       (run-on state "HQ")
-      (card-subroutine state :corp pup 0)
-      (prompt-choice :runner "Done")
-      (prompt-choice :corp "Yes")
-      (is (= 2 (count (:discard (get-runner)))) "1 brain damage suffered")
-      (is (= 1 (:brain-damage (get-runner)))))))
-
-(deftest tori-hanzo-hokusai
-  ;; Tori Hanzō + Hokusai Grid: Issue #2702
-  (do-game
-    (new-game (default-corp ["Tori Hanzō" "Hokusai Grid"])
-              (default-runner))
-    (core/gain state :corp :credit 5)
-    (play-from-hand state :corp "Hokusai Grid" "Archives")
-    (play-from-hand state :corp "Tori Hanzō" "Archives")
-    (take-credits state :corp)
-    (run-on state "Archives")
-    (let [hg (get-content state :archives 0)
-          tori (get-content state :archives 1)]
-      (core/rez state :corp hg)
-      (core/rez state :corp tori)
-      (run-successful state)
-      (prompt-choice :corp "No") ; Tori prompt to pay 2c to replace 1 net with 1 brain
-      (is (= 1 (count (:discard (get-runner)))) "1 net damage suffered")
-      (prompt-choice :runner "Hokusai Grid")
-      (prompt-choice :runner "No action")
-      (prompt-choice :runner "Tori Hanzō")
-      (prompt-choice :runner "No action")
-      (is (and (empty (:prompt (get-runner))) (not (:run @state))) "No prompts, run ended")
-      (run-empty-server state "Archives")
-      (prompt-choice :corp "Yes") ; Tori prompt to pay 2c to replace 1 net with 1 brain
-      (is (= 2 (count (:discard (get-runner)))))
-      (is (= 1 (:brain-damage (get-runner))) "1 brain damage suffered")
-      (prompt-choice :runner "Hokusai Grid")
-      (prompt-choice :runner "No action")
-      (prompt-choice :runner "Tori Hanzō")
-      (prompt-choice :runner "No action")
-      (is (and (empty (:prompt (get-runner))) (not (:run @state))) "No prompts, run ended"))))
-
-(deftest tori-hanzo-net
-  ;; Tori Hanzō breaking subsequent net damage: Issue #3176
-  (do-game
-    (new-game (default-corp ["Tori Hanzō" (qty "Pup" 2) (qty "Neural EMP" 2)])
-              (default-runner))
-    (core/gain state :corp :credit 8)
-    (play-from-hand state :corp "Tori Hanzō" "New remote")
-    (play-from-hand state :corp "Pup" "Server 1")
-    (take-credits state :corp)
-    (run-on state "Server 1")
-    (let [tori (get-content state :remote1 0)
-          pup (get-ice state :remote1 0)]
-      (core/rez state :corp pup)
-      (core/rez state :corp tori)
-      (card-subroutine state :corp pup 0)
-      (prompt-choice :corp "Yes") ; pay 2c to replace 1 net with 1 brain
-      (is (= 1 (count (:discard (get-runner)))) "1 brain damage suffered")
-      (is (= 1 (:brain-damage (get-runner))))
-      (run-jack-out state)
-      (take-credits state :runner)
-      (play-from-hand state :corp "Neural EMP")
-      (is (= 2 (count (:discard (get-runner)))) "Net damage processed correctly"))))
+      (let [pup (get-ice state :hq 0)
+            tori (get-content state :hq 0)
+            nshld (get-in @state [:runner :rig :program 0])]
+        (core/rez state :corp pup)
+        (core/rez state :corp tori)
+        (card-subroutine state :corp pup 0)
+        (card-ability state :runner nshld 0)
+        (prompt-choice :runner "Done")
+        (is (empty? (:discard (get-runner))) "1 net damage prevented")
+        (card-subroutine state :corp pup 0)
+        (prompt-choice :runner "Done") ; decline to prevent
+        (is (= 1 (count (:discard (get-runner)))) "1 net damage; previous prevention stopped Tori ability")
+        (run-jack-out state)
+        (run-on state "HQ")
+        (card-subroutine state :corp pup 0)
+        (prompt-choice :runner "Done")
+        (prompt-choice :corp "Yes")
+        (is (= 2 (count (:discard (get-runner)))) "1 brain damage suffered")
+        (is (= 1 (:brain-damage (get-runner)))))))
+  (testing "with Hokusai Grid: Issue #2702"
+    (do-game
+      (new-game (default-corp ["Tori Hanzō" "Hokusai Grid"])
+                (default-runner))
+      (core/gain state :corp :credit 5)
+      (play-from-hand state :corp "Hokusai Grid" "Archives")
+      (play-from-hand state :corp "Tori Hanzō" "Archives")
+      (take-credits state :corp)
+      (run-on state "Archives")
+      (let [hg (get-content state :archives 0)
+            tori (get-content state :archives 1)]
+        (core/rez state :corp hg)
+        (core/rez state :corp tori)
+        (run-successful state)
+        (prompt-choice :corp "No") ; Tori prompt to pay 2c to replace 1 net with 1 brain
+        (is (= 1 (count (:discard (get-runner)))) "1 net damage suffered")
+        (prompt-choice :runner "Hokusai Grid")
+        (prompt-choice :runner "No action")
+        (prompt-choice :runner "Tori Hanzō")
+        (prompt-choice :runner "No action")
+        (is (and (empty (:prompt (get-runner))) (not (:run @state))) "No prompts, run ended")
+        (run-empty-server state "Archives")
+        (prompt-choice :corp "Yes") ; Tori prompt to pay 2c to replace 1 net with 1 brain
+        (is (= 2 (count (:discard (get-runner)))))
+        (is (= 1 (:brain-damage (get-runner))) "1 brain damage suffered")
+        (prompt-choice :runner "Hokusai Grid")
+        (prompt-choice :runner "No action")
+        (prompt-choice :runner "Tori Hanzō")
+        (prompt-choice :runner "No action")
+        (is (and (empty (:prompt (get-runner))) (not (:run @state))) "No prompts, run ended"))))
+  (testing "breaking subsequent net damage: Issue #3176"
+    (do-game
+      (new-game (default-corp ["Tori Hanzō" (qty "Pup" 2) (qty "Neural EMP" 2)])
+                (default-runner))
+      (core/gain state :corp :credit 8)
+      (play-from-hand state :corp "Tori Hanzō" "New remote")
+      (play-from-hand state :corp "Pup" "Server 1")
+      (take-credits state :corp)
+      (run-on state "Server 1")
+      (let [tori (get-content state :remote1 0)
+            pup (get-ice state :remote1 0)]
+        (core/rez state :corp pup)
+        (core/rez state :corp tori)
+        (card-subroutine state :corp pup 0)
+        (prompt-choice :corp "Yes") ; pay 2c to replace 1 net with 1 brain
+        (is (= 1 (count (:discard (get-runner)))) "1 brain damage suffered")
+        (is (= 1 (:brain-damage (get-runner))))
+        (run-jack-out state)
+        (take-credits state :runner)
+        (play-from-hand state :corp "Neural EMP")
+        (is (= 2 (count (:discard (get-runner)))) "Net damage processed correctly")))))
 
 (deftest underway-grid
   ;; Underway Grid - prevent expose of cards in server
@@ -1699,21 +1668,22 @@
       (prompt-select :runner eve1)
       (is (empty? (:discard (get-corp))) "Expose and trash prevented"))))
 
-(deftest valley-grid-trash
-  ;; Valley Grid - Reduce Runner max hand size and restore it even if trashed
-  (do-game
-    (new-game (default-corp [(qty "Valley Grid" 3) (qty "Ice Wall" 3)])
-              (default-runner))
-    (play-from-hand state :corp "Valley Grid" "New remote")
-    (take-credits state :corp 2)
-    (run-on state "Server 1")
-    (let [vg (get-content state :remote1 0)]
-      (core/rez state :corp vg)
-      (card-ability state :corp vg 0)
-      (card-ability state :corp vg 0) ; only need the run to exist for test, just pretending the Runner has broken all subs on 2 ice
-      (is (= 3 (core/hand-size state :runner)) "Runner max hand size reduced by 2")
-      (is (= 2 (get-in (refresh vg) [:times-used])) "Saved number of times Valley Grid used")
-      (run-successful state)
-      (prompt-choice-partial :runner "Pay") ; pay to trash
-      (take-credits state :runner 3)
-      (is (= 5 (core/hand-size state :runner)) "Runner max hand size increased by 2 at start of Corp turn"))))
+(deftest valley-grid
+  ;; Valley Grid
+  (testing "Reduce Runner max hand size and restore it even if trashed"
+    (do-game
+      (new-game (default-corp [(qty "Valley Grid" 3) (qty "Ice Wall" 3)])
+                (default-runner))
+      (play-from-hand state :corp "Valley Grid" "New remote")
+      (take-credits state :corp 2)
+      (run-on state "Server 1")
+      (let [vg (get-content state :remote1 0)]
+        (core/rez state :corp vg)
+        (card-ability state :corp vg 0)
+        (card-ability state :corp vg 0) ; only need the run to exist for test, just pretending the Runner has broken all subs on 2 ice
+        (is (= 3 (core/hand-size state :runner)) "Runner max hand size reduced by 2")
+        (is (= 2 (get-in (refresh vg) [:times-used])) "Saved number of times Valley Grid used")
+        (run-successful state)
+        (prompt-choice-partial :runner "Pay") ; pay to trash
+        (take-credits state :runner 3)
+        (is (= 5 (core/hand-size state :runner)) "Runner max hand size increased by 2 at start of Corp turn")))))


### PR DESCRIPTION
Added a new task to measure test coverage of cards: `lein card-coverage`.

You can specify a few options:
- `--only <Type>` where `Type` is `Agenda`, `ICE`, etc. Only checks coverage on cards of a specific type
- `--show-none` By default all cards without a test have their names displayed, this will limit information to counts only.
- `--show-all` Will display the names of cards that have tests, which are not displayed by default.

In addition, you can set metadata on the tests to work around a few issues:
- Use `(deftest ^:skip-card-coverage end-the-run-test ...)` to mark that this test in a `game-test.cards` namespace is not for a specific card.
- Use `(deftest ^{:card-title "15-minutes"} fifteen-minutes ...)` to indicate which card the test is covering. Useful when the card name is not a valid clojure function name.

