### PR TITLE
Fix crash in cutlery events

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -22,13 +22,14 @@
           cdef)))
 
 (defn- cutlery
-  [subtype]
+  [_subtype]
   ;; Subtype does nothing currently, but might be used if trashing is properly implemented
   {:implementation "Ice trash is manual, always enables Reprisals"
-   :prompt "Choose a server"
-   :choices (req runnable-servers)
-   :effect (req (run state :runner target nil card)
-                (swap! state assoc-in [:runner :register :trashed-card] true))})
+   :async true
+   :effect (req (continue-ability state :runner
+                                  (run-event nil nil nil
+                                             (req (swap! state assoc-in [:runner :register :trashed-card] true)))
+                                  card nil))})
 
 (def card-definitions
   {"Account Siphon"

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -1650,6 +1650,18 @@
       (play-from-hand state :runner "Apocalypse")
       (is (not (= "Flatline" (:reason @state))) "Win condition does not report flatline"))))
 
+(deftest knifed
+  ;; Knifed - Make a run, trash a barrier if all subs broken
+  (do-game
+    (new-game (default-corp ["Ice Wall"])
+              (default-runner ["Knifed"]))
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Knifed")
+    (click-prompt state :runner "HQ")
+    (run-successful state)))
+
 (deftest lawyer-up
   ;; Lawyer Up - Lose 2 tags and draw 3 cards
   (do-game


### PR DESCRIPTION
All cutlery events (Knifed, Forked, Spooned) would crash when attempting to play their run event.
Add a trivial test just to verify it doesn't crash.