### PR TITLE
Disable chat sending if message too long

### DIFF
--- a/src/clj/web/api.clj
+++ b/src/clj/web/api.clj
@@ -39,6 +39,7 @@
            (GET "/data/cycles" [] data/cycles-handler)
            (GET "/data/donors" [] data/donors-handler)
 
+           (GET "/chat/config" [] chat/config-handler)
            (GET "/messages/:channel" [] chat/messages-handler)
 
            (POST "/forgot" [] auth/forgot-password-handler)

--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -16,6 +16,11 @@
 (def msg-collection "messages")
 (def log-collection "moderator_actions")
 
+(defn- chat-max-length [] (:max-length chat-config 144))
+
+(defn config-handler [req]
+  (response 200 {:max-length (chat-max-length)}))
+
 (defn messages-handler [{{:keys [channel]} :params}]
   (response 200 (reverse (q/with-collection db msg-collection
                                             (q/find {:channel channel})
@@ -33,7 +38,7 @@
 (defn- insert-msg [{{{:keys [username emailhash]} :user} :ring-req
                     client-id :client-id
                     {:keys [:channel :msg]} :?data :as event}]
-  (let [len-valid (<= (count msg) (:max-length chat-config 144))
+  (let [len-valid (<= (count msg) (chat-max-length))
         rate-valid (within-rate-limit username)]
     (when (and username
                emailhash


### PR DESCRIPTION
Disables the `Send` button and blocks the `submit` action (triggered via `Return/Enter`) in the main lobby chat window if the message length exceeds the value configured on the server or if the message is `blank?`. 
If no value is available from the server, any non-`blank?` message is allowed.