### PR TITLE
Fix Rashida async

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1450,8 +1450,9 @@
 
    "Rashida Jaheem"
    (let [ability {:once :per-turn
+                  :async true
                   :label "Gain 3 [Credits] and draw 3 cards (start of turn)"
-                  :effect (effect (resolve-ability
+                  :effect (effect (continue-ability
                                     {:optional
                                      {:prompt "Trash Rashida Jaheem to gain 3 [Credits] and draw 3 cards?"
                                       :yes-ability {:async true


### PR DESCRIPTION
This may or not fix the Rashida issues people are seeing, but her ability is coded wrong and that would cause it to not play nice with other start-of-turn effects. Because her event handler resolves another effect, the outermost handler needs to be marked `:async`, otherwise the start-of-turn trigger will move on to resolving the next triggered ability before Rashida is resolved. I dunno if that will be enough.