### PR TITLE
FIX: Oberth Protocol

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -690,8 +690,8 @@
    "Oberth Protocol"
    {:additional-cost [:forfeit]
     :events {:advance {:req (req (and (same-server? card target)
-                                      (empty? (filter #(= (second (:zone %)) (second (:zone card)))
-                                                      (map first (turn-events state side :advance))))))
+                                      (= 1 (count (filter #(= (second (:zone %)) (second (:zone card)))
+                                                          (map first (turn-events state side :advance)))))))
                        :msg (msg "place an additional advancement token on " (card-str state target))
                        :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}}}
 

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1024,6 +1024,23 @@
       (core/advance state :corp {:card (refresh (get-ice state :remote1 0))})
       (is (= 2 (:credit (get-corp))) "No credit gained from advancing ICE"))))
 
+(deftest oberth-protocol
+  ;; Oberth Protocol
+  (do-game
+    (new-game (default-corp ["Hostile Takeover" "Oberth Protocol" "Oaktown Renovation"])
+              (default-runner))
+    (play-and-score state "Hostile Takeover")
+    (play-from-hand state :corp "Oberth Protocol" "Server 1")
+    (play-from-hand state :corp "Oaktown Renovation" "Server 1")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (let [oberth (get-content state :remote1 0)
+          oak (get-content state :remote1 1) ]
+      (core/rez state :corp (refresh oberth))
+      (prompt-select :corp (get-scored state :corp 0))
+      (advance state oak)
+      (is (= 2 (get-counters (refresh oak) :advancement)) "Oaktown should have 2 advancement tokens on it"))))
+
 (deftest off-the-grid
   ;; Off the Grid run restriction - and interaction with RP
   (do-game

--- a/test/clj/game_test/macros.clj
+++ b/test/clj/game_test/macros.clj
@@ -34,7 +34,8 @@
                                   (= ~'type (-> @~'state ~'side :prompt first :prompt-type))))
 
          ~'prompt-map (fn [side#] (first (get-in @~'state [side# :prompt])))
-         ~'prompt-titles (fn [side#] (map #(:title %) (:choices (~'prompt-map side#))))]
+         ~'prompt-titles (fn [side#] (map #(:title %) (:choices (~'prompt-map side#))))
+         ~'prompt? (fn [~'side] (-> @~'state ~'side :prompt first))]
      ~@body))
 
 (defmacro deftest-pending [name & body]


### PR DESCRIPTION
Oberth was based on the old system of turn events not happening until after the effect is done. Now it works as it should, based on it having _just_ happened.

Fixes #3629 