### PR TITLE
Refactor access-bonus, fix The Turning Wheel and Divide and Conquer

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -117,7 +117,7 @@
             :unsuccessful {:effect (effect (register-events (:events (card-def card))
                                                             (assoc card :zone '(:discard))))}}
     :events {:pre-access {:req (req (#{:hq :rd} target))
-                          :effect (effect (access-bonus 2))}
+                          :effect (effect (access-bonus target 2))}
              :runner-turn-ends {:effect (effect (unregister-events card))}}}
 
    "Bribery"
@@ -368,7 +368,7 @@
     :effect (effect (run :rd nil card)
                     (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
     :events {:successful-run {:silent (req true)
-                              :effect (effect (access-bonus (max 0 (min 4 (available-mu state)))))}
+                              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}
              :run-ends {:effect (effect (unregister-events card))}}}
 
    "Demolition Run"
@@ -1223,7 +1223,7 @@
     :effect (effect (run :hq nil card) (register-events (:events (card-def card))
                                                         (assoc card :zone '(:discard))))
     :events {:successful-run {:silent (req true)
-                              :effect (effect (access-bonus 2))}
+                              :effect (effect (access-bonus :hq 2))}
              :run-ends {:effect (effect (unregister-events card))}}}
 
    "Leverage"
@@ -1951,7 +1951,7 @@
                     (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
     :events {:successful-run {:silent (req true)
                               :req (req (= target :rd))
-                              :effect (effect (access-bonus 2))}
+                              :effect (effect (access-bonus :rd 2))}
              :run-ends {:effect (effect (unregister-events card))}}}
 
    "The Noble Path"
@@ -1970,12 +1970,16 @@
                     :effect (req (let [runtgt [(last (server->zone state target))]
                                        ices (get-in @state (concat [:corp :servers] runtgt [:ices]))]
                                    (swap! state assoc :per-run nil
-                                                      :run {:server runtgt :position (count ices)
-                                                            :access-bonus 0 :run-effect nil})
+                                                      :run {:server runtgt
+                                                            :position (count ices)
+                                                            :access-bonus []
+                                                            :run-effect nil})
                                    (gain-run-credits state :runner (:bad-publicity corp))
                                    (swap! state update-in [:runner :register :made-run] #(conj % (first runtgt)))
-                                   (trigger-event state :runner :run runtgt)))} card nil))
-    :events {:pre-damage nil :run-ends nil}}
+                                   (trigger-event state :runner :run runtgt)))}
+                   card nil))
+    :events {:pre-damage nil
+             :run-ends nil}}
 
    "The Price of Freedom"
    {:additional-cost [:connection 1]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -518,14 +518,13 @@
    {:req (req archives-runnable)
     :makes-run true
     :async true
-    :effect
-    (effect (run :archives
-                 {:end-run
-                  {:async true
-                   :effect
-                   (req (wait-for (do-access state side [:hq] {:no-root true})
-                                  (do-access state side eid [:rd] {:no-root true})))}}
-                 card))}
+    :effect (effect (run :archives nil card)
+                    (register-events (:events (card-def card)) (assoc card :zone '(:discard))))
+    :events {:end-access-phase {:async true
+                                :req (req (= :archives (:from-server target)))
+                                :effect (req (wait-for (do-access state side [:hq] {:no-root true})
+                                                       (do-access state side eid [:rd] {:no-root true})))}
+             :run-ends {:effect (effect (unregister-events card))}}}
 
    "Drive By"
    {:choices {:req #(let [topmost (get-nested-host %)]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1111,25 +1111,32 @@
 
    "Severnius Stim Implant"
    {:abilities [{:cost [:click 1]
-                 :prompt "Choose a server to run with Severnius Stim Implant" :choices ["HQ" "R&D"]
+                 :prompt "Choose a server to run with Severnius Stim Implant"
+                 :choices ["HQ" "R&D"]
                  :effect (req (let [n (count (:hand runner))
-                                    srv target]
+                                    srv target
+                                    kw (if (= "R&D" target) :rd :hq)]
                                 (resolve-ability state side
                                   {:prompt "Choose at least 2 cards in your Grip to trash with Severnius Stim Implant"
-                                   :choices {:max n :req #(and (= (:side %) "Runner") (in-hand? %))}
-                                   :msg (msg "trash " (count targets) " card" (if (not= 1 (count targets)) "s")
-                                             " and access " (quot (count targets) 2) " additional cards")
+                                   :choices {:max n
+                                             :req #(and (= (:side %) "Runner")
+                                                        (in-hand? %))}
+                                   :msg (msg "trash " (pluralize "card" (count targets))
+                                             " and access " (pluralize "additional card" (quot (count targets) 2)))
                                    :effect (req (let [bonus (quot (count targets) 2)]
                                                    (trash-cards state side (make-eid state) targets
-                                                                {:unpreventable true :suppress-event true})
+                                                                {:unpreventable true
+                                                                 :suppress-event true})
                                                    (game.core/run state side srv nil card)
                                                    (register-events state side
                                                      {:pre-access
                                                       {:silent (req true)
-                                                       :effect (effect (access-bonus bonus))}
-                                                      :run-ends {:effect (effect (unregister-events card))}} card)))}
+                                                       :effect (effect (access-bonus kw bonus))}
+                                                      :run-ends {:effect (effect (unregister-events card))}}
+                                                     card)))}
                                  card nil)))}]
