### PR TITLE
FIX: The Turning Wheel granting accesses across runs

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1943,6 +1943,11 @@
    "The Turning Wheel"
    {:events {:agenda-stolen {:effect (effect (update! (assoc card :agenda-stolen true)))
                              :silent (req true)}
+             :pre-access {:req (req (and (pos? (get-in @state [:run :ttw-bonus] 0))
+                                         (:run @state)
+                                         (not (#{:hq :rd} target))))
+                          :effect (effect (access-bonus (- (get-in @state [:run :ttw-bonus] 0))))
+                          :silent (req true)}
              :run-ends {:effect (req (when (and (not (:agenda-stolen card))
                                                 (#{:hq :rd} target))
                                        (add-counter state side card :power 1)
@@ -1952,12 +1957,8 @@
     :abilities [{:counter-cost [:power 2]
                  :req (req (:run @state))
                  :msg "access 1 additional card from HQ or R&D for the remainder of the run"
-                 :effect  (req (swap! state update-in [:run :ttw-spent] (fnil inc 0))
-                               (register-events state side
-                                                {:pre-access {:req (req (and (get-in @state [:run :ttw-spent]) (#{:hq :rd} target)))
-                                                              :effect (effect (access-bonus 1)
-                                                                              (unregister-events #(find-latest state card) {:events {:pre-access nil}}))
-                                                              :silent (req true)}} #(find-latest state card)))}]}
+                 :effect  (req (swap! state update-in [:run :ttw-bonus] (fnil inc 0))
+                               (access-bonus state side 1))}]}
 
    "Theophilius Bagbiter"
    {:effect (req (lose-credits :runner :all)

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -2444,6 +2444,74 @@
       (is (= 9 (:credit (get-runner))) "Gained 4cr")
       (is (= 12 (get-counters (get-resource state 0) :credit)) "Temjin has 12 credits remaining"))))
 
+(deftest the-turning-wheel
+  ;; The Turning Wheel
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover" "Ice Wall" "Ice Wall"])
+                (default-runner ["The Turning Wheel"]))
+      (core/move state :corp (find-card "Ice Wall" (:hand (get-corp))) :deck)
+      (core/move state :corp (find-card "Hostile Takeover" (:hand (get-corp))) :deck)
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Turning Wheel")
+      (core/gain state :runner :click 10 :credit 10)
+      (let [ttw (get-resource state 0)]
+        (run-empty-server state "R&D")
+        (prompt-choice :runner "No action")
+        (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel should gain 1 counter")
+        (run-empty-server state "R&D")
+        (prompt-choice :runner "No action")
+        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel should gain 1 counter")
+        (run-on state "R&D")
+        (card-ability state :runner ttw 0)
+        (is (zero? (get-counters (refresh ttw) :power)) "Using The Turning Wheel ability costs 2 counters")
+        (is (= 1 (-> @state :run :access-bonus)) "Runner should access 1 additional card"))))
+  (testing "Access bonus shouldn't carry over to other runs if prematurely ended after spending TTW counters. #3598"
+    (do-game
+      (new-game (default-corp ["Nisei MK II"])
+                (default-runner ["The Turning Wheel"]))
+      (play-and-score state "Nisei MK II")
+      (is (= 1 (get-counters (get-scored state :corp 0) :agenda)))
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Turning Wheel")
+      (core/gain state :runner :click 10 :credit 10)
+      (let [nisei (get-scored state :corp 0)
+            ttw (get-resource state 0)]
+        (run-empty-server state "HQ")
+        (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel should gain 1 counter")
+        (run-empty-server state "HQ")
+        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel should gain 1 counter")
+        (run-on state "R&D")
+        (card-ability state :runner ttw 0)
+        (is (zero? (get-counters (refresh ttw) :power)) "Using The Turning Wheel ability costs 2 counters")
+        (is (= 1 (-> @state :run :access-bonus)) "Runner should access 1 additional card")
+        (card-ability state :corp nisei 0)
+        (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel should gain 1 counter from corp using Nisei counter")
+        (run-on state "R&D")
+        (is (zero? (-> @ state :run :access-bonus)) "Access bonus should be reset on new run"))))
+  (testing "Spending counters shouldn't increase accesses when running a non-R&D/HQ server"
+    (do-game
+      (new-game (default-corp ["Hostile Takeover" "Ice Wall"])
+                (default-runner ["The Turning Wheel"]))
+      (core/move state :corp (find-card "Ice Wall" (:hand (get-corp))) :deck)
+      (trash-from-hand state :corp "Hostile Takeover")
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Turning Wheel")
+      (core/gain state :runner :click 10 :credit 10)
+      (let [ttw (get-resource state 0)]
+        (run-empty-server state "R&D")
+        (prompt-choice :runner "No action")
+        (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel should gain 1 counter")
+        (run-empty-server state "R&D")
+        (prompt-choice :runner "No action")
+        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel should gain 1 counter")
+        (run-on state "Archives")
+        (card-ability state :runner ttw 0)
+        (is (zero? (get-counters (refresh ttw) :power)) "Using The Turning Wheel ability costs 2 counters")
+        (is (= 1 (-> @state :run :access-bonus)) "Runner should access 1 additional card")
+        (run-successful state)
+        (is (zero? (-> @state :run :access-bonus)) "Access bonuses are zeroed out when attacked server isn't R&D or HQ")))))
+
 (deftest tri-maf-contact
   ;; Tri-maf Contact - Click for 2c once per turn; take 3 meat dmg when trashed
   (do-game


### PR DESCRIPTION
Because the `register-event` only cancelled the access-bonus if the run was successful, it would persist across runs. This fixes it to remove any access-bonuses if the run ends or the attacked server isn't R&D or HQ. Adds tests to handle various cases as well.

Fixes #3598 