### PR TITLE
Lobby chat restrictions

### DIFF
--- a/dev.edn
+++ b/dev.edn
@@ -11,7 +11,9 @@
          :cookie     {:http-only true
                       :max-age   5184000                    ; 60 days
                       }}
- :chat  {:max-length 144}
+ :chat  {:max-length 144
+         :rate-window 60  ;; sliding window size in seconds
+         :rate-cnt 10}    ;; number of messages allowed in the sliding window
  :web   {:port 1042}
  :email {:host nil
          :user nil

--- a/dev.edn
+++ b/dev.edn
@@ -11,6 +11,7 @@
          :cookie     {:http-only true
                       :max-age   5184000                    ; 60 days
                       }}
+ :chat  {:max-length 144}
  :web   {:port 1042}
  :email {:host nil
          :user nil

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -50,7 +50,7 @@
           u (when user (mc/find-one-as-map db "users" {:_id (object-id _id) :emailhash emailhash}))]
       (if u
         (handler (-> req
-                     (assoc :user (select-keys u [:_id :username :emailhash :isadmin :special :options :stats]))
+                     (assoc :user (select-keys u [:_id :username :emailhash :isadmin :ismoderator :special :options :stats]))
                      (update-in [:user :_id] str)))
         (handler req)))))
 

--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -20,7 +20,9 @@
 
 (defn- insert-msg [{{{:keys [username emailhash]} :user} :ring-req
                     {:keys [:channel :msg]} :?data :as event}]
-  (when (and (not (s/blank? msg))
+  (when (and username
+             emailhash
+             (not (s/blank? msg))
              (<= (count msg) (:max-length chat-config 144)))
     (let [message {:emailhash emailhash
                    :username  username

--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -1,12 +1,16 @@
 (ns web.chat
   (:require [buddy.sign.jwt :as jwt]
+            [clojure.string :as s]
             [monger.query :as q]
             [monger.collection :as mc]
             [monger.result :refer [acknowledged?]]
+            [web.config :refer [server-config]]
             [web.db :refer [db]]
             [web.utils :refer [response]]
             [web.ws :as ws])
   (:import org.bson.types.ObjectId))
+
+(defonce chat-config (:chat server-config))
 
 (defn messages-handler [{{:keys [channel]} :params}]
   (response 200 (reverse (q/with-collection db "messages"
@@ -14,18 +18,23 @@
                                             (q/sort (array-map :date -1))
                                             (q/limit 100)))))
 
-(defn post-message [{{{:keys [username emailhash]} :user} :ring-req
-                     {:keys [:channel :msg]} :?data :as event}]
-  (let [message {:emailhash emailhash
-                 :username  username
-                 :msg       msg
-                 :channel   channel
-                 :date      (java.util.Date.)}]
-    (mc/insert db "messages" message)
-    message))
+(defn- insert-msg [{{{:keys [username emailhash]} :user} :ring-req
+                    {:keys [:channel :msg]} :?data :as event}]
+  (when (and (not (s/blank? msg))
+             (<= (count msg) (:max-length chat-config 144)))
+    (let [message {:emailhash emailhash
+                   :username  username
+                   :msg       msg
+                   :channel   channel
+                   :date      (java.util.Date.)}]
+      (mc/insert db "messages" message)
+      message)))
 
+(defn broadcast-msg
+  [arg]
+  (when-let [msg (insert-msg arg)]
+    (ws/broadcast! :chat/message msg)))
 
 (ws/register-ws-handler!
-  :chat/say
-  #(ws/broadcast! :chat/message (post-message %)))
+  :chat/say broadcast-msg)
 

--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -54,18 +54,18 @@
   (when-let [id (:_id msg)]
     (when (or isadmin ismoderator)
       (println username "deleted message" msg "\n")
-      (mc/remove-by-id db msg-collection (ObjectId. id)))))
+      (mc/remove-by-id db msg-collection (ObjectId. id))
+      (ws/broadcast! :chat/delete-msg msg))))
 
 (defn- delete-all-msg [{{{:keys [username isadmin ismoderator]} :user} :ring-req
                         {:keys [sender]} :?data :as event}]
-  (println event)
   (when (and sender
              (or isadmin ismoderator))
-      (println username "deleted all messages from" sender "\n")
-      (mc/remove db msg-collection {:username sender})))
+      (println username "deleted all messages from user" sender "\n")
+      (mc/remove db msg-collection {:username sender})
+      (ws/broadcast! :chat/delete-all {:username sender})))
 
 (ws/register-ws-handlers!
   :chat/say broadcast-msg
   :chat/delete-msg delete-msg
   :chat/delete-all delete-all-msg)
-

--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -1,6 +1,8 @@
 (ns web.chat
   (:require [buddy.sign.jwt :as jwt]
             [clojure.string :as s]
+            [clj-time.core :as t]
+            [clj-time.coerce :as c]
             [monger.query :as q]
             [monger.collection :as mc]
             [monger.result :refer [acknowledged?]]
@@ -18,12 +20,21 @@
                                             (q/sort (array-map :date -1))
                                             (q/limit 100)))))
 
