### PR TITLE
WIP: Various fixes Mk 2

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -252,7 +252,8 @@
                                                   (when-scored? %)
                                                   (:abilities %))}
                              :msg (msg "trigger the \"when scored\" ability of " (:title target))
-                             :effect (effect (continue-ability (card-def target) target nil))}}}
+                             :effect (effect (continue-ability (card-def target) target nil))}
+               :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
 
    "Brain Rewiring"
    {:effect (effect (show-wait-prompt :runner "Corp to use Brain Rewiring")

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1593,10 +1593,6 @@
                  ;; enable-identity does not do everything that init-identity does
                  (init-identity state side new-id))
 
-               (system-msg state side "NOTE: passive abilities (Kate, Gabe, etc) will incorrectly fire
-                if their once per turn condition was met this turn before Rebirth was played.
-                Please adjust your game state manually for the rest of this turn if necessary")
-
                ;; Handle Ayla - Part 2
                (when-not (empty? (-> @state :runner :temp-nvram))
                  (doseq [c (-> @state :runner :temp-nvram)]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -21,6 +21,15 @@
                            ((or post-run-effect (effect)) eid card targets))}
           cdef)))
 
+(defn- cutlery
+  [subtype]
+  ;; Subtype does nothing currently, but might be used if trashing is properly implemented
+  {:implementation "Ice trash is manual, always enables Reprisals"
+   :prompt "Choose a server"
+   :choices (req runnable-servers)
+   :effect (req (run state :runner target nil card)
+                (swap! state assoc-in [:runner :register :trashed-card] true))})
+
 (def card-definitions
   {"Account Siphon"
    {:req (req hq-runnable)
@@ -780,10 +789,7 @@
                      card nil)))}
 
    "Forked"
-   {:implementation "Ice trash is manual"
-    :prompt "Choose a server"
-    :choices (req runnable-servers)
-    :effect (effect (run target nil card))}
+   (cutlery "Sentry")
 
    "Frame Job"
    {:prompt "Choose an agenda to forfeit"
@@ -1131,10 +1137,7 @@
                      (gain state :corp :hand-size {:mod (:bad-publicity corp)}))}
 
    "Knifed"
-   {:implementation "Ice trash is manual"
-    :prompt "Choose a server"
-    :choices (req runnable-servers)
-    :effect (effect (run target nil card))}
+   (cutlery "Barrier")
 
    "Kraken"
    {:req (req (:stole-agenda runner-reg)) :prompt "Choose a server" :choices (req servers)
@@ -1822,10 +1825,7 @@
     :choices (req (cancellable (filter #(has-subtype? % "Icebreaker") (:deck runner)) :sorted))}
 
    "Spooned"
-   {:implementation "Ice trash is manual"
-    :prompt "Choose a server"
-    :choices (req runnable-servers)
-    :effect (effect (run target nil card))}
+   (cutlery "Code Gate")
 
    "Spot the Prey"
    {:prompt "Select 1 non-ICE card to expose"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1189,8 +1189,7 @@
    {:events {:pre-start-game {:effect draft-points-target}}}
 
    "The Outfit: Family Owned and Operated"
-   {:events {:corp-gain-bad-publicity {:async true
-                                       :msg "gain 3 [Credit]"
+   {:events {:corp-gain-bad-publicity {:msg "gain 3 [Credit]"
                                        :effect (effect (gain-credits 3))}}}
 
    ;; No special implementation

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -152,7 +152,7 @@
                                  (:runner-phase-12 @state)))
                   :effect (effect (runner-install target {:facedown true}))}]
      {:events {:runner-turn-begins ability}
-      :flags {:runner-phase-12 (req (pos? (count (:hand runner))))}
+      :flags {:runner-phase-12 (req true)}
       :abilities [ability]})
 
    "Argus Security: Protection Guaranteed"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1153,7 +1153,11 @@
                              (handle-end-run state side)))})]
    {:implementation "Does not handle UFAQ interaction with Singularity"
     :events {:runner-trash {:async true
-                            :req (req (= (-> card :zone second) (-> target :zone second)))
+                            :req (req (let [target-zone (:zone target)
+                                            target-zone (or (central->zone target-zone) target-zone)
+                                            warroid-zone (:zone card)]
+                                        (= (second warroid-zone)
+                                           (second target-zone))))
                             :trace {:base 4
                                     :successful
                                     {:effect

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -32,7 +32,7 @@
 
 (defn is-ability?
   "Checks to see if a given map represents a card ability. Looks for :effect, :optional, :trace, or :psi."
-  [{:keys [effect optional trace psi] :as abi}]
+  [{:keys [effect optional trace psi]}]
   (or effect optional trace psi))
 
 (defn resolve-ability

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -252,13 +252,19 @@
   ([state side ev pred]
    (empty? (filter pred (turn-events state side ev)))))
 
+(defn event-count
+  "Returns the number of an event this turn."
+  ([state side ev] (event-count state side ev (constantly true)))
+  ([state side ev pred]
+   (count (filter pred (turn-events state side ev)))))
+
 (defn first-event?
   "Returns true if the given event has only occured once this turn.
   Includes itself if this is checked in the requirement for an event ability.
   Filters on events satisfying (pred targets) if given pred."
   ([state side ev] (first-event? state side ev (constantly true)))
   ([state side ev pred]
-   (= 1 (count (filter pred (turn-events state side ev))))))
+   (= 1 (event-count state side ev pred))))
 
 (defn second-event?
   "Returns true if the given event has occurred twice this turn.
@@ -266,12 +272,7 @@
   Filters on events satisfying (pred targets) if given pred."
   ([state side ev] (second-event? state side ev (constantly true)))
   ([state side ev pred]
-   (= 2 (count (filter pred (turn-events state side ev))))))
-
-(defn event-count
-  "Returns the number of an event this turn."
-  [state side ev]
-  (count (turn-events state side ev)))
+   (= 2 (event-count state side ev pred))))
 
 (defn first-successful-run-on-server?
   "Returns true if the active run is the first succesful run on the given server"

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2138,6 +2138,7 @@
       chaos "Chaos Theory: Wünderkind"
       whizzard "Whizzard: Master Gamer"
       reina "Reina Roja: Freedom Fighter"]
+
   (deftest rebirth
     ;; Rebirth - Kate's discount applies after rebirth
     (testing "Kate"
@@ -2198,18 +2199,31 @@
         (play-from-hand state :runner "Rebirth")
         (choose-runner chaos state prompt-map)
         (is (= :full (get-in (get-runner) [:identity :implementation])) "Implementation note kept as `:full`"))))
