### PR TITLE
Remove superfluous periods from Bankroll text.

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -57,14 +57,14 @@
    "Bankroll"
    {:implementation "Bankroll gains credits automatically."
     :events {:successful-run {:effect (effect (add-counter card :credit 1)
-                                              (system-msg "places 1 [Credit] on Bankroll."))}}
-    :abilities [{:label "[Trash]: Take all credits from Bankroll."
+                                              (system-msg "places 1 [Credit] on Bankroll"))}}
+    :abilities [{:label "[Trash]: Take all credits from Bankroll"
                  :async true
                  :effect (req (let [credits-on-bankroll (get-counters card :credit)]
                                 (wait-for (trash state :runner card {:cause :ability-cost})
                                           (take-credits state :runner credits-on-bankroll)
                                           (system-msg state :runner (str "trashes Bankroll and takes "
-                                                                         credits-on-bankroll " credits from it.")))))}]}
+                                                                         credits-on-bankroll " credits from it")))))}]}
 
    "Bishop"
    {:abilities [{:cost [:click 1]


### PR DESCRIPTION
Periods are automatically added to system messages.