### PR TITLE
Use async cost payment for card abilities

### DIFF
--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -222,27 +222,27 @@
              (or (not advance-counter-cost)
                  (<= advance-counter-cost (or advance-counter 0))))
     ;; Ensure that any costs can be paid
-    (when-let [cost-str (apply pay (concat [state side card] cost [{:action (:cid card)}]))]
-      (let [c (if counter-cost
-                (update-in card [:counter (first counter-cost)]
-                           #(- (or % 0) (or (second counter-cost) 0)))
-                card)
-            c (if advance-counter-cost
-                (update-in c [:advance-counter] #(- (or % 0) (or advance-counter-cost 0)))
-                c)]
-        ;; Remove any counters
-        (when (or counter-cost advance-counter-cost)
-          (update! state side c)
-          (when (is-type? card "Agenda")
-            (trigger-event state side :agenda-counter-spent card)))
-        ;; Print the message
-        (print-msg state side ability card targets cost-str)
-        ;; Trigger the effect
-        (do-effect state side ability c targets)
-        ;; Record the :end-turn effect
-        (register-end-turn state side ability card targets))
-      ;; Record the ability has been triggered if it is restricted to happening once
-      (register-once state ability card))))
+    (wait-for
+      (pay-sync state side card cost {:action (:cid card)})
+      (if-let [cost-str async-result]
+        (let [c (if counter-cost
+                  (update-in card [:counter (first counter-cost)]
+                             #(- (or % 0) (or (second counter-cost) 0)))
+                  card)
+              c (if advance-counter-cost
+                  (update-in c [:advance-counter] #(- (or % 0) (or advance-counter-cost 0)))
+                  c)]
+          ;; Remove any counters
+          (when (or counter-cost advance-counter-cost)
+            (update! state side c)
+            (when (is-type? card "Agenda")
+              (trigger-event state side :agenda-counter-spent card)))
+          ;; Print the message
+          (print-msg state side ability card targets cost-str)
+          ;; Trigger the effect
+          (do-effect state side ability c targets)
+          (register-end-turn state side ability card targets)
+          (register-once state ability card))))))
 
 (defn- print-msg
   "Prints the ability message"

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -1357,16 +1357,34 @@
    (is (= 3 (:credit (get-runner))) "Gained 1 more credit from exposing")))
 
 (deftest zer0
-  ;; Zer0 - Once per turn, deal 1 damage to self, to gain 1 credit and 2 cards.
-  (do-game
-    (new-game (default-corp)
-              (default-runner ["Zer0" "Corroder" (qty "Sure Gamble" 2)]))
-    (starting-hand state :runner ["Zer0" "Corroder"])
-    (take-credits state :corp)
-    (play-from-hand state :runner "Zer0")
-    (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
-    (let  [z (get-hardware state 0)]
-      (card-ability state :runner z 0)
-      (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
-      (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards")
-      (is (find-card "Corroder" (:discard (get-runner))) "Corroder is in heap"))))
+  (testing "Basic ability"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Zer0" "Corroder" (qty "Sure Gamble" 2)]))
+      (starting-hand state :runner ["Zer0" "Corroder"])
+      (take-credits state :corp)
+      (play-from-hand state :runner "Zer0")
+      (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
+      (let  [z (get-hardware state 0)]
+        (card-ability state :runner z 0)
+        (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
+        (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards")
+        (is (find-card "Corroder" (:discard (get-runner))) "Corroder is in heap"))))
+  (testing "With Titanium Ribs"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Zer0" "Titanium Ribs" (qty "Sure Gamble" 5)]))
+      (starting-hand state :runner ["Zer0" "Titanium Ribs" "Sure Gamble" "Sure Gamble" "Sure Gamble"])
+      (take-credits state :corp)
+      (play-from-hand state :runner "Zer0")
+      (play-from-hand state :runner "Titanium Ribs")
+      (prompt-select :runner (first (:hand (get-runner))))
+      (prompt-select :runner (second (:hand (get-runner))))
+      (is (= 3 (:credit (get-runner))) "Runner has 3 credits")
+      (let  [z (get-hardware state 0)]
+        (card-ability state :runner z 0)
+        (is (= 3 (:credit (get-runner))) "Zer0 has not yet resolved because Ribs prompt is open")
+        (is (= 1 (count (:hand (get-runner)))) "Zer0 has not yet resolved because Ribs prompt is open")
+        (prompt-select :runner (first (:hand (get-runner))))
+        (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
+        (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards")))))

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -1387,4 +1387,25 @@
         (is (= 1 (count (:hand (get-runner)))) "Zer0 has not yet resolved because Ribs prompt is open")
         (prompt-select :runner (first (:hand (get-runner))))
         (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
-        (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards")))))
+        (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards"))))
+  (testing "With Respirocytes"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Zer0" "Titanium Ribs" "Respirocytes"(qty "Sure Gamble" 7)]))
+      (starting-hand state :runner ["Zer0" "Titanium Ribs" "Respirocytes" "Sure Gamble" "Sure Gamble" "Sure Gamble" "Sure Gamble"])
+      (take-credits state :corp)
+      (play-from-hand state :runner "Zer0")
+      (play-from-hand state :runner "Titanium Ribs")
+      (prompt-select :runner (second (:hand (get-runner))))
+      (prompt-select :runner (nth (:hand (get-runner)) 2))
+      (play-from-hand state :runner "Respirocytes")
+      (prompt-select :runner (find-card "Sure Gamble" (:hand (get-runner))))
+      ;; Now 1 Gamble in hand
+      (is (= 3 (:credit (get-runner))) "Runner has 3 credits")
+      (let  [z (get-hardware state 0)]
+        (card-ability state :runner z 0)
+        (is (= 3 (:credit (get-runner))) "Zer0 has not yet resolved because Ribs prompt is open")
+        (is (= 1 (count (:hand (get-runner)))) "Zer0 has not yet resolved because Ribs prompt is open")
+        (prompt-select :runner (first (:hand (get-runner))))
+        (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
+        (is (= 3 (count (:hand (get-runner)))) "Runner has 3 cards")))))


### PR DESCRIPTION
Upgrades `resolve-ability` to use `pay-sync` instead of `pay`, so that we can properly await the payment of the ability before resolving the effect. Necessary for #3587, in which Zer0's net damage cost invokes an async prompt (Titanium Ribs), and Zer0's ability (draw 2) cannot resolve until the cost is resolved (via Ribs choice).