-    :events {:pre-access nil :run-ends nil}}
+    :events {:pre-access nil
+             :run-ends nil}}
 
    "Şifr"
    {:in-play [:memory 2]
@@ -1198,7 +1205,7 @@
                                                       ;; Makes number of ice on server (HQ) the upper limit.
                                                       ;; This should work since trashed ice do not count according to UFAQ
                                                       :choices {:number (req (count (get-in @state [:corp :servers :hq :ices])))}
-                                                      :effect (effect (access-bonus target))}
+                                                      :effect (effect (access-bonus :hq target))}
                                                      card nil))}}}
 
    "The Personal Touch"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2229,7 +2229,7 @@
                   (trace-ability 2 {:label "Runner reduces cards accessed by 1 for this run"
                                     :async true
                                     :msg "reduce cards accessed for this run by 1"
-                                    :effect (effect (access-bonus -1))})]}
+                                    :effect (effect (access-bonus (-> card :zone second) -1))})]}
 
    "Tapestry"
    {:subroutines [{:label "force the Runner to lose 1 [Click], if able"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -141,7 +141,7 @@
                           :interactive (req true)
                           :psi {:player :runner
                                 :equal {:msg "access 1 additional card"
-                                        :effect (effect (access-bonus 1)
+                                        :effect (effect (access-bonus :rd 1)
                                                         (effect-completed eid))}}}}}
 
    "Alice Merchant: Clan Agitator"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -658,7 +658,7 @@
                                      :choices {:number (req (dec (get-virus-counters state card)))
                                                :default (req (dec (get-virus-counters state card)))}
                                      :msg (msg "access " target " additional cards from R&D")
-                                     :effect (effect (access-bonus (max 0 target)))}
+                                     :effect (effect (access-bonus :rd (max 0 target)))}
                                     card nil))}}}
    "Misdirection"
    {:abilities [{:cost [:click 2]
@@ -683,7 +683,7 @@
                                      :choices {:number (req (dec (get-virus-counters state card)))
                                                :default (req (dec (get-virus-counters state card)))}
                                      :msg (msg "access " target " additional cards from HQ")
-                                     :effect (effect (access-bonus (max 0 target)))}
+                                     :effect (effect (access-bonus :hq (max 0 target)))}
                                     card nil))}}}
 
    "Net Shield"
@@ -702,7 +702,7 @@
                                             {:optional
                                              {:prompt "Spend a power counter on Nyashia to access 1 additional card?"
                                               :yes-ability {:msg "access 1 additional card from R&D"
-                                                            :effect (effect (access-bonus 1)
+                                                            :effect (effect (access-bonus :rd 1)
                                                                             (add-counter card :power -1)
                                                                             (clear-wait-prompt :corp))}
                                               :no-ability {:effect (effect (clear-wait-prompt :corp))}}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -463,7 +463,7 @@
                                                                                                   tags " cards by paying "
                                                                                                   tags " [Credit]"))
                                                                       (pay state side card :credit tags)
-                                                                      (access-bonus state side (- tags 1)))
+                                                                      (access-bonus state side target (- tags 1)))
                                                                   ;; Can't pay, don't access cards
                                                                   (do (system-msg state side "could not afford to use Counter Surveillance")
                                                                       ;; Cannot access any cards
@@ -2047,31 +2047,22 @@
              :pre-steal-cost {:effect (effect (steal-cost-bonus [:credit 3]))}}}
 
    "The Turning Wheel"
