### PR TITLE
RaR: District 99 (feat. @nicohasa)

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -552,7 +552,7 @@
                                  true)))
                            (trash card {:cause :ability-cost}))}]}
 
-   "Dean Lister"
+   "Den Lister"
    {:abilities [{:req (req (:run @state))
                  :msg (msg "add +1 strength for each card in their Grip to " (:title target) " until the end of the run")
                  :choices {:req #(and (has-subtype? % "Icebreaker")
@@ -575,6 +575,19 @@
                               :req (req true)}]}
     :abilities [{:msg "avoid 1 tag" :effect (effect (tag-prevent 1) (trash card {:cause :ability-cost}))}]}
 
+   "District 99"
+   {:abilities [{:req (req (seq (filter #(= (:faction (:identity runner)) (:faction %)) (:discard runner))))
+                 :counter-cost [:power 3] :cost [:click 1]
+                 :prompt (msg "Which card to add to grip?")
+                 :choices (req (filter #(= (:faction (:identity runner)) (:faction %)) (:discard runner)))
+                 :effect (effect (move target :hand))
+                 :msg (msg "Add " (:title target) " to grip")}]
+    :events (let [f (fn [t] (some #(or (is-type? % "Program") (is-type? % "Hardware")) t))
+                  ab {:req (req (and (first-event? state :corp :corp-trash f)
+                                     (first-event? state :runner :runner-trash f)))
+                      :effect (effect (add-counter card :power 1))}]
+              {:corp-trash ab :runner-trash ab})}
+ 
    "DJ Fenris"
    (let [is-draft-id? #(.startsWith (:code %) "00")
          can-host? (fn [runner c] (and (is-type? c "Identity")

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -479,11 +479,11 @@
      (play-from-hand state :runner "Sure Gamble")
      (play-from-hand state :runner "District 99")
      (play-from-hand state :runner "Rebirth")
-     (let [fisk "Khan: Savvy Skiptracer"
-           fisk-choice (some #(when (= fisk (:title %)) %) (:choices (prompt-map :runner)))]
+     (let [khan "Khan: Savvy Skiptracer"
+           khan-choice (some #(when (= khan (:title %)) %) (:choices (prompt-map :runner)))]
        (core/resolve-prompt state :runner
-                            {:card fisk-choice})
-       (is (= fisk (-> (get-runner) :identity :title)) "Rebirthed into Fisk"))
+                            {:card khan-choice})
+       (is (= khan (-> (get-runner) :identity :title)) "Rebirthed into Khan"))
      (play-from-hand state :runner "Spy Camera")
      (play-from-hand state :runner "Faerie")
      (let [d99 (get-resource state 0)

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -437,6 +437,94 @@
     (is (= 1 (count (:discard (get-runner)))) "Decoy trashed")
     (is (zero? (:tag (get-runner))) "Tag avoided")))
 
+(deftest district-99
+  ;; District 99 - Gains power counters on hardware/program trashes, can spend 3 power counters to recur a card matching identity
+  (testing "Trashes by both sides and manual triggers"
+    (do-game
+     (new-game (default-corp ["Bio-Ethics Association"])
+               (default-runner ["District 99" (qty "Spy Camera" 2) "Faerie"]))
+     (play-from-hand state :corp "Bio-Ethics Association" "New remote")
+     (take-credits state :corp)
+     (play-from-hand state :runner "District 99")
+     (let [d99 (get-resource state 0)
+           bea (get-content state :remote1 0)]
+       (card-ability state :runner (refresh d99) 1) ; manually add power counter
+       (is (= 1 (get-counters (refresh d99) :power)) "1 power counter was added manually")
+       (card-ability state :runner (refresh d99) 1) ; try to manually add power counter twice
+       (is (= 1 (get-counters (refresh d99) :power)) "Manual power counter addition is only possible once per turn")
+       (play-from-hand state :runner "Spy Camera")
+       (card-ability state :runner (get-hardware state 0) 1) ; pop spy camera
+       (prompt-choice :runner "OK")
+       (is (= 1 (get-counters (refresh d99) :power)) "Manual power counter addition suppressed later trigger")
+       (play-from-hand state :runner "Spy Camera")
+       (is (= 1 (count (:hand (get-runner)))) "Faerie in hand")
+       (is (= "Faerie" (:title (first (:hand (get-runner))))))
+       (core/rez state :corp bea)
+       (take-credits state :runner)
+       (is (= 0 (count (:hand (get-runner)))) "Faerie was trashed")
+       (is (= 2 (get-counters (refresh d99) :power)) "Trashing Faerie from grip placed a counter")
+       (card-ability state :runner (get-hardware state 0) 1) ; pop spy camera
+       (prompt-choice :runner "OK")
+       (is (= 2 (get-counters (refresh d99) :power)) "Trashing Spy Camera after Faerie did not place a counter"))))
+  (testing "Rebirth interaction, basic functionality"
+    (do-game
+     (new-game (default-corp ["Grim"])
+               (make-deck "Armand \"Geist\" Walker: Tech Lord"
+                          ["District 99" (qty "Spy Camera" 3) "Faerie" "Rebirth" "Sure Gamble"]))
+     (play-from-hand state :corp "Grim" "HQ")
+     (take-credits state :corp)
+     (core/gain state :runner :click 10)
+     (core/click-draw state :runner nil)
+     (core/click-draw state :runner nil)
+     (play-from-hand state :runner "Sure Gamble")
+     (play-from-hand state :runner "District 99")
+     (play-from-hand state :runner "Rebirth")
+     (let [fisk "Khan: Savvy Skiptracer"
+           fisk-choice (some #(when (= fisk (:title %)) %) (:choices (prompt-map :runner)))]
+       (core/resolve-prompt state :runner
+                            {:card fisk-choice})
+       (is (= fisk (-> (get-runner) :identity :title)) "Rebirthed into Fisk"))
+     (play-from-hand state :runner "Spy Camera")
+     (play-from-hand state :runner "Faerie")
+     (let [d99 (get-resource state 0)
+           faerie (get-program state 0)
+           spycam (get-hardware state 0)
+           grim (get-ice state :hq 0)]
+       (run-on state :hq)
+       (core/rez state :corp grim)
+       (card-subroutine state :corp (refresh grim) 0)
+       (is (= 0 (get-counters (refresh d99) :power)) "No power counters before Faerie is trashed")
+       (prompt-select :corp faerie)
+       (is (= 1 (get-counters (refresh d99) :power)) "1 power counter was added for Faerie being trashed")
+       (card-ability state :runner spycam 1) ; pop spycam
+       (prompt-choice :runner "OK")
+       (is (= 1 (get-counters (refresh d99) :power)) "Trashing Spy Camera after Faerie did not add a second power counter")
+       (card-ability state :runner (refresh d99) 2) ; manually add counter
+       (is (= 1 (get-counters (refresh d99) :power)) "Can't manually add power counter after one has already been added") 
+       (run-jack-out state)
+       (play-from-hand state :runner "Spy Camera")
+       (take-credits state :runner)
+       (card-ability state :runner (get-hardware state 0) 1) ; pop spycam
+       (prompt-choice :runner "OK")
+       (is (= 2 (get-counters (refresh d99) :power)) "Trashing Spy Camera on Corp turn added a second power counter")
+       (take-credits state :corp)
+       (play-from-hand state :runner "Spy Camera")
+       (take-credits state :runner)
+       (card-ability state :runner (get-hardware state 0) 1) ; pop spycam
+       (prompt-choice :runner "OK")
+       (take-credits state :corp)
+       (is (= 3 (get-counters (refresh d99) :power)) "Trashing Spy Camera on Runner turn added a third power counter")
+       (let [faerie (first (filter #(= (:title %) "Faerie") (:discard (get-runner))))]
+         (doseq [c ["Sure Gamble" "Faerie" "Spy Camera"]]
+           (is (some? (filter #(= (:title %) c) (:hand (get-runner)))) (str c " is in the discard")))
+         (is (zero? (count (:hand (get-runner)))) "Faerie is not in hand")
+         (card-ability state :runner (refresh d99) 0)  ; Retrieve card from Archives
+         (is (= 2 (count (:choices (prompt-map :runner)))) "Runner can choose between Spy Camera and Faerie only")
+         (prompt-card :runner faerie)
+         (is (= 1 (count (:hand (get-runner)))) "1 card added to hand")
+         (is (= "Faerie" (-> (get-runner) :hand first :title)) "Faerie added to hand")
+         (is (zero? (get-counters (refresh d99) :power)) "Picking up Faerie removed 3 counters"))))))
+
 (let [choose-runner
       (fn [name state prompt-map]
                       (let [the-choice (some #(when (= name (:title %)) %) (:choices (prompt-map :runner)))]


### PR DESCRIPTION
Took this one over after @nicohasa left it half finished. Card is almost fully functional, but some trashes must be manually triggered. This interacts well with automatic triggers.

Specifically, programs trashed by installing over another program are customarily done by dragging them to heap, so it's hard for the game engine to know that this was a real trash. One option is to hook that up to trashes, but it's also pretty common for mistakes to be corrected like that ("actually, i don't want to install that black orchestra after all"), and I suspect having this trigger trash events causes more problems than it solves, so I did the lazy thing and added a "add power counter" ability. This 'eats' the D99 trigger for that turn, meaning users who trigger D99 manually, then later on pop a spycam won't have to remember they triggered it already.