### PR TITLE
Expose card fetch through the web interface

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:lein-alpine
+FROM clojure:lein-alpine as builder
 
 RUN apk --no-cache add \
     git \
@@ -15,4 +15,18 @@ RUN lein deps
 RUN lein cljsbuild once prod
 RUN lein uberjar
 
-ENTRYPOINT ["java", "-jar", "target/netrunner-standalone.jar"]
+
+FROM openjdk:8-alpine
+
+WORKDIR /netrunner
+COPY --from=builder /netrunner/target/netrunner-standalone.jar .
+COPY --from=builder /netrunner/dev.edn .
+WORKDIR /netrunner/resources
+COPY --from=builder /netrunner/resources .
+WORKDIR /netrunner/data/cards
+COPY --from=builder /netrunner/data/cards .
+WORKDIR /netrunner/src
+COPY --from=builder /netrunner/src .
+
+WORKDIR /netrunner
+ENTRYPOINT ["java", "-jar", "netrunner-standalone.jar"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,8 @@ COPY --from=builder /netrunner/target/netrunner-standalone.jar .
 COPY --from=builder /netrunner/dev.edn .
 WORKDIR /netrunner/resources
 COPY --from=builder /netrunner/resources .
-WORKDIR /netrunner/data/cards
-COPY --from=builder /netrunner/data/cards .
+WORKDIR /netrunner/data
+COPY --from=builder /netrunner/data .
 WORKDIR /netrunner/src
 COPY --from=builder /netrunner/src .
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,8 +10,9 @@ Contains an application server and a database server. Suitable for experimenting
 ```
 % cd docker
 % docker-compose up
-% docker-compose exec jnet lein fetch
-% docker-compose restart jnet
+% open http://localhost:1042
+# then Sign Up for a new account
+% open http://localhost:1042/admin/fetch
 ```
 
 To stop a running instance, use `docker-compose stop`.
@@ -25,13 +26,14 @@ Contains an application server, database server, and reverse-proxy server. Close
 ```
 % cd docker
 % docker-compose -f docker-compose-production.yml up
-% docker-compose exec jnet lein fetch
-% docker-compose restart jnet
+% open http://localhost:1042
+# then Sign Up for a new account
+% open http://localhost/admin/fetch
 ```
 
 To stop a running instance, use `docker-compose stop`.
 
-The Jinteki interface should now be available at http://localhost:8080
+The Jinteki interface should now be available at http://localhost
 
 ## Data Storage
 The database and card images are stored in Docker volumes. The volumes will persist until `docker-compose down` is executed or the volumes are manually deleted.

--- a/docker/docker-compose-production.yml
+++ b/docker/docker-compose-production.yml
@@ -27,7 +27,7 @@ services:
     networks:
       - web_network
     ports:
-      - 8080:80
+      - 80:80
     depends_on:
       - jnet
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ./config.edn:/netrunner/config.edn
     ports:
-      - "1042:1042"
+      - 1042:1042
     depends_on:
       - mongodb
   mongodb:

--- a/src/clj/tasks/fetch.clj
+++ b/src/clj/tasks/fetch.clj
@@ -7,11 +7,8 @@
             [tasks.nrdb :refer :all]
             [tasks.altart :refer [add-art]]))
 
