### PR TITLE
Card legality per format

### DIFF
--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -217,9 +217,9 @@
 
     [:div.formats
      (doall (for [[k name] (-> slug->format butlast)]
-              ^{:key k}
               (let [status (keyword (get-in card [:format (keyword k)] "unknown"))
                     c (text-class-for-status status)]
+                ^{:key k}
                 [:div {:class c} name
                  (case status
                    :banned banned-span

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -828,6 +828,7 @@ nav ul
 
   .pack
     font-style: italic
+    margin-top: 8px
 
   .selected-alt
     font-style: italic

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1131,9 +1131,6 @@ nav ul
         line-height: 18px
         flex(1)
 
-.deck-status.shift-tooltip
-    padding-right: 12px
-
 .deck-status, .user-status
   position: relative
 


### PR DESCRIPTION
In the `Card Browser`, display the legality for all supported formats.