### PR TITLE
FIX: Trace refactoring, Power Tap + more

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -770,17 +770,13 @@
    (let [nq {:effect (req (let [extra (int (/ (:runner-spent target) 2))]
                             (when (pos? extra)
                               (gain-credits state side extra)
-                              (system-msg state :corp (str "uses Net Quarantine to gain " extra " [Credits]")))
-                            (when (some? (get-in @state [:runner :temp-link]))
-                              (swap! state assoc-in [:runner :link] (:temp-link runner))
-                              (swap! state dissoc-in [:runner :temp-link]))))}]
-   {:events {:trace {:once :per-turn
-                     :silent (req true)
-                     :effect (req (system-msg state :corp "uses Net Quarantine to reduce Runner's base link to zero")
-                                  (swap! state assoc-in [:runner :temp-link] (:link runner))
-                                  (swap! state assoc-in [:runner :link] 0))}
-             :successful-trace nq
-             :unsuccessful-trace nq}})
+                              (system-msg state :corp (str "uses Net Quarantine to gain " extra "[Credits]")))))}]
+     {:events {:pre-init-trace {:once :per-turn
+                                :silent (req true)
+                                :effect (req (system-msg state :corp "uses Net Quarantine to reduce Runner's base link to zero")
+                                             (swap! state assoc-in [:trace :force-link] 0))}
+               :successful-trace nq
+               :unsuccessful-trace nq}})
 
    "NEXT Wave 2"
    {:not-when-scored true

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1456,10 +1456,8 @@
                                 (swap! state update-in [:bonus] dissoc :trash)))}]}
 
    "Power Tap"
-   (let [ability {:msg "gain 1[Credits]"
-                  :effect (effect (gain-credits :runner 1))}]
-     {:events {:successful-trace ability
-               :unsuccessful-trace ability}})
+   {:events {:pre-init-trace {:msg "gain 1[Credits]"
+                              :effect (effect (gain-credits :runner 1))}}}
 
    "Professional Contacts"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1456,8 +1456,10 @@
                                 (swap! state update-in [:bonus] dissoc :trash)))}]}
 
    "Power Tap"
-   {:events {:trace {:successful {:msg "gain 1 [Credits]"
-                                  :effect (effect (gain-credits :runner 1))}}}}
+   (let [ability {:msg "gain 1[Credits]"
+                  :effect (effect (gain-credits :runner 1))}]
+     {:events {:successful-trace ability
+               :unsuccessful-trace ability}})
 
    "Professional Contacts"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -514,12 +514,6 @@
   [trace]
   (= :corp (:player trace)))
 
-(defn reset-trace-modifications
-  [state]
-  (swap! state dissoc-in [:trace :force-base])
-  (swap! state dissoc-in [:trace :force-link])
-  (swap! state dissoc-in [:bonus :trace]))
-
 (defn resolve-trace
   "Compares trace strength and link strength and triggers the appropriate effects."
   [state side card {:keys [eid player other base bonus link priority ability strength] :as trace} boost]
@@ -559,8 +553,7 @@
                                       (do (when-let [kicker (:kicker trace)]
                                             (when (>= corp-strength (:min kicker))
                                               (resolve-ability state :corp kicker card [corp-strength runner-strength])))
-                                          (effect-completed state side eid nil)
-                                          (reset-trace-modifications state)))))))
+                                          (effect-completed state side eid nil)))))))
 
 (defn trace-reply
   "Shows a trace prompt to the second player, after the first has already spent credits to boost."
@@ -599,8 +592,15 @@
                      #(trace-reply state side card trace %)
                      trace))
 
