### PR TITLE
Allow moderators to reset game names in the lobby

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -12,6 +12,8 @@
             [clj-time.core :as t])
   (:import org.bson.types.ObjectId))
 
+(def log-collection "moderator_actions")
+
 ;; All games active on the server.
 (defonce all-games (atom {}))
 
@@ -348,6 +350,27 @@
                         :games/diff
                         {:diff {:update {gameid (game-public-view (game-for-id gameid))}}}))))
 
+(defn handle-rename-game
+  [{{{:keys [username isadmin ismoderator] :as user} :user} :ring-req
+    client-id                                     :client-id
+    {:keys [gameid]} :?data :as event}]
+  (when-let [game (game-for-id gameid)]
+    (when (and username
+               (or isadmin ismoderator))
+      (let [player-name (:username (:user (first (:players game))))
+            bad-name (:title game)]
+        (println username "renamed game '" bad-name "' from first player" player-name)
+        (swap! all-games assoc-in [gameid :title] (str player-name "'s game"))
+        (refresh-lobby :update gameid)
+        (ws/broadcast-to! (lobby-clients gameid)
+                          :games/diff
+                          {:diff {:update {gameid (game-public-view (game-for-id gameid))}}})
+        (mc/insert db log-collection
+                   {:moderator username
+                    :action :rename-game
+                    :game-name bad-name
+                    :first-player player-name
+                    :date (java.util.Date.)})))))
 
 (ws/register-ws-handlers!
   :chsk/uidport-open handle-ws-connect
@@ -357,4 +380,5 @@
   :lobby/watch handle-lobby-watch
   :lobby/say handle-lobby-say
   :lobby/swap handle-swap-sides
-  :lobby/deck handle-select-deck)
+  :lobby/deck handle-select-deck
+  :lobby/rename-game handle-rename-game)

--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -286,58 +286,75 @@
                      :on-change #(swap! s assoc :msg (-> % .-target .-value))}]
             [:button "Send"]]]])})))
 
