### PR TITLE
Fix block list in the game lobby on the server side

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -277,8 +277,6 @@
     {:keys [gameid password options]}   :?data
     reply-fn                            :?reply-fn
     :as                                 msg}]
-  (println "Join: " user)
-  (println "Game: " (@all-games gameid))
   (if-let [{game-password :password :as game} (@all-games gameid)]
     (when (and user game (allowed-in-game game user))
       (if (and (not (already-in-game? user game))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -199,8 +199,8 @@
   [{:keys [players] :as game}]
   (mapcat #(get-in % [:user :options :blocked-users]) players))
 
-(defn allowed-in-game [{:keys [username]} game]
-  (not (some #(= username (:username %)) (blocked-users game))))
+(defn allowed-in-game [game {:keys [username]}]
+  (not (some #(= username %) (blocked-users game))))
 
 (defn handle-ws-connect [{:keys [client-id] :as msg}]
   (ws/send! client-id [:games/list (mapv game-public-view (vals @all-games))]))
@@ -277,6 +277,8 @@
     {:keys [gameid password options]}   :?data
     reply-fn                            :?reply-fn
     :as                                 msg}]
+  (println "Join: " user)
+  (println "Game: " (@all-games gameid))
   (if-let [{game-password :password :as game} (@all-games gameid)]
     (when (and user game (allowed-in-game game user))
       (if (and (not (already-in-game? user game))

--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -355,7 +355,7 @@
 
 (defn game-list [user {:keys [current-room games gameid password-game editing]}]
    (let [roomgames (r/track (fn [] (filter #(= (:room %) current-room) @games)))
-         filtered-games (r/track #(filter-blocked-games user @roomgames))]
+         filtered-games (r/track #(filter-blocked-games @user @roomgames))]
         [:div.game-list
          (if (empty? @filtered-games)
            [:h4 "No games"]


### PR DESCRIPTION
Argument ordering bug and a `map` vs. `string` error when blocking users from joining or watching games on the server side.

I took a look at filtering on the front end, but I couldn't get it figured out. @danhut will have to take a look.

Fixes #3812 