### PR TITLE
Updates Surveyor and Seidr Adaptive Barrier

### DIFF
--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -46,7 +46,8 @@
 (defn update-ice-strength
   "Updates the given ice's strength by triggering strength events and updating the card."
   [state side ice]
-  (let [ice (get-card state ice) oldstren (or (:current-strength ice) (:strength ice))]
+  (let [ice (get-card state ice)
+        oldstren (or (:current-strength ice) (:strength ice))]
     (when (:rezzed ice)
       (swap! state update-in [:bonus] dissoc :ice-strength)
       (trigger-event state side :pre-ice-strength ice)

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1141,7 +1141,9 @@
       (play-from-hand state :corp "Ice Wall" "HQ")
       (is (= 4 (:current-strength (refresh sab))) "+2 strength for 2 pieces of ICE")
       (play-from-hand state :corp "Ice Wall" "HQ")
-      (is (= 5 (:current-strength (refresh sab))) "+3 strength for 3 pieces of ICE"))))
+      (is (= 5 (:current-strength (refresh sab))) "+3 strength for 3 pieces of ICE")
+      (core/move-card state :corp {:card (get-ice state :hq 1) :server "Archives"})
+      (is (= 4 (:current-strength (refresh sab))) "+2 strength for 2 pieces of ICE"))))
 
 (deftest self-adapting-code-wall
   ;; Self-Adapting Code Wall
@@ -1316,7 +1318,9 @@
       (is (= 6 (-> (get-corp) :prompt first :base)) "Trace should be base 6")
       (prompt-choice :corp 0)
       (prompt-choice :runner 6)
-      (is (= 2 (:tag (get-runner))) "Runner did not take tags from Surveyor Trace 6 with boost 6"))))
+      (is (= 2 (:tag (get-runner))) "Runner did not take tags from Surveyor Trace 6 with boost 6")
+      (core/move-card state :corp {:card (get-ice state :hq 1) :server "Archives"})
+      (is (= 4 (:current-strength (refresh surv))) "Surveyor has 4 strength for 2 pieces of ICE"))))
 
 (deftest tithonium
   ;; Forfeit option as rez cost, can have hosted condition counters


### PR DESCRIPTION
Uses relevant events instead of a watch state to manage own strength.

Fixes comment made in #3287.