### PR TITLE
FIX: Mti + Kakugo

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -717,15 +717,9 @@
                  :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
                  :choices {:req #(and (ice? %)
                                       (in-hand? %))}
-                 :effect (req (let [server (first (:server run))
-                                    newice (assoc target :zone [:servers server :ices])
-                                    newices (vec (concat [newice] run-ices))]
-                                (swap! state assoc-in [:corp :servers server :ices] newices)
-                                (swap! state update-in (cons :corp (:zone target))
-                                       (fn [coll] (remove-once #(= (:cid %) (:cid target)) coll)))
-                                (card-init state side newice {:resolve-effect false :init-data true})
-                                (trigger-event state side :corp-install newice)
-                                (swap! state assoc-in [:run :position] 1)))}]}
+                 :effect (req (corp-install state side target (:server run) {:no-install-cost true
+                                                                             :front true})
+                              (swap! state assoc-in [:run :position] 1))}]}
 
    "Nasir Meidan: Cyber Explorer"
    {:events {:rez {:req (req (and (:run @state)

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -115,8 +115,8 @@
              moved-card (if (and (= (first (:zone moved-card)) :scored) (card-flag? moved-card :has-abilities-when-stolen true))
                           (merge moved-card {:abilities (:abilities (card-def moved-card))}) moved-card)]
          (if front
-           (swap! state update-in (cons side dest) #(cons moved-card (vec %)))
-           (swap! state update-in (cons side dest) #(conj (vec %) moved-card)))
+           (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))
+           (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card))))
          (doseq [s [:runner :corp]]
            (if host
              (remove-from-host state side card)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -204,7 +204,7 @@
 (defn- corp-install-continue
   "Used by corp-install to actually install the card, rez it if it's supposed to be installed
   rezzed, and calls :corp-install in an awaitable fashion."
-  [state side eid card server {:keys [install-state host-card] :as args} slot cost-str]
+  [state side eid card server {:keys [install-state host-card front] :as args} slot cost-str]
   (let [cdef (card-def card)
         dest-zone (get-in @state (cons :corp slot))
         install-state (or install-state (:install-state cdef))
@@ -218,7 +218,7 @@
 
     (let [moved-card (if host-card
                        (host state side host-card (assoc c :installed true))
-                       (move state side c slot))]
+                       (move state side c slot {:front front}))]
       (when (is-type? c "Agenda")
         (update-advancement-cost state side moved-card))
 

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1193,7 +1193,22 @@
       (prompt-select :corp (find-card "Enigma" (:hand (get-corp))))
       (is (= 1 (get-in @state [:run :position])) "Now approaching new ice")
       (is (= "Enigma" (:title (get-ice state :rd 0))) "Enigma was installed")
-      (is (empty? (:hand (get-corp))) "Enigma removed from HQ"))))
+      (is (empty? (:hand (get-corp))) "Enigma removed from HQ")))
+  (testing "with Kakugo, passing shouldn't fire net damage twice. #3588"
+    (do-game
+      (new-game (make-deck "Mti Mwekundu: Life Improved" ["Kakugo"])
+                (default-runner))
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (is (zero? (get-in @state [:run :position])) "Initial position approaching server")
+      (card-ability state :corp (get-in @state [:corp :identity]) 0)
+      (prompt-select :corp (find-card "Kakugo" (:hand (get-corp))))
+      (is (= 1 (get-in @state [:run :position])) "Now approaching new ice")
+      (is (= "Kakugo" (:title (get-ice state :hq 0))) "Kakugo was installed")
+      (is (empty? (:hand (get-corp))) "Kakugo removed from HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (is (= 1 (-> (get-runner) :discard count)) "Runner should take 1 net damage from Kakugo"))))
 
 (deftest nasir-meidan:-cyber-explorer
   ;; Nasir


### PR DESCRIPTION
Rewrites Mti Mwekundu to use `corp-install`, adds functionality to `corp-install` to handle placing a piece of ice at the innermost position, and adds a test to verify Kakugo only fires the one time.

Fixes #3588 