### PR TITLE
Updated deps to support Java 11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
 
   :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.16"]
                                   [binaryage/devtools "0.9.7"]
-                                  [com.cemerick/piggieback "0.2.1"]]
+                                  [cider/piggieback "0.3.10"]]
                    :plugins [[lein-figwheel "0.5.16"]]
                    :source-paths ["src/clj" "src/cljs" "src/dev" "src/cljc"]}}
 


### PR DESCRIPTION
Updated the `piggieback` dependency which was required to get jnet building on Java 11. Be aware the dependencies specified in your `~/.lein/profile.clj` may also need to be updated.