### PR TITLE
FIX: NEXT Sapphire shuffling

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1638,8 +1638,9 @@
                                         (= [:hand] (:zone %)))
                              :max (req (next-ice-count corp))}
                    :effect (req (doseq [c targets]
-                                  (move state side c :deck))
-                                (shuffle! state side :deck))
+                                  (move state :corp c :deck))
+                                (shuffle! state :corp :deck))
+                   :cancel-effect (effect (shuffle! :corp :deck))
                    :msg (msg "shuffle " (count targets) " cards from HQ into R&D")}]}
 
    "NEXT Silver"


### PR DESCRIPTION
Turns out there's a ruling on Jackson Howard that says you can shuffle even if you choose to put no cards back into R&D, which means in NEXT Sapphire's last subroutine, the shuffle is mandatory even if you choose 0 cards. This PR adds a test to handle the case as well as fixing it.