### PR TITLE
FIX: #3701 Bloodletter corp prompt

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -407,9 +407,9 @@
                                           :choices ["Trash 1 program" "Trash top 2 of Stack"]
                                           :effect (req (if (and (= target "Trash top 2 of Stack") (pos? (count (:deck runner))))
                                                          (do (mill state :runner 2)
-                                                             (system-msg state :runner (str "trashes the top 2 cards of their Stack"))
-                                                             (clear-wait-prompt state :corp))
-                                                         (resolve-ability state :runner trash-program card nil)))}
+                                                             (system-msg state :runner (str "trashes the top 2 cards of their Stack")))
+                                                         (resolve-ability state :runner trash-program card nil))
+                                                      (clear-wait-prompt state :corp))}
                                         card nil))))}]}
 
    "Bloom"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -405,7 +405,7 @@
                                        (resolve-ability state :runner
                                          {:prompt "Trash 1 program or trash top 2 cards of the Stack?"
                                           :choices ["Trash 1 program" "Trash top 2 of Stack"]
-                                          :effect (req (if (and (= target "Trash top 2 of Stack") (pos? (count (:deck runner))))
+                                          :effect (req (if (and (= target "Trash top 2 of Stack") (> (count (:deck runner)) 1))
                                                          (do (mill state :runner 2)
                                                              (system-msg state :runner (str "trashes the top 2 cards of their Stack")))
                                                          (resolve-ability state :runner trash-program card nil))


### PR DESCRIPTION
clear-wait-prompt regardless of which option the runner chooses.
Also fixed issue with Bloodletter which allowed the runner to trash 2 from the stack with only 1 card in the stack, will now only allow Trash 2 from stack if there are more than 1 cards in the stack.