### PR TITLE
Fix Rip Deal prompt issue, fix tests

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1707,28 +1707,36 @@
 
    "Rip Deal"
    {:req (req hq-runnable)
-    :effect (effect (run :hq {:req (req (= target :hq))
-                              :replace-access
-                                   {:async true
-                                    :effect (req (let [n (min (-> @state :corp :hand count) (access-count state side :hq-access))
-                                                       heap (-> @state :runner :discard count (- 1))]
-                                                   (move state side (find-cid (:cid card) (:discard runner)) :rfg)
-                                                   (if (pos? heap)
-                                                     (resolve-ability state side
-                                                                      {:show-discard true
-                                                                       :prompt (str "Choose " (min n heap) " card(s) to move from the Heap to your Grip")
-                                                                       :async true
-                                                                       :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
-                                                                       :choices {:max (min n heap)
-                                                                                 :all true
-                                                                                 :req #(and (= (:side %) "Runner")
-                                                                                            (in-discard? %))}
-                                                                       :effect (req (doseq [c targets] (move state side c :hand))
-                                                                                    (do-access state side eid (:server run) {:hq-root-only true}))} card nil)
-                                                     (resolve-ability state side
-                                                                      {:async true
-                                                                       :msg (msg "take no cards from their Heap to their Grip")
-                                                                       :effect (req (do-access state side eid (:server run) {:hq-root-only true}))} card nil))))}} card))}
+    :effect (effect
+              (run :hq {:req (req (= target :hq))
+                        :replace-access
+                        {:async true
+                         :effect
+                         (req (let [n (min (-> corp :hand count) (access-count state side :hq-access))
+                                    heap (-> runner :discard count (- 1))]
+                                (move state side (find-cid (:cid card) (:discard runner)) :rfg)
+                                (if (pos? heap)
+                                  (continue-ability
+                                    state side
+                                    {:show-discard true
+                                     :prompt (str "Choose " (quantify (min n heap) "card") " to move from the Heap to your Grip")
+                                     :async true
+                                     :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
+                                     :choices {:max (min n heap)
+                                               :all true
+                                               :req #(and (= (:side %) "Runner")
+                                                          (in-discard? %))}
+                                     :effect (req (doseq [c targets]
+                                                    (move state side c :hand))
+                                                  (do-access state side eid (:server run) {:hq-root-only true}))}
+                                    card nil)
+                                  (continue-ability
+                                    state side
+                                    {:async true
+                                     :msg (msg "take no cards from their Heap to their Grip")
+                                     :effect (req (do-access state side eid (:server run) {:hq-root-only true}))}
+                                    card nil))))}}
+                   card))}
 
    "Rumor Mill"
    (letfn [(eligible? [card] (and (:uniqueness card)

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2357,21 +2357,26 @@
   ;; Rip Deal - replaces number of HQ accesses with heap retrieval
   (testing "Basic test"
     (do-game
-      (new-game {:corp {:deck [(qty "Crisium Grid" 2)(qty "Vanilla" 2)]}
-                 :runner {:deck ["The Gauntlet" "Rip Deal" (qty "Easy Mark" 2)]}})
-      (trash-from-hand state :runner "Easy Mark")
+      (new-game {:corp {:deck ["Vanilla"]}
+                 :runner {:deck ["Rip Deal" "Easy Mark"]}})
       (trash-from-hand state :runner "Easy Mark")
       (take-credits state :corp)
       (play-from-hand state :runner "Rip Deal")
       (run-successful state)
       (click-prompt state :runner "Replacement effect")
-      (is (= "Choose 1 card(s) to move from the Heap to your Grip" (-> (get-runner) :prompt first :msg)))))
+      (is (= "Choose 1 card to move from the Heap to your Grip" (:msg (prompt-map :runner))))
+      (click-card state :runner "Easy Mark")
+      (is (= 1 (-> (get-runner) :hand count)))
+      (is (= "Easy Mark" (-> (get-runner) :hand first :title)))
+      (is (nil? (prompt-map :corp)) "Corp should have no more prompts")
+      (is (nil? (prompt-map :runner)) "Runner should have no more prompts")
+      (is (nil? (get-run)) "Run is ended")))
   (testing "with Gauntlet #2942"
     (do-game
-      (new-game {:corp {:deck [(qty "Crisium Grid" 2)(qty "Vanilla" 2)]}
-                 :runner {:deck ["The Gauntlet" "Rip Deal" (qty "Easy Mark" 2)]}})
+      (new-game {:corp {:deck [(qty "Vanilla" 3)]}
+                 :runner {:deck ["The Gauntlet" "Rip Deal" "Easy Mark" "Sure Gamble"]}})
       (trash-from-hand state :runner "Easy Mark")
-      (trash-from-hand state :runner "Easy Mark")
+      (trash-from-hand state :runner "Sure Gamble")
       (play-from-hand state :corp "Vanilla" "HQ")
       (core/rez state :corp (get-ice state :hq 0))
       (take-credits state :corp)
@@ -2381,7 +2386,14 @@
       (run-successful state)
       (click-prompt state :runner "1")
       (click-prompt state :runner "Replacement effect")
-      (is (= "Choose 2 card(s) to move from the Heap to your Grip" (-> (get-runner) :prompt first :msg))))))
+      (is (= "Choose 2 cards to move from the Heap to your Grip" (:msg (prompt-map :runner))))
+      (click-card state :runner "Easy Mark")
+      (click-card state :runner "Sure Gamble")
+      (is (= 2 (-> (get-runner) :hand count)))
+      (is (= ["Sure Gamble" "Easy Mark"] (->> (get-runner) :hand (map :title) (into []))))
+      (is (nil? (prompt-map :corp)) "Corp should have no more prompts")
+      (is (nil? (prompt-map :runner)) "Runner should have no more prompts")
+      (is (nil? (get-run)) "Run is ended"))))
 
 (deftest rumor-mill
   ;; Rumor Mill - interactions with rez effects, additional costs, general event handlers, and trash-effects


### PR DESCRIPTION
Rip Deal was using `resolve-ability` which wasn't actually handling the `eid`, so switching to `continue-ability` took care of it. Fixed up the tests to actually handle the card's ability. Checking that the prompt has appeared isn't good enough, lol, you have to actually check that the effect finishes correctly.

Closes #3967 