### PR TITLE
RaR: Saraswati Mnemonics: Endless Exploration

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -890,6 +890,38 @@
                                 (trigger-event state side :ice-subtype-changed ice)))}]
     :events {:run-ends nil}}
 
+   "Saraswati Mnemonics: Endless Exploration"
+   (letfn [(install-card [chosen]
+                        {:prompt "Select a remote server"
+                         :choices (req (conj (vec (get-remote-names state)) "New remote"))
+                         :async true
+                         :effect (req (corp-install state side (assoc chosen :advance-counter 1) target)
+                                      (effect-completed state side eid)
+                                      (let [tgtcid (:cid chosen)]
+                                        (register-turn-flag! state side
+                                                             card :can-rez
+                                                             (fn [state side card]
+                                                               (if (= (:cid card) tgtcid)
+                                                                 ((constantly false) (toast state :corp "Cannot rez due to Saraswati Mnemonics: Endless Exploration." "warning"))
+                                                                 true)))
+                                        (register-turn-flag! state side
+                                                             card :can-score
+                                                             (fn [state side card]
+                                                               (if (and (= (:cid card) tgtcid)
+                                                                        (>= (get-counters card :advancement) (or (:current-cost card) (:advancementcost card))))
+                                                                 ((constantly false) (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
+                                                                 true)))))})]
+   {:abilities [{:async true
+                 :label "[Click], 1 [Credits]: Install a card from HQ in a remote server, then place 1 advancement token on it. You cannot score or rez that card until your next turn begins."
+                 :cost [:click 1 :credit 1]
+                 :prompt "Select a card to install from HQ"
+                 :choices {:req #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))
+                                      (= (:side %) "Corp")
+                                      (in-hand? %))}
+                 :msg (msg "install a card in a remote server and place 1 advancement token on it")
+                 :effect (effect (continue-ability (install-card target) card nil))
+                 }]})
+
    "Seidr Laboratories: Destiny Defined"
    {:implementation "Manually triggered"
     :abilities [{:req (req (:run @state))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -909,7 +909,7 @@
                                                                         (>= (get-counters card :advancement) (or (:current-cost card) (:advancementcost card))))
                                                                  ((constantly false) (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
                                                                  true))))
-                                      (corp-install state side (assoc chosen :advance-counter 1) target))})]
+                                      (corp-install state side eid (assoc chosen :advance-counter 1) target nil))})]
    {:abilities [{:async true
                  :label "Install a card from HQ"
                  :cost [:click 1 :credit 1]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -911,7 +911,7 @@
                                                                  true))))
                                       (corp-install state side (assoc chosen :advance-counter 1) target))})]
    {:abilities [{:async true
-                 :label "[Click], 1 [Credits]: Install a card from HQ in a remote server, then place 1 advancement token on it. You cannot score or rez that card until your next turn begins."
+                 :label "Install a card from HQ"
                  :cost [:click 1 :credit 1]
                  :prompt "Select a card to install from HQ"
                  :choices {:req #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -895,8 +895,7 @@
                         {:prompt "Select a remote server"
                          :choices (req (conj (vec (get-remote-names state)) "New remote"))
                          :async true
-                         :effect (req
-                                      (let [tgtcid (:cid chosen)]
+                         :effect (req (let [tgtcid (:cid chosen)]
                                         (register-turn-flag! state side
                                                              card :can-rez
                                                              (fn [state side card]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -895,8 +895,7 @@
                         {:prompt "Select a remote server"
                          :choices (req (conj (vec (get-remote-names state)) "New remote"))
                          :async true
-                         :effect (req (corp-install state side (assoc chosen :advance-counter 1) target)
-                                      (effect-completed state side eid)
+                         :effect (req
                                       (let [tgtcid (:cid chosen)]
                                         (register-turn-flag! state side
                                                              card :can-rez
@@ -910,7 +909,8 @@
                                                                (if (and (= (:cid card) tgtcid)
                                                                         (>= (get-counters card :advancement) (or (:current-cost card) (:advancementcost card))))
                                                                  ((constantly false) (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
-                                                                 true)))))})]
+                                                                 true))))
+                                      (corp-install state side (assoc chosen :advance-counter 1) target))})]
    {:abilities [{:async true
                  :label "[Click], 1 [Credits]: Install a card from HQ in a remote server, then place 1 advancement token on it. You cannot score or rez that card until your next turn begins."
                  :cost [:click 1 :credit 1]

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1622,6 +1622,37 @@
       (is (core/has-subtype? (refresh iwall) "Barrier") "Ice Wall has Barrier")
       (is (core/has-subtype? (refresh iwall) "Code Gate") "Ice Wall has Code Gate"))))
 
+(deftest saraswati-mnemonics:-endless-exploration
+  ;; Saraswati Mnemonics
+  (do-game
+    (new-game
+      (make-deck "Saraswati Mnemonics: Endless Exploration" ["Gene Splicer" "House of Knives"])
+      (default-runner))
+    (card-ability state :corp (get-in @state [:corp :identity]) 0)
+    (prompt-select :corp (find-card "Gene Splicer" (:hand (get-corp))))
+    (prompt-choice :corp "New remote")
+    (let [splicer (get-content state :remote1 0)]
+      (is (= 1 (get-counters (refresh splicer) :advancement)) "1 advancements placed on Gene Splicer")
+      (core/rez state :corp (refresh splicer))
+      (is (not (:rezzed (refresh splicer))) "Gene Splicer did not rez")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (core/rez state :corp (refresh splicer))
+      (is (:rezzed (refresh splicer)) "Gene Splicer now rezzed")
+      (card-ability state :corp (get-in @state [:corp :identity]) 0)
+      (prompt-select :corp (find-card "House of Knives" (:hand (get-corp))))
+      (prompt-choice :corp "New remote")
+      (let [house (get-content state :remote2 0)]
+        (advance state house)
+        (advance state house)
+        (core/score state :corp (refresh house))
+        (is (empty? (:scored (get-corp))) "House of Knives not scored")
+        (is (zero? (:agenda-point (get-corp))))
+        (take-credits state :corp)
+        (take-credits state :runner)
+        (core/score state :corp (refresh house))
+        (is (= 1 (:agenda-point (get-corp))) "House of Knives was able to be scored")))))
+
 (deftest skorpios-defense-systems:-persuasive-power
   ; Remove a card from game when it moves to discard once per round
   (do-game


### PR DESCRIPTION
Imeplements Saraswati Mnemonics: Endless Exploration with test.

Worth noting that this carries the same issue as Mushin No Shin, allowing the Corp to Rez/Score the affected card as soon as they end their turn.