### PR TITLE
RaR: Giordano Memorial Field

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -352,7 +352,8 @@
                  :effect (effect (mill :corp :runner 2))}]}
 
    "Georgia Emelyov"
-   {:events {:unsuccessful-run {:req (req (= (first (:server target)) (second (:zone card))))
+   {:events {:unsuccessful-run {:req (req (= (first (:server target))
+                                             (second (:zone card))))
                                 :async true
                                 :msg "do 1 net damage"
                                 :effect (effect (damage eid :net 1 {:card card}))}}
@@ -368,6 +369,31 @@
                                                    (unregister-events state side card)
                                                    (register-events state side (:events (card-def c)) c)))}
                                    card nil))}]}
+
+   "Giordano Memorial Field"
+   {:events
+    {:successful-run
+     {:interactive (req true)
+      :async true
+      :req (req this-server)
+      :effect (req (let [credits (:credit runner)
+                         cost (* 2 (count (:scored runner)))
+                         pay-str (str "Pay " cost " [Credits]")]
+                     (show-wait-prompt state :corp (str "Runner to pay " cost " [Credits]"))
+                     (continue-ability
+                       state :runner
+                       {:player :runner
+                        :async true
+                        :prompt (str pay-str " or end the run?")
+                        :choices (concat (when (>= credits cost)
+                                           [pay-str])
+                                         ["End the run"])
+                        :effect (req (clear-wait-prompt state :corp)
+                                     (if (= pay-str target)
+                                       (pay state :runner card :credit cost)
+                                       (end-run state side))
+                                     (effect-completed state side eid))}
+                       card nil)))}}}
 
    "Heinlein Grid"
    {:abilities [{:req (req this-server)

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -596,6 +596,31 @@
         (run-jack-out state)
         (is (= 2 (count (:discard (get-runner)))) "Runner did not take damage")))))
 
+(deftest giordano-memorial-field
+  ;; Giordano Memorial Field
+  (do-game
+    (new-game (default-corp ["Giordano Memorial Field" "Hostile Takeover"])
+              (default-corp [(qty "Fan Site" 3)]))
+    (play-from-hand state :corp "Giordano Memorial Field" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Fan Site")
+    (play-from-hand state :runner "Fan Site")
+    (play-from-hand state :runner "Fan Site")
+    (take-credits state :runner)
+    (play-and-score state "Hostile Takeover")
+    (take-credits state :corp)
+    (run-empty-server state "Server 1")
+    (let [credits (:credit (get-runner))]
+      (prompt-choice-partial :runner "Pay")
+      (is (= (- credits 6) (:credit (get-runner))) "Runner pays 6 credits to not end the run"))
+    (prompt-choice :runner "No action")
+    (run-empty-server state "Server 1")
+    (is (= 1 (-> (get-runner) :prompt first :choices count)) "Runner should only get 1 choice")
+    (is (= "End the run" (-> (get-runner) :prompt first :choices first)) "Only choice should be End the run")
+    (prompt-choice :runner "End the run")
+    (is (not (:run @state)) "Run should be ended from Giordano Memorial Field ability")))
+
 (deftest helheim-servers
   ;; Helheim Servers - Full test
   (do-game


### PR DESCRIPTION
Implements Giordano with a test.

Also of note is a change to the run timing: previously, there was no check for if a run had been ended between the marking of a successful run and access. However, this card now allows that, so I've added a check in `successful-run-trigger` for if the `(:run @state)` has been marked as ended. If it has, clean up the run. If it hasn't, continue!