### PR TITLE
Add toast prompt for Mti Mwekundu: Life Improved 

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -762,23 +762,24 @@
       :abilities [ability]})
 
    "Mti Mwekundu: Life Improved"
-   {:abilities [{:effect (req (trigger-event state :corp :mti-ability))}]
-    :events {:approach-server {:req (req (not (first-event? state side :mti-ability)))
-                               :effect (req (toast state :corp "You may use Mti Mwekundu: Life Improved to install ice from HQ." "info"))}
-             :mti-ability {:once :per-turn
-                           :label "Install a piece of ice from HQ at the innermost position"
-                           :req (req (and (:run @state)
-                                          (zero? (:position run))
-                                          (not (contains? run :corp-phase-43))
-                                          (not (contains? run :successful))))
-                           :prompt "Choose ICE to install from HQ"
-                           :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
-                           :choices {:req #(and (ice? %)
-                                                (in-hand? %))}
-                           :effect (req (corp-install state side target (zone->name (first (:server run)))
-                                                      {:ignore-all-cost true
-                                                       :front true})
-                                        (swap! state assoc-in [:run :position] 1))}}}
+   (let [ability {:once :per-turn
+                  :label "Install a piece of ice from HQ at the innermost position"
+                  :req (req (and (:run @state)
+                                 (zero? (:position run))
+                                 (not (contains? run :corp-phase-43))
+                                 (not (contains? run :successful))))
+                  :prompt "Choose ICE to install from HQ"
+                  :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
+                  :choices {:req #(and (ice? %)
+                                       (in-hand? %))}
+                  :effect (req (corp-install state side target (zone->name (first (:server run)))
+                                             {:ignore-all-cost true
+                                              :front true})
+                               (swap! state assoc-in [:run :position] 1))}]
+     {:abilities [ability]
+      :events {:approach-server {:req (req (can-trigger? state side ability card nil))
+                                 :effect (req (toast state :corp "You may use Mti Mwekundu: Life Improved to install ice from HQ." "info"))
+                                 :msg "test message 2" }}})
 
    "Nasir Meidan: Cyber Explorer"
    {:events {:rez {:req (req (and (:run @state)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -772,9 +772,13 @@
                  :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
                  :choices {:req #(and (ice? %)
                                       (in-hand? %))}
-                 :effect (req (corp-install state side target (:server run) {:ignore-all-cost true
-                                                                             :front true})
-                              (swap! state assoc-in [:run :position] 1))}]}
+                 :effect (req (corp-install state side target (zone->name (first (:server run)))
+                                            {:ignore-all-cost true
+                                             :front true})
+                              (swap! state assoc-in [:run :position] 1))}]
+    :events {:approach-server {:req (req true)
+                               :effect (req (toast state :corp "You may use Mti Mwekundu: Life Improved now."))
+                               :msg "test message 3"}}}
 
    "Nasir Meidan: Cyber Explorer"
    {:events {:rez {:req (req (and (:run @state)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -778,8 +778,7 @@
                                (swap! state assoc-in [:run :position] 1))}]
      {:abilities [ability]
       :events {:approach-server {:req (req (can-trigger? state side ability card nil))
-                                 :effect (req (toast state :corp "You may use Mti Mwekundu: Life Improved to install ice from HQ." "info"))
-                                 :msg "test message 2" }}})
+                                 :effect (req (toast state :corp "You may use Mti Mwekundu: Life Improved to install ice from HQ." "info"))}}})
 
    "Nasir Meidan: Cyber Explorer"
    {:events {:rez {:req (req (and (:run @state)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -764,7 +764,7 @@
    "Mti Mwekundu: Life Improved"
    (let [ability {:once :per-turn
                   :label "Install a piece of ice from HQ at the innermost position"
-                  :req (req (and (:run @state)
+                  :req (req (and run
                                  (zero? (:position run))
                                  (not (contains? run :corp-phase-43))
                                  (not (contains? run :successful))))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -762,23 +762,23 @@
       :abilities [ability]})
 
    "Mti Mwekundu: Life Improved"
-   {:abilities [{:once :per-turn
-                 :label "Install a piece of ice from HQ at the innermost position"
-                 :req (req (and (:run @state)
-                                (zero? (:position run))
-                                (not (contains? run :corp-phase-43))
-                                (not (contains? run :successful))))
-                 :prompt "Choose ICE to install from HQ"
-                 :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
-                 :choices {:req #(and (ice? %)
-                                      (in-hand? %))}
-                 :effect (req (corp-install state side target (zone->name (first (:server run)))
-                                            {:ignore-all-cost true
-                                             :front true})
-                              (swap! state assoc-in [:run :position] 1))}]
-    :events {:approach-server {:req (req true)
-                               :effect (req (toast state :corp "You may use Mti Mwekundu: Life Improved now."))
-                               :msg "test message 3"}}}
+   {:abilities [{:effect (req (trigger-event state :corp :mti-ability))}]
+    :events {:approach-server {:req (req (not (first-event? state side :mti-ability)))
+                               :effect (req (toast state :corp "You may use Mti Mwekundu: Life Improved to install ice from HQ." "info"))}
+             :mti-ability {:once :per-turn
+                           :label "Install a piece of ice from HQ at the innermost position"
+                           :req (req (and (:run @state)
+                                          (zero? (:position run))
+                                          (not (contains? run :corp-phase-43))
+                                          (not (contains? run :successful))))
+                           :prompt "Choose ICE to install from HQ"
+                           :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
+                           :choices {:req #(and (ice? %)
+                                                (in-hand? %))}
+                           :effect (req (corp-install state side target (zone->name (first (:server run)))
+                                                      {:ignore-all-cost true
+                                                       :front true})
+                                        (swap! state assoc-in [:run :position] 1))}}}
 
    "Nasir Meidan: Cyber Explorer"
    {:events {:rez {:req (req (and (:run @state)


### PR DESCRIPTION
Fixes #3618

Added an info toast that appears when the runner has approached the server and Mti is available for use.
![image](https://user-images.githubusercontent.com/4904988/52535970-aeef4380-2d8f-11e9-87f7-5f593fed6c99.png)

Not sure if this is the proper way of implementing it, I basically created a new event for it and checked if it has fired so that the toast would only appear if Mti is usable.

Also, I found a bug where after using the ability it would print something like:

> j installs ICE protecting [:rd].

So I fixed it to:
> j installs ICE protecting R&D.