### PR TITLE
Adding log messages

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1383,9 +1383,13 @@
                        :choices ["Gain 4 [Credits]" "Draw 4 cards"]
                        :effect (req (cond
                                       (= target "Gain 4 [Credits]")
-                                      (gain-credits state :runner 4)
+                                      (do
+                                        (system-msg state :runner (str "uses Office Supplies to gain 4 [Credits]"))
+                                        (gain-credits state :runner 4))
                                       (= target "Draw 4 cards")
-                                      (draw state :runner 4)))}
+                                      (do
+                                        (system-msg state :runner (str "uses Office Supplies to draw 4 cards"))
+                                        (draw state :runner 4))))}
                       card nil))}
 
    "On the Lam"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1004,9 +1004,12 @@
                                    (= (:zone %) (:zone cice))
                                    (= 1 (abs (- (ice-index state %)
                                                 (ice-index state cice)))))}
-              :msg "swap a piece of Barrier ICE"
               :effect (req (let [tgtndx (ice-index state target)
                                  cidx (ice-index state cice)]
+                             (system-msg state :runner (str "uses Surfer to swap "
+                                                            (card-str state cice)
+                                                            " and "
+                                                            (card-str state (nth run-ices tgtndx))))
                              (swap! state update-in (cons :corp (:zone cice))
                                     #(assoc % tgtndx cice))
                              (swap! state update-in (cons :corp (:zone cice))
@@ -1015,6 +1018,7 @@
                              (update-all-ice state side)
                              (trigger-event state side :approach-ice current-ice)))})]
      {:abilities [{:cost [:credit 2]
+                   :msg "swap a piece of Barrier ICE"
                    :req (req (and (:run @state)
                                   (rezzed? current-ice)
                                   (has-subtype? current-ice "Barrier")))


### PR DESCRIPTION
Added cost and which ICE were swapped log messages for `Surfer`.
Added action selected log message for `Office Supplies`

Fixes #3884 
Fixes #3845 (probably)