### PR TITLE
Magnum Opus: Timely Public Release

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1289,7 +1289,8 @@
                                            :choices (vec (map str (range (inc num-ice))))
                                            :effect (req (corp-install state side chosen-ice chosen-server
                                                                          {:no-install-cost true :index (Integer/parseInt target)})
-                                                        (if (and run (= (:server run) chosen-server))
+                                                        (if (and run (= (zone->name (first (:server run)))
+                                                                        chosen-server))
                                                           (let [curr-pos (get-in @state [:run :position])] 
                                                             (if (>= curr-pos (Integer/parseInt target))
                                                               (swap! state assoc-in [:run :position] (inc curr-pos))))))})

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -149,7 +149,7 @@
 (defn move
   "Moves the given card to the given new zone."
   ([state side card to] (move state side card to nil))
-  ([state side {:keys [zone host] :as card} to {:keys [front keep-server-alive force]}]
+  ([state side {:keys [zone host] :as card} to {:keys [front index keep-server-alive force]}]
    (let [zone (if host (map to-keyword (:zone host)) zone)
          src-zone (first zone)
          target-zone (if (vector? to) (first to) to)]
@@ -169,7 +169,9 @@
            (remove-old-card state side card)
            (if front
              (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))
-             (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card))))
+             (if index ; (vec (concat (take i v) [e] (drop i v))))
+               (swap! state update-in (cons side dest) #(into [] (concat (take index %) [moved-card] (drop index %))))
+               (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card)))))
            (let [z (vec (cons :corp (butlast zone)))]
              (when (and (not keep-server-alive)
                         (is-remote? z)

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -167,11 +167,10 @@
          (let [dest (if (sequential? to) (vec to) [to])
                moved-card (get-moved-card state side card to)]
            (remove-old-card state side card)
-           (if front
-             (swap! state update-in (cons side dest) #(into [] (cons moved-card (vec %))))
-             (if index ; (vec (concat (take i v) [e] (drop i v))))
-               (swap! state update-in (cons side dest) #(into [] (concat (take index %) [moved-card] (drop index %))))
-               (swap! state update-in (cons side dest) #(into [] (conj (vec %) moved-card)))))
+           (let [pos-to-move-to (cond index index
+                                      front 0
+                                      :else (count (get-in @state (cons side dest))))]
+             (swap! state update-in (cons side dest) #(into [] (concat (take pos-to-move-to %) [moved-card] (drop pos-to-move-to %)))))
            (let [z (vec (cons :corp (butlast zone)))]
              (when (and (not keep-server-alive)
                         (is-remote? z)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -205,7 +205,7 @@
 (defn- corp-install-continue
   "Used by corp-install to actually install the card, rez it if it's supposed to be installed
   rezzed, and calls :corp-install in an awaitable fashion."
-  [state side eid card server {:keys [install-state host-card front] :as args} slot cost-str]
+  [state side eid card server {:keys [install-state host-card front index] :as args} slot cost-str]
   (let [cdef (card-def card)
         dest-zone (get-in @state (cons :corp slot))
         install-state (or install-state (:install-state cdef))
@@ -219,7 +219,8 @@
 
     (let [moved-card (if host-card
                        (host state side host-card (assoc c :installed true))
-                       (move state side c slot {:front front}))]
+                       (move state side c slot {:front front
+                                                :index index}))]
       (when (is-type? c "Agenda")
         (update-advancement-cost state side moved-card))
 


### PR DESCRIPTION
Prompts player for card to install, then server, then the position to install it in. The latter is given by clicking on buttons. It is slightly clunky but seemingly functional. Allowing for mid-server installs necessitated adding a keyword argument to move-card, so it now supports :index 3. :front true should then be equivalent to :index 0, but because people are used to :front I left it in rather than refactor.

There are a couple of small hacks in the card definition. Conversions between strings, numbers and :rd, etc, were very much done on a "damnit why won't this ru- oh" basis, so I'd appreciate any cleanups here.