### PR TITLE
Rename delayed completion functions

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -53,7 +53,7 @@
                 (if (= dest "bottom") "under " "onto ")
                 (if (= reorder-side :corp) "R&D" "your Stack"))
    :choices remaining
-   :delayed-completion true
+   :async true
    :effect (req (let [chosen (cons target chosen)]
                   (if (< (count chosen) n)
                     (continue-ability
@@ -77,7 +77,7 @@
               (str "The top cards of " (if (= reorder-side :corp) "R&D" "your Stack")
                    " will be " (join  ", " (map :title chosen)) "."))
    :choices ["Done" "Start over"]
-   :delayed-completion true
+   :async true
    :effect (req
              (cond
                (and (= dest "bottom") (= target "Done"))
@@ -146,7 +146,7 @@
   "Do specified amount of net-damage."
   [dmg]
   {:label (str "Do " dmg " net damage")
-   :delayed-completion true
+   :async true
    :msg (str "do " dmg " net damage")
    :effect (effect (damage eid :net dmg {:card card}))})
 
@@ -154,7 +154,7 @@
   "Do specified amount of meat damage."
   [dmg]
   {:label (str "Do " dmg " meat damage")
-   :delayed-completion true
+   :async true
    :msg (str "do " dmg " meat damage")
    :effect (effect (damage eid :meat dmg {:card card}))})
 
@@ -162,7 +162,7 @@
   "Do specified amount of brain damage."
   [dmg]
   {:label (str "Do " dmg " brain damage")
-   :delayed-completion true
+   :async true
    :msg (str "do " dmg " brain damage")
    :effect (effect (damage eid :brain dmg {:card card}))})
 
@@ -175,7 +175,7 @@
   ([] (pick-virus-counters-to-spend (hash-map) 0 nil))
   ([target-count] (pick-virus-counters-to-spend (hash-map) 0 target-count))
   ([selected-cards counter-count target-count]
-   {:delayed-completion true
+   {:async true
     :prompt (str "Select a card with virus counters ("
                  counter-count (when (and target-count (pos? target-count))
                                  (str " of " target-count))

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -84,13 +84,13 @@
                (do (swap! state update-in [reorder-side :deck]
                           #(vec (concat (drop (count chosen) %) (reverse chosen))))
                    (clear-wait-prompt state wait-side)
-                   (effect-completed state side eid card))
+                   (effect-completed state side eid))
 
                (= target "Done")
                (do (swap! state update-in [reorder-side :deck]
                           #(vec (concat chosen (drop (count chosen) %))))
                    (clear-wait-prompt state wait-side)
-                   (effect-completed state side eid card))
+                   (effect-completed state side eid))
 
                :else
                (continue-ability state side (reorder-choice reorder-side wait-side original '() (count original) original dest) card nil)))}))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -37,7 +37,7 @@
    "Accelerated Beta Test"
    (letfn [(abt [n i]
              (if (pos? i)
-               {:delayed-completion true
+               {:async true
                 :prompt "Select a piece of ICE from the Temporary Zone to install"
                 :choices {:req #(and (= (:side %) "Corp")
                                      (ice? %)
@@ -67,7 +67,7 @@
                                (trash state side c {:unpreventable true})))}))]
      {:interactive (req true)
       :optional {:prompt "Look at the top 3 cards of R&D?"
-                 :yes-ability {:delayed-completion true
+                 :yes-ability {:async true
                                :msg "look at the top 3 cards of R&D"
                                :effect (req (register-events state side
                                                              {:corp-shuffle-deck
@@ -107,16 +107,16 @@
 
    "AR-Enhanced Security"
    {:events {:runner-trash {:once :per-turn
-                            :delayed-completion true
+                            :async true
                             :req (req (some #(card-is? % :side :corp) targets))
                             :msg "give the Runner a tag for trashing a Corp card"
                             :effect (effect (tag-runner :runner eid 1))}}}
 
    "Armed Intimidation"
-   {:delayed-completion true
+   {:async true
     :effect (effect (show-wait-prompt :corp "Runner to suffer 5 meat damage or take 2 tags")
                     (continue-ability :runner
-                      {:delayed-completion true
+                      {:async true
                        :choices ["Suffer 5 meat damage" "Take 2 tags"]
                        :prompt "Choose Armed Intimidation score effect"
                        :effect (req (clear-wait-prompt state :corp)
@@ -147,11 +147,11 @@
 
    "Award Bait"
    {:flags {:rd-reveal (req true)}
-    :access {:delayed-completion true
+    :access {:async true
              :req (req (not-empty (filter #(can-be-advanced? %) (all-installed state :corp))))
              :effect (effect (show-wait-prompt :runner "Corp to place advancement tokens with Award Bait")
                              (continue-ability
-                               {:delayed-completion true
+                               {:async true
                                 :choices ["0", "1", "2"]
                                 :prompt "How many advancement tokens?"
                                 :effect (req (let [c (str->int target)]
@@ -167,7 +167,7 @@
 
    "Bacterial Programming"
    (letfn [(hq-step [remaining to-trash to-hq]
-             {:delayed-completion true
+             {:async true
               :prompt "Select a card to move to HQ"
               :choices (conj (vec remaining) "Done")
               :effect (req (if (= "Done" target)
@@ -188,7 +188,7 @@
                                                              to-trash
                                                              (conj to-hq target)) card nil)))})
            (trash-step [remaining to-trash]
-             {:delayed-completion true
+             {:async true
               :prompt "Select a card to discard"
               :choices (conj (vec remaining) "Done")
               :effect (req (if (= "Done" target)
@@ -198,9 +198,9 @@
                                                              (conj to-trash target)) card nil)))})]
      (let [arrange-rd (effect (continue-ability
                                 {:optional
-                                 {:delayed-completion true
+                                 {:async true
                                   :prompt "Arrange top 7 cards of R&D?"
-                                  :yes-ability {:delayed-completion true
+                                  :yes-ability {:async true
                                                 :effect (req (let [c (take 7 (:deck corp))]
                                                                (when (:run @state)
                                                                 (swap! state assoc-in [:run :shuffled-during-access :rd] true))
@@ -208,8 +208,8 @@
                                                                (continue-ability state :corp (trash-step c `()) card nil)))}}}
                                 card nil))]
        {:effect arrange-rd
-        :delayed-completion true
-        :stolen {:delayed-completion true
+        :async true
+        :stolen {:async true
                  :effect arrange-rd}
         :interactive (req true)}))
 
@@ -220,7 +220,7 @@
                        :corp
                        {:optional
                         {:prompt "Give the runner 1 tag?"
-                         :yes-ability {:delayed-completion true
+                         :yes-ability {:async true
                                        :msg (str "give the Runner a tag for " kind)
                                        :effect (req (swap! state assoc-in [:per-turn (:cid card)] true)
                                                     (tag-runner state :runner eid 1))}
@@ -229,13 +229,13 @@
     {:events {:play-event {:req (req (and (first-event? state :runner :run)
                                           (has-subtype? target "Run")
                                           (not (used-this-turn? (:cid card) state))))
-                           :delayed-completion true
+                           :async true
                            :effect (ability "playing a run event")}
               :runner-install {:silent (req true)
                                :req (req (and (has-subtype? target "Icebreaker")
                                               (first-event? state :runner :runner-install #(has-subtype? (first %) "Icebreaker"))
                                               (not (used-this-turn? (:cid card) state))))
-                               :delayed-completion true
+                               :async true
                                :effect (ability "installing an icebreaker")}}})
 
    "Bifrost Array"
@@ -284,7 +284,7 @@
                             :effect (req (rez-cost-bonus state side (- (get-counters card :agenda))))}}}
 
    "Breaking News"
-   {:delayed-completion true
+   {:async true
     :effect (effect (tag-runner :runner eid 2))
     :silent (req true)
     :msg "give the Runner 2 tags"
@@ -303,7 +303,7 @@
                          (is-type? % "Resource"))}
     :msg (msg "trash " (:title target))
     :interactive (req true)
-    :delayed-completion true
+    :async true
     :effect (effect (trash eid target {:unpreventable true}))}
 
    "Chronos Project"
@@ -316,7 +316,7 @@
      {:install-state :face-up
       :access {:req (req installed)
                :msg (msg "do " (meat-damage state card) " meat damage")
-               :delayed-completion true
+               :async true
                :effect (effect (damage eid :meat (meat-damage state card) {:card card}))}})
 
    "Clone Retirement"
@@ -343,7 +343,7 @@
 
    "Crisis Management"
    (let [ability {:req (req tagged)
-                  :delayed-completion true
+                  :async true
                   :label "Do 1 meat damage (start of turn)"
                   :once :per-turn
                   :msg "do 1 meat damage"
@@ -353,7 +353,7 @@
 
    "Dedicated Neural Net"
     (let [psi-effect
-           {:delayed-completion true
+           {:async true
             :mandatory true
             :effect (req (if (not-empty (:hand corp))
                            (do (show-wait-prompt state :runner "Corp to select cards in HQ to be accessed")
@@ -464,7 +464,7 @@
 
    "Explode-a-palooza"
    {:flags {:rd-reveal (req true)}
-    :access {:delayed-completion true
+    :access {:async true
              :effect (effect (show-wait-prompt :runner "Corp to use Explode-a-palooza")
                              (continue-ability
                                {:optional {:prompt "Gain 5 [Credits] with Explode-a-palooza ability?"
@@ -482,7 +482,7 @@
 
    "Fetal AI"
    {:flags {:rd-reveal (req true)}
-    :access {:delayed-completion true
+    :access {:async true
              :req (req (not= (first (:zone card)) :discard)) :msg "do 2 net damage"
              :effect (effect (damage eid :net 2 {:card card}))}
     :steal-cost-bonus (req [:credit 2])}
@@ -548,7 +548,7 @@
 
    "Graft"
    (letfn [(graft [n] {:prompt "Choose a card to add to HQ with Graft"
-                       :delayed-completion true
+                       :async true
                        :choices (req (cancellable (:deck corp) :sorted))
                        :msg (msg "add " (:title target) " to HQ from R&D")
                        :cancel-effect (req (shuffle! state side :deck)
@@ -560,7 +560,7 @@
                                       (do (shuffle! state side :deck)
                                           (system-msg state side (str "shuffles R&D"))
                                           (effect-completed state side eid card))))})]
-     {:delayed-completion true
+     {:async true
       :msg "add up to 3 cards from R&D to HQ"
       :effect (effect (continue-ability (graft 1) card nil))})
 
@@ -633,7 +633,7 @@
    {:steal-cost-bonus (req [:credit 2 :click 1])}
 
    "Illicit Sales"
-   {:delayed-completion true
+   {:async true
     :effect (req (when-completed
                    (resolve-ability state side
                      {:optional
@@ -690,7 +690,7 @@
                     :choices {:req #(and (installed? %)
                                          (ice? %))
                               :max 2}
-                    :delayed-completion true
+                    :async true
                     :effect (req (if (= (count targets) 2)
                                    (do (swap-ice state side (first targets) (second targets))
                                        (system-msg state side
@@ -701,7 +701,7 @@
                                        (continue-ability state side (msr) card nil))
                                    (do (system-msg state :corp (str "has finished rearranging ICE"))
                                        (effect-completed state side eid))))})]
-     {:delayed-completion true
+     {:async true
       :msg "rearrange any number of ICE"
       :effect (effect (continue-ability (msr) card nil))})
 
@@ -737,7 +737,7 @@
 
    "Meteor Mining"
    {:interactive (req true)
-    :delayed-completion true
+    :async true
     :prompt "Use Meteor Mining?"
     :choices (req (if (< (:tag runner) 2)
                     ["Gain 7 [Credits]" "No action"]
@@ -848,7 +848,7 @@
    "Posted Bounty"
    {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
                :yes-ability {:msg "give the Runner 1 tag and take 1 bad publicity"
-                             :delayed-completion true
+                             :async true
                              :effect (effect (gain-bad-publicity :corp eid 1)
                                              (tag-runner :runner eid 1)
                                              (forfeit card))}}}
@@ -882,7 +882,7 @@
       :req (req (and (> (get-counters card :advancement) 4)
                      (pos? (count (all-installed state :runner)))))
       :msg (msg "force the Runner to trash " (trash-count-str card) " and take 1 bad publicity")
-      :delayed-completion true
+      :async true
       :effect (effect (show-wait-prompt :corp "Runner to trash installed cards")
                       (continue-ability
                        :runner
@@ -953,7 +953,7 @@
    "Puppet Master"
    {:events {:successful-run
              {:interactive (req true)
-              :delayed-completion true
+              :async true
               :effect (req (show-wait-prompt state :runner "Corp to use Puppet Master")
                            (continue-ability
                              state :corp
@@ -968,7 +968,7 @@
    "Quantum Predictive Model"
    {:flags {:rd-reveal (req true)}
     :access {:req (req tagged)
-             :delayed-completion true
+             :async true
              :interactive (req true)
              :effect (req (when-completed (as-agenda state side card 1)
                                           (continue-ability state :runner
@@ -1000,7 +1000,7 @@
    (letfn [(corp-final [chosen original]
              {:prompt (str "The bottom cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
               :choices ["Done" "Start over"]
-              :delayed-completion true
+              :async true
               :msg (req (let [n (count chosen)]
                           (str "add " n " cards from HQ to the bottom of R&D and draw " n " cards.
                           The Runner randomly adds " (if (<= n (count (:hand runner))) n 0) " cards from their Grip
@@ -1018,7 +1018,7 @@
            (corp-choice [remaining chosen original] ; Corp chooses cards until they press 'Done'
              {:prompt "Choose a card to move to bottom of R&D"
               :choices (conj (vec remaining) "Done")
-              :delayed-completion true
+              :async true
               :effect (req (let [chosen (cons target chosen)]
                              (if (not= target "Done")
                                (continue-ability
@@ -1030,7 +1030,7 @@
                                  (do (system-msg state side "does not add any cards from HQ to bottom of R&D")
                                      (clear-wait-prompt state :runner)
                                      (effect-completed state side eid card))))))})]
-   {:delayed-completion true
+   {:async true
     :effect (req (show-wait-prompt state :runner "Corp to add cards from HQ to bottom of R&D")
                  (let [from (get-in @state [:corp :hand])]
                    (if (pos? (count from))
@@ -1049,12 +1049,12 @@
    "Remote Enforcement"
    {:interactive (req true)
     :optional {:prompt "Search R&D for a piece of ice to install protecting a remote server?"
-               :yes-ability {:delayed-completion true
+               :yes-ability {:async true
                              :prompt "Choose a piece of ice"
                              :choices (req (filter ice? (:deck corp)))
                              :effect (req (let [chosen-ice target]
                                             (continue-ability state side
-                                              {:delayed-completion true
+                                              {:async true
                                                :prompt (str "Select a server to install " (:title chosen-ice) " on")
                                                :choices (filter #(not (#{"HQ" "Archives" "R&D"} %))
                                                                 (corp-install-list state chosen-ice))
@@ -1066,11 +1066,11 @@
    {:interactive (req true)
     :silent (req (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp))))
     :req (req (not (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp)))))
-    :delayed-completion true
+    :async true
     :effect (effect (continue-ability
                       {:prompt "Select another installed copy of Research Grant to score"
                        :choices {:req #(= (:title %) "Research Grant")}
-                       :delayed-completion true
+                       :async true
                        :effect (effect (set-prop target :advance-counter (:advancementcost target))
                                        (score eid (get-card state target)))
                        :msg "score another installed copy of Research Grant"}
@@ -1080,7 +1080,7 @@
    {:abilities [{:cost [:click 1]
                  :trace {:base 2
                          :successful {:msg "give the Runner 1 tag"
-                                      :delayed-completion true
+                                      :async true
                                       :effect (effect (tag-runner :runner eid 1))}}}]}
 
    "Self-Destruct Chips"
@@ -1115,7 +1115,7 @@
                                   :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Show of Force"
-   {:delayed-completion true
+   {:async true
     :msg "do 2 meat damage"
     :effect (effect (damage eid :meat 2 {:card card}))}
 
@@ -1136,7 +1136,7 @@
 
    "Standoff"
    (letfn [(stand [side]
-             {:delayed-completion true
+             {:async true
               :prompt "Choose one of your installed cards to trash due to Standoff"
               :choices {:req #(and (installed? %)
                                    (same-side? side (:side %)))}
@@ -1157,14 +1157,14 @@
                                              (show-wait-prompt state side (str (side-str (other-side side)) " to trash a card for Standoff"))
                                              (continue-ability state (other-side side) (stand (other-side side)) card nil))))})]
      {:interactive (req true)
-      :delayed-completion true
+      :async true
       :effect (effect (show-wait-prompt (str (side-str (other-side side)) " to trash a card for Standoff"))
                       (continue-ability :runner (stand :runner) card nil))})
 
    "Successful Field Test"
    (letfn [(sft [n max] {:prompt "Select a card in HQ to install with Successful Field Test"
                          :priority -1
-                         :delayed-completion true
+                         :async true
                          :choices {:req #(and (= (:side %) "Corp")
                                               (not (is-type? % "Operation"))
                                               (in-hand? %))}
@@ -1173,7 +1173,7 @@
                                         (if (< n max)
                                           (continue-ability state side (sft (inc n) max) card nil)
                                           (effect-completed state side eid card))))})]
-     {:delayed-completion true
+     {:async true
       :msg "install cards from HQ, ignoring all costs"
       :effect (req (let [max (count (filter #(not (is-type? % "Operation")) (:hand corp)))]
                      (continue-ability state side (sft 1 max) card nil)))})
@@ -1184,7 +1184,7 @@
    "TGTBT"
    {:flags {:rd-reveal (req true)}
     :access {:msg "give the Runner 1 tag"
-             :delayed-completion true
+             :async true
              :effect (effect (tag-runner :runner eid 1))}}
 
    "The Cleaners"
@@ -1222,8 +1222,8 @@
                          :effect (effect (mill :corp :runner (adv4? state card)))}}})
 
    "Unorthodox Predictions"
-   {:implementation "Prevention of subroutine breaking is not enforced"
-    :delayed-completion false
+   {:async false
+    :implementation "Prevention of subroutine breaking is not enforced"
     :prompt "Choose an ICE type for Unorthodox Predictions"
     :choices ["Barrier" "Code Gate" "Sentry"]
     :msg (msg "prevent subroutines on " target " ICE from being broken until next turn.")}
@@ -1243,7 +1243,7 @@
 
    "Viral Weaponization"
    (let [dmg {:msg "do 1 net damage for each card in the grip"
-              :delayed-completion true
+              :async true
               :effect (req (let [cnt (count (:hand runner))]
                              (unregister-events state side card)
                              (damage state side eid :net cnt {:card card})))}]
@@ -1258,7 +1258,7 @@
    {:silent (req true)
     :effect (effect (add-counter card :agenda 3))
     :events {:runner-turn-begins
-             {:delayed-completion true
+             {:async true
               :req (req (pos? (get-counters card :agenda)))
               :effect (effect (show-wait-prompt :runner "Corp to use Voting Machine Initiative")
                               (continue-ability

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -19,7 +19,7 @@
      (installed-access-trigger cost ab prompt)))
   ([cost ability prompt]
    {:access {:req (req (and installed (>= (:credit corp) cost)))
-             :delayed-completion true
+             :async true
              :effect (effect (show-wait-prompt :runner (str "Corp to use " (:title card)))
                              (continue-ability
                               {:optional
@@ -85,12 +85,12 @@
 
    "Aggressive Secretary"
    (advance-ambush 2 {:req (req (pos? (get-counters (get-card state card) :advancement)))
-                      :delayed-completion true
+                      :async true
                       :effect (req (let [agg (get-counters (get-card state card) :advancement)
                                          ab (-> trash-program
                                                 (assoc-in [:choices :max] agg)
                                                 (assoc :prompt (msg "Choose " (quantify agg "program") " to trash")
-                                                       :delayed-completion true
+                                                       :async true
                                                        :effect (effect (trash-cards eid targets nil))
                                                        :msg (msg "trash " (join ", " (map :title targets)))))]
                                      (continue-ability state side ab card nil)))})
@@ -166,7 +166,7 @@
       :events {:corp-turn-begins ability
                :rez {:req (req (and (ice? target)
                                     (pos? (get-counters card :advancement))))
-                     :delayed-completion true
+                     :async true
                      :effect (req (let [ice (get-card state target)
                                         icename (:title ice)]
                                     (show-wait-prompt state :runner "Corp to use Anson Rose")
@@ -192,7 +192,7 @@
 
    "Bio-Ethics Association"
    (let [ability {:req (req unprotected)
-                  :delayed-completion true
+                  :async true
                   :label "Do 1 net damage (start of turn)"
                   :once :per-turn
                   :msg "do 1 net damage"
@@ -219,7 +219,7 @@
 
    "Breached Dome"
    {:flags {:rd-reveal (req true)}
-    :access {:delayed-completion true
+    :access {:async true
              :effect (req (let [c (first (get-in @state [:runner :deck]))]
                             (system-msg state :corp (str "uses Breached Dome to do one meat damage and to trash " (:title c)
                                                          " from the top of the Runner's Stack"))
@@ -233,7 +233,7 @@
               :effect (effect (rez-cost-bonus (- (:click runner))))}}}
 
    "Broadcast Square"
-   {:events {:pre-bad-publicity {:delayed-completion true
+   {:events {:pre-bad-publicity {:async true
                                  :trace {:base 3
                                          :successful {:msg "prevents all bad publicity"
                                                       :effect (effect (bad-publicity-prevent Integer/MAX_VALUE))}}}}}
@@ -244,7 +244,7 @@
                  :effect (effect (gain-credits 2))}]}
 
    "Cerebral Overwriter"
-   (advance-ambush 3 {:delayed-completion true
+   (advance-ambush 3 {:async true
                       :req (req (pos? (get-counters (get-card state card) :advancement)))
                       :msg (msg "do " (get-counters (get-card state card) :advancement) " brain damage")
                       :effect (effect (damage eid :brain (get-counters (get-card state card) :advancement) {:card card}))})
@@ -255,7 +255,7 @@
     :trash-effect {:when-inactive true
                    :req (req (:access @state))
                    :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
-                   :delayed-completion true
+                   :async true
                    :effect (req (as-agenda state :runner eid card 2))}}
 
    "Chief Slee"
@@ -264,7 +264,7 @@
                                  (system-msg (str "adds 1 power counter to Chief Slee")))}
                 {:counter-cost [:power 5]
                  :cost [:click 1]
-                 :delayed-completion true
+                 :async true
                  :msg "do 5 meat damage"
                  :effect (effect (damage eid :meat 5 {:card card}))}]}
 
@@ -297,7 +297,7 @@
                               "Pay 1[Credits]")
                              "Take 1 tag"])
               :msg "make the Runner pay 1[Credits] or take 1 tag"
-              :delayed-completion true
+              :async true
               :effect (req (case target
                              "Pay 1[Credits]"
                              (do (system-msg state :runner "pays 1[Credits]")
@@ -407,7 +407,7 @@
    "Contract Killer"
    {:advanceable :always
     :abilities [{:label "Trash a connection"
-                 :delayed-completion true
+                 :async true
                  :cost [:click 1]
                  :req (req (>= (get-counters card :advancement) 2))
                  :choices {:req #(has-subtype? % "Connection")}
@@ -415,7 +415,7 @@
                  :effect (effect (trash card {:cause :ability-cost})
                                  (trash eid target nil))}
                 {:label "Do 2 meat damage"
-                 :delayed-completion true
+                 :async true
                  :cost [:click 1]
                  :req (req (>= (get-counters card :advancement) 2))
                  :msg "do 2 meat damage"
@@ -432,7 +432,7 @@
                                           pos?)))}
     :abilities [{:label "Trash a resource"
                  :once :per-turn
-                 :delayed-completion true
+                 :async true
                  :prompt "Select a resource to trash with Corporate Town"
                  :choices {:req resource?}
                  :msg (msg "trash " (:title target))
@@ -462,7 +462,7 @@
              {:req (req (first-event? state :corp :post-corp-draw))
               :once :per-turn
               :once-key :daily-business-show-put-bottom
-              :delayed-completion true
+              :async true
               :effect (req (let [dbs (count (filter #(and (= "06086" (:code %))
                                                           (rezzed? %))
                                                     (all-installed state :corp)))
@@ -483,7 +483,7 @@
    "Dedicated Response Team"
    {:events {:successful-run-ends {:req (req tagged)
                                    :msg "do 2 meat damage"
-                                   :delayed-completion true
+                                   :async true
                                    :effect (effect (damage eid :meat 2 {:card card}))}}}
 
    "Dedicated Server"
@@ -494,7 +494,7 @@
     :trash-effect {:when-inactive true
                    :req (req (:access @state))
                    :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
-                   :delayed-completion true
+                   :async true
                    :effect (req (as-agenda state :runner eid card 2))}}
 
    "Docklands Crackdown"
@@ -528,14 +528,14 @@
    {:abilities [{:label "Add Echo Chamber to your score area as an agenda worth 1 agenda point"
                  :cost [:click 3]
                  :msg "add it to their score area as an agenda worth 1 agenda point"
-                 :delayed-completion true
+                 :async true
                  :effect (req (as-agenda state :corp eid card 1))}]}
 
    "Edge of World"
    (letfn [(ice-count [state]
              (count (get-in (:corp @state) [:servers (last (:server (:run @state))) :ices])))]
      (installed-access-trigger 3 {:msg (msg "do " (ice-count state) " brain damage")
-                                  :delayed-completion true
+                                  :async true
                                   :effect (effect (damage eid :brain (ice-count state)
                                                           {:card card}))}))
 
@@ -584,7 +584,7 @@
     :abilities [{:choices {:req (complement rezzed?)}
                  :label "Rez a card, lowering the cost by 1[Credits]"
                  :msg (msg "rez " (:title target))
-                 :delayed-completion true
+                 :async true
                  :effect (req (rez-cost-bonus state side -1)
                               (when-completed (rez state side target {:no-warning true})
                                               (update! state side (assoc card :ebc-rezzed (:cid target)))))}
@@ -627,19 +627,19 @@
      {:advanceable :always
       :access {:req (req (pos? (get-counters (get-card state card) :advancement)))
                :msg (msg "give the runner " (quantify (tag-count (get-card state card)) "tag"))
-               :delayed-completion true
+               :async true
                :effect (effect (tag-runner :runner eid (tag-count (get-card state card))))}
       :abilities [{:cost [:click 1]
                    :advance-counter-cost 7
                    :label "Add False Flag to your score area as an agenda worth 3 agenda points"
                    :msg "add it to their score area as an agenda worth 3 agenda points"
-                   :delayed-completion true
+                   :async true
                    :effect (req (as-agenda state :corp eid card 3))}]})
 
    "Franchise City"
    {:events {:access {:req (req (is-type? target "Agenda"))
                       :msg "add it to their score area as an agenda worth 1 agenda point"
-                      :delayed-completion true
+                      :async true
                       :effect (req (as-agenda state :corp eid card 1))}}}
 
    "Full Immersion RecStudio"
@@ -666,7 +666,7 @@
 
    "Fumiko Yamamori"
    {:events {:psi-game-done {:req (req (not= (first targets) (second targets)))
-                             :delayed-completion true
+                             :async true
                              :msg "do 1 meat damage"
                              :effect (effect (damage eid :meat 1 {:card card}))}}}
 
@@ -674,14 +674,14 @@
    {:advanceable :always
     :access {:req (req (pos? (get-counters (get-card state card) :advancement)))
              :msg (msg "do " (get-counters (get-card state card) :advancement) " net damage")
-             :delayed-completion true
+             :async true
              :effect (effect (damage eid :net (get-counters (get-card state card) :advancement)
                                       {:card card}))}
     :abilities [{:cost [:click 1]
                  :advance-counter-cost 3
                  :label "Add Gene Splicing to your score area as an agenda worth 1 agenda point"
                  :msg "add it to their score area as an agenda worth 1 agenda point"
-                 :delayed-completion true
+                 :async true
                  :effect (req (as-agenda state :corp eid card 1))}]}
 
    "Genetics Pavilion"
@@ -693,7 +693,7 @@
     :leave-play (req (swap! state update-in [:runner :register] dissoc :max-draw :cannot-draw))}
 
    "Ghost Branch"
-   (advance-ambush 0 {:delayed-completion true
+   (advance-ambush 0 {:async true
                       :req (req (pos? (get-counters (get-card state card) :advancement)))
                       :msg (msg "give the Runner " (quantify (get-counters (get-card state card) :advancement) "tag"))
                       :effect (effect (tag-runner :runner eid (get-counters (get-card state card) :advancement)))})
@@ -721,7 +721,7 @@
              :effect (effect (lose-credits :runner 1))}}
 
    "Hostile Infrastructure"
-   {:events {:runner-trash {:delayed-completion true
+   {:events {:runner-trash {:async true
                             :req (req (some #(card-is? % :side :corp) targets))
                             :msg (msg (str "do " (count (filter #(card-is? % :side :corp) targets))
                                            " net damage"))
@@ -732,7 +732,7 @@
                                                      (effect-completed state side eid card)))]
                                            (do-damage (filter #(card-is? % :side :corp) targets))))}}
     :abilities [{:msg "do 1 net damage"
-                 :delayed-completion true
+                 :async true
                  :effect (effect (damage eid :net 1 {:card card}))}]}
 
    "Hyoubu Research Facility"
@@ -763,7 +763,7 @@
    (let [ability {:msg "gain 1 [Credits] and draw 1 card"
                   :label "Gain 1 [Credits] and draw 1 card (start of turn)"
                   :once :per-turn
-                  :delayed-completion true
+                  :async true
                   :req (req (:corp-phase-12 @state))
                   :effect (effect (gain-credits 1)
                                   (draw eid 1 nil))}]
@@ -854,7 +854,7 @@
     :flags {:corp-phase-12 (req true)}
     :abilities [{:label "Trace X - do 1 brain damage (start of turn)"
                  :trace {:base (req (get-counters card :power))
-                          :successful {:delayed-completion true
+                          :successful {:async true
                                        :msg "do 1 brain damage"
                                        :effect (effect (damage :runner eid :brain 1 {:card card})
                                                        (trash card))}
@@ -899,7 +899,7 @@
                                  (shuffle! :deck))}]}
 
    "Lily Lockwell"
-   {:delayed-completion true
+   {:async true
     :effect (effect (draw eid 3 nil))
     :msg (msg "draw 3 cards")
     :abilities [{:label "Remove a tag to search R&D for an operation"
@@ -949,7 +949,7 @@
                   :once :per-turn
                   :req (req (:corp-phase-12 @state))
                   :label (str "Gain 2 [Credits] (start of turn)")
-                  :delayed-completion true
+                  :async true
                   :effect (req (gain-credits state :corp 2)
                                (if (zero? (get-counters (get-card state card) :credit))
                                  (trash state :corp eid card {:unpreventable true})
@@ -958,7 +958,7 @@
       :derezzed-events {:runner-turn-ends corp-rez-toast}
       :events {:corp-turn-begins ability}
       :trash-effect {:req (req (= :servers (first (:previous-zone card))))
-                     :delayed-completion true
+                     :async true
                      :effect (effect (show-wait-prompt :runner "Corp to use Marilyn Campaign")
                                      (continue-ability :corp
                                        {:optional
@@ -1032,7 +1032,7 @@
       :abilities [ability]})
 
    "Mr. Stone"
-   {:events {:runner-gain-tag {:delayed-completion true
+   {:events {:runner-gain-tag {:async true
                                :msg "do 1 meat damage"
                                :effect (effect (damage :corp eid :meat 1 {:card card}))}}}
 
@@ -1145,10 +1145,10 @@
    "News Team"
    {:flags {:rd-reveal (req true)}
     :access {:msg (msg "force the Runner take 2 tags or add it to their score area as an agenda worth -1 agenda point")
-             :delayed-completion true
+             :async true
              :effect (effect (continue-ability
                                {:player :runner
-                                :delayed-completion true
+                                :async true
                                 :prompt "Take 2 tags or add News Team to your score area as an agenda worth -1 agenda point?"
                                 :choices ["Take 2 tags" "Add News Team to score area"]
                                 :effect (req (if (= target "Add News Team to score area")
@@ -1176,11 +1176,11 @@
               :msg (msg (if (-> corp :deck count pos?)
                           (str "reveal and draw " (-> corp :deck first :title) " from R&D")
                           "reveal and draw from R&D but it is empty"))
-              :delayed-completion true
+              :async true
               :effect (effect (draw 1)
                               (continue-ability
                                 {:prompt "Choose a card in HQ to put on top of R&D"
-                                 :delayed-completion true
+                                 :async true
                                  :choices {:req #(and (in-hand? %)
                                                       (= (:side %) "Corp"))}
                                  :msg "add 1 card from HQ to the top of R&D"
@@ -1259,7 +1259,7 @@
    (letfn [(pdhelper [agendas n]
              {:optional
               {:prompt (msg "Reveal and install " (:title (nth agendas n)) "?")
-               :yes-ability {:delayed-completion true
+               :yes-ability {:async true
                              :msg (msg "reveal " (:title (nth agendas n)))
                              :effect (req (when-completed (corp-install
                                                             state side (nth agendas n) nil
@@ -1270,13 +1270,13 @@
                                             (if (< (inc n) (count agendas))
                                               (continue-ability state side (pdhelper agendas (inc n)) card nil)
                                               (effect-completed state side eid))))}
-               :no-ability {:delayed-completion true
+               :no-ability {:async true
                             :effect (req (if (< (inc n) (count agendas))
                                            (continue-ability state side (pdhelper agendas (inc n)) card nil)
                                            (effect-completed state side eid)))}}})]
      {:events
       {:corp-draw
-       {:delayed-completion true
+       {:async true
         :req (req (let [drawn (get-in @state [:corp :register :most-recent-drawn])
                         agendas (filter #(is-type? % "Agenda") drawn)]
                     (seq agendas)))
@@ -1299,14 +1299,14 @@
    "Project Junebug"
    (advance-ambush 1 {:req (req (pos? (get-counters (get-card state card) :advancement)))
                       :msg (msg "do " (* 2 (get-counters (get-card state card) :advancement)) " net damage")
-                      :delayed-completion true
+                      :async true
                       :effect (effect (damage eid :net (* 2 (get-counters (get-card state card) :advancement))
                                               {:card card}))})
 
    "Psychic Field"
    (let [ab {:psi {:req (req installed)
                    :not-equal {:msg (msg "do " (count (:hand runner)) " net damage")
-                               :delayed-completion true
+                               :async true
                                :effect (effect (damage eid :net (count (:hand runner)) {:card card}))}}}]
      {:expose ab :access ab})
 
@@ -1314,7 +1314,7 @@
    {:effect (effect (add-counter card :power 3))
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     :events {:corp-turn-begins
-             {:delayed-completion true
+             {:async true
               :effect (req (add-counter state side card :power -1)
                            (if (zero? (get-counters (get-card state card) :power))
                              (do (system-msg state :corp "uses Public Support to add it to their score area as an agenda worth 1 agenda point")
@@ -1323,7 +1323,7 @@
 
    "Quarantine System"
    (letfn [(rez-ice [cnt] {:prompt "Select an ICE to rez"
-                           :delayed-completion true
+                           :async true
                            :choices {:req #(and (ice? %) (not (rezzed? %)))}
                            :msg (msg "rez " (:title target))
                            :effect (req (let [agenda (last (:rfg corp))
@@ -1373,7 +1373,7 @@
                   :effect (effect (resolve-ability
                                     {:optional
                                      {:prompt "Trash Rashida Jaheem to gain 3 [Credits] and draw 3 cards?"
-                                      :yes-ability {:delayed-completion true
+                                      :yes-ability {:async true
                                                     :msg "gain 3 [Credits] and draw 3 cards"
                                                     :effect (req (when-completed (trash state side card nil)
                                                                                  (do (gain-credits state side 3)
@@ -1455,7 +1455,7 @@
     :abilities [{:cost [:click 1]
                  :req (req (>= (get-counters card :advancement) 4))
                  :msg "do 3 net damage"
-                 :delayed-completion true
+                 :async true
                  :effect (effect (trash card {:cause :ability-cost})
                                  (damage eid :net 3 {:card card}))}]}
 
@@ -1526,7 +1526,7 @@
     :abilities [ability]
     :events {:corp-turn-begins ability
              :corp-install {:req (req (ice? target))
-                            :delayed-completion true
+                            :async true
                             :effect (req (when-completed (trash state side card nil)
                                                          (do (system-msg state :runner "trashes Server Diagnostics")
                                                              (effect-completed state side eid card))))}}})
@@ -1550,7 +1550,7 @@
                                  (move target :deck))}]}
 
    "Shattered Remains"
-   (advance-ambush 1 {:delayed-completion true
+   (advance-ambush 1 {:async true
                       :req (req (pos? (get-counters (get-card state card) :advancement)))
                       :effect (req (let [counters (get-counters (get-card state card) :advancement)]
                                      (continue-ability
@@ -1564,7 +1564,7 @@
 
    "Shi.Kyū"
    {:access
-    {:delayed-completion true
+    {:async true
      :req (req (not= (first (:zone card)) :deck))
      :effect (effect (show-wait-prompt :runner "Corp to use Shi.Kyū")
                      (continue-ability
@@ -1574,7 +1574,7 @@
                          {:prompt "How many [Credits] for Shi.Kyū?"
                           :choices :credit
                           :msg (msg "attempt to do " target " net damage")
-                          :delayed-completion true
+                          :async true
                           :effect (req (let [dmg target]
                                          (clear-wait-prompt state :runner)
                                          (continue-ability
@@ -1582,7 +1582,7 @@
                                            {:player :runner
                                             :prompt (str "Take " dmg " net damage or add Shi.Kyū to your score area as an agenda worth -1 agenda point?")
                                             :choices [(str "Take " dmg " net damage") "Add Shi.Kyū to score area"]
-                                            :delayed-completion true
+                                            :async true
                                             :effect (req (if (= target "Add Shi.Kyū to score area")
                                                            (do (system-msg state :runner (str "adds Shi.Kyū to their score area as as an agenda worth -1 agenda point"))
                                                                (trigger-event state side :no-trash card)
@@ -1596,19 +1596,19 @@
    "Shock!"
    {:flags {:rd-reveal (req true)}
     :access {:msg "do 1 net damage"
-             :delayed-completion true
+             :async true
              :effect (effect (damage eid :net 1 {:card card}))}}
 
    "Snare!"
    {:flags {:rd-reveal (req true)}
     :access {:req (req (not= (first (:zone card)) :discard))
-             :delayed-completion true
+             :async true
              :effect (effect (show-wait-prompt :runner "Corp to use Snare!")
                              (continue-ability
                                {:optional
                                 {:prompt "Pay 4 [Credits] to use Snare! ability?"
                                  :end-effect (effect (clear-wait-prompt :runner))
-                                 :yes-ability {:delayed-completion true
+                                 :yes-ability {:async true
                                                :cost [:credit 4]
                                                :msg "do 3 net damage and give the Runner 1 tag"
                                                :effect (req (when-completed (damage state side :net 3 {:card card})
@@ -1617,7 +1617,7 @@
 
    "Space Camp"
    {:flags {:rd-reveal (req true)}
-    :access {:delayed-completion true
+    :access {:async true
              :effect (effect (show-wait-prompt :runner "Corp to use Space Camp")
                              (continue-ability
                                {:optional
@@ -1657,7 +1657,7 @@
                              :prompt "Select a card from Archives or HQ to install"
                              :show-discard true
                              :interactive (req true)
-                             :delayed-completion true
+                             :async true
                              :choices {:req #(and (not (is-type? % "Operation"))
                                                   (= (:side %) "Corp")
                                                   (#{[:hand] [:discard]} (:zone %)))}
@@ -1704,7 +1704,7 @@
 
    "Test Ground"
    (letfn [(derez-card [advancements]
-             {:delayed-completion true
+             {:async true
               :prompt "Derez a card"
               :choices {:req #(and (installed? %)
                                    (rezzed? %))}
@@ -1732,7 +1732,7 @@
           :trash-effect {:when-inactive true
                          :req (req (:access @state))
                          :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
-                         :delayed-completion true
+                         :async true
                          :effect (req (as-agenda state :runner eid card 2))}
           :events {:agenda-stolen (dissoc the-board :req)
                    :as-agenda the-board
@@ -1795,7 +1795,7 @@
    {:effect (effect (add-counter card :power 3))
     :derezzed-events {:runner-turn-ends corp-rez-toast}
     :events {:corp-turn-begins
-             {:delayed-completion true
+             {:async true
               :effect (req (add-counter state side card :power -1)
                            (if (zero? (get-counters (get-card state card) :power))
                              (when-completed (trash state side card nil)
@@ -1813,7 +1813,7 @@
     :trash-effect {:when-inactive true
                    :req (req (:access @state))
                    :msg "add it to the Runner's score area as an agenda worth 2 agenda points"
-                   :delayed-completion true
+                   :async true
                    :effect (req (as-agenda state :runner eid card 2))}}
 
    "Warden Fatuma"
@@ -1853,7 +1853,7 @@
                  :once :per-turn
                  :req (req (and (pos? (count (:hand corp)))
                                 (pos? (count (:discard corp)))))
-                 :delayed-completion true
+                 :async true
                  :effect (req (show-wait-prompt state :runner "Corp to use Whampoa Reclamation")
                               (when-completed (resolve-ability state side
                                                 {:prompt "Choose a card in HQ to trash"
@@ -1888,7 +1888,7 @@
                               :req (req true)}]}
     :derezzed-events
     {:pre-expose
-     {:delayed-completion true
+     {:async true
       :effect (req (let [etarget target]
                      (continue-ability
                        state side
@@ -1907,7 +1907,7 @@
 
    "Zealous Judge"
    {:rez-req (req tagged)
-    :abilities [{:delayed-completion true
+    :abilities [{:async true
                  :label "Give the Runner 1 tag"
                  :cost [:click 1 :credit 1]
                  :msg (msg "give the Runner 1 tag")

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1,7 +1,7 @@
 (ns game.cards.assets
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -478,7 +478,7 @@
                                                          (move state side c :deck)))}
                                          card targets)
                                        (do (clear-wait-prompt state :runner)
-                                           (effect-completed state side eid card)))))}}}
+                                           (effect-completed state side eid)))))}}}
 
    "Dedicated Response Team"
    {:events {:successful-run-ends {:req (req tagged)
@@ -729,7 +729,7 @@
                                                    (if-not (empty? t)
                                                      (wait-for (damage state side :net 1 {:card card})
                                                                (do-damage (rest t)))
-                                                     (effect-completed state side eid card)))]
+                                                     (effect-completed state side eid)))]
                                            (do-damage (filter #(card-is? % :side :corp) targets))))}}
     :abilities [{:msg "do 1 net damage"
                  :async true
@@ -1529,7 +1529,7 @@
                             :async true
                             :effect (req (wait-for (trash state side card nil)
                                                    (do (system-msg state :runner "trashes Server Diagnostics")
-                                                       (effect-completed state side eid card))))}}})
+                                                       (effect-completed state side eid))))}}})
 
    "Shannon Claire"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1,7 +1,7 @@
 (ns game.cards.events
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -174,7 +174,7 @@
               :effect (req (if (= target "Done")
                              (do (doseq [c (reverse chosen)] (move state :corp c :deck {:front true}))
                                  (clear-wait-prompt state :runner)
-                                 (effect-completed state side eid card))
+                                 (effect-completed state side eid))
                              (continue-ability state side (cbi-choice original '() (count original) original)
                                                card nil)))})
            (cbi-choice [remaining chosen n original]
@@ -197,7 +197,7 @@
                                                 (if (pos? (count from))
                                                   (continue-ability state :corp (cbi-choice from '() (count from) from) card nil)
                                                   (do (clear-wait-prompt state :runner)
-                                                      (effect-completed state side eid card)))))}} card))})
+                                                      (effect-completed state side eid)))))}} card))})
 
    "Code Siphon"
    {:req (req rd-runnable)
@@ -569,7 +569,7 @@
                             (trash state side c {:unpreventable true}))
                           (install-cost-bonus state side [:credit (- trash-cost)])
                           (runner-install state side target)
-                          (effect-completed state side eid card))})]
+                          (effect-completed state side eid))})]
    {:prompt "Choose Hardware and Programs to trash from your Grip"
     :choices {:req #(and (or (is-type? % "Hardware")
                              (is-type? % "Program"))
@@ -724,7 +724,7 @@
                                                                                    " forcing the Corp to trash " target " cards"
                                                                                    " from the top of R&D"))))}
                                                  card nil)
-                                                (effect-completed state side eid card))))}} card))}
+                                                (effect-completed state side eid))))}} card))}
 
    "Feint"
    {:req (req hq-runnable)
@@ -850,7 +850,7 @@
                                                        :effect (req (doseq [c (take 5 (shuffle (:hand corp)))]
                                                                       (trash state :corp c))
                                                                     (clear-wait-prompt state :runner)
-                                                                    (effect-completed state :runner eid card))}
+                                                                    (effect-completed state :runner eid))}
                                                       card nil)))}
         access-effect {:mandatory true
                        :async true
@@ -967,7 +967,7 @@
                                             (continue-ability state side (reorder-choice :corp :corp from '()
                                                                                          (count from) from) card nil)
                                             (do (clear-wait-prompt state :corp)
-                                                (effect-completed state side eid card)))))}} card))}
+                                                (effect-completed state side eid)))))}} card))}
 
    "Infiltration"
    {:prompt "Gain 2 [Credits] or expose a card?" :choices ["Gain 2 [Credits]" "Expose a card"]
@@ -988,7 +988,7 @@
                              (if (< 1 (count cards))
                                (continue-ability state side (access-pile (next cards) pile pile-size) card nil)
                                (do (swap! state assoc-in [:run :cards-accessed] pile-size)
-                                   (effect-completed state side eid card)))))})
+                                   (effect-completed state side eid)))))})
            (which-pile [p1 p2]
              {:prompt "Choose a pile to access"
               :choices [(str "Pile 1 (" (count p1) " cards)") (str "Pile 2 (" (count p2) " cards)")]
@@ -1019,7 +1019,7 @@
                                                                                 (set (:hand corp)) (set targets)))))
                                                     card nil))
                                   } card nil))
-                           (effect-completed state side eid card)))}]
+                           (effect-completed state side eid)))}]
        {:req (req hq-runnable)
         :effect (effect (run :hq {:req (req (= target :hq))
                                   :replace-access access-effect}
@@ -1201,7 +1201,7 @@
                                (continue-ability state side (reorder-choice :runner :corp cards '()
                                                                             (count cards) cards) card nil)
                                (do (clear-wait-prompt state :corp)
-                                   (effect-completed state side eid card)))
+                                   (effect-completed state side eid)))
                              (do (trash state side target {:unpreventable true})
                                  (continue-ability state side (entrance-trash (remove-once #(= % target) cards))
                                                    card nil))))})]
@@ -1564,7 +1564,7 @@
              {:prompt "Select a piece of ICE to bypass"
               :choices {:req #(ice? %)}
               :msg (msg "bypass " (card-str state target))
-              :effect (final-effect (run (second (:zone target))))})
+              :effect (effect (run (second (:zone target))))})
            (corp-choice [spent]
              {:prompt "Guess how many credits were spent"
               :choices ["0" "1" "2"]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1,7 +1,7 @@
 (ns game.cards.hardware
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -1085,7 +1085,7 @@
                                   (continue-ability state side (reorder-choice :runner :corp from '()
                                                                                (count from) from) card nil)
                                   (do (clear-wait-prompt state :corp)
-                                      (effect-completed state side eid card)))))}
+                                      (effect-completed state side eid)))))}
                 {:label "[Trash]: Look at the top card of R&D"
                  :msg "trash it and look at the top card of R&D"
                  :effect (effect (prompt! card (str "The top card of R&D is " (:title (first (:deck corp)))) ["OK"] {})
@@ -1193,7 +1193,7 @@
                                                            (swap-agendas state side scored stolen)
                                                            (system-msg state side (str "uses Turntable to swap "
                                                                                        (:title stolen) " for " (:title scored)))
-                                                           (effect-completed state side eid card)))}
+                                                           (effect-completed state side eid)))}
                                            card targets))}}}
                             card targets)))}}}
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -11,7 +11,7 @@
   {"Acacia"
    {:events {:pre-purge {:effect (req (let [counters (number-of-virus-counters state)]
                                         (update! state side (assoc-in (get-card state card) [:special :numpurged] counters))))}
-             :purge {:delayed-completion true
+             :purge {:async true
                      :effect (effect (show-wait-prompt  :corp "Runner to decide if they will use Acacia")
                                      (continue-ability
                                        {:optional
@@ -48,7 +48,7 @@
    "Archives Interface"
    {:events
     {:pre-access
-     {:delayed-completion true
+     {:async true
       :interactive (req true)
       :req (req (and (= target :archives)
                      (not= (:max-access run) 0)
@@ -64,7 +64,7 @@
    "Astrolabe"
    {:in-play [:memory 1]
     :events {:server-created {:msg "draw 1 card"
-                              :delayed-completion true
+                              :async true
                               :effect (effect (draw :runner eid 1 nil))}}}
 
    "Autoscripter"
@@ -85,7 +85,7 @@
    {:in-play [:memory 2]
     :events {:expose
              {:msg (msg "attempt to force the rez of " (:title target))
-              :delayed-completion true
+              :async true
               :effect (req (let [c target
                                  cdef (card-def c)
                                  cname (:title c)]
@@ -263,10 +263,10 @@
              {:optional
               {:req (req (has-subtype? target "Caïssa"))
                :prompt "Use Deep Red?" :priority 1
-               :yes-ability {:delayed-completion true
+               :yes-ability {:async true
                              :effect (req (let [cid (:cid target)]
                                             (continue-ability state side
-                                              {:delayed-completion true
+                                              {:async true
                                                :prompt "Choose the just-installed Caïssa to have Deep Red trigger its [Click] ability"
                                                :choices {:req #(= cid (:cid %))}
                                                :msg (msg "trigger the [Click] ability of " (:title target)
@@ -324,7 +324,7 @@
                :player :runner
                :prompt "Use Doppelgänger to run again?"
                :yes-ability {:prompt "Choose a server"
-                             :delayed-completion true
+                             :async true
                              :choices (req runnable-servers)
                              :msg (msg "make a run on " target)
                              :makes-run true
@@ -396,7 +396,7 @@
                                  (damage-prevent :brain 2))}]}
 
    "Flame-out"
-   (let [turn-end {:delayed-completion true
+   (let [turn-end {:async true
                    :effect (req (unregister-events state :runner card)
                                 (if-let [hosted (first (:hosted card))]
                                   (do
@@ -474,7 +474,7 @@
                    :label "Toggle auomatically adding virus counters"}]
       :effect (effect (toast "Tip: You can toggle automatically adding virus counters by clicking Friday Chip."))
       :events {:runner-turn-begins ability
-               :runner-trash {:delayed-completion true
+               :runner-trash {:async true
                               :req (req (some #(card-is? % :side :corp) targets))
                               :effect (req (let [amt-trashed (count (filter #(card-is? % :side :corp) targets))
                                                  auto-ab {:effect (effect (system-msg :runner
@@ -520,7 +520,7 @@
    "GPI Net Tap"
    {:implementation "Trash and jack out effect is manual"
     :abilities [{:req (req (and (ice? current-ice) (not (rezzed? current-ice))))
-                 :delayed-completion true
+                 :async true
                  :effect (effect (expose eid current-ice))}]}
 
    "Grimoire"
@@ -546,7 +546,7 @@
     :abilities [{:label "Remove Hippo from the game: trash outermost piece of ICE if all subroutines were broken"
                  :req (req (and run
                                 (pos? (count run-ices))))
-                 :delayed-completion true
+                 :async true
                  :effect (req (let [ice (last run-ices)]
                                 (system-msg
                                   state :runner
@@ -636,7 +636,7 @@
    "Maya"
    {:in-play [:memory 2]
     :abilities [{:once :per-turn
-                 :delayed-completion true
+                 :async true
                  :label "Move this accessed card to bottom of R&D"
                  :req (req (when-let [accessed-card (-> @state :runner :prompt first :card)]
                              (in-deck? accessed-card)))
@@ -648,7 +648,7 @@
                 {:once :per-turn
                  :label "Move a previously accessed card to bottom of R&D"
                  :effect (effect (resolve-ability
-                                   {:delayed-completion true
+                                   {:async true
                                     ;; only allow targeting cards that were accessed this turn
                                     :choices {:req #(some (fn [accessed-card]
                                                             (= (:cid %) (:cid accessed-card)))
@@ -670,7 +670,7 @@
    "Mirror"
    {:in-play [:memory 2]
     :events {:successful-run
-             {:delayed-completion true
+             {:async true
               :req (req (= target :rd))
               :effect (effect (continue-ability
                                 {:prompt "Select a card and replace 1 spent [Recurring Credits] on it"
@@ -818,13 +818,13 @@
       :events {:pass-ice {:req (req (and (= (:server run) [:hq])
                                          (= (:position run) 1) ; trigger when last ICE passed
                                          (pos? (count (:deck runner)))))
-                          :delayed-completion true
+                          :async true
                           :once :per-turn
                           :effect (req (continue-ability state :runner abi card nil))}
                :run {:req (req (and (= (:server run) [:hq])
                                     (zero? (:position run)) ; trigger on unprotected HQ
                                     (pos? (count (:deck runner)))))
-                     :delayed-completion true
+                     :async true
                      :once :per-turn
                      :effect (req (continue-ability state :runner abi card nil))}}})
 
@@ -895,16 +895,16 @@
                                 :req (req (:access @state))}]}
       :abilities [{:req (req (= (:cid (second (:pre-damage (eventmap @state))))
                                 (:cid (first (:pre-access-card (eventmap @state))))))
-                :effect (effect (resolve-ability
-                                  {:prompt "Choose how much damage to prevent"
-                                   :priority 50
-                                   :choices {:number (req (min (last (:pre-damage (eventmap @state)))
-                                                               (:credit runner)))}
-                                   :msg (msg "prevent " target " damage")
-                                   :effect (effect (trash card {:cause :ability-cost})
-                                                   (damage-prevent (first (:pre-damage (eventmap @state))) target)
-                                                   (lose-credits target))}
-                                  card nil))}]})
+                   :effect (effect (resolve-ability
+                                     {:prompt "Choose how much damage to prevent"
+                                      :priority 50
+                                      :choices {:number (req (min (last (:pre-damage (eventmap @state)))
+                                                                  (:credit runner)))}
+                                      :msg (msg "prevent " target " damage")
+                                      :effect (effect (trash card {:cause :ability-cost})
+                                                      (damage-prevent (first (:pre-damage (eventmap @state))) target)
+                                                      (lose-credits target))}
+                                     card nil))}]})
 
    "Record Reconstructor"
    {:events
@@ -968,7 +968,7 @@
    "Rubicon Switch"
    {:abilities [{:cost [:click 1]
                  :once :per-turn
-                 :delayed-completion true
+                 :async true
                  :prompt "How many [Credits]?" :choices :credit
                  :effect (effect (system-msg (str "spends a [Click] and " target " [Credit] on Rubicon Switch"))
                                  (resolve-ability {:choices {:req #(and (ice? %)
@@ -1005,7 +1005,7 @@
     :in-play [:memory 1 :link 1]
     :abilities [{:req (req (:run @state))
                  :once :per-turn
-                 :delayed-completion true
+                 :async true
                  :msg "force the Corp to initiate a trace"
                  :label "Trace 5 - Give the Runner 1 tag and end the run"
                  :trace {:base 5
@@ -1074,7 +1074,7 @@
 
    "Spy Camera"
    {:abilities [{:cost [:click 1]
-                 :delayed-completion true
+                 :async true
                  :label "Look at the top X cards of your Stack"
                  :msg "look at the top X cards of their Stack and rearrange them"
                  :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their stack")
@@ -1097,7 +1097,7 @@
     :events {:post-successful-run {:req (req (and (= :hq target)
                                                   run))
                                    :silent (req true)
-                                   :delayed-completion true
+                                   :async true
                                    :effect (effect (continue-ability
                                                      {:prompt "How many ICE protecting HQ did you break all subroutines on?"
                                                       ;; Makes number of ice on server (HQ) the upper limit.
@@ -1120,7 +1120,7 @@
    "Titanium Ribs"
    {:events
     {:pre-resolve-damage
-     {:delayed-completion true
+     {:async true
       :req (req (and (pos? (last targets))
                      (runner-can-choose-damage? state)
                      (not (get-in @state [:damage :damage-replace]))))
@@ -1134,7 +1134,7 @@
                        (swap! state update-in [:runner :hand-size :mod] #(- % dmg)))
                      (show-wait-prompt state :corp "Runner to use Titanium Ribs to choose cards to be trashed")
                      (when-completed (resolve-ability state side
-                                       {:delayed-completion true
+                                       {:async true
                                         :prompt (msg "Select " dmg " cards to trash for the " (name dtype) " damage")
                                         :player :runner
                                         :choices {:max dmg :all true :req #(and (in-hand? %) (= (:side %) "Runner"))}
@@ -1149,7 +1149,7 @@
                                      (do (trigger-event state side :damage dtype src dmg)
                                          (effect-completed state side eid)))))}
     :damage-chosen {:effect (effect (enable-runner-damage-choice))}}
-    :delayed-completion true
+    :async true
     :effect (effect (enable-runner-damage-choice)
                     (system-msg (str "suffers 2 meat damage from installing Titanium Ribs"))
                     (damage eid :meat 2 {:unboostable true :card card}))
@@ -1157,7 +1157,7 @@
 
    "Top Hat"
    (letfn [(ability [n]
-             {:delayed-completion true
+             {:async true
               :mandatory true
               :prompt "Which card from the top of R&D would you like to access? (Card 1 is on top.)"
               :choices (take n ["1" "2" "3" "4" "5"])
@@ -1175,7 +1175,7 @@
     :events {:agenda-stolen
              {:interactive (req true)
               :req (req (not (empty? (:scored corp))))
-              :delayed-completion true
+              :async true
               :effect (req
                         (let [stolen target]
                           (continue-ability
@@ -1183,7 +1183,7 @@
                             {:optional
                              {:prompt (msg "Swap " (:title stolen) " for an agenda in the Corp's score area?")
                               :yes-ability
-                              {:delayed-completion true
+                              {:async true
                                :effect (req
                                          (continue-ability
                                            state side

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1,7 +1,7 @@
 (ns game.cards.ice
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -682,7 +682,7 @@
                                                        (do (system-msg state :corp (str "trashes " (:title (first from))))
                                                            (trash state side (first from) {:unpreventable true})
                                                            (clear-wait-prompt state :runner)
-                                                           (effect-completed state side eid card)))))})]})
+                                                           (effect-completed state side eid)))))})]})
 
    "Data Loop"
    {:implementation "Encounter effect is manual"
@@ -1016,7 +1016,7 @@
                                      (continue-ability state side (hort (inc n)) card nil)
                                      (do (shuffle! state side :deck)
                                          (system-msg state side (str "shuffles R&D"))
-                                         (effect-completed state side eid card))))})]
+                                         (effect-completed state side eid))))})]
      {:advanceable :always
       :subroutines [{:label "Gain 1 [Credits] (Gain 4 [Credits])"
                      :msg (msg "gain " (if (wonder-sub card 3) "4" "1") " [Credits]")
@@ -1407,7 +1407,7 @@
                                      :msg (msg "swap the positions of " (card-str state (first targets)) " and " (card-str state (second targets)))
                                      :effect (req (when (= (count targets) 2)
                                                     (swap-ice state side (first targets) (second targets))
-                                                    (effect-completed state side eid card)))}
+                                                    (effect-completed state side eid)))}
                                     card nil)
                                   (continue-ability
                                     state side
@@ -1417,7 +1417,7 @@
                                      :msg (msg "swap the positions of " (card-str state (first targets)) " and " (card-str state (second targets)))
                                      :effect (req (when (= (count targets) 2)
                                                     (swap-installed state side (first targets) (second targets))
-                                                    (effect-completed state side eid card)))}
+                                                    (effect-completed state side eid)))}
                                     card nil)))}]}
 
    "Mganga"
@@ -1939,7 +1939,7 @@
                                     (continue-ability state side (reorder-choice :corp :runner from '()
                                                                                  (count from) from) card nil)
                                     (do (clear-wait-prompt state :runner)
-                                        (effect-completed state side eid card)))))}
+                                        (effect-completed state side eid)))))}
                   {:label "Force the Runner to access the top card of R&D"
                    :effect (req (wait-for (trigger-event-sync state side :pre-access :rd)
                                           (let [total-cards (access-count state side :rd-access)]

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -1,7 +1,7 @@
 (ns game.cards.icebreakers
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -1,7 +1,7 @@
 (ns game.cards.icebreakers
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -254,30 +254,31 @@
                              :effect (effect (system-msg "adds 1 virus counter to " (:title card))
                                              (add-counter card :virus 1))}}
    :abilities [{:label (str  "Break " ice-type "subroutine(s)")
-                :effect (req (when-completed (resolve-ability
-                                              state side (pick-virus-counters-to-spend) card nil)
-                               (do (if-let [msg (:msg async-result)]
-                                     (do (system-msg state :runner
-                                                     (str "spends " msg" to break " (:number async-result)
-                                                          " " ice-type " subroutine(s)")))))))}
+                :effect (req (wait-for (resolve-ability
+                                         state side (pick-virus-counters-to-spend) card nil)
+                                       (do (if-let [msg (:msg async-result)]
+                                             (do (system-msg state :runner
+                                                             (str "spends " msg" to break " (:number async-result)
+                                                                  " " ice-type " subroutine(s)")))))))}
                {:label "Match strength of currently encountered ice"
                 :req (req (and current-ice
                                (> (ice-strength state side current-ice)
                                   (or (:current-strength card) (:strength card)))))
-                :effect (req (when-completed (resolve-ability
-                                              state side (pick-virus-counters-to-spend
-                                                          (- (ice-strength state side current-ice)
-                                                             (or (:current-strength card) (:strength card))))
-                                              card nil)
-                               (if-let [msg (:msg async-result)]
-                                 (do (system-msg state :runner (str "spends " msg " to add "
-                                                                    (:number async-result) " strength"))
-                                     (dotimes [_ (:number async-result)]
-                                       (pump state side (get-card state card) 1))))))}
+                :effect (req (wait-for (resolve-ability
+                                         state side
+                                         (pick-virus-counters-to-spend
+                                           (- (ice-strength state side current-ice)
+                                              (or (:current-strength card) (:strength card))))
+                                         card nil)
+                                       (if-let [msg (:msg async-result)]
+                                         (do (system-msg state :runner (str "spends " msg " to add "
+                                                                            (:number async-result) " strength"))
+                                             (dotimes [_ (:number async-result)]
+                                               (pump state side (get-card state card) 1))))))}
                {:label "Add strength"
-                :effect (req (when-completed
-                                 (resolve-ability
-                                  state side (pick-virus-counters-to-spend) card nil)
+                :effect (req (wait-for
+                               (resolve-ability
+                                 state side (pick-virus-counters-to-spend) card nil)
                                (if-let [msg (:msg async-result)]
                                  (do (system-msg state :runner (str "spends " msg" to add "
                                                                     (:number async-result)
@@ -642,13 +643,13 @@
                                   :msg "break 1 subroutine"}
                                  {:label "Take 1 tag to place 2 virus counters (start of turn)"
                                   :once :per-turn
-                                  :effect (req (when-completed (tag-runner state :runner 1)
-                                                               (if (not (get-in @state [:tag :tag-prevent]))
-                                                                 (do (add-counter state side card :virus 2)
-                                                                     (system-msg state side
-                                                                                 (str "takes 1 tag to place 2 virus counters on God of War"))
-                                                                     (effect-completed state side eid))
-                                                                 (effect-completed state side eid))))}]})
+                                  :effect (req (wait-for (tag-runner state :runner 1)
+                                                         (if (not (get-in @state [:tag :tag-prevent]))
+                                                           (do (add-counter state side card :virus 2)
+                                                               (system-msg state side
+                                                                           (str "takes 1 tag to place 2 virus counters on God of War"))
+                                                               (effect-completed state side eid))
+                                                           (effect-completed state side eid))))}]})
 
    "Golden"
    (auto-icebreaker ["Sentry"]

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -200,7 +200,7 @@
                                        (rezzed? current-ice)
                                        (has-subtype? current-ice ice-type)
                                        (not (install-locked? state :runner))))
-                        :delayed-completion true
+                        :async true
                         :effect (effect (continue-ability
                                           {:optional {:req (req (and (not-any? #(= title (:title %)) (all-active-installed state :runner))
                                                                      (not (get-in @state [:run :register :conspiracy (:cid current-ice)]))))
@@ -406,11 +406,11 @@
     :events {:encounter-ice {:req (req (and (= (:cid target) (:cid current-ice))
                                             (has-subtype? target "Barrier")
                                             (rezzed? target)))
-                             :delayed-completion true
+                             :async true
                              :effect (effect (continue-ability :runner
                                                {:prompt "How many subroutines are on the encountered Barrier?"
                                                 :choices {:number (req 10)}
-                                                :delayed-completion true
+                                                :async true
                                                 :effect (effect (system-msg (str "pumps Berserker by " target " on encounter with the current ICE"))
                                                                 (pump card target))} card nil))}}}
 
@@ -892,7 +892,7 @@
                      :events {:pass-ice {:req (req (and (has-subtype? target "Sentry") (rezzed? target)) (pos? (count (:deck runner))))
                                          :optional {:prompt (msg "Use Persephone's ability??")
                                                     :yes-ability {:prompt "How many subroutines resolved on the passed ICE?"
-                                                                  :delayed-completion true
+                                                                  :async true
                                                                   :choices {:number (req 10)}
                                                                   :msg (msg (if (pos? target)
                                                                               (str "trash " (:title (first (:deck runner))) " from their Stack and trash " target " cards from R&D")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1,7 +1,7 @@
 (ns game.cards.identities
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -194,7 +194,7 @@
                  :choices (req (cancellable (:hosted card)))
                  :msg "move a card from NVRAM to their Grip"
                  :effect (effect (move target :hand)
-                                 (effect-completed eid card))}]
+                                 (effect-completed eid))}]
     :events {:pre-start-game
              {:req (req (= side :runner))
               :async true
@@ -214,7 +214,7 @@
                                                                (move state side c :deck))
                                                              (shuffle! state side :deck)
                                                              (clear-wait-prompt state :corp)
-                                                             (effect-completed state side eid card))} card nil))}}}
+                                                             (effect-completed state side eid))} card nil))}}}
 
    "Azmari EdTech: Shaping the Future"
    (let [choose-type {:prompt "Name a Runner card type"
@@ -430,7 +430,7 @@
                                 {:prompt "Select a Bioroid to rez" :player :corp
                                  :choices {:req #(and (has-subtype? % "Bioroid") (not (rezzed? %)))}
                                  :msg (msg "rez " (:title target))
-                                 :cancel-effect (final-effect (clear-wait-prompt :runner))
+                                 :cancel-effect (effect (clear-wait-prompt :runner))
                                  :effect (effect (rez-cost-bonus -4)
                                                  (rez target)
                                                  (clear-wait-prompt :runner))}
@@ -681,7 +681,7 @@
                 :prompt "Select an unrezzed card to return to HQ"
                 :choices {:req #(and (not (rezzed? %)) (installed? %) (card-is? % :side :corp))}
                 :msg (msg "add " (card-str state target) " to HQ")
-                :effect (final-effect (move :corp target :hand))}]
+                :effect (effect (move :corp target :hand))}]
      {:flags {:slow-hq-access (req true)}
       :events {:agenda-scored leela
                :agenda-stolen leela}})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1,7 +1,7 @@
 (ns game.cards.identities
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -361,17 +361,17 @@
                                           :effect (effect (clear-wait-prompt :corp)
                                                           (trash-no-cost eid accessed-card))}
                                          card nil)
-                       (when-completed (resolve-ability state side (pick-virus-counters-to-spend play-or-rez) card nil)
-                                       (do (clear-wait-prompt state :corp)
-                                           (if-let [msg (:msg async-result)]
-                                             (do (system-msg state :runner
-                                                             (str "uses Freedom Khumalo: Crypto-Anarchist to"
-                                                                  " trash " (:title accessed-card)
-                                                                  " at no cost, spending " msg))
-                                                 (trash-no-cost state side eid accessed-card))
-                                             ;; Player cancelled ability
-                                             (do (swap! state dissoc-in [:per-turn (:cid card)])
-                                                 (access-non-agenda state side eid accessed-card :skip-trigger-event true))))))))}}}
+                       (wait-for (resolve-ability state side (pick-virus-counters-to-spend play-or-rez) card nil)
+                                 (do (clear-wait-prompt state :corp)
+                                     (if-let [msg (:msg async-result)]
+                                       (do (system-msg state :runner
+                                                       (str "uses Freedom Khumalo: Crypto-Anarchist to"
+                                                            " trash " (:title accessed-card)
+                                                            " at no cost, spending " msg))
+                                           (trash-no-cost state side eid accessed-card))
+                                       ;; Player cancelled ability
+                                       (do (swap! state dissoc-in [:per-turn (:cid card)])
+                                           (access-non-agenda state side eid accessed-card :skip-trigger-event true))))))))}}}
 
    "Fringe Applications: Tomorrow, Today"
    {:events

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -36,7 +36,7 @@
 (def card-definitions
   {"419: Amoral Scammer"
    {:events {:corp-install
-             {:delayed-completion true
+             {:async true
               :req (req (and (first-event? state :corp :corp-install)
                              (pos? (:turn @state))
                              (not (rezzed? target))))
@@ -50,7 +50,7 @@
                            :player :runner
                            :no-ability {:effect (req (clear-wait-prompt state :corp))}
                            :yes-ability
-                           {:delayed-completion true
+                           {:async true
                             :effect (req (clear-wait-prompt state :corp)
                                          (if (not (can-pay? state :corp nil :credit 1))
                                            (do
@@ -64,7 +64,7 @@
                                                 {:prompt "Pay 1 [Credits] to prevent exposure of installed card?"
                                                  :player :corp
                                                  :no-ability
-                                                 {:delayed-completion true
+                                                 {:async true
                                                   :effect (req (expose state side eid itarget)
                                                                (clear-wait-prompt state :runner))}
                                                  :yes-ability
@@ -78,7 +78,7 @@
    "Adam: Compulsive Hacker"
    {:events {:pre-start-game
              {:req (req (= side :runner))
-              :delayed-completion true
+              :async true
               :effect (req (show-wait-prompt state :corp "Runner to choose starting directives")
                            (let [is-directive? #(has-subtype? % "Directive")
                                  directives (filter is-directive? (vals @all-cards))
@@ -113,7 +113,7 @@
 
    "Alice Merchant: Clan Agitator"
    {:events {:successful-run
-             {:delayed-completion true
+             {:async true
               :interactive (req true)
               :req (req (and (= target :archives)
                              (first-successful-run-on-server? state :archives)
@@ -150,7 +150,7 @@
    "Argus Security: Protection Guaranteed"
    {:events {:agenda-stolen
              {:prompt "Take 1 tag or suffer 2 meat damage?"
-              :delayed-completion true
+              :async true
               :choices ["1 tag" "2 meat damage"] :player :runner
               :msg "make the Runner take 1 tag or suffer 2 meat damage"
               :effect (req (if (= target "1 tag")
@@ -166,7 +166,7 @@
 
    "Asa Group: Security Through Vigilance"
    {:events {:corp-install
-             {:delayed-completion true
+             {:async true
               :req (req (first-event? state :corp :corp-install))
               :effect (req (let [installed-card target
                                  z (butlast (:zone installed-card))]
@@ -189,7 +189,7 @@
    "Ayla \"Bios\" Rahim: Simulant Specialist"
    {:abilities [{:label "[:click] Add 1 card from NVRAM to your grip"
                  :cost [:click 1]
-                 :delayed-completion true
+                 :async true
                  :prompt "Choose a card from NVRAM"
                  :choices (req (cancellable (:hosted card)))
                  :msg "move a card from NVRAM to their Grip"
@@ -197,13 +197,13 @@
                                  (effect-completed eid card))}]
     :events {:pre-start-game
              {:req (req (= side :runner))
-              :delayed-completion true
+              :async true
               :effect (req (show-wait-prompt state :corp "the Runner to choose cards for NVRAM")
                            (doseq [c (take 6 (:deck runner))]
                              (move state side c :play-area))
                              (continue-ability state side
                                                {:prompt (str "Select 4 cards for NVRAM")
-                                                :delayed-completion true
+                                                :async true
                                                 :choices {:max 4
                                                           :all true
                                                           :req #(and (= (:side %) "Runner")
@@ -267,7 +267,7 @@
     {:corp-phase-12 {:effect (effect (enable-corp-damage-choice))}
      :runner-phase-12 {:effect (effect (enable-corp-damage-choice))}
      :pre-resolve-damage
-     {:delayed-completion true
+     {:async true
       :req (req (and (= target :net)
                      (corp-can-choose-damage? state)
                      (pos? (last targets))
@@ -332,7 +332,7 @@
    {:flags {:runner-install-draw true}
     :events {:runner-install {:silent (req (not (and (is-type? target "Program")
                                                      (some #{:discard} (:previous-zone target)))))
-                              :delayed-completion true
+                              :async true
                               :req (req (and (is-type? target "Program")
                                              (some #{:discard} (:previous-zone target))))
                               :msg (msg "draw a card")
@@ -343,7 +343,7 @@
     :interactions
     {:trash-ability
      {:interactive (req true)
-      :delayed-completion true
+      :async true
       :label "[Freedom]: Trash card"
       :req (req (and (not (get-in @state [:per-turn (:cid card)]))
                      (not (is-type? target "Agenda"))
@@ -356,7 +356,7 @@
                      (show-wait-prompt state :corp "Runner to use Freedom Khumalo's ability")
                      (if (zero? play-or-rez)
                        (continue-ability state side
-                                         {:delayed-completion true
+                                         {:async true
                                           :msg (msg "trash " (:title accessed-card) " at no cost")
                                           :effect (effect (clear-wait-prompt :corp)
                                                           (trash-no-cost eid accessed-card))}
@@ -419,7 +419,7 @@
 
    "Haas-Bioroid: Architects of Tomorrow"
    {:events {:pass-ice
-             {:delayed-completion true
+             {:async true
               :once :per-turn
               :req (req (and (rezzed? target)
                              (has-subtype? target "Bioroid")
@@ -473,7 +473,7 @@
               :req (req (and (first-event? state side :runner-install)
                              (some #(is-type? % (:type target)) (:hand runner))))
               :once :per-turn
-              :delayed-completion true
+              :async true
               :effect
               (req (let [itarget target
                          type (:type itarget)]
@@ -505,7 +505,7 @@
    {:events (let [inf {:req (req (and (not (:disabled card))
                                       (has-most-faction? state :corp "NBN")))
                        :msg "give the Runner 1 tag"
-                       :delayed-completion true
+                       :async true
                        :effect (effect (tag-runner :runner eid 1))}]
               {:pre-start-game {:effect draft-points-target}
                :agenda-scored inf :agenda-stolen inf})}
@@ -521,7 +521,7 @@
 
    "Jemison Astronautics: Sacrifice. Audacity. Success."
    {:events {:corp-forfeit-agenda
-             {:delayed-completion true
+             {:async true
               :effect (req (show-wait-prompt state :runner "Corp to place advancement tokens")
                            (let [p (inc (get-agenda-points state :corp target))]
                              (continue-ability state side
@@ -541,12 +541,12 @@
 
    "Jinteki: Personal Evolution"
    {:events {:agenda-scored {:interactive (req true)
-                             :delayed-completion true
+                             :async true
                              :req (req (not (:winner @state)))
                              :msg "do 1 net damage"
                              :effect (effect (damage eid :net 1 {:card card}))}
              :agenda-stolen {:msg "do 1 net damage"
-                             :delayed-completion true
+                             :async true
                              :req (req (not (:winner @state)))
                              :effect (effect (damage eid :net 1 {:card card}))}}}
 
@@ -648,12 +648,12 @@
    "Khan: Savvy Skiptracer"
    {:events {:pass-ice
              {:req (req (first-event? state :corp :pass-ice))
-              :delayed-completion true
+              :async true
               :effect (req (if (some #(has-subtype? % "Icebreaker") (:hand runner))
                              (continue-ability state side
                                                {:prompt "Select an icebreaker to install from your Grip"
                                                 :choices {:req #(and (in-hand? %) (has-subtype? % "Icebreaker"))}
-                                                :delayed-completion true
+                                                :async true
                                                 :msg (msg "install " (:title target))
                                                 :effect (effect (install-cost-bonus [:credit -1])
                                                                 (runner-install eid target nil))}
@@ -663,7 +663,7 @@
    "Laramy Fisk: Savvy Investor"
    {:events
     {:successful-run
-     {:delayed-completion true
+     {:async true
       :interactive (req true)
       :req (req (and (is-central? (:server run))
                      (first-event? state side :successful-run #(is-central? %))))
@@ -671,7 +671,7 @@
                         {:optional
                          {:prompt "Force the Corp to draw a card?"
                           :yes-ability {:msg "force the Corp to draw 1 card"
-                                        :delayed-completion true
+                                        :async true
                                         :effect (effect (draw :corp eid 1 nil))}
                           :no-ability {:effect (effect (system-msg "declines to use Laramy Fisk: Savvy Investor"))}}}
                         card nil))}}}
@@ -742,7 +742,7 @@
    {:events {:corp-turn-ends {:effect cleanup}
              :runner-turn-ends {:effect cleanup}
              :runner-trash
-             {:delayed-completion true
+             {:async true
               :req (req (and (not (:saw-trash card))
                              (card-is? target :side :corp)
                              (installed? target)))
@@ -755,7 +755,7 @@
                                :yes-ability {:trace {:base 4
                                                      :successful
                                                      {:msg "give the Runner 1 tag"
-                                                      :delayed-completion true
+                                                      :async true
                                                       :effect (effect (tag-runner :runner eid 1 {:unpreventable true}))}}}
                                :end-effect (effect (clear-wait-prompt :runner))}}
                              card nil))}}})
@@ -770,7 +770,7 @@
    "Near-Earth Hub: Broadcast Center"
    {:events {:server-created {:req (req (first-event? state :corp :server-created))
                               :msg "draw 1 card"
-                              :delayed-completion true
+                              :async true
                               :effect (effect (draw :corp eid 1 nil))}}}
 
    "Nero Severn: Information Broker"
@@ -786,7 +786,7 @@
                                                 (concat (:hand corp) (:discard corp))))))
                  :yes-ability {:prompt "Select a Current to play from HQ or Archives"
                                :show-discard true
-                               :delayed-completion true
+                               :async true
                                :choices {:req #(and (has-subtype? % "Current")
                                                     (= (:side %) "Corp")
                                                     (#{[:hand] [:discard]} (:zone %)))}
@@ -902,18 +902,18 @@
    "Silhouette: Stealth Operative"
    {:events {:successful-run
              {:interactive (req (some #(not (rezzed? %)) (all-installed state :corp)))
-              :delayed-completion true
+              :async true
               :req (req (and (= target :hq)
                              (first-successful-run-on-server? state :hq)))
               :effect (effect (continue-ability {:choices {:req #(and (installed? %) (not (rezzed? %)))}
                                                  :effect (effect (expose eid target)) :msg "expose 1 card"
-                                                 :delayed-completion true }
+                                                 :async true }
                                                 card nil))}}}
 
    "Skorpios Defense Systems: Persuasive Power"
    {:implementation "Manually triggered, no restriction on which cards in Heap can be targeted.  Cannot use on in progress run event"
     :abilities [{:label "Remove a card in the Heap that was just trashed from the game"
-                 :delayed-completion true
+                 :async true
                  :effect (req (when-not (and (used-this-turn? (:cid card) state) (active-prompt? state side card))
                                 (show-wait-prompt state :runner "Corp to use Skorpios' ability" {:card card})
                                 (continue-ability state side {:prompt "Choose a card in the Runner's Heap that was just trashed"
@@ -958,7 +958,7 @@
                              (not-empty (installed-faceup-agendas state))
                              (not-empty (ice-with-no-advancement-tokens state))))
                  :yes-ability
-                 {:delayed-completion true
+                 {:async true
                   :effect (req (show-wait-prompt state :runner "Corp to use SSO Industries' ability")
                             (let [agendas (installed-faceup-agendas state)
                                   agenda-points (->> agendas
@@ -985,9 +985,9 @@
                                (> (count (:discard runner)) 2)
                                (> (count (:discard runner)) 1))))
               :interactive (req true)
-              :delayed-completion true
+              :async true
               :effect (effect (continue-ability
-                                {:delayed-completion true
+                                {:async true
                                  :prompt "Select 2 cards in your Heap"
                                  :show-discard true
                                  :choices {:max 2 :req #(and (in-discard? %)
@@ -1099,7 +1099,7 @@
    {:events {:pre-start-game {:effect draft-points-target}}}
 
    "The Outfit: Family Owned and Operated"
-   {:events {:corp-gain-bad-publicity {:delayed-completion true
+   {:events {:corp-gain-bad-publicity {:async true
                                        :msg "gain 3 [Credit]"
                                        :effect (effect (gain-credits 3))}}}
 
@@ -1129,7 +1129,7 @@
                  :once :per-turn
                  :prompt "Do a meat damage from identity ability?"
                  :choices (cancellable ["Yes"])
-                 :delayed-completion true
+                 :async true
                  :effect (req (when (= target "Yes")
                                 (damage state side eid :meat 1 {:card card})
                                 (system-msg state side "uses Weyland Consortium: Builder of Nations to do 1 meat damage")))}]}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -131,7 +131,7 @@
    (letfn [(custsec-host [cards]
              {:prompt "Choose a program to host on Customized Secretary"
               :choices (cons "None" cards)
-              :delayed-completion true
+              :async true
               :effect (req (if (or (= target "None") (not (is-type? target "Program")))
                              (do (clear-wait-prompt state :corp)
                                  (shuffle! state side :deck)
@@ -141,7 +141,7 @@
                                  (system-msg state side (str "hosts " (:title target) " on Customized Secretary"))
                                  (continue-ability state side (custsec-host (remove-once #(= % target) cards))
                                                    card nil))))})]
-     {:delayed-completion true
+     {:async true
       :interactive (req (some #(card-flag? % :runner-install-draw true) (all-active state :runner)))
       :msg (msg "reveal the top 5 cards of their Stack: " (join ", " (map :title (take 5 (:deck runner)))))
       :effect (req (show-wait-prompt state :corp "Runner to host programs on Customized Secretary")
@@ -155,7 +155,7 @@
                    :effect (req (when (can-pay? state side nil :credit (:cost target))
                                   (runner-install state side target)))}]})
    "Consume"
-   {:events {:runner-trash {:delayed-completion true
+   {:events {:runner-trash {:async true
                             :req (req (some #(card-is? % :side :corp) targets))
                             :effect (req (let [amt-trashed (count (filter #(card-is? % :side :corp) targets))
                                                auto-ab {:effect (effect (add-counter :runner card :virus amt-trashed))
@@ -283,7 +283,7 @@
    "Disrupter"
    {:events
     {:pre-init-trace
-     {:delayed-completion true
+     {:async true
       :effect (effect (show-wait-prompt :corp "Runner to use Disrupter")
                       (continue-ability :runner
                         {:optional
@@ -366,20 +366,20 @@
    "Equivocation"
    (let [force-draw (fn [title]
                       {:optional {:prompt (str "Force the Corp to draw " title "?")
-                                  :yes-ability {:delayed-completion true
+                                  :yes-ability {:async true
                                                 :effect (req (show-wait-prompt state :runner "Corp to draw")
                                                              (when-completed (draw state :corp 1 nil)
                                                                              (do (system-msg state :corp (str "is forced to draw " title))
                                                                                  (clear-wait-prompt state :runner)
                                                                                  (effect-completed state side eid))))}}})
          reveal {:optional {:prompt "Reveal the top card of R&D?"
-                            :yes-ability {:delayed-completion true
+                            :yes-ability {:async true
                                           :effect (req (let [topcard (-> corp :deck first :title)]
                                                          (system-msg state :runner (str "reveals " topcard
                                                                                         " from the top of R&D"))
                                                          (continue-ability state side (force-draw topcard) card nil)))}}}]
      {:events {:successful-run {:req (req (= target :rd))
-                                :delayed-completion true
+                                :async true
                                 :interactive (req true)
                                 :effect (effect (continue-ability reveal card nil))}}})
 
@@ -513,7 +513,7 @@
                                    :counter-cost [:virus 1]
                                    :msg (msg "trash " (:title target) " at no cost")
                                    :once :per-turn
-                                   :delayed-completion true
+                                   :async true
                                    :effect (effect (trash-no-cost eid target))}}}
 
    "Incubator"
@@ -606,7 +606,7 @@
    {:events
     {:successful-run {:req (req (= target :rd))
                       :effect (effect (add-counter card :virus 1))}
-     :pre-access {:delayed-completion true
+     :pre-access {:async true
                   :req (req (= target :rd))
                   :effect (effect (continue-ability
                                     {:req (req (< 1 (get-virus-counters state side card)))
@@ -631,7 +631,7 @@
    {:events
     {:successful-run {:req (req (= target :hq))
                       :effect (effect (add-counter card :virus 1))}
-     :pre-access {:delayed-completion true
+     :pre-access {:async true
                   :req (req (= target :hq))
                   :effect (effect (continue-ability
                                     {:req (req (< 1 (get-virus-counters state side card)))
@@ -650,7 +650,7 @@
 
    "Nyashia"
    {:data {:counter {:power 3}}
-    :events {:pre-access {:delayed-completion true
+    :events {:pre-access {:async true
                           :req (req (and (pos? (get-counters card :power))
                                          (= target :rd)))
                           :effect (effect (show-wait-prompt :corp "Runner to use Nyashia")
@@ -818,7 +818,7 @@
 
    "RNG Key"
    {:events {:pre-access-card {:req (req (get-in card [:special :rng-guess]))
-                               :delayed-completion true
+                               :async true
                                :msg (msg "to reveal " (:title target))
                                :effect (req (if-let [guess (get-in card [:special :rng-guess])]
                                               (if (installed? target)
@@ -943,7 +943,7 @@
 
    "Snitch"
    {:abilities [{:once :per-run :req (req (and (ice? current-ice) (not (rezzed? current-ice))))
-                 :delayed-completion true
+                 :async true
                  :effect (req (when-completed (expose state side current-ice)
                                               (continue-ability
                                                 state side
@@ -1051,12 +1051,12 @@
                  {:optional {:prompt (msg "Place a virus counter on Trypano?")
                              :yes-ability {:effect (req (system-msg state :runner "places a virus counter on Trypano")
                                                         (add-counter state side card :virus 1))}}}
-                 :counter-added {:delayed-completion true
+                 :counter-added {:async true
                                  :effect trash-if-5}
                  :card-moved {:effect trash-if-5
-                              :delayed-completion true}
+                              :async true}
                  :runner-install {:effect trash-if-5
-                                  :delayed-completion true}}})
+                                  :async true}}})
 
    "Upya"
    {:implementation "Power counters added automatically"
@@ -1073,14 +1073,14 @@
    (letfn [(prompt-for-subtype []
              {:prompt "Choose a subtype"
               :choices ["Barrier" "Code Gate" "Sentry"]
-              :delayed-completion true
+              :async true
               :effect (req (when-completed (trash state side card {:unpreventable true})
                              (continue-ability state side
                                                (expose-and-maybe-bounce target)
                                                card nil)))})
            (expose-and-maybe-bounce [chosen-subtype]
              {:choices {:req #(and (ice? %) (not (rezzed? %)))}
-              :delayed-completion true
+              :async true
               :msg (str "name " chosen-subtype)
               :effect (req (when-completed (expose state side target)
                              (do (if (and async-result
@@ -1091,7 +1091,7 @@
                                  (effect-completed state side eid))))})]
      {:events {:successful-run
               {:interactive (req true)
-               :delayed-completion true
+               :async true
                :req (req (and (= target :hq)
                               (first-successful-run-on-server? state :hq)
                               (some #(and (ice? %) (not (rezzed? %)))
@@ -1099,7 +1099,7 @@
                :effect (effect (continue-ability
                                 {:prompt "Use Wari?"
                                  :choices ["Yes" "No"]
-                                 :delayed-completion true
+                                 :async true
                                  :effect (req (if (= target "Yes")
                                                 (continue-ability state side
                                                                   (prompt-for-subtype)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1,7 +1,7 @@
 (ns game.cards.programs
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -136,7 +136,7 @@
                              (do (clear-wait-prompt state :corp)
                                  (shuffle! state side :deck)
                                  (system-msg state side (str "shuffles their Stack"))
-                                 (effect-completed state side eid card))
+                                 (effect-completed state side eid))
                              (do (host state side (get-card state card) target)
                                  (system-msg state side (str "hosts " (:title target) " on Customized Secretary"))
                                  (continue-ability state side (custsec-host (remove-once #(= % target) cards))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -48,12 +48,12 @@
 
    "Activist Support"
    {:events
-    {:corp-turn-begins {:delayed-completion true
+    {:corp-turn-begins {:async true
                         :effect (req (if (zero? (:tag runner))
                                        (do (tag-runner state :runner eid 1)
                                            (system-msg state :runner (str "uses " (:title card) " to take 1 tag")))
                                        (effect-completed state :runner eid card)))}
-     :runner-turn-begins {:delayed-completion true
+     :runner-turn-begins {:async true
                           :effect (req (if (not has-bad-pub)
                                          (do (gain-bad-publicity state :corp eid 1)
                                              (system-msg state :runner
@@ -225,14 +225,14 @@
       {:runner-install
        {:interactive (req (hardware-and-in-hand? target runner))
         :silent (req (not (hardware-and-in-hand? target runner)))
-        :delayed-completion true
+        :async true
         :req (req (and (is-type? target "Hardware") (= [:hand] (:previous-zone target))))
         :effect (req (let [hw (:title target)]
                        (continue-ability state side
                                          {:optional {:req (req (some #(when (= (:title %) hw) %) (:hand runner)))
                                                      :prompt (msg "Install another copy of " hw "?")
                                                      :msg (msg "install another copy of " hw)
-                                                     :yes-ability {:delayed-completion true
+                                                     :yes-ability {:async true
                                                                    :effect (req (if-let [c (some #(when (= (:title %) hw) %)
                                                                                                  (:hand runner))]
                                                                                   (runner-install state side eid c nil)))}}} card nil)))}}})
@@ -599,7 +599,7 @@
 
                                        (clear-wait-prompt state :corp)
                                        (effect-completed state side eid)))}]
-     {:delayed-completion true
+     {:async true
       :effect (req (show-wait-prompt state :corp "Runner to pick identity to host on DJ Fenris")
                    (continue-ability state side fenris-effect card nil))})
 
@@ -650,7 +650,7 @@
 
    "Dummy Box"
    (letfn [(dummy-prevent [type] {:msg (str "prevent a " type " from being trashed")
-                                  :delayed-completion true
+                                  :async true
                                   :priority 15
                                   :prompt (str "Choose a " type " in your Grip")
                                   :choices {:req #(and (is-type? % (capitalize type))
@@ -709,7 +709,7 @@
 
    "Fan Site"
    {:events {:agenda-scored {:msg "add it to their score area as an agenda worth 0 agenda points"
-                             :delayed-completion true
+                             :async true
                              :req (req (installed? card))
                              :effect (req (as-agenda state :runner eid card 0))}}}
 
@@ -729,11 +729,11 @@
      {:events {:access {:req (req (and (empty? (filter #(= "Agenda" (:type %)) (:hosted card)))
                                        (is-type? target "Agenda")))
                         :interactive (req true)
-                        :delayed-completion true
+                        :async true
                         :effect (effect (continue-ability (host-agenda? target) card nil))}}
       :abilities [{:cost [:click 2] :label "Add hosted agenda to your score area"
                    :req (req (get-agenda card))
-                   :delayed-completion true
+                   :async true
                    :effect (req (let [c (get-agenda card)
                                       points (get-agenda-points state :runner c)]
                                   (as-agenda state :runner eid c points)))
@@ -760,7 +760,7 @@
 
    "Gang Sign"
    {:events {:agenda-scored
-             {:delayed-completion true
+             {:async true
               :interactive (req true)
               :msg (msg "access " (quantify (get-in @state [:runner :hq-access]) "card") " from HQ")
               :effect (req (when-completed
@@ -839,7 +839,7 @@
                               card nil)))}}}
 
    "Hades Shard"
-   (shard-constructor :archives "access all cards in Archives" {:delayed-completion true}
+   (shard-constructor :archives "access all cards in Archives" {:async true}
                       (req (trash state side card {:cause :ability-cost})
                            (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                            (when (:run @state)
@@ -898,7 +898,7 @@
 
    "Jackpot!"
    (let [jackpot {:interactive (req true)
-                  :delayed-completion true
+                  :async true
                   :req (req (= :runner (:as-agenda-side target)))
                   :effect (req (show-wait-prompt state :corp "Runner to use Jackpot!")
                                (continue-ability
@@ -909,7 +909,7 @@
                                    :yes-ability
                                    {:prompt "Choose how many [Credit] to take"
                                     :choices {:number (req (get-counters card :credit))}
-                                    :delayed-completion true
+                                    :async true
                                     :effect (req (gain-credits state :runner target)
                                                  (system-msg state :runner (str "trashes Jackpot! to gain " target " credits"))
                                                  (clear-wait-prompt state :corp)
@@ -955,7 +955,7 @@
                               :msg "draw 1 card" :once-key :john-masanori-draw
                               :effect (effect (draw))}
              :unsuccessful-run {:req (req (= 1 (count (get-in @state [:runner :register :unsuccessful-run]))))
-                                :delayed-completion true
+                                :async true
                                 :msg "take 1 tag" :once-key :john-masanori-tag
                                 :effect (effect (tag-runner :runner eid 1))}}}
 
@@ -964,7 +964,7 @@
                   :once :per-turn
                   :label "Gain [Click] (start of turn)"
                   :effect (effect (gain :click 1))
-                  :end-turn {:delayed-completion true
+                  :end-turn {:async true
                              :effect (effect (tag-runner eid 1))
                              :msg "gain 1 tag"}}]
      {:flags {:runner-phase-12 (req true)}
@@ -1042,7 +1042,7 @@
    (letfn [(lab-keep [cards]
              {:prompt "Choose a Program to keep"
               :choices (cons "None" (filter #(= "Program" (:type %)) cards))
-              :delayed-completion true
+              :async true
               :msg (msg (if (= target "None") "take no card to their Grip" (str "take " (-> target :title) " to their Grip")))
               :effect (req (when (not= target "None")
                              (move state side target :hand))
@@ -1054,7 +1054,7 @@
                                  (effect-completed state side eid card))))})]
    {:abilities [{:cost [:click 1]
                  :msg (msg "draw 4 cards: " (join ", " (map :title (take 4 (:deck runner)))))
-                 :delayed-completion true
+                 :async true
                  :effect (req (show-wait-prompt state :corp "Runner to choose card to keep")
                               (let [from (take 4 (:deck runner))]
                                 (continue-ability state side (lab-keep from) card nil)))}]})
@@ -1071,7 +1071,7 @@
    "Liberated Chela"
    {:abilities [{:cost [:click 5 :forfeit]
                  :msg "add it to their score area"
-                 :delayed-completion true
+                 :async true
                  :effect (req (if (not (empty? (:scored corp)))
                                 (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent Liberated Chela")
                                     (resolve-ability
@@ -1086,14 +1086,14 @@
                                                                   :effect (effect (forfeit target)
                                                                                   (move :runner card :rfg)
                                                                                   (clear-wait-prompt :runner))}
-                                                                 {:delayed-completion true
+                                                                 {:async true
                                                                   :effect (req (clear-wait-prompt state :runner)
                                                                                (as-agenda state :runner eid card 2))
                                                                   :msg "add it to their score area as an agenda worth 2 points"})
                                                               card nil))} card nil))
                                 (resolve-ability
                                   state side
-                                  {:delayed-completion true
+                                  {:async true
                                    :effect (req (as-agenda state :runner eid card 2))
                                    :msg "add it to their score area as an agenda worth 2 points"} card nil)))}]}
 
@@ -1190,7 +1190,7 @@
              {:req (req (and (:run @state)
                              (has-subtype? target "Stealth")))
               :once :per-run
-              :delayed-completion true
+              :async true
               :effect (effect (show-wait-prompt :corp "Runner to use Net Mercur")
                               (continue-ability
                                 {:prompt "Place 1 [Credits] on Net Mercur or draw 1 card?"
@@ -1252,7 +1252,7 @@
      {:interactions {:prevent [{:type #{:net :tag}
                                 :req (req (first-chance? state side))}]}
       :abilities [{:msg "force the Corp to trace"
-                   :delayed-completion true
+                   :async true
                    :effect (req (let [type (get-in @state [:prevent :current])]
                                   (when-completed (trash state side card {:unpreventable true})
                                                   (continue-ability state side (start-trace type)
@@ -1355,7 +1355,7 @@
                                                                           (quantify target "cop" "y" "ies")
                                                                           " of " title)))))}}})]
      {:events {:runner-install {:req (req (first-event? state side :runner-install))
-                                :delayed-completion true
+                                :async true
                                 :effect (effect (continue-ability
                                                  (pphelper (:title target)
                                                            (->> (:deck runner)
@@ -1486,7 +1486,7 @@
     :leave-play (req (remove-watch state :raymond-flint))
     :abilities [{:msg "expose 1 card"
                  :choices {:req installed?}
-                 :delayed-completion true
+                 :async true
                  :effect (effect (expose eid target) (trash card {:cause :ability-cost}))}]}
 
    "Reclaim"
@@ -1496,7 +1496,7 @@
       :req (req (not-empty (:hand runner)))
       :prompt "Choose a card to trash"
       :choices (req (cancellable (:hand runner) :sorted))
-      :delayed-completion true
+      :async true
       :effect (req (when-completed
                      (trash state :runner card {:cause :ability-cost})
                      (when-completed
@@ -1513,12 +1513,12 @@
                                                   (:discard runner))
                                           :sorted))
                           :msg (msg "install " (:title target) " from the Heap")
-                          :delayed-completion true
+                          :async true
                           :effect (req (runner-install state :runner eid target nil))}
                          card nil))))}]}
 
    "Rolodex"
-   {:delayed-completion true
+   {:async true
     :msg "look at the top 5 cards of their Stack"
     :effect (req (show-wait-prompt state :corp "Runner to rearrange the top cards of their Stack")
                  (let [from (take 5 (:deck runner))]
@@ -1596,7 +1596,7 @@
    "Safety First"
    {:in-play [:hand-size {:mod -2}]
     :events {:runner-turn-ends
-             {:delayed-completion true
+             {:async true
               :effect (req (if (< (count (:hand runner)) (hand-size state :runner))
                              (do (system-msg state :runner (str "uses " (:title card) " to draw a card"))
                                  (draw state :runner eid 1 nil))
@@ -1792,7 +1792,7 @@
                               {:prompt "Use Tallie Perrault to give the Corp 1 bad publicity and take 1 tag?"
                                :player :runner
                                :yes-ability {:msg "give the Corp 1 bad publicity and take 1 tag"
-                                             :delayed-completion true
+                                             :async true
                                              :effect (effect (gain-bad-publicity :corp 1)
                                                              (tag-runner :runner eid 1)
                                                              (clear-wait-prompt :corp))}
@@ -1846,7 +1846,7 @@
     :events {:agenda-scored {:req (req (or (has-subtype? target "Initiative")
                                            (has-subtype? target "Security")))
                              :interactive (req true)
-                             :delayed-completion true
+                             :async true
                              :msg "force the Corp to initiate a trace"
                              :label "Trace 1 - If unsuccessful, take 1 bad publicity"
                              :trace {:base 1

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -62,7 +62,7 @@
    "Bamboo Dome"
    (letfn [(dome [dcard]
              {:prompt "Select a card to add to HQ"
-              :delayed-completion true
+              :async true
               :choices {:req #(and (= (:side %) "Corp")
                                    (= (:zone %) [:play-area]))}
               :msg "move a card to HQ"
@@ -70,7 +70,7 @@
                               (continue-ability (put dcard) dcard nil))})
            (put [dcard]
              {:prompt "Select first card to put back onto R&D"
-              :delayed-completion true
+              :async true
               :choices {:req #(and (= (:side %) "Corp")
                                    (= (:zone %) [:play-area]))}
               :msg "move remaining cards back to R&D"
@@ -82,7 +82,7 @@
    {:init {:root "R&D"}
     :abilities [{:cost [:click 1]
                  :req (req (>= (count (:deck corp)) 3))
-                 :delayed-completion true
+                 :async true
                  :msg (msg (str "reveal " (join ", " (map :title (take 3 (:deck corp)))) " from R&D"))
                  :label "Reveal the top 3 cards of R&D. Secretly choose 1 to add to HQ. Return the others to the top of R&D, in any order."
                  :effect (req (doseq [c (take 3 (:deck corp))]
@@ -108,7 +108,7 @@
                               :req (req this-server)
                               :trace {:base 5
                                       :successful {:msg "give the Runner 1 tag"
-                                                   :delayed-completion true
+                                                   :async true
                                                    :effect (effect (tag-runner :runner eid 1))}
                                       :unsuccessful
                                       {:effect (effect (system-msg "trashes Bernice Mai from the unsuccessful trace")
@@ -121,7 +121,7 @@
                 :advance-counter-cost 2
                 :req (req (:run @state))
                 :msg "end the run. Bio Vault is trashed"
-                :delayed-completion true
+                :async true
                 :effect (effect
                           (end-run)
                           (trash eid card {:cause :ability-cost}))}]}
@@ -130,7 +130,7 @@
    {:events {:successful-run
              {:interactive (req true)
               :req (req this-server)
-              :delayed-completion true
+              :async true
               :effect (effect (continue-ability
                                 {:prompt "Take 1 brain damage or jack out?"
                                  :player :runner
@@ -168,11 +168,11 @@
    "Calibration Testing"
    {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
     :abilities [{:label "[Trash]: Place 1 advancement token on a card in this server"
-                 :delayed-completion true
+                 :async true
                  :effect (effect (continue-ability
                                    {:prompt "Select a card in this server"
                                     :choices {:req #(in-same-server? % card)}
-                                    :delayed-completion true
+                                    :async true
                                     :msg (msg "place an advancement token on " (card-str state target))
                                     :effect (effect (add-prop target :advance-counter 1 {:placed true})
                                                     (trash eid card {:cause :ability-cost}))}
@@ -193,7 +193,7 @@
 
    "ChiLo City Grid"
    {:events {:successful-trace {:req (req this-server)
-                                :delayed-completion true
+                                :async true
                                 :effect (effect (tag-runner :runner eid 1))
                                 :msg "give the Runner 1 tag"}}}
 
@@ -245,7 +245,7 @@
 
    "Cyberdex Virus Suite"
    {:flags {:rd-reveal (req true)}
-    :access {:delayed-completion true
+    :access {:async true
              :effect (effect (show-wait-prompt :runner "Corp to use Cyberdex Virus Suite")
                              (continue-ability
                                {:optional {:prompt "Purge virus counters with Cyberdex Virus Suite?"
@@ -283,7 +283,7 @@
               :prompt "Select a card in HQ to add to the bottom of R&D"
               :choices {:req #(and (= (:side %) "Corp")
                                    (in-hand? %))}
-              :delayed-completion true
+              :async true
               :msg "add a card to the bottom of R&D"
               :effect (req (move state side target :deck)
                            (if (< n i)
@@ -293,13 +293,13 @@
                                (effect-completed state side eid))))
               :cancel-effect (final-effect (clear-wait-prompt :runner))})]
      {:flags {:rd-reveal (req true)}
-      :access {:delayed-completion true
+      :access {:async true
                :effect (req (let [n (count (:hand corp))]
                               (show-wait-prompt state :runner "Corp to finish using Disposable HQ")
                               (continue-ability state side
                                 {:optional
                                  {:prompt "Use Disposable HQ to add cards to the bottom of R&D?"
-                                  :yes-ability {:delayed-completion true
+                                  :yes-ability {:async true
                                                 :msg "add cards in HQ to the bottom of R&D"
                                                 :effect (effect (continue-ability (dhq 1 n) card nil))}
                                   :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
@@ -307,7 +307,7 @@
 
    "Drone Screen"
    {:events {:run {:req (req (and this-server tagged))
-                   :delayed-completion true
+                   :async true
                    :trace {:base 3
                            :successful
                            {:msg "do 1 meat damage"
@@ -339,7 +339,7 @@
              :interactive (req true)
              :trace {:base 3
                      :successful {:msg "give the Runner 2 tags"
-                                  :delayed-completion true
+                                  :async true
                                   :effect (effect (tag-runner :runner eid 2))}}}}
 
    "Fractal Threat Matrix"
@@ -353,12 +353,12 @@
 
    "Georgia Emelyov"
    {:events {:unsuccessful-run {:req (req (= (first (:server target)) (second (:zone card))))
-                                :delayed-completion true
+                                :async true
                                 :msg "do 1 net damage"
                                 :effect (effect (damage eid :net 1 {:card card}))}}
     :abilities [{:cost [:credit 2]
                  :label "Move to another server"
-                 :delayed-completion true
+                 :async true
                  :effect (effect (continue-ability
                                    {:prompt "Choose a server"
                                     :choices (server-list state)
@@ -379,7 +379,7 @@
    "Helheim Servers"
    {:abilities [{:label "Trash 1 card from HQ: All ice protecting this server has +2 strength until the end of the run"
                  :req (req (and this-server (pos? (count run-ices)) (pos? (count (:hand corp)))))
-                 :delayed-completion true
+                 :async true
                  :effect (req (show-wait-prompt state :runner "Corp to use Helheim Servers")
                               (when-completed
                                 (resolve-ability
@@ -408,7 +408,7 @@
    "Hokusai Grid"
    {:events {:successful-run {:req (req this-server)
                               :msg "do 1 net damage"
-                              :delayed-completion true
+                              :async true
                               :effect (effect (damage eid :net 1 {:card card}))}}}
 
    "Intake"
@@ -418,7 +418,7 @@
              :trace {:base 4
                      :label "add an installed program or virtual resource to the Grip"
                      :successful
-                     {:delayed-completion true
+                     {:async true
                       :effect (req (show-wait-prompt state :runner "Corp to resolve Intake")
                                    (continue-ability
                                      state :corp
@@ -428,7 +428,7 @@
                                                            (or (program? %)
                                                                (and (resource? %)
                                                                     (has-subtype? % "Virtual"))))}
-                                      :delayed-completion true
+                                      :async true
                                       :msg (msg "move " (:title target) " to the Grip")
                                       :effect (effect (move :runner target :hand))
                                       :end-effect (effect (clear-wait-prompt :runner)
@@ -438,7 +438,7 @@
    "Jinja City Grid"
    (letfn [(install-ice [ice ices grids server]
              (let [remaining (remove-once #(= (:cid %) (:cid ice)) ices)]
-             {:delayed-completion true
+             {:async true
               :effect (req (if (= "None" server)
                              (continue-ability state side (choose-ice remaining grids) card nil)
                              (do (system-msg state side (str "reveals that they drew " (:title ice)))
@@ -451,7 +451,7 @@
            (choose-grid [ice ices grids]
              (if (= 1 (count grids))
                (install-ice ice ices grids (-> (first grids) :zone second zone->name))
-               {:delayed-completion true
+               {:async true
                 :prompt (str "Choose a server to install " (:title ice))
                 :choices (conj (mapv #(-> % :zone second zone->name) grids) "None")
                 :effect (effect (continue-ability (install-ice ice ices grids target) card nil))}))
@@ -459,7 +459,7 @@
            (choose-ice [ices grids]
              (if (empty? ices)
                nil
-               {:delayed-completion true
+               {:async true
                 :prompt "Choose an ice to reveal and install, or None to decline"
                 :choices (conj (mapv :title ices) "None")
                 :effect (req (if (= "None" target)
@@ -474,7 +474,7 @@
                            ;; THIS IS A HACK: it prevents multiple Jinja from showing the "choose a server to install into" sequence
                            :once :per-turn
                            :once-key :jinja-city-grid-draw
-                           :delayed-completion true
+                           :async true
                            :effect (req (let [ices (filter #(and (is-type? % "ICE")
                                                                  (get-card state %))
                                                            (:most-recent-drawn corp-reg))
@@ -510,11 +510,11 @@
                              (do (end-run state side)
                                  (system-msg state :corp (str "uses K. P. Lynn. Runner chooses to end the run")))))}]
      {:events {:pass-ice {:req (req (and this-server (= (:position run) 1))) ; trigger when last ice passed
-                          :delayed-completion true
+                          :async true
                           :effect (req (continue-ability state :runner abi card nil))}
                :run {:req (req (and this-server
                                     (zero? (:position run)))) ; trigger on unprotected server
-                     :delayed-completion true
+                     :async true
                      :effect (req (continue-ability state :runner abi card nil))}}})
 
    "Manta Grid"
@@ -645,7 +645,7 @@
    {:events
     {:successful-run
      {:interactive (req true)
-      :delayed-completion true
+      :async true
       :req (req (and this-server
                      (or (< (:credit runner) 6)
                          (< (count (:hand runner)) 2))
@@ -657,12 +657,12 @@
                          {:optional
                           {:prompt "Use Nihongai Grid to look at top 5 cards of R&D and swap one with a card from HQ?"
                            :yes-ability
-                           {:delayed-completion true
+                           {:async true
                             :prompt "Choose a card to swap with a card from HQ"
                             :choices top5
                             :effect (req (let [rdc target]
                                            (continue-ability state side
-                                             {:delayed-completion true
+                                             {:async true
                                               :prompt (msg "Choose a card in HQ to swap for " (:title rdc))
                                               :choices {:req in-hand?}
                                               :msg "swap a card from the top 5 of R&D with a card in HQ"
@@ -735,7 +735,7 @@
 
    "Overseer Matrix"
    (let [om {:req (req (in-same-server? card target))
-             :delayed-completion true
+             :async true
              :effect (effect (show-wait-prompt :runner "Corp to use Overseer Matrix")
                              (continue-ability
                                {:optional
@@ -745,7 +745,7 @@
                                                      (effect-completed eid))
                                  :yes-ability {:cost [:credit 1]
                                                :msg "give the Runner 1 tag"
-                                               :delayed-completion true
+                                               :async true
                                                :effect (req (tag-runner state :runner eid 1))}}}
                                card nil))}]
      {:trash-effect
@@ -777,7 +777,7 @@
 
    "Prisec"
    {:access {:req (req (installed? card))
-             :delayed-completion true
+             :async true
              :effect (effect (show-wait-prompt :runner "Corp to use Prisec")
                              (continue-ability
                                {:optional
@@ -785,7 +785,7 @@
                                  :end-effect (effect (clear-wait-prompt :runner))
                                  :yes-ability {:cost [:credit 2]
                                                :msg "do 1 meat damage and give the Runner 1 tag"
-                                               :delayed-completion true
+                                               :async true
                                                :effect (req (when-completed (damage state side :meat 1 {:card card})
                                                                             (tag-runner state :runner eid 1)))}}}
                                card nil))}}
@@ -829,7 +829,7 @@
    "Ryon Knight"
    {:abilities [{:label "[Trash]: Do 1 brain damage"
                  :msg "do 1 brain damage" :req (req (and this-server (zero? (:click runner))))
-                 :delayed-completion true
+                 :async true
                  :effect (effect (trash card) (damage eid :brain 1 {:card card}))}]}
 
    "SanSan City Grid"
@@ -938,7 +938,7 @@
              :trace {:base 3
                      :successful
                      {:msg "make the Runner choose between losing [Click][Click] or suffering 1 brain damage"
-                      :delayed-completion true
+                      :async true
                       :effect (req (let [tempus card]
                                      (if (< (:click runner) 2)
                                        (do
@@ -951,7 +951,7 @@
                                            {:prompt "Lose [Click][Click] or take 1 brain damage?"
                                             :player :runner
                                             :choices ["Lose [Click][Click]" "Take 1 brain damage"]
-                                            :delayed-completion true
+                                            :async true
                                             :effect
                                             (req (clear-wait-prompt state :corp)
                                                  (if (.startsWith target "Take")
@@ -986,7 +986,7 @@
    {:events
     {:pre-resolve-damage
      {:once :per-run
-      :delayed-completion true
+      :async true
       :req (req (and this-server
                      (= target :net)
                      (pos? (last targets))
@@ -998,7 +998,7 @@
                      {:optional
                       {:prompt (str "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?")
                        :player :corp
-                       :yes-ability {:delayed-completion true
+                       :yes-ability {:async true
                                      :msg "do 1 brain damage instead of net damage"
                                      :effect (req (swap! state update-in [:damage] dissoc :damage-replace :defer-damage)
                                                   (clear-wait-prompt state :runner)
@@ -1006,7 +1006,7 @@
                                                   (when-completed (damage state side :brain 1 {:card card})
                                                                   (do (swap! state assoc-in [:damage :damage-replace] true)
                                                                       (effect-completed state side eid))))}
-                       :no-ability {:delayed-completion true
+                       :no-ability {:async true
                                     :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
                                                  (clear-wait-prompt state :runner)
                                                  (effect-completed state side eid))}}}
@@ -1062,7 +1062,7 @@
    "Warroid Tracker"
    (letfn [(wt [card n t]
              {:prompt "Choose an installed card to trash due to Warroid Tracker"
-              :delayed-completion true
+              :async true
               :player :runner
               :priority 2
               :choices {:req #(and (installed? %) (= (:side %) "Runner"))}
@@ -1076,7 +1076,7 @@
                            (when (zero? (count (cards-to-access state side (get-in @state [:run :server]))))
                              (handle-end-run state side)))})]
    {:implementation "Does not handle UFAQ interaction with Singularity"
-    :events {:runner-trash {:delayed-completion true
+    :events {:runner-trash {:async true
                             :req (req (= (-> card :zone second) (-> target :zone second)))
                             :trace {:base 4
                                     :successful
@@ -1098,7 +1098,7 @@
    {:events
     {:successful-run
      {:interactive (req true)
-      :delayed-completion true
+      :async true
       :req (req (and this-server
                      (some #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
       :effect (req (show-wait-prompt state :runner "Corp to use Will-o'-the-Wisp")
@@ -1106,7 +1106,7 @@
                      {:optional
                       {:prompt "Trash Will-o'-the-Wisp?"
                        :choices {:req #(has-subtype? % "Icebreaker")}
-                       :yes-ability {:delayed-completion true
+                       :yes-ability {:async true
                                      :prompt "Choose an icebreaker used to break at least 1 subroutine during this run"
                                      :choices {:req #(has-subtype? % "Icebreaker")}
                                      :msg (msg "add " (:title target) " to the bottom of the Runner's Stack")

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1,7 +1,7 @@
 (ns game.cards.upgrades
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -291,7 +291,7 @@
                              (do
                                (clear-wait-prompt state :runner)
                                (effect-completed state side eid))))
-              :cancel-effect (final-effect (clear-wait-prompt :runner))})]
+              :cancel-effect (effect (clear-wait-prompt :runner))})]
      {:flags {:rd-reveal (req true)}
       :access {:async true
                :effect (req (let [n (count (:hand corp))]
@@ -679,10 +679,10 @@
                                                              (effect-completed state side eid)))}
                                             card nil)))}
                            :no-ability {:effect (req (clear-wait-prompt state :runner)
-                                                     (effect-completed state side eid card))}}}
+                                                     (effect-completed state side eid))}}}
                         card nil)
                        (do (clear-wait-prompt state :runner)
-                           (effect-completed state side eid card)))))}}}
+                           (effect-completed state side eid)))))}}}
 
    "Oaktown Grid"
    {:events {:pre-trash {:req (req (in-same-server? card target))
@@ -1071,7 +1071,7 @@
                            (if (> n t)
                              (continue-ability state side (wt card n (inc t)) card nil)
                              (do (clear-wait-prompt state :corp)
-                                 (effect-completed state side eid card)))
+                                 (effect-completed state side eid)))
                            ;; this ends-the-run if WT is the only card and is trashed, and trashes at least one runner card
                            (when (zero? (count (cards-to-access state side (get-in @state [:run :server]))))
                              (handle-end-run state side)))})]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1,7 +1,7 @@
 (ns game.cards.upgrades
   (:require [game.core :refer :all]
             [game.utils :refer :all]
-            [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer [str->int]]
@@ -381,7 +381,7 @@
                  :req (req (and this-server (pos? (count run-ices)) (pos? (count (:hand corp)))))
                  :async true
                  :effect (req (show-wait-prompt state :runner "Corp to use Helheim Servers")
-                              (when-completed
+                              (wait-for
                                 (resolve-ability
                                   state side
                                   {:prompt "Choose a card in HQ to trash"
@@ -442,11 +442,11 @@
               :effect (req (if (= "None" server)
                              (continue-ability state side (choose-ice remaining grids) card nil)
                              (do (system-msg state side (str "reveals that they drew " (:title ice)))
-                                 (when-completed (corp-install state side ice server {:extra-cost [:credit -4]})
-                                                 (if (= 1 (count ices))
-                                                   (effect-completed state side eid)
-                                                   (continue-ability state side (choose-ice remaining grids)
-                                                                     card nil))))))}))
+                                 (wait-for (corp-install state side ice server {:extra-cost [:credit -4]})
+                                           (if (= 1 (count ices))
+                                             (effect-completed state side eid)
+                                             (continue-ability state side (choose-ice remaining grids)
+                                                               card nil))))))}))
 
            (choose-grid [ice ices grids]
              (if (= 1 (count grids))
@@ -786,8 +786,8 @@
                                  :yes-ability {:cost [:credit 2]
                                                :msg "do 1 meat damage and give the Runner 1 tag"
                                                :async true
-                                               :effect (req (when-completed (damage state side :meat 1 {:card card})
-                                                                            (tag-runner state :runner eid 1)))}}}
+                                               :effect (req (wait-for (damage state side :meat 1 {:card card})
+                                                                      (tag-runner state :runner eid 1)))}}}
                                card nil))}}
 
    "Product Placement"
@@ -1003,9 +1003,9 @@
                                      :effect (req (swap! state update-in [:damage] dissoc :damage-replace :defer-damage)
                                                   (clear-wait-prompt state :runner)
                                                   (pay state :corp card :credit 2)
-                                                  (when-completed (damage state side :brain 1 {:card card})
-                                                                  (do (swap! state assoc-in [:damage :damage-replace] true)
-                                                                      (effect-completed state side eid))))}
+                                                  (wait-for (damage state side :brain 1 {:card card})
+                                                            (do (swap! state assoc-in [:damage :damage-replace] true)
+                                                                (effect-completed state side eid))))}
                        :no-ability {:async true
                                     :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
                                                  (clear-wait-prompt state :runner)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1,6 +1,6 @@
 (ns game.core
   (:require [game.utils :refer :all]
-            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for continue-ability]]
             [clj-time.core :as t]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.java.io :as io]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1,6 +1,6 @@
 (ns game.core
   (:require [game.utils :refer :all]
-            [game.macros :refer [effect req msg when-completed final-effect continue-ability]]
+            [game.macros :refer [effect req msg wait-for final-effect continue-ability]]
             [clj-time.core :as t]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.java.io :as io]

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -113,7 +113,7 @@
 (defn- resolve-ability-eid
   ([state side {:keys [eid] :as ability} card targets]
    (if (= 1 (count ability)) ;; only has the eid, in effect a nil ability
-     (effect-completed state side eid card)
+     (effect-completed state side eid)
      (if (and ability (not eid))
        (resolve-ability-eid state side (assoc ability :eid (make-eid state)) card targets)
        (when-let [ability (if (and (:makes-run ability)
@@ -134,7 +134,7 @@
              (do-choices state side ability card targets)
              ;; Not a prompt. Trigger the ability.
              (do-ability state side ability card targets))
-           (effect-completed state side eid card))
+           (effect-completed state side eid))
          (complete-ability state side ability card))))))
 
 ;;; Checking functions for resolve-ability
@@ -144,7 +144,7 @@
   ;; if it does have choices and has false async
   (when (or (and (not choices) (not optional) (not psi) (not trace) (not async))
             (and (or optional psi choices trace) (false? async)))
-    (effect-completed state side eid card)))
+    (effect-completed state side eid)))
 
 (defn- check-optional
   "Checks if there is an optional ability to resolve"
@@ -152,7 +152,7 @@
   (when-let [optional (:optional ability)]
     (if (can-trigger? state side optional card targets)
       (optional-ability state (or (:player optional) side) eid card (:prompt optional) optional targets)
-      (effect-completed state side eid card))))
+      (effect-completed state side eid))))
 
 (defn- check-psi
   "Checks if a psi-game is to be resolved"
@@ -160,7 +160,7 @@
   (when-let [psi (:psi ability)]
     (if (can-trigger? state side psi card targets)
       (psi-game state side eid card psi)
-      (effect-completed state side eid card))))
+      (effect-completed state side eid))))
 
 (defn- check-trace
   "Checks if there is a trace to resolve"
@@ -168,7 +168,7 @@
   (when-let [trace (:trace ability)]
     (if (can-trigger? state side ability card targets)
       (init-trace state side card (assoc trace :eid (:eid ability)))
-      (effect-completed state side eid card))))
+      (effect-completed state side eid))))
 
 (defn- do-choices
   "Handle a choices ability"
@@ -290,7 +290,7 @@
                     (resolve-ability state side (assoc yes-ability :eid eid) card targets)
                     (if-let [no-ability (:no-ability ability)]
                       (resolve-ability state side (assoc no-ability :eid eid) card targets)
-                      (effect-completed state side eid card))))
+                      (effect-completed state side eid))))
                 ability)))
 
 
@@ -417,7 +417,7 @@
           (resolve-ability state side (:ability selected) (:card curprompt) cards))
       (if-let [cancel-effect (:cancel-effect curprompt)]
         (cancel-effect nil)
-        (effect-completed state side (:eid (:ability selected)) nil)))))
+        (effect-completed state side (:eid (:ability selected)))))))
 
 (defn show-wait-prompt
   "Shows a 'Waiting for ...' prompt to the given side with the given message.
@@ -490,7 +490,7 @@
           (wait-for (trigger-event-sync state side :psi-game bet opponent-bet)
                     (if-let [ability (if (= bet opponent-bet) (:equal psi) (:not-equal psi))]
                       (resolve-ability state (:side card) (assoc ability :eid eid :async true) card nil)
-                      (effect-completed state side eid card)))
+                      (effect-completed state side eid)))
           (trigger-event state side :psi-game-done bet opponent-bet))
       (show-wait-prompt
         state side (str (clojure.string/capitalize (name opponent)) " to choose psi game credits")))))
@@ -540,7 +540,7 @@
                           (do (when-let [kicker (:kicker trace)]
                                 (when (>= corp-strength (:min kicker))
                                   (resolve-ability state :corp kicker card [corp-strength runner-strength])))
-                              (effect-completed state side eid nil)))))))
+                              (effect-completed state side eid)))))))
 
 (defn trace-reply
   "Shows a trace prompt to the second player, after the first has already spent credits to boost."

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -139,11 +139,11 @@
 
 ;;; Checking functions for resolve-ability
 (defn- complete-ability
-  [state side {:keys [eid choices optional prompt delayed-completion psi trace] :as ability} card]
-  ;if it doesn't have choices and it doesn't have a true delayed-completion; or
-  ;if it does have choices and has false delayed-completion
-  (when (or (and (not choices) (not optional) (not psi) (not trace) (not delayed-completion))
-            (and (or optional psi choices trace) (false? delayed-completion)))
+  [state side {:keys [eid choices optional prompt async psi trace] :as ability} card]
+  ;; If it doesn't have choices and it doesn't have a true async or
+  ;; if it does have choices and has false async
+  (when (or (and (not choices) (not optional) (not psi) (not trace) (not async))
+            (and (or optional psi choices trace) (false? async)))
     (effect-completed state side eid card)))
 
 (defn- check-optional
@@ -489,7 +489,7 @@
           (trigger-event state side (keyword (str "psi-bet-" (name opponent))) opponent-bet)
           (when-completed (trigger-event-sync state side :psi-game bet opponent-bet)
                           (if-let [ability (if (= bet opponent-bet) (:equal psi) (:not-equal psi))]
-                            (resolve-ability state (:side card) (assoc ability :eid eid :delayed-completion true) card nil)
+                            (resolve-ability state (:side card) (assoc ability :eid eid :async true) card nil)
                             (effect-completed state side eid card)))
           (trigger-event state side :psi-game-done bet opponent-bet))
       (show-wait-prompt

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -184,7 +184,7 @@
       (do (if-let [cancel-effect (:cancel-effect prompt)]
             ;; trigger the cancel effect
             (cancel-effect choice)
-            (effect-completed state side (:eid prompt) nil))
+            (effect-completed state side (:eid prompt)))
           (finish-prompt state side prompt card)))))
 
 (defn select

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -358,7 +358,7 @@
                (if (and altcost (can-pay? state side nil altcost)(not ignore-cost))
                  (let [curr-bonus (get-rez-cost-bonus state side)]
                    (prompt! state side card (str "Pay the alternative Rez cost?") ["Yes" "No"]
-                            {:delayed-completion true
+                            {:async true
                              :effect (req (if (and (= target "Yes")
                                                    (can-pay? state side (:title card) altcost))
                                             (do (pay state side card altcost)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -523,19 +523,19 @@
                     (get-card state (nth run-ice (dec pos))))
           next-ice (when (and pos (< 1 pos) (<= (dec pos) (count run-ice)))
                      (get-card state (nth run-ice (- pos 2))))]
-      (when-completed (trigger-event-sync state side :pass-ice cur-ice)
-                      (do (update-ice-in-server
-                            state side (get-in @state (concat [:corp :servers] (get-in @state [:run :server]))))
-                          (swap! state update-in [:run :position] (fnil dec 1))
-                          (swap! state assoc-in [:run :no-action] false)
-                          (system-msg state side "continues the run")
-                          (when cur-ice
-                            (update-ice-strength state side cur-ice))
-                          (when next-ice
-                            (trigger-event-sync state side (make-eid state) :approach-ice next-ice))
-                          (doseq [p (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
-                            (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
-                            (update-breaker-strength state side p)))))))
+      (wait-for (trigger-event-sync state side :pass-ice cur-ice)
+                (do (update-ice-in-server
+                      state side (get-in @state (concat [:corp :servers] (get-in @state [:run :server]))))
+                    (swap! state update-in [:run :position] (fnil dec 1))
+                    (swap! state assoc-in [:run :no-action] false)
+                    (system-msg state side "continues the run")
+                    (when cur-ice
+                      (update-ice-strength state side cur-ice))
+                    (when next-ice
+                      (trigger-event-sync state side (make-eid state) :approach-ice next-ice))
+                    (doseq [p (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
+                      (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
+                      (update-breaker-strength state side p)))))))
 
 (defn view-deck
   "Allows the player to view their deck by making the cards in the deck public."

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -190,8 +190,8 @@
 (defn shuffle!
   "Shuffles the vector in @state [side kw]."
   [state side kw]
-  (when-completed (trigger-event-sync state side (keyword (str (name side) "-shuffle-deck")))
-                  (swap! state update-in [side kw] shuffle)))
+  (wait-for (trigger-event-sync state side (keyword (str (name side) "-shuffle-deck")))
+            (swap! state update-in [side kw] shuffle)))
 
 (defn shuffle-into-deck
   [state side & args]

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -91,7 +91,7 @@
   (let [cost-name (cost-names n :forfeit)]
     (continue-ability state side
                     {:prompt "Choose an Agenda to forfeit"
-                     :delayed-completion true
+                     :async true
                      :choices {:max n
                                :req #(is-scored? state side %)}
                      :effect (req (when-completed (forfeit state side target)
@@ -110,7 +110,7 @@
                        {:prompt (str "Choose a " type " to trash")
                         :choices {:max amount
                                   :req select-fn}
-                        :delayed-completion true
+                        :async true
                         :effect (req (when-completed (trash state side target (merge args {:unpreventable true}))
                                                      (effect-completed state side (make-result eid cost-name))))}
                        card nil)
@@ -132,7 +132,7 @@
                      :choices {:max amount
                                :all true
                                :req #(and (installed? %) (= (:side %) "Runner"))}
-                     :delayed-completion true
+                     :async true
                      :effect (req
                                (doseq [c targets]
                                  (move state :runner c :deck))

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -97,7 +97,7 @@
                                  (remove-once #(= (get-cid to-resolve) (get-cid %)) handlers)
                                  (next handlers))]
                     (if-let [the-card (get-card state card-to-resolve)]
-                      {:delayed-completion true
+                      {:async true
                        :effect (req (when-completed (resolve-ability state (to-keyword (:side the-card))
                                                                      ability-to-resolve
                                                                      the-card event-targets)
@@ -105,13 +105,13 @@
                                                       (continue-ability state side
                                                                         (choose-handler others) nil event-targets)
                                                       (effect-completed state side eid nil))))}
-                      {:delayed-completion true
+                      {:async true
                        :effect (req (if (should-continue state handlers)
                                       (continue-ability state side (choose-handler (next handlers)) nil event-targets)
                                       (effect-completed state side eid nil)))}))
                   {:prompt "Choose a trigger to resolve"
                    :choices titles
-                   :delayed-completion true
+                   :async true
                    :effect (req (let [to-resolve (some #(when (= target (:title (:card %))) %) handlers)
                                       ability-to-resolve (dissoc (:ability to-resolve) :req)
                                       the-card (get-card state (:card to-resolve))]

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -47,7 +47,7 @@
         (wait-for (resolve-ability state side ability card targets)
                   (apply trigger-event-sync-next state side eid (next handlers) event targets)))
       (apply trigger-event-sync-next state side eid (next handlers) event targets))
-    (effect-completed state side eid nil)))
+    (effect-completed state side eid)))
 
 (defn trigger-event-sync
   "Triggers the given event synchronously, requiring each handler to complete before alerting the next handler. Does not
@@ -104,11 +104,11 @@
                                               (if (should-continue state handlers)
                                                 (continue-ability state side
                                                                   (choose-handler others) nil event-targets)
-                                                (effect-completed state side eid nil))))}
+                                                (effect-completed state side eid))))}
                       {:async true
                        :effect (req (if (should-continue state handlers)
                                       (continue-ability state side (choose-handler (next handlers)) nil event-targets)
-                                      (effect-completed state side eid nil)))}))
+                                      (effect-completed state side eid)))}))
                   {:prompt "Choose a trigger to resolve"
                    :choices titles
                    :async true
@@ -123,10 +123,10 @@
                                                         (choose-handler
                                                           (remove-once #(= target (:title (:card %))) handlers))
                                                         nil event-targets)
-                                      (effect-completed state side eid nil)))))})))]
+                                      (effect-completed state side eid)))))})))]
 
       (continue-ability state side (choose-handler handlers) nil event-targets))
-    (effect-completed state side eid nil)))
+    (effect-completed state side eid)))
 
 (defn ability-as-handler
   "Wraps a card ability as an event handler."
@@ -295,8 +295,7 @@
   (swap! state update-in [:effect-completed (:eid eid)] #(conj % {:card card :effect effect})))
 
 (defn effect-completed
-  ([state side eid] (effect-completed state side eid nil))
-  ([state side eid card]
-   (doseq [handler (get-in @state [:effect-completed (:eid eid)])]
-     ((:effect handler) state side eid (:card card) nil))
-   (swap! state update-in [:effect-completed] dissoc (:eid eid))))
+  [state side eid]
+  (doseq [handler (get-in @state [:effect-completed (:eid eid)])]
+    ((:effect handler) state side eid nil nil))
+  (swap! state update-in [:effect-completed] dissoc (:eid eid)))

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -44,8 +44,8 @@
   (if-let [e (first handlers)]
     (if-let [card (get-card state (:card e))]
       (let [ability (dissoc (:ability e) :req)]
-        (when-completed (resolve-ability state side ability card targets)
-                        (apply trigger-event-sync-next state side eid (next handlers) event targets)))
+        (wait-for (resolve-ability state side ability card targets)
+                  (apply trigger-event-sync-next state side eid (next handlers) event targets)))
       (apply trigger-event-sync-next state side eid (next handlers) event targets))
     (effect-completed state side eid nil)))
 
@@ -61,8 +61,8 @@
           handlers (filter #(and (not (apply trigger-suppress state side event (cons (:card %) targets)))
                                  (can-trigger? state side (:ability %) (get-card state (:card %)) targets))
                            handlers)]
-      (when-completed (apply trigger-event-sync-next state side handlers event targets)
-                      (effect-completed state side eid nil)))))
+      (wait-for (apply trigger-event-sync-next state side handlers event targets)
+                (effect-completed state side eid)))))
 
 (defn- trigger-event-simult-player
   "Triggers the simultaneous event handlers for the given event trigger and player.
@@ -98,13 +98,13 @@
                                  (next handlers))]
                     (if-let [the-card (get-card state card-to-resolve)]
                       {:async true
-                       :effect (req (when-completed (resolve-ability state (to-keyword (:side the-card))
-                                                                     ability-to-resolve
-                                                                     the-card event-targets)
-                                                    (if (should-continue state handlers)
-                                                      (continue-ability state side
-                                                                        (choose-handler others) nil event-targets)
-                                                      (effect-completed state side eid nil))))}
+                       :effect (req (wait-for (resolve-ability state (to-keyword (:side the-card))
+                                                               ability-to-resolve
+                                                               the-card event-targets)
+                                              (if (should-continue state handlers)
+                                                (continue-ability state side
+                                                                  (choose-handler others) nil event-targets)
+                                                (effect-completed state side eid nil))))}
                       {:async true
                        :effect (req (if (should-continue state handlers)
                                       (continue-ability state side (choose-handler (next handlers)) nil event-targets)
@@ -115,7 +115,7 @@
                    :effect (req (let [to-resolve (some #(when (= target (:title (:card %))) %) handlers)
                                       ability-to-resolve (dissoc (:ability to-resolve) :req)
                                       the-card (get-card state (:card to-resolve))]
-                                  (when-completed
+                                  (wait-for
                                     (resolve-ability state (to-keyword (:side the-card))
                                                      ability-to-resolve the-card event-targets)
                                     (if (should-continue state handlers)
@@ -187,11 +187,11 @@
          active-player-events (get-handlers active-player)
          opponent-events (get-handlers opponent)]
      ; let active player activate their events first
-     (when-completed
+     (wait-for
        (resolve-ability state side first-ability nil nil)
        (do (show-wait-prompt state opponent (str (side-str active-player) " to resolve " (event-title event) " triggers")
                              {:priority -1})
-           (when-completed
+           (wait-for
              (trigger-event-simult-player state side event active-player-events cancel-fn targets)
              (do (when after-active-player
                    (resolve-ability state side after-active-player nil nil))
@@ -199,9 +199,9 @@
                  (show-wait-prompt state active-player
                                    (str (side-str opponent) " to resolve " (event-title event) " triggers")
                                    {:priority -1})
-                 (when-completed (trigger-event-simult-player state opponent event opponent-events cancel-fn targets)
-                                 (do (clear-wait-prompt state active-player)
-                                     (effect-completed state side eid nil))))))))))
+                 (wait-for (trigger-event-simult-player state opponent event opponent-events cancel-fn targets)
+                           (do (clear-wait-prompt state active-player)
+                               (effect-completed state side eid))))))))))
 
 
 ; Functions for registering trigger suppression events.

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -170,7 +170,7 @@
              (not (:host card)))
       (continue-ability state side {:prompt (str "The " (:title prev-card) " in " server " will now be trashed.")
                                     :choices ["OK"]
-                                    :delayed-completion true
+                                    :async true
                                     :effect (req (system-msg state :corp (str "trashes " (card-str state prev-card)))
                                                  (if (get-card state prev-card) ; make sure they didn't trash the card themselves
                                                    (trash state :corp eid prev-card {:keep-server-alive true})
@@ -299,7 +299,7 @@
      (continue-ability state side
                        {:prompt (str "Choose a location to install " (:title card))
                         :choices (corp-install-list state card)
-                        :delayed-completion true
+                        :async true
                         :effect (effect (corp-install eid card target args))}
                        card nil)
      ;; A card was selected as the server; recurse, with the :host-card parameter set.
@@ -406,7 +406,7 @@
        (continue-ability state side
                          {:choices hosting
                           :prompt (str "Choose a card to host " (:title card) " on")
-                          :delayed-completion true
+                          :async true
                           :effect (effect (runner-install eid card (assoc params :host-card target)))}
                          card nil)
        (do (trigger-event state side :pre-install card facedown)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -270,7 +270,7 @@
         all-cost (concat extra-cost [:credit ice-cost])
         end-cost (if no-install-cost 0 (install-cost state side card all-cost))
         end-fn #((clear-install-cost-bonus state side)
-                 (effect-completed state side eid card))]
+                 (effect-completed state side eid))]
     (if (and (corp-can-install? state side card dest-zone)
              (not (install-locked? state :corp)))
       (wait-for (pay-sync state side card end-cost {:action action})

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -74,9 +74,9 @@
                    (if-let [cost-str async-result]
                      (complete-play-instant state side eid card cost-str ignore-cost)
                      ;; could not pay the card's price; mark the effect as being over.
-                     (effect-completed state side eid card)))
+                     (effect-completed state side eid)))
          ;; card's req was not satisfied; mark the effect as being over.
-         (effect-completed state side eid card))))))
+         (effect-completed state side eid))))))
 
 (defn max-draw
   "Put an upper limit on the number of cards that can be drawn in this turn."
@@ -225,7 +225,7 @@
                               (trigger-event state side :damage type card n)))))))
                 (swap! state update-in [:damage :defer-damage] dissoc type)
                 (swap! state update-in [:damage] dissoc :damage-replace)
-                (effect-completed state side eid card))))
+                (effect-completed state side eid))))
 
 (defn damage
   "Attempts to deal n damage of the given type to the runner. Starts the

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -465,8 +465,8 @@
   ([state side eid {:keys [zone type] :as card} {:keys [unpreventable cause suppress-event] :as args}]
    (wait-for (prevent-trash state side card eid args)
              (if-let [c (first (get-in @state [:trash :trash-list eid]))]
-  (resolve-trash state side eid c args)
-  (effect-completed state side eid)))))
+               (resolve-trash state side eid c args)
+               (effect-completed state side eid)))))
 
 (defn trash-cards
   ([state side cards] (trash-cards state side (make-eid state) cards nil))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -57,7 +57,7 @@
   ([state side eid card]
    (let [c (move state :runner (dissoc card :advance-counter :new) :scored {:force true})
          points (get-agenda-points state :runner c)]
-     (when-completed
+     (wait-for
        (trigger-event-simult
          state :runner :agenda-stolen
          {:first-ability {:effect (req (system-msg state :runner (str "steals " (:title c) " and gains "
@@ -172,8 +172,8 @@
                                         (swap! state assoc-in [:run :did-access] true)))
                                     (swap! state assoc-in [:runner :register :trashed-card] true)
                                     (system-msg state side pay-str)
-                                    (when-completed (trash state side card nil)
-                                                    (access-end state side eid c))))
+                                    (wait-for (trash state side card nil)
+                                              (access-end state side eid c))))
 
                               (some #(= % target) ability-strs)
                               (let [idx (.indexOf ability-strs target)
@@ -183,8 +183,8 @@
                                              :trash-ability)]
                                 (when (:run @state)
                                   (swap! state assoc-in [:run :did-trash] true))
-                                (when-completed (resolve-ability state side cdef trash-ab-card [card])
-                                                (access-end state side eid c)))))}
+                                (wait-for (resolve-ability state side cdef trash-ab-card [card])
+                                          (access-end state side eid c)))))}
               card nil)))))
     (access-end state side eid c)))
 
@@ -206,7 +206,7 @@
                      kw (first cost)
                      v (second cost)]
                  (if (and cost (can-pay? state side title [kw v]))
-                   (when-completed
+                   (wait-for
                      (pay-sync state side nil [kw v] {:action :steal-cost})
                      (do (system-msg state side (str "pays " target " to steal " title))
                          (if (> (count cost-map) 1)
@@ -271,10 +271,10 @@
                                                           (steal-pay-choice state :runner cost-map c)
                                                           c nil)
                                         ;; Otherwise, just handle everything right friggin here
-                                        (when-completed (pay-sync state side nil cost {:action :steal-cost})
-                                                        (do (system-msg state side
-                                                                        (str "pays " cost-as-symbol " to steal " card-name))
-                                                            (steal-agenda state side eid c))))
+                                        (wait-for (pay-sync state side nil cost {:action :steal-cost})
+                                                  (do (system-msg state side
+                                                                  (str "pays " cost-as-symbol " to steal " card-name))
+                                                      (steal-agenda state side eid c))))
 
                                       ;; Use trash ability
                                       (some #(= % target) ability-strs)
@@ -285,9 +285,9 @@
                                                      :trash-ability)]
                                         (when (:run @state)
                                           (swap! state assoc-in [:run :did-trash] true))
-                                        (when-completed (resolve-ability state side cdef trash-ab-card [c])
-                                                        (do (trigger-event state side :no-steal c)
-                                                            (access-end state side eid c))))))}
+                                        (wait-for (resolve-ability state side cdef trash-ab-card [c])
+                                                  (do (trigger-event state side :no-steal c)
+                                                      (access-end state side eid c))))))}
                       c nil)))
 
 (defn- reveal-access?
@@ -324,17 +324,17 @@
         access-effect (when-let [acc (:access cdef)]
                         (ability-as-handler c acc))]
     (msg-handle-access state side c title)
-    (when-completed (trigger-event-simult state side :access
-                                          {:card-ability access-effect
-                                           ;; Cancel other access handlers if the card moves zones because of a handler
-                                           :cancel-fn (fn [state] (not (get-card state c)))}
-                                          c)
-                    (if (get-card state c) ; make sure the card has not been moved by a handler
-                      (if (is-type? c "Agenda")
-                        (access-agenda state side eid c)
-                        ;; Accessing a non-agenda
-                        (access-non-agenda state side eid c))
-                      (access-end state side eid c)))))
+    (wait-for (trigger-event-simult state side :access
+                                    {:card-ability access-effect
+                                     ;; Cancel other access handlers if the card moves zones because of a handler
+                                     :cancel-fn (fn [state] (not (get-card state c)))}
+                                    c)
+              (if (get-card state c) ; make sure the card has not been moved by a handler
+                (if (is-type? c "Agenda")
+                  (access-agenda state side eid c)
+                  ;; Accessing a non-agenda
+                  (access-non-agenda state side eid c))
+                (access-end state side eid c)))))
 
 (defn- access-pay
   "Force the runner to pay any costs to access this card, if any, before proceeding with access."
@@ -357,10 +357,10 @@
 
       (not-empty acost)
       ;; Await the payment of the costs; if payment succeeded, proceed with access.
-      (when-completed (pay-sync state side anon-card acost)
-                      (if async-result
-                        (access-trigger-events state side eid c title)
-                        (resolve-ability state :runner eid cant-pay c nil)))
+      (wait-for (pay-sync state side anon-card acost)
+                (if async-result
+                  (access-trigger-events state side eid c title)
+                  (resolve-ability state :runner eid cant-pay c nil)))
       :else
       ;; The runner cannot afford the cost to access the card
       (resolve-ability state :runner eid cant-pay c nil))))
@@ -377,8 +377,8 @@
    (swap! state update-in [:bonus] dissoc :steal-cost)
    (swap! state update-in [:bonus] dissoc :access-cost)
     ;; First trigger pre-access-card, then move to determining if we can trash or steal.
-   (when-completed (trigger-event-sync state side :pre-access-card card)
-                   (access-pay state side eid card title))))
+   (wait-for (trigger-event-sync state side :pre-access-card card)
+             (access-pay state side eid card title))))
 
 (defn prevent-access
   "Prevents the runner from accessing cards this run. This will cancel any run effects and not trigger access routines."
@@ -412,11 +412,11 @@
   {:prompt "Click a card to access it. You must access all cards in this server."
    :choices {:req #(some (fn [c] (= (:cid %) (:cid c))) cards)}
    :async true
-   :effect (req (when-completed (access-card state side target)
-                                (if (< 1 (count cards))
-                                  (continue-ability state side (access-helper-remote (filter #(not= (:cid %) (:cid target)) cards))
-                                                    card nil)
-                                  (effect-completed state side eid nil))))})
+   :effect (req (wait-for (access-card state side target)
+                          (if (< 1 (count cards))
+                            (continue-ability state side (access-helper-remote (filter #(not= (:cid %) (:cid target)) cards))
+                                              card nil)
+                            (effect-completed state side eid nil))))})
 
 (defmethod choose-access :remote [cards server]
   {:async true
@@ -455,14 +455,14 @@
                                            from-root)]
                       (if (= 1 (count unrezzed))
                         ;; only one unrezzed upgrade; access it and continue
-                        (when-completed (access-card state side (first unrezzed))
-                                        (if (or (pos? amount) (< 1 (count from-root)))
-                                          (continue-ability
-                                            state side
-                                            (access-helper-hq-or-rd state chosen-zone label amount select-fn title-fn
-                                                                    (conj already-accessed (first unrezzed)))
-                                            card nil)
-                                          (effect-completed state side eid)))
+                        (wait-for (access-card state side (first unrezzed))
+                                  (if (or (pos? amount) (< 1 (count from-root)))
+                                    (continue-ability
+                                      state side
+                                      (access-helper-hq-or-rd state chosen-zone label amount select-fn title-fn
+                                                              (conj already-accessed (first unrezzed)))
+                                      card nil)
+                                    (effect-completed state side eid)))
                         ;; more than one unrezzed upgrade. allow user to select with mouse.
                         (continue-ability
                           state side
@@ -470,44 +470,44 @@
                            :prompt (str "Choose an upgrade in " server-name " to access.")
                            :choices {:req #(and (= (second (:zone %)) chosen-zone)
                                                 (complement already-accessed))}
-                           :effect (req (when-completed (access-card state side target)
-                                                        (continue-ability
-                                                          state side
-                                                          (access-helper-hq-or-rd state chosen-zone label amount select-fn title-fn
-                                                                                  (conj already-accessed target))
-                                                          card nil)))}
+                           :effect (req (wait-for (access-card state side target)
+                                                  (continue-ability
+                                                    state side
+                                                    (access-helper-hq-or-rd state chosen-zone label amount select-fn title-fn
+                                                                            (conj already-accessed target))
+                                                    card nil)))}
                           card nil)))
                     ;; accessing a card in deck
                     (= target card-from)
                     (let [accessed (select-fn already-accessed)]
-                      (when-completed (access-card state side (make-eid state) accessed
-                                                   (title-fn accessed))
+                      (wait-for (access-card state side (make-eid state) accessed
+                                             (title-fn accessed))
 
-                                      (let [from-root (get-root-content state)]
-                                        (if (or (< 1 amount) (not-empty from-root))
-                                          (continue-ability
-                                            state side
-                                            (access-helper-hq-or-rd state chosen-zone label (dec amount) select-fn title-fn
-                                                                    (if (-> @state :run :shuffled-during-access chosen-zone)
-                                                                      ;; if the zone was shuffled because of the access,
-                                                                      ;; the runner "starts over" excepting any upgrades that were accessed
-                                                                      (do (swap! state update-in [:run :shuffled-during-access] dissoc chosen-zone)
-                                                                          (set (filter #(= :servers (first (:zone %)))
-                                                                                       already-accessed)))
-                                                                      (conj already-accessed accessed)))
-                                            card nil)
-                                          (effect-completed state side eid)))))
+                                (let [from-root (get-root-content state)]
+                                  (if (or (< 1 amount) (not-empty from-root))
+                                    (continue-ability
+                                      state side
+                                      (access-helper-hq-or-rd state chosen-zone label (dec amount) select-fn title-fn
+                                                              (if (-> @state :run :shuffled-during-access chosen-zone)
+                                                                ;; if the zone was shuffled because of the access,
+                                                                ;; the runner "starts over" excepting any upgrades that were accessed
+                                                                (do (swap! state update-in [:run :shuffled-during-access] dissoc chosen-zone)
+                                                                    (set (filter #(= :servers (first (:zone %)))
+                                                                                 already-accessed)))
+                                                                (conj already-accessed accessed)))
+                                      card nil)
+                                    (effect-completed state side eid)))))
                     ;; accessing a rezzed upgrade
                     :else
                     (let [accessed (some #(when (= (:title %) target) %) (get-root-content state))]
-                      (when-completed (access-card state side accessed)
-                                      (if (or (pos? amount) (< 1 (count (get-root-content state))))
-                                        (continue-ability
-                                          state side
-                                          (access-helper-hq-or-rd state chosen-zone label amount select-fn title-fn
-                                                                  (conj already-accessed accessed))
-                                          card nil)
-                                        (effect-completed state side eid))))))}))
+                      (wait-for (access-card state side accessed)
+                                (if (or (pos? amount) (< 1 (count (get-root-content state))))
+                                  (continue-ability
+                                    state side
+                                    (access-helper-hq-or-rd state chosen-zone label amount select-fn title-fn
+                                                            (conj already-accessed accessed))
+                                    card nil)
+                                  (effect-completed state side eid))))))}))
 
 (defmethod choose-access :rd [cards server]
   {:async true
@@ -608,10 +608,10 @@
                     ;; accessing a card that was added to archives because of the effect of another card
                     (let [accessed (first (shuffle (facedown-cards already-accessed)))
                           already-accessed (conj already-accessed accessed)]
-                      (when-completed (access-card state side accessed)
-                                      (if (must-continue? already-accessed)
-                                        (next-access state side eid already-accessed card)
-                                        (effect-completed state side eid))))
+                      (wait-for (access-card state side accessed)
+                                (if (must-continue? already-accessed)
+                                  (next-access state side eid already-accessed card)
+                                  (effect-completed state side eid))))
 
                     (= target "Unrezzed upgrade in Archives")
                     ;; accessing an unrezzed upgrade
@@ -620,10 +620,10 @@
                       (if (= 1 (count unrezzed))
                         ;; only one unrezzed upgrade; access it and continue
                         (let [already-accessed (conj already-accessed (first unrezzed))]
-                          (when-completed (access-card state side (first unrezzed))
-                                          (if (must-continue? already-accessed)
-                                            (next-access state side eid already-accessed card)
-                                            (effect-completed state side eid))))
+                          (wait-for (access-card state side (first unrezzed))
+                                    (if (must-continue? already-accessed)
+                                      (next-access state side eid already-accessed card)
+                                      (effect-completed state side eid))))
                         ;; more than one unrezzed upgrade. allow user to select with mouse.
                         (continue-ability
                           state side
@@ -632,10 +632,10 @@
                            :choices {:req #(and (= (second (:zone %)) :archives)
                                                 (not (already-accessed %)))}
                            :effect (req (let [already-accessed (conj already-accessed target)]
-                                          (when-completed (access-card state side target)
-                                                          (if (must-continue? already-accessed)
-                                                            (next-access state side eid already-accessed card)
-                                                            (effect-completed state side eid)))))}
+                                          (wait-for (access-card state side target)
+                                                    (if (must-continue? already-accessed)
+                                                      (next-access state side eid already-accessed card)
+                                                      (effect-completed state side eid)))))}
                           card nil)))
 
                     :else
@@ -643,10 +643,10 @@
                     (let [accessed (some #(when (= (:title %) target) %)
                                          (concat (faceup-accessible already-accessed) (root-content already-accessed)))
                           already-accessed (conj already-accessed accessed)]
-                      (when-completed (access-card state side accessed)
-                                      (if (must-continue? already-accessed)
-                                        (next-access state side eid already-accessed card)
-                                        (effect-completed state side eid))))))}))
+                      (wait-for (access-card state side accessed)
+                                (if (must-continue? already-accessed)
+                                  (next-access state side eid already-accessed card)
+                                  (effect-completed state side eid))))))}))
 
 (defmethod choose-access :archives [cards server]
   {:async true
@@ -689,26 +689,26 @@
   "Starts the access routines for the run's server."
   ([state side eid server] (do-access state side eid server nil))
   ([state side eid server {:keys [hq-root-only] :as args}]
-   (when-completed (trigger-event-sync state side :pre-access (first server))
-                   (do (let [cards (cards-to-access state side server)
-                             cards (if hq-root-only (remove #(= '[:hand] (:zone %)) cards) cards)
-                             n (count cards)]
-                         ;; Make `:did-access` true when reaching the access step (no replacement)
-                         (when (:run @state) (swap! state assoc-in [:run :did-access] true))
-                         (if (or (zero? n)
-                                 (safe-zero? (get-in @state [:run :max-access])))
-                           (system-msg state side "accessed no cards during the run")
-                           (do (swap! state assoc-in [:runner :register :accessed-cards] true)
-                               (when-completed (resolve-ability state side (choose-access cards server) nil nil)
-                                               (effect-completed state side eid nil))
-                               (swap! state update-in [:run :cards-accessed] (fnil #(+ % n) 0)))))
-                       (handle-end-run state side)))))
+   (wait-for (trigger-event-sync state side :pre-access (first server))
+             (do (let [cards (cards-to-access state side server)
+                       cards (if hq-root-only (remove #(= '[:hand] (:zone %)) cards) cards)
+                       n (count cards)]
+                   ;; Make `:did-access` true when reaching the access step (no replacement)
+                   (when (:run @state) (swap! state assoc-in [:run :did-access] true))
+                   (if (or (zero? n)
+                           (safe-zero? (get-in @state [:run :max-access])))
+                     (system-msg state side "accessed no cards during the run")
+                     (do (swap! state assoc-in [:runner :register :accessed-cards] true)
+                         (wait-for (resolve-ability state side (choose-access cards server) nil nil)
+                                   (effect-completed state side eid nil))
+                         (swap! state update-in [:run :cards-accessed] (fnil #(+ % n) 0)))))
+                 (handle-end-run state side)))))
 
 (defn replace-access
   "Replaces the standard access routine with the :replace-access effect of the card"
   [state side ability card]
-  (when-completed (resolve-ability state side ability card nil)
-                  (run-cleanup state side)))
+  (wait-for (resolve-ability state side ability card nil)
+            (run-cleanup state side)))
 
 ;;;; OLDER ACCESS ROUTINES. DEPRECATED.
 
@@ -719,10 +719,10 @@
   ([state side eid server]
    (swap! state update-in [:runner :register :successful-run] #(conj % (first server)))
    (swap! state assoc-in [:run :successful] true)
-   (when-completed (trigger-event-simult state side :pre-successful-run nil (first server))
-                   (when-completed (trigger-event-simult state side :successful-run nil (first (get-in @state [:run :server])))
-                                   (when-completed (trigger-event-simult state side :post-successful-run nil (first (get-in @state [:run :server])))
-                                                   (effect-completed state side eid nil))))))
+   (wait-for (trigger-event-simult state side :pre-successful-run nil (first server))
+             (wait-for (trigger-event-simult state side :successful-run nil (first (get-in @state [:run :server])))
+                       (wait-for (trigger-event-simult state side :post-successful-run nil (first (get-in @state [:run :server])))
+                                 (effect-completed state side eid nil))))))
 
 (defn- successful-run-trigger
   "The real 'successful run' trigger."
@@ -732,35 +732,35 @@
     (when (and successful-run-effect
                (not (apply trigger-suppress state side :successful-run card)))
       (resolve-ability state side successful-run-effect (:card successful-run-effect) nil)))
-  (when-completed (register-successful-run state side (get-in @state [:run :server]))
-                  (let [the-run (:run @state)
-                        server (:server the-run) ; bind here as the server might have changed
-                        run-effect (:run-effect the-run)
-                        run-req (:req run-effect)
-                        card (:card run-effect)
-                        replace-effect (:replace-access run-effect)]
-                    (if (:prevent-access the-run)
-                      (do (system-msg state :runner "is prevented from accessing any cards this run")
-                          (resolve-ability state :runner
-                                           {:prompt "You are prevented from accessing any cards this run."
-                                            :choices ["OK"]
-                                            :effect (effect (handle-end-run))}
-                                           nil nil))
-                      (if (and replace-effect
-                               (or (not run-req)
-                                   (run-req state side (make-eid state) card [(first server)])))
-                        (if (:mandatory replace-effect)
-                          (replace-access state side replace-effect card)
-                          (swap! state update-in [side :prompt]
-                                 (fn [p]
-                                   (conj (vec p) {:msg "Use replacement effect instead of accessing cards?"
-                                                  :choices ["Replacement effect" "Access cards"]
-                                                  :effect #(if (= % "Replacement effect")
-                                                             (replace-access state side replace-effect card)
-                                                             (when-completed (do-access state side server)
-                                                                             (handle-end-run state side)))}))))
-                        (when-completed (do-access state side server)
-                                        (handle-end-run state side)))))))
+  (wait-for (register-successful-run state side (get-in @state [:run :server]))
+            (let [the-run (:run @state)
+                  server (:server the-run) ; bind here as the server might have changed
+                  run-effect (:run-effect the-run)
+                  run-req (:req run-effect)
+                  card (:card run-effect)
+                  replace-effect (:replace-access run-effect)]
+              (if (:prevent-access the-run)
+                (do (system-msg state :runner "is prevented from accessing any cards this run")
+                    (resolve-ability state :runner
+                                     {:prompt "You are prevented from accessing any cards this run."
+                                      :choices ["OK"]
+                                      :effect (effect (handle-end-run))}
+                                     nil nil))
+                (if (and replace-effect
+                         (or (not run-req)
+                             (run-req state side (make-eid state) card [(first server)])))
+                  (if (:mandatory replace-effect)
+                    (replace-access state side replace-effect card)
+                    (swap! state update-in [side :prompt]
+                           (fn [p]
+                             (conj (vec p) {:msg "Use replacement effect instead of accessing cards?"
+                                            :choices ["Replacement effect" "Access cards"]
+                                            :effect #(if (= % "Replacement effect")
+                                                       (replace-access state side replace-effect card)
+                                                       (wait-for (do-access state side server)
+                                                                 (handle-end-run state side)))}))))
+                  (wait-for (do-access state side server)
+                            (handle-end-run state side)))))))
 
 (defn successful-run
   "Run when a run has passed all ice and the runner decides to access. The corp may still get to act in 4.3."
@@ -814,23 +814,23 @@
   "The runner decides to jack out."
   ([state side] (jack-out state side (make-eid state)))
   ([state side eid]
-  (swap! state update-in [:jack-out] dissoc :jack-out-prevent)
-  (when-completed (trigger-event-sync state side :pre-jack-out)
-                  (let [prevent (get-prevent-list state :corp :jack-out)]
-                    (if (cards-can-prevent? state :corp prevent :jack-out)
-                      (do (system-msg state :corp "has the option to prevent the Runner from jacking out")
-                          (show-wait-prompt state :runner "Corp to prevent the jack out" {:priority 10})
-                          (show-prompt state :corp nil
-                                       (str "Prevent the Runner from jacking out?") ["Done"]
-                                       (fn [_]
-                                         (clear-wait-prompt state :runner)
-                                         (if-let [_ (get-in @state [:jack-out :jack-out-prevent])]
-                                           (effect-completed state side (make-result eid false))
-                                           (do (system-msg state :corp "will not prevent the Runner from jacking out")
-                                               (resolve-jack-out state side eid))))
-                                       {:priority 10}))
-                      (do (resolve-jack-out state side eid)
-                          (effect-completed state side (make-result eid false))))))))
+   (swap! state update-in [:jack-out] dissoc :jack-out-prevent)
+   (wait-for (trigger-event-sync state side :pre-jack-out)
+             (let [prevent (get-prevent-list state :corp :jack-out)]
+               (if (cards-can-prevent? state :corp prevent :jack-out)
+                 (do (system-msg state :corp "has the option to prevent the Runner from jacking out")
+                     (show-wait-prompt state :runner "Corp to prevent the jack out" {:priority 10})
+                     (show-prompt state :corp nil
+                                  (str "Prevent the Runner from jacking out?") ["Done"]
+                                  (fn [_]
+                                    (clear-wait-prompt state :runner)
+                                    (if-let [_ (get-in @state [:jack-out :jack-out-prevent])]
+                                      (effect-completed state side (make-result eid false))
+                                      (do (system-msg state :corp "will not prevent the Runner from jacking out")
+                                          (resolve-jack-out state side eid))))
+                                  {:priority 10}))
+                 (do (resolve-jack-out state side eid)
+                     (effect-completed state side (make-result eid false))))))))
 
 (defn- trigger-run-end-events
   [state side eid run]

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -416,7 +416,7 @@
                           (if (< 1 (count cards))
                             (continue-ability state side (access-helper-remote (filter #(not= (:cid %) (:cid target)) cards))
                                               card nil)
-                            (effect-completed state side eid nil))))})
+                            (effect-completed state side eid))))})
 
 (defmethod choose-access :remote [cards server]
   {:async true
@@ -700,7 +700,7 @@
                      (system-msg state side "accessed no cards during the run")
                      (do (swap! state assoc-in [:runner :register :accessed-cards] true)
                          (wait-for (resolve-ability state side (choose-access cards server) nil nil)
-                                   (effect-completed state side eid nil))
+                                   (effect-completed state side eid))
                          (swap! state update-in [:run :cards-accessed] (fnil #(+ % n) 0)))))
                  (handle-end-run state side)))))
 
@@ -722,7 +722,7 @@
    (wait-for (trigger-event-simult state side :pre-successful-run nil (first server))
              (wait-for (trigger-event-simult state side :successful-run nil (first (get-in @state [:run :server])))
                        (wait-for (trigger-event-simult state side :post-successful-run nil (first (get-in @state [:run :server])))
-                                 (effect-completed state side eid nil))))))
+                                 (effect-completed state side eid))))))
 
 (defn- successful-run-trigger
   "The real 'successful run' trigger."
@@ -885,7 +885,7 @@
   (let [prompt (-> @state side :prompt first)
         eid (:eid prompt)]
     (swap! state update-in [side :prompt] rest)
-    (effect-completed state side eid nil)
+    (effect-completed state side eid)
     (when-let [run (:run @state)]
       (when (and (:ended run) (empty? (get-in @state [:runner :prompt])) )
         (handle-end-run state :runner)))))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -100,10 +100,10 @@
     (init-identity state :runner runner-identity)
     ;(swap! game-states assoc gameid state)
     (let [side :corp]
-      (when-completed (trigger-event-sync state side :pre-start-game)
-                      (let [side :runner]
-                        (when-completed (trigger-event-sync state side :pre-start-game)
-                                        (init-hands state)))))
+      (wait-for (trigger-event-sync state side :pre-start-game)
+                (let [side :runner]
+                  (wait-for (trigger-event-sync state side :pre-start-game)
+                            (init-hands state)))))
     state))
 
 (defn server-card
@@ -186,23 +186,23 @@
    (turn-message state side true)
    (let [extra-clicks (get-in @state [side :extra-click-temp] 0)]
      (gain state side :click (get-in @state [side :click-per-turn]))
-     (when-completed (trigger-event-sync state side (if (= side :corp) :corp-turn-begins :runner-turn-begins))
-                     (do (when (= side :corp)
-                           (when-completed (draw state side 1 nil)
-                                           (trigger-event-simult state side eid :corp-mandatory-draw nil nil)))
+     (wait-for (trigger-event-sync state side (if (= side :corp) :corp-turn-begins :runner-turn-begins))
+               (do (when (= side :corp)
+                     (wait-for (draw state side 1 nil)
+                               (trigger-event-simult state side eid :corp-mandatory-draw nil nil)))
 
-                         (cond
+                   (cond
 
-                          (neg? extra-clicks)
-                          (lose state side :click (abs extra-clicks))
+                     (neg? extra-clicks)
+                     (lose state side :click (abs extra-clicks))
 
-                          (pos? extra-clicks)
-                          (gain state side :click extra-clicks))
+                     (pos? extra-clicks)
+                     (gain state side :click extra-clicks))
 
-                         (swap! state dissoc-in [side :extra-click-temp])
-                         (swap! state dissoc (if (= side :corp) :corp-phase-12 :runner-phase-12))
-                         (when (= side :corp)
-                           (update-all-advancement-costs state side)))))))
+                   (swap! state dissoc-in [side :extra-click-temp])
+                   (swap! state dissoc (if (= side :corp) :corp-phase-12 :runner-phase-12))
+                   (when (= side :corp)
+                     (update-all-advancement-costs state side)))))))
 
 (defn start-turn
   "Start turn."
@@ -244,7 +244,7 @@
        (when (and (= side :runner)
                   (neg? (hand-size state side)))
          (flatline state))
-       (when-completed
+       (wait-for
          (trigger-event-sync state side (if (= side :runner) :runner-turn-ends :corp-turn-ends))
          (do (when (= side :runner)
                (trigger-event state side :post-runner-turn-ends))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -75,10 +75,10 @@
        (str ~@expr))))
 
 (defmacro wait-for
-  ([action expr]
+  ([action & expr]
    (let [reqmac `(fn [~'state1 ~'side1 ~'eid1 ~'card1 ~'target1]
                    (let [~'async-result (:result ~'eid1)]
-                     ~expr))
+                     ~@expr))
    ;; this creates a five-argument function to be resolved later,
    ;; without overriding any local variables name state, card, etc.
          totake (if (= 'apply (first action)) 4 3)
@@ -89,9 +89,6 @@
         (if ~'use-eid
           ~(concat (take totake action) (list 'new-eid) (drop (inc totake) action))
           ~(concat (take totake action) (list 'new-eid) (drop totake action)))))))
-
-(defmacro final-effect [& expr]
-  (macroexpand (apply list `(effect ~@expr ~(list (quote effect-completed) 'eid 'card)))))
 
 (defmacro continue-ability
   [state side ability card targets]

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -74,7 +74,7 @@
             'tagged '(or (pos? (:tagged runner)) (pos? (:tag runner)))]
        (str ~@expr))))
 
-(defmacro when-completed
+(defmacro wait-for
   ([action expr]
    (let [reqmac `(fn [~'state1 ~'side1 ~'eid1 ~'card1 ~'target1]
                    (let [~'async-result (:result ~'eid1)]

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -837,7 +837,7 @@
         (is (= 2 (get-counters (refresh ice-wall) :advancement)) "Ice Wall has 2 advancement counters from HT forfeit"))
       (prompt-select :corp (get-scored state :corp 0)) ; select AI to trigger
       (prompt-choice :runner "Take 2 tags") ; First runner has prompt
-      (is (= 4 (:tag (get-runner))) "Runner took 2 more tags from AI -- happens at the end of all the delayed-completion"))))
+      (is (= 4 (:tag (get-runner))) "Runner took 2 more tags from AI -- happens at the end of all the async completion"))))
 
 (deftest jesminder-sareen:-girl-behind-the-curtain
   ;; Jesminder Sareen - avoid tags only during a run


### PR DESCRIPTION
`:delayed-completion` -> `:async`

`when-completed` -> `wait-for`

Shorter without semantic loss of meaning. Async/await are common terms in other languages like C# and JavaScript. I would have preferred `await` but that is a function in clojure.core, so `wait-for` suffices.