### PR TITLE
FIX: Biased Reporting not giving Corp credits

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -182,30 +182,36 @@
                     card nil)))}
 
    "Biased Reporting"
-   {:async true
-    :req (req (not-empty (all-active-installed state :runner)))
-    :prompt "Choose a card type"
-    :choices ["Resource" "Hardware" "Program"]
-    :effect (req (let [t target
-                       num (count (filter #(is-type? % t) (all-active-installed state :runner)))]
-                   (show-wait-prompt state :corp "Runner to choose cards to trash")
-                   (wait-for
-                     (resolve-ability state :runner
-                       {:prompt (msg "Choose any number of cards of type " t " to trash")
-                        :choices {:max num :req #(and (installed? %) (is-type? % t))}
-                        :cancel-effect (effect (clear-wait-prompt :corp))
-                        :effect (req (doseq [c targets]
-                                       (trash state :runner c {:unpreventable true}))
-                                     (gain-credits state :runner (count targets))
-                                     (system-msg state :runner (str "trashes " (join ", " (map :title (sort-by :title targets)))
-                                                                    " and gains " (count targets) " [Credits]"))
-                                     (clear-wait-prompt state :corp))}
-                      card nil)
-                     (do (let [n (* 2 (count (filter #(is-type? % t) (all-active-installed state :runner))))]
-                           (when (pos? n)
-                             (gain-credits state :corp n)
-                             (system-msg state :corp (str "uses Biased Reporting to gain " n " [Credits]")))
-                           (effect-completed state side eid))))))}
+   (letfn [(num-installed [state t]
+             (count (filter #(is-type? % t) (all-active-installed state :runner))))]
+     {:async true
+      :req (req (not-empty (all-active-installed state :runner)))
+      :prompt "Choose a card type"
+      :choices ["Resource" "Hardware" "Program"]
+      :effect (req (let [t target
+                         n (num-installed state t)]
+                     (show-wait-prompt state :corp "Runner to choose cards to trash")
+                     (wait-for
+                       (resolve-ability
+                         state :runner
+                         {:prompt (msg "Choose any number of cards of type " t " to trash")
+                          :choices {:max n
+                                    :req #(and (installed? %) (is-type? % t))}
+                          :effect (req (doseq [c targets]
+                                         (trash state :runner c {:unpreventable true}))
+                                       (gain-credits state :runner (count targets))
+                                       (system-msg state :runner
+                                                   (str "trashes "
+                                                        (join ", " (map :title (sort-by :title targets)))
+                                                        " and gains " (count targets) " [Credits]"))
+                                       (effect-completed state side eid))}
+                         card nil)
+                       (clear-wait-prompt state :corp)
+                       (let [n (* 2 (num-installed state t))]
+                         (when (pos? n)
+                           (gain-credits state :corp n)
+                           (system-msg state :corp (str "uses Biased Reporting to gain " n " [Credits]")))
+                         (effect-completed state side eid)))))})
 
    "Big Brother"
    {:req (req tagged)

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -64,9 +64,17 @@
   [card property value]
   (let [cv (property card)]
     (cond
-      (or (keyword? cv) (and (string? value) (string? cv))) (= value cv)
-      (and (keyword? value) (string? cv)) (= value (keyword (.toLowerCase cv)))
-      :else (= value cv))))
+      (or (keyword? cv)
+          (and (string? value)
+               (string? cv)))
+      (= value cv)
+
+      (and (keyword? value)
+           (string? cv))
+      (= value (keyword (.toLowerCase cv)))
+
+      :else
+      (= value cv))))
 
 (defn zone
   "Associate the specified zone to each item in the collection.

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -148,6 +148,26 @@
     (is (= 1 (count (:discard (get-corp)))))
     (is (find-card "Celebrity Gift" (:discard (get-corp))))))
 
+(deftest biased-reporting
+  ;; Biased Reporting
+  (do-game
+    (new-game (default-corp ["Biased Reporting"])
+              (default-runner [(qty "Fan Site" 5)]))
+    (take-credits state :corp)
+    (starting-hand state :runner (repeat 5 "Fan Site"))
+    (core/gain state :runner :click 10)
+    (dotimes [_ 5]
+      (play-from-hand state :runner "Fan Site"))
+    (take-credits state :runner)
+    (play-from-hand state :corp "Biased Reporting")
+    (let [cc (:credit (get-corp))
+          rc (:credit (get-runner))]
+      (prompt-choice :corp "Resource")
+      (prompt-select :runner (get-resource state 0))
+      (prompt-choice :runner "Done")
+      (is (= (inc rc) (:credit (get-runner))) "Runner should gain 1 credit for trashing a Fan Site")
+      (is (= (+ (* 4 2) cc) (:credit (get-corp))) "Corp should gain 8 credits for remaining 4 Fan Sites"))))
+
 (deftest big-brother
   ;; Big Brother - Give the Runner 2 tags if already tagged
   (do-game


### PR DESCRIPTION
By using `:cancel-effect`, the Runner clicking "Done" would not call "effect-completed", thus not finishing the rest of the ability. This refactors and revamps it a bit, and includes a test.

Fixes #3678