### PR TITLE
Implement Sundew

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1736,11 +1736,22 @@
                               (play-cost-bonus [:credit 2]))}}}
 
    "Sundew"
-   {:implementation "it's all broken just don't even try man"}
-    ; :events {:runner-spent-click {:once :per-turn
-    ;                               :msg (req (when (not this-server) "gain 2 [Credits]"))
-    ;                               :effect (req (when (not this-server)
-    ;                                              (gain-credits state :corp 2)))}}
+   ; If this a run event then handle in :begin-run as we do not know the server
+   ; being run on in :runner-spent-click.
+   {:events {:runner-spent-click {:req (req (first-event? state side :runner-spent-click))
+                                  :msg (req (if (not= :run (get-in @state [:runner :register :click-type]))
+                                              "gain 2 [Credits]"))
+                                  :effect (req (if (not= :run (get-in @state [:runner :register :click-type]))
+                                                 (gain-credits state :corp 2)))}
+             :begin-run {:once :per-turn
+                         :req (req (first-event? state side :runner-spent-click))
+                         :msg (req (if (and (= :run (get-in @state [:runner :register :click-type]))
+                                            (not this-server))
+                                     "gain 2 [Credits]"))
+                         :effect (req (if (and (= :run (get-in @state [:runner :register :click-type]))
+                                               (not this-server))
+                                        (gain-credits state :corp 2)))}}}
+
 
    "Synth DNA Modification"
    {:implementation "Manual fire once subroutine is broken"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -555,6 +555,7 @@
     (when (and (can-run? state side)
                (can-run-server? state server)
                (can-pay? state :runner "a run" :click 1 cost-bonus click-cost-bonus))
+      (swap! state assoc-in [:runner :register :click-type] :run)
       (swap! state assoc-in [:runner :register :made-click-run] true)
       (when-let [cost-str (pay state :runner nil :click 1 cost-bonus click-cost-bonus)]
         (run state side server)

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -44,6 +44,8 @@
    (swap! state update-in [:bonus] dissoc :play-cost)
    (wait-for (trigger-event-simult state side :pre-play-instant nil card)
              (when (empty? (get-in @state [side :locked (-> card :zone first)]))
+               (if (has-subtype? card "Run")
+                 (swap! state assoc-in [:runner :register :click-type] :run))
                (let [{:keys [req additional-cost]} (card-def card)
                      additional-cost (if (has-subtype? card "Triple")
                                        (concat additional-cost [:click 2])

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -24,6 +24,7 @@
                     :access-bonus 0
                     :run-effect (assoc run-effect :card card)
                     :eid eid})
+       (trigger-event state side :begin-run :server s)
        (gain-run-credits state side (+ (get-in @state [:corp :bad-publicity]) (get-in @state [:corp :has-bad-pub])))
        (swap! state update-in [:runner :register :made-run] #(conj % (first s)))
        (update-all-ice state :corp)


### PR DESCRIPTION
The :runner-spent-click event happens before the run is initiated, so we
do not know which server the run is going to happen on. This prevents us
from fully handling this ability in :runner-spent-click.

To fix, add a new field in the register, :click-type, which we can use
to determine if the click was spent on a run event. If so, we then wait
for the :begin-run event to handle the ability.

--

The :click-type feels a bit hacky to me but it was the best I could think of. Any ideas for a better way?