### PR TITLE
FIX: Product Recall trash bonus miscalculation

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -499,8 +499,10 @@
       :abilities [ability]})
 
    "Industrial Genomics: Growing Solutions"
-   {:events {:pre-trash {:effect (effect (trash-cost-bonus
-                                           (count (filter #(not (:seen %)) (:discard corp)))))}}}
+   {:events
+    {:pre-trash
+     {:effect
+      (effect (trash-cost-bonus (count (remove #(:seen %) (:discard corp)))))}}}
 
    "Information Dynamics: All You Need To Know"
    {:events (let [inf {:req (req (and (not (:disabled card))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -34,8 +34,7 @@
 
 ;;; Card definitions
 (def card-definitions
-  {
-   "419: Amoral Scammer"
+  {"419: Amoral Scammer"
    {:events {:corp-install
              {:delayed-completion true
               :req (req (and (first-event? state :corp :corp-install)
@@ -499,10 +498,8 @@
       :abilities [ability]})
 
    "Industrial Genomics: Growing Solutions"
-   {:events
-    {:pre-trash
-     {:effect
-      (effect (trash-cost-bonus (count (remove #(:seen %) (:discard corp)))))}}}
+   {:events {:pre-trash {:effect (effect (trash-cost-bonus
+                                           (count (remove #(:seen %) (:discard corp)))))}}}
 
    "Information Dynamics: All You Need To Know"
    {:events (let [inf {:req (req (and (not (:disabled card))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1014,15 +1014,12 @@
     :choices {:req #(and (rezzed? %)
                          (or (is-type? % "Asset")
                              (is-type? % "Upgrade")))}
-    :effect (req (let [c target]
-                   (swap! state update-in [:bonus] dissoc :trash)
-                   (trigger-event state side :pre-trash c)
-                   (let [tcost (trash-cost state side c)]
-                     (trash state side c)
-                     (gain-credits state :corp tcost)
-                     (system-msg state side (str "uses Product Recall to trash " (card-str state c)
-                                                 " and gain " tcost "[Credits]"))
-                     (effect-completed state side eid card))))}
+    :effect (req (let [tcost (modified-trash-cost state side target)]
+                   (trash state side target)
+                   (gain-credits state :corp tcost)
+                   (system-msg state side (str "uses Product Recall to trash " (card-str state target)
+                                               " and gain " tcost "[Credits]"))
+                   (effect-completed state side eid card)))}
 
    "Psychographics"
    {:req (req tagged)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1012,16 +1012,16 @@
    "Product Recall"
    {:prompt "Select a rezzed asset or upgrade to trash"
     :choices {:req #(and (rezzed? %)
-                         (or (is-type? % "Asset") (is-type? % "Upgrade")))}
+                         (or (is-type? % "Asset")
+                             (is-type? % "Upgrade")))}
     :effect (req (let [c target]
+                   (swap! state update-in [:bonus] dissoc :trash)
                    (trigger-event state side :pre-trash c)
                    (let [tcost (trash-cost state side c)]
                      (trash state side c)
                      (gain-credits state :corp tcost)
-                     (resolve-ability state side
-                       {:msg (msg "trash " (card-str state c) " and gain " tcost " [Credits]")}
-                      card nil)
-                     (swap! state update-in [:bonus] dissoc :trash)
+                     (system-msg state side (str "uses Product Recall to trash " (card-str state c)
+                                                 " and gain " tcost "[Credits]"))
                      (effect-completed state side eid card))))}
 
    "Psychographics"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1010,16 +1010,17 @@
       :effect (effect (continue-ability (install-card target) card nil))})
 
    "Product Recall"
-   {:prompt "Select a rezzed asset or upgrade to trash"
+   {:delayed-completion true
+    :prompt "Select a rezzed asset or upgrade to trash"
     :choices {:req #(and (rezzed? %)
                          (or (is-type? % "Asset")
                              (is-type? % "Upgrade")))}
     :effect (req (let [tcost (modified-trash-cost state side target)]
-                   (trash state side target)
-                   (gain-credits state :corp tcost)
-                   (system-msg state side (str "uses Product Recall to trash " (card-str state target)
-                                               " and gain " tcost "[Credits]"))
-                   (effect-completed state side eid card)))}
+                   (when-completed (trash state side target {:unpreventable true})
+                                   (do (gain-credits state :corp tcost)
+                                       (system-msg state side (str "uses Product Recall to trash " (card-str state target)
+                                                                   " and gain " tcost "[Credits]"))
+                                        (effect-completed state side eid)))))}
 
    "Psychographics"
    {:req (req tagged)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1441,19 +1441,17 @@
    "Political Operative"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
     :abilities [{:prompt "Select a rezzed card with a trash cost"
-                 :choices {:req #(and (:trash %) (rezzed? %))}
-                 :effect (req (let [c target]
-                                (trigger-event state side :pre-trash c)
-                                (let [cost (trash-cost state :runner c)]
-                                  (when (can-pay? state side nil [:credit cost])
-                                    (resolve-ability
-                                      state side
-                                      {:msg (msg "pay " cost " [Credit] and trash " (:title c))
-                                       :effect (effect (lose-credits cost)
-                                                       (trash card {:cause :ability-cost})
-                                                       (trash c))}
-                                     card nil)))
-                                (swap! state update-in [:bonus] dissoc :trash)))}]}
+                 :choices {:req #(and (:trash %)
+                                      (rezzed? %))}
+                 :effect (req (let [cost (modified-trash-cost state :runner target)]
+                                (when (can-pay? state side nil [:credit cost])
+                                  (resolve-ability
+                                    state side
+                                    {:msg (msg "pay " cost " [Credit] and trash " (:title target))
+                                     :effect (effect (lose-credits cost)
+                                                     (trash card {:cause :ability-cost})
+                                                     (trash target))}
+                                    card nil))))}]}
 
    "Power Tap"
    {:events {:trace {:successful {:msg "gain 1 [Credits]"

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -308,6 +308,16 @@
         (+ (get-in @state [:bonus :trash] 0))
         (max 0))))
 
+(defn modified-trash-cost
+  "Returns the numbe of credits required to trash the given card, after modification effects.
+  Allows cards like Product Recall to pre-calculate trash costs without manually triggering the effects."
+  [state side card]
+  (swap! state update-in [:bonus] dissoc :trash)
+  (trigger-event state side :pre-trash card)
+  (let [tcost (trash-cost state side card)]
+    (swap! state update-in [:bonus] dissoc :trash)
+    tcost))
+
 (defn install-cost-bonus [state side n]
   (swap! state update-in [:bonus :install-cost] #(merge-costs (concat % n))))
 

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -745,21 +745,44 @@
 
 (deftest industrial-genomics:-growing-solutions
   ;; Industrial Genomics - Increase trash cost
-  (do-game
-    (new-game
-      (make-deck "Industrial Genomics: Growing Solutions" [(qty "PAD Campaign" 3)
-                                                           (qty "Hedge Fund" 3)])
-      (default-runner))
-    (play-from-hand state :corp "PAD Campaign" "New remote")
-    (trash-from-hand state :corp "PAD Campaign")
-    (trash-from-hand state :corp "PAD Campaign")
-    (trash-from-hand state :corp "Hedge Fund")
-    (trash-from-hand state :corp "Hedge Fund")
-    (let [pad (get-content state :remote1 0)]
-      (core/rez state :corp pad)
-      (take-credits state :corp)
-      (run-empty-server state "Server 1")
-      (is (= 8 (core/trash-cost state :runner (refresh pad)))))))
+  (testing "Basic test"
+    (do-game
+      (new-game
+        (make-deck "Industrial Genomics: Growing Solutions"
+                   [(qty "PAD Campaign" 3) (qty "Hedge Fund" 3)])
+        (default-runner))
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (trash-from-hand state :corp "PAD Campaign")
+      (trash-from-hand state :corp "PAD Campaign")
+      (trash-from-hand state :corp "Hedge Fund")
+      (trash-from-hand state :corp "Hedge Fund")
+      (let [pad (get-content state :remote1 0)]
+        (core/rez state :corp pad)
+        (take-credits state :corp)
+        (run-empty-server state "Server 1")
+        (is (= 8 (core/trash-cost state :runner (refresh pad)))))))
+  (testing "with Product Recall"
+    (do-game
+      (new-game
+        (make-deck "Industrial Genomics: Growing Solutions"
+                   ["Product Recall" (qty "PAD Campaign" 3) (qty "Hedge Fund" 2)])
+        (default-runner))
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (trash-from-hand state :corp "PAD Campaign")
+      (trash-from-hand state :corp "PAD Campaign")
+      (trash-from-hand state :corp "Hedge Fund")
+      (trash-from-hand state :corp "Hedge Fund")
+      (let [pad (get-content state :remote1 0)]
+        (core/rez state :corp pad)
+        (take-credits state :corp)
+        (run-empty-server state "Server 1")
+        (is (= 8 (core/trash-cost state :runner (refresh pad))))
+        (run-jack-out state)
+        (take-credits state :runner)
+        (play-from-hand state :corp "Product Recall")
+        (let [credits (:credit (get-corp))]
+          (prompt-select :corp pad)
+          (is (= (+ credits 8) (:credit (get-corp))) "Gain 8 credits from trashing PAD Campaign"))))))
 
 (deftest jemison-astronautics:-sacrifice.-audacity.-success.
   ;; Jemison Astronautics - Place advancements when forfeiting agendas


### PR DESCRIPTION
Product Recall was clearing the trash bonus at the end of the effect instead of at the beginning, which caused lingering trash cost bonuses to be rolled into the new calculations when `:pre-trash` was triggered within the card effect.

This fixes that bug and adds a test to handle the case.

Fixes #3560