### PR TITLE
Fix alt art display

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -63,6 +63,7 @@
   :aot [#"game\.*"
         #"web\.*"
         #"tasks.fetch"
+        #"tasks.altart"
         #"jinteki\.*"]
   :jar-name "netrunner.jar"
   :uberjar-name "netrunner-standalone.jar"

--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -220,6 +220,7 @@
        (into {})
        (swap! all-cards merge))
   (replace-collection "cards" (vals @all-cards))
+  (add-art false)
   (update-config))
 
 (defn load-all-cards

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -10,6 +10,7 @@
             [jinteki.utils :refer [str->int other-side is-tagged? has-subtype?]]
             [jinteki.cards :refer [all-cards]]
             [tasks.nrdb :refer [replace-collection update-config]]
+            [tasks.altart :refer [add-art]]
             [game.quotes :as quotes]))
 
 (load "core/events")    ; triggering of events

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -3,7 +3,6 @@
             [cheshire.generate :refer [add-encoder encode-str]]
             [game.core :refer [card-is-public? game-states show-error-toast toast] :as core]
             [game.utils :refer [private-card]]
-            [jinteki.cards :refer [all-cards]]
             [differ.core :as differ]))
 
 (add-encoder java.lang.Object encode-str)
@@ -110,13 +109,6 @@
      (if (get-in @state [:options :spectatorhands])
        (assoc @state :corp corp-deck :runner runner-deck)
        (assoc @state :corp corp-private :runner runner-private))]))
-
-(defn- reset-all-cards
-  [cards]
-  (let [;; split the cards into regular cards and alt-art cards
-        [regular alt] ((juxt filter remove) #(not= "Alternates" (:setname %)) cards)
-        regular (into {} (map (juxt :title identity) regular))]
-    (reset! all-cards regular)))
 
 (defn public-states [state]
   (let [[new-corp new-runner new-spect] (private-states state)]

--- a/src/clj/web/core.clj
+++ b/src/clj/web/core.clj
@@ -9,7 +9,8 @@
             [game.quotes :as quotes]
             [jinteki.cards :as cards]
             [jinteki.nav :as nav]
-            [tasks.nrdb :refer [replace-collection]]
+            [tasks.nrdb :refer [replace-collection update-config]]
+            [tasks.altart :refer [add-art]]
             [web.api :refer [app]]
             [web.chat :as chat]
             [web.config :refer [frontend-version server-config server-mode]]
@@ -37,7 +38,9 @@
            edn/read-string
            ((juxt :title identity))
            (swap! cards/all-cards merge))
-      (replace-collection "cards" (vals @cards/all-cards)))))
+      (replace-collection "cards" (vals @cards/all-cards))
+      (add-art false)
+      (update-config))))
 
 
 (defn -main [& args]

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -90,12 +90,6 @@
     (when user-name
       (swap! s assoc-in [:blocked-users] (vec (remove #(= % user-name) current-blocked-list))))))
 
-(defn select-card
-  [value s]
-  (swap! s assoc-in [:alt-card] value)
-  (swap! s assoc-in [:alt-card-version]
-                 (get (:alt-arts @s) (keyword value) "default")))
-
 (defn- remove-card-art
   [card s]
   (swap! s update-in [:alt-arts] #(dissoc % (keyword (:code card))))
@@ -121,13 +115,6 @@
       (let [versions (keys (:alt_art card))]
         (when (some #(= % (keyword art)) versions)
           (add-card-art card art s))))))
-
-(defn set-card-art
-  [value s]
-  (swap! s assoc-in [:alt-card-version] value)
-  (let [code (:alt-card @s)
-        card (some #(when (= code (:code %)) %) @all-cards)]
-    (update-card-art card value s)))
 
 (defn reset-card-art
   ([s] (let [art (:all-art-select @s)]
@@ -206,7 +193,7 @@
                      (:name option)]]))]
 
          [:section
-          [:h3 " Game Win/Lose Statistics "]
+          [:h3 " Game Win/Lose statistics "]
           (doall (for [option [{:name "Always"                   :ref "always"}
                                {:name "Competitive Lobby Only"   :ref "competitive"}
                                {:name "None"                     :ref "none"}]]
@@ -219,7 +206,7 @@
                      (:name option)]]))]
 
          [:section
-          [:h3 " Deck Statistics "]
+          [:h3 " Deck statistics "]
           (doall (for [option [{:name "Always"                   :ref "always"}
                                {:name "Competitive Lobby Only"   :ref "competitive"}
                                {:name "None"                     :ref "none"}]]
@@ -242,33 +229,6 @@
 
           (when (and (:special @user) (:alt-arts @app-state))
             [:div {:id "my-alt-art"}
-             [:h4 "My alternate card arts"]
-             [:select {:value (:alt-card @s)
-                       :on-change #(select-card (.. % -target -value) s)}
-              (doall (for [card (sort-by :title (vals (:alt-arts @app-state)))] ^{:key (:code card)}
-                [:option {:value (:code card)} (:title card)]))]
-
-             [:div {:class "alt-art-group"}
-              (doall (for [version (conj (keys (get-in (:alt-arts @app-state) [(:alt-card @s) :alt_art])) :default)]
-                       (let [curr-alt (:alt-card @s)
-                             url (image-url curr-alt version)
-                             alt (get (:alt-arts @app-state) curr-alt)]
-                         [:div {:key version}
-                          [:div
-                           [:div [:label [:input {:type "radio"
-                                                  :key version
-                                                  :name "alt-art-radio"
-                                                  :value (name version)
-                                                  :on-change #(set-card-art (.. % -target -value) s)
-                                                  :checked (= (:alt-card-version @s) (name version))}]
-                                 (alt-art-name version)]]]
-                          [:div
-                           [:img {:class "alt-art-select"
-                                  :src url
-                                  :alt (str (:title alt) " (" (alt-art-name version) ")")
-                                  :on-click #(set-card-art (name version) s)
-                                  :onError #(-> % .-target js/$ .hide)
-                                  :onLoad #(-> % .-target js/$ .show)}]]])))]
              [:div {:id "set-all"}
               "Set all cards to: "
               [:select {:ref "all-art-select"
@@ -278,14 +238,12 @@
                         [:option {:value t :key t} (alt-art-name t)]))]
               [:button
                {:type "button"
-                :on-click #(do (reset-card-art s)
-                               (select-card (:alt-card @s) s))}
+                :on-click #(do (reset-card-art s))}
                "Set"]]
              [:div.reset-all
               [:button
                {:type "button"
-                :on-click #(do (reset-card-art s "default")
-                               (select-card (:alt-card @s) s))}
+                :on-click #(do (reset-card-art s "default"))}
                "Reset All to Official Art"]]])]
 
          [:section


### PR DESCRIPTION
Since we overwrite the `cards` collection on startup, we need to re-insert the alternate art info.

Also removed the individual alt art selector from the `Settings`. Users should specify individual alt arts in the `Card Browser`. Mass setting/resetting of alts is still in `Settings.`