### PR TITLE
RaR: Thimblerig

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -171,7 +171,7 @@
    {:flags {:runner-phase-12 (req (>= 2 (count (all-installed state :runner))))}
     :abilities [{:msg (msg "trash " (:title target))
                  :choices {:req #(and (= (:side %) "Runner") (:installed %))
-                           :not-self (req (:cid card))}
+                           :not-self true}
                  :effect (effect (trash target)
                                  (resolve-ability
                                    {:prompt "Draw 1 card or remove 1 tag" :msg (msg (.toLowerCase target))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2060,6 +2060,16 @@
                                     :msg (msg "force the Runner to lose " (:tag runner) " [Credits]")
                                     :effect (effect (lose-credits :runner (:tag runner)))})]}
 
+   "Thimblerig"
+   {:flags {:corp-phase-12 (req true)}
+    :implementation "Does not restrict usage of swap ability to start of turn or after pass"
+    :abilities [{:label "Swap Thimblerig with a piece of ice"
+                 :prompt "Swap Thimblerig with a piece of ice"
+                 :choices {:req ice?
+                           :not-self (req (:cid card))}
+                 :effect (effect (swap-ice card target))}]
+    :subroutines [end-the-run]}
+
    "Tithonium"
    {:alternative-cost [:forfeit]
     :implementation "Does not handle UFAQ for Pawn or Blackguard interaction"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2061,7 +2061,7 @@
                                     :effect (effect (lose-credits :runner (:tag runner)))})]}
 
    "Thimblerig"
-   {:flags {:corp-phase-12 (req true)}
+   {:flags {:corp-phase-12 (req (>= (count (filter ice? (all-installed state :corp))) 2))}
     :implementation "Does not restrict usage of swap ability to start of turn or after pass"
     :abilities [{:label "Swap Thimblerig with a piece of ice"
                  :prompt "Swap Thimblerig with a piece of ice"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1668,7 +1668,7 @@
                 {:label "Place X advancement token on another piece of ice"
                  :msg (msg "place " (get-counters card :advancement) " advancement token on " (card-str state target))
                  :choices {:req ice?
-                           :not-self (req (:cid card))}
+                           :not-self true}
                  :effect (req (add-prop state side target :advance-counter (get-counters card :advancement) {:placed true}))}]
     :subroutines [end-the-run]}
 
@@ -2066,7 +2066,7 @@
     :abilities [{:label "Swap Thimblerig with a piece of ice"
                  :prompt "Choose a piece of ice to swap Thimblerig with"
                  :choices {:req ice?
-                           :not-self (req (:cid card))}
+                           :not-self true}
                  :effect (effect (swap-ice card target))}]
     :subroutines [end-the-run]}
 

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2064,7 +2064,7 @@
    {:flags {:corp-phase-12 (req (>= (count (filter ice? (all-installed state :corp))) 2))}
     :implementation "Does not restrict usage of swap ability to start of turn or after pass"
     :abilities [{:label "Swap Thimblerig with a piece of ice"
-                 :prompt "Swap Thimblerig with a piece of ice"
+                 :prompt "Choose a piece of ice to swap Thimblerig with"
                  :choices {:req ice?
                            :not-self (req (:cid card))}
                  :effect (effect (swap-ice card target))}]

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1432,6 +1432,47 @@
       (core/move-card state :corp {:card (get-ice state :hq 1) :server "Archives"})
       (is (= 4 (:current-strength (refresh surv))) "Surveyor has 4 strength for 2 pieces of ICE"))))
 
+(deftest thimblerig
+  (testing "Thimblerig does not flag phase 1.2 if it's the only piece of ice"
+    (do-game
+      (new-game (default-corp ["Thimblerig" "Guard"])
+                (default-runner))
+      (play-from-hand state :corp "Thimblerig" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (not (:corp-phase-12 @state)) "Corp not in phase 1.2 when Thimblerig is the only piece of ice")
+      (play-from-hand state :corp "Guard" "New remote")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (:corp-phase-12 @state) "Corp in phase 1.2 when there are 2 pieces of ice")))
+  (testing "Basic of swap ability - usable both during and outside runs"
+    (do-game
+      (new-game (default-corp ["Vanilla" "Pup" "Thimblerig"])
+                (default-runner))
+      (play-from-hand state :corp "Thimblerig" "HQ")
+      (play-from-hand state :corp "Pup" "HQ")
+      (play-from-hand state :corp "Vanilla" "New remote")
+      (let [thimble (get-ice state :hq 0)
+            pup (get-ice state :hq 1)]
+        (core/rez state :corp thimble)
+        (core/rez state :corp pup)
+        (is (= "Thimblerig" (:title (get-ice state :hq 0))) "Thimblerig innermost ice on HQ")
+        (is (= "Pup" (:title (get-ice state :hq 1))) "Pup outermost ice on HQ")
+        (card-ability state :corp (refresh thimble) 0)
+        (prompt-select :corp (refresh pup))
+        (is (= "Pup" (:title (get-ice state :hq 0))) "Pup innermost ice on HQ after swap")
+        (is (= "Thimblerig" (:title (get-ice state :hq 1))) "Thimblerig outermost ice on HQ after swap"))
+      (let [thimble (get-ice state :hq 1)
+            vanilla (get-ice state :remote1 0)]
+        (run-on state "Server 1")
+        (is (= "Thimblerig" (:title (get-ice state :hq 1))) "Thimblerig outermost ice on HQ")
+        (is (= "Vanilla" (:title (get-ice state :remote1 0))) "Vanilla ice on remote")
+        (card-ability state :corp thimble 0)
+        (prompt-select :corp vanilla)
+        (is (= "Vanilla" (:title (get-ice state :hq 1))) "Vanilla outermost ice on HQ after swap during run")
+        (is (= "Thimblerig" (:title (get-ice state :remote1 0))) "Thimblerig ice on remote after swap during run")))))
+
 (deftest tithonium
   ;; Forfeit option as rez cost, can have hosted condition counters
   (testing "Basic test"


### PR DESCRIPTION
Does not restrict usage of swap ability at all, so it can be triggered outside start of turn, more than once per turn, or outside ice being passed. I did this because swapping ice manually is notoriously annoying, so it seemed best to make misclicks or missed triggers easily fixable, but can add restrictions if desired. 

Does not prompt for use after pass, which is good to keep runs easy but bad if people rush ahead and do irreversible stuff without noticing that Corp can trigger, so who knows. Does flag phase 1.2 if it rezzed and has a legal target.