### PR TITLE
Preload chat messages from all channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pom.xml
 .repl
 .nrepl-port
 .nrepl-history
+.rebel_readline_history
 .idea
 
 /resources/public/js/

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -26,5 +26,5 @@
            :stats (:stats (js->clj js/user :keywordize-keys true))
            :games [] :gameid nil :messages []
            :channels {:general [] :america [] :europe [] :asia-pacific [] :united-kingdom [] :français []
-                      :español [] :italia [] :português [] :sverige [] :stimhack-league []}
+                      :español [] :italia [] :polska [] :português [] :sverige [] :stimhack-league [] :русский []}
            }))


### PR DESCRIPTION
In the current implementation, the frontend requested the list of chat messages in a channel if the `@app-state` was empty. If the channel actually had no messages, it would then loop.

In addition, since messages were only requested when you entered a channel, if a message was sent to that channel before you clicked on it, then messages were not pulled from the server, since the local copy had the new message in it.

So now we just preload all of them when the component is created.