### PR TITLE
Extract Sound Into It's own Component

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1378,8 +1378,7 @@
             {:display-name "audio-component"
              :component-did-update
              (fn []
-                 (update-audio {:sfx (:sfx @game-state) :sfx-current-id (:sfx-current-id @game-state)
-                                :gameid (:gameid @game-state)} soundbank))
+                 (update-audio (select-keys @game-state [:sfx :sfx-current-id :gameid]) soundbank))
              :reagent-render
              (fn [{:keys [sfx] :as cursor}]
               (let [_ @sfx]))}))) ;; make this component rebuild when sfx changes.

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1382,8 +1382,8 @@
                                 :gameid (:gameid @game-state)} soundbank))
              :reagent-render
              (fn [{:keys [sfx] :as cursor}]
-              (let [_ @sfx]) ;; hack: make this component rebuild when sfx changes. Could probably move audio to its own component.
-             )})))
+              (let [_ @sfx]))}))) ;; make this component rebuild when sfx changes.
+             
 
 (defn button-pane [{:keys [side active-player run end-turn runner-phase-12 corp-phase-12 corp runner me opponent] :as cursor}]
   (let [s (r/atom {})

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1383,8 +1383,7 @@
              :reagent-render
              (fn [{:keys [sfx] :as cursor}]
               (let [_ @sfx]) ;; hack: make this component rebuild when sfx changes. Could probably move audio to its own component.
-             )
-            })))
+             )})))
 
 (defn button-pane [{:keys [side active-player run end-turn runner-phase-12 corp-phase-12 corp runner me opponent] :as cursor}]
   (let [s (r/atom {})


### PR DESCRIPTION
Extracting sound into it's own component. This was motivated to ensure
that sound was set up in spectating mode.

Fixes #3866 