+(defn- within-rate-limit
+  [username]
+  (let [window (:rate-window chat-config 60)
+        start-date (c/to-date (t/plus (t/now) (t/seconds (- window))))
+        max-cnt (:rate-cnt chat-config 10)
+        msg-cnt (mc/count db "messages" {:username username :date {"$gt" start-date}})]
+    (< msg-cnt max-cnt)))
+
 (defn- insert-msg [{{{:keys [username emailhash]} :user} :ring-req
                     {:keys [:channel :msg]} :?data :as event}]
   (when (and username
              emailhash
              (not (s/blank? msg))
-             (<= (count msg) (:max-length chat-config 144)))
+             (<= (count msg) (:max-length chat-config 144))
+             (within-rate-limit username))
     (let [message {:emailhash emailhash
                    :username  username
                    :msg       msg

--- a/src/cljs/netrunner/chat.cljs
+++ b/src/cljs/netrunner/chat.cljs
@@ -53,6 +53,18 @@
     (non-game-toast (str "Blocked user " blocked-user ". Refresh browser to update.") "success" nil)
     (non-game-toast "Failed to block user" "error" nil)))
 
+(defn- delete-message
+  [owner message]
+  (authenticated
+   (fn [user]
+     (ws/ws-send! [:chat/delete-msg {:msg message}]))))
+
+(defn- delete-all-messages
+  [owner username]
+  (authenticated
+   (fn [user]
+     (ws/ws-send! [:chat/delete-all {:sender username}]))))
+
 (defn block-user
   [owner blocked-user]
   (authenticated
@@ -119,6 +131,14 @@
                (when (not my-msg)
                  [:div.panel.blue-shade.block-menu
                   {:ref "user-msg-buttons"}
+                  (when (or (:isadmin user) (:ismoderator user))
+                    [:div {:on-click #(do
+                                        (delete-message owner message)
+                                        (hide-block-menu owner))} "Delete Message"])
+                  (when (or (:isadmin user) (:ismoderator user))
+                    [:div {:on-click #(do
+                                        (delete-all-messages owner (:username message))
+                                        (hide-block-menu owner))} "Delete All Messages From User"])
                   [:div {:on-click #(do
                                       (block-user owner (:username message))
                                       (hide-block-menu owner))} "Block User"]


### PR DESCRIPTION
Limited min and max length of a lobby chat message.
Limited number of chat messages from an individual user within a given time span.

All values configurable in `dev.edn` (or `config.edn` locally)

Added an `:ismoderator` flag for users. If set (or if `:isadmin` is set), clicking on a username in the lobby chat will add two additional options to the `block user` menu:
  - `Delete Message` which deletes a single message
  - `Delete All Messages From User` which deletes all messages in all channels from that user

Both of these actions update the database and send a message to all connected clients to filter the specified messages out of their local message lists.

New menu:
<img width="317" alt="screen shot 2018-06-11 at 11 04 19 am" src="https://user-images.githubusercontent.com/47226/41240096-b68259fe-6d67-11e8-863f-582d7921d146.png">
