### PR TITLE
FIX: PAD Tap missing trash message

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1330,12 +1330,13 @@
                              (= 1 (->> (turn-events state :corp :corp-credit-gain)
                                        (remove #(= (first %) :corp-click-credit))
                                        count))))
-              :msg "gain 1[Credits] from PAD Tap"
+              :msg "gain 1 [Credits]"
               :effect (effect (gain-credits :runner 1))}}
     :corp-abilities [{:label "Trash PAD Tap"
                       :cost [:credit 3 :click 1]
                       :req (req (= :corp side))
-                      :effect (effect (trash :corp card))}]}
+                      :effect (effect (system-msg :corp "trashes PAD Tap")
+                                      (trash :corp card))}]}
 
    "Paige Piper"
    (letfn [(pphelper [title cards]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1335,7 +1335,7 @@
     :corp-abilities [{:label "Trash PAD Tap"
                       :cost [:credit 3 :click 1]
                       :req (req (= :corp side))
-                      :effect (effect (system-msg :corp "trashes PAD Tap")
+                      :effect (effect (system-msg :corp "spends [Click] and 3 [Credits] to trash PAD Tap")
                                       (trash :corp card))}]}
 
    "Paige Piper"


### PR DESCRIPTION
Adds a message to when the corp trashes PAD Tap.

Fixes #3600 