### PR TITLE
Fix tags in UI

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags]]
             [jinteki.cards :refer [all-cards]]))
 
 (defn ice-boost-agenda [subtype]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags]]
             [jinteki.cards :refer [all-cards]]))
 
 ;;; Asset-specific helpers

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags]]
             [jinteki.cards :refer [all-cards]]))
 
 (defn- run-event

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags]]
             [jinteki.cards :refer [all-cards]]))
 
 (def card-definitions

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags]]
             [jinteki.cards :refer [all-cards]]))
 
 ;;;; Helper functions specific for ICE

--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged?]]
             [jinteki.cards :refer [all-cards]]))
 
 (def breaker-auto-pump

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged?]]
             [jinteki.cards :refer [all-cards]]))
 
 ;;; Helper functions for Draft cards

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags]]
             [jinteki.cards :refer [all-cards]]))
 
 (def card-definitions

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged?]]
             [jinteki.cards :refer [all-cards]]))
 
 (def card-definitions

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags]]
             [jinteki.cards :refer [all-cards]]))
 
 (defn- genetics-trigger?

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -4,7 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged?]]
             [jinteki.cards :refer [all-cards]]))
 
 (def card-definitions

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -6,7 +6,7 @@
             [clojure.java.io :as io]
             [clojure.core.match :refer [match]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side]]
+            [jinteki.utils :refer [str->int other-side is-tagged?]]
             [jinteki.cards :refer [all-cards]]
             [game.quotes :as quotes]))
 

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -71,6 +71,16 @@
               (str "sets unused MU to " (available-mu state)
                    " (" (if (pos? delta) (str "+" delta) delta) ")")))
 
+(defn- change-tags
+  "Change a player's base tag count"
+  [state delta]
+  (if (neg? delta)
+    (deduct state :runner [:tag (Math/abs delta)])
+    (gain state :runner :tag delta))
+  (system-msg state :runner
+              (str "sets Tags to " (get-in @state [:runner :tag :base])
+                   " (" (if (pos? delta) (str "+" delta) delta) ")")))
+
 (defn change
   "Increase/decrease a player's property (clicks, credits, MU, etc.) by delta."
   [state side {:keys [key delta]}]
@@ -82,6 +92,10 @@
     ;; Hand size needs special treatment as it expects a map
     (= :hand-size key)
     (change-map state side key delta)
+
+    ;; Tags need special treatment since they are a more complex map
+    (= :tag key)
+    (change-tags state delta)
 
     :else
     (do (if (neg? delta)

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -2,7 +2,7 @@
 
 (declare can-trigger? card-def clear-wait-prompt effect-completed event-title get-card get-nested-host get-remote-names
          get-runnable-zones get-zones installed? make-eid register-effect-completed register-suppress resolve-ability
-         show-wait-prompt trigger-suppress unregister-suppress is-tagged?)
+         show-wait-prompt trigger-suppress unregister-suppress)
 
 ; Functions for registering and dispatching events.
 (defn register-events

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -173,19 +173,6 @@
   ([state n]
    (gain state :runner :memory {:used n})))
 
-(defn count-tags
-  "Counts number of tags runner has (real + additional)"
-  [state]
-  (+ (get-in @state [:runner :tag :base] 0)
-     (get-in @state [:runner :tag :additional] 0)))
-
-(defn is-tagged?
-  "Returns truthy if runner is tagged"
-  [state]
-  (or (pos? (get-in @state [:runner :tag :is-tagged] 0))
-      (pos? (count-tags state))))
-
-
 ;;; Other helpers
 
 (defn swap-agendas

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -20,3 +20,15 @@
 (defn other-side [side]
   (cond (= side :corp) :runner
         (= side :runner) :corp))
+
+(defn count-tags
+  "Counts number of tags runner has (real + additional)"
+  [state]
+  (+ (get-in @state [:runner :tag :base] 0)
+     (get-in @state [:runner :tag :additional] 0)))
+
+(defn is-tagged?
+  "Returns truthy if runner is tagged"
+  [state]
+  (or (pos? (get-in @state [:runner :tag :is-tagged] 0))
+      (pos? (count-tags state))))

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1519,7 +1519,7 @@
                [cond-button "Remove Tag"
                 (and (pos? (:click @me))
                      (>= (:credit @me) (- 2 (or (:tag-remove-bonus @me) 0)))
-                     (pos? (:tag @me)))
+                     (pos? (get-in @me [:tag :base])))
                 #(send-command "remove-tag")]
                [:div.run-button
                 [cond-button "Run" (and (pos? (:click @me))
@@ -1537,8 +1537,7 @@
             (when (= side :corp)
               [cond-button "Trash Resource" (and (pos? (:click @me))
                                                  (>= (:credit @me) (- 2 (or (:trash-cost-bonus @me) 0)))
-                                                 (or (pos? (:tagged @opponent))
-                                                     (pos? (:tag @opponent))))
+                                                 (pos? (get-in @opponent [:tag :base])))
                #(send-command "trash-resource")])
             [cond-button "Draw" (and (pos? (:click @me)) (not-empty (:deck @me))) #(send-command "draw")]
             [cond-button "Gain Credit" (pos? (:click @me)) #(send-command "credit")]]))])})))

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -3,15 +3,14 @@
   (:require [cljs.core.async :refer [chan put! <!] :as async]
             [clojure.string :refer [capitalize includes? join lower-case split]]
             [differ.core :as differ]
-            [jinteki.utils :refer [str->int]]
+            [jinteki.utils :refer [str->int is-tagged?] :as utils]
             [jinteki.cards :refer [all-cards]]
             [nr.appstate :refer [app-state]]
             [nr.auth :refer [avatar] :as auth]
             [nr.cardbrowser :refer [add-symbols] :as cb]
             [nr.utils :refer [influence-dot map-longest toastr-options]]
             [nr.ws :as ws]
-            [reagent.core :as r]
-            [jinteki.utils :as utils]))
+            [reagent.core :as r]))
 
 (defonce game-state (r/atom {}))
 (defonce last-state (atom {}))
@@ -1537,7 +1536,7 @@
             (when (= side :corp)
               [cond-button "Trash Resource" (and (pos? (:click @me))
                                                  (>= (:credit @me) (- 2 (or (:trash-cost-bonus @me) 0)))
-                                                 (pos? (get-in @opponent [:tag :base])))
+                                                 (is-tagged? game-state))
                #(send-command "trash-resource")])
             [cond-button "Draw" (and (pos? (:click @me)) (not-empty (:deck @me))) #(send-command "draw")]
             [cond-button "Gain Credit" (pos? (:click @me)) #(send-command "credit")]]))])})))

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -3,6 +3,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "agendas"))
@@ -123,7 +124,7 @@
       (run-successful state)
       (click-prompt state :runner "Pay 1 [Credits] to trash")
       (is (= 1 (count (:discard (get-corp)))) "trashed")
-      (is (zero? (core/count-tags state)) "Runner took 0 tags")
+      (is (zero? (count-tags state)) "Runner took 0 tags")
       (take-credits state :runner)
       (play-and-score state "AR-Enhanced Security")
       (take-credits state :corp))
@@ -132,13 +133,13 @@
       (run-successful state)
       (click-prompt state :runner "Pay 1 [Credits] to trash")
       (is (= 2 (count (:discard (get-corp)))) "trashed")
-      (is (= 1 (core/count-tags state)) "Runner took 1 tag"))
+      (is (= 1 (count-tags state)) "Runner took 1 tag"))
     (testing "don't gain a tag from second trash"
       (run-on state :remote3)
       (run-successful state)
       (click-prompt state :runner "Pay 1 [Credits] to trash")
       (is (= 3 (count (:discard (get-corp)))) "trashed")
-      (is (= 1 (core/count-tags state)) "Runner took 0 tags"))))
+      (is (= 1 (count-tags state)) "Runner took 0 tags"))))
 
 (deftest armed-intimidation
   ;; Armed Intimidation
@@ -147,7 +148,7 @@
               (default-runner [(qty "Sure Gamble" 3) (qty "Diesel" 2)]))
     (play-and-score state "Armed Intimidation")
     (click-prompt state :runner "Take 2 tags")
-    (is (= 2 (core/count-tags state)) "Runner took 2 tags from Armed Intimidation tag choice")
+    (is (= 2 (count-tags state)) "Runner took 2 tags from Armed Intimidation tag choice")
     (play-and-score state "Armed Intimidation")
     (is (= 5 (count (:hand (get-runner)))) "Runner has 5 cards before Armed Intimidation meat damage")
     (click-prompt state :runner "Suffer 5 meat damage")
@@ -280,22 +281,22 @@
       (play-and-score state "Better Citizen Program")
       (take-credits state :corp)
       (core/gain state :runner :credit 10)
