### PR TITLE
Fix Rashida Jaheem's trigger event

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1462,7 +1462,7 @@
                                     card nil))}]
      {:derezzed-events {:runner-turn-ends corp-rez-toast}
       :flags {:corp-phase-12 (req true)}
-      :events {:corp-turn-begins ability}
+      :events {:corp-phase-12 ability}
       :abilities [ability]})
 
    "Reality Threedee"


### PR DESCRIPTION
Fixes #3855 

Simple change, changing the trigger from start of turn to before mandatory draw. Now the prompt appears after clicking "Start turn" but before taking the mandatory draw.

Further potential changes:
Remove `:flags {:corp-phase-12 (req true)}` - there's no more point for this because the prompt appears?

I noticed a couple of other cards with start of turn abilities have this problem as well, although it is significantly less prominent and seeing the card first doesn't matter as much. For example, Bio-Ethics Association happens after the mandatory draw step too, even though it's technically supposed to happen before. Perhaps those cards could be changed in the same way too? It would make the code somewhat less understandable though (`corp-turn-begins` is more clear than `corp-phase-12`)

Also, I hear there's a slack channel, could I get an invite? I know mtgred has retired, do I email someone else?