### PR TITLE
Magnum Opus: Embolus

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -378,20 +378,20 @@
     :trash-effect {:effect (req (update-all-ice state side))}}
 
    "Embolus"
-   (let [maybe-gain-counter
-         {:once :per-turn
-          :label "Place a power counter on Embolus"
-          :effect (effect (continue-ability {:optional
-                                             {:prompt "Pay 1 [Credit] to place a power counter on Embolus?"
-                                              :yes-ability {:effect (effect (add-counter card :power 1))
-                                                            :cost [:credit 1]
-                                                            :msg "pay 1 [Credit] to place a power counter on Embolus"}}}
-                                            card nil))}
-         etr
-         {:req (req this-server)
-          :counter-cost [:power 1]
-          :msg "end the run"
-          :effect (effect (end-run))}]
+   (let [maybe-gain-counter {:once :per-turn
+                             :label "Place a power counter on Embolus"
+                             :effect (effect
+                                       (continue-ability
+                                         {:optional
+                                          {:prompt "Pay 1 [Credit] to place a power counter on Embolus?"
+                                           :yes-ability {:effect (effect (add-counter card :power 1))
+                                                         :cost [:credit 1]
+                                                         :msg "pay 1 [Credit] to place a power counter on Embolus"}}}
+                                         card nil))}
+         etr {:req (req this-server)
+              :counter-cost [:power 1]
+              :msg "end the run"
+              :effect (effect (end-run))}]
      {:derezzed-events {:runner-turn-ends corp-rez-toast}
       :events {:corp-turn-begins maybe-gain-counter
                :successful-run {:req (req (pos? (get-counters card :power)))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -377,11 +377,30 @@
     :derez-effect {:effect (req (update-ice-in-server state side (card->server state card)))}
     :trash-effect {:effect (req (update-all-ice state side))}}
 
+   "Embolus"
+   (let [maybe-gain-counter
+         {:once :per-turn
+          :label "Place a power counter on Embolus"
+          :effect (effect (continue-ability {:optional
+                                             {:prompt "Pay 1 [Credit] to place a power counter on Embolus?"
+                                              :yes-ability {:effect (effect (add-counter card :power 1))
+                                                            :cost [:credit 1]
+                                                            :msg "pay 1 [Credit] to place a power counter on Embolus"}}}
+                                            card nil))}
+         etr
+         {:req (req this-server)
+          :counter-cost [:power 1]
+          :msg "end the run"
+          :effect (effect (end-run))}]
+     {:derezzed-events {:runner-turn-ends corp-rez-toast}
+      :events {:corp-turn-begins maybe-gain-counter
+               :successful-run {:req (req (pos? (get-counters card :power)))
+                                :msg "remove 1 power counter from Embolus"
+                                :effect (effect (add-counter card :power -1))}}
+      :abilities [maybe-gain-counter etr]})
+
    "Expo Grid"
-   (let [ability {:req (req (some #(and (is-type? % "Asset")
-                                        (rezzed? %))
-                                  (get-in corp (:zone card))))
-                  :msg "gain 1 [Credits]"
+   (let [ability {:msg "gain 1 [Credits]"
                   :once :per-turn
                   :label "Gain 1 [Credits] (start of turn)"
                   :effect (effect (gain-credits 1))}]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -400,7 +400,10 @@
       :abilities [maybe-gain-counter etr]})
 
    "Expo Grid"
-   (let [ability {:msg "gain 1 [Credits]"
+   (let [ability {:req (req (some #(and (is-type? % "Asset")
+                                        (rezzed? %))
+                                  (get-in corp (:zone card))))
+                  :msg "gain 1 [Credits]"
                   :once :per-turn
                   :label "Gain 1 [Credits] (start of turn)"
                   :effect (effect (gain-credits 1))}]


### PR DESCRIPTION
The only design choice I think is questionable is whether Embolus should prompt you if you have 0 creds. I elected to have it do so in part so I didn't have to think about whether there were any weird edge cases in which players might need the prompt in order to manually trigger card abilities to ensure they had the credit to add the counter. However, if anyone has strong opinions on this I'll happily change it, although I'll then want to add a test ensuring it works as well as one can expect with Launch Campaign.