### PR TITLE
Install-ice command

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1285,7 +1285,7 @@
                                               num-ice (count (get-in (:corp @state)
                                                                      (conj (server->zone state target) :ices)))]
                                           {:prompt "Which position to install in? (0 is innermost)"
-                                           :choices (vec (map str (range (inc num-ice))))
+                                           :choices (vec (reverse (map str (range (inc num-ice)))))
                                            :effect (req (corp-install state side chosen-ice chosen-server
                                                                          {:no-install-cost true :index (Integer/parseInt target)})
                                                         (if (and run (= (zone->name (first (:server run)))


### PR DESCRIPTION
Closes #3879!

Also reverses the order of the numbers on both the command and Timely Public Release so they more intuitively match the layout of existing ice.