### PR TITLE
Rar: Patchwork

### DIFF
--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -409,36 +409,36 @@
                           :async true
                           :effect (effect (runner-install eid card (assoc params :host-card target)))}
                          card nil)
-       (do (trigger-event state side :pre-install card facedown)
-           (let [cost (runner-get-cost state side card params)]
-             (if (runner-can-install? state side card facedown)
-               (if-let [cost-str (pay state side card cost)]
-                 (let [c (if host-card
-                           (host state side host-card card)
-                           (move state side card
-                                 [:rig (if facedown :facedown (to-keyword (:type card)))]))
-                       c (assoc c :installed true :new true)
-                       installed-card (if facedown
-                                        (update! state side c)
-                                        (card-init state side c {:resolve-effect false
-                                                                 :init-data true}))]
-                   (runner-install-message state side (:title card) cost-str params)
-                   (play-sfx state side "install-runner")
-                   (when (and (is-type? card "Program")
-                              (not facedown)
-                              (not no-mu))
-                     ;; Use up mu from program not installed facedown
-                     (use-mu state (:memoryunits card))
-                     (toast-check-mu state))
-                   (handle-virus-counter-flag state side installed-card)
-                   (when (and (not facedown) (is-type? card "Resource"))
-                     (swap! state assoc-in [:runner :register :installed-resource] true))
-                   (when (and (not facedown) (has-subtype? c "Icebreaker"))
-                     (update-breaker-strength state side c))
-                   (trigger-event-simult state side eid :runner-install
-                                         {:card-ability (card-as-handler installed-card)}
-                                         installed-card))
-                 (effect-completed state side eid))
-               (effect-completed state side eid)))
-           (clear-install-cost-bonus state side)))
+       (wait-for (trigger-event-simult state side :pre-install nil card facedown)
+                 (let [cost (runner-get-cost state side card params)]
+                   (if (runner-can-install? state side card facedown)
+                     (if-let [cost-str (pay state side card cost)]
+                       (let [c (if host-card
+                                 (host state side host-card card)
+                                 (move state side card
+                                       [:rig (if facedown :facedown (to-keyword (:type card)))]))
+                             c (assoc c :installed true :new true)
+                             installed-card (if facedown
+                                              (update! state side c)
+                                              (card-init state side c {:resolve-effect false
+                                                                       :init-data true}))]
+                         (runner-install-message state side (:title card) cost-str params)
+                         (play-sfx state side "install-runner")
+                         (when (and (is-type? card "Program")
+                                    (not facedown)
+                                    (not no-mu))
+                           ;; Use up mu from program not installed facedown
+                           (use-mu state (:memoryunits card))
+                           (toast-check-mu state))
+                         (handle-virus-counter-flag state side installed-card)
+                         (when (and (not facedown) (is-type? card "Resource"))
+                           (swap! state assoc-in [:runner :register :installed-resource] true))
+                         (when (and (not facedown) (has-subtype? c "Icebreaker"))
+                           (update-breaker-strength state side c))
+                         (trigger-event-simult state side eid :runner-install
+                                               {:card-ability (card-as-handler installed-card)}
+                                               installed-card))
+                       (effect-completed state side eid))
+                     (effect-completed state side eid)))
+                 (clear-install-cost-bonus state side)))
      (effect-completed state side eid))))

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -805,6 +805,36 @@
       (prompt-choice-partial :runner "No")
       (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run"))))
 
+(deftest patchwork
+  (testing "Play event"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Patchwork" (qty "Sure Gamble" 4)]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 4)
+      (play-from-hand state :runner "Patchwork")
+      (play-from-hand state :runner "Sure Gamble")
+      (is (= 5 (:credit (get-runner))) "Runner has not been charged credits yet")
+      (is (empty? (:discard (get-runner))) "Sure Gamble is not in heap yet")
+      (prompt-select :runner (find-card "Sure Gamble" (:hand (get-runner))))
+      (is (= 11 (:credit (get-runner))) "Runner was only charge 3 credits to play Sure Gamble")
+      (is (= 2 (count (:discard (get-runner)))) "2 cards now in heap")
+      (play-from-hand state :runner "Sure Gamble")
+      (is (= 15 (:credit (get-runner))) "Patchwork is once-per-turn")))
+
+  (testing "Install a card"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Patchwork" (qty "Cyberfeeder" 4)]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 4)
+      (play-from-hand state :runner "Patchwork")
+      (play-from-hand state :runner "Cyberfeeder")
+      (is (= 5 (:credit (get-runner))) "Runner has not been charged credits yet")
+      (is (empty? (:discard (get-runner))) "Cyberfeeder is not in heap yet")
+      (prompt-select :runner (find-card "Cyberfeeder" (:hand (get-runner))))
+      (is (= 5 (:credit (get-runner))) "Runner was charged 0 credits to play Cyberfeeder"))))
+
 (deftest plascrete-carapace
   ;; Plascrete Carapace - Prevent meat damage
   (do-game


### PR DESCRIPTION
This implementation upgrades the `runner-install` and `play-instant` functions so they await their "`:pre-X`" events before calculating costs to play/install. This allows Patchwork to use a prompt to ask the Runner to trash a card to lower costs. This prompt is only shown if there are at least 2 cards in hand (including the card-to-play). Clicking Done instead of a card will decline the discount.

Compared with @nicohasa's alternative idea -- in which Patchwork gets an ability that you manually click prior to installing/playing your desired card -- this solutions has both pros and cons:

1. Can't "forget" to apply the discount -- you're prompted in the middle of your play/install process.
2. Works with all sources of installs/plays (Same Old Thing, Clone Chip, or straight from grip)
3. Prompts on _every_ play/install until it is used. That requires 1 extra click for each play that you don't want the discount. 
    a. Hard to know if the average player will more frequently want to use or decline this card's discount. My gut says use. In this solution, we require 1 mouse click per decline; in the alternative, it's 1 mouse click per use. 

Open to discussion, and for abandoning this attempt if it's more work for the players.
