### PR TITLE
Fix Kyuban to not disappear

### DIFF
--- a/src/clj/game/cards/icebreakers.clj
+++ b/src/clj/game/cards/icebreakers.clj
@@ -73,7 +73,7 @@
                       stargets (:subtype-target ice)
                       stypes (:subtype ice)
                       remove-subtype {:effect
-                                      (effect (update! (assoc ice
+                                      (effect (update! (assoc (get-card state ice)
                                                               :subtype-target stargets
                                                               :subtype stypes))
                                               (unregister-events card)


### PR DESCRIPTION
The log is what solved the case. If you installed kyuban after using Engolo's "Change Type" ability, Engolo would save the old version of the card and then overwrite the new version that held the hosted card with the old, no-hosted version.

Fixes #3932