-      (is (zero? (core/count-tags state)) "Runner starts with 0 tags")
+      (is (zero? (count-tags state)) "Runner starts with 0 tags")
       (play-from-hand state :runner "The Maker's Eye")
       (click-prompt state :corp "Yes")
-      (is (= 1 (core/count-tags state)) "Runner takes 1 tag for playing a Run event")
+      (is (= 1 (count-tags state)) "Runner takes 1 tag for playing a Run event")
       (run-successful state)
       (play-from-hand state :runner "Wyrm")
       (is (empty? (-> (get-corp) :prompt)) "Corp shouldn't get a prompt to use Better Citizen Program")
-      (is (= 1 (core/count-tags state)) "Runner doesn't gain a tag from installing an icebreaker after playing a Run event")
+      (is (= 1 (count-tags state)) "Runner doesn't gain a tag from installing an icebreaker after playing a Run event")
       (take-credits state :runner)
       (take-credits state :corp)
       (play-from-hand state :runner "Wyrm")
       (click-prompt state :corp "Yes")
-      (is (= 2 (core/count-tags state)) "Runner gains 1 tag for installing an Icebreaker")
+      (is (= 2 (count-tags state)) "Runner gains 1 tag for installing an Icebreaker")
       (play-from-hand state :runner "The Maker's Eye")
       (is (empty? (-> (get-corp) :prompt)) "Corp shouldn't get a prompt to use Better Citizen Program")
-      (is (= 2 (core/count-tags state)) "Runner doesn't gain a tag from playing a Run event after installing an Icebreaker")
+      (is (= 2 (count-tags state)) "Runner doesn't gain a tag from playing a Run event after installing an Icebreaker")
       (run-successful state)))
   (testing "Should only trigger on Run events. #3619"
     (do-game
@@ -307,7 +308,7 @@
       (play-from-hand state :runner "Mining Accident")
       (click-prompt state :corp "Pay 5 [Credits]")
       (is (empty? (-> (get-corp) :prompt)) "Corp shouldn't get a prompt to use Better Citizen Program")
-      (is (zero? (core/count-tags state)) "Runner should not gain a tag from playing a non-Run event"))))
+      (is (zero? (count-tags state)) "Runner should not gain a tag from playing a non-Run event"))))
 
 (deftest bifrost-array
   ;; Bifrost Array
@@ -357,9 +358,9 @@
     (new-game (default-corp [(qty "Breaking News" 3)])
               (default-runner))
     (play-and-score state "Breaking News")
-    (is (= 2 (core/count-tags state)) "Runner receives 2 tags from Breaking News")
+    (is (= 2 (count-tags state)) "Runner receives 2 tags from Breaking News")
     (take-credits state :corp)
-    (is (zero? (core/count-tags state))) "Two tags removed at the end of the turn"))
+    (is (zero? (count-tags state))) "Two tags removed at the end of the turn"))
 
 (deftest broad-daylight
   ;; Broad Daylight
@@ -783,7 +784,7 @@
     (play-and-score state "Escalate Vitriol")
     (let [ev-scored (get-scored state :corp 0)]
       (dotimes [tag 10]
-        (is (zero? (core/count-tags state)) "Should start with 0 tags")
+        (is (zero? (count-tags state)) "Should start with 0 tags")
         (is (zero? (:credit (get-corp))) "Should start with 0 credits")
         (core/gain-tags state :runner tag)
         (card-ability state :corp ev-scored 0)
@@ -897,9 +898,9 @@
   (do-game
     (new-game (default-corp ["Fly on the Wall"])
               (default-runner))
-    (is (zero? (core/count-tags state)) "Runner starts with no tags")
+    (is (zero? (count-tags state)) "Runner starts with no tags")
     (play-and-score state "Fly on the Wall")
-    (is (= 1 (core/count-tags state)) "Runner is tagged")))
+    (is (= 1 (count-tags state)) "Runner is tagged")))
 
 (deftest firmware-updates
   ;; Firmware Updates
@@ -1306,7 +1307,7 @@
       (is (= 1 (-> (get-corp) :prompt first :bonus)) "Should gain 1 bonus trace strength")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= 1 (core/count-tags state)))
+      (is (= 1 (count-tags state)))
       (run-jack-out state)
       (run-on state "HQ")
       (card-subroutine state :corp nh 0)
@@ -1314,7 +1315,7 @@
           "Should gain only 1 bonus trace strength regardless of number of runs in a turn")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= 2 (core/count-tags state)))
+      (is (= 2 (count-tags state)))
       (run-on state "R&D")
       (card-ability state :corp io 1)
       (is (zero? (-> (get-corp) :prompt first :bonus)) "Should gain 0 bonus trace strength, as it's an encounter ability"))))
@@ -1844,7 +1845,7 @@
       (click-prompt state :corp "Yes")
       (is (zero? (:agenda-point (get-corp))) "Forfeiting Posted Bounty nullifies agenda points")
       (is (= 1 (:bad-publicity (get-corp))) "Forfeiting takes 1 bad publicity")
-      (is (= 1 (core/count-tags state)) "Runner receives 1 tag forfeiting Posted Bounty")))
+      (is (= 1 (count-tags state)) "Runner receives 1 tag forfeiting Posted Bounty")))
   (testing "Choosing not to forfeit scores normally"
     (do-game
       (new-game (default-corp ["Posted Bounty"])
@@ -1853,7 +1854,7 @@
       (click-prompt state :corp "No")
       (is (= 1 (:agenda-point (get-corp))))
       (is (zero? (:bad-publicity (get-corp))))
-      (is (zero? (core/count-tags state))))))
+      (is (zero? (count-tags state))))))
 
 (deftest priority-requisition
   ;; Priority Requisition
@@ -2242,13 +2243,13 @@
   (do-game
     (new-game (default-corp ["Restructured Datapool"])
               (default-runner))
-    (is (zero? (core/count-tags state)) "Runner should start with no tags")
+    (is (zero? (count-tags state)) "Runner should start with no tags")
     (play-and-score state "Restructured Datapool")
     (let [rd-scored (get-scored state :corp 0)]
       (card-ability state :corp rd-scored 0)
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= 1 (core/count-tags state)) "Runner should gain a tag from Restructured Datapool ability"))))
+      (is (= 1 (count-tags state)) "Runner should gain a tag from Restructured Datapool ability"))))
 
 (deftest self-destruct-chips
   ;; Self-Destruct Chips
@@ -2529,14 +2530,14 @@
       (run-successful state)
       (click-card state :runner tg1)
       ;; Accesses TGTBT but can't steal
-      (is (= 1 (core/count-tags state)) "Runner took 1 tag from accessing without stealing")
+      (is (= 1 (count-tags state)) "Runner took 1 tag from accessing without stealing")
       (click-prompt state :runner "No action")
       (click-card state :runner ohg))
     (click-prompt state :runner "Pay 4 [Credits] to trash") ;; Trashes OHG
     (run-empty-server state "Server 2")
     ;; Accesses TGTBT and can steal
     (click-prompt state :runner "Steal")
-    (is (= 2 (core/count-tags state)) "Runner took 1 tag from accessing and stealing")))
+    (is (= 2 (count-tags state)) "Runner took 1 tag from accessing and stealing")))
 
 (deftest the-cleaners
   ;; The Cleaners

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -4,6 +4,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "events"))
@@ -19,7 +20,7 @@
       ;; play Account Siphon, use ability
       (play-run-event state "Account Siphon" :hq)
       (click-prompt state :runner "Replacement effect")
-      (is (= 2 (core/count-tags state)) "Runner took 2 tags")
+      (is (= 2 (count-tags state)) "Runner took 2 tags")
       (is (= 15 (:credit (get-runner))) "Runner gained 10 credits")
       (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))
   (testing "Access"
@@ -31,7 +32,7 @@
       ;; play another Siphon, do not use ability
       (play-run-event state "Account Siphon" :hq)
       (click-prompt state :runner "Access cards")
-      (is (zero? (core/count-tags state)) "Runner did not take any tags")
+      (is (zero? (count-tags state)) "Runner did not take any tags")
       (is (= 5 (:credit (get-runner))) "Runner did not gain any credits")
       (is (= 8 (:credit (get-corp))) "Corp did not lose any credits")))
   (testing "New Angeles City Hall interaction"
@@ -57,7 +58,7 @@
         (card-ability state :runner nach 0)
         (is (zero? (:credit (get-runner))) "Runner has no credits left")
         (click-prompt state :runner "Done"))
-      (is (zero? (core/count-tags state)) "Runner did not take any tags")
+      (is (zero? (count-tags state)) "Runner did not take any tags")
       (is (= 10 (:credit (get-runner))) "Runner gained 10 credits")
       (is (= 3 (:credit (get-corp))) "Corp lost 5 credits"))))
 
