### PR TITLE
More permissive rejoining of games before old client is fully disconnected

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -114,7 +114,7 @@
     reply-fn                            :?reply-fn}]
   (let [{:keys [original-players started players state] :as game} (lobby/game-for-id gameid)]
     (if (and started
-             (< (count players) 2)
+             (< (count (filter #(not= _id (-> % :user :_id)) players)) 2)
              (some #(= _id (:_id %)) (map :user original-players)))
       (let [player (lobby/join-game user client-id gameid)
             side (keyword (str (.toLowerCase (:side player)) "-state"))]

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -114,7 +114,7 @@
     reply-fn                            :?reply-fn}]
   (let [{:keys [original-players started players state] :as game} (lobby/game-for-id gameid)]
     (if (and started
-             (< (count (filter #(not= _id (-> % :user :_id)) players)) 2)
+             (< (count (filter #(not= _id (get-in % [:user :_id])) players)) 2)
              (some #(= _id (:_id %)) (map :user original-players)))
       (let [player (lobby/join-game user client-id gameid)
             side (keyword (str (.toLowerCase (:side player)) "-state"))]

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -164,7 +164,7 @@
   "Adds the given user as a player in the given gameid."
   [{options :options _id :_id :as user} client-id gameid]
   (let [{players :players :as game} (game-for-id gameid)]
-    (when (< (count (filter #(not= _id (-> % :user :_id)) players)) 2)
+    (when (< (count (filter #(not= _id (get-in % [:user :_id])) players)) 2)
       (let [{side :side :as fplayer} (first players)
             new-side (if (= "Corp" side) "Runner" "Corp")
             new-player {:user    user

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -162,9 +162,9 @@
 
 (defn join-game
   "Adds the given user as a player in the given gameid."
-  [{options :options :as user} client-id gameid]
+  [{options :options _id :_id :as user} client-id gameid]
   (let [{players :players :as game} (game-for-id gameid)]
-    (when (< (count players) 2)
+    (when (< (count (filter #(not= _id (-> % :user :_id)) players)) 2)
       (let [{side :side :as fplayer} (first players)
             new-side (if (= "Corp" side) "Runner" "Corp")
             new-player {:user    user


### PR DESCRIPTION
Instead of requiring < 2 players (which includes a "ghost" player whose websocket is still connected/timing out but unresponsive), we can rejoin if there are < 2 players who are not us. As a fun fact, this lets you open two separate browsers and rejoin your own game while your other browser is still active, then play the game across two browser windows with no issues. 