### PR TITLE
FIX: Trash abilities now aware of recurring credits

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -372,7 +372,7 @@
                                                  (trash-no-cost state side eid accessed-card))
                                              ;; Player cancelled ability
                                              (do (swap! state dissoc-in [:per-turn (:cid card)])
-                                                 (access-non-agenda state side eid accessed-card))))))))}}}
+                                                 (access-non-agenda state side eid accessed-card :skip-trigger-event true))))))))}}}
 
    "Fringe Applications: Tomorrow, Today"
    {:events

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -77,7 +77,7 @@
   [state side cost]
   (>= (+ (- (get-in @state [side :credit] -1) cost)
          (->> (all-installed state side)
-              (map #(:rec-counter % 0))
+              (map #(get-counters % :recurring))
               (reduce +)))
       0))
 

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -77,7 +77,8 @@
   [state side cost]
   (>= (+ (- (get-in @state [side :credit] -1) cost)
          (->> (all-installed state side)
-              (map #(get-counters % :recurring))
+              (map #(+ (get-counters % :recurring)
+                       (get-counters % :credit)))
               (reduce +)))
       0))
 

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -42,7 +42,6 @@
   (let [cost-type (first cost)
         amount (last cost)
         computer-says-no "Unable to pay"]
-
     (cond
 
       (flag-stops-pay? state side cost-type)
@@ -56,7 +55,7 @@
                (and (= cost-type :hardware) (>= (- (count (get-in @state [:runner :rig :hardware])) amount) 0))
                (and (= cost-type :program) (>= (- (count (get-in @state [:runner :rig :program])) amount) 0))
                (and (= cost-type :connection) (>= (- (count (filter #(has-subtype? % "Connection")
-                                                               (all-active-installed state :runner))) amount) 0))
+                                                                    (all-active-installed state :runner))) amount) 0))
                (and (= cost-type :shuffle-installed-to-stack) (>= (- (count (all-installed state :runner)) amount) 0))
                (>= (- (get-in @state [side cost-type] -1) amount) 0)))
       computer-says-no)))
@@ -72,6 +71,15 @@
     (if-not cost-msg
       costs
       (when title (toast state side (str cost-msg " for " title ".")) false))))