@@ -702,7 +703,7 @@
       (let [iw (get-ice state :rd 0)]
         (click-card state :runner iw)
         (is (:icon (refresh iw)) "Ice Wall has an icon")))
-    (is (= 1 (core/count-tags state)) "Runner gained a tag")))
+    (is (= 1 (count-tags state)) "Runner gained a tag")))
 
 (deftest data-breach
   ;; Data Breach
@@ -825,9 +826,9 @@
     (click-prompt state :runner "Steal")
     (is (= 1 (count (:scored (get-runner)))) "TFP stolen")
     (core/gain-tags state :runner 1)
-    (is (= 1 (core/count-tags state)) "Runner has 1 tag")
+    (is (= 1 (count-tags state)) "Runner has 1 tag")
     (click-prompt state :runner "Remove 1 tag")
-    (is (zero? (core/count-tags state)))))
+    (is (zero? (count-tags state)))))
 
 (deftest dirty-laundry
   ;; Dirty Laundry - Gain 5 credits at the end of the run if it was successful
@@ -1133,7 +1134,7 @@
         (click-prompt state :runner "Replacement effect")
         (click-prompt state :runner "2")
         (click-card state :runner (refresh tg))
-        (is (zero? (core/count-tags state)) "No tags, didn't access TGTBT")
+        (is (zero? (count-tags state)) "No tags, didn't access TGTBT")
         (is (zero? (get-counters (refresh tg) :advancement)) "Advancements removed"))))
   (testing "Don't remove more than the existing number of advancement tokens"
     (do-game
@@ -1149,7 +1150,7 @@
         (click-prompt state :runner "Replacement effect")
         (click-prompt state :runner "3")
         (click-card state :runner (refresh tg))
-        (is (zero? (core/count-tags state)) "No tags, didn't access TGTBT")
+        (is (zero? (count-tags state)) "No tags, didn't access TGTBT")
         (is (zero? (get-counters (refresh tg) :advancement)) "Advancements removed")))))
 
 (deftest falsified-credentials
@@ -1419,7 +1420,7 @@
     (take-credits state :corp)
     (play-run-event state (first (:hand (get-runner))) :hq)
     (is (= (+ 5 -2 9) (:credit (get-runner))) "Gained 9 credits on successful run")
-    (is (= 1 (core/count-tags state)) "Took 1 tag on successful run")
+    (is (= 1 (count-tags state)) "Took 1 tag on successful run")
     (is (prompt-map :runner) "Still have access prompt")))
 
 (deftest independent-thinking
@@ -1676,7 +1677,7 @@
     (play-from-hand state :runner "Lawyer Up")
     (is (= 3 (count (:hand (get-runner)))) "Drew 3 cards")
     (is (= 2 (:click (get-runner))) "Spent 2 clicks")
-    (is (= 1 (core/count-tags state)) "Lost 2 tags")))
+    (is (= 1 (count-tags state)) "Lost 2 tags")))
 
 (deftest leave-no-trace
   ;; Leave No Trace should derez ICE that was rezzed during the run
@@ -1780,7 +1781,7 @@
     (take-credits state :runner)
     (take-credits state :corp)
     (core/gain-tags state :runner 4)
-    (is (= 5 (core/count-tags state)) "+1 tag from Jarogniew Mercs")
+    (is (= 5 (count-tags state)) "+1 tag from Jarogniew Mercs")
     (is (= 1 (count (:hand (get-runner)))))
     (is (= 2 (:credit (get-runner))))
     (play-from-hand state :runner "Mars for Martians")
@@ -1913,7 +1914,7 @@
       (click-prompt state :runner "0")
       (card-ability state :runner (-> (get-resource state 0) :hosted first) 0)
       (click-prompt state :runner "Done")
-      (is (zero? (core/count-tags state)) "Runner should avoid tag")
+      (is (zero? (count-tags state)) "Runner should avoid tag")
       (is (= 1 (-> (get-runner) :discard count)) "Runner should have 1 card in Heap")))
   (testing "vs damage"
     (do-game
@@ -1928,7 +1929,7 @@
       (play-and-score state "Show of Force")
       (card-ability state :runner (-> (get-resource state 0) :hosted first) 1)
       (click-prompt state :runner "Done")
-      (is (zero? (core/count-tags state)) "Runner should avoid all meat damage")
+      (is (zero? (count-tags state)) "Runner should avoid all meat damage")
       (is (= 1 (-> (get-runner) :discard count)) "Runner should have 1 card in Heap"))))
 
 (deftest out-of-the-ashes
@@ -2879,7 +2880,7 @@
     (play-run-event state (find-card "Vamp" (:hand (get-runner))) :hq)
     (click-prompt state :runner "Replacement effect")
     (click-prompt state :runner "8")
-    (is (= 1 (core/count-tags state)) "Took 1 tag")
+    (is (= 1 (count-tags state)) "Took 1 tag")
     (is (= 5 (:credit (get-runner))) "Paid 8 credits")
     (is (zero? (:credit (get-corp))) "Corp lost all 8 credits")))
 

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -3,6 +3,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "hardware"))
@@ -325,7 +326,7 @@
       (is (= :waiting (-> @state :runner :prompt first :prompt-type))
           "Runner has prompt to wait for Snare!")
       (click-prompt state :corp "Yes")
-      (is (zero? (core/count-tags state)) "Runner has 0 tags")
+      (is (zero? (count-tags state)) "Runner has 0 tags")
       (is (= 3 (get-counters (refresh dorm) :power))))))
 
 (deftest feedback-filter
@@ -1279,11 +1280,11 @@
     (let [nexus (get-hardware state 0)]
       (run-on state :rd)
       (card-ability state :runner nexus 0)
-      (is (zero? (core/count-tags state)) "Runner should have no tags to start")
+      (is (zero? (count-tags state)) "Runner should have no tags to start")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (is (not (:run @state)) "Run should end from losing Security Nexus trace")
-      (is (= 1 (core/count-tags state)) "Runner should take 1 tag from losing Security Nexus trace")
+      (is (= 1 (count-tags state)) "Runner should take 1 tag from losing Security Nexus trace")
       (take-credits state :runner)
       (take-credits state :corp)
       (run-on state :rd)
@@ -1291,7 +1292,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "10")
       (is (:run @state) "Run should still be going on from winning Security Nexus trace")
-      (is (= 1 (core/count-tags state)) "Runner should still only have 1 tag"))))
+      (is (= 1 (count-tags state)) "Runner should still only have 1 tag"))))
 
 (deftest sifr
   ;; Sifr - Once per turn drop encountered ICE to zero strenght

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -4,6 +4,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags is-tagged?]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "ice"))
@@ -101,14 +102,14 @@
       (run-on state "Archives")
       (core/rez state :corp bw)
       (card-subroutine state :corp bw 0)
-      (is (= 1 (core/count-tags state)) "Runner took 1 tag")
+      (is (= 1 (count-tags state)) "Runner took 1 tag")
       (run-successful state)
-      (is (zero? (core/count-tags state)) "Run successful; Runner lost 1 tag")
+      (is (zero? (count-tags state)) "Run successful; Runner lost 1 tag")
       (run-on state "Archives")
       (card-subroutine state :corp bw 0)
-      (is (= 1 (core/count-tags state)) "Runner took 1 tag")
+      (is (= 1 (count-tags state)) "Runner took 1 tag")
       (run-jack-out state)
-      (is (= 1 (core/count-tags state)) "Run unsuccessful; Runner kept 1 tag"))))
+      (is (= 1 (count-tags state)) "Run unsuccessful; Runner kept 1 tag"))))
 
 (deftest blockchain
   (do-game
@@ -311,7 +312,7 @@
       (card-subroutine state :corp drac 0)
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= 1 (core/count-tags state)) "Runner took 1 tag")
+      (is (= 1 (count-tags state)) "Runner took 1 tag")
       (is (nil? (get-in @state [:run])) "Run was ended"))))
 
 (deftest enigma
@@ -603,18 +604,18 @@
           corp-creds (:credit (get-corp))]
       (core/rez state :corp hydra)
       (is (= (- corp-creds 10) (:credit (get-corp))) "Cost 10 credits to rez Hydra")
