### PR TITLE
Look up credit icons case insensitively

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -98,24 +98,24 @@
 (ws/register-ws-handler! :netrunner/diff #(handle-diff (parse-state %)))
 (ws/register-ws-handler! :netrunner/timeout #(handle-timeout (parse-state %)))
 
-(def anr-icons {"[Credits]" "credit"
+(def anr-icons {"[credits]" "credit"
                 "[$]" "credit"
                 "[c]" "credit"
-                "[Credit]" "credit"
-                "[Click]" "click"
-                "[Subroutine]" "subroutine"
-                "[Recurring Credits]" "recurring-credit"
-                "1[Memory Unit]" "mu1"
+                "[credit]" "credit"
+                "[click]" "click"
+                "[subroutine]" "subroutine"
+                "[recurring credits]" "recurring-credit"
+                "1[memory unit]" "mu1"
                 "1[mu]" "mu1"
-                "2[Memory Unit]" "mu2"
+                "2[memory unit]" "mu2"
                 "2[mu]" "mu2"
-                "3[Memory Unit]" "mu3"
+                "3[memory unit]" "mu3"
                 "3[mu]" "mu3"
-                "[Link]" "link"
+                "[link]" "link"
                 "[l]" "link"
-                "[Memory Unit]" "mu"
+                "[memory unit]" "mu"
                 "[mu]" "mu"
-                "[Trash]" "trash"
+                "[trash]" "trash"
                 "[t]" "trash"})
 
 (defn send-command
@@ -323,7 +323,7 @@
     [:hr]
     (if (= "[!]" item)
       [:div.smallwarning "!"]
-      (if-let [class (anr-icons item)]
+      (if-let [class (anr-icons (lower-case item))]
         [:span {:class (str "anr-icon " class) :key class}]
         (if-let [[title code cid] (extract-card-info item)]
           [:span {:class "fake-link" :id code :key title} title]
@@ -1361,7 +1361,7 @@
              :reagent-render
              (fn [{:keys [sfx] :as cursor}]
               (let [_ @sfx]))}))) ;; make this component rebuild when sfx changes.
-             
+
 
 (defn button-pane [{:keys [side active-player run end-turn runner-phase-12 corp-phase-12 corp runner me opponent] :as cursor}]
   (let [s (r/atom {})


### PR DESCRIPTION
This lookup only seems to be used in the log pane, which uses a somewhat specialised function that returns differing spans depending on whether the input is a reference to a symbol. Elsewhere `add-symbols` from `nr.cardbrowser` is used to do a standard search/replace case insensitively across a string.

I don't understand exactly why log-pane uses a different method, but on the bright side it's probably faster as it's not iterating over regex substitutions? 🤷‍♂

Fixes  #4017