+
+(defn can-pay-with-recurring?
+  "Returns true if the player can pay the cost factoring in available recurring credits"
+  [state side cost]
+  (>= (+ (- (get-in @state [side :credit] -1) cost)
+         (->> (all-installed state side)
+              (map #(:rec-counter % 0))
+              (reduce +)))
+      0))
 
 (defn pay-forfeit
   "Forfeit agenda as part of paying for a card or ability
@@ -219,7 +227,7 @@
       (doseq [[subtype amount] amount]
         (swap! state update-in [side type subtype] (safe-inc-n amount))
         (swap! state update-in [:stats side :gain type subtype] (fnil + 0) amount))
-    
+
       ;; Default cases for the types that expect a map
       (#{:hand-size :memory} type)
       (gain state side type {:mod amount})

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -161,7 +161,7 @@
                               (.contains target "Pay")
                               (if (> trash-cost (get-in @state [:runner :credit] 0))
                                 (do (toast state side (str "You don't have the credits to pay for " card-name
-                                                           ". Did you mean to first gain recurring credits?"))
+                                                           ". Did you mean to first gain credits from installed cards?"))
                                     (access-non-agenda state side eid c :skip-trigger-event true))
                                 (do (lose state side :credit trash-cost)
                                     (when (:run @state)

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -113,15 +113,17 @@
 
 (defn access-non-agenda
   "Access a non-agenda. Show a prompt to trash for trashable cards."
-  [state side eid c]
-  (trigger-event state side :pre-trash c)
+  [state side eid c & {:keys [skip-trigger-event]}]
+  (when-not skip-trigger-event
+    (trigger-event state side :pre-trash c))
   (swap! state update-in [:stats :runner :access :cards] (fnil inc 0))
   (if (not= (:zone c) [:discard]) ; if not accessing in Archives
     ;; The card has a trash cost (Asset, Upgrade)
     (let [card (assoc c :seen true)
           card-name (:title card)
           trash-cost (trash-cost state side c)
-          can-pay (when trash-cost (can-pay? state :runner nil :credit trash-cost))]
+          can-pay (when trash-cost (or (can-pay? state :runner nil :credit trash-cost)
+                                       (can-pay-with-recurring? state :runner trash-cost)))]
       ;; Show the option to pay to trash the card.
       (when-not (and (is-type? card "Operation")
                      ;; Don't show the option if Edward Kim's auto-trash flag is true.
@@ -157,15 +159,19 @@
                               (access-end state side eid c)
 
                               (.contains target "Pay")
-                              (do (lose state side :credit trash-cost)
-                                  (when (:run @state)
-                                    (swap! state assoc-in [:run :did-trash] true)
-                                    (when forced-to-trash?
-                                      (swap! state assoc-in [:run :did-access] true)))
-                                  (swap! state assoc-in [:runner :register :trashed-card] true)
-                                  (system-msg state side pay-str)
-                                  (when-completed (trash state side card nil)
-                                                  (access-end state side eid c)))
+                              (if (> trash-cost (get-in @state [:runner :credit] 0))
+                                (do (toast state side (str "You don't have the credits to pay for " card-name
+                                                           ". Did you mean to first gain recurring credits?"))
+                                    (access-non-agenda state side eid c :skip-trigger-event true))
+                                (do (lose state side :credit trash-cost)
+                                    (when (:run @state)
+                                      (swap! state assoc-in [:run :did-trash] true)
+                                      (when forced-to-trash?
+                                        (swap! state assoc-in [:run :did-access] true)))
+                                    (swap! state assoc-in [:runner :register :trashed-card] true)
+                                    (system-msg state side pay-str)
+                                    (when-completed (trash state side card nil)
+                                                    (access-end state side eid c))))
 
                               (some #(= % target) ability-strs)
                               (let [idx (.indexOf ability-strs target)

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -453,8 +453,8 @@
                 (take-credits state :corp)
                 (play-from-hand state :runner "Cache")
                 (run-empty-server state "HQ")
-                (is (= 1 (->> @state :runner :prompt first :choices count)) "Should only have 1 option")
-                (is (= "No action" (->> @state :runner :prompt first :choices first)) "Only option should be 'No action'")))]
+                (is (= 1 (-> @state :runner :prompt first :choices count)) "Should only have 1 option")
+                (is (= "No action" (-> @state :runner :prompt first :choices first)) "Only option should be 'No action'")))]
       (doall (map fk-test
                   ["Archer"
                    "Fire Wall"
@@ -490,7 +490,7 @@
         (prompt-choice :runner "Yes")
         (run-empty-server state "HQ")
         (prompt-choice-partial :runner "Freedom")
-        (prompt-select :runner (->> (refresh iw) :hosted first)))
+        (prompt-select :runner (-> (refresh iw) :hosted first)))
       (is (= 1 (count (:discard (get-corp)))) "Accessed Ice Wall should be discarded after selecting 1 virus counter")))
   (testing "Doesn't trigger when accessing an Agenda"
     (do-game
@@ -500,7 +500,7 @@
       (play-from-hand state :runner "Cache")
       (run-empty-server state "HQ")
       (is (= 1 (->> @state :runner :prompt first :choices count)) "Should only have 1 option")
-      (is (= "Steal" (->> @state :runner :prompt first :choices first)) "Only option should be 'Steal'")))
+      (is (= "Steal" (-> @state :runner :prompt first :choices first)) "Only option should be 'Steal'")))
   (testing "Shows multiple prompts when playing Imp"
     (do-game
       (new-game (default-corp ["Dedicated Response Team"])
@@ -511,7 +511,7 @@
       (play-from-hand state :runner "Cache")
       (play-from-hand state :runner "Imp")
       (run-empty-server state "HQ")
-      (is (= 4 (->> @state :runner :prompt first :choices count)) "Should have 4 options: Freedom, Imp, Trash, No action")))
+      (is (= 4 (-> @state :runner :prompt first :choices count)) "Should have 4 options: Freedom, Imp, Trash, No action")))
   (testing "Should return to access prompts when Done is pressed"
     (do-game
       (new-game (default-corp ["Dedicated Response Team"])
@@ -523,9 +523,9 @@
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (prompt-choice :runner "Done")
-      (is (= 3 (->> @state :runner :prompt first :choices count))
+      (is (= 3 (-> @state :runner :prompt first :choices count))
           (str "Should go back to access prompts, with 3 choices: Freedom, Trash, No action. "
-               "Choices seen: " (->> @state :runner :prompt first :choices)))
+               "Choices seen: " (-> @state :runner :prompt first :choices)))
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (prompt-select :runner (get-program state 0))
@@ -553,7 +553,7 @@
       (prompt-choice-partial :runner "Freedom")
       (prompt-select :runner (get-program state 0))
       (is (= 1 (count (:discard (get-corp)))) "Ice Wall should be discarded now")
-      (is (zero? (->> (get-program state 1) :counter :virus)) "Aumakua doesn't gain any virus counters from trash ability.")
+      (is (zero? (get-counters (get-program state 1) :virus)) "Aumakua doesn't gain any virus counters from trash ability.")
       (is (not (:run @state)) "Run ended")))
   (testing "interaction with trash-cost-bonuses, and declining ability once initiated"
     (do-game

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1725,6 +1725,55 @@
     (take-credits state :runner)
     (is (= 3 (count (:hand (get-runner)))) "Drew no cards, at maximum")))
 
+(deftest scrubber
+  ;; Scrubber
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["The Board"])
+                (default-runner ["Scrubber"]))
+      (play-from-hand state :corp "The Board" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (is (= 1 (-> (get-runner) :prompt first :choices count)) "Runner doesn't have enough credits to trash")
+      (prompt-choice :runner "No action")
+      (play-from-hand state :runner "Scrubber")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (= 5 (:credit (get-runner))) "Runner should only have 5 credits in pool")
+      (run-empty-server state "Server 1")
+      (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner can use Scrubber credits to trash")
+      (let [scrubber (get-resource state 0)]
+        (card-ability state :runner scrubber 0)
+        (card-ability state :runner scrubber 0))
+      (prompt-choice-partial :runner "Pay")
+      (is (= 2 (:agenda-point (get-runner))) "Runner should trash The Board and gain 2 agenda points")))
+  (testing "when under trash cost but can up with recurring credits"
+    (do-game
+      (new-game (default-corp ["The Board"])
+                (default-runner ["Scrubber" "Skulljack" "Sure Gamble"]))
+      (play-from-hand state :corp "The Board" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (is (= 1 (-> (get-runner) :prompt first :choices count)) "Runner doesn't have enough credits to trash")
+      (prompt-choice :runner "No action")
+      (play-from-hand state :runner "Scrubber")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Skulljack")
+      (core/gain state :runner :credit 1)
+      (is (= 4 (:credit (get-runner))) "Runner should only have 4 credits in pool")
+      (run-empty-server state "Server 1")
+      (is (= 6 (core/trash-cost state :runner (get-content state :remote1 0))) "The Board should cost 6 to trash")
+      (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner can use Scrubber credits to trash")
+      (prompt-choice-partial :runner "Pay") ;; Whoops, runner forgot to actually get the credits from Scrubber
+      (is (= 6 (core/trash-cost state :runner (get-content state :remote1 0))) "Skulljack shouldn't trigger a second time")
+      (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner can still use Scrubber credits the second time around")
+      (let [scrubber (get-resource state 0)]
+        (card-ability state :runner scrubber 0)
+        (card-ability state :runner scrubber 0))
+      (prompt-choice-partial :runner "Pay") ;; Now the runner has actually gained the Scrubber credits
+      (is (= 2 (:agenda-point (get-runner))) "Runner should trash The Board and gain 2 agenda points"))))
+
 (deftest salsette-slums
   ;; Salsette Slums - Once per turn, when the trash cost of a card is paid, optionally remove from the game
   (do-game


### PR DESCRIPTION
Makes access prompts informally aware of runner recurring credits, shows "Pay X[Credits]" choice when combination of credits and available recurring credits is enough to trash a given card. Allows for pressing "Pay X [Credits]" in those cases, which will show a toast and return to the access prompt.

Fixes undocumented bug where Freedom Khumalo would retrigger `:pre-trash` whenever the runner started and then cancelled out of using the ability.

Fixes #3571 