### PR TITLE
RaR: Patchwork (Improved!)

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -799,37 +799,34 @@
    "Patchwork"
    (letfn [(patchwork-discount [cost-type bonus-fn]
              {:async true
-              :req (req (and (= "Runner" (:side target))
-                             ;; The card being installed/played is still in the hand; we therefore need at least 2
-                             ;; cards for this effect to make sense.
-                             (< 0 (count (remove (partial same-card? target) (:hand runner))))))
+              :req (req (and (get-in card [:special :patchwork])
+                             (= "Runner" (:side target))
+                             ;; We need at least one card (that is not the card played) in hand
+                             (not-empty (remove (partial same-card? target) (:hand runner)))))
               :effect (req (let [playing target]
                              (continue-ability
                                state side
                                {:prompt (str "Trash a card to lower the " cost-type " cost of " (:title playing) " by 2 [Credits].")
+                                :priority 2
                                 :choices {:req #(and (in-hand? %)
                                                      (= "Runner" (:side %))
                                                      (not (same-card? % playing)))}
                                 :msg (msg "trash " (:title target) " to lower the " cost-type " cost of "
                                           (:title playing) " by 2 [Credits]")
-                                :effect (req (trash state side target {:unpreventable true})
-                                             (bonus-fn state side [:credit -2])
-                                             (unregister-events state side card))
+                                :effect (effect (trash target {:unpreventable true})
+                                             (bonus-fn [:credit -2])
+                                             (update! (dissoc-in card [:special :patchwork])))
                                 :cancel-effect (effect (effect-completed eid))}
                                card nil)))})]
      {:in-play [:memory 1]
       :implementation "Click Patchwork before playing/installing a card."
       :abilities [{:once :per-turn
-                   :effect (effect (register-events {:pre-play-instant (patchwork-discount "play" play-cost-bonus)
-                                                     :pre-install (patchwork-discount "install" install-cost-bonus)
-                                                     :runner-turn-ends {:effect (effect (unregister-events card))}
-                                                     :corp-turn-ends {:effect (effect (unregister-events card))}}
-                                                    card)
+                   :effect (effect (update! (assoc-in card [:special :patchwork] true))
                              (toast "Your next card played will trigger Patchwork." "info"))}]
-      :events {:pre-play-instant nil
-               :pre-install nil
-               :runner-turn-ends nil
-               :corp-turn-ends nil}})
+      :events {:pre-play-instant (patchwork-discount "play" play-cost-bonus)
+               :pre-install (patchwork-discount "install" install-cost-bonus)
+               :runner-turn-ends {:effect (effect (update! (dissoc-in card [:special :patchwork])))}
+               :corp-turn-ends {:effect (effect (update! (dissoc-in card [:special :patchwork])))}}})
 
    "Plascrete Carapace"
    {:data [:counter {:power 4}]

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -409,36 +409,36 @@
                           :async true
                           :effect (effect (runner-install eid card (assoc params :host-card target)))}
                          card nil)
