### PR TITLE
Have Kakugo perform selfcheck on :cid

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1242,7 +1242,7 @@
 
    "Kakugo"
    {:events {:pass-ice {:async true
-                        :req (req (= (:cid target) (:cid card)))
+                        :req (req (same-card? target card))
                         :msg "do 1 net damage"
                         :effect (effect (damage eid :net 1 {:card card}))}}
     :subroutines [end-the-run]}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1242,7 +1242,7 @@
 
    "Kakugo"
    {:events {:pass-ice {:async true
-                        :req (req (= target card))
+                        :req (req (= (:cid target) (:cid card)))
                         :msg "do 1 net damage"
                         :effect (effect (damage eid :net 1 {:card card}))}}
     :subroutines [end-the-run]}

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -739,6 +739,26 @@
         (run-continue state)
         (is (= 1 (-> (get-runner) :discard count)) "Runner should take 1 net damage from Kakugo")))))
 
+(deftest kakugo-wrestler
+  (testing "After wrassling, Kakugo should still do damage despite temporary card change")
+    (do-game
+      (new-game (default-corp ["Kakugo"])
+                (default-runner ["Engolo" (qty "Sure Gamble" 2)]))
+      (play-from-hand state :corp "Kakugo" "R&D")
+      (take-credits state :corp) ;; This also ends the corps turn.
+      (play-from-hand state :runner "Sure Gamble") ;; Needed to ensure that we can pay for Kakugo + ability
+      (play-from-hand state :runner "Engolo")
+      (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
+      (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card before run")
+      (let [kakugo (get-ice state :rd 0)
+            engolo (get-program state 0)]
+        (run-on state "R&D")
+        (core/rez state :corp kakugo)
+        (card-ability state :runner engolo 2)
+        (is (core/has-subtype? (refresh kakugo) "Code Gate") "Kakugo was made into a code gate")
+        (run-continue state)
+        (is (= 0 (count (:hand (get-runner)))) "Runner took damage passing kakugo"))))
+
 (deftest kakugo
   ;; Kakugo
   (testing "ability continues to work when ice is swapped"

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -739,26 +739,6 @@
         (run-continue state)
         (is (= 1 (-> (get-runner) :discard count)) "Runner should take 1 net damage from Kakugo")))))
 
-(deftest kakugo-wrestler
-  (testing "After wrassling, Kakugo should still do damage despite temporary card change")
-    (do-game
-      (new-game (default-corp ["Kakugo"])
-                (default-runner ["Engolo" (qty "Sure Gamble" 2)]))
-      (play-from-hand state :corp "Kakugo" "R&D")
-      (take-credits state :corp) ;; This also ends the corps turn.
-      (play-from-hand state :runner "Sure Gamble") ;; Needed to ensure that we can pay for Kakugo + ability
-      (play-from-hand state :runner "Engolo")
-      (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
-      (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card before run")
-      (let [kakugo (get-ice state :rd 0)
-            engolo (get-program state 0)]
-        (run-on state "R&D")
-        (core/rez state :corp kakugo)
-        (card-ability state :runner engolo 2)
-        (is (core/has-subtype? (refresh kakugo) "Code Gate") "Kakugo was made into a code gate")
-        (run-continue state)
-        (is (= 0 (count (:hand (get-runner)))) "Runner took damage passing kakugo"))))
-
 (deftest kakugo
   ;; Kakugo
   (testing "ability continues to work when ice is swapped"
@@ -780,7 +760,25 @@
         (run-on state "Archives")
         (run-continue state)
         (run-jack-out state)
-        (is (= 1 (count (:hand (get-runner)))) "Runner took damage after swap")))))
+        (is (= 1 (count (:hand (get-runner)))) "Runner took damage after swap"))))
+  (testing "After wrassling, Kakugo should still do damage despite temporary card change")
+    (do-game
+      (new-game (default-corp ["Kakugo"])
+                (default-runner ["Engolo" (qty "Sure Gamble" 2)]))
+      (play-from-hand state :corp "Kakugo" "R&D")
+      (take-credits state :corp) ;; This also ends the corps turn.
+      (play-from-hand state :runner "Sure Gamble") ;; Needed to ensure that we can pay for Kakugo + ability
+      (play-from-hand state :runner "Engolo")
+      (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
+      (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card before run")
+      (let [kakugo (get-ice state :rd 0)
+            engolo (get-program state 0)]
+        (run-on state "R&D")
+        (core/rez state :corp kakugo)
+        (card-ability state :runner engolo 2)
+        (is (core/has-subtype? (refresh kakugo) "Code Gate") "Kakugo was made into a code gate")
+        (run-continue state)
+        (empty? (:hand (get-runner)))) "Runner took damage passing kakugo"))
 
 (deftest kamali-1.0
   ;; Kamali 1.0


### PR DESCRIPTION
If Kakugo was passed, but it had been modified, game logic would say
it's not the same card, and not recognize that it had just been passed.
By checking against the :cid property, which is invariant under
temporary transformations, Kakugo sucessfully performs damage even under
type transformation.

Tested with new unit test.

Fixes #3826