### PR TITLE
RaR: Ika

### DIFF
--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -709,17 +709,15 @@
    "Ika"
    (auto-icebreaker ["Sentry"]
                     {:abilities [(break-sub 1 2 "Sentry")
-                                 (strength-pump 2 3 :all-run)
+                                 (strength-pump 2 3)
                                  {:label "2 [Credits]: Host Ika on a piece of ICE"
-                                  :effect (req (let [ika (get-card state card)]
-                                                 (resolve-ability state side
-                                                                  {:prompt (msg "Host Ika on a piece of ICE")
-                                                                   :cost [:credit 2]
-                                                                   :choices {:req #(and (ice? %)
-                                                                                        (installed? %)
-                                                                                        (can-host? %))}
-                                                                   :msg (msg "host it on " (card-str state target))
-                                                                   :effect (effect (host target card))} card nil)))}]})
+                                  :prompt (msg "Host Ika on a piece of ICE")
+                                  :cost [:credit 2]
+                                  :choices {:req #(and (ice? %)
+                                                       (installed? %)
+                                                       (can-host? %))}
+                                  :msg (msg "host it on " (card-str state target))
+                                  :effect (effect (host target card))}]})
 
    "Knight"
    {:abilities [{:label "Host Knight on a piece of ICE"

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -710,7 +710,7 @@
    (auto-icebreaker ["Sentry"]
                     {:abilities [(break-sub 1 2 "Sentry")
                                  (strength-pump 2 3)
-                                 {:label "2 [Credits]: Host Ika on a piece of ICE"
+                                 {:label "Host Ika on a piece of ICE"
                                   :prompt (msg "Host Ika on a piece of ICE")
                                   :cost [:credit 2]
                                   :choices {:req #(and (ice? %)

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -706,6 +706,21 @@
                                  (break-sub 1 1 "Code Gate")
                                  (strength-pump 1 1)]})
 
+   "Ika"
+   (auto-icebreaker ["Sentry"]
+                    {:abilities [(break-sub 1 2 "Sentry")
+                                 (strength-pump 2 3 :all-run)
+                                 {:label "2 [Credits]: Host Ika on a piece of ICE"
+                                  :effect (req (let [ika (get-card state card)]
+                                                 (resolve-ability state side
+                                                                  {:prompt (msg "Host Ika on a piece of ICE")
+                                                                   :cost [:credit 2]
+                                                                   :choices {:req #(and (ice? %)
+                                                                                        (installed? %)
+                                                                                        (can-host? %))}
+                                                                   :msg (msg "host it on " (card-str state target))
+                                                                   :effect (effect (host target card))} card nil)))}]})
+
    "Knight"
    {:abilities [{:label "Host Knight on a piece of ICE"
                  :effect (req (let [k (get-card state card)

--- a/test/clj/game_test/cards/icebreakers.clj
+++ b/test/clj/game_test/cards/icebreakers.clj
@@ -396,6 +396,50 @@
      (is (= 1 (:tag (get-runner))))
      (is (= 2 (get-counters (refresh gow) :virus)) "God of War has 2 virus counters"))))
 
+(deftest ika
+  (testing "Can be hosted on both rezzed/unrezzed ice, respects no-host, is blanked by Magnet"
+    (do-game
+      (new-game (default-corp ["Tithonium" "Enigma" "Magnet"])
+                (default-runner ["Ika"]))
+      (play-from-hand state :corp "Enigma" "HQ")
+      (play-from-hand state :corp "Tithonium" "Archives")
+      (play-from-hand state :corp "Magnet" "R&D")
+      (take-credits state :corp)
+
+      (play-from-hand state :runner "Ika")
+      (core/gain state :runner :credit 100)
+      (core/gain state :corp :credit 100)
+      (let [ika (get-program state 0)
+            enigma (get-ice state :hq 0)
+            tithonium (get-ice state :archives 0)
+            magnet (get-ice state :rd 0)]
+        (let [creds (:credit (get-runner))]
+          (card-ability state :runner ika 2) ; host on a piece of ice
+          (prompt-select :runner tithonium)
+          (is (game.utils/same-card? ika (first (:hosted (refresh tithonium)))) "Ika was rehosted")
+          (is (= (- creds 2) (:credit (get-runner))) "Rehosting from rig cost 2 creds"))
+        (run-on state :archives)
+        (let [creds (:credit (get-runner))
+              ika (first (:hosted (refresh tithonium)))]
+          (card-ability state :runner ika 2)
+          (prompt-select :runner enigma)
+          (is (game.utils/same-card? ika (first (:hosted (refresh enigma)))) "Ika was rehosted")
+          (is (= (- creds 2) (:credit (get-runner))) "Rehosting from ice during run cost 2 creds"))
+        (core/rez state :corp tithonium)
+        (let [creds (:credit (get-runner))
+              ika (first (:hosted (refresh enigma)))]
+          (card-ability state :runner ika 2)
+          (prompt-select :runner tithonium)
+          (is (= 0 (count (:hosted (refresh tithonium)))) "Ika was not hosted on Tithonium")
+          (is (= creds (:credit (get-runner))) "Clicking invalid targets is free")
+          (prompt-select :runner "Done")
+          (core/rez state :corp magnet)
+          (prompt-select :corp ika)
+          (is (= 0 (count (:hosted (refresh enigma)))) "Ika was removed from Enigma")
+          (is (= 1 (count (:hosted (refresh magnet)))) "Ika was hosted onto Magnet")
+          (let [ika (first (:hosted (refresh magnet)))]
+            (is (= 0 (count (:abilities ika))) "Ika was blanked")))))))
+
 (deftest inversificator
   ;; Inversificator shouldn't hook up events for unrezzed ice
   (do-game


### PR DESCRIPTION
Auto-pump is displayed even when currently encountered ice is not the one Ika is hosted on. This is in part intentional to allow for easier use of Flame-Out, and in part laziness. 