### PR TITLE
Set `standard` as the default format for new decks

### DIFF
--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -290,7 +290,7 @@
                 side-identities
                 (sort-by :title)
                 first)]
-    (swap! s assoc :deck {:name "New deck" :cards [] :identity id})
+    (swap! s assoc :deck {:name "New deck" :cards [] :identity id :format "standard"})
     (try (js/ga "send" "event" "deckbuilder" "new" side) (catch js/Error e))
     (edit-deck s)
     (swap! s assoc :old-deck old-deck)))


### PR DESCRIPTION
Otherwise the ID shows up as invalid until you change the format to something.