### PR TITLE
Fixed mistake in flagging of 1.2 for Aesops

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -79,7 +79,7 @@
                                                  :effect (effect (gain-credits 1))}}}}}
 
    "Aesops Pawnshop"
-   {:flags {:runner-phase-12 (req (>= 2 (count (all-installed state :runner))))}
+   {:flags {:runner-phase-12 (req (>= (count (all-installed state :runner)) 2))}
     :abilities [{:effect (req (resolve-ability
                                 state side
                                 {:msg (msg "trash " (:title target) " and gain 3 [Credits]")


### PR DESCRIPTION
Super minor bugfix - Aesop's 1.2 flag req had the inequality the wrong way around, meaning it will flag phase 1.2 (almost) precisely when it shouldn't. This can affect play in very very niche situations (Stim Dealer about to deal brain damage, Aesops, Reaver and something else installed with an empty grip, maybe?).