### PR TITLE
Fixes Femme Fatale + Credit Kiting interaction

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -292,9 +292,10 @@
                              (is-type? % "Program")
                              (is-type? % "Resource"))
                          (in-hand? %))}
-    :effect (effect (install-cost-bonus [:credit -8])
-                    (runner-install target)
-                    (tag-runner 1))}
+    :async true
+    :effect (req (install-cost-bonus state :runner [:credit -8])
+                 (wait-for (runner-install state :runner target nil)
+                           (tag-runner state eid :runner 1)))}
 
    "Cyber Threat"
    {:prompt "Choose a server"

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -607,8 +607,7 @@
                     {:prompt "Select a piece of ICE to target for bypassing"
                      :choices {:req ice?}
                      :leave-play (req (remove-icon state side card))
-                     :effect (req (let [ice target
-                                        serv (zone->name (second (:zone ice)))]
+                     :effect (req (let [ice target]
                                     (add-icon state side card ice "F" "blue")
                                     (system-msg state side
                                                 (str "selects " (card-str state ice)

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -685,9 +685,10 @@
 (deftest credit-kiting
   ;; After successful central run lower install cost by 8 and gain a tag
   (do-game
-    (new-game (default-corp ["PAD Campaign"])
+    (new-game (default-corp ["PAD Campaign" "Ice Wall"])
               (default-runner ["Credit Kiting" "Femme Fatale"]))
     (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "Ice Wall" "HQ")
     (take-credits state :corp)
     (run-empty-server state "Server 1")
     (play-from-hand state :runner "Credit Kiting")
@@ -696,6 +697,14 @@
     (play-from-hand state :runner "Credit Kiting")
     (prompt-select :runner (find-card "Femme Fatale" (:hand (get-runner))))
     (is (= 4 (:credit (get-runner))) "Femme Fatale only cost 1 credit")
+
+    (testing "Femme Fatale can still target ice when installed with Credit Kiting, issue #3715"
+      (let [iw (get-ice state :hq 0)
+            ff (get-program state 0)]
+        (is (prompt-is-card? :runner ff) "Ice target prompt open for Femme Fatale")
+        (prompt-select :runner iw)
+        (is (= (:title iw) (-> ff refresh :icon :card :title)) "Femme Fatale icon targets Ice Wall")))
+
     (is (= 1 (:tag (get-runner))) "Runner gained a tag")))
 
 (deftest data-breach

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -688,7 +688,7 @@
     (new-game (default-corp ["PAD Campaign" "Ice Wall"])
               (default-runner ["Credit Kiting" "Femme Fatale"]))
     (play-from-hand state :corp "PAD Campaign" "New remote")
-    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Ice Wall" "R&D")
     (take-credits state :corp)
     (run-empty-server state "Server 1")
     (play-from-hand state :runner "Credit Kiting")
@@ -699,11 +699,9 @@
     (is (= 4 (:credit (get-runner))) "Femme Fatale only cost 1 credit")
 
     (testing "Femme Fatale can still target ice when installed with Credit Kiting, issue #3715"
-      (let [iw (get-ice state :hq 0)
-            ff (get-program state 0)]
-        (is (prompt-is-card? :runner ff) "Ice target prompt open for Femme Fatale")
+      (let [iw (get-ice state :rd 0)]
         (prompt-select :runner iw)
-        (is (= (:title iw) (-> ff refresh :icon :card :title)) "Femme Fatale icon targets Ice Wall")))
+        (is (:icon (refresh iw)) "Ice Wall has an icon")))
 
     (is (= 1 (:tag (get-runner))) "Runner gained a tag")))
 


### PR DESCRIPTION
Makes Credit Kiting await `runner-install` before tagging runner. Adds regression test.

Fixes #3715.