+(defn- reset-game-name
+  [gameid]
+  (authenticated
+    (fn [user]
+      (ws/ws-send! [:lobby/rename-game {:gameid gameid}]))))
+
 (defn game-view [{:keys [title format password started players gameid current-game password-game original-players editing] :as game}]
-  (r/with-let [s (r/atom {})
-                join (fn [action]
-                       (let [password (:password password-game password)]
-                         (if (empty? password)
-                           (join-game (if password-game (:gameid password-game) gameid) s action nil)
-                           (if-let [input-password (:password @s)]
-                             (join-game (if password-game (:gameid password-game) gameid) s action input-password)
-                             (do (swap! app-state assoc :password-gameid gameid) (swap! s assoc :prompt action))))))]
-      [:div.gameline {:class (when (= current-game gameid) "active")}
-       (when (and (:allowspectator game) (not (or password-game current-game editing)))
-         [:button {:on-click #(do (join "watch") (resume-sound))} "Watch" editing])
-       (when-not (or current-game editing (= (count players) 2) started password-game)
-         [:button {:on-click #(do (join "join") (resume-sound))} "Join"])
-       (when (and (not current-game) (not editing) started (not password-game)
-                  (some #(= % (get-in @app-state [:user :_id]))
-                        (map #(get-in % [:user :_id]) original-players)))
-         [:button {:on-click #(do (join "rejoin") (resume-sound))} "Rejoin"])
-       (let [c (count (:spectators game))]
-         [:h4 (str (when-not (empty? (:password game))
-                     "[PRIVATE] ")
-                   (:title game)
-                   (when (pos? c)
-                     (str  " (" c " spectator" (when (> c 1) "s") ")")))])
+  (r/with-let [s (r/atom {:show-mod-menu false})
+               user (:user @app-state)
+               join (fn [action]
+                      (let [password (:password password-game password)]
+                        (if (empty? password)
+                          (join-game (if password-game (:gameid password-game) gameid) s action nil)
+                          (if-let [input-password (:password @s)]
+                            (join-game (if password-game (:gameid password-game) gameid) s action input-password)
+                            (do (swap! app-state assoc :password-gameid gameid) (swap! s assoc :prompt action))))))]
+    [:div.gameline {:class (when (= current-game gameid) "active")}
+     (when (and (:allowspectator game) (not (or password-game current-game editing)))
+       [:button {:on-click #(do (join "watch") (resume-sound))} "Watch" editing])
+     (when-not (or current-game editing (= (count players) 2) started password-game)
+       [:button {:on-click #(do (join "join") (resume-sound))} "Join"])
+     (when (and (not current-game) (not editing) started (not password-game)
+                (some #(= % (get-in @app-state [:user :_id]))
+                      (map #(get-in % [:user :_id]) original-players)))
+       [:button {:on-click #(do (join "rejoin") (resume-sound))} "Rejoin"])
+     (let [c (count (:spectators game))]
+       [:h4
+        {:on-click #(swap! s assoc :show-mod-menu (not (:show-mod-menu @s false)))
+         :class (when (or (:isadmin user) (:ismoderator user)) "clickable")}
+        (str (when-not (empty? (:password game))
+               "[PRIVATE] ")
+             (:title game)
+             (when (pos? c)
+               (str  " (" c " spectator" (when (> c 1) "s") ")")))])
 
-       [:div {:class "game-format"}
-        [:span.format-label "Format:  "]
-        [:span.format-type (slug->format format "Unknown")]]
+     (when (and (:show-mod-menu @s)
+                (or (:isadmin user) (:ismoderator user)))
+       [:div.panel.blue-shade.mod-menu
+        [:div {:on-click #(do (reset-game-name gameid)
+                              (swap! s assoc :show-mod-menu false))} "Reset Game Name"]
+        [:div {:on-click #(swap! s assoc :show-mod-menu false)} "Cancel"]])
 
-       [:div (doall
-               (for [player (:players game)]
-                 ^{:key (-> player :user :_id)}
-                 [player-view player game]))]
+     [:div {:class "game-format"}
+      [:span.format-label "Format:  "]
+      [:span.format-type (slug->format format "Unknown")]]
 
-       (when-let [prompt (:prompt @s)]
-         [:div.password-prompt
-          [:h3 (str "Password for " (if password-game (:title password-game) title))]
-          [:p
-           [:input.game-title {:on-change #(swap! s assoc :password (.. % -target -value))
-                               :type "password"
-                               :value (:password @s) :placeholder "Password" :maxLength "30"}]]
-          [:p
-           [:button {:type "button" :on-click #(join prompt)}
-            prompt]
-           [:span.fake-link {:on-click #(do
-                                          (swap! app-state dissoc :password-gameid)
-                                          (swap! s assoc :prompt false)
-                                          (swap! s assoc :error-msg nil)
-                                          (swap! s assoc :password nil))}
-            "Cancel"]]
-          (when-let [error-msg (:error-msg @s)]
-            [:p.flash-message error-msg])])]))
+     [:div (doall
+             (for [player (:players game)]
+               ^{:key (-> player :user :_id)}
+               [player-view player game]))]
+
+     (when-let [prompt (:prompt @s)]
+       [:div.password-prompt
+        [:h3 (str "Password for " (if password-game (:title password-game) title))]
+        [:p
+         [:input.game-title {:on-change #(swap! s assoc :password (.. % -target -value))
+                             :type "password"
+                             :value (:password @s) :placeholder "Password" :maxLength "30"}]]
+        [:p
+         [:button {:type "button" :on-click #(join prompt)}
+          prompt]
+         [:span.fake-link {:on-click #(do
+                                        (swap! app-state dissoc :password-gameid)
+                                        (swap! s assoc :prompt false)
+                                        (swap! s assoc :error-msg nil)
+                                        (swap! s assoc :password nil))}
+          "Cancel"]]
+        (when-let [error-msg (:error-msg @s)]
+          [:p.flash-message error-msg])])]))
 
 (defn- blocked-from-game
   "Remove games for which the user is blocked by one of the players"

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1173,6 +1173,30 @@ nav ul
   width: 995px
   display-flex()
 
+  .clickable
+    cursor: pointer
+
+  .mod-menu
+    display: block
+    position: absolute
+    z-index: 30
+    width: 200px
+    font-size: 12px
+    line-height: 16px
+
+    > div
+      border: 1px solid white
+      padding: 3px 6px
+      border-radius: 4px
+      margin-bottom: 4px
+      cursor: pointer
+
+      &:last-child
+        margin-bottom: 0
+
+      &:hover
+        border-color: orange
+
   .games
     position: relative
 


### PR DESCRIPTION
Added a menu when admins or moderators click on a game title. They can choose to reset a game name, which will change it back to `Player1's game`. This action is printed to the log and captured in the `moderator_actions` table.

<img width="677" alt="screen shot 2018-12-14 at 4 52 14 pm" src="https://user-images.githubusercontent.com/47226/50029519-f8eebf80-ffc0-11e8-94e2-dcbff10fa872.png">
