### PR TITLE
Fixed Acme `run-ends` event. Fixed Acme triggering on non-ice rez.

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -89,15 +89,16 @@
       :events {:run {:effect (req (when (and (outermost? run-position run-ices)
                                              (rezzed? current-ice))
                                     (activate state card true)))}
-               :rez {:effect (req (when (outermost? run-position run-ices)
-                                    (activate state card true)))}
+               :rez {:effect (req (when (and (outermost? run-position run-ices)
+                                               (= (:cid current-ice) (:cid target)))
+                                      (activate state card true)))}
                :derez {:effect (req (when (outermost? run-position run-ices)
                                       (activate state card false)))}
                :pass-ice {:effect (req (when (and (outermost? run-position run-ices)
                                                   (get-in card [:special :acme-active]))
                                          (activate state card false)))}
-               :end-run {:effect (req (when (get-in card [:special :acme-active])
-                                        (activate state card false)))}}})
+               :run-ends {:effect (req (when (get-in card [:special :acme-active])
+                                         (activate state card false)))}}})
 
    "Adam: Compulsive Hacker"
    {:events {:pre-start-game

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -150,7 +150,7 @@
       (run-on state :archives)
       (is (is-tagged? state) "Runner is tagged when encountering outermost ice")
       (run-continue state)
-      (is (not (core/is-tagged? state)) "Runner is not tagged when encountering second ice")))
+      (is (not (is-tagged? state)) "Runner is not tagged when encountering second ice")))
   (testing "Tag loss when runner jacks out"
     (do-game
       (new-game
@@ -160,9 +160,9 @@
       (core/rez state :corp (get-ice state :archives 0))
       (take-credits state :corp)
       (run-on state :archives)
-      (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
+      (is (is-tagged? state) "Runner is tagged when encountering outermost ice")
       (run-jack-out state)
-      (is (not (core/is-tagged? state)) "Runner no longer tagged after jacking out")))
+      (is (not (is-tagged? state)) "Runner no longer tagged after jacking out")))
   (testing "No tag gained when rezzing something other than ice"
     (do-game
       (new-game
@@ -172,14 +172,14 @@
       (play-from-hand state :corp "NGO Front" "New remote")
       (take-credits state :corp)
       (run-on state :archives)
-      (is (not (core/is-tagged? state)) "Runner is not yet tagged when encountering outermost ice")
+      (is (not (is-tagged? state)) "Runner is not yet tagged when encountering outermost ice")
       (core/rez state :corp (get-ice state :archives 0))
       (is (= 1 (get-in @state [:runner :tag :additional])) "Runner gains 1 additional tag when ice rezzed")
       (core/rez state :corp (get-content state :remote1 0))
       (is (:rezzed (get-content state :remote1 0)) "NGO Front now rezzed")
       (is (= 1 (get-in @state [:runner :tag :additional])) "Runner does not gain a tag when asset rezzed")
       (run-continue state)
-      (is (not (core/is-tagged? state)) "Runner is not tagged when encountering second ice"))))
+      (is (not (is-tagged? state)) "Runner is not tagged when encountering second ice"))))
 
 (deftest adam:-compulsive-hacker
   ;; Adam

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -149,6 +149,35 @@
       (run-on state :archives)
       (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
       (run-continue state)
+      (is (not (core/is-tagged? state)) "Runner is not tagged when encountering second ice")))
+  (testing "Tag loss when runner jacks out"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" ["Vanilla" (qty "Hedge Fund" 5)])
+        (default-runner))
+      (play-from-hand state :corp "Vanilla" "Archives")
+      (core/rez state :corp (get-ice state :archives 0))
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (core/is-tagged? state) "Runner is tagged when encountering outermost ice")
+      (run-jack-out state)
+      (is (not (core/is-tagged? state)) "Runner no longer tagged after jacking out")))
+  (testing "No tag gained when rezzing something other than ice"
+    (do-game
+      (new-game
+        (make-deck "Acme Consulting: The Truth You Need" ["Vanilla" "NGO Front"])
+        (default-runner))
+      (play-from-hand state :corp "Vanilla" "Archives")
+      (play-from-hand state :corp "NGO Front" "New remote")
+      (take-credits state :corp)
+      (run-on state :archives)
+      (is (not (core/is-tagged? state)) "Runner is not yet tagged when encountering outermost ice")
+      (core/rez state :corp (get-ice state :archives 0))
+      (is (= 1 (get-in @state [:runner :tag :additional])) "Runner gains 1 additional tag when ice rezzed")
+      (core/rez state :corp (get-content state :remote1 0))
+      (is (:rezzed (get-content state :remote1 0)) "NGO Front now rezzed")
+      (is (= 1 (get-in @state [:runner :tag :additional])) "Runner does not gain a tag when asset rezzed")
+      (run-continue state)
       (is (not (core/is-tagged? state)) "Runner is not tagged when encountering second ice"))))
 
 (deftest adam:-compulsive-hacker


### PR DESCRIPTION
We referenced an non-existent event trying to catch the end of the run.
Checking card `:cid` when determining if the outermost ice was just rezzed.

Fixes #3814 