### PR TITLE
FIX: Better Citizen Program

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -214,16 +214,27 @@
         :interactive (req true)}))
 
    "Better Citizen Program"
-   {:events {:play-event {:req (req (first-event? state :runner :run))
-                          :delayed-completion true
-                          :msg "give the Runner a tag for playing a run event"
-                          :effect (effect (tag-runner :runner eid 1))}
-             :runner-install {:silent (req true)
-                              :req (req (and (has-subtype? target "Icebreaker")
-                                             (first-event? state :runner :runner-install #(has-subtype? (first %) "Icebreaker"))))
-                              :delayed-completion true
-                              :msg "give the Runner a tag for installing an icebreaker"
-                              :effect (effect (tag-runner :runner eid 1))}}}
+   (letfn [(ability [kind]
+             (effect (show-wait-prompt :runner "Corp to use Better Citizen Program")
+                     (continue-ability
+                       :corp
+                       {:optional
+                        {:prompt "Give the runner 1 tag?"
+                         :yes-ability {:msg (str "give the Runner a tag for " kind)
+                                       :effect (req (swap! state assoc-in [:per-turn (:cid card)] true)
+                                                    (tag-runner state :runner eid 1))}
+                         :end-effect (effect (clear-wait-prompt :runner))}}
+                       card nil)))]
+    {:events {:play-event {:req (req (and (first-event? state :runner :run)
+                                          (not (used-this-turn? (:cid card) state))))
+                           :delayed-completion true
+                           :effect (ability "playing a run event")}
+              :runner-install {:silent (req true)
+                               :req (req (and (has-subtype? target "Icebreaker")
+                                              (first-event? state :runner :runner-install #(has-subtype? (first %) "Icebreaker"))
+                                              (not (used-this-turn? (:cid card) state))))
+                               :delayed-completion true
+                               :effect (ability "installing an icebreaker")}}})
 
    "Bifrost Array"
    {:req (req (not (empty? (filter #(not= (:title %)

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -220,7 +220,8 @@
                        :corp
                        {:optional
                         {:prompt "Give the runner 1 tag?"
-                         :yes-ability {:msg (str "give the Runner a tag for " kind)
+                         :yes-ability {:delayed-completion true
+                                       :msg (str "give the Runner a tag for " kind)
                                        :effect (req (swap! state assoc-in [:per-turn (:cid card)] true)
                                                     (tag-runner state :runner eid 1))}
                          :end-effect (effect (clear-wait-prompt :runner))}}

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -271,6 +271,33 @@
       (is (empty (:prompt (get-runner))) "Bacterial Programming prompts finished")
       (is (not (:run @state))))))
 
+(deftest better-citizen-program
+  ;; Better Citizen Program
+  (do-game
+    (new-game (default-corp ["Better Citizen Program"])
+              (default-runner [(qty "The Maker's Eye" 2)
+                               (qty "Wyrm" 2)]))
+    (play-and-score state "Better Citizen Program")
+    (take-credits state :corp)
+    (core/gain state :runner :credit 10)
+    (is (zero? (:tag (get-runner))) "Runner starts with 0 tags")
+    (play-from-hand state :runner "The Maker's Eye")
+    (prompt-choice :corp "Yes")
+    (is (= 1 (:tag (get-runner))) "Runner takes 1 tag for playing a Run event")
+    (run-successful state)
+    (play-from-hand state :runner "Wyrm")
+    (is (empty? (-> (get-corp) :prompt)) "Corp shouldn't get a prompt to use Better Citizen Program")
+    (is (= 1 (:tag (get-runner))) "Runner doesn't gain a tag from installing an icebreaker after playing a Run event")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (play-from-hand state :runner "Wyrm")
+    (prompt-choice :corp "Yes")
+    (is (= 2 (:tag (get-runner))) "Runner gains 1 tag for installing an Icebreaker")
+    (play-from-hand state :runner "The Maker's Eye")
+    (is (empty? (-> (get-corp) :prompt)) "Corp shouldn't get a prompt to use Better Citizen Program")
+    (is (= 2 (:tag (get-runner))) "Runner doesn't gain a tag from playing a Run event after installing an Icebreaker")
+    (run-successful state)))
+
 (deftest bifrost-array
   ;; Bifrost Array
   (do-game


### PR DESCRIPTION
Better Citizen Program was firing once for both installing an icebreaker and playing a run event, instead of once whichever came first. This fix also moved BCP to be an optional ability, mirroring the card text and allowing for situations where the corp might not want to give the runner another tag (Counter-Surveillance, etc).

Fixes #3602 