-      (is (not (core/is-tagged? state)) "Runner is not tagged approaching Hydra")
+      (is (not (is-tagged? state)) "Runner is not tagged approaching Hydra")
 
       (testing "Hydra subroutines give tags if Runner is not tagged"
         (doseq [n (range 3)]
           (card-subroutine state :corp hydra n)
-          (is (= 1 (core/count-tags state)) (str "Hydra sub " (inc n) " gave Runner 1 tag"))
+          (is (= 1 (count-tags state)) (str "Hydra sub " (inc n) " gave Runner 1 tag"))
           (core/lose-tags state :runner 1)))
 
       (testing "Hydra subroutines do their effect if the Runner is tagged"
         ;; Gain 1 tag to turn on main effect of subroutines
         (core/gain-tags state :runner 1)
-        (is (core/is-tagged? state) "Runner is tagged")
+        (is (is-tagged? state) "Runner is tagged")
 
         (is (= 3 (count (:hand (get-runner)))) "3 cards in Runner grip before Hydra damage")
         (card-subroutine state :corp hydra 0)
@@ -971,13 +972,13 @@
       (run-on state :hq)
       (is (= 3 (:credit (get-corp))) "corp starts encounter with 3 crs")
       (is (zero? (count (:discard (get-runner)))) "runner starts encounter with no cards in heap")
-      (is (zero? (core/count-tags state)) "runner starts encounter with 0 tags")
+      (is (zero? (count-tags state)) "runner starts encounter with 0 tags")
       (card-subroutine state :corp mau 0)
       (card-subroutine state :corp mau 1)
       (card-subroutine state :corp mau 2)
       (is (= 4 (:credit (get-corp))) "corp gains 1 cr from mausolus")
       (is (= 1 (count (:discard (get-runner)))) "corp does 1 net damage")
-      (is (= 1 (core/count-tags state)) "corp gives 1 tag")
+      (is (= 1 (count-tags state)) "corp gives 1 tag")
       (run-jack-out state)
       (take-credits state :runner)
       (core/advance state :corp {:card (refresh mau)})
@@ -986,13 +987,13 @@
       (run-on state :hq)
       (is (= 1 (:credit (get-corp))) "corp starts encounter with 1 crs")
       (is (= 1 (count (:discard (get-runner)))) "runner starts encounter with 1 card in heap")
-      (is (= 1 (core/count-tags state)) "runner starts encounter with 1 tags")
+      (is (= 1 (count-tags state)) "runner starts encounter with 1 tags")
       (card-subroutine state :corp mau 0)
       (card-subroutine state :corp mau 1)
       (card-subroutine state :corp mau 2)
       (is (= 4 (:credit (get-corp))) "corp gains 3 cr")
       (is (= 4 (count (:discard (get-runner)))) "corp does 3 net damage")
-      (is (= 2 (core/count-tags state)) "corp gives 1 tag")
+      (is (= 2 (count-tags state)) "corp gives 1 tag")
       (is (not (:run @state)) "Run is ended")
       (is (get-in @state [:runner :register :unsuccessful-run]) "Run was unsuccessful"))))
 
@@ -1348,7 +1349,7 @@
       (card-side-ability state :runner tom 1)
       (card-side-ability state :runner tom 1)
       (card-side-ability state :runner tom 1)
-      (is (= 4 (core/count-tags state)) "Tag ability sucessful")
+      (is (= 4 (count-tags state)) "Tag ability sucessful")
       (card-side-ability state :runner tom 0)
       (is (not (:run @state)) "Run ended"))))
 
@@ -1362,7 +1363,7 @@
       (core/rez state :corp resistor)
       (is (zero? (:current-strength (refresh resistor))) "No Runner tags; 0 strength")
       (core/gain-tags state :runner 2)
-      (is (= 2 (core/count-tags state)))
+      (is (= 2 (count-tags state)))
       (is (= 2 (:current-strength (refresh resistor))) "2 Runner tags; 2 strength")
       (take-credits state :corp)
       (core/remove-tag state :runner 1)
@@ -1456,12 +1457,12 @@
       (card-subroutine state :corp (refresh searchlight) 0)
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (zero? (core/count-tags state)) "Trace failed with 0 advancements")
+      (is (zero? (count-tags state)) "Trace failed with 0 advancements")
       (advance state searchlight 1)
       (card-subroutine state :corp (refresh searchlight) 0)
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= 1 (core/count-tags state)) "Trace succeeds with 1 advancement"))))
+      (is (= 1 (count-tags state)) "Trace succeeds with 1 advancement"))))
 
 (deftest seidr-adaptive-barrier
   ;; Seidr Adaptive Barrier - +1 strength for every ice protecting its server
@@ -1675,12 +1676,12 @@
       (is (= 6 (-> (get-corp) :prompt first :base)) "Trace should be base 6")
       (click-prompt state :corp "0")
       (click-prompt state :runner "5")
-      (is (= 2 (core/count-tags state)) "Runner took 2 tags from Surveyor Trace 6 with boost 5")
+      (is (= 2 (count-tags state)) "Runner took 2 tags from Surveyor Trace 6 with boost 5")
       (card-subroutine state :corp surv 0)
       (is (= 6 (-> (get-corp) :prompt first :base)) "Trace should be base 6")
       (click-prompt state :corp "0")
       (click-prompt state :runner "6")
-      (is (= 2 (core/count-tags state)) "Runner did not take tags from Surveyor Trace 6 with boost 6")
+      (is (= 2 (count-tags state)) "Runner did not take tags from Surveyor Trace 6 with boost 6")
       (core/move-card state :corp {:card (get-ice state :hq 1) :server "Archives"})
       (is (= 4 (:current-strength (refresh surv))) "Surveyor has 4 strength for 2 pieces of ICE"))))
 

--- a/test/clj/game_test/cards/icebreakers.clj
+++ b/test/clj/game_test/cards/icebreakers.clj
@@ -3,6 +3,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "icebreakers"))
@@ -417,7 +418,7 @@
    (take-credits state :corp)
    (let [gow (get-program state 0)]
      (card-ability state :runner gow 2)
-     (is (= 1 (core/count-tags state)))
+     (is (= 1 (count-tags state)))
      (is (= 2 (get-counters (refresh gow) :virus)) "God of War has 2 virus counters"))))
 
 (deftest ika
@@ -693,7 +694,7 @@
     (run-continue state)
     (click-prompt state :runner "Yes")
     (click-prompt state :runner "2")
-    (is (= 1 (core/count-tags state)) "Runner took 1 tag from using Persephone's ability while AR-Enhanced Security is scored")
+    (is (= 1 (count-tags state)) "Runner took 1 tag from using Persephone's ability while AR-Enhanced Security is scored")
     (take-credits state :runner)
     ;; Gotta move the discarded cards back to the deck
     (core/move state :corp (find-card "Zed 2.0" (:discard (get-corp))) :deck)
@@ -703,7 +704,7 @@
     (run-continue state)
     (click-prompt state :runner "Yes")
     (click-prompt state :runner "2")
-    (is (= 2 (core/count-tags state)) "Runner took 1 tag from using Persephone's ability while AR-Enhanced Security is scored")))
+    (is (= 2 (count-tags state)) "Runner took 1 tag from using Persephone's ability while AR-Enhanced Security is scored")))
 
 (deftest shiv
   ;; Shiv - Gain 1 strength for each installed breaker; no MU cost when 2+ link

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -3,6 +3,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags is-tagged?]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "identities"))
@@ -85,11 +86,11 @@
       (play-from-hand state :corp "Vanilla" "Archives")
       (take-credits state :corp)
       (run-on state :archives)
-      (is (not (core/is-tagged? state)) "Runner does not encounter an unrezzed ice")
+      (is (not (is-tagged? state)) "Runner does not encounter an unrezzed ice")
       (core/rez state :corp (get-ice state :archives 0))
