### PR TITLE
Clear runner prompt when Daily Business Show completes

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -468,16 +468,17 @@
                                                     (all-installed state :corp)))
                                  drawn (get-in @state [:corp :register :most-recent-drawn])]
                              (show-wait-prompt state :runner "Corp to use Daily Business Show")
-                             (continue-ability
-                               state side
-                               {:prompt (str "Select " (quantify dbs "card") " to add to the bottom of R&D")
-                                :msg (msg "add " (quantify dbs "card") " to the bottom of R&D")
-                                :choices {:max dbs
-                                          :req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
-                                :effect (req (doseq [c targets]
-                                               (move state side c :deck)))
-                                :end-effect (effect (clear-wait-prompt :runner))}
-                               card targets)))}}}
+                             (when-completed (resolve-ability
+                                               state side
+                                               {:prompt (str "Select " (quantify dbs "card") " to add to the bottom of R&D")
+                                                :msg (msg "add " (quantify dbs "card") " to the bottom of R&D")
+                                                :choices {:max dbs
+                                                          :req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
+                                                :effect (req (doseq [c targets]
+                                                               (move state side c :deck)))}
+                                               card targets)
+                                             (do (clear-wait-prompt state :runner)
+                                                 (effect-completed state side eid card)))))}}}
 
    "Dedicated Response Team"
    {:events {:successful-run-ends {:req (req tagged)

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -188,8 +188,8 @@
      (gain state side :click (get-in @state [side :click-per-turn]))
      (when-completed (trigger-event-sync state side (if (= side :corp) :corp-turn-begins :runner-turn-begins))
                      (do (when (= side :corp)
-                           (draw state side)
-                           (trigger-event-simult state side eid :corp-mandatory-draw nil nil))
+                           (when-completed (draw state side 1 nil)
+                                           (trigger-event-simult state side eid :corp-mandatory-draw nil nil)))
 
                          (cond
 

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -739,6 +739,7 @@
       (prompt-select :corp (find-card "Resistor" (:hand (get-corp))))
       (prompt-select :corp (find-card "Product Placement" (:hand (get-corp))))
       (prompt-select :corp (find-card "Breaking News" (:hand (get-corp))))
+      (is (empty? (:prompt (get-runner))) "Runner prompt cleared")
       (is (= 2 (count (:hand (get-corp)))))
       (is (= "Hedge Fund" (:title (first (:hand (get-corp))))))
       (is (= "Jackson Howard" (:title (second (:hand (get-corp))))))
@@ -795,7 +796,24 @@
       (core/rez state :corp (get-content state :remote1 0))
       (core/draw state :corp)
       (is (= 1 (count (:hand (get-corp)))) "DBS did not fire on manual draw")
-      (is (empty? (:prompt (get-corp))) "Corp is not being asked to bury a card with DBS"))))
+      (is (empty? (:prompt (get-corp))) "Corp is not being asked to bury a card with DBS")))
+  (testing "Fire on Runner turn"
+    (do-game
+      (new-game (default-corp ["Daily Business Show" "Hedge Fund"
+                               "Resistor" "Product Placement" "Breaking News"])
+                (default-runner ["Fisk Investment Seminar"]))
+      (starting-hand state :corp ["Daily Business Show"])
+      (play-from-hand state :corp "Daily Business Show" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (is (empty? (:hand (get-corp))) "Corp hand is empty")
+      (play-from-hand state :runner "Fisk Investment Seminar")
+      (is (= 4 (count (:hand (get-corp)))) "Drew an additional card from FIS")
+      (is (not-empty (:prompt (get-runner))) "Runner is waiting for Corp to use DBS")
+      (prompt-select :corp (find-card "Resistor" (:hand (get-corp))))
+      (is (empty? (:prompt (get-runner))) "Runner prompt cleared")
+      (is (= 3 (count (:hand (get-corp))))))))
+
 
 (deftest dedicated-response-team
   ;; Dedicated Response Team - Do 2 meat damage when successful run ends if Runner is tagged


### PR DESCRIPTION
Made the `turn-starts` code wait for the completion of the `draw` event, which triggers `Daily Business Show`.

Fixes #3599