### PR TITLE
FIX: Jua and side-based install-locks

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1154,7 +1154,7 @@
    "Jua"
    {:implementation "Encounter effect is manual"
     :abilities [{:msg "prevent the Runner from installing cards for the rest of the turn"
-                 :effect (effect (register-turn-flag! card :lock-install (constantly true)))}]
+                 :effect (effect (register-turn-flag! card :runner-lock-install (constantly true)))}]
     :subroutines [{:label "Choose 2 installed Runner cards, if able. The Runner must add 1 of those to the top of the Stack."
                    :req (req (>= (count (all-installed state :runner)) 2))
                    :delayed-completion true

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -199,7 +199,7 @@
   (let [install-prompt {:req (req (and (= (:zone card) [:discard])
                                        (rezzed? current-ice)
                                        (has-subtype? current-ice ice-type)
-                                       (not (install-locked? state side))))
+                                       (not (install-locked? state :runner))))
                         :delayed-completion true
                         :effect (effect (continue-ability
                                           {:optional {:req (req (and (not-any? #(= title (:title %)) (all-active-installed state :runner))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -884,14 +884,10 @@
                  :msg (msg "prevent cards being installed until the end of the run")
                  :req (req this-server)
                  :effect (effect (trash (get-card state card) {:cause :ability-cost}))}]
-    :trash-effect {:effect (effect (lock-install (:cid card) :runner)
-                                   (lock-install (:cid card) :corp)
+    :trash-effect {:effect (effect (register-run-flag! card :corp-lock-install (constantly true))
+                                   (register-run-flag! card :runner-lock-install (constantly true))
                                    (toast :runner "Cannot install until the end of the run")
-                                   (toast :corp "Cannot install until the end of the run")
-                                   (register-events {:run-ends {:effect (effect (unlock-install (:cid card) :runner)
-                                                                                (unlock-install (:cid card) :corp)
-                                                                                (unregister-events card))}}
-                                                    (assoc card :zone '(:discard))))}
+                                   (toast :corp "Cannot install until the end of the run"))}
     :events {:run-ends nil}}
 
    "Simone Diego"

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -201,12 +201,6 @@
 (defn release-zone [state side cid tside tzone]
   (swap! state update-in [tside :locked tzone] #(remove #{cid} %)))
 
-(defn lock-install [state side cid tside]
-  (swap! state update-in [tside :lock-install] #(conj % cid)))
-
-(defn unlock-install [state side cid tside]
-  (swap! state update-in [tside :lock-install] #(remove #{cid} %)))
-
 ;;; Small utilities for card properties.
 (defn in-server?
   "Checks if the specified card is installed in -- and not PROTECTING -- a server"
@@ -312,9 +306,10 @@
 (defn install-locked?
   "Checks if installing is locked"
   [state side]
-  (or (seq (get-in @state [side :lock-install]))
-      (seq (get-in @state [:stack :current-turn :lock-install]))
-      (seq (get-in @state [:stack :persistent :lock-install]))))
+  (let [kw (keyword (str (name side) "-lock-install"))]
+    (or (seq (get-in @state [:stack :current-run kw]))
+        (seq (get-in @state [:stack :current-turn kw]))
+        (seq (get-in @state [:stack :persistent kw])))))
 
 (defn- can-rez-reason
   "Checks if the corp can rez the card.

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -133,7 +133,7 @@
          (not (turn-flag? state side card :can-install-ice)))
     :ice
     ;; Installing not locked
-    (install-locked? state side) :lock-install
+    (install-locked? state :corp) :lock-install
     ;; no restrictions
     :default true))
 
@@ -337,7 +337,7 @@
            (some #(has-subtype? % "Console") (all-active-installed state :runner)))
       :console
       ;; Installing not locked
-      (install-locked? state side) :lock-install
+      (install-locked? state :runner) :lock-install
       ;; Uniqueness check
       (and uniqueness (in-play? state card)) :unique
       ;; Req check
@@ -401,7 +401,7 @@
   ([state side card params] (runner-install state side (make-eid state) card params))
   ([state side eid card {:keys [host-card facedown no-mu] :as params}]
    (if (and (empty? (get-in @state [side :locked (-> card :zone first)]))
-            (not (seq (get-in @state [:runner :lock-install]))))
+            (not (install-locked? state :runner)))
      (if-let [hosting (and (not host-card) (not facedown) (:hosting (card-def card)))]
        (continue-ability state side
                          {:choices hosting


### PR DESCRIPTION
Previously, `install-locked?` and the associated :lock-install system didn't differentiate between sides, so blocking installs for meant both sides couldn't install, which broke with Jua + Architect or Mti. By refactoring the installation lock system, we can be more specific in which side we mean to lock. Adds a test to verify it works.

Fixes #3613 