### PR TITLE
[WIP] Deck API

### DIFF
--- a/src/clj/web/api.clj
+++ b/src/clj/web/api.clj
@@ -11,6 +11,7 @@
             [web.admin :as admin]
             [web.news :as news]
             [web.decks :as decks]
+            [web.deck-api :as deck-api]
             [compojure.route :as route]
             [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
@@ -46,6 +47,9 @@
            (POST "/forgot" [] auth/forgot-password-handler)
            (GET "/reset/:token" [] pages/reset-password-page)
            (POST "/reset/:token" [] auth/reset-password-handler)
+
+           (GET "/api/v1/decks" [] deck-api/decks-list-handler)
+           (GET "/api/v1/deck/:deck_id" [] deck-api/deck-list-handler)
 
            (GET "/ws" req ws/handshake-handler)
            (POST "/ws" req ws/post-handler)

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -23,8 +23,7 @@
 (defn create-token [{:keys [_id emailhash]}]
   (let [claims {:_id _id
                 :emailhash emailhash
-                :exp (-> (:expiration auth-config) days from-now)}
-        token (jwt/sign claims (:secret auth-config) {:alg :hs512})]
+                :exp (-> (:expiration auth-config) days from-now)}]
     (jwt/sign claims (:secret auth-config) {:alg :hs512})))
 
 (defn unsign-token [token]

--- a/src/clj/web/chat.clj
+++ b/src/clj/web/chat.clj
@@ -1,6 +1,5 @@
 (ns web.chat
-  (:require [buddy.sign.jwt :as jwt]
-            [clojure.string :as s]
+  (:require [clojure.string :as s]
             [clj-time.core :as t]
             [clj-time.coerce :as c]
             [monger.query :as q]

--- a/src/clj/web/core.clj
+++ b/src/clj/web/core.clj
@@ -13,6 +13,7 @@
             [tasks.altart :refer [add-art]]
             [web.api :refer [app]]
             [web.chat :as chat]
+            [web.integration :as integration]
             [web.config :refer [frontend-version server-config server-mode]]
             [web.db :refer [db]]
             [web.game :as game]

--- a/src/clj/web/deck_api.clj
+++ b/src/clj/web/deck_api.clj
@@ -1,0 +1,61 @@
+(ns web.deck-api
+  (:require [monger.collection :as mc]
+            [clojure.string :as s]
+            [web.utils :refer [response]]
+            [web.db :refer [db]]
+            [web.tokens :as tokens])
+  (:import org.bson.types.ObjectId))
+
+(defn- validate-request [{headers :headers}]
+  (if-let [auth (get headers "authorization")]
+    (let [[bearer, token] (s/split (s/trim auth) #"\s+" 2)]
+      (if (= "Bearer" bearer)
+        (if-let [entry (mc/find-one-as-map db "api_keys" {:token token})]
+          (let [[is-valid data] (tokens/verify-api-token token (:public-key entry))]
+            (case is-valid
+              :valid (response 200 data)
+              (response 403 {:message data})))
+          (response 403 {:message "Unknown Token"}))
+        (response 400 {:message "No Bearer Token"})))
+    (response 400 {:message "No Authorization Header"})))
+
+(defn- get-username
+  [checked-response]
+  (if-let [emailhash (get-in checked-response [:body :emailhash] nil)]
+    (:username (mc/find-one-as-map db "users" {:emailhash emailhash}))
+    nil))
+
+(defn- send-decks
+  [username]
+  (let [decks (mc/find-maps db "decks" {:username username} ["_id" "name" "date" "format"])]
+    (response 200 {:decks decks})))
+
+(defn- send-deck
+  [username deck_id]
+  (try
+    (if-let [deck (mc/find-one-as-map db "decks"
+                                      {:_id (ObjectId. deck_id) :username username}
+                                      ["_id" "name" "date" "format" "cards" "identity"])]
+      (response 200 {:deck 
+                     (update deck :identity #(select-keys % [:title :side]))})
+      (response 404 {:message "Unknown deck"}))
+    (catch Exception e (response 404 {:message "Invalid deck id"}))))
+
+(defn decks-list-handler
+  [req]
+  (let [checked-response (validate-request req)]
+    (if (not= 200 (:status checked-response))
+      checked-response
+      (if-let [username (get-username checked-response)]
+        (send-decks username)
+        (response 403 {:message "Unknown user"})))))
+
+(defn deck-list-handler
+  [req]
+  (let [checked-response (validate-request req)]
+    (if (not= 200 (:status checked-response))
+      checked-response
+      (if-let [username (get-username checked-response)]
+        (let [deck_id (get-in req [:params :deck_id] nil)]
+          (send-deck username deck_id))
+        (response 403 {:message "Unknown user"})))))

--- a/src/clj/web/integration.clj
+++ b/src/clj/web/integration.clj
@@ -1,0 +1,55 @@
+(ns web.integration
+  (:require [clojure.string :as s]
+            [clj-time.core :as t]
+            [clj-time.coerce :as c]
+            [monger.query :as q]
+            [monger.collection :as mc]
+            [monger.result :refer [acknowledged?]]
+            [web.config :refer [server-config]]
+            [web.db :refer [db]]
+            [web.utils :refer [response]]
+            [cheshire.core :as json]
+            [web.ws :as ws])
+  (:import org.bson.types.ObjectId))
+
+(def api-key-collection "api_keys")
+
+(defn- send-keys
+  [username client-id]
+  (when client-id
+    (let [raw-keys (reverse (q/with-collection db api-key-collection
+                              (q/find {:username username})
+                              (q/sort (array-map :date -1))
+                              (q/limit 10)))
+          api-keys (->> raw-keys
+                        (map #(select-keys % [:name :_id]))
+                        (map #(update % :_id (fn [x] (.toString x))))
+                        vec)]
+      (ws/send! client-id [:integration/key-list {:keys api-keys}]))))
+
+(defn list-keys
+  [{{{:keys [username]} :user} :ring-req
+    client-id :client-id}]
+  (send-keys username client-id))
+
+(defn create-key
+  [{{{:keys [username]} :user} :ring-req
+    client-id :client-id}]
+  (mc/insert db api-key-collection
+             {:username username
+              :date (java.util.Date.)
+              :name "A key value"})
+  (send-keys username client-id))
+
+(defn delete-key
+  [{{{:keys [username]} :user} :ring-req
+    client-id :client-id
+  {:keys [_id]} :?data :as event}]
+  (mc/remove db api-key-collection {:_id (ObjectId. _id)
+                                    :username username})
+  (send-keys username client-id))
+
+(ws/register-ws-handlers!
+  :integration/list-keys list-keys
+  :integration/delete-key delete-key
+  :integration/create-key create-key)

--- a/src/clj/web/integration.clj
+++ b/src/clj/web/integration.clj
@@ -9,7 +9,7 @@
 (def api-key-collection "api_keys")
 (def ^:const max-keys 5)
 
-(defn- send-keys
+(defn send-keys
   [emailhash client-id]
   (when client-id
     (let [raw-keys (reverse (q/with-collection db api-key-collection

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -3,6 +3,7 @@
             [web.utils :refer [response tick remove-once]]
             [web.ws :as ws]
             [web.stats :as stats]
+            [web.integration :as integration]
             [game.core :as core]
             [crypto.password.bcrypt :as bcrypt]
             [monger.collection :as mc]
@@ -202,8 +203,11 @@
 (defn allowed-in-game [game {:keys [username]}]
   (not (some #(= username %) (blocked-users game))))
 
-(defn handle-ws-connect [{:keys [client-id] :as msg}]
-  (ws/send! client-id [:games/list (mapv game-public-view (vals @all-games))]))
+(defn handle-ws-connect
+  [{{{:keys [emailhash]} :user} :ring-req
+    client-id :client-id}]
+  (ws/send! client-id [:games/list (mapv game-public-view (vals @all-games))])
+  (integration/send-keys emailhash client-id))
 
 (defn handle-lobby-create
   [{{{:keys [username emailhash] :as user} :user} :ring-req

--- a/src/clj/web/pages.clj
+++ b/src/clj/web/pages.clj
@@ -91,6 +91,9 @@
         [:div.account-bg]
         [:div#account]]
        [:div.item
+        [:div.account-bg]
+        [:div#integration]]
+       [:div.item
         [:div.stats-bg]
         [:div#stats]]
        [:div.item

--- a/src/clj/web/pages.clj
+++ b/src/clj/web/pages.clj
@@ -31,8 +31,11 @@
      (hiccup/include-js "/lib/toastr/toastr.min.js")
      (hiccup/include-js "/lib/howler/dist/howler.min.js")
      (hiccup/include-js "https://browser.sentry-cdn.com/4.1.1/bundle.min.js")
+     (hiccup/include-js "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js")
      [:script {:type "text/javascript"}
       (str "var user=" (json/generate-string user) ";")]
+
+     [:script {:type "text/javascript"} "new ClipboardJS('.clipboard-btn');" ]
 
      (when-let [sentry-dsn (:sentry-dsn server-config)]
        [:script {:type "text/javascript"}

--- a/src/clj/web/tokens.clj
+++ b/src/clj/web/tokens.clj
@@ -48,3 +48,10 @@
      :public-key public-key-str
      :issued now
      :expires expires}))
+
+(defn verify-api-token [token public-key]
+  (try
+    (let [decoded-key (der-string->pub-key public-key)
+          verified-token (jwt/unsign token decoded-key {:alg :rs256})]
+      [:valid verified-token])
+    (catch Exception e [:invalid (.getMessage e)])))

--- a/src/clj/web/tokens.clj
+++ b/src/clj/web/tokens.clj
@@ -1,0 +1,50 @@
+(ns web.tokens
+  (:require [clj-time.core :as t]
+            [buddy.sign.jwt :as jwt]))
+
+(defn- kp-generator [length]
+  (doto (java.security.KeyPairGenerator/getInstance "RSA")
+    (.initialize length)))
+
+(defn- generate-keypair [length]
+  (assert (>= length 512) "RSA Key must be at least 512 bits long.")
+  (.generateKeyPair (kp-generator length)))
+
+(defn- decode64 [str]
+  (.decode (java.util.Base64/getDecoder) str))
+
+(defn- encode64 [bytes]
+  (.encodeToString (java.util.Base64/getEncoder) bytes))
+
+(defn- der-string->pub-key [string]
+  "Generate an RSA public key from a DER-encoded Base64 string.
+   Some systems like to line-wrap these at 64 characters, so we
+   have to get rid of any newlines before decoding."
+  (let [non-wrapped (clojure.string/replace string #"\n" "")
+        key-bytes (decode64 non-wrapped)
+        spec (java.security.spec.X509EncodedKeySpec. key-bytes)
+        key-factory (java.security.KeyFactory/getInstance "RSA")]
+    (.generatePublic key-factory spec)))
+
+(defn- public-key->der-string [key]
+  "Generate DER-formatted string for a public key."
+  (-> key
+      .getEncoded
+      encode64
+      (clojure.string/replace #"\n" "")))
+
+(defn create-api-token [emailhash]
+  (let [keypair (generate-keypair 1024)
+        private-key (.getPrivate keypair)
+        public-key (.getPublic keypair)
+        public-key-str (public-key->der-string public-key)
+        now (t/now)
+        expires (-> 365 t/days t/from-now)
+        claims {:sub "deck-api"
+                :emailhash emailhash
+                :iat now
+                :exp expires}]
+    {:token (jwt/sign claims private-key {:alg :rs256})
+     :public-key public-key-str
+     :issued now
+     :expires expires}))

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -1,7 +1,6 @@
 (ns web.ws
   (:require [clojure.core.async :refer [go <! timeout]]
             [aero.core :refer [read-config]]
-            [buddy.sign.jwt :as jwt]
             [taoensso.sente :as sente]
             [taoensso.sente.server-adapters.http-kit :refer (get-sch-adapter)]))
 

--- a/src/cljc/jinteki/nav.cljc
+++ b/src/cljc/jinteki/nav.cljc
@@ -6,5 +6,6 @@
    ["Play" "/play" 3 nil]
    ["Help" "/help" 4 nil]
    ["Settings" "/account" 5 #(:user %)]
-   ["Stats" "/stats" 6 #(:user %)]
-   ["About" "/about" 7 nil]])
+   ["Integration" "/integration" 6 #(:user %)]
+   ["Stats" "/stats" 7 #(:user %)]
+   ["About" "/about" 8 nil]])

--- a/src/cljs/nr/integration.cljs
+++ b/src/cljs/nr/integration.cljs
@@ -1,0 +1,56 @@
+(ns nr.integration
+  (:require-macros [cljs.core.async.macros :refer [go]])
+  (:require [nr.ws :as ws]
+            [cljs.core.async :refer [chan put! <!] :as async]
+            [nr.auth :refer [authenticated] :as auth]
+            [reagent.core :as r]))
+
+(def integration-state (r/atom {:api-keys nil}))
+(def key-channel (chan))
+
+(go (while true
+      (let [msg (<! key-channel)]
+        (swap! integration-state assoc :api-keys (:keys msg)))))
+
+(defn- send-key-message
+  ([k] (send-key-message k {}))
+  ([k args]
+   (authenticated
+     (fn [user]
+       (ws/ws-send! [k args])))))
+
+(defn- request-all-keys []
+  (send-key-message :integration/list-keys))
+
+(defn- add-key []
+  (send-key-message :integration/create-key))
+
+(defn- remove-key [k]
+  (send-key-message :integration/delete-key {:_id (:_id k)}))
+
+(defn api-key-view [k]
+  [:div.api-key
+   (str "An API key " k)
+   [:button.api-key-remove {:on-click #(remove-key k)} "Delete"]])
+
+(defn integration []
+  (let [api-keys (r/cursor integration-state [:api-keys])]
+    (r/create-class
+      {:display-name "integration"
+
+       :component-did-mount
+       (fn [] (request-all-keys))
+
+       :reagent-render
+       (fn []
+         [:div.integration.panel.content-page.blue-shade
+          [:h3 "3rd Party Integration"]
+          [:h4 "API Keys"]
+          [:div.api-keys
+           (for [k @api-keys]
+             ^{:key (:_id k)}
+             [:div (api-key-view k)])
+           [:div.api-button-div
+            [:button.api-key-add {:on-click #(add-key)} "New"]]]])})))
+
+(ws/register-ws-handler! :integration/key-list (partial put! key-channel))

--- a/src/cljs/nr/integration.cljs
+++ b/src/cljs/nr/integration.cljs
@@ -57,9 +57,6 @@
     (r/create-class
       {:display-name "integration"
 
-       ;; :component-did-mount
-       ;; (fn [] (request-all-keys))
-
        :reagent-render
        (fn []
          [:div.integration.panel.content-page.blue-shade

--- a/src/cljs/nr/integration.cljs
+++ b/src/cljs/nr/integration.cljs
@@ -3,6 +3,7 @@
   (:require [nr.ws :as ws]
             [cljs.core.async :refer [chan put! <!] :as async]
             [nr.auth :refer [authenticated] :as auth]
+            [nr.cardbrowser :refer [non-game-toast] :as cb]
             [reagent.core :as r]))
 
 (def integration-state (r/atom {:api-keys nil}))
@@ -30,16 +31,34 @@
 
 (defn api-key-view [k]
   [:div.api-key
-   (str "An API key " k)
-   [:button.api-key-remove {:on-click #(remove-key k)} "Delete"]])
+   [:div
+    [:input {:value (:token k) :readOnly true}]
+    [:button.clipboard-btn
+     {:data-clipboard-text (:token k)
+      :onClick #(cb/non-game-toast "Copied key" "success" nil)}
+     "Copy"]
+    [:button.api-key-remove
+     {:on-click #(do
+                   (remove-key k)
+                   (cb/non-game-toast "Deleted key" "success" nil))}
+     "Delete"]]
+   [:div
+    [:span [:strong "Issued: "]
+     [:span.date (-> (:issued k) js/Date. js/moment (.format "Do MMM YYYY"))] ]
+    [:span.expires-text
+     (if (-> (:expires k) js/Date. js/moment .isBefore)
+       {:class "expired"})
+     [:strong "Expires: "]
+     [:span.date (-> (:expires k) js/Date. js/moment (.format "Do MMM YYYY"))] ]
+    ]])
 
 (defn integration []
   (let [api-keys (r/cursor integration-state [:api-keys])]
     (r/create-class
       {:display-name "integration"
 
-       :component-did-mount
-       (fn [] (request-all-keys))
+       ;; :component-did-mount
+       ;; (fn [] (request-all-keys))
 
        :reagent-render
        (fn []

--- a/src/cljs/nr/main.cljs
+++ b/src/cljs/nr/main.cljs
@@ -6,6 +6,7 @@
             [nr.about :refer [about]]
             [nr.auth :refer [auth-forms auth-menu]]
             [nr.account :refer [account]]
+            [nr.integration :refer [integration]]
             [nr.cardbrowser :refer [card-browser]]
             [nr.chat :refer [chat]]
             [nr.deckbuilder :refer [deck-builder]]
@@ -17,7 +18,7 @@
             [reagent.core :as r])
   (:import goog.history.Html5History))
 
-(def tokens #js ["/" "/cards" "/deckbuilder" "/play" "/help" "/account" "/stats" "/about"])
+(def tokens #js ["/" "/cards" "/deckbuilder" "/play" "/help" "/account" "/integration" "/stats" "/about"])
 
 (def history (Html5History.))
 
@@ -90,6 +91,7 @@
   (r/render [gameboard] (.getElementById js/document "gameboard"))
   (r/render [game-lobby] (.getElementById js/document "gamelobby"))
   (r/render [help] (.getElementById js/document "help"))
+  (r/render [integration] (.getElementById js/document "integration"))
   (r/render [news] (.getElementById js/document "news"))
   (r/render [stats] (.getElementById js/document "stats")))
 

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2190,6 +2190,41 @@ nav ul
   to
     opacity: 1
 
+#integration
+  height: 100%
+  margin-top: -31px
+  overflow: auto
+  -webkit-overflow-scrolling: touch
+  flex(1)
+
+  .api-key-remove
+    float: right
+
+  .api-key-add
+    margin-top: 10px
+
+  .api-key
+    height: 65px
+    padding: 5px 8px
+    margin: 0 0 5px
+    border: 1px solid white
+    border-radius: 4px
+    cursor: pointer
+    clear: both
+
+    &:hover
+      border-color: orange
+
+    p
+      margin-top: 0
+
+    h4
+      margin: 0
+      text-overflow: ellipsis
+      white-space: nowrap
+      overflow: hidden
+      width: 260px
+
 #about
   position: absolute
   top: 0

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2197,6 +2197,16 @@ nav ul
   -webkit-overflow-scrolling: touch
   flex(1)
 
+  input
+    width: 400px
+    margin-bottom: 10px
+
+  .expires-text
+    margin-left: 150px
+
+  .expired
+    color: red
+
   .api-key-remove
     float: right
 


### PR DESCRIPTION
**Still a work in progress, do not merge**
**TODO: adding new decks, editing existing decks, deleting decks**

Implements a new UI page (`Integrations`) which allows a user to generate up to 5 API keys. User can also delete existing keys. Keys have an associated expiration date, which is highlighted in the UI if the current date is greater than the expiration date.

<img width="677" alt="screen shot 2018-12-11 at 4 51 46 pm" src="https://user-images.githubusercontent.com/47226/49832586-16275200-fd65-11e8-86a8-0016eb03882a.png">

The API keys are JWTs, with the user's `emailhash` encoded in them. The standard fields of `iat` and `exp` are used to specify when the token was issued and when it will expire.

The JWT is signed with am asymmetric key. The private portion is discarded after signing. The public portion is stored in the `api_keys` Mongo collection. Additionally, the signed token the email hash, and the associated dates are stored in the same Mongo document.

The backed exposes the endpoints `/api/v1/decks` for listing all decks and `/api/v1/deck/<deck_id>` for listing an individual deck. Current format is json, very similar to what is stored in the `decks` collection today. **THIS MAY CHANGE IN LATER COMMITS**

The backed checks for a token in the `Authorization` HTTP headers, expecting the form: `Authorization: Bearer <Token>`. If the token is invalid or expired, the request is denied. If the token is not found in the `api_keys` collection, the request is denied. The `emailhash` from the signed token is used to look up a user in the `users` collection. Only decks for that user may be accessed.

This JWT-based verification scheme is overkill as currently used. But, I hope to reuse the majority of it for future OAuth integration work.