### PR TITLE
RaR: Acme Consulting and Daruma

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -75,6 +75,28 @@
                                                card nil))))}}}
                          card nil)))}}}
 
+   "Acme Consulting: The Truth You Need"
+   (letfn [(activate [state card active]
+             (update! state :corp (assoc-in card [:special :acme-active] active))
+             (swap! state update-in [:runner :additional-tag] (if active inc dec)))
+           (outermost? [run-position run-ices]
+             (and run-position
+                  (pos? run-position)
+                  (= run-position (count run-ices))))]
+     {:implementation "Tag is gained on approach, not on encounter"
+      :events {:run {:effect (req (when (and (outermost? run-position run-ices)
+                                             (rezzed? current-ice))
+                                    (activate state card true)))}
+               :rez {:effect (req (when (outermost? run-position run-ices)
+                                    (activate state card true)))}
+               :derez {:effect (req (when (outermost? run-position run-ices)
+                                      (activate state card false)))}
+               :pass-ice {:effect (req (when (and (outermost? run-position run-ices)
+                                                  (get-in card [:special :acme-active]))
+                                         (activate state card false)))}
+               :end-run {:effect (req (when (get-in card [:special :acme-active])
+                                        (activate state card false)))}}})
+
    "Adam: Compulsive Hacker"
    {:events {:pre-start-game
              {:req (req (= side :runner))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -282,6 +282,37 @@
     :abilities [{:label "[Trash]: Purge virus counters"
                  :msg "purge virus counters" :effect (effect (trash card) (purge))}]}
 
+   "Daruma"
+   (letfn [(choose-swap [to-swap]
+             {:prompt (str "Select a card to swap with " (:title to-swap))
+              :choices {:not-self true
+                        :req #(and (= "Corp" (:side %))
+                                   (#{"Asset" "Agenda" "Upgrade"} (:type %))
+                                   (or (in-hand? %) ; agenda, asset or upgrade from HQ
+                                       (and (installed? %) ; card installed in a server
+                                            ;; central upgrades are not in a server
+                                            (not (#{:hq :rd :archives} (first (:zone %)))))))}
+              :effect (req (wait-for (trash state :corp card nil )
+                                     (move state :corp to-swap (:zone target) {:keep-server-alive true})
+                                     (move state :corp target (:zone to-swap) {:keep-server-alive true})
+                                     (system-msg state :corp
+                                                 (str "uses Daruma to swap " (card-str state to-swap)
+                                                      " with " (card-str state target)))
+                                     (clear-wait-prompt state :runner)))
+              :cancel-effect (effect (clear-wait-prompt :runner))})
+           (ability [card]
+             {:optional {:prompt "Trash Daruma to swap a card in this server?"
+                         :yes-ability {:async true
+                                       :prompt "Select a card in this server to swap"
+                                       :choices {:req #(and (installed? %)
+                                                            (in-same-server? card %))
+                                                 :not-self true}
+                                       :effect (effect (continue-ability (choose-swap target) card nil))}
+                         :no-ability {:effect (effect (clear-wait-prompt :runner))}}})]
+   {:events {:approach-server {:async true
+                               :effect (effect (show-wait-prompt :runner "Corp to use Daruma")
+                                               (continue-ability :corp (ability card) card nil))}}})
+
    "Dedicated Technician Team"
    {:recurring 2}
 

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -531,8 +531,9 @@
                     (system-msg state side "continues the run")
                     (when cur-ice
                       (update-ice-strength state side cur-ice))
-                    (when next-ice
-                      (trigger-event-sync state side (make-eid state) :approach-ice next-ice))
+                    (if  next-ice
+                      (trigger-event-sync state side (make-eid state) :approach-ice next-ice)
+                      (trigger-event-sync state side (make-eid state) :approach-server))
                     (doseq [p (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
                       (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
                       (update-breaker-strength state side p)))))))

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -36,7 +36,8 @@
   "Returns true if the runner is tagged."
   [state]
   (or (pos? (get-in state [:runner :tag]))
-      (pos? (get-in state [:runner :tagged]))))
+      (pos? (get-in state [:runner :tagged]))
+      (pos? (get-in state [:runner :additional-tag]))))
 
 ;;; Generic flag functions
 (defn- register-flag!

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -28,8 +28,10 @@
        (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
        (update-all-ice state :corp)
        (swap! state update-in [:stats side :runs :started] (fnil inc 0))
-       (trigger-event-sync state :runner (make-eid state) :run s)
-       (when (>= n 2) (trigger-event state :runner :run-big s n))))))
+       (wait-for (trigger-event-sync state :runner :run s)
+                 (when (>= n 2) (trigger-event state :runner :run-big s n))
+                 (when (zero? n)
+                   (trigger-event-sync state :runner (make-eid state) :approach-server nil)))))))
 
 (defn gain-run-credits
   "Add temporary credits that will disappear when the run is over."

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -70,11 +70,14 @@
               :hand []
               :discard [] :scored [] :rfg [] :play-area []
               :servers {:hq {} :rd {} :archives {}}
-              :click 0 :credit 5 :bad-publicity 0 :has-bad-pub 0
+              :click 0 :click-per-turn 3
+              :credit 5
+              :bad-publicity 0 :has-bad-pub 0
               :toast []
               :hand-size {:base 5 :mod 0}
               :agenda-point 0
-              :click-per-turn 3 :agenda-point-req 7 :keep false}
+              :agenda-point-req 7
+              :keep false}
        :runner {:user (:user runner) :identity runner-identity
                 :options runner-options
                 :deck (zone :deck runner-deck)
@@ -83,12 +86,17 @@
                 :discard [] :scored [] :rfg [] :play-area []
                 :rig {:program [] :resource [] :hardware []}
                 :toast []
-                :click 0 :credit 5 :run-credit 0 :link 0 :tag 0
+                :click 0 :click-per-turn 4
+                :credit 5 :run-credit 0
+                :link 0
+                :tag 0 :tagged 0 :additional-tag 0
                 :memory {:base 4 :mod 0 :used 0}
                 :hand-size {:base 5 :mod 0}
                 :agenda-point 0
-                :hq-access 1 :rd-access 1 :tagged 0
-                :brain-damage 0 :click-per-turn 4 :agenda-point-req 7 :keep false}})))
+                :hq-access 1 :rd-access 1
+                :brain-damage 0
+                :agenda-point-req 7
+                :keep false}})))
 
 (defn init-game
   "Initializes a new game with the given players vector."

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -29,9 +29,9 @@
             'run-server '(when (:run @state)
                            (get-in @state (concat [:corp :servers] (:server (:run @state)))))
             'run-ices '(:ices run-server)
-            'current-ice '(when-let [run-pos (:position (:run @state))]
-                            (when (and (pos? run-pos) (<= run-pos (count (:ices run-server))))
-                              (nth (:ices run-server) (dec run-pos))))
+            'run-position '(:position (:run @state))
+            'current-ice '(when (and run-position (pos? run-position ) (<= run-position (count (:ices run-server))))
+                            (nth (:ices run-server) (dec run-position)))
             'corp-reg '(get-in @state [:corp :register])
             'corp-reg-last '(get-in @state [:corp :register-last-turn])
             'runner-reg '(get-in @state [:runner :register])
@@ -47,7 +47,9 @@
             'hq-runnable '(not (:hq (get-in runner [:register :cannot-run-on-server])))
             'rd-runnable '(not (:rd (get-in runner [:register :cannot-run-on-server])))
             'archives-runnable '(not (:archives (get-in runner [:register :cannot-run-on-server])))
-            'tagged '(or (pos? (:tagged runner)) (pos? (:tag runner)))
+            'tagged '(or (pos? (:tagged runner))
+                         (pos? (:tag runner))
+                         (pos? (:additional-tag runner)))
             'has-bad-pub '(or (pos? (:bad-publicity corp)) (pos? (:has-bad-pub corp)))
             'this-server '(let [s (-> card :zone rest butlast)
                                 r (:server run)]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -244,9 +244,9 @@
   "Converts a central zone keyword to a string."
   [zone]
   (case (if (keyword? zone) zone (last zone))
-    :hq "HQ"
-    :rd "R&D"
-    :archives "Archives"
+    (:hand :hq) "HQ"
+    (:deck :rd) "R&D"
+    (:discard :archives) "Archives"
     nil))
 
 (defn zone->name

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -149,9 +149,7 @@
       (run-on state :archives)
       (is (core/is-tagged? @state) "Runner is tagged when encountering outermost ice")
       (run-continue state)
-      (is (not (core/is-tagged? @state)) "Runner is not tagged when encountering second ice")))
-
-  )
+      (is (not (core/is-tagged? @state)) "Runner is not tagged when encountering second ice"))))
 
 (deftest adam:-compulsive-hacker
   ;; Adam

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -76,6 +76,83 @@
         (is (= 1 (- corp-credits (:credit (get-corp)))) "Should lose 1 credit from 419 ability")
         (is (zero? (- runner-credits (:credit (get-runner)))) "Should not gain any credits from Ixodidae")))))
 
