### PR TITLE
FIX: Marilyn Campaign regression

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -950,11 +950,10 @@
                   :label (str "Gain 2 [Credits] (start of turn)")
                   :delayed-completion true
                   :effect (req (gain-credits state :corp 2)
-                               (when (zero? (get-counters (get-card state card) :credit))
+                               (if (zero? (get-counters (get-card state card) :credit))
                                  (trash state :corp eid card {:unpreventable true})
                                  (effect-completed state :corp eid)))}]
      {:effect (effect (add-counter card :credit 8))
-      :flags {:corp-phase-12 (req (= 2 (get-counters card :credit)))}
       :derezzed-events {:runner-turn-ends corp-rez-toast}
       :events {:corp-turn-begins ability}
       :trash-effect {:req (req (= :servers (first (:previous-zone card))))

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -2025,12 +2025,10 @@
       (is (= 2 (get-counters (refresh marilyn) :credit)) "Marilyn Campaign should lose 2 credits start of turn")
       (take-credits state :corp)
       (take-credits state :runner)
-      (is (:corp-phase-12 @state) "Corp is in Step 1.2")
-      (core/end-phase-12 state :corp nil)
       (is (zero? (get-counters (refresh marilyn) :credit)) "Marilyn Campaign should lose 2 credits start of turn")
       (prompt-choice :corp "Yes")
-      (is (= 1 (-> (get-corp) :deck count)) "R&D should have 1 card in it")
-      (is (= "Marilyn Campaign" (-> (get-corp) :deck first :title)) "Marilyn Campaign should be in R&D"))))
+      (is (= 1 (-> (get-corp) :hand count)) "HQ should have 1 card in it, after mandatory draw")
+      (is (= "Marilyn Campaign" (-> (get-corp) :hand first :title)) "Marilyn Campaign should be in HQ, after mandatory draw"))))
 
 (deftest mark-yale
   ;; Mark Yale


### PR DESCRIPTION
Marilyn Campaign never called `(effect-completed)` during `:corp-phase-12` because the `if` was overwritten by the older `when` in the course of converting from the old `(get-in card [:counter :credit])` system to the newer `(get-counters card :credit)` system.

Fixes #3585 