### PR TITLE
RaR: Mind's Eye and Divide and Conquer; do-access refactor and Shiro/Mwanza bugfixes

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -886,7 +886,7 @@
    (run-event
     {:choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
                          bad-zones (keys (filter (complement unrezzed-ice) (get-in @state [:corp :servers])))]
-                     (zones->sorted-names (remove (set bad-zones) (get-runnable-zones @state)))))}
+                     (zones->sorted-names (remove (set bad-zones) (get-runnable-zones state)))))}
     {:end-run {:req (req (:successful run))
                :msg "gain 12 [Credits]"
                :effect (effect (gain-credits :runner 12))}})
@@ -1386,9 +1386,9 @@
     :effect (req (gain-credits state :runner 10)
                  (gain-credits state :corp 5)
                  (apply prevent-run-on-server
-                        state card (get-zones @state))
+                        state card (get-zones state))
                  (register-events state side
-                   {:runner-turn-ends {:effect (req (apply enable-run-on-server state card (get-zones @state)))}}
+                   {:runner-turn-ends {:effect (req (apply enable-run-on-server state card (get-zones state)))}}
                   (assoc card :zone '(:discard))))
     :events {:runner-turn-ends nil}}
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -501,6 +501,20 @@
                                              (gain-credits :runner (five-or-all corp)))})}
                       card))}
 
