### PR TITLE
FIX: Shiro - Mwanza interaction

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -610,7 +610,6 @@
    "Mwanza City Grid"
    (let [gain-creds {:req (req (and installed
                                     this-server
-                                    (:successful run)
                                     (pos? (:cards-accessed run 0))))
                      :silent (req true)
                      :effect (req (let [cnt (:cards-accessed run)

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1234,37 +1234,61 @@
       (is (= "Gordian Blade" (:title (last (:deck (get-runner))))) "Gordian on bottom of Stack"))))
 
 (deftest shiro
-  ;; Shiro - Full test
-  (do-game
-    (new-game (default-corp ["Shiro" "Caprice Nisei"
-                             "Quandary" "Jackson Howard"])
-              (default-runner ["R&D Interface"]))
-    (starting-hand state :corp ["Shiro"])
-    (play-from-hand state :corp "Shiro" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "R&D Interface")
-    (let [shiro (get-ice state :hq 0)]
-      (run-on state :hq)
-      (core/rez state :corp shiro)
-      (card-subroutine state :corp shiro 0)
-      (prompt-card :corp (find-card "Caprice Nisei" (:deck (get-corp))))
-      (prompt-card :corp (find-card "Quandary" (:deck (get-corp))))
-      (prompt-card :corp (find-card "Jackson Howard" (:deck (get-corp))))
-      ;; try starting over
-      (prompt-choice :corp "Start over")
-      (prompt-card :corp (find-card "Jackson Howard" (:deck (get-corp))))
-      (prompt-card :corp (find-card "Quandary" (:deck (get-corp))))
-      (prompt-card :corp (find-card "Caprice Nisei" (:deck (get-corp)))) ;this is the top card of R&D
-      (prompt-choice :corp "Done")
-      (is (= "Caprice Nisei" (:title (first (:deck (get-corp))))))
-      (is (= "Quandary" (:title (second (:deck (get-corp))))))
-      (is (= "Jackson Howard" (:title (second (rest (:deck (get-corp)))))))
-      (card-subroutine state :corp shiro 1)
-      (is (= (:cid (first (:deck (get-corp))))
-             (:cid (:card (first (:prompt (get-runner)))))) "Access the top card of R&D")
-      (prompt-choice :runner "No")
-      (is (= (:cid (second (:deck (get-corp))))
-             (:cid (:card (first (:prompt (get-runner)))))) "Access another card due to R&D Interface"))))
+  ;; Shiro
+  (testing "Full test"
+    (do-game
+      (new-game (default-corp ["Shiro" "Caprice Nisei"
+                               "Quandary" "Jackson Howard"])
+                (default-runner ["R&D Interface"]))
+      (starting-hand state :corp ["Shiro"])
+      (play-from-hand state :corp "Shiro" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "R&D Interface")
+      (let [shiro (get-ice state :hq 0)]
+        (run-on state :hq)
+        (core/rez state :corp shiro)
+        (card-subroutine state :corp shiro 0)
+        (prompt-card :corp (find-card "Caprice Nisei" (:deck (get-corp))))
+        (prompt-card :corp (find-card "Quandary" (:deck (get-corp))))
+        (prompt-card :corp (find-card "Jackson Howard" (:deck (get-corp))))
+        ;; try starting over
+        (prompt-choice :corp "Start over")
+        (prompt-card :corp (find-card "Jackson Howard" (:deck (get-corp))))
+        (prompt-card :corp (find-card "Quandary" (:deck (get-corp))))
+        (prompt-card :corp (find-card "Caprice Nisei" (:deck (get-corp)))) ;this is the top card of R&D
+        (prompt-choice :corp "Done")
+        (is (= "Caprice Nisei" (:title (first (:deck (get-corp))))))
+        (is (= "Quandary" (:title (second (:deck (get-corp))))))
+        (is (= "Jackson Howard" (:title (second (rest (:deck (get-corp)))))))
+        (card-subroutine state :corp shiro 1)
+        (is (= (:cid (first (:deck (get-corp))))
+               (:cid (:card (first (:prompt (get-runner)))))) "Access the top card of R&D")
+        (prompt-choice :runner "No action")
+        (is (= (:cid (second (:deck (get-corp))))
+               (:cid (:card (first (:prompt (get-runner)))))) "Access another card due to R&D Interface"))))
+  (testing "with Mwanza City Grid, should access additional 3 cards"
+    (do-game
+      (new-game (default-corp ["Shiro" "Mwanza City Grid"
+                               (qty "Ice Wall" 10)])
+                (default-runner ["R&D Interface"]))
+      (starting-hand state :corp ["Shiro" "Mwanza City Grid"])
+      (play-from-hand state :corp "Mwanza City Grid" "R&D")
+      (play-from-hand state :corp "Shiro" "R&D")
+      (take-credits state :corp)
+      (core/gain state :corp :credit 100)
+      (play-from-hand state :runner "R&D Interface")
+      (let [shiro (get-ice state :rd 0)
+            mwanza (get-content state :rd 0)]
+        (run-on state :rd)
+        (core/rez state :corp shiro)
+        (core/rez state :corp mwanza)
+        (let [credits (:credit (get-corp))]
+          (card-subroutine state :corp shiro 1)
+          (is (= 3 (-> @state :run :access-bonus)) "Should access an additional 3 cards")
+          (dotimes [_ 5]
+            (prompt-choice :runner "No action"))
+          (run-jack-out state)
+          (is (= (+ credits 10) (:credit (get-corp))) "Corp should gain 10 credits from accessing 5 cards total"))))))
 
 (deftest snowflake
   ;; Snowflake - Win a psi game to end the run


### PR DESCRIPTION
Moves changes from #3299 to a separate PR, updates Shiro code to handle Mwanza City Grid, updates Mwanza's req to not require a successful run, as that's not how the card works.

Fixes #3561 