### PR TITLE
Improve Arella Salvatore interaction with other on-scored triggers

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -21,24 +21,29 @@
                                  :yes-ability {:effect (effect (rez-cost-bonus -3) (rez target))}}}}}
 
    "Arella Salvatore"
-   {:events
-    {:agenda-scored
-     {:req (req (and (= (:previous-zone target) (:zone card))
-                     (some #(corp-installable-type? %) (:hand corp))))
-      :interactive (req true)
-      :prompt "Select a card to install with Arella Salvatore"
-      :choices {:req #(and (corp-installable-type? %)
-                           (in-hand? %)
-                           (= (:side %) "Corp"))}
-      :async true
-      :cancel-effect (req (effect-completed state side eid))
-      :effect (req (wait-for (corp-install state :corp target nil {:no-install-cost true :display-message false})
-                             (let [inst-target (find-latest state target)]
-                               (add-prop state :corp inst-target :advance-counter 1 {:placed true})
-                               (system-msg state :corp
-                                           (str "uses Arella Salvatore to install and place a counter on "
-                                                (card-str state inst-target) ", ignoring all costs"))
-                               (effect-completed state side eid))))}}}
+   (let [select-ability
+         {:prompt "Select a card to install with Arella Salvatore"
+          :choices {:req #(and (corp-installable-type? %)
+                               (in-hand? %)
+                               (= (:side %) "Corp"))}
+          :async true
+          :cancel-effect (req (effect-completed state side eid))
+          :effect (req (wait-for (corp-install state :corp target nil {:no-install-cost true :display-message false})
+                                 (let [inst-target (find-latest state target)]
+                                   (add-prop state :corp inst-target :advance-counter 1 {:placed true})
+                                   (system-msg state :corp
+                                               (str "uses Arella Salvatore to install and place a counter on "
+                                                    (card-str state inst-target) ", ignoring all costs"))
+                                   (effect-completed state side eid))))}]
+     {:events
+      {:agenda-scored
+       {:req (req (and (= (:previous-zone target) (:zone card))))
+        :interactive (req true)
+        :silent (req (empty? (filter corp-installable-type? (:hand corp))))
+        :async true
+        :effect (req (if (some corp-installable-type? (:hand corp))
+                       (continue-ability state side select-ability card nil)
+                       (effect-completed state side eid)))}}})
 
    "Ash 2X3ZB9CY"
    {:events {:successful-run {:interactive (req true)

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -45,6 +45,24 @@
         (is (= 2 (count (get-scored state :corp))) "2 Agendas scored")
         (is (= 1 (count (get-content state :remote3))) "Bryan installed in new remote")
         (is (= 1 (get-counters (get-content state :remote3 0) :advancement)) "Bryan has 1 advancement counter"))))
+  (testing "Interaction w/ other on-scored triggers"
+    (do-game
+      (new-game (make-deck "Sportsmetal: Go Big or Go Home" ["Arella Salvatore" "Domestic Sleepers" "Project Vitruvius" "Hedge Fund"])
+                (default-runner))
+      (starting-hand state :corp ["Arella Salvatore" "Domestic Sleepers"])
+      (play-from-hand state :corp "Arella Salvatore" "New remote")
+      (play-from-hand state :corp "Domestic Sleepers" "Server 1")
+      (let [arella (get-content state :remote1 0)
+            domest (get-content state :remote1 1)]
+        (core/rez state :corp arella)
+        (score-agenda state :corp (refresh domest))
+        ;; Simultaneous prompt: Sportsmetal automatically triggers, as Arella is silent because there are no installable cards in HQ
+        (prompt-choice-partial :corp "cards")
+        ;; Arella is no longer silent and now triggers
+        (prompt-select :corp (find-card "Project Vitruvius" (:hand (get-corp))))
+        (prompt-choice :corp "Server 1")
+        (is (= 2 (count (get-content state :remote1))) "Agenda installed in server 1")
+        (is (= 1 (get-counters (get-content state :remote1 1) :advancement)) "Agenda has 1 advancement counter"))))
   (testing "No cost"
     (do-game
       (new-game (default-corp ["Arella Salvatore" "TGTBT" (qty "Ice Wall" 2)])


### PR DESCRIPTION
Reminder to self and other devs: the `:req` of an event handler is for deciding whether the handler exists at all, and not for helpful shortcut logic. When an event is triggered, we gather all handlers whose `:req` evaluates to true, thus the `:req` should only determine if the triggered event is compatible with the wording of the handler (in this case, that the scored agenda came from Arella's server). Any other conditional logic, including the "Y" in the generic template "Whenever X, if Y then do Z", needs to be in the `:effect` of the handler. Since Arella does not read "If you have at least one installable card in HQ when you score an agenda...", that part of the logic goes in the effect.

A second improvement to this card uses `:silent` to hide Arella as a possible simultaneous event resolution target if there are no installables in HQ. `:silent` is re-evaluated after each individual handler resolves, so this allows Arella to be invisible if there is no reason to interact with her; but if another handler goes first and causes a draw (like Sportsmetal), then after that handler resolves, Arella will now show up in the menu. If all other handlers complete and Arella is still silent, then she will automatically be invoked (silent event handlers are invoked once all non-silent handlers have resolved) and go to the false branch of her effect, skipping her prompt completely.

I think that should work well.