### PR TITLE
Fix erratic deck sorting bug

### DIFF
--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -179,28 +179,19 @@
   (-> "#gameboard" js/$ .fadeOut)
   (-> "#gamelobby" js/$ .fadeIn))
 
-(defn- deck-sorter
-  [fmt d1 d2]
-  (let [fmt (keyword fmt)
-        d1 (get-in d1 [fmt :legal])
-        d2 (get-in d2 [fmt :legal])]
-    (cond
-      (= d1 d2) 0
-      (true? d1) -1
-      (true? d2) 1
-      :else 0)))
-
 (defn deckselect-modal [user {:keys [gameid games decks format]}]
   [:div
     [:h3 "Select your deck"]
     [:div.deck-collection
      (let [players (:players (some #(when (= (:gameid %) @gameid) %) @games))
-           side (:side (some #(when (= (-> % :user :_id) (:_id @user)) %) players))]
+           side (:side (some #(when (= (-> % :user :_id) (:_id @user)) %) players))
+           same-side? (fn [deck] (= side (get-in deck [:identity :side])))
+           legal? (fn [deck] (get-in deck [:status (keyword format) :legal]))]
        [:div
         (doall
-          (for [deck (sort-by :status (partial deck-sorter format)
-                              (filter #(= (get-in % [:identity :side]) side)
-                                      (sort-by :date > @decks)))]
+          (for [deck (->> @decks
+                          (filter same-side?)
+                          (sort-by (juxt legal? :date) >))]
             ^{:key (:_id deck)}
             [:div.deckline {:on-click #(do (ws/ws-send! [:lobby/deck (:_id deck)])
                                            (reagent-modals/close-modal!))}


### PR DESCRIPTION
Previously, the "deck sorting" feature I wrote at the beginning of December was fundamentally broken because I fundamentally misunderstood how to write a comparator, lol. Thankfully, I learned about the power of `juxt` and have fixed my mistake.

_Now_ the game lobby sorts decks based first on whether they're legal or not and then second by date, recent first.

This also fixes a small bug/oversight where newly created decks weren't being assigned a `:status` from `calculate-deck-status`, meaning they'd be listed at the bottom of any legality-based sorting. Only once they'd be re-opened and saved would they properly sort themselves.