-   {:events {:agenda-stolen {:effect (effect (update! (assoc card :agenda-stolen true)))
-                             :silent (req true)}
-             :pre-access {:req (req (and (:run @state)
-                                         (pos? (get-in @state [:run :ttw-bonus] 0))))
-                          :effect (req (let [ttw-bonus (get-in @state [:run :ttw-bonus] 0)
-                                             deferred-bonus (get-in @state [:run :ttw-deferred-bonus] 0)]
-                                         (if (#{:hq :rd} target)
-                                           (when (pos? deferred-bonus)
-                                             (access-bonus state side ttw-bonus)
-                                             (swap! state assoc-in [:run :ttw-deferred-bonus] 0))
-                                           (when (zero? deferred-bonus)
-                                             (access-bonus state side (- ttw-bonus))
-                                             (swap! state assoc-in [:run :ttw-deferred-bonus] ttw-bonus)))))
-                          :silent (req true)}
-             :run-ends {:effect (req (when (and (not (:agenda-stolen card))
-                                                (#{:hq :rd} target))
-                                       (add-counter state side card :power 1)
-                                       (system-msg state :runner (str "places a power counter on " (:title card))))
-                                     (update! state side (dissoc (get-card state card) :agenda-stolen)))
-                        :silent (req true)}}
-    :abilities [{:counter-cost [:power 2]
-                 :req (req (:run @state))
-                 :msg "access 1 additional card from HQ or R&D for the remainder of the run"
-                 :effect  (req (swap! state update-in [:run :ttw-bonus] (fnil inc 0))
-                               (access-bonus state side 1))}]}
+   (let [ttw-ab (fn [m s]
+                  {:label (str "Access an additional card in " m)
+                   :counter-cost [:power 2]
+                   :req (req (:run @state))
+                   :msg "access 1 additional card from " m " for the remainder of the run"
+                   :effect (req (access-bonus state side s 1))})]
+    {:events {:agenda-stolen {:effect (effect (update! (assoc card :agenda-stolen true)))
+                              :silent (req true)}
+              :run-ends {:effect (req (when (and (not (:agenda-stolen card))
+                                                 (#{:hq :rd} target))
+                                        (add-counter state side card :power 1)
+                                        (system-msg state :runner (str "places a power counter on " (:title card))))
+                                      (update! state side (dissoc (get-card state card) :agenda-stolen)))
+                         :silent (req true)}}
+     :abilities [(ttw-ab "R&D" :rd)
+                 (ttw-ab "HQ" :hq)]})
 
    "Theophilius Bagbiter"
    {:effect (req (lose-credits state :runner :all)

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -762,14 +762,14 @@
                                :silent (req true)
                                :effect (req (let [cnt (total-cards-accessed run)
                                                   total (* 2 cnt)]
-                                              (access-bonus state :runner -3)
+                                              (access-bonus state :runner (-> card :zone second) -3)
                                               (when cnt
                                                 (gain-credits state :corp total)
                                                 (system-msg state :corp
                                                             (str "gains " total " [Credits] from Mwanza City Grid")))))}
          boost-access-by-3 {:req (req (= target (second (:zone card))))
                             :msg "force the Runner to access 3 additional cards"
-                            :effect (req (access-bonus state :runner 3))}]
+                            :effect (req (access-bonus state :runner (-> card :zone second) 3))}]
      {:install-req (req (filter #{"HQ" "R&D"} targets))
       :events {:pre-access boost-access-by-3
                :end-access-phase gain-creds-and-clear}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -758,11 +758,11 @@
                    :effect (req (swap! state assoc-in [:runner :register :force-trash] false))}}
 
    "Mwanza City Grid"
-   (let [gain-creds-and-clear {:req (req (= (:from-server target) (second (:zone card))))
+   (let [gain-creds-and-clear {:req (req (= (:from-server target)
+                                            (second (:zone card))))
                                :silent (req true)
                                :effect (req (let [cnt (total-cards-accessed run)
                                                   total (* 2 cnt)]
-                                              (access-bonus state :runner (-> card :zone second) -3)
                                               (when cnt
                                                 (gain-credits state :corp total)
                                                 (system-msg state :corp

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -403,8 +403,6 @@
   For temporary/per-run effects like Legwork, Maker's Eye.
   Not for permanent increases like RDI."
   [state side server bonus]
-  (when-not (#{:hq :rd} server)
-    (println "access-bonus" server))
   (swap! state update-in [:run :access-bonus] conj [server bonus]))
 
 (defn access-bonus-count
@@ -424,8 +422,6 @@
            :rd-access :rd
            :hq-access :hq
            kw)
-        _ (when-not (#{:hq :rd} s)
-            (println "access-count" s))
         accesses (+ (get-in @state [:runner kw])
                     (access-bonus-count run s))]
     (if-let [max-access (:max-access run)]

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -927,6 +927,25 @@
             "The Turning Wheel should provide 1 additional access on HQ")
         (is (= 6 (-> (get-runner) :register :last-run core/total-cards-accessed))
             "Runner should access 2 cards in Archives, 1 + 1 in R&D, and 1 + 1 in HQ"))))
+  (testing "The Turning Wheel gains counters after using D&C. Issue #3810"
+    (do-game
+      (new-game {:corp {:deck [(qty "Ice Wall" 100)]}
+                 :runner {:deck ["Divide and Conquer" "The Turning Wheel"]}})
+      (starting-hand state :corp ["Ice Wall" "Ice Wall" "Ice Wall"])
+      (trash-from-hand state :corp "Ice Wall")
+      (trash-from-hand state :corp "Ice Wall")
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Turning Wheel")
+      (let [ttw (get-resource state 0)
+            counters (get-counters (refresh ttw) :power)]
+        (play-from-hand state :runner "Divide and Conquer")
+        (run-successful state)
+        (click-prompt state :runner "No action")
+        (click-prompt state :runner "No action")
+        (is (= counters (get-counters (refresh ttw) :power)) "Gains no counters")
+        (run-empty-server state "R&D")
+        (click-prompt state :runner "No action")
+        (is (= (+ 1 counters) (get-counters (refresh ttw) :power)) "Gains 1 counters"))))
   (testing "vs Nisei Mk II. Issue #3803"
     (do-game
       (new-game {:corp {:deck ["Nisei MK II" (qty "Ice Wall" 100)]}

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -910,19 +910,20 @@
         (core/add-counter state :runner ttw :power 4)
         (play-from-hand state :runner "Divide and Conquer")
         (card-ability state :runner ttw 0)
-        (card-ability state :runner ttw 0)
+        (card-ability state :runner ttw 1)
         (run-successful state)
         ;; HQ
-        (dotimes [_ 3]
+        (dotimes [_ 2]
           (click-prompt state :runner "Card from hand")
           (click-prompt state :runner (-> (prompt-map :runner) :choices first)))
         ;; R&D
-        (dotimes [_ 3]
+        (dotimes [_ 2]
           (click-prompt state :runner "Card from deck")
           (click-prompt state :runner "No action"))
         (is (empty? (:prompt (get-runner))) "No prompts after all accesses are complete")
-        (is (= 2 (-> (get-runner) :register :last-run :access-bonus)) "The Turning Wheel should provide 2 additional accesses")
-        (is (= 8 (-> (get-runner) :register :last-run core/total-cards-accessed)) "Runner should access 2 cards in Archives, 1 + 2 in R&D, and 1 + 2 in HQ")))))
+        (is (= 1 (-> (get-runner) :register :last-run (core/access-bonus-count :rd))) "The Turning Wheel should provide 1 additional access on R&D")
+        (is (= 1 (-> (get-runner) :register :last-run (core/access-bonus-count :hq))) "The Turning Wheel should provide 1 additional access on HQ")
+        (is (= 6 (-> (get-runner) :register :last-run core/total-cards-accessed)) "Runner should access 2 cards in Archives, 1 + 1 in R&D, and 1 + 1 in HQ")))))
 
 (deftest drive-by
   ;; Drive By - Expose card in remote server and trash if asset or upgrade

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1609,7 +1609,7 @@
         (core/rez state :corp mwanza)
         (let [credits (:credit (get-corp))]
           (card-subroutine state :corp shiro 1)
-          (is (= 3 (-> @state :run :access-bonus)) "Should access an additional 3 cards")
+          (is (= 3 (core/access-bonus-count (:run @state) :rd)) "Should access an additional 3 cards")
           (dotimes [_ 5]
             (click-prompt state :runner "Card from deck")
             (click-prompt state :runner "No action"))

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -711,7 +711,8 @@
     (run-on state "R&D")
     (run-successful state)
     (click-prompt state :runner "Yes")
-    (is (= 2 (+ (get-in @state [:runner :rd-access]) (:access-bonus (:run @state) 0))))))
+    (is (= 2 (+ (get-in @state [:runner :rd-access])
+                (core/access-bonus-count (:run @state) :rd))))))
 
 (deftest origami
   ;; Origami - Increases Runner max hand size


### PR DESCRIPTION
The Turning Wheel has been broken for a while, owing to the binary nature of `access-bonus`. I have refactored it from a single integer to a vector of tuples, each tuple structured as `[:server bonus]`. Instead of attempting to add or subtract the right amount, forcing each card to properly handle when to apply or not apply their bonus, this change allows for seamless additions and subtractions to be appended with no worry that they will overwrite each other or get reset accidentally.

This neatly fixes the otherwise hairy and ugly bugs in The Turning Wheel specifically but also in any other cards that interact with the non-normal accesses (Divide and Conquer, Mwanza, Shiro, etc).

Fixes #3956 
Fixes #3803 
Fixes #3810
Fixes #3938
Fixes #3798 