### PR TITLE
Fix crash in Power Shutdown

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1124,7 +1124,9 @@
                                              (- target (second targets)))))}}}
 
    "Power Shutdown"
-   {:req (req (last-turn? state :runner :made-run))
+   {:req (req (and (last-turn? state :runner :made-run))
+              (not-empty (filter #(or (= "Program" (:type %)) (= "Hardware" (:type %)))
+                                 (all-active-installed state :runner))))
     :prompt "Trash how many cards from the top R&D?"
     :choices {:number (req (apply max (map :cost (filter #(or (= "Program" (:type %)) (= "Hardware" (:type %))) (all-active-installed state :runner)))))}
     :msg (msg "trash " target " cards from the top of R&D")

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -1424,27 +1424,35 @@
 
 (deftest power-shutdown
   ;; Power Shutdown - Trash cards from R&D to force Runner to trash a program or hardware
-  (do-game
-    (new-game {:corp {:deck [(qty "Power Shutdown" 3) (qty "Hive" 3)]}
-               :runner {:deck ["Grimoire" "Cache"]}})
-    (play-from-hand state :corp "Power Shutdown")
-    (is (empty? (:discard (get-corp))) "Not played, no run last turn")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Cache")
-    (play-from-hand state :runner "Grimoire")
-    (run-empty-server state :archives)
-    (take-credits state :runner)
-    (core/move state :corp (find-card "Hive" (:hand (get-corp))) :deck)
-    (core/move state :corp (find-card "Hive" (:hand (get-corp))) :deck)
-    (core/move state :corp (find-card "Hive" (:hand (get-corp))) :deck)
-    (play-from-hand state :corp "Power Shutdown")
-    (click-prompt state :corp "2")
-    (is (= 3 (count (:discard (get-corp)))) "2 cards trashed from R&D")
-    (is (= 1 (count (:deck (get-corp)))) "1 card remaining in R&D")
-    (click-card state :runner (get-hardware state 0)) ; try targeting Grimoire
-    (is (empty? (:discard (get-runner))) "Grimoire too expensive to be targeted")
-    (click-card state :runner (get-program state 0))
-    (is (= 1 (count (:discard (get-runner)))) "Cache trashed")))
+  (testing "Default behavior"
+    (do-game
+      (new-game {:corp {:deck [(qty "Power Shutdown" 3) (qty "Hive" 3)]}
+                 :runner {:deck ["Grimoire" "Cache"]}})
+      (play-from-hand state :corp "Power Shutdown")
+      (is (empty? (:discard (get-corp))) "Not played, no run last turn")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Cache")
+      (play-from-hand state :runner "Grimoire")
+      (run-empty-server state :archives)
+      (take-credits state :runner)
+      (core/move state :corp (find-card "Hive" (:hand (get-corp))) :deck)
+      (core/move state :corp (find-card "Hive" (:hand (get-corp))) :deck)
+      (core/move state :corp (find-card "Hive" (:hand (get-corp))) :deck)
+      (play-from-hand state :corp "Power Shutdown")
+      (click-prompt state :corp "2")
+      (is (= 3 (count (:discard (get-corp)))) "2 cards trashed from R&D")
+      (is (= 1 (count (:deck (get-corp)))) "1 card remaining in R&D")
+      (click-card state :runner (get-hardware state 0)) ; try targeting Grimoire
+      (is (empty? (:discard (get-runner))) "Grimoire too expensive to be targeted")
+      (click-card state :runner (get-program state 0))
+      (is (= 1 (count (:discard (get-runner)))) "Cache trashed")))
+  (testing "No installed runner cards"
+    (do-game
+      (new-game {:corp {:deck ["Power Shutdown"]}})
+      (take-credits state :corp)
+      (run-empty-server state :archives)
+      (take-credits state :runner)
+      (play-from-hand state :corp "Power Shutdown"))))
 
 (deftest precognition
   ;; Precognition - Full test


### PR DESCRIPTION
Throws `clojure.lang.ArityException: Wrong number of args (0) passed to: core/max` if Runner doesn't have any trashable cards.