-      (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
+      (is (is-tagged? state) "Runner is tagged when encountering outermost ice")
       (run-continue state)
-      (is (not (core/is-tagged? state)) "Runner no longer encountering outermost ice")))
+      (is (not (is-tagged? state)) "Runner no longer encountering outermost ice")))
   (testing "Interaction with Data Ward"
     (do-game
       (new-game
@@ -99,9 +100,9 @@
       (play-from-hand state :corp "Data Ward" "Archives")
       (take-credits state :corp)
       (run-on state :archives)
-      (is (not (core/is-tagged? state)) "Runner does not encounter an unrezzed ice")
+      (is (not (is-tagged? state)) "Runner does not encounter an unrezzed ice")
       (core/rez state :corp (get-ice state :archives 0))
-      (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
+      (is (is-tagged? state) "Runner is tagged when encountering outermost ice")
       (card-subroutine state :corp (get-ice state :archives 0) 0)
       (is (not (:run @state)) "Run ended by Data Ward")))
   (testing "Tag gain when starting run"
@@ -113,9 +114,9 @@
       (core/rez state :corp (get-ice state :archives 0))
       (take-credits state :corp)
       (run-on state :archives)
-      (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
+      (is (is-tagged? state) "Runner is tagged when encountering outermost ice")
       (run-continue state)
-      (is (not (core/is-tagged? state)) "Runner no longer encountering outermost ice")))
+      (is (not (is-tagged? state)) "Runner no longer encountering outermost ice")))
   (testing "Tag loss when derezzing ice"
     (do-game
       (new-game
@@ -125,9 +126,9 @@
       (core/rez state :corp (get-ice state :archives 0))
       (take-credits state :corp)
       (run-on state :archives)
-      (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
+      (is (is-tagged? state) "Runner is tagged when encountering outermost ice")
       (core/derez state :corp (get-ice state :archives 0))
-      (is (not (core/is-tagged? state)) "Runner no longer encountering the derezzed ice")))
+      (is (not (is-tagged? state)) "Runner no longer encountering the derezzed ice")))
   (testing "No tag on empty server"
     (do-game
       (new-game
@@ -135,7 +136,7 @@
         (default-runner))
       (take-credits state :corp)
       (run-on state :archives)
-      (is (not (core/is-tagged? state)) "No ice to encounter")))
+      (is (not (is-tagged? state)) "No ice to encounter")))
   (testing "No tag when encountering second ice"
     (do-game
       (new-game
@@ -147,9 +148,9 @@
       (core/rez state :corp (get-ice state :archives 1))
       (take-credits state :corp)
       (run-on state :archives)
-      (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
+      (is (is-tagged? state) "Runner is tagged when encountering outermost ice")
       (run-continue state)
-      (is (not (core/is-tagged? state)) "Runner is not tagged when encountering second ice"))))
+      (is (not (is-tagged? state)) "Runner is not tagged when encountering second ice"))))
 
 (deftest adam:-compulsive-hacker
   ;; Adam
@@ -960,7 +961,7 @@
       (play-and-score state "Armed Intimidation")
       (click-prompt state :runner "Take 2 tags")
       (is (= 3 (:agenda-point (get-corp))) "Corp has 3 agenda points from HT + Armed Intimidation")
-      (is (= 2 (core/count-tags state)) "Runner took 2 tags from AI")
+      (is (= 2 (count-tags state)) "Runner took 2 tags from AI")
       (play-from-hand state :corp "Ice Wall" "HQ")
       (take-credits state :corp)
       (take-credits state :runner)
@@ -971,7 +972,7 @@
         (is (= 2 (get-counters (refresh ice-wall) :advancement)) "Ice Wall has 2 advancement counters from HT forfeit"))
       (click-card state :corp (get-scored state :corp 0)) ; select AI to trigger
       (click-prompt state :runner "Take 2 tags") ; First runner has prompt
-      (is (= 4 (core/count-tags state)) "Runner took 2 more tags from AI -- happens at the end of all the async completion"))))
+      (is (= 4 (count-tags state)) "Runner took 2 more tags from AI -- happens at the end of all the async completion"))))
 
 (deftest jesminder-sareen:-girl-behind-the-curtain
   ;; Jesminder Sareen - avoid tags only during a run
@@ -985,9 +986,9 @@
         (core/rez state :corp dr)
         (core/click-run state :runner {:server "Archives"})
         (card-ability state :corp dr 0)
-        (is (zero? (core/count-tags state)) "Jesminder avoided first tag during the run")
+        (is (zero? (count-tags state)) "Jesminder avoided first tag during the run")
         (card-ability state :corp dr 0)
-        (is (= 1 (core/count-tags state)) "Jesminder did not avoid the second tag during the run")
+        (is (= 1 (count-tags state)) "Jesminder did not avoid the second tag during the run")
         (core/no-action state :corp nil)
         (core/continue state :runner nil)
         (core/no-action state :corp nil)
@@ -997,7 +998,7 @@
         (play-from-hand state :corp "SEA Source")
         (click-prompt state :corp "0")
         (click-prompt state :runner "0")
-        (is (= 2 (core/count-tags state)) "Jesminder did not avoid the tag outside of a run"))))
+        (is (= 2 (count-tags state)) "Jesminder did not avoid the tag outside of a run"))))
   (testing "don't avoid John Masanori tag"
     (do-game
       (new-game (default-corp)
@@ -1006,7 +1007,7 @@
       (play-from-hand state :runner "John Masanori")
       (run-on state "HQ")
       (core/jack-out state :runner nil)
-      (is (= 1 (core/count-tags state)) "Jesminder did not avoid John Masanori tag"))))
+      (is (= 1 (count-tags state)) "Jesminder did not avoid John Masanori tag"))))
 
 (deftest jinteki-biotech:-life-imagined
   ;; Jinteki Biotech
@@ -1281,7 +1282,7 @@
     (take-credits state :corp)
     (run-empty-server state "R&D")
     (is (= 7 (count (:hand (get-runner)))) "Drew 2 cards from successful run on Archives")
-    (is (= 1 (core/count-tags state)) "Took 1 tag from successful run on Archives")))
+    (is (= 1 (count-tags state)) "Took 1 tag from successful run on Archives")))
 
 (deftest maxx:-maximum-punk-rock
   ;; MaxX
@@ -1445,7 +1446,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (is (empty? (:prompt (get-runner))) "Forger can't avoid the tag")
-      (is (= 1 (core/count-tags state)) "Runner took 1 unpreventable tag")
+      (is (= 1 (count-tags state)) "Runner took 1 unpreventable tag")
       (core/gain state :runner :credit 2)
       (run-empty-server state "Server 2")
       (click-prompt state :runner "Pay 2 [Credits] to trash")
@@ -1464,7 +1465,7 @@
       (click-prompt state :corp "Yes")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= 1 (core/count-tags state)) "Runner took 1 unpreventable tag")
+      (is (= 1 (count-tags state)) "Runner took 1 unpreventable tag")
       (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage from DRT"))))
 
 (deftest new-angeles-sol:-your-news

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -4,6 +4,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "operations"))
@@ -22,15 +23,15 @@
         (score-agenda state :corp ag1)
         (score-agenda state :corp ag2)
         (take-credits state :corp)
-        (is (zero? (core/count-tags state))) ; tags cleared
+        (is (zero? (count-tags state))) ; tags cleared
         (take-credits state :runner)
         (play-from-hand state :corp "24/7 News Cycle")
         (click-card state :corp (find-card "Breaking News" (:scored (get-corp))))
         (is (= 1 (:agenda-point (get-corp))) "Forfeited Breaking News")
         (click-card state :corp (find-card "Breaking News" (:scored (get-corp))))
-        (is (= 2 (core/count-tags state)) "Runner given 2 tags")
+        (is (= 2 (count-tags state)) "Runner given 2 tags")
         (take-credits state :corp 2)
-        (is (= 2 (core/count-tags state)) "Tags remained after Corp ended turn"))))
+        (is (= 2 (count-tags state)) "Tags remained after Corp ended turn"))))
   (testing "Posted Bounty interaction -- Issue #1043"
     (do-game
       (new-game (default-corp [(qty "Posted Bounty" 2) (qty "24/7 News Cycle" 3)])
@@ -48,7 +49,7 @@
         (is (= 1 (:agenda-point (get-corp))) "Forfeited Posted Bounty")
         (click-card state :corp (find-card "Posted Bounty" (:scored (get-corp))))
         (click-prompt state :corp "Yes") ; "Forfeit Posted Bounty to give 1 tag?"
-        (is (= 1 (core/count-tags state)) "Runner given 1 tag")
+        (is (= 1 (count-tags state)) "Runner given 1 tag")
         (is (= 1 (:bad-publicity (get-corp))) "Corp has 1 bad publicity")
         (is (zero? (:agenda-point (get-corp))) "Forfeited Posted Bounty to 24/7 News Cycle"))))
   (testing "Swapped agendas are able to be used. #1555"
@@ -201,7 +202,7 @@
     (is (= 1 (count (:hand (get-corp)))) "Card not played because Runner has no tags")
     (core/gain-tags state :runner 1)
     (play-from-hand state :corp "Big Brother")
-    (is (= 3 (core/count-tags state)) "Runner gained 2 tags")))
+    (is (= 3 (count-tags state)) "Runner gained 2 tags")))
 
 (deftest biotic-labor
   ;; Biotic Labor - Gain 2 clicks
@@ -278,7 +279,7 @@
           (run-empty-server state "Server 2")
           (click-card state :runner oak)
           (click-prompt state :runner "Steal")
-          (is (= 2 (core/count-tags state)) "Runner took 2 tags from accessing agenda with Casting Call hosted on it"))))))
+          (is (= 2 (count-tags state)) "Runner took 2 tags from accessing agenda with Casting Call hosted on it"))))))
 
 (deftest cerebral-cast
   ;; Cerebral Cast
@@ -295,7 +296,7 @@
       (click-prompt state :corp "0 [Credits]")
       (click-prompt state :runner "0 [Credits]")
       (is (zero? (count (:discard (get-runner)))) "Runner took no damage")
-      (is (zero? (core/count-tags state)) "Runner took no tags")))
+      (is (zero? (count-tags state)) "Runner took no tags")))
   (testing "Corp wins"
     (do-game
       (new-game (default-corp [(qty "Cerebral Cast" 2)])
@@ -308,13 +309,13 @@
       (click-prompt state :runner "1 [Credits]")
       (click-prompt state :runner "1 brain damage")
       (is (= 1 (count (:discard (get-runner)))) "Runner took a brain damage")
-      (is (zero? (core/count-tags state)) "Runner took no tags from brain damage choice")
+      (is (zero? (count-tags state)) "Runner took no tags from brain damage choice")
       (play-from-hand state :corp "Cerebral Cast")
       (click-prompt state :corp "0 [Credits]")
       (click-prompt state :runner "1 [Credits]")
       (click-prompt state :runner "1 tag")
       (is (= 1 (count (:discard (get-runner)))) "Runner took no additional damage")
-      (is (= 1 (core/count-tags state)) "Runner took a tag from Cerebral Cast choice"))))
+      (is (= 1 (count-tags state)) "Runner took a tag from Cerebral Cast choice"))))
 
 (deftest cerebral-static
   ;; Cerebral Static
@@ -537,17 +538,17 @@
               (default-runner))
     (play-from-hand state :corp "Door to Door")
     (take-credits state :corp)