+(deftest acme-consulting:-the-truth-you-need
+  (testing "Tag gain when rezzing outermost ice"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" ["Vanilla" (qty "Hedge Fund" 5)])
+        (default-runner))
+      (play-from-hand state :corp "Vanilla" "Archives")
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (not (core/is-tagged? @state)) "Runner does not encounter an unrezzed ice")
+      (core/rez state :corp (get-ice state :archives 0))
+      (is (core/is-tagged? @state) "Runner is tagged when encountering outermost ice")
+      (run-continue state)
+      (is (not (core/is-tagged? @state)) "Runner no longer encountering outermost ice")))
+  (testing "Interaction with Data Ward"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" ["Data Ward" (qty "Hedge Fund" 5)])
+        (default-runner))
+      (core/gain state :corp :credit 10)
+      (play-from-hand state :corp "Data Ward" "Archives")
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (not (core/is-tagged? @state)) "Runner does not encounter an unrezzed ice")
+      (core/rez state :corp (get-ice state :archives 0))
+      (is (core/is-tagged? @state) "Runner is tagged when encountering outermost ice")
+      (card-subroutine state :corp (get-ice state :archives 0) 0)
+      (is (not (:run @state)) "Run ended by Data Ward")))
+  (testing "Tag gain when starting run"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" ["Vanilla" (qty "Hedge Fund" 5)])
+        (default-runner))
+      (play-from-hand state :corp "Vanilla" "Archives")
+      (core/rez state :corp (get-ice state :archives 0))
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (core/is-tagged? @state) "Runner is tagged when encountering outermost ice")
+      (run-continue state)
+      (is (not (core/is-tagged? @state)) "Runner no longer encountering outermost ice")))
+  (testing "Tag loss when derezzing ice"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" ["Vanilla" (qty "Hedge Fund" 5)])
+        (default-runner))
+      (play-from-hand state :corp "Vanilla" "Archives")
+      (core/rez state :corp (get-ice state :archives 0))
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (core/is-tagged? @state) "Runner is tagged when encountering outermost ice")
+      (core/derez state :corp (get-ice state :archives 0))
+      (is (not (core/is-tagged? @state)) "Runner no longer encountering the derezzed ice")))
+  (testing "No tag on empty server"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" ["Vanilla" (qty "Hedge Fund" 5)])
+        (default-runner))
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (not (core/is-tagged? @state)) "No ice to encounter")))
+  (testing "No tag when encountering second ice"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" [(qty "Vanilla" 2) (qty "Hedge Fund" 4)])
+        (default-runner))
+      (play-from-hand state :corp "Vanilla" "Archives")
+      (play-from-hand state :corp "Vanilla" "Archives")
+      (core/rez state :corp (get-ice state :archives 0))
+      (core/rez state :corp (get-ice state :archives 1))
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (core/is-tagged? @state) "Runner is tagged when encountering outermost ice")
+      (run-continue state)
+      (is (not (core/is-tagged? @state)) "Runner is not tagged when encountering second ice")))
+
+  )
+
 (deftest adam:-compulsive-hacker
   ;; Adam
   (testing "Allow runner to choose directives"


### PR DESCRIPTION
Adds `:additional-tag` counter to Runner's state, giving us three tag counters: `:tag` (physical tags), `:tagged` ("is tagged", Papparazi), and `:additional-tag` (Acme). Updated `is-tagged?` and the `req` macro to account for this.

Acme grants `:additional-tag`  in the following situations:

* Starting a run on a server with a rezzed outermost ice.
* Rezzing the outermost ice during a run.

Gaining a tag thus sets a flag on the identity that is used to determine when to remove the additional tag:

Loses a tag (all of these require the flag being set):

* Run ends.
* Outermost ice is derezzed.
* Passing the outermost ice.

I think that should cover it.

Known issues that we can fix later:

* Does not cause Rachel Beckman to trash herself.
* Does not account for bypassing on approach with Charlatan.



### Daruma

Added a `:approach-server` event. Known issue: can swap a second agenda into a server that already has one. Did not write a test, short on time.