### PR TITLE
Wait for Saraswati's card to be installed before adding a counter

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -940,7 +940,8 @@
                                                                  ((constantly false) (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
                                                                  true))))
                                       (wait-for (corp-install state side chosen target nil)
-                                                (add-prop state :corp (find-latest state chosen) :advance-counter 1 {:placed true}))})]
+                                                (add-prop state :corp (find-latest state chosen) :advance-counter 1 {:placed true})
+                                                (effect-completed state side eid)))})]
    {:abilities [{:async true
                  :label "Install a card from HQ"
                  :cost [:click 1 :credit 1]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -939,7 +939,8 @@
                                                                         (>= (get-counters card :advancement) (or (:current-cost card) (:advancementcost card))))
                                                                  ((constantly false) (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
                                                                  true))))
-                                      (corp-install state side eid (assoc chosen :advance-counter 1) target nil))})]
+                                      (wait-for (corp-install state side chosen target nil)
+                                                (add-prop state :corp (find-latest state chosen) :advance-counter 1 {:placed true}))})]
    {:abilities [{:async true
                  :label "Install a card from HQ"
                  :cost [:click 1 :credit 1]


### PR DESCRIPTION
The wording of the card implies that the target is first installed, then an advancement is placed. Fixes #3766.