### PR TITLE
TEST: Alice Merchant

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -124,8 +124,8 @@
                                  :player :corp
                                  :choices (req (:hand corp))
                                  :msg "force the Corp to trash 1 card from HQ"
-                                 :effect (effect (clear-wait-prompt :runner)
-                                                 (trash :corp eid (assoc target :seen false) nil))}
+                                 :effect (effect (trash :corp target)
+                                                 (clear-wait-prompt :runner))}
                                card nil))}}}
 
    "Andromeda: Dispossessed Ristie"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -124,8 +124,8 @@
                                  :player :corp
                                  :choices (req (:hand corp))
                                  :msg "force the Corp to trash 1 card from HQ"
-                                 :effect (effect (trash :corp target)
-                                                 (clear-wait-prompt :runner))}
+                                 :effect (effect (clear-wait-prompt :runner)
+                                                 (trash :corp eid (assoc target :seen false) nil))}
                                card nil))}}}
 
    "Andromeda: Dispossessed Ristie"

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -101,7 +101,9 @@
              hosted (seq (flatten (map
                       (if same-zone? update-hosted trash-hosted)
                       (:hosted card))))
-             c (if (and (= side :corp) (= (first dest) :discard) (rezzed? card))
+             c (if (and (= side :corp)
+                        (= (first dest) :discard)
+                        (rezzed? card))
                  (assoc card :seen true) card)
              c (if (and (or installed host (#{:servers :scored :current} (first zone)))
                         (or (#{:hand :deck :discard :rfg} (first dest)) to-facedown)
@@ -110,9 +112,12 @@
              c (if to-installed (assoc c :installed true) (dissoc c :installed))
              c (if to-facedown (assoc c :facedown true) (dissoc c :facedown))
              moved-card (assoc c :zone dest :host nil :hosted hosted :previous-zone (:zone c))
-             moved-card (if (and (= side :corp) (#{:hand :deck} (first dest)))
-                          (dissoc moved-card :seen) moved-card)
-             moved-card (if (and (= (first (:zone moved-card)) :scored) (card-flag? moved-card :has-abilities-when-stolen true))
+             moved-card (if (and (= side :corp)
+                                 (#{:hand :deck} (first dest)))
+                          (dissoc moved-card :seen)
+                          moved-card)
+             moved-card (if (and (= (first (:zone moved-card)) :scored)
+                                 (card-flag? moved-card :has-abilities-when-stolen true))
                           (merge moved-card {:abilities (:abilities (card-def moved-card))}) moved-card)]
          (if front
            (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -132,8 +132,7 @@
 (deftest alice-merchant:-clan-agitator
   ;; Alice Merchant
   (do-game
-    (new-game (default-corp [;"Hostile Takeover"
-                             (qty "Hedge Fund" 3)])
+    (new-game (default-corp)
               (make-deck "Alice Merchant: Clan Agitator"
                          ["Security Testing"]))
     ; (trash-from-hand state :corp "Hostile Takeover")

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -129,6 +129,25 @@
       (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")
       (is (= 1 (count (:discard (get-corp)))) "1 card in archives"))))
 
+(deftest alice-merchant:-clan-agitator
+  ;; Alice Merchant
+  (do-game
+    (new-game (default-corp [;"Hostile Takeover"
+                             (qty "Hedge Fund" 3)])
+              (make-deck "Alice Merchant: Clan Agitator"
+                         ["Security Testing"]))
+    ; (trash-from-hand state :corp "Hostile Takeover")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Security Testing")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (prompt-choice :runner "Archives")
+    (run-empty-server state "Archives")
+    (prompt-choice :runner "Alice Merchant: Clan Agitator")
+    (prompt-card :corp (find-card "Hedge Fund" (:hand (get-corp))))
+    (is (= 1 (-> (get-corp) :discard count)) "Alice ability should trash 1 card from HQ")
+    (is (-> (get-corp) :discard first :seen not) "Discarded card should be facedown when access is replaced")))
+
 (deftest andromeda:-dispossessed-ristie
   ;; Andromeda - 9 card starting hand, 1 link
   (testing "Basic test"


### PR DESCRIPTION
~Alice Merchant was forcing the corp to trash from hand, which wouldn't set `:seen`. This led to the card being faceup in Archives when using an access replacement effect. I've fixed it so that the card is discarded face down first and foremost, before access is checked.~

Now it's just a good test for Alice.

Fixes #3684