### PR TITLE
FIX: Improved Tracers, expands eid to handle cause

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -658,7 +658,8 @@
     :swapped {:effect (req (update-all-ice state side))}
     :events {:pre-ice-strength {:req (req (has-subtype? target "Tracer"))
                                 :effect (effect (ice-strength-bonus 1 target))}
-             :pre-init-trace {:req (req (has-subtype? target "Tracer"))
+             :pre-init-trace {:req (req (and (has-subtype? target "Tracer")
+                                             (= :subroutine (:source-type (second targets)))))
                               :effect (effect (init-trace-bonus 1))}}}
 
    "Labyrinthine Servers"

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -599,9 +599,9 @@
   (swap! state dissoc-in [:bonus :trace]))
 
 (defn init-trace
-  [state side card {:keys [base priority] :as trace}]
+  [state side card {:keys [base priority eid] :as trace}]
   (reset-trace-modifications state)
-  (when-completed (trigger-event-sync state :corp :pre-init-trace card)
+  (when-completed (trigger-event-sync state :corp :pre-init-trace card eid)
                   (let [force-base (get-in @state [:trace :force-base])
                         force-link (get-in @state [:trace :force-link])
                         base (cond force-base force-base

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -291,7 +291,10 @@
 
 (defn play-subroutine
   "Triggers a card's subroutine using its zero-based index into the card's :subroutines vector."
-  ([state side args] (play-subroutine state side (make-eid state) args))
+  ([state side args]
+   (let [eid (make-eid state {:source (-> args :card :title)
+                              :source-type :subroutine})]
+     (play-subroutine state side eid args)))
   ([state side eid {:keys [card subroutine targets] :as args}]
    (let [card (get-card state card)
          sub (nth (:subroutines card) subroutine nil)]

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -142,8 +142,12 @@
   (get-in (swap! state update-in [:rid] inc) [:rid]))
 
 (defn make-eid
-  [state]
-  {:eid (:eid (swap! state update-in [:eid] inc))})
+  ([state] (make-eid state nil))
+  ([state {:keys [source source-type]}]
+   (merge {:eid (:eid (swap! state update-in [:eid] inc))}
+          (when source
+            {:source source
+             :source-type source-type}))))
 
 (defn make-result
   [eid result]

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -1184,10 +1184,12 @@
 (deftest improved-tracers
   ;; Improved Tracers
   (do-game
-    (new-game (default-corp ["Improved Tracers" "News Hound"])
+    (new-game (default-corp ["Improved Tracers" "News Hound" "Restructured Datapool"])
               (default-runner))
     (play-from-hand state :corp "News Hound" "HQ")
-    (let [nh (get-ice state :hq 0)]
+    (play-and-score state "Restructured Datapool")
+    (let [nh (get-ice state :hq 0)
+          rd (get-scored state :corp 0)]
       (core/rez state :corp nh)
       (is (= 4 (:current-strength (refresh nh))) "Should start with base strength of 4")
       (is (= 3 (:credit (get-corp))) "Should have 2 credits after rez")
@@ -1209,7 +1211,10 @@
           "Should gain only 1 bonus trace strength regardless of number of runs in a turn")
       (prompt-choice :corp 0)
       (prompt-choice :runner 0)
-      (is (= 2 (:tag (get-runner)))))))
+      (is (= 2 (:tag (get-runner))))
+      (take-credits state :runner)
+      (card-ability state :corp rd 0)
+      (is (zero? (-> (get-corp) :prompt first :bonus)) "Should gain 0 bonus trace strength"))))
 
 (deftest labyrinthine-servers
   ;; Labyrinthine Servers

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -1184,20 +1184,21 @@
 (deftest improved-tracers
   ;; Improved Tracers
   (do-game
-    (new-game (default-corp ["Improved Tracers" "News Hound" "Restructured Datapool"])
+    (new-game (default-corp ["Improved Tracers" "News Hound" "Information Overload"])
               (default-runner))
+    (core/gain state :corp :credit 10)
     (play-from-hand state :corp "News Hound" "HQ")
-    (play-and-score state "Restructured Datapool")
+    (play-from-hand state :corp "Information Overload" "R&D")
     (let [nh (get-ice state :hq 0)
-          rd (get-scored state :corp 0)]
+          io (get-ice state :rd 0)]
       (core/rez state :corp nh)
+      (core/rez state :corp io)
       (is (= 4 (:current-strength (refresh nh))) "Should start with base strength of 4")
-      (is (= 3 (:credit (get-corp))) "Should have 2 credits after rez")
+      (is (= 7 (:credit (get-corp))) "Should have 7 credits after rez")
       (play-and-score state "Improved Tracers")
       (is (= 5 (:current-strength (refresh nh))) "Should gain 1 strength from 4 to 5")
       (take-credits state :corp)
       (run-on state "HQ")
-      (run-phase-43 state)
       (card-subroutine state :corp nh 0)
       (is (= 1 (-> (get-corp) :prompt first :bonus)) "Should gain 1 bonus trace strength")
       (prompt-choice :corp 0)
@@ -1205,16 +1206,15 @@
       (is (= 1 (:tag (get-runner))))
       (run-jack-out state)
       (run-on state "HQ")
-      (run-phase-43 state)
       (card-subroutine state :corp nh 0)
       (is (= 1 (-> (get-corp) :prompt first :bonus))
           "Should gain only 1 bonus trace strength regardless of number of runs in a turn")
       (prompt-choice :corp 0)
       (prompt-choice :runner 0)
       (is (= 2 (:tag (get-runner))))
-      (take-credits state :runner)
-      (card-ability state :corp rd 0)
-      (is (zero? (-> (get-corp) :prompt first :bonus)) "Should gain 0 bonus trace strength"))))
+      (run-on state "R&D")
+      (card-ability state :corp io 1)
+      (is (zero? (-> (get-corp) :prompt first :bonus)) "Should gain 0 bonus trace strength, as it's an encounter ability"))))
 
 (deftest labyrinthine-servers
   ;; Labyrinthine Servers


### PR DESCRIPTION
The major issue of #2652/Improved Tracers is that it's only supposed to modify a single type of ability, but our system assumes that all abilities are the same underneath. To handle this, I've done two different things that can be applied to other effects as they're needed in the future:

1) I expanded `make-eid` to hold `:source` and `:source-type` when it's provided. This doesn't fully handle our use-case, however, as `req` checks make their own eid, and it would be extremely cumbersome to extract/pass along the source and type data when it exists.

2) So instead, extract the eid from the ability and pass it to `trigger-event`s. In this case, I'm only doing this for `:pre-init-trace`, because I don't want to muddy other events, but it's usable everywhere.

Fixes #2652 