-  (deftest-pending rebirth-kate-twice
-    ;; Rebirth - Kate's discount does not after rebirth if something already installed
-    (do-game
-      (new-game (default-corp)
-                (default-runner ["Akamatsu Mem Chip" "Rebirth" "Clone Chip"])
-                {:start-as :runner})
-      (play-from-hand state :runner "Clone Chip")
-      (play-from-hand state :runner "Rebirth")
-      (choose-runner kate state prompt-map)
-      (is (changes-credits (get-corp) -1
-                           (play-from-hand state :runner "Akamatsu Mem Chip"))
-          "Discount not applied for 2nd install"))))
+
+  (deftest rebirth-kate-twice
+    ;; Rebirth - Kate does not give discount after rebirth if Hardware or Program already installed
+    (testing "Installing Hardware before does prevent discount"
+      (do-game
+        (new-game (default-corp)
+                  (default-runner ["Akamatsu Mem Chip" "Rebirth" "Clone Chip"])
+                  {:start-as :runner})
+        (play-from-hand state :runner "Clone Chip")
+        (play-from-hand state :runner "Rebirth")
+        (choose-runner kate state prompt-map)
+        (is (changes-credits (get-runner) -1
+                             (play-from-hand state :runner "Akamatsu Mem Chip"))
+            "Discount not applied for 2nd install")))
+    (testing "Installing Resource before does not prevent discount"
+      (do-game
+        (new-game (default-corp)
+                  (default-runner ["Akamatsu Mem Chip" "Rebirth" "Same Old Thing"])
+                  {:start-as :runner})
+        (play-from-hand state :runner "Same Old Thing")
+        (play-from-hand state :runner "Rebirth")
+        (choose-runner kate state prompt-map)
+        (is (changes-credits (get-runner) 0
+                             (play-from-hand state :runner "Akamatsu Mem Chip"))
+            "Discount is applied for 2nd install (since it is the first Hardware / Program)"))))
 
 (deftest reboot
   ;; Reboot - run on Archives, install 5 cards from head facedown

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2126,11 +2126,7 @@
       (is (= (- runner-creds 4) (:credit (get-runner))) "Paid 4 credits to trash PAD Campaign"))))
 
 ;; Rebirth