-    (is (zero? (core/count-tags state)) "Runner should start with 0 tags")
+    (is (zero? (count-tags state)) "Runner should start with 0 tags")
     (is (= 3 (-> (get-runner) :hand count)) "Runner should start with 3 cards in hand")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 1 (core/count-tags state)) "Runner should gain 1 tag from Door to Door")
+    (is (= 1 (count-tags state)) "Runner should gain 1 tag from Door to Door")
     (is (= 3 (-> (get-runner) :hand count)) "Runner should start with 3 cards in hand")
     (take-credits state :runner)
     (take-credits state :corp)
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 1 (core/count-tags state)) "Runner should still have 1 tag")
+    (is (= 1 (count-tags state)) "Runner should still have 1 tag")
     (is (= 2 (-> (get-runner) :hand count)) "Runner should take 1 meat damage from Door to Door")))
 
 (deftest economic-warfare
@@ -744,9 +745,9 @@
                 (default-runner))
       (score-agenda state :corp (find-card "Market Research" (:hand (get-corp))))
       (score-agenda state :corp (find-card "Breaking News" (:hand (get-corp))))
-      (is (= 2 (core/count-tags state)) "Runner gained 2 tags")
+      (is (= 2 (count-tags state)) "Runner gained 2 tags")
       (take-credits state :corp)
-      (is (zero? (core/count-tags state)) "Runner lost 2 tags")
+      (is (zero? (count-tags state)) "Runner lost 2 tags")
       (core/steal state :runner (find-card "Project Beale" (:hand (get-corp))))
       (core/steal state :runner (find-card "Explode-a-palooza" (:hand (get-corp))))
       (take-credits state :runner)
@@ -771,15 +772,15 @@
       (core/steal state :runner (find-card "Explode-a-palooza" (:hand (get-corp))))
       (take-credits state :runner)
       (score-agenda state :corp (find-card "Breaking News" (:hand (get-corp))))
-      (is (= 2 (core/count-tags state)) "Runner gained 2 tags")
+      (is (= 2 (count-tags state)) "Runner gained 2 tags")
       (play-from-hand state :corp "Exchange of Information")
       (click-card state :corp (find-card "Project Beale" (:scored (get-runner))))
       (click-card state :corp (find-card "Breaking News" (:scored (get-corp))))
-      (is (= 2 (core/count-tags state)) "Still has tags after swap and before end of turn")
+      (is (= 2 (count-tags state)) "Still has tags after swap and before end of turn")
       (take-credits state :corp)
       (is (= 3 (:agenda-point (get-runner))))
       (is (= 2 (:agenda-point (get-corp))))
-      (is (= 2 (core/count-tags state)) "Runner does not lose tags at end of turn")))
+      (is (= 2 (count-tags state)) "Runner does not lose tags at end of turn")))
   (testing "Swapping a 15 Minutes still keeps the ability. #1783"
     (do-game
       (new-game (default-corp [(qty "Exchange of Information" 2) "15 Minutes"
@@ -971,10 +972,10 @@
     (is (= 3 (:click (get-corp))) "Corp should start with 3 clicks")
     (play-from-hand state :corp "Hard-Hitting News")
     (is (zero? (:click (get-corp))) "Playing Hard-Hitting News should lose all remaining clicks")
-    (is (zero? (core/count-tags state)) "Runner should start with 0 tags")
+    (is (zero? (count-tags state)) "Runner should start with 0 tags")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 4 (core/count-tags state)) "Runner should gain 4 tags from losing Hard-Hitting News trace")))
+    (is (= 4 (count-tags state)) "Runner should gain 4 tags from losing Hard-Hitting News trace")))
 
 (deftest hatchet-job
   ;; Hatchet Job - Win trace to add installed non-virtual to grip
@@ -1217,7 +1218,7 @@
     (is (:prompt (get-corp)) "Manhunt trace initiated")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 1 (core/count-tags state)) "Runner took 1 tag")
+    (is (= 1 (count-tags state)) "Runner took 1 tag")
     (click-prompt state :runner "No action")
     (is (not (:run @state)) "Run ended")
     (run-empty-server state "HQ")
@@ -1315,7 +1316,7 @@
       (play-from-hand state :corp "Midseason Replacements")
       (click-prompt state :corp "0") ; default trace
       (click-prompt state :runner "0") ; Runner won't match
-      (is (= 6 (core/count-tags state)) "Runner took 6 tags"))))
+      (is (= 6 (count-tags state)) "Runner took 6 tags"))))
 
 (deftest mushin-no-shin
   ;; Mushin No Shin - Add 3 advancements to a card; prevent rez/score of that card the rest of the turn
@@ -1821,11 +1822,11 @@
     (take-credits state :corp)
     (run-empty-server state :rd)
     (take-credits state :runner)
-    (is (zero? (core/count-tags state)) "Runner should start with 0 tags")
+    (is (zero? (count-tags state)) "Runner should start with 0 tags")
     (play-from-hand state :corp "SEA Source")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 1 (core/count-tags state)) "Runner should get 1 tag from losing SEA Source trace")))
+    (is (= 1 (count-tags state)) "Runner should get 1 tag from losing SEA Source trace")))
 
 (deftest self-growth-program
   ;; Self-Growth Program - Add 2 installed cards to grip if runner is tagged
@@ -2019,13 +2020,13 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Scrubber")
     (take-credits state :runner)
-    (is (zero? (core/count-tags state)) "Runner should start with 0 tags")
+    (is (zero? (count-tags state)) "Runner should start with 0 tags")
     (play-from-hand state :corp "Snatch and Grab")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
     (click-card state :corp (get-resource state 0))
     (click-prompt state :runner "Yes")
-    (is (= 1 (core/count-tags state)) "Runner should get 1 tag from losing Snatch and Grab trace and opting to take the tag")
+    (is (= 1 (count-tags state)) "Runner should get 1 tag from losing Snatch and Grab trace and opting to take the tag")
     (is (zero? (-> (get-runner) :discard count)) "Runner should start with 0 cards in heap")
     (play-from-hand state :corp "Snatch and Grab")
     (click-prompt state :corp "0")
@@ -2096,7 +2097,7 @@
       (click-card state :corp (find-card "Hard-Hitting News" (:hand (get-corp))))
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= 5 (core/count-tags state)) "Runner has 5 tags")
+      (is (= 5 (count-tags state)) "Runner has 5 tags")
       (is (empty? (:prompt (get-corp))) "Corp does not have a second Subcontract selection prompt"))))
 
 (deftest subliminal-messaging
@@ -2302,7 +2303,7 @@
     (do-game
       (new-game (default-corp ["Restructured Datapool" "Surveillance Sweep" "Data Raven"])
                 (default-runner ["Scrubbed"]))
-      (is (zero? (core/count-tags state)) "Runner should start with no tags")
+      (is (zero? (count-tags state)) "Runner should start with no tags")
       (play-from-hand state :corp "Surveillance Sweep")
       (play-and-score state "Restructured Datapool")
       (let [rd-scored (get-scored state :corp 0)]
@@ -2310,7 +2311,7 @@
         (is (not= :waiting (-> (get-corp) :prompt first :prompt-type)) "Surveillance Sweep only works during a run")
         (click-prompt state :corp "0")
         (click-prompt state :runner "0")
-        (is (= 1 (core/count-tags state)) "Runner should gain a tag from Restructured Datapool ability"))
+        (is (= 1 (count-tags state)) "Runner should gain a tag from Restructured Datapool ability"))
       (take-credits state :corp)
       (take-credits state :runner)
       (play-from-hand state :corp "Data Raven" "HQ")
@@ -2452,17 +2453,17 @@
     (play-from-hand state :runner "Desperado")
     (play-from-hand state :runner "Corroder")
     (take-credits state :runner)
-    (is (zero? (core/count-tags state)) "Runner starts with 0 tags")
+    (is (zero? (count-tags state)) "Runner starts with 0 tags")
     (play-from-hand state :corp "Threat Assessment")
     (click-card state :corp (find-card "Desperado" (-> (get-runner) :rig :hardware)))
     (click-prompt state :runner "2 tags")
-    (is (= 2 (core/count-tags state)) "Runner took 2 tags")
+    (is (= 2 (count-tags state)) "Runner took 2 tags")
     (is (= 1 (count (-> (get-runner) :rig :hardware))) "Didn't trash Desperado")
     (is (= "Threat Assessment" (:title (first (:rfg (get-corp))))) "Threat Assessment removed from game")
     (play-from-hand state :corp "Threat Assessment")
     (click-card state :corp (find-card "Corroder" (-> (get-runner) :rig :program)))
     (click-prompt state :runner "Move Corroder")
-    (is (= 2 (core/count-tags state)) "Runner didn't take tags")
+    (is (= 2 (count-tags state)) "Runner didn't take tags")
     (is (= "Corroder" (:title (first (:deck (get-runner))))) "Moved Corroder to the deck")
     (is (= 2 (count (:rfg (get-corp)))))
     (take-credits state :runner)
@@ -2478,16 +2479,16 @@
               (default-runner))
     (core/gain state :corp :click 2)
     (core/gain state :corp :credit 2)
