### PR TITLE
Fix #3751, Citadel Sanctuary + Thunder Art Gallery

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -379,7 +379,8 @@
               :label "Trace 1 - If unsuccessful, Runner removes 1 tag"
               :trace {:base 1
                       :unsuccessful {:msg "remove 1 tag"
-                                     :effect (effect (lose-tags :runner 1))}}}}}
+                                     :async true
+                                     :effect (effect (lose-tags :runner eid 1))}}}}}
 
    "Clan Vengeance"
    {:events {:pre-resolve-damage {:req (req (pos? (last targets)))
@@ -2019,9 +2020,11 @@
    "Thunder Art Gallery"
    (let [first-event-check (fn [state fn1 fn2] (and (fn1 state :runner :runner-lose-tag #(= :runner (second %)))
                                             (fn2 state :runner :runner-prevent (fn [t] (seq (filter #(some #{:tag} %) t))))))
-         ability {:choices (req (cancellable (remove #(is-type? % "Event") (:hand runner))))
+         ability {:choices {:req #(and (= "Runner" (:side %))
+                                       (in-hand? %)
+                                       (not (is-type? % "Event")))}
                   :async true
-                  :prompt (msg "Which card to install?")
+                  :prompt (msg "Select a card to install with Thunder Art Gallery")
                   :effect (req (if (and (runner-can-install? state side target)
                                         (can-pay? state side target
                                                   (install-cost state side target [:credit (dec (:cost target))])))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -232,6 +232,29 @@
     (play-from-hand state :corp "Traffic Accident")
     (is (= 3 (count (:discard (get-runner)))) "Conventional meat damage not prevented by Parlor")))
 
+(deftest citadel-sanctuary
+  (testing "Interaction with Corporate Grant and Thunder Art Gallery"
+    (do-game
+      (new-game (default-corp)
+                (default-runner ["Citadel Sanctuary" "Thunder Art Gallery" "Corroder" "Corporate \"Grant\""]))
+      (take-credits state :corp)
+      (core/gain state :runner :credit 5)
+      (play-from-hand state :runner "Citadel Sanctuary")
+      (play-from-hand state :runner "Thunder Art Gallery")
+      (play-from-hand state :runner "Corporate \"Grant\"")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (core/gain-tags state :runner 1)
+      (core/lose state :runner :click 3)
+      (core/end-turn state :runner nil)
+      (is (= 11 (:credit (get-corp))) "Corp has 11 credits before Corporate Grant")
+      (prompt-choice :corp 0)
+      (prompt-choice :runner 1)
+      (is (not (:end-turn @state)) "Runner turn has not yet ended")
+      (prompt-select :runner (find-card "Corroder" (:hand (get-runner))))
+      (is (:end-turn @state) "Runner turn has now ended")
+      (is (= 10 (:credit (get-corp))) "Corp lost 1 credit to Corporate Grant"))))
+
 (deftest compromised-employee
   ;; Compromised Employee - Gain 1c every time Corp rezzes ICE
   (do-game
@@ -2561,7 +2584,7 @@
       (core/gain-credits state :runner 1)
       (core/gain-tags state :corp 1)
       (core/remove-tag state :runner nil)
-      (prompt-card :runner (find-card "New Angeles City Hall" (:hand (get-runner))))
+      (prompt-select :runner (find-card "New Angeles City Hall" (:hand (get-runner))))
       (is (= 1 (:credit (get-runner))) "Runner paid one less to install (but 2 to remove tag)")
       (is (= "New Angeles City Hall" (:title (get-resource state 1))) "NACH is installed")
       (take-credits state :runner)
@@ -2569,7 +2592,7 @@
       (core/gain-tags state :corp 1)
       (card-ability state :runner (get-resource state 1) 0)
       (prompt-choice :runner "Done")
-      (prompt-card :runner (find-card "Corroder" (:hand (get-runner))))
+      (prompt-select :runner (find-card "Corroder" (:hand (get-runner))))
       (is (= 0 (:credit (get-runner))) "Runner paid one less to install")
       (is (= "Corroder" (:title (get-program state 0))) "Corroder is installed"))))
 


### PR DESCRIPTION
Saintis nailed it, `lose-tags` is async to Citadel's trace effect must be async.

I also changed Thunder Art Gallery to use a selection prompt instead of a choices prompt. Remember the general guideline: if the valid targets can be seen by the player, use a selection prompt.