-(let [choose-runner
-      (fn [id-name state prompt-map]
-        (let [kate-choice (some #(when (= id-name (:title %)) %) (:choices (prompt-map :runner)))]
-          (core/resolve-prompt state :runner {:card kate-choice})))
-      akiko "Akiko Nisei: Head Case"
+(let [akiko "Akiko Nisei: Head Case"
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"
       kit "Rielle \"Kit\" Peddler: Transhuman"
       professor "The Professor: Keeper of Knowledge"
@@ -2152,7 +2148,7 @@
                     [kate kit]))
         (is (not-any? #(some #{%} (prompt-titles :runner))
                       [professor whizzard jamie]))
-        (choose-runner kate state prompt-map)
+        (rebirth-choice state kate)
         (is (= kate (-> (get-runner) :identity :title)))
         (is (= 1 (:link (get-runner))) "1 link")
         (is (empty? (:discard (get-runner))))
@@ -2165,7 +2161,7 @@
         (play-from-hand state :corp "Ice Wall" "R&D")
         (take-credits state :corp)
         (play-from-hand state :runner "Rebirth")
-        (choose-runner whizzard state prompt-map)
+        (rebirth-choice state whizzard)
         (card-ability state :runner (:identity (get-runner)) 0)
         (is (= 6 (:credit (get-runner))) "Took a Whizzard credit")
         (is (changes-credits (get-corp) -1
@@ -2179,7 +2175,7 @@
         (play-from-hand state :runner "Access to Globalsec")
         (is (= 2 (:link (get-runner))) "2 link before rebirth")
         (play-from-hand state :runner "Rebirth")
-        (choose-runner chaos state prompt-map)
+        (rebirth-choice state chaos)
         (is (= 1 (:link (get-runner))) "1 link after rebirth")))
     (testing "Gain link from ID"
       (do-game
@@ -2189,7 +2185,7 @@
         (play-from-hand state :runner "Access to Globalsec")
         (is (= 1 (:link (get-runner))) "1 link before rebirth")
         (play-from-hand state :runner "Rebirth")
-        (choose-runner kate state prompt-map)
+        (rebirth-choice state kate)
         (is (= 2 (:link (get-runner))) "2 link after rebirth")))
     (testing "Implementation notes are kept, regression test for #3722"
       (do-game
@@ -2197,7 +2193,7 @@
                   (default-runner ["Rebirth"])
                   {:start-as :runner})
         (play-from-hand state :runner "Rebirth")
-        (choose-runner chaos state prompt-map)
+        (rebirth-choice state chaos)
         (is (= :full (get-in (get-runner) [:identity :implementation])) "Implementation note kept as `:full`"))))
 
   (deftest rebirth-kate-twice
@@ -2209,7 +2205,8 @@
                   {:start-as :runner})
         (play-from-hand state :runner "Clone Chip")
         (play-from-hand state :runner "Rebirth")
-        (choose-runner kate state prompt-map)
+        (rebirth-choice state kate)
+        (is (= kate (get-in (get-runner) [:identity :title])) "Rebirthed into Kate")
         (is (changes-credits (get-runner) -1
                              (play-from-hand state :runner "Akamatsu Mem Chip"))
             "Discount not applied for 2nd install")))
@@ -2220,10 +2217,54 @@
                   {:start-as :runner})
         (play-from-hand state :runner "Same Old Thing")
         (play-from-hand state :runner "Rebirth")
-        (choose-runner kate state prompt-map)
+        (rebirth-choice state kate)
+        (is (= kate (get-in (get-runner) [:identity :title])) "Rebirthed into Kate")
         (is (changes-credits (get-runner) 0
                              (play-from-hand state :runner "Akamatsu Mem Chip"))
             "Discount is applied for 2nd install (since it is the first Hardware / Program)"))))
