### PR TITLE
Add _id field to chat message sent over the websocket

### DIFF
--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -41,9 +41,9 @@
                    :username  username
                    :msg       msg
                    :channel   channel
-                   :date      (java.util.Date.)}]
-      (mc/insert db msg-collection message)
-      message)))
+                   :date      (java.util.Date.)}
+          inserted (mc/insert-and-return db msg-collection message)]
+      (update inserted :_id str))))
 
 (defn broadcast-msg
   [arg]


### PR DESCRIPTION
Allows for deletion of chat messages received from the websocket, not just those fetched by a refresh.