+(defn reset-trace-modifications
+  [state]
+  (swap! state dissoc-in [:trace :force-base])
+  (swap! state dissoc-in [:trace :force-link])
+  (swap! state dissoc-in [:bonus :trace]))
+
 (defn init-trace
   [state side card {:keys [base priority] :as trace}]
+  (reset-trace-modifications state)
   (when-completed (trigger-event-sync state :corp :pre-init-trace card)
                   (let [force-base (get-in @state [:trace :force-base])
                         force-link (get-in @state [:trace :force-link])

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -677,8 +677,3 @@
   [state]
   (system-msg state :corp "is decked")
   (win state :runner "Decked"))
-
-(defn init-trace-bonus
-  "Applies a bonus base strength of n to the next trace attempt."
-  [state side n]
-  (swap! state update-in [:bonus :trace] (fnil #(+ % n) 0)))

--- a/src/cljs/netrunner/gameboard.cljs
+++ b/src/cljs/netrunner/gameboard.cljs
@@ -1180,7 +1180,7 @@
                    (if (nil? (:strength prompt))
                      (if (= "corp" (:player prompt))
                        ;; This is a trace prompt for the corp, show runner link + credits
-                       [:div.info "Runner: " (:link runner) [:span {:class "anr-icon link"}]
+                       [:div.info "Runner: " (:link prompt) [:span {:class "anr-icon link"}]
                         " + " (:credit runner) [:span {:class "anr-icon credit"}]]
                        ;; Trace in which the runner pays first, showing base trace strength and corp credits
                        [:div.info "Trace: " (when (:bonus prompt) (+ base (:bonus prompt)) base)
@@ -1196,9 +1196,9 @@
                       (if (= "corp" (:player prompt))
                         (let [strength (when (:bonus prompt) (+ base (:bonus prompt)) base)]
                           [:span (str strength " + ")])
-                        [:span (:link runner) " " [:span {:class "anr-icon link"}] (str " + " )])
+                        [:span (:link prompt) " " [:span {:class "anr-icon link"}] (str " + " )])
                       (if (= "corp" (:player prompt))
-                        [:span (:link runner) " " [:span {:class "anr-icon link"}] (str " + " )]
+                        [:span (:link prompt) " " [:span {:class "anr-icon link"}] (str " + " )]
                         (let [strength (when (:bonus prompt) (+ base (:bonus prompt)) base)]
                           [:span (str strength " + ")]))))
                   [:select#credit (for [i (range (inc (:credit me)))]

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -1170,10 +1170,19 @@
       (run-on state "HQ")
       (run-phase-43 state)
       (card-subroutine state :corp nh 0)
-      (is (= 1 (get-in @state [:bonus :trace])) "Should gain 1 bonus trace strength")
+      (is (= 1 (-> (get-corp) :prompt first :bonus)) "Should gain 1 bonus trace strength")
       (prompt-choice :corp 0)
       (prompt-choice :runner 0)
-      (is (= 1 (:tag (get-runner)))))))
+      (is (= 1 (:tag (get-runner))))
+      (run-jack-out state)
+      (run-on state "HQ")
+      (run-phase-43 state)
+      (card-subroutine state :corp nh 0)
+      (is (= 1 (-> (get-corp) :prompt first :bonus))
+          "Should gain only 1 bonus trace strength regardless of number of runs in a turn")
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (= 2 (:tag (get-runner)))))))
 
 (deftest labyrinthine-servers
   ;; Labyrinthine Servers
@@ -1463,20 +1472,20 @@
     (core/gain state :runner :link 1)
     (core/gain state :corp :click 3)
     (play-and-score state "Net Quarantine")
-    (is (= 5 (:credit (get-corp))) "Corp has 5 credits")
-    (is (= 1 (:link (get-runner))) "Runner has 1 link")
-    (core/init-trace state :corp {:title "/trace command" :side :corp} {:base 1})
-    (prompt-choice :corp 0)
-    (is (zero? (:link (get-runner))) "Runner has 0 link")
-    (prompt-choice :runner 3)
-    (is (= 1 (:link (get-runner))) "Runner has 1 link again")
-    (is (= 6 (:credit (get-corp))) "Corp gained a credit from NQ")
-    ; second trace of turn - no link reduction
-    (core/init-trace state :corp {:title "/trace command" :side :corp} {:base 1})
-    (prompt-choice :corp 0)
-    (is (= 1 (:link (get-runner))) "Runner has 1 link")
-    (prompt-choice :runner 2)
-    (is (= 7 (:credit (get-corp))) "Corp gained a credit from NQ")))
+    (let [credits (:credit (get-corp))]
+      (is (= credits (:credit (get-corp))) (str "Corp has " credits " credits"))
+      (is (= 1 (:link (get-runner))) "Runner has 1 link")
+      (core/init-trace state :corp {:title "/trace command" :side :corp} {:base 1})
+      (prompt-choice :corp 0)
+      (is (zero? (-> (get-runner) :prompt first :link)) "Runner has 0 link during first trace")
+      (prompt-choice :runner 3)
+      (is (= (+ credits 1) (:credit (get-corp))) "Corp gained a credit from NQ")
+      ; second trace of turn - no link reduction
+      (core/init-trace state :corp {:title "/trace command" :side :corp} {:base 1})
+      (prompt-choice :corp 0)
+      (is (= 1 (-> (get-runner) :prompt first :link)) "Runner has 1 link during later traces")
+      (prompt-choice :runner 2)
+      (is (= (+ credits 2) (:credit (get-corp))) "Corp gained a credit from NQ"))))
 
 (deftest new-construction
   ;; New Construction

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1621,6 +1621,32 @@
         (core/end-phase-12 state :runner nil)
         (is (empty? (:prompt (get-runner))) "No second prompt for Patron - used already")))))
 
+(deftest power-tap
+  ;; Power Tap
+  (do-game
+    (new-game (default-corp ["Restructured Datapool"])
+              (default-runner ["Power Tap"]))
+    (play-and-score state "Restructured Datapool")
+    (let [agenda (get-scored state :corp 0)
+          tags (:tag (get-runner))
+          credits (:credit (get-runner))]
+      (card-ability state :corp agenda 0)
+      (is (= credits (:credit (get-runner))) "Runner shouldn't gain any credits from trace")
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (= (+ tags 1) (:tag (get-runner))) "Runner should gain 1 tag from losing trace"))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Power Tap")
+    (take-credits state :runner)
+    (let [agenda (get-scored state :corp 0)
+          tags (:tag (get-runner))
+          credits (:credit (get-runner))]
+      (card-ability state :corp agenda 0)
+      (is (= (+ credits 1) (:credit (get-runner))) "Runner should gain 1 credit from trace initiation")
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 0)
+      (is (= (+ tags 1) (:tag (get-runner))) "Runner should gain 1 tag from losing trace"))))
+
 (deftest professional-contacts
   ;; Professional Contacts - Click to gain 1 credit and draw 1 card
   (do-game


### PR DESCRIPTION
Improved Tracers, Net Quarantine, and Power Tap all had bugs. I've fixed them, cleaned up how traces handle bonuses and forced base strength and link, fixed runner link display, and fixed the tests to accurately handle those changes.

Fixes #3580, #3244 