### PR TITLE
Catching null pointer when tracking agenda points gained in stats

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -236,7 +236,7 @@
       ;; Else assume amount is a number and try to increment type by it.
       :else
       (do (swap! state update-in [side type] (safe-inc-n amount))
-          (swap! state update-in [:stats side :gain type] (fnil + 0) amount)))))
+          (swap! state update-in [:stats side :gain type] (fnil + 0 0) amount)))))
 
 (defn lose [state side & args]
   (doseq [r (partition 2 args)]


### PR DESCRIPTION
Same problem that was fixed for game state agenda points applied to stats tracking.