-    (is (zero? (core/count-tags state)))
+    (is (zero? (count-tags state)))
     (play-from-hand state :corp "Threat Level Alpha")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 1 (core/count-tags state)) "Runner took 1 tag because they had 0")
+    (is (= 1 (count-tags state)) "Runner took 1 tag because they had 0")
     (core/gain-tags state :runner 2)
     (play-from-hand state :corp "Threat Level Alpha")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 6 (core/count-tags state)) "Runner took 3 tag because they had 3")))
+    (is (= 6 (count-tags state)) "Runner took 3 tag because they had 3")))
 
 (deftest transparency-initiative
   ;; Transparency Initiative - Full test

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -4,6 +4,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "programs"))
@@ -271,7 +272,7 @@
     (is (= 1 (-> (get-runner) :discard count)) "Disrupter should be in Heap")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (zero? (core/count-tags state)) "Runner should gain no tag from beating trace")
+    (is (zero? (count-tags state)) "Runner should gain no tag from beating trace")
     (play-from-hand state :corp "SEA Source")
     (is (= 3 (-> (get-corp) :prompt first :base)) "Base trace should be reset to 3")))
 
@@ -495,7 +496,7 @@
       (play-from-hand state :corp "Prisec" "New remote")
       (take-credits state :corp)
       (let [credits (:credit (get-corp))
-            tags (core/count-tags state)
+            tags (count-tags state)
             grip (count (:hand (get-runner)))
             archives (count (:discard (get-corp)))]
         (play-from-hand state :runner "Imp")
@@ -503,7 +504,7 @@
         (click-prompt state :corp "Yes")
         (click-prompt state :runner "[Imp]: Trash card")
         (is (= 2 (- credits (:credit (get-corp)))) "Corp paid 2 for Prisec")
-        (is (= 1 (- (core/count-tags state) tags)) "Runner has 1 tag")
+        (is (= 1 (- (count-tags state) tags)) "Runner has 1 tag")
         (is (= 2 (- grip (count (:hand (get-runner))))) "Runner took 1 meat damage")
         (is (= 1 (- (count (:discard (get-corp))) archives)) "Used Imp to trash Prisec"))))
   (testing "vs The Future Perfect"

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -3,6 +3,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "resources"))
@@ -14,14 +15,14 @@
               (default-runner ["Activist Support"]))
     (take-credits state :corp)
     (play-from-hand state :runner "Activist Support")
-    (is (zero? (core/count-tags state)))
+    (is (zero? (count-tags state)))
     (take-credits state :runner)
-    (is (= 1 (core/count-tags state)) "Runner took 1 tag; had none")
+    (is (= 1 (count-tags state)) "Runner took 1 tag; had none")
     (is (zero? (:bad-publicity (get-corp))))
     (take-credits state :corp)
     (is (= 1 (:bad-publicity (get-corp))) "Corp took 1 bad pub; had none")
     (take-credits state :runner)
-    (is (= 1 (core/count-tags state)) "Runner had 1 tag; didn't take another")
+    (is (= 1 (count-tags state)) "Runner had 1 tag; didn't take another")
     (take-credits state :corp)
     (is (= 1 (:bad-publicity (get-corp))) "Corp had 1 bad pub; didn't take another")))
 
@@ -481,7 +482,7 @@
     (is (= 1 (count (:prompt (get-runner)))) "Runner prompted to avoid tag")
     (card-ability state :runner (get-resource state 0) 0)
     (is (= 1 (count (:discard (get-runner)))) "Decoy trashed")
-    (is (zero? (core/count-tags state)) "Tag avoided")))
+    (is (zero? (count-tags state)) "Tag avoided")))
 
 (deftest district-99
   ;; District 99 - Gains power counters on hardware/program trashes, can spend 3 power counters to recur a card matching identity
@@ -1261,10 +1262,10 @@
     (is (= 5 (count (:hand (get-runner)))) "No card drawn from second successful run")
     (run-on state "HQ")
     (run-jack-out state)
-    (is (= 1 (core/count-tags state)) "1 tag taken from first unsuccessful run")
+    (is (= 1 (count-tags state)) "1 tag taken from first unsuccessful run")
     (run-on state "HQ")
     (run-jack-out state)
-    (is (= 1 (core/count-tags state)) "No tag taken from second unsuccessful run")))
+    (is (= 1 (count-tags state)) "No tag taken from second unsuccessful run")))
 
 (deftest joshua-b.
   ;; Joshua B. - Take 1 tag at turn end if you choose to gain the extra click
@@ -1282,7 +1283,7 @@
     (core/end-phase-12 state :runner nil)
     (is (= 5 (:click (get-runner))) "Gained normal clicks as well")
     (take-credits state :runner)
-    (is (= 1 (core/count-tags state)) "Took 1 tag")))
+    (is (= 1 (count-tags state)) "Took 1 tag")))
 
 (deftest kati-jones
   ;; Kati Jones - Click to store and take
@@ -1584,7 +1585,7 @@
         (click-prompt state :runner "0") ; Runner won't match
         (card-ability state :runner nach 0)
         (click-prompt state :runner "Done")
-        (is (zero? (core/count-tags state)) "Avoided SEA Source tag")
+        (is (zero? (count-tags state)) "Avoided SEA Source tag")
         (is (= 4 (:credit (get-runner))) "Paid 2 credits")
         (take-credits state :corp)
         (run-empty-server state "Server 1")
@@ -1604,7 +1605,7 @@
         (card-ability state :runner nach 0)
         (card-ability state :runner nach 0)
         (click-prompt state :runner "Done")
-        (is (zero? (core/count-tags state)) "Tags avoided")
+        (is (zero? (count-tags state)) "Tags avoided")
         (is (= 10 (:credit (get-runner))) "10 credits siphoned")
         (is (= 3 (:credit (get-corp))) "Corp lost 5 credits")))))
 
@@ -1639,7 +1640,7 @@
       (click-prompt state :runner "0")
       (click-prompt state :runner "Done")
       (is (= 3 (count (:discard (get-runner)))) "Two NOH trashed, 1 gamble played")
-      (is (zero? (core/count-tags state)) "Tags avoided")
+      (is (zero? (count-tags state)) "Tags avoided")
       (take-credits state :corp)
       (play-from-hand state :runner "No One Home")
       (take-credits state :runner)
@@ -1835,24 +1836,24 @@
               (default-runner ["Power Tap"]))
     (play-and-score state "Restructured Datapool")
     (let [agenda (get-scored state :corp 0)
-          tags (core/count-tags state)
+          tags (count-tags state)
           credits (:credit (get-runner))]
       (card-ability state :corp agenda 0)
       (is (= credits (:credit (get-runner))) "Runner shouldn't gain any credits from trace")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= (+ tags 1) (core/count-tags state)) "Runner should gain 1 tag from losing trace"))
