### PR TITLE
Fixes DJ Fenris

### DIFF
--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -64,88 +64,127 @@
         (when (not-empty tail)
           (swap! state assoc-in z (vec (concat head [card] (rest tail)))))))))
 
+;; Helpers for move
+(defn- remove-old-card
+  "Removes the old pre-move card from the game state, for use in move"
+  [state side {:keys [zone host] :as card}]
+  (doseq [s [:runner :corp]]
+    (if host
+      (remove-from-host state side card)
+      (swap! state update-in (cons s (vec zone)) (fn [coll] (remove-once #(same-card? card %) coll))))))
+
+(defn- get-moved-card
+  "Get the moved cards with correct abilities and keys hooked up / removed etc."
+  [state side {:keys [zone host installed] :as card} to]
+  (let [zone (if host (map to-keyword (:zone host)) zone)
+        src-zone (first zone)
+        target-zone (if (vector? to) (first to) to)
+        same-zone? (= src-zone target-zone)
+        dest (if (sequential? to) (vec to) [to])
+        to-facedown (= dest [:rig :facedown])
+        to-installed (#{:servers :rig} (first dest))
+        trash-hosted (fn [h]
+                       (trash state side
+                              (update-in h [:zone] #(map to-keyword %))
+                              {:unpreventable true
+                               :suppress-event true
+                               ;; this handles executives getting trashed before World's Plaza #2949
+                               :host-trashed true})
+                       ())
+        update-hosted (fn [h]
+                        (let [newz (flatten (list dest))
+                              newh (-> h
+                                       (assoc-in [:zone] '(:onhost))
+                                       (assoc-in [:host :zone] newz))]
+                          (update! state side newh)
+                          (unregister-events state side h)
+                          (register-events state side (:events (card-def newh)) newh)
+                          newh))
+        hosted (seq (flatten (map (if same-zone? update-hosted trash-hosted) (:hosted card))))
+        ;; Set :seen correctly
+        c (if (= :corp side)
+            (cond
+              ;; Moving rezzed card to discard, explicitly mark as seen
+              (and (= :discard (first dest))
+                   (rezzed? card))
+              (assoc card :seen true)
+
+              ;; Moving card to HQ or R&D, explicitly mark as not seen
+              (#{:hand :deck} (first dest))
+              (dissoc card :seen)
+
+              ;; Else return card
+              :else
+              card)
+            card)
+        c (if (and (or installed
+                       host
+                       (#{:servers :scored :current} src-zone))
+                   (or (#{:hand :deck :discard :rfg} target-zone)
+                       to-facedown)
+                   (not (:facedown c)))
+            (deactivate state side c to-facedown)
+            c)
+        c (if to-installed
+            (assoc c :installed true)
+            (dissoc c :installed))
+        c (if to-facedown
+            (assoc c :facedown true)
+            (dissoc c :facedown))
+        moved-card (assoc c :zone dest
+                            :host nil
+                            :hosted hosted
+                            :previous-zone (:zone c))
+        ;; Set up abilities for stolen agendas
+        moved-card (if (and (= :scored (first dest))
+                            (card-flag? moved-card :has-abilities-when-stolen true))
+                     (merge moved-card {:abilities (:abilities (card-def moved-card))})
+                     moved-card)]
+    moved-card))
+
 (defn move
   "Moves the given card to the given new zone."
   ([state side card to] (move state side card to nil))
-  ([state side {:keys [zone cid host installed] :as card} to {:keys [front keep-server-alive force] :as options}]
-   (let [to (if (is-type? card "Fake-Identity") :rfg to)          ; Fake-Identities always get moved to RFG
-         zone (if host (map to-keyword (:zone host)) zone)
+  ([state side {:keys [zone host] :as card} to {:keys [front keep-server-alive force]}]
+   (let [zone (if host (map to-keyword (:zone host)) zone)
          src-zone (first zone)
-         target-zone (if (vector? to) (first to) to)
-         same-zone? (= src-zone target-zone)]
-     (when (and card (or host
-                         (some #(when (= cid (:cid %)) %) (get-in @state (cons :runner (vec zone))))
-                         (some #(when (= cid (:cid %)) %) (get-in @state (cons :corp (vec zone)))))
-                (or (empty? (get-in @state [side :locked (-> card :zone first)]))
-                    force))
-       (trigger-event state side :pre-card-moved card src-zone target-zone)
-       (let [dest (if (sequential? to) (vec to) [to])
-             to-facedown (= dest [:rig :facedown])
-             to-installed (#{:servers :rig} (first dest))
-             trash-hosted (fn [h]
-                             (trash state side
-                                    (update-in h [:zone] #(map to-keyword %))
-                                    {:unpreventable true
-                                     :suppress-event true
-                                     ;; this handles executives getting trashed before World's Plaza #2949
-                                     :host-trashed true})
-                               ())
-             update-hosted (fn [h]
-                             (let [newz (flatten (list (if (vector? to) to [to])))
-                                   newh (-> h
-                                      (assoc-in [:zone] '(:onhost))
-                                      (assoc-in [:host :zone] newz))]
-                               (update! state side newh)
-                               (unregister-events state side h)
-                               (register-events state side (:events (card-def newh)) newh)
-                               newh))
-             hosted (seq (flatten (map
-                      (if same-zone? update-hosted trash-hosted)
-                      (:hosted card))))
-             c (if (and (= side :corp)
-                        (= (first dest) :discard)
-                        (rezzed? card))
-                 (assoc card :seen true) card)
-             c (if (and (or installed host (#{:servers :scored :current} (first zone)))
-                        (or (#{:hand :deck :discard :rfg} (first dest)) to-facedown)
-                        (not (:facedown c)))
-                 (deactivate state side c to-facedown) c)
-             c (if to-installed (assoc c :installed true) (dissoc c :installed))
-             c (if to-facedown (assoc c :facedown true) (dissoc c :facedown))
-             moved-card (assoc c :zone dest :host nil :hosted hosted :previous-zone (:zone c))
-             moved-card (if (and (= side :corp)
-                                 (#{:hand :deck} (first dest)))
-                          (dissoc moved-card :seen)
-                          moved-card)
-             moved-card (if (and (= (first (:zone moved-card)) :scored)
-                                 (card-flag? moved-card :has-abilities-when-stolen true))
-                          (merge moved-card {:abilities (:abilities (card-def moved-card))}) moved-card)]
-         (doseq [s [:runner :corp]]
-           (if host
-             (remove-from-host state side card)
-             (swap! state update-in (cons s (vec zone)) (fn [coll] (remove-once #(= (:cid %) cid) coll)))))
-         (if front
-           (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))
-           (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card))))
-         (let [z (vec (cons :corp (butlast zone)))]
-           (when (and (not keep-server-alive)
-                      (is-remote? z)
-                      (empty? (get-in @state (conj z :content)))
-                      (empty? (get-in @state (conj z :ices))))
-             (when-let [run (:run @state)]
-               (when (= (last (:server run)) (last z))
-                 (handle-end-run state side)))
-             (swap! state dissoc-in z)))
-         (when-let [card-moved (:move-zone (card-def c))]
-           (card-moved state side (make-eid state) moved-card card))
-         (trigger-event state side :card-moved card (assoc moved-card :move-to-side side))
-         ;; Default a card when moved to inactive zones (except :persistent key)
-         (when (#{:discard :hand :deck :rfg} to)
-           (reset-card state side moved-card)
-           (when-let [icon-card (get-in moved-card [:icon :card])]
-             ;; Remove icon and icon-card keys
-             (remove-icon state side icon-card moved-card)))
-         moved-card)))))
+         target-zone (if (vector? to) (first to) to)]
+     (if (is-type? card "Fake-Identity")
+       ;; Make Fake-Identity cards "disappear"
+       (do (deactivate state side card false)
+           (remove-old-card state side card))
+       (when (and card
+                  (or host
+                      (some #(same-card? card %) (get-in @state (cons :runner (vec zone))))
+                      (some #(same-card? card %) (get-in @state (cons :corp (vec zone)))))
+                  (or force
+                      (empty? (get-in @state [side :locked (-> card :zone first)]))))
+         (trigger-event state side :pre-card-moved card src-zone target-zone)
+         (let [dest (if (sequential? to) (vec to) [to])
+               moved-card (get-moved-card state side card to)]
+           (remove-old-card state side card)
+           (if front
+             (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))
+             (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card))))
+           (let [z (vec (cons :corp (butlast zone)))]
+             (when (and (not keep-server-alive)
+                        (is-remote? z)
+                        (empty? (get-in @state (conj z :content)))
+                        (empty? (get-in @state (conj z :ices))))
+               (when-let [run (:run @state)]
+                 (when (= (last (:server run)) (last z))
+                   (handle-end-run state side)))
+               (swap! state dissoc-in z)))
+           (when-let [move-zone-fn (:move-zone (card-def moved-card))]
+             (move-zone-fn state side (make-eid state) moved-card card))
+           (trigger-event state side :card-moved card (assoc moved-card :move-to-side side))
+           ;; Default a card when moved to inactive zones (except :persistent key)
+           (when (#{:discard :hand :deck :rfg} to)
+             (reset-card state side moved-card)
+             (when-let [icon-card (get-in moved-card [:icon :card])]
+               ;; Remove icon and icon-card keys
+               (remove-icon state side icon-card moved-card)))
+           moved-card))))))
 
 (defn move-zone
   "Moves all cards from one zone to another, as in Chronos Project."

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -31,17 +31,17 @@
   "Deactivates a card, unregistering its events, removing certain attribute keys, and triggering
   some events."
   ([state side card] (deactivate state side card nil))
-  ([state side card keep-counter]
+  ([state side {:keys [cid disabled facedown installed memoryunits rezzed] :as card} keep-counter]
    (unregister-events state side card)
    (trigger-leave-effect state side card)
-   (when-let [mu (:memoryunits card)]
-     (when (and (:installed card)
-                (not (:facedown card)))
-       (free-mu state mu)))
-   (when (and (find-cid (:cid card) (all-active-installed state side))
-              (not (:disabled card))
-              (or (:rezzed card)
-                  (:installed card)))
+   (when (and memoryunits
+              installed
+              (not facedown))
+     (free-mu state memoryunits))
+   (when (and (find-cid cid (all-active-installed state side))
+              (not disabled)
+              (or rezzed
+                  installed))
      (when-let [in-play (:in-play (card-def card))]
        (apply lose state side in-play)))
    (dissoc-card card keep-counter)))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -131,8 +131,8 @@
 
 (defn reset-card
   "Resets a card back to its original state - retaining any data in the :persistent key"
-  ([state side card]
-   (update! state side (merge (make-card (get @all-cards (:title card)) (:cid card)) {:persistent card}))))
+  ([state side {:keys [title cid persistent]}]
+   (update! state side (assoc (make-card (get @all-cards title) cid) :persistent persistent))))
 
 (defn create-deck
   "Creates a shuffled draw deck (R&D/Stack) from the given list of cards.

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -603,7 +603,10 @@
         (is (= 5 (core/available-mu state)) "+1 MU from Chaos Theory")
         ;; Trash DJ Fenris
         (trash-resource state "DJ Fenris")
-        (is (= chaos (get-in (get-runner) [:rfg 0 :title])) "Chaos Theory moved to RFG")
+        (is (not= chaos (-> (get-runner) :rfg last :title)) "Chaos Theory not moved to rfg")
+        (is (not= chaos (-> (get-runner) :discard last :title)) "Chaos Theory not moved to discard")
+        (is (not= chaos (-> (get-runner) :hand last :title)) "Chaos Theory not moved to hand")
+        (is (not= chaos (-> (get-runner) :identity :title)) "Chaos Theory not moved to identity")
         (is (= 1 (count (:discard (get-runner)))) "1 card in heap: DJ Fenris")
         (is (= 4 (core/available-mu state)) "+1 MU from Chaos Theory removed")
         ;; Recover DJ Fenris
@@ -611,11 +614,13 @@
         (core/gain state :runner :credit 3)
         ;; Re-play DJ Fenris
         (play-from-hand state :runner "DJ Fenris")
-        (is (not (some #(= chaos (:title %)) (:choices (prompt-map :runner)))) "Chaos Theory isn't available anymore")
+        (is (some #(= chaos (:title %)) (:choices (prompt-map :runner))) "Chaos Theory still available")
         ;; Try moving CT to hand
-        (game.core/move state :runner (get-in (get-resource state 0) [:hosted 0]) :hand)
-        (is (= chaos (get-in (get-runner) [:rfg 0 :title])) "Chaos Theory moved to RFG")
-        (is (zero? (count (:hand (get-runner)))) "Chaos Theory _not_ moved to hand")
+        (game.core/move state :runner (-> (get-resource state 0) :hosted first) :hand)
+        (is (not= chaos (-> (get-runner) :rfg last :title)) "Chaos Theory not moved to rfg")
+        (is (not= chaos (-> (get-runner) :discard last :title)) "Chaos Theory not moved to discard")
+        (is (not= chaos (-> (get-runner) :hand last :title)) "Chaos Theory not moved to hand")
+        (is (not= chaos (-> (get-runner) :identity :title)) "Chaos Theory not moved to identity")
         (is (= 4 (core/available-mu state)) "+1 MU from Chaos Theory removed")))
     (testing "Hosting Geist"
       ;; Ensure Geist effect triggers
@@ -640,7 +645,10 @@
           (is (= (+ 1 hand-count) (count (:hand (get-runner))))
               "Drew one card with Geist when using All-nighter trash ability")
           (trash-resource state "DJ Fenris")
-          (is (= geist (get-in (get-runner) [:rfg 0 :title])) "Geist moved to RFG")
+          (is (not= geist (-> (get-runner) :rfg last :title)) "Geist not moved to rfg")
+          (is (not= geist (-> (get-runner) :discard last :title)) "Geist not moved to discard")
+          (is (not= geist (-> (get-runner) :hand last :title)) "Geist not moved to hand")
+          (is (not= geist (-> (get-runner) :identity :title)) "Geist not moved to identity")
           (is (= 2 (count (:discard (get-runner)))) "2 cards in heap: All-nighter and DJ Fenris")
           (card-ability state :runner (get-resource state 0) 0) ; Use All-nighter (again)
           (is (= (+ 1 hand-count) (count (:hand (get-runner))))


### PR DESCRIPTION
Also refactors `move` a bit to make it more understandable (and make it dissapear the DJ Fenris ID).

Fixes #3791.