-       (do (trigger-event state side :pre-install card facedown)
-           (let [cost (runner-get-cost state side card params)]
-             (if (runner-can-install? state side card facedown)
-               (if-let [cost-str (pay state side card cost)]
-                 (let [c (if host-card
-                           (host state side host-card card)
-                           (move state side card
-                                 [:rig (if facedown :facedown (to-keyword (:type card)))]))
-                       c (assoc c :installed true :new true)
-                       installed-card (if facedown
-                                        (update! state side c)
-                                        (card-init state side c {:resolve-effect false
-                                                                 :init-data true}))]
-                   (runner-install-message state side (:title card) cost-str params)
-                   (play-sfx state side "install-runner")
-                   (when (and (is-type? card "Program")
-                              (not facedown)
-                              (not no-mu))
-                     ;; Use up mu from program not installed facedown
-                     (use-mu state (:memoryunits card))
-                     (toast-check-mu state))
-                   (handle-virus-counter-flag state side installed-card)
-                   (when (and (not facedown) (is-type? card "Resource"))
-                     (swap! state assoc-in [:runner :register :installed-resource] true))
-                   (when (and (not facedown) (has-subtype? c "Icebreaker"))
-                     (update-breaker-strength state side c))
-                   (trigger-event-simult state side eid :runner-install
-                                         {:card-ability (card-as-handler installed-card)}
-                                         installed-card))
-                 (effect-completed state side eid))
-               (effect-completed state side eid)))
-           (clear-install-cost-bonus state side)))
+       (wait-for (trigger-event-simult state side :pre-install nil card facedown)
+                 (let [cost (runner-get-cost state side card params)]
+                   (if (runner-can-install? state side card facedown)
+                     (if-let [cost-str (pay state side card cost)]
+                       (let [c (if host-card
+                                 (host state side host-card card)
+                                 (move state side card
+                                       [:rig (if facedown :facedown (to-keyword (:type card)))]))
+                             c (assoc c :installed true :new true)
+                             installed-card (if facedown
+                                              (update! state side c)
+                                              (card-init state side c {:resolve-effect false
+                                                                       :init-data true}))]
+                         (runner-install-message state side (:title card) cost-str params)
+                         (play-sfx state side "install-runner")
+                         (when (and (is-type? card "Program")
+                                    (not facedown)
+                                    (not no-mu))
+                           ;; Use up mu from program not installed facedown
+                           (use-mu state (:memoryunits card))
+                           (toast-check-mu state))
+                         (handle-virus-counter-flag state side installed-card)
+                         (when (and (not facedown) (is-type? card "Resource"))
+                           (swap! state assoc-in [:runner :register :installed-resource] true))
+                         (when (and (not facedown) (has-subtype? c "Icebreaker"))
+                           (update-breaker-strength state side c))
+                         (trigger-event-simult state side eid :runner-install
+                                               {:card-ability (card-as-handler installed-card)}
+                                               installed-card))
+                       (effect-completed state side eid))
+                     (effect-completed state side eid)))
+                 (clear-install-cost-bonus state side)))
      (effect-completed state side eid))))

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -809,14 +809,15 @@
   (testing "Play event"
     (do-game
       (new-game (default-corp)
-                (default-runner ["Patchwork" (qty "Sure Gamble" 4)]))
+                (default-runner ["Patchwork" (qty "Sure Gamble" 2) "Easy Mark"]))
       (take-credits state :corp)
       (core/gain state :runner :credit 4)
       (play-from-hand state :runner "Patchwork")
+      (card-ability state :runner (get-hardware state 0) 0)
       (play-from-hand state :runner "Sure Gamble")
       (is (= 5 (:credit (get-runner))) "Runner has not been charged credits yet")
       (is (empty? (:discard (get-runner))) "Sure Gamble is not in heap yet")
-      (prompt-select :runner (find-card "Sure Gamble" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Easy Mark" (:hand (get-runner))))
       (is (= 11 (:credit (get-runner))) "Runner was only charge 3 credits to play Sure Gamble")
       (is (= 2 (count (:discard (get-runner)))) "2 cards now in heap")
       (play-from-hand state :runner "Sure Gamble")
@@ -825,14 +826,15 @@
   (testing "Install a card"
     (do-game
       (new-game (default-corp)
-                (default-runner ["Patchwork" (qty "Cyberfeeder" 4)]))
+                (default-runner ["Patchwork" "Easy Mark" "Cyberfeeder"]))
       (take-credits state :corp)
       (core/gain state :runner :credit 4)
       (play-from-hand state :runner "Patchwork")
+      (card-ability state :runner (get-hardware state 0) 0)
       (play-from-hand state :runner "Cyberfeeder")
       (is (= 5 (:credit (get-runner))) "Runner has not been charged credits yet")
       (is (empty? (:discard (get-runner))) "Cyberfeeder is not in heap yet")
-      (prompt-select :runner (find-card "Cyberfeeder" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Easy Mark" (:hand (get-runner))))
       (is (= 5 (:credit (get-runner))) "Runner was charged 0 credits to play Cyberfeeder"))))
 
 (deftest plascrete-carapace

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -805,6 +805,36 @@
       (prompt-choice-partial :runner "No")
       (is (= 1 (count (:hand (get-runner)))) "Obelus drew a card on first successful run"))))
 
+(deftest patchwork
+  (testing "Play event"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Patchwork" (qty "Sure Gamble" 4)]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 4)
+      (play-from-hand state :runner "Patchwork")
+      (play-from-hand state :runner "Sure Gamble")
+      (is (= 5 (:credit (get-runner))) "Runner has not been charged credits yet")
+      (is (empty? (:discard (get-runner))) "Sure Gamble is not in heap yet")
+      (prompt-select :runner (find-card "Sure Gamble" (:hand (get-runner))))
+      (is (= 11 (:credit (get-runner))) "Runner was only charge 3 credits to play Sure Gamble")
+      (is (= 2 (count (:discard (get-runner)))) "2 cards now in heap")
+      (play-from-hand state :runner "Sure Gamble")
+      (is (= 15 (:credit (get-runner))) "Patchwork is once-per-turn")))
+
+  (testing "Install a card"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Patchwork" (qty "Cyberfeeder" 4)]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 4)
+      (play-from-hand state :runner "Patchwork")
+      (play-from-hand state :runner "Cyberfeeder")
+      (is (= 5 (:credit (get-runner))) "Runner has not been charged credits yet")
+      (is (empty? (:discard (get-runner))) "Cyberfeeder is not in heap yet")
+      (prompt-select :runner (find-card "Cyberfeeder" (:hand (get-runner))))
+      (is (= 5 (:credit (get-runner))) "Runner was charged 0 credits to play Cyberfeeder"))))
+
 (deftest plascrete-carapace
   ;; Plascrete Carapace - Prevent meat damage
   (do-game


### PR DESCRIPTION
Built upon #3694, but fixed so it does not ask you every time, just after you've clicked patchwork.

Still gives you the option to cancel, and will then keep the ability until you use it.

Removes the ability between turns so you can't "save" it for a turn, then use it twice in a row.