+      (is (= (+ tags 1) (count-tags state)) "Runner should gain 1 tag from losing trace"))
     (take-credits state :corp)
     (play-from-hand state :runner "Power Tap")
     (take-credits state :runner)
     (let [agenda (get-scored state :corp 0)
-          tags (core/count-tags state)
+          tags (count-tags state)
           credits (:credit (get-runner))]
       (card-ability state :corp agenda 0)
       (is (= (+ credits 1) (:credit (get-runner))) "Runner should gain 1 credit from trace initiation")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (= (+ tags 1) (core/count-tags state)) "Runner should gain 1 tag from losing trace"))))
+      (is (= (+ tags 1) (count-tags state)) "Runner should gain 1 tag from losing trace"))))
 
 (deftest professional-contacts
   ;; Professional Contacts - Click to gain 1 credit and draw 1 card

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -3,6 +3,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs "upgrades"))
@@ -234,7 +235,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (click-prompt state :runner "Pay 3 [Credits] to trash")
-      (is (= 1 (core/count-tags state)))
+      (is (= 1 (count-tags state)))
       (is (= 2 (:credit (get-runner))) "Runner paid 3cr to trash Bernice")
       (core/rez state :corp (get-content state :remote2 0))
       (core/gain state :runner :credit 20)
@@ -261,7 +262,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (click-prompt state :runner "Pay 3 [Credits] to trash")
-      (is (= 1 (core/count-tags state)))
+      (is (= 1 (count-tags state)))
       (is (= 2 (:credit (get-runner))) "Runner paid 3cr to trash Bernice")
       (is (= 2 (count (:discard (get-runner)))) "Runner took 1 meat damage"))))
 
@@ -426,14 +427,14 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (is (= 3 (:credit (get-corp))) "Trace was successful")
-      (is (zero? (core/count-tags state)) "No tags given for run on different server")
+      (is (zero? (count-tags state)) "No tags given for run on different server")
       (run-successful state)
       (run-on state "Server 1")
       (card-subroutine state :corp cad 0)
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (is (= 6 (:credit (get-corp))) "Trace was successful")
-      (is (= 1 (core/count-tags state))
+      (is (= 1 (count-tags state))
           "Runner took 1 tag given from successful trace during run on ChiLo server"))))
 
 (deftest code-replicator
@@ -617,19 +618,19 @@
     (starting-hand state :corp ["Forced Connection" "Forced Connection"])
     (play-from-hand state :corp "Forced Connection" "New remote")
     (take-credits state :corp)
-    (is (zero? (core/count-tags state)) "Runner starts with 0 tags")
+    (is (zero? (count-tags state)) "Runner starts with 0 tags")
     (run-empty-server state :remote1)
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
     (click-prompt state :runner "Pay 0 [Credits] to trash") ; trash
-    (is (= 2 (core/count-tags state)) "Runner took two tags")
+    (is (= 2 (count-tags state)) "Runner took two tags")
     (run-empty-server state "Archives")
-    (is (= 2 (core/count-tags state)) "Runner doesn't take tags when accessed from Archives")
+    (is (= 2 (count-tags state)) "Runner doesn't take tags when accessed from Archives")
     (run-empty-server state "HQ")
     (click-prompt state :corp "0")
     (click-prompt state :runner "3")
     (click-prompt state :runner "Pay 0 [Credits] to trash") ; trash
-    (is (= 2 (core/count-tags state)) "Runner doesn't take tags when trace won")))
+    (is (= 2 (count-tags state)) "Runner doesn't take tags when trace won")))
 
 (deftest georgia-emelyov
   ;; Georgia Emelyov
@@ -823,7 +824,7 @@
       (core/gain-tags state :runner 2)
       (card-ability state :corp keeg 0)
       (click-card state :corp (get-program state 0))
-      (is (= 1 (core/count-tags state)) "1 tag removed")
+      (is (= 1 (count-tags state)) "1 tag removed")
       (is (= 1 (count (:discard (get-corp)))) "Keegan trashed")
       (is (= 1 (count (:discard (get-runner)))) "Corroder trashed"))))
 
@@ -1271,15 +1272,15 @@
         (run-on state "Server 1")
         (core/rez state :corp om)
         (run-successful state)
-        (is (zero? (core/count-tags state)) "Runner starts with no tags")
+        (is (zero? (count-tags state)) "Runner starts with no tags")
         (click-card state :runner rh)
         (click-prompt state :runner "Pay 1 [Credits] to trash")
         (click-prompt state :corp "Yes")
-        (is (= 1 (core/count-tags state)) "Runner takes a tag")
+        (is (= 1 (count-tags state)) "Runner takes a tag")
         (click-card state :runner om)
         (click-prompt state :runner "Pay 2 [Credits] to trash")
         (click-prompt state :corp "Yes")
-        (is (= 2 (core/count-tags state)) "Runner takes a tag"))))
+        (is (= 2 (count-tags state)) "Runner takes a tag"))))
   (testing "Effect persists after trash"
     (do-game
       (new-game (default-corp ["Overseer Matrix" (qty "Red Herrings" 3)])
@@ -1292,15 +1293,15 @@
         (run-on state "Server 1")
         (core/rez state :corp om)
         (run-successful state)
-        (is (zero? (core/count-tags state)) "Runner starts with no tags")
+        (is (zero? (count-tags state)) "Runner starts with no tags")
         (click-card state :runner om)
         (click-prompt state :runner "Pay 2 [Credits] to trash")
         (click-prompt state :corp "Yes")
-        (is (= 1 (core/count-tags state)) "Runner takes a tag")
+        (is (= 1 (count-tags state)) "Runner takes a tag")
         (click-card state :runner rh)
         (click-prompt state :runner "Pay 1 [Credits] to trash")
         (click-prompt state :corp "Yes")
-        (is (= 2 (core/count-tags state)) "Runner takes a tag"))))
+        (is (= 2 (count-tags state)) "Runner takes a tag"))))
   (testing "Effect ends after current run"
     (do-game
       (new-game (default-corp ["Overseer Matrix" (qty "Red Herrings" 3)])
@@ -1313,19 +1314,19 @@
         (run-on state "Server 1")
         (core/rez state :corp om)
         (run-successful state)
-        (is (zero? (core/count-tags state)) "Runner starts with no tags")
+        (is (zero? (count-tags state)) "Runner starts with no tags")
         (click-card state :runner om)
         (click-prompt state :runner "Pay 2 [Credits] to trash")
         (click-prompt state :corp "Yes")
-        (is (= 1 (core/count-tags state)) "Runner takes a tag")
+        (is (= 1 (count-tags state)) "Runner takes a tag")
         (click-card state :runner rh)
         (click-prompt state :runner "No action")
-        (is (= 1 (core/count-tags state)) "Runner doesn't take a tag")
+        (is (= 1 (count-tags state)) "Runner doesn't take a tag")
         (run-on state "Server 1")
         (run-successful state)
         (click-prompt state :runner "Pay 1 [Credits] to trash")
         (is (empty? (:prompt (get-corp))) "No prompt for Overseer Matrix")
-        (is (= 1 (core/count-tags state)) "Runner doesn't take a tag")))))
+        (is (= 1 (count-tags state)) "Runner doesn't take a tag")))))
 
 (deftest port-anson-grid
   ;; Port Anson Grid - Prevent the Runner from jacking out until they trash a program
@@ -1362,7 +1363,7 @@
       (let [pre-creds (:credit (get-corp))]
         (click-prompt state :corp "Yes")
         (is (= (- pre-creds 2) (:credit (get-corp))) "Pay 2 [Credits] to pay for Prisec"))
-      (is (= 1 (core/count-tags state)) "Give runner 1 tag")
+      (is (= 1 (count-tags state)) "Give runner 1 tag")
       (is (= 1 (count (:discard (get-runner)))) "Prisec does 1 damage")
       ;; Runner trashes Prisec
       (click-prompt state :runner "Pay 3 [Credits] to trash")

--- a/test/clj/game_test/games/scenarios.clj
+++ b/test/clj/game_test/games/scenarios.clj
@@ -3,6 +3,7 @@
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
+            [jinteki.utils :refer [count-tags]]
             [clojure.test :refer :all]))
 
 (use-fixtures :once load-all-cards (partial reset-card-defs nil))
@@ -38,7 +39,7 @@
           (play-from-hand state :corp "SEA Source")
           (click-prompt state :corp "3") ; boost trace to 6
           (click-prompt state :runner "0")
-          (is (= 1 (core/count-tags state)) "Runner took tag from SEA Source")
+          (is (= 1 (count-tags state)) "Runner took tag from SEA Source")
           (is (= 7 (:credit (get-corp))))
           (core/trash-resource state :corp nil)
           (click-card state :corp "Off-Campus Apartment")


### PR DESCRIPTION
If a user attempted to change the number of `tags` via the UI, the game would crash. Added the correct map handler.

Also fixed activation of `Trash Resource` and `Remove Tag` buttons.

Fixes #3847 