+   "Divide and Conquer"
+   {:req (req archives-runnable)
+    :makes-run true
+    :async true
+    :effect
+    (effect (run :archives
+                 {:end-run
+                  {:async true
+                   :effect
+                   (req (wait-for (do-access state side [:rd] {:no-root true})
+                                  (wait-for (do-access state side [:hq] {:no-root true})
+                                            (effect-completed state side eid))))}}
+                 card))}
+
    "Drive By"
    {:choices {:req #(let [topmost (get-nested-host %)]
                      (and (is-remote? (second (:zone topmost)))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -667,6 +667,18 @@
    {:implementation "MU usage restriction not enforced"
     :in-play [:memory 3]}
 
+   "Minds Eye"
+   {:in-play [:memory 1]
+    :implementation "Power counters added automatically"
+    :events {:successful-run {:silent (req true)
+                              :req (req (= target :rd))
+                              :effect (effect (add-counter card :power 1))}}
+    :abilities [{:async true
+                 :cost [:click 1]
+                 ;; :counter-cost [:power 3]
+                 :msg "access the top card of R&D"
+                 :effect single-access-rd}]}
+
    "Mirror"
    {:in-play [:memory 2]
     :events {:successful-run

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -675,9 +675,9 @@
                               :effect (effect (add-counter card :power 1))}}
     :abilities [{:async true
                  :cost [:click 1]
-                 ;; :counter-cost [:power 3]
+                 :counter-cost [:power 3]
                  :msg "access the top card of R&D"
-                 :effect single-access-rd}]}
+                 :effect (req (do-access state side eid [:rd] {:no-root true}))}]}
 
    "Mirror"
    {:in-play [:memory 2]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1942,14 +1942,7 @@
                                     (do (clear-wait-prompt state :runner)
                                         (effect-completed state side eid)))))}
                   {:label "Force the Runner to access the top card of R&D"
-                   :effect (req (wait-for (trigger-event-sync state side :pre-access :rd)
-                                          (let [total-cards (access-count state side :rd-access)]
-                                            (swap! state assoc-in [:run :did-access] true)
-                                            (swap! state assoc-in [:runner :register :accessed-cards] true)
-                                            (doseq [c (take total-cards (:deck corp))]
-                                              (system-msg state :runner (str "accesses " (:title c)))
-                                              (access-card state side c))
-                                            (swap! state update-in [:run :cards-accessed] (fnil #(+ % total-cards) 0)))))}]}
+                   :effect single-access-rd}]}
 
    "Snoop"
    {:implementation "Encounter effect is manual"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1942,7 +1942,8 @@
                                     (do (clear-wait-prompt state :runner)
                                         (effect-completed state side eid)))))}
                   {:label "Force the Runner to access the top card of R&D"
-                   :effect single-access-rd}]}
+                   :async true
+                   :effect (req (do-access state :runner eid [:rd] {:no-root true}))}]}
 
    "Snoop"
    {:implementation "Encounter effect is manual"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -847,7 +847,7 @@
                            (wait-for (trigger-event-sync state side :pre-access :archives)
                                      (resolve-ability state :runner
                                                       (choose-access (get-in @state [:corp :discard])
-                                                                     '(:archives)) card nil))))
+                                                                     '(:archives) {:no-root true}) card nil))))
 
    "Hard at Work"
    (let [ability {:msg "gain 2 [Credits] and lose [Click]"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1944,10 +1944,17 @@
    "The Turning Wheel"
    {:events {:agenda-stolen {:effect (effect (update! (assoc card :agenda-stolen true)))
                              :silent (req true)}
-             :pre-access {:req (req (and (pos? (get-in @state [:run :ttw-bonus] 0))
-                                         (:run @state)
-                                         (not (#{:hq :rd} target))))
-                          :effect (effect (access-bonus (- (get-in @state [:run :ttw-bonus] 0))))
+             :pre-access {:req (req (and (:run @state)
+                                         (pos? (get-in @state [:run :ttw-bonus] 0))))
+                          :effect (req (let [ttw-bonus (get-in @state [:run :ttw-bonus] 0)
+                                             deferred-bonus (get-in @state [:run :ttw-deferred-bonus] 0)]
+                                         (if (#{:hq :rd} target)
+                                           (when (pos? deferred-bonus)
+                                             (access-bonus state side ttw-bonus)
+                                             (swap! state assoc-in [:run :ttw-deferred-bonus] 0))
+                                           (when (zero? deferred-bonus)
+                                             (access-bonus state side (- ttw-bonus))
+                                             (swap! state assoc-in [:run :ttw-deferred-bonus] ttw-bonus)))))
                           :silent (req true)}
              :run-ends {:effect (req (when (and (not (:agenda-stolen card))
                                                 (#{:hq :rd} target))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -609,27 +609,28 @@
                    :effect (req (swap! state assoc-in [:runner :register :force-trash] false))}}
 
    "Mwanza City Grid"
-   (let [gain-creds {:req (req (and installed
-                                    this-server
-                                    (pos? (:cards-accessed run 0))))
-                     :silent (req true)
-                     :effect (req (let [cnt (:cards-accessed run)
-                                        total (* 2 cnt)]
-                                    (gain-credits state :corp total)
-                                    (system-msg state :corp
-                                                (str "gains " total " [Credits] from Mwanza City Grid"))))}]
-     {:install-req (req (filter #{"HQ" "R&D"} targets))
-      :events {:pre-access {:req (req (and installed
-                                           ;; Pre-access server is same server as that Mwanza is in the root of
-                                           (= target (second  (:zone card)))))
+   (let [gain-creds-and-clear {:req (req (= (:from-server target) (second (:zone card))))
+                               :silent (req true)
+                               :effect (req (let [cnt (:cards-accessed run) ; TODO: this fails if the run featured multiple access phases (e.g. shiro sub firing)
+                                                  total (* 2 cnt)]
+                                              (access-bonus state :runner -3)
+                                              (gain-credits state :corp total)
+                                              (system-msg state :corp
+                                                          (str "gains " total " [Credits] from Mwanza City Grid"))))}
+         boost-access-by-3 {:req (req (= target (second (:zone card))))
                             :msg "force the Runner to access 3 additional cards"
-                            :effect (effect (access-bonus 3))}
-               :run-ends gain-creds}
-      :trash-effect
-      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
-       :effect (effect (register-events {:run-ends
-                                         (assoc gain-creds :req (req (= (first (:server run))
-                                                                        (second (:previous-zone card)))))
+                            :effect (req (access-bonus state :runner 3))}]
+
+     {:install-req (req (filter #{"HQ" "R&D"} targets))
+      :events {:pre-access boost-access-by-3
+               :end-access-phase gain-creds-and-clear}
+      ;; TODO: as written, this may fail if mwanza is trashed outside of a run on its server
+      ;; (e.g. mwanza on R&D, run HQ, use polop to trash mwanza mid-run, shiro fires to cause RD
+      :trash-effect                     ; if there is a run, mark mwanza effects to remain active until the end of the run
+      {:req (req (:run @state))
+       :effect (effect (register-events {:pre-access (assoc boost-access-by-3 :req (req (= target (second (:previous-zone card)))))
+                                         :end-access-phase (assoc gain-creds-and-clear :req (req (= (:from-server target) (second (:previous-zone card)))))
+                                         :unsuccessful-run-ends {:effect (effect (unregister-events card))}
                                          :successful-run-ends {:effect (effect (unregister-events card))}}
                                         (assoc card :zone '(:discard))))}})
 

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -611,12 +611,12 @@
    "Mwanza City Grid"
    (let [gain-creds-and-clear {:req (req (= (:from-server target) (second (:zone card))))
                                :silent (req true)
-                               :effect (req (let [cnt (:cards-accessed run) ; TODO: this fails if the run featured multiple access phases (e.g. shiro sub firing)
-                                                  total (* 2 cnt)]
+                               :effect (req (let [cnt (:cards-accessed run)]
                                               (access-bonus state :runner -3)
-                                              (gain-credits state :corp total)
-                                              (system-msg state :corp
-                                                          (str "gains " total " [Credits] from Mwanza City Grid"))))}
+                                              (if cnt ; TODO: this fails if the run featured multiple access phases (e.g. shiro sub firing)
+                                                (gain-credits state :corp (* 2 cnt))
+                                                (system-msg state :corp
+                                                            (str "gains " (* 2 cnt) " [Credits] from Mwanza City Grid")))))}
          boost-access-by-3 {:req (req (= target (second (:zone card))))
                             :msg "force the Runner to access 3 additional cards"
                             :effect (req (access-bonus state :runner 3))}]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -613,14 +613,13 @@
                                :silent (req true)
                                :effect (req (let [cnt (:cards-accessed run)]
                                               (access-bonus state :runner -3)
-                                              (if cnt ; TODO: this fails if the run featured multiple access phases (e.g. shiro sub firing)
+                                              (when cnt
                                                 (gain-credits state :corp (* 2 cnt))
                                                 (system-msg state :corp
                                                             (str "gains " (* 2 cnt) " [Credits] from Mwanza City Grid")))))}
          boost-access-by-3 {:req (req (= target (second (:zone card))))
                             :msg "force the Runner to access 3 additional cards"
                             :effect (req (access-bonus state :runner 3))}]
-
      {:install-req (req (filter #{"HQ" "R&D"} targets))
       :events {:pre-access boost-access-by-3
                :end-access-phase gain-creds-and-clear}

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -664,6 +664,15 @@
       hosted-cards
       (concat hosted-cards (get-all-hosted hosted-cards)))))
 
+(def single-access-rd
+  (req (wait-for (trigger-event-sync state side :pre-access :rd)
+                 (let [total-cards (access-count state side :rd-access)]
+                   (when (:run @state)
+                     (swap! state assoc-in [:run :did-access] true)
+                     (swap! state assoc-in [:runner :register :accessed-cards] true))
+                   (doseq [c (take total-cards (:deck corp))] ;TODO: see if bacterial programming messes with this
+                     (wait-for (access-card state side c "an unseen card")))
+                   (when (:run @state) (swap! state update-in [:run :cards-accessed] (fnil #(+ % total-cards) 0)))))))
 
 (defmulti cards-to-access
   "Gets the list of cards to access for the server"

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -658,7 +658,11 @@
                       archives-count (+ (count (-> @state :corp :discard)) (count (-> @state :corp :servers :archives :content)))]
                   (if (not-empty cards)
                     (if (= 1 archives-count)
-                      (access-card state side eid (first cards))
+                      ;; (wait-for (access-card state side accessed)
+                      ;;           (if (must-continue? already-accessed)
+                      ;;             (next-access state side eid already-accessed card)
+                      ;;             (effect-completed state side eid)))
+                      (wait-for (access-card state side eid (first cards)))
                       (continue-ability state side (access-helper-archives state archives-count
                                                                            (if no-root
                                                                              (set (get-in @state [:corp :servers :archives :content]))
@@ -713,12 +717,8 @@
                  (do (swap! state assoc-in [:runner :register :accessed-cards] true)
                      (wait-for (resolve-ability state side (choose-access cards server args) nil nil)
                                (wait-for (trigger-event-sync state side :end-access-phase {:from-server (first server)})
-                                         (effect-completed state side eid))
-                               
-                               ;; 
-                               )
-                     (swap! state update-in [:run :cards-accessed] (fnil #(+ % n) 0)))))
-             )))
+                                         (swap! state update-in [:run :cards-accessed] (fnil #(+ % n) 0))
+                                         (effect-completed state side eid)))))))))
 
 (defn replace-access
   "Replaces the standard access routine with the :replace-access effect of the card"

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -658,10 +658,6 @@
                       archives-count (+ (count (-> @state :corp :discard)) (count (-> @state :corp :servers :archives :content)))]
                   (if (not-empty cards)
                     (if (= 1 archives-count)
-                      ;; (wait-for (access-card state side accessed)
-                      ;;           (if (must-continue? already-accessed)
-                      ;;             (next-access state side eid already-accessed card)
-                      ;;             (effect-completed state side eid)))
                       (wait-for (access-card state side eid (first cards)))
                       (continue-ability state side (access-helper-archives state archives-count
                                                                            (if no-root

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -1325,6 +1325,20 @@
       (core/rez state :corp jackson)
       (is (= 1 (count (:discard (get-corp)))) "Card discarded to rez Jackson - Hacktivist active"))))
 
+(deftest high-stakes-job
+  ;; High Stakes Job - run on server with at least 1 piece of unrezzed ice, gains 12 credits if successful
+  (do-game
+    (new-game (default-corp ["Ice Wall"])
+              (default-runner ["High-Stakes Job"]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp)
+    (core/gain state :runner :credit 1)
+    (is (= 6 (:credit (get-runner))) "Runner starts with 6 credits")
+    (play-from-hand state :runner "High-Stakes Job")
+    (prompt-choice :runner "HQ")
+    (run-successful state)
+    (is (= 12 (:credit (get-runner))) "Runner gains 12 credits")))
+
 (deftest independent-thinking
   ;; Independent Thinking - Trash 2 installed cards, including a facedown directive, and draw 2 cards
   (do-game
@@ -1815,6 +1829,20 @@
     (run-successful state)
     (is (zero? (count (:discard (get-runner)))))
     (is (= 6 (count (:rfg (get-runner)))))))
+
+(deftest peace-in-our-time
+  ;; Peace in Our Time - runner gains 10, corp gains 5. No runs allowed during turn.
+  (do-game
+    (new-game (default-corp)
+              (default-runner ["Peace in Our Time"]))
+    (take-credits state :corp)
+    (is (= 8 (:credit (get-corp))) "Corp starts with 8 credits")
+    (is (= 5 (:credit (get-runner))) "Runner starts with 5 credits")
+    (play-from-hand state :runner "Peace in Our Time")
+    (is (= 13 (:credit (get-corp))) "Corp gains 5 credits")
+    (is (= 14 (:credit (get-runner))) "Runner gains 10 credits")
+    (run-on state "HQ")
+    (is (not (:run @state)) "Not allowed to make a run")))
 
 (deftest political-graffiti
   ;; Political Graffiti - swapping with Turntable works / purging viruses restores points

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -694,35 +694,31 @@
 
 (deftest minds-eye
   ;; Mind's Eye - Gain power tokens on R&D runs, and for 3 tokens and a click, access the top card of R&D
-  (do-game
-   (new-game (default-corp [(qty "Jackson Howard" 2)])
-             (default-runner ["Mind's Eye" "R&D Interface" "Aeneas Informant"]))
-   
-   (dotimes [_ 2]
-     (core/move state :corp (find-card "Jackson Howard" (:hand (get-corp))) :deck))
-   (take-credits state :corp)
-   (core/gain state :runner :credit 10 :click 20)
-   (play-from-hand state :runner "Mind's Eye")
-   (let [eye (get-hardware state 0)]
-     (is (= 0 (get-counters (refresh eye) :power)) "0 counters on install")
-     (dotimes [_ 3]
-       (run-empty-server state :rd)
-       (prompt-choice :runner "No action"))
-     (is (= 3 (get-counters (refresh eye) :power)) "3 counters after 3 runs")
-     (play-from-hand state :runner "R&D Interface")
-     (play-from-hand state :runner "Aeneas Informant")
-   
-     (card-ability state :runner (refresh eye) 0)
-     (let [num-creds (:credit (get-runner))]
-       (prompt-choice :runner "No action")
-
-       ;; todo: these two lines must be transposed, but they shouldn't 
-       (prompt-choice :runner "Yes")    ;Aeneas
-       (prompt-choice :runner "No action")
+  (testing "Interaction with RDI + Aeneas"
+    (do-game
+     (new-game (default-corp [(qty "Jackson Howard" 2)])
+               (default-runner ["Mind's Eye" "R&D Interface" "Aeneas Informant"]))
+     (dotimes [_ 2]
+       (core/move state :corp (find-card "Jackson Howard" (:hand (get-corp))) :deck))
+     (take-credits state :corp)
+     (core/gain state :runner :credit 10 :click 20)
+     (play-from-hand state :runner "Mind's Eye")
+     (let [eye (get-hardware state 0)]
+       (is (= 0 (get-counters (refresh eye) :power)) "0 counters on install")
+       (dotimes [_ 3]
+         (run-empty-server state :rd)
+         (prompt-choice :runner "No action"))
+       (is (= 3 (get-counters (refresh eye) :power)) "3 counters after 3 runs")
+       (play-from-hand state :runner "R&D Interface")
+       (play-from-hand state :runner "Aeneas Informant")
        
-       (prompt-choice :runner "Yes")    ;Aeneas
-       
-       (is (= (+ num-creds 2) (:credit (get-runner))) "Runner has gained 2 from Aeneas")))))
+       (card-ability state :runner (refresh eye) 0)
+       (let [num-creds (:credit (get-runner))]
+         (dotimes [_ 2]
+           (prompt-choice :runner "Card from deck")
+           (prompt-choice :runner "No action")
+           (prompt-choice :runner "Yes")) ;Aeneas
+         (is (= (+ num-creds 2) (:credit (get-runner))) "Runner has gained 2 from Aeneas"))))))
 
 (deftest net-ready-eyes
   ;; Net-Ready Eyes

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -692,6 +692,38 @@
         (is (= (:cid accessed) (:cid (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")
         (is (:prompt (get-runner)) "Runner has next access prompt")))))
 
+(deftest minds-eye
+  ;; Mind's Eye - Gain power tokens on R&D runs, and for 3 tokens and a click, access the top card of R&D
+  (do-game
+   (new-game (default-corp [(qty "Jackson Howard" 2)])
+             (default-runner ["Mind's Eye" "R&D Interface" "Aeneas Informant"]))
+   
+   (dotimes [_ 2]
+     (core/move state :corp (find-card "Jackson Howard" (:hand (get-corp))) :deck))
+   (take-credits state :corp)
+   (core/gain state :runner :credit 10 :click 20)
+   (play-from-hand state :runner "Mind's Eye")
+   (let [eye (get-hardware state 0)]
+     (is (= 0 (get-counters (refresh eye) :power)) "0 counters on install")
+     (dotimes [_ 3]
+       (run-empty-server state :rd)
+       (prompt-choice :runner "No action"))
+     (is (= 3 (get-counters (refresh eye) :power)) "3 counters after 3 runs")
+     (play-from-hand state :runner "R&D Interface")
+     (play-from-hand state :runner "Aeneas Informant")
+   
+     (card-ability state :runner (refresh eye) 0)
+     (let [num-creds (:credit (get-runner))]
+       (prompt-choice :runner "No action")
+
+       ;; todo: these two lines must be transposed, but they shouldn't 
+       (prompt-choice :runner "Yes")    ;Aeneas
+       (prompt-choice :runner "No action")
+       
+       (prompt-choice :runner "Yes")    ;Aeneas
+       
+       (is (= (+ num-creds 2) (:credit (get-runner))) "Runner has gained 2 from Aeneas")))))
+
 (deftest net-ready-eyes
   ;; Net-Ready Eyes
   (do-game

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1326,6 +1326,7 @@
         (is (= (:cid (first (:deck (get-corp))))
                (:cid (:card (first (:prompt (get-runner)))))) "Access the top card of R&D")
         (prompt-choice :runner "No action")
+        (prompt-choice :runner "Card from deck")
         (is (= (:cid (second (:deck (get-corp))))
                (:cid (:card (first (:prompt (get-runner)))))) "Access another card due to R&D Interface"))))
   (testing "with Mwanza City Grid, should access additional 3 cards"

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1350,8 +1350,9 @@
           (dotimes [_ 5]
             (prompt-choice :runner "Card from deck")
             (prompt-choice :runner "No action"))
+          (is (= (+ credits 10) (:credit (get-corp))) "Corp should gain 10 credits from accessing 5 cards before jack out")
           (run-jack-out state)
-          (is (= (+ credits 10) (:credit (get-corp))) "Corp should gain 10 credits from accessing 5 cards total"))))))
+          (is (= (+ credits 10) (:credit (get-corp))) "Corp should only gain money once"))))))
 
 (deftest snowflake
   ;; Snowflake - Win a psi game to end the run

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1322,6 +1322,7 @@
         (is (= "Quandary" (:title (second (:deck (get-corp))))))
         (is (= "Jackson Howard" (:title (second (rest (:deck (get-corp)))))))
         (card-subroutine state :corp shiro 1)
+        (prompt-choice :runner "Card from deck")
         (is (= (:cid (first (:deck (get-corp))))
                (:cid (:card (first (:prompt (get-runner)))))) "Access the top card of R&D")
         (prompt-choice :runner "No action")
@@ -1347,6 +1348,7 @@
           (card-subroutine state :corp shiro 1)
           (is (= 3 (-> @state :run :access-bonus)) "Should access an additional 3 cards")
           (dotimes [_ 5]
+            (prompt-choice :runner "Card from deck")
             (prompt-choice :runner "No action"))
           (run-jack-out state)
           (is (= (+ credits 10) (:credit (get-corp))) "Corp should gain 10 credits from accessing 5 cards total"))))))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -2536,7 +2536,7 @@
         (is (zero? (get-counters (refresh ttw) :power)) "Using The Turning Wheel ability costs 2 counters")
         (is (= 1 (-> @state :run :access-bonus)) "Runner should access 1 additional card")
         (run-successful state)
-        (is (zero? (-> @state :run :access-bonus)) "Access bonuses are zeroed out when attacked server isn't R&D or HQ")))))
+        (is (zero? (-> (get-runner) :register :last-run :access-bonus)) "Access bonuses are zeroed out when attacked server isn't R&D or HQ")))))
 
 (deftest theophilius-bagbiter
   ;; Theophilius Bagbiter - hand size is equal to credit pool

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -742,10 +742,10 @@
     (core/click-draw state :runner nil)
     (core/click-draw state :runner nil)
     (run-empty-server state "HQ")
-    (prompt-choice :runner "No") ; don't trash Manta Grid
+    (prompt-choice :runner "No action") ; don't trash Manta Grid
     (is (= 1 (:click (get-runner))) "Running last click")
     (run-empty-server state "HQ")
-    (prompt-choice :runner "No") ; don't trash Manta Grid
+    (prompt-choice :runner "No action") ; don't trash Manta Grid
     (take-credits state :runner)
     (is (= 5 (:click (get-corp))) "Corp gained 2 clicks due to 2 runs with < 6 Runner credits")
     (take-credits state :corp)
@@ -754,7 +754,7 @@
     (take-credits state :corp)
     (take-credits state :runner 3)
     (run-empty-server state "HQ")
-    (prompt-choice :runner "No") ; don't trash Manta Grid
+    (prompt-choice :runner "No action") ; don't trash Manta Grid
     (take-credits state :runner)
     (is (= 4 (:click (get-corp))) "Corp gained a click due to running last click")))
 
@@ -944,6 +944,7 @@
         (run-successful state)
         (prompt-choice :runner "Mwanza City Grid")
         (prompt-choice-partial :runner "Pay")
+        
         (dotimes [c 4]
           (prompt-choice :runner "Card from hand")
           (prompt-choice :runner "No action"))

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -944,7 +944,6 @@
         (run-successful state)
         (prompt-choice :runner "Mwanza City Grid")
         (prompt-choice-partial :runner "Pay")
-        
         (dotimes [c 4]
           (prompt-choice :runner "Card from hand")
           (prompt-choice :runner "No action"))


### PR DESCRIPTION
This is a bit of a doozy. I have implemented Mind's Eye, which basically boils down to making `do-access` usable outside of runs. This was done using Noah's work on D&C. I anticipate there are lots of things which need changing, not least of which is a bug with Shiro/Mwanza, but I figured it would be best to get some feedback on what's been done so far before I make an even larger mess.