### PR TITLE
FIX: :no-trash-or-steal shouldn't increment in Archives

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -46,7 +46,7 @@
     (trigger-event state side :no-steal c))
   (when (and (get-card state c)
              ;; Don't increment :no-trash-or-steal if accessing a card in Archives
-             (not (find-cid (:cid c) (get-in @state [:corp :discard]))))
+             (not= (:zone c) [:discard]))
     (swap! state update-in [:runner :register :no-trash-or-steal] (fnil inc 0)))
   (trigger-event-sync state side eid :post-access-card c))
 

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -44,7 +44,9 @@
   (when (and (is-type? c "Agenda")
              (not (find-cid (:cid c) (get-in @state [:runner :scored]))))
     (trigger-event state side :no-steal c))
-  (when (get-card state c)
+  (when (and (get-card state c)
+             ;; Don't increment :no-trash-or-steal if accessing a card in Archives
+             (not (find-cid (:cid c) (get-in @state [:corp :discard]))))
     (swap! state update-in [:runner :register :no-trash-or-steal] (fnil inc 0)))
   (trigger-event-sync state side eid :post-access-card c))
 

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -604,7 +604,7 @@
       (run-empty-server state :remote1)
       (prompt-choice :runner "Steal")
       (is (zero? (count (:discard (get-corp)))) "No HQ card in discard as agenda was stolen")))
-  (testing "Maw shouldn't trigger when accessing a card in archives"
+  (testing "Maw shouldn't trigger when accessing a card in archives. #3388"
     (do-game
       (new-game (default-corp ["Rashida Jaheem" "Cyberdex Virus Suite" (qty "Ice Wall" 4)])
                 (make-deck "Alice Merchant: Clan Agitator" ["Maw" "Imp"]))
@@ -620,7 +620,25 @@
       (prompt-choice :corp "Yes")
       (run-empty-server state :rd)
       (prompt-choice-partial :runner "Pay")
-      (is (= 3 (count (:discard (get-corp)))) "Ice Wall, CVS, and Rashida"))))
+      (is (= 3 (count (:discard (get-corp)))) "Ice Wall, CVS, and Rashida")))
+ (testing "Maw should trigger when declining to steal. #3388"
+    (do-game
+      (new-game (default-corp [(qty "Obokata Protocol" 2) (qty "Ice Wall" 4)])
+                (make-deck "Alice Merchant: Clan Agitator" ["Maw" "Archives Interface"]))
+      (trash-from-hand state :corp "Ice Wall")
+      (starting-hand state :corp ["Obokata Protocol" "Obokata Protocol"])
+      (take-credits state :corp)
+      (core/gain state :runner :credit 100)
+      (play-from-hand state :runner "Maw")
+      (play-from-hand state :runner "Archives Interface")
+      (run-empty-server state :archives)
+      (prompt-card :corp (find-card "Obokata Protocol" (:hand (get-corp))))
+      (prompt-choice :runner "Yes")
+      (prompt-card :runner (find-card "Ice Wall" (:discard (get-corp))))
+      (prompt-choice :runner "No action")
+      (run-empty-server state :hq)
+      (prompt-choice :runner "No action")
+      (is (= 2 (count (:discard (get-corp)))) "Ice Wall and Obokata"))))
 
 (deftest maya
   ;; Maya - Move accessed card to bottom of R&D

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -615,12 +615,13 @@
       (play-from-hand state :runner "Maw")
       (play-from-hand state :runner "Imp")
       (run-empty-server state :archives)
-      (prompt-card :corp (find-card "Ice Wall" (:hand (get-corp))))
+      (prompt-card :corp (find-card "Ice Wall" (:hand (get-corp)))) ;; Alice's ability
       (prompt-choice :runner "Cyberdex Virus Suite")
       (prompt-choice :corp "Yes")
       (run-empty-server state :rd)
       (prompt-choice-partial :runner "Pay")
-      (is (= 3 (count (:discard (get-corp)))) "Ice Wall, CVS, and Rashida")))
+      (is (= 3 (count (:discard (get-corp)))) "Ice Wall, CVS, and Rashida")
+      (is (empty? (:prompt (get-runner))) "No more prompts for runner")))
  (testing "Maw should trigger when declining to steal. #3388"
     (do-game
       (new-game (default-corp [(qty "Obokata Protocol" 2) (qty "Ice Wall" 4)])

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -603,7 +603,24 @@
       (play-from-hand state :runner "Maw")
       (run-empty-server state :remote1)
       (prompt-choice :runner "Steal")
-      (is (zero? (count (:discard (get-corp)))) "No HQ card in discard as agenda was stolen"))))
+      (is (zero? (count (:discard (get-corp)))) "No HQ card in discard as agenda was stolen")))
+  (testing "Maw shouldn't trigger when accessing a card in archives"
+    (do-game
+      (new-game (default-corp ["Rashida Jaheem" "Cyberdex Virus Suite" (qty "Ice Wall" 4)])
+                (make-deck "Alice Merchant: Clan Agitator" ["Maw" "Imp"]))
+      (core/move state :corp (find-card "Rashida Jaheem" (:hand (get-corp))) :deck)
+      (trash-from-hand state :corp "Cyberdex Virus Suite")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 100)
+      (play-from-hand state :runner "Maw")
+      (play-from-hand state :runner "Imp")
+      (run-empty-server state :archives)
+      (prompt-card :corp (find-card "Ice Wall" (:hand (get-corp))))
+      (prompt-choice :runner "Cyberdex Virus Suite")
+      (prompt-choice :corp "Yes")
+      (run-empty-server state :rd)
+      (prompt-choice-partial :runner "Pay")
+      (is (= 3 (count (:discard (get-corp)))) "Ice Wall, CVS, and Rashida"))))
 
 (deftest maya
   ;; Maya - Move accessed card to bottom of R&D


### PR DESCRIPTION
We were incrementing `:no-trash-or-steal` when accessing cards in Archives, and while I could hear an argument for it needing to increment in that case because you can technically decline to steal agendas in Archives with additional steal costs, this system only exists for Maw and I'm only interested in fixing it right now.

Fixes #3388 