### PR TITLE
RaR: Formicary

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1456,6 +1456,33 @@
                    :prompt "Choose an ICE to install from HQ"
                    :effect (req (corp-install state side target (zone->name (first (:server run))) {:no-install-cost true}))}]}
 
+   "Formicary"
+   {:req (req (and (:run @state)
+                   (zero? (:position run))
+                   (not (contains? run :corp-phase-43))
+                   (not (contains? run :successful))))
+    :effect (effect (resolve-ability
+                     {:optional
+                      {:prompt "Move Formicary?"
+                       :yes-ability {:msg "rez and move Formicary. The Runner is now approaching Formicary."
+                                     :effect (req
+                                              (move state side card
+                                                    [:servers (first (:server run)) :ices]
+                                                    {:front true})
+                                              (swap! state assoc-in [:run :position] 1))}
+                       :no-ability {:msg "rez Formicary without moving it"}}}
+                     card nil))
+    :subroutines [{:label "End the run unless the Runner suffers 2 net damage"
+                   :effect (req (wait-for (resolve-ability
+                                           state :runner
+                                           {:optional
+                                            {:prompt "Suffer 2 net damage? (If not, end the run)"
+                                             :yes-ability {:async true
+                                                           :msg "let the Runner suffer 2 net damage"
+                                                           :effect (effect (damage eid :net 2 {:card card :unpreventable true}))}
+                                             :no-ability end-the-run}}
+                                           card nil)))}]}
+
    "Mirāju"
    {:abilities [{:label "Runner broke subroutine: Redirect run to Archives"
                  :msg "make the Runner continue the run on Archives. Mirāju is derezzed"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1469,6 +1469,7 @@
                                           (swap! state assoc-in [:run :position] 1))}
                :no-ability {:msg "rez Formicary without moving it"}}
     :subroutines [{:label "End the run unless the Runner suffers 2 net damage"
+                   :async true
                    :effect (req (wait-for (resolve-ability
                                            state :runner
                                            {:optional

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1457,21 +1457,17 @@
                    :effect (req (corp-install state side target (zone->name (first (:server run))) {:no-install-cost true}))}]}
 
    "Formicary"
-   {:req (req (and (:run @state)
+   {:optional {:prompt "Move Formicary?"
+               :req (req (and (:run @state)
                    (zero? (:position run))
                    (not (contains? run :corp-phase-43))
                    (not (contains? run :successful))))
-    :effect (effect (resolve-ability
-                     {:optional
-                      {:prompt "Move Formicary?"
-                       :yes-ability {:msg "rez and move Formicary. The Runner is now approaching Formicary."
-                                     :effect (req
-                                              (move state side card
-                                                    [:servers (first (:server run)) :ices]
-                                                    {:front true})
-                                              (swap! state assoc-in [:run :position] 1))}
-                       :no-ability {:msg "rez Formicary without moving it"}}}
-                     card nil))
+               :yes-ability {:msg "rez and move Formicary. The Runner is now approaching Formicary."
+                             :effect (req (move state side card
+                                                [:servers (first (:server run)) :ices]
+                                                {:front true})
+                                          (swap! state assoc-in [:run :position] 1))}
+               :no-ability {:msg "rez Formicary without moving it"}}
     :subroutines [{:label "End the run unless the Runner suffers 2 net damage"
                    :effect (req (wait-for (resolve-ability
                                            state :runner

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -119,13 +119,13 @@
              moved-card (if (and (= (first (:zone moved-card)) :scored)
                                  (card-flag? moved-card :has-abilities-when-stolen true))
                           (merge moved-card {:abilities (:abilities (card-def moved-card))}) moved-card)]
-         (if front
-           (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))
-           (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card))))
          (doseq [s [:runner :corp]]
            (if host
              (remove-from-host state side card)
              (swap! state update-in (cons s (vec zone)) (fn [coll] (remove-once #(= (:cid %) cid) coll)))))
+         (if front
+           (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))
+           (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card))))
          (let [z (vec (cons :corp (butlast zone)))]
            (when (and (not keep-server-alive)
                       (is-remote? z)

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -419,7 +419,26 @@
        (is (= 1 (get-in @state [:run :position])) "Now approaching Formicary")
        (card-subroutine state :corp (refresh form2) 0)
        (prompt-choice :runner "No")      ; ETR
-       (is (not (get-in @state [:run])) "Formicary ended the run")))))
+       (is (not (get-in @state [:run])) "Formicary ended the run"))))
+  (testing "Verifies that Formicary can be moved to the innermost positon of its own server"
+    (do-game
+     (new-game (default-corp ["Ice Wall" "Formicary"])
+               (default-runner))
+     (play-from-hand state :corp "Ice Wall" "HQ")
+     (play-from-hand state :corp "Formicary" "HQ")
+     (take-credits state :corp)
+     (let [form (get-ice state :hq 1)]
+       (run-on state "HQ")
+       (run-continue state)             ; pass the first ice
+       (run-continue state)             ; pass the second ice
+       (is (= 0 (get-in @state [:run :position])) "Now approaching server")
+       (core/rez state :corp form)
+       (is (= "Ice Wall" (:title (get-ice state :hq 0))) "Ice Wall is the innermost piece of ice before swap")
+       (is (= "Formicary" (:title (get-ice state :hq 1))) "Formicary is the outermost piece of ice before swap")
+       (prompt-choice :corp "Yes")      ; Move Formicary
+       (is (= 1 (get-in @state [:run :position])) "Now approaching the innermost piece of ice")
+       (is (= "Formicary" (:title (get-ice state :hq 0))) "Formicary is the innermost piece of ice after swap")
+       (is (= "Ice Wall" (:title (get-ice state :hq 1))) "Ice Wall is the outermost piece of ice after swap")))))
 
 (deftest free-lunch
   ;; Free Lunch - Spend 1 power counter to make Runner lose 1c

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -383,6 +383,44 @@
       (is (= 3 (count (:discard (get-runner)))) "Clone Chip plus 2 cards lost from damage in discard")
       (is (not (:run @state)) "Run ended"))))
 
+(deftest formicary
+  ;; Formicary - when approaching server, may rez and move to innermost
+  (testing "Verifies basic functionality and that First Responders may trigger"
+    (do-game
+     (new-game (default-corp [(qty "Ice Wall" 2) (qty "Formicary" 3)])
+               (default-runner [(qty "First Responders" 6)]))
+     (play-from-hand state :corp "Ice Wall" "HQ") 
+     (play-from-hand state :corp "Formicary" "Archives")
+     (play-from-hand state :corp "Formicary" "R&D")
+     (take-credits state :corp)
+     (play-from-hand state :runner "First Responders")
+     (let [iw (get-ice state :hq 0)
+           form1 (get-ice state :rd 0)
+           form2 (get-ice state :archives 0)
+           responders (get-resource state 0)]
+       (run-on state "HQ")
+       (run-continue state)             ; pass the first ice
+       (is (= 0 (get-in @state [:run :position])) "Now approaching server")
+       (core/rez state :corp form1)
+       (prompt-choice :corp "Yes")      ; Move Formicary
+       (is (= 2 (count (get-in @state [:corp :servers :hq :ices]))) "2 ICE protecting HQ")
+       (is (= 1 (get-in @state [:run :position])) "Now approaching Formicary")
+       (card-subroutine state :corp (get-ice state :hq 0) 0)
+       (prompt-choice :runner "Yes")      ; take 2 net
+       (is (= 2 (count (:discard (get-runner)))) "Did 2 net damage")
+       (run-jack-out state)
+       (let [cards-in-hand (count (:hand (get-runner)))]
+         (card-ability state :runner responders 0)
+         (is (= (inc cards-in-hand) (count (:hand (get-runner)))) "First Responders was able to trigger"))
+       (run-on state "Archives")
+       (run-continue state)
+       (core/rez state :corp form2)
+       (prompt-choice :corp "Yes")      ; Move Formicary
+       (is (= 1 (get-in @state [:run :position])) "Now approaching Formicary")
+       (card-subroutine state :corp (refresh form2) 0)
+       (prompt-choice :runner "No")      ; ETR
+       (is (not (get-in @state [:run])) "Formicary ended the run")))))
+
 (deftest free-lunch
   ;; Free Lunch - Spend 1 power counter to make Runner lose 1c
   (do-game


### PR DESCRIPTION
Current implementation is that when rezzed, it checks whether its ability is triggerable (runner is in innermost position of server but has not yet committed to access), and if so, asks the corp whether they want to trigger it. It might be less confusing to make this ability manually triggerable. The net damage taken to not ETR is made unpreventable. This may allow for weird interactions (I think if Guru Davinder is on the table, the Runner should not be able to select '2 net damage' on Formicary at all, whereas the current implementation would allow them to) - please let me know if you can think of anything extra weird here.