### PR TITLE
Fix: Card reload from the repl

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -206,7 +206,7 @@
   ([] (load-all-cards nil))
   ([path]
    (doall (pmap load-file
-                (->> (io/file (str "src/clj/game/cards" (when path (str "/" path))))
+                (->> (io/file (str "src/clj/game/cards" (when path (str "/" path ".clj"))))
                      (file-seq)
                      (filter #(.isFile %))
                      (map str))))))
@@ -231,4 +231,5 @@
                      (constantly
                        (merge cards
                               (do (load-all-cards path)
-                                  (get-card-defs path))))))))
+                                  (get-card-defs path))))))
+   'loaded))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1,7 +1,6 @@
 (ns game.cards.operations
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.cards.ice :refer [end-the-run]]
             [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
@@ -1386,8 +1385,10 @@
     :effect (effect (gain :credit (* 3 (count (:scored runner)))))}
 
    "Sub Boost"
-   (let [new-sub {:label "[Sub Boost] End the run"}]
-     {:sub-effect end-the-run
+   (let [new-sub {:label "[Sub Boost]: End the run"}]
+     {:sub-effect {:label "End the run"
+                   :msg "end the run"
+                   :effect (effect (end-run))}
       :choices {:req #(and (ice? %) (rezzed? %))}
       :msg (msg "make " (card-str state target) " gain Barrier and \"[Subroutine] End the run\"")
       :effect (req (update! state side (assoc target :subtype (combine-subtypes true (:subtype target) "Barrier")))

--- a/test/clj/game_test/games/scenarios.clj
+++ b/test/clj/game_test/games/scenarios.clj
@@ -5,7 +5,7 @@
             [game-test.macros :refer :all]
             [clojure.test :refer :all]))
 
-(use-fixtures :once load-all-cards)
+(use-fixtures :once load-all-cards (partial reset-card-defs nil))
 
 (deftest minigame-prevent-netdmg-resourcetrash
   (testing "Mini-game testing prevention of net damage and resource trashing, with hosted Fall Guy"

--- a/test/clj/game_test/rules.clj
+++ b/test/clj/game_test/rules.clj
@@ -5,7 +5,7 @@
             [game-test.macros :refer :all]
             [clojure.test :refer :all]))
 
-(use-fixtures :once load-all-cards)
+(use-fixtures :once load-all-cards (partial reset-card-defs nil))
 
 (deftest undo-turn
   (do-game


### PR DESCRIPTION
Fixes a small miss where trying to load cards in the REPL while manually testing wouldn't work.

Fixes test files `scenarios.clj` and `rules.clj` not hot-reloading cards.

Fixes a parallel-compilation bug that would appear sometimes on CircleCI, when it tried to load Operations before Ice, causing it to throw an error over not being able to import the `end-the-run` helper function.