### PR TITLE
RaR: Psych Mike

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -992,11 +992,11 @@
                              (access-card state side (first cards))
                              (if (< 1 (count cards))
                                (continue-ability state side (access-pile (next cards) pile pile-size) card nil)
-                               (do (swap! state assoc-in [:run :cards-accessed] pile-size)
-                                   (effect-completed state side eid)))))})
+                               (effect-completed state side eid))))})
            (which-pile [p1 p2]
              {:prompt "Choose a pile to access"
-              :choices [(str "Pile 1 (" (count p1) " cards)") (str "Pile 2 (" (count p2) " cards)")]
+              :choices [(str "Pile 1 (" (count p1) " cards)")
+                        (str "Pile 2 (" (count p2) " cards)")]
               :async true
               :effect (req (let [choice (if (.startsWith target "Pile 1") 1 2)]
                              (clear-wait-prompt state :corp)
@@ -1022,8 +1022,8 @@
                                                     (which-pile (shuffle targets)
                                                                 (shuffle (vec (clojure.set/difference
                                                                                 (set (:hand corp)) (set targets)))))
-                                                    card nil))
-                                  } card nil))
+                                                    card nil))}
+                                 card nil))
                            (effect-completed state side eid)))}]
        {:req (req hq-runnable)
         :effect (effect (run :hq {:req (req (= target :hq))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -768,8 +768,8 @@
                                    :req (req (and (#{:rd :hq} (first (:server target)))
                                                   (first-event? state side :successful-run-ends
                                                                 #(#{:rd :hq} (first (:server (first %)))))))
-                                   :msg (msg "draw " (:cards-accessed target 0) " cards")
-                                   :effect (effect (draw (:cards-accessed target 0)))}}}
+                                   :msg (msg "draw " (total-cards-accessed target) " cards")
+                                   :effect (effect (draw (total-cards-accessed target)))}}}
 
    "Omni-drive"
    {:recurring 1

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1948,8 +1948,7 @@
                                             (swap! state assoc-in [:runner :register :accessed-cards] true)
                                             (doseq [c (take total-cards (:deck corp))]
                                               (system-msg state :runner (str "accesses " (:title c)))
-                                              (access-card state side c))
-                                            (swap! state update-in [:run :cards-accessed] (fnil #(+ % total-cards) 0)))))}]}
+                                              (access-card state side c)))))}]}
 
    "Snoop"
    {:implementation "Encounter effect is manual"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -843,7 +843,7 @@
                       (req (trash state side card {:cause :ability-cost})
                            (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                            (when (:run @state)
-                             (swap! state update-in [:run :cards-accessed] (fnil #(+ % (count (:discard corp))) 0)))
+                             (swap! state update-in [:run :cards-accessed :discard] (fnil #(+ % (count (:discard corp))) 0)))
                            (wait-for (trigger-event-sync state side :pre-access :archives)
                                      (resolve-ability state :runner
                                                       (choose-access (get-in @state [:corp :discard])
@@ -1457,6 +1457,12 @@
                  :msg "gain 1 [Credits] and draw 1 card"
                  :effect (effect (gain-credits 1)
                                  (draw))}]}
+
+   "Psych Mike"
+   {:events {:successful-run-ends
+             {:req (req (and (= [:rd] (:server target))
+                             (first-event? state side :successful-run-ends)))
+              :effect (effect (gain-credits :runner (total-cards-accessed target :deck)))}}}
 
    "Public Sympathy"
    {:in-play [:hand-size 2]}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -611,9 +611,9 @@
    "Mwanza City Grid"
    (let [gain-creds {:req (req (and installed
                                     this-server
-                                    (pos? (:cards-accessed run 0))))
+                                    (pos? (total-cards-accessed run))))
                      :silent (req true)
-                     :effect (req (let [cnt (:cards-accessed run)
+                     :effect (req (let [cnt (total-cards-accessed run)
                                         total (* 2 cnt)]
                                     (gain-credits state :corp total)
                                     (system-msg state :corp

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1665,6 +1665,47 @@
       (is (= 2 (:credit (get-runner))) "Gained 1 credit")
       (is (= 6 (count (:hand (get-runner)))) "Drew 1 card"))))
 
+(deftest psych-mike
+  ;; Psych Mike
+  (testing "Basic test"
+    (do-game
+      (new-game (default-corp [(qty "Ice Wall" 100)])
+                (default-runner ["Psych Mike" "Deep Data Mining"]))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Psych Mike")
+      (let [credits (:credit (get-runner))]
+        (run-empty-server state "R&D")
+        (prompt-choice :runner "No action")
+        (is (= (inc credits) (:credit (get-runner))) "Psych Mike should give 1 credit for accessing 1 card"))
+      (let [credits (:credit (get-runner))]
+        (run-empty-server state "R&D")
+        (prompt-choice :runner "No action")
+        (is (= credits (:credit (get-runner))) "Psych Mike should give 0 credits for second run of the turn"))
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Deep Data Mining")
+      (let [credits (:credit (get-runner))]
+        (run-successful state)
+        (dotimes [_ 5]
+          (prompt-choice :runner "Card from deck")
+          (prompt-choice :runner "No action"))
+        (is (= (+ credits 5) (:credit (get-runner))) "Psych Mike should give 5 credits for DDM accesses"))))
+  (testing "vs upgrades"
+    (do-game
+      (new-game (default-corp ["Bryan Stinson" (qty "Ice Wall" 100)])
+                (default-runner ["Psych Mike"]))
+      (starting-hand state :corp ["Bryan Stinson"])
+      (play-from-hand state :corp "Bryan Stinson" "R&D")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Psych Mike")
+      (let [credits (:credit (get-runner))]
+        (run-empty-server state "R&D")
+        (prompt-choice :runner "Card from deck")
+        (prompt-choice :runner "No action")
+        (prompt-choice-partial :runner "Unrezzed")
+        (prompt-choice :runner "No action")
+        (is (= (inc credits) (:credit (get-runner))) "Psych Mike should give 1 credit for accessing 1 card")))))
+
 (deftest reclaim
   ;; Reclaim - trash Reclaim, trash card from grip, install program, hardware, or virtual resource from heap
   (testing "Basic behavior"


### PR DESCRIPTION
Medium-big change: `:cards-accessed` is now a map containing the server keyword where you accessed a given card from. If it's from the R&D or Archives or HQ, it'll be in the form of `:deck`, `:discard`, or `:hand`, with `:rd`, `:archives`, and `:hq` denoting root.

Adds a new utility function to `runs.clj`, `total-cards-accessed`, which returns either the full number of cards accessed in the run so far or the number of cards accessed in a single server. To combine, you have to do it manually, lol. (The name could be changed cuz it's bulky.)

NOTE: ACTIVELY CLASHES WITH #3703 , SO PLEASE DO NOT MERGE WILLY NILLY. PING ME AND I'LL HANDLE FIXING ERRORS.