+
+  (deftest rebirth-reina-twice
+    ;; Rebirth - Reina does not increase rez cost after rebirth if Ice already rezzed
+    (testing "Rezzing Ice before does prevent cost"
+      (do-game
+        (new-game (default-corp [(qty "Ice Wall" 2)])
+                  (make-deck whizzard ["Rebirth"]))
+        (play-from-hand state :corp "Ice Wall" "HQ")
+        (play-from-hand state :corp "Ice Wall" "R&D")
+        (take-credits state :corp)
+
+        (is (changes-credits (get-corp) -1
+                             (core/rez state :corp (get-ice state :hq 0)))
+            "Only pay 1 to rez ice wall when against Whizzard")
+
+        (play-from-hand state :runner "Rebirth")
+        (rebirth-choice state reina)
+        (is (= reina (get-in (get-runner) [:identity :title])) "Rebirthed into Reina")
+
+        (is (changes-credits (get-corp) -1
+                             (core/rez state :corp (get-ice state :rd 0)))
+            "Additional cost from Reina not applied for 2nd ice rez")))
+
+    (testing "Rezzing Asset before does not prevent additional cost"
+      (do-game
+        (new-game (default-corp ["Ice Wall" "Mark Yale"])
+                  (make-deck whizzard ["Rebirth"]))
+        (println "Reina Rebirth twice test")
+        (play-from-hand state :corp "Ice Wall" "HQ")
+        (play-from-hand state :corp "Mark Yale" "New remote")
+        (take-credits state :corp)
+
+        (is (changes-credits (get-corp) -1
+                             (core/rez state :corp (get-content state :remote1 0)))
+            "Only pay 1 to rez Mark Yale")
+
+        (play-from-hand state :runner "Rebirth")
+        (rebirth-choice state reina)
+        (is (= reina (get-in (get-runner) [:identity :title])) "Rebirthed into Reina")
+
+        (is (changes-credits (get-corp) -2
+                             (core/rez state :corp (get-ice state :hq 0)))
+            "Additional cost from Reina applied for 1st ice rez")))))
 
 (deftest reboot
   ;; Reboot - run on Archives, install 5 cards from head facedown

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1883,23 +1883,50 @@
 
 (deftest warroid-tracker
   ;; Warroid Tracker
-  (do-game
-    (new-game (default-corp ["Warroid Tracker"])
-              (default-runner ["Corroder" "Dyson Mem Chip"]))
-    (play-from-hand state :corp "Warroid Tracker" "New remote")
-    (take-credits state :corp)
-    (core/gain state :runner :credit 10)
-    (play-from-hand state :runner "Corroder")
-    (play-from-hand state :runner "Dyson Mem Chip")
-    (let [war (get-content state :remote1 0)
-          cor (get-program state 0)
-          mem (get-hardware state 0)]
-      (core/rez state :corp war)
-      (run-empty-server state "Server 1")
-      (prompt-choice-partial :runner "Pay")
-      (prompt-choice :corp 0)
-      (prompt-choice :runner 0)
-      (is (zero? (-> (get-runner) :discard count)) "Runner should start with 0 cards in heap")
-      (prompt-select :runner cor)
-      (prompt-select :runner mem)
-      (is (= 2 (-> (get-runner) :discard count)) "Runner should trash 2 installed cards"))))
+  (testing "Trashing Warroid starts trace"
+    (do-game
+      (new-game (default-corp ["Warroid Tracker"])
+                (default-runner ["Corroder" "Dyson Mem Chip"]))
+      (play-from-hand state :corp "Warroid Tracker" "New remote")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Corroder")
+      (play-from-hand state :runner "Dyson Mem Chip")
+      (let [war (get-content state :remote1 0)
+            cor (get-program state 0)
+            mem (get-hardware state 0)]
+        (core/rez state :corp war)
+        (run-empty-server state "Server 1")
+        (prompt-choice-partial :runner "Pay")
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (zero? (-> (get-runner) :discard count)) "Runner should start with 0 cards in heap")
+        (prompt-select :runner cor)
+        (prompt-select :runner mem)
+        (is (= 2 (-> (get-runner) :discard count)) "Runner should trash 2 installed cards"))))
+  (testing "Trashing from central triggers Warroid in root"
+    ;; Regression test for #3725
+    (do-game
+      (new-game (default-corp ["Warroid Tracker" (qty "Hedge Fund" 3)])
+                (default-runner ["Clan Vengeance" "Corroder" "Dyson Mem Chip"]))
+      (play-from-hand state :corp "Warroid Tracker" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Corroder")
+      (play-from-hand state :runner "Dyson Mem Chip")
+      (play-from-hand state :runner "Clan Vengeance")
+      (let [war (get-content state :hq 0)
+            clv (get-resource state 0)
+            cor (get-program state 0)
+            mem (get-hardware state 0)]
+        (core/rez state :corp war)
+        (core/add-counter state :runner clv :power 2)
+        (card-ability state :runner (refresh clv) 0)
+        ;; Prompt choice checks there is a trace prompt from Warroid
+        (prompt-choice :corp 0)
+        (prompt-choice :runner 0)
+        (is (= 1 (-> (get-runner) :discard count)) "Runner should start with 1 card in heap (Clan Vengeance)")
+        (prompt-select :runner cor)
+        (prompt-select :runner mem)
+        (is (= 3 (-> (get-runner) :discard count)) "Runner should trash 2 installed cards (and CV already in heap)")
+        (is (= 2 (count (:discard (get-corp)))) "Two cards trashed from HQ by Clan Vengeance")))))

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -266,3 +266,10 @@
   [state title]
   (play-from-hand state :corp title "New remote")
   (score-agenda state :corp (get-content state (keyword (str "remote" (:rid @state))) 0)))
+
+(defn rebirth-choice
+  [state id-name]
+  (let [choice (some #(when (= id-name (:title %)) %)
+                     (-> @state :runner :prompt first :choices))]
+    (is choice (str id-name " is a valid Rebirth target"))
+    (core/resolve-prompt state :runner {:card choice})))


### PR DESCRIPTION
More fixes. 

Fixed Kate and Reina rebirth interaction, so now Rebirth should be fully functional. Removed the rebirth system message that notifies this as well.

Added `rebirth-choice` helper function to make it easier to construct tests with rebirth.