### PR TITLE
Show fake prompt from Jinja City Grid when drawing non-ice on runner's turn

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -490,7 +490,7 @@
                                           (= :runner (:active-player @state))
                                           (continue-ability
                                             state :corp
-                                            {:prompt "This prompt is being shown so the Runner can't infer that you did not draw any ice"
+                                            {:prompt "You did not draw any ice to use with Jinja City Grid"
                                              :choices ["Carry on!"]
                                              :prompt-type :bogus
                                              :effect nil}

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -172,11 +172,11 @@
 
 (defn- do-choices
   "Handle a choices ability"
-  [state side {:keys [choices player priority cancel-effect not-distinct prompt eid] :as ability}
+  [state side {:keys [choices player priority cancel-effect not-distinct prompt eid prompt-type] :as ability}
    card targets]
   (let [s (or player side)
         ab (dissoc ability :choices)
-        args {:priority priority :cancel-effect cancel-effect}]
+        args {:priority priority :cancel-effect cancel-effect :prompt-type prompt-type}]
    (if (map? choices)
      ;; Two types of choices use maps: select prompts, and :number prompts.
      (cond

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -692,7 +692,8 @@
 
 (deftest jinja-city-grid
   ;; Jinja City Grid - install drawn ice, lowering install cost by 4
-  (do-game
+  (testing "Single draws"
+    (do-game
     (new-game (default-corp ["Jinja City Grid" (qty "Vanilla" 3) (qty "Ice Wall" 3)])
               (default-runner))
     (starting-hand state :corp ["Jinja City Grid"])
@@ -708,6 +709,20 @@
     (prompt-choice :corp (-> (get-corp) :prompt first :choices first))
     (is (= 3 (:credit (get-corp))) "Charged to install ice")
     (is (= 6 (count (get-in @state [:corp :servers :remote1 :ices]))) "6 ICE protecting Remote1")))
+  (testing "Drawing non-ice on runner's turn"
+    (do-game
+      (new-game
+        (default-corp ["Jinja City Grid" (qty "Hedge Fund" 3)])
+        (make-deck "Laramy Fisk: Savvy Investor" ["Eden Shard"]))
+      (starting-hand state :corp ["Jinja City Grid"])
+      (play-from-hand state :corp "Jinja City Grid" "HQ")
+      (core/rez state :corp (get-content state :hq 0))
+      (take-credits state :corp)
+      (run-empty-server state :rd)
+      (prompt-choice :runner "Yes")
+      (is (= :bogus (-> (get-corp) :prompt first :prompt-type)) "Corp has a bogus prompt to fake out the runner")
+      (prompt-choice :corp "Carry on!")
+      (prompt-choice :runner "No action"))))
 
 (deftest keegan-lane
   ;; Keegan Lane - Trash self and remove 1 Runner tag to trash a program


### PR DESCRIPTION
As recommended by @Saintis  in #3607. Fixes #3577. Should also be applied to Political Dealings.