### PR TITLE
Fix research grant to work with team sponsorship

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1118,12 +1118,13 @@
    "Research Grant"
    {:interactive (req true)
     :silent (req (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp))))
-    :req (req (not (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp)))))
     :async true
     :effect (effect (continue-ability
                       {:prompt "Select another installed copy of Research Grant to score"
                        :choices {:req #(= (:title %) "Research Grant")}
+                       :interactive (req true)
                        :async true
+                       :req (req (not (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp)))))
                        :effect (effect (set-prop target :advance-counter (:advancementcost target))
                                        (score eid (get-card state target)))
                        :msg "score another installed copy of Research Grant"}


### PR DESCRIPTION
Fixes #3390

Fixes as suggested by @nealterrell in the original issue.

Basically moves the requirement to when the effect triggers (So the effect will always fire, but only ends up resolving if the trigger works) and adds interactive so that the user gets to order them manually, instead of the game ordering it manually.

The way the simultaneous triggers work become obvious if there are 2 copies of team sponsorship rezzed, in which case the first trigger adds Research's grants trigger to the simultaneous trigger selection but allows the user to pick between the 2nd team sponsorship's trigger and the research grant's trigger.