### PR TITLE
Sentry.io integration

### DIFF
--- a/dev.edn
+++ b/dev.edn
@@ -18,4 +18,6 @@
  :email {:host nil
          :user nil
          :pass nil
-         :ssl  nil}}
+         :ssl  nil}
+ :sentry-dsn nil          ;; sentry.io javascript error logging
+ }

--- a/src/clj/web/pages.clj
+++ b/src/clj/web/pages.clj
@@ -7,6 +7,7 @@
             [monger.operators :refer :all]
             [monger.result :refer [acknowledged?]]
             [web.db :refer [db object-id]]
+            [web.config :refer [server-config]]
             [web.utils :refer [response]]))
 
 (defn layout [{:keys [version user] :as req} & content]
@@ -29,8 +30,17 @@
      (hiccup/include-js "/lib/marked/marked.min.js")
      (hiccup/include-js "/lib/toastr/toastr.min.js")
      (hiccup/include-js "/lib/howler/dist/howler.min.js")
+     (hiccup/include-js "https://browser.sentry-cdn.com/4.1.1/bundle.min.js")
      [:script {:type "text/javascript"}
-      (str "var user=" (json/generate-string user))]
+      (str "var user=" (json/generate-string user) ";")]
+
+     (when-let [sentry-dsn (:sentry-dsn server-config)]
+       [:script {:type "text/javascript"}
+        (str "Sentry.init({ dsn: '" sentry-dsn "' });"
+             (when user
+               (str "Sentry.configureScope((scope) => {scope.setUser({\"username\": \""
+                    (:username user)
+                    "\"});});")))])
 
      (if (= "dev" @web.config/server-mode)
        (list (hiccup/include-js "/cljs/goog/base.js")


### PR DESCRIPTION
If a `sentry-dsn` key is present in the `config.edn` file, all client side javascript errors will be sent to the specified https://sentry.io account.