-(defn fetch
-  "Import data from NetrunnerDB.
-  Can accept `--local <path>` to use the `netrunner-card-json` project locally,
-  otherwise pulls data from NRDB.
-  Specifying `--no-card-images` will not attempt to download images for cards."
+(defn fetch-with-db
+  "Import data from NRDB. Assumes the database is already open. See `fetch` for arguments."
   [& args]
   (zp/set-options!
     {:style :community
@@ -19,18 +16,28 @@
            :force-nl? true}
      :width 1000})
 
+  (let [localpath (first (remove #(string/starts-with? % "--") args))
+        download-images (not (some #{"--no-card-images"} args))
+        data (fetch-data localpath download-images)]
+    (println (count (:cycles data)) "cycles imported")
+    (println (count (:sets data)) "sets imported")
+    (println (count (:mwls data)) "MWL versions imported")
+    (println (count (:cards data)) "cards imported")
+    (add-art false)
+    (update-config)))
+
+(defn fetch
+  "Import data from NetrunnerDB.
+  Can accept `--local <path>` to use the `netrunner-card-json` project locally,
+  otherwise pulls data from NRDB.
+  Specifying `--no-card-images` will not attempt to download images for cards."
+  [& args]
+
   (webdb/connect)
   (try
-    (let [localpath (first (remove #(string/starts-with? % "--") args))
-          download-images (not (some #{"--no-card-images"} args))
-          data (fetch-data localpath download-images)]
-      (println (count (:cycles data)) "cycles imported")
-      (println (count (:sets data)) "sets imported")
-      (println (count (:mwls data)) "MWL versions imported")
-      (println (count (:cards data)) "cards imported")
-      (add-art false)
-      (update-config))
+    (apply fetch-with-db args)
     (catch Exception e (do
                          (println "Import data failed:" (.getMessage e))
                          (.printStackTrace e)))
     (finally (webdb/disconnect))))
+

--- a/src/clj/web/admin.clj
+++ b/src/clj/web/admin.clj
@@ -2,6 +2,8 @@
   (:require [web.db :refer [db object-id]]
             [web.lobby :refer [all-games]]
             [game.main :as main]
+            [game.core :refer [reset-card-defs]]
+            [tasks.fetch :refer [fetch-with-db]]
             [web.utils :refer [response]]
             [monger.collection :as mc]
             [monger.operators :refer :all]
@@ -23,3 +25,15 @@
   (reset! frontend-version version)
   (mc/update db "config" {} {$set {:version version}})
   (response 200 {:message "ok" :version version}))
+
+(defn fetch-handler
+  [req]
+  (try
+    (do
+      (fetch-with-db)
+      (reset-card-defs)
+      (response 200 {:message "ok"}))
+    (catch Exception e (do
+                         (println "fetch-handler failed:" (.getMessage e))
+                         (.printStackTrace e)
+                         (response 500 {:message (str "Import data failed: " (.getMessage e))})))))

--- a/src/clj/web/api.clj
+++ b/src/clj/web/api.clj
@@ -56,7 +56,9 @@
            (GET "/admin/announce" [] pages/announce-page)
            (POST "/admin/announce" [] admin/announcement-handler)
            (GET "/admin/version" [] pages/version-page)
-           (POST "/admin/version" [] admin/version-handler))
+           (POST "/admin/version" [] admin/version-handler)
+           (GET "/admin/fetch" [] pages/fetch-page)
+           (POST "/admin/fetch" [] admin/fetch-handler))
 
 (defroutes user-routes
            (POST "/logout" [] auth/logout-handler)

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -60,7 +60,8 @@
     (response 423 {:message "Usernames are limited to 20 characters"})
     (if-let [_ (mc/find-one-as-map db "users" {:username {$regex (str "^" username "$") $options "i"}})]
       (response 422 {:message "Username taken"})
-      (let [emailhash (digest/md5 email)
+      (let [first_user (not (mc/any? db "users"))
+            emailhash (digest/md5 email)
             registrationDate (java.util.Date.)
             lastConnection registrationDate
             hash-pw (password/encrypt password)
@@ -70,6 +71,7 @@
                                                        :registrationDate registrationDate
                                                        :lastConnection   lastConnection
                                                        :password         hash-pw
+                                                       :isadmin          first_user
                                                        :options          {}})
             demo-decks (mc/find-maps db "decks" {:username "__demo__"})]
         (when (not-empty demo-decks)

--- a/src/clj/web/pages.clj
+++ b/src/clj/web/pages.clj
@@ -129,6 +129,25 @@
       [:p
        [:button.btn.btn-primary {:type "submit"} "Submit"]]]]))
 
+(defn fetch-page [req]
+  (hiccup/html5
+    [:head
+     [:title "Update Card Data"]
+     (hiccup/include-css "/css/netrunner.css")]
+    [:body
+     [:div.reset-bg]
+     [:form.panel.blue-shade.reset-form {:method "POST"}
+      (when-let [card-info (mc/find-one-as-map db "config" {})]
+        [:div.admin
+         [:div
+          [:h3 "Card Version:"]
+          (:cards-version card-info)]
+         [:div
+          [:h3 "Last Updated:"]
+          (:last-updated card-info)]])
+      [:br]
+      [:button.btn.btn-primary {:type "submit"} "Fetch Cards"]]]))
+
 (defn reset-password-page
   [{{:keys [token]} :params}]
   (if-let [user (mc/find-one-as-map db "users" {:resetPasswordToken   token

--- a/src/cljs/nr/auth.cljs
+++ b/src/cljs/nr/auth.cljs
@@ -45,6 +45,10 @@
      (:username user)
      [:b.caret]]
     [:div.dropdown-menu.blue-shade.float-right
+     (when (:isadmin user)
+       [:a.block-link "[Admin]"])
+     (when (:ismoderator user)
+       [:a.block-link "[Moderator]"])
      [:a.block-link {:href "/account"} "Settings"]
      [:a.block-link {:on-click #(handle-logout %)} "Logout"]]]])
 

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2236,3 +2236,8 @@ nav ul
     .date
       margin-right: 10px
       font-weight: bold
+
+// Admin
+
+.admin
+  color: orange


### PR DESCRIPTION
Made a `/admin/fetch` endpoint which displays the current card information and allows the user to run the `tasks.fetch/fetch` command. Only accessible to admin users.

Also updated the user creation code to make the first created user an admin.

This allows us to slim down the Docker containers by removing `leiningen`.