### PR TITLE
Changed event play rules to be compliant with Nisei rules. Fixed Chacon+trace bug

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -550,11 +550,10 @@
                                  (trash card {:cause :ability-cost}))}]}
 
    "Dadiana Chacon"
-   (let [trashme {:effect (effect (system-msg "trashes Dadiana Chacon and suffers 3 meat damage")
-                                  (register-events {:play {:req (req (= "Runner" (:side target)))
-                                                           :effect (effect (unregister-events card)
-                                                                           (damage eid :meat 3 {:unboostable true :card card})
-                                                                           (trash card {:cause :ability-cost}))}} card))}
+   (let [trashme {:effect (effect (unregister-events card)
+                                  (damage eid :meat 3 {:unboostable true :card card})
+                                  (trash card {:cause :ability-cost}))
+                  :msg (msg "trashes Dadiana Chacon and suffers 3 meat damage")}
          ability {:once :per-turn
                   :msg "gain 1 [Credits]"
                   :req (req (< (get-in @state [:runner :credit]) 6))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -71,13 +71,14 @@
                           (not (and (has-subtype? card "Priority")
                                     (get-in @state [side :register :spent-click]))))
                    ;; Wait on pay-sync to finish before triggering instant-effect
-                   (let [moved-card (move state side (assoc card :seen true) :play-area)]
+                   (let [original-zone (:zone card)
+                         moved-card (move state side (assoc card :seen true) :play-area)]
                      (wait-for (pay-sync state side moved-card (if ignore-cost 0 total-cost) {:action :play-instant})
                                (if-let [cost-str async-result]
                                  (complete-play-instant state side eid moved-card cost-str ignore-cost)
                                 ;; could not pay the card's price; put it back and mark the effect as being over.
                                  (do
-                                   (move state side moved-card :hand)
+                                   (move state side moved-card original-zone)
                                    (effect-completed state side eid)))))
                    ;; card's req was not satisfied; mark the effect as being over.
                    (effect-completed state side eid)))))))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -448,6 +448,31 @@
           (take-credits state :runner)
           (is (empty? (:prompt (get-runner))) "Crowdfunding shouldn't prompt for install")))))
 
+(deftest dadiana-chacon
+  ;; gain 1 cr at start of turn if you have less than 6,
+  ;; take 3 meat and trash if you have 0
+  (testing "Can fire mid-trace"
+    (do-game
+     (new-game {:runner {:deck ["Dadiana Chacon"
+                                "Corroder"
+                                (qty "Sure Gamble" 3)]}
+                :corp {:deck ["SEA Source"]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Dadiana Chacon")
+     (play-from-hand state :runner "Corroder") ;to get money
+     (take-credits state :runner)
+     (is (< (:credit (get-runner)) 6)
+         "Chacon can trigger because runner has < 6 creds")
+     (is (changes-credits (get-runner) 1
+                          (take-credits state :corp)))
+     (run-empty-server state :hq)
+     (take-credits state :runner)
+     (play-from-hand state :corp "SEA Source")
+     (click-prompt state :corp "0")
+     (changes-val-macro -3 (count (:hand (get-runner)))
+                        "Spending all their money on trace causes Chacon to resolve"
+                        (click-prompt state :runner (str (:credit (get-runner))))))))
+
 (deftest daily-casts
   ;; Play and tick through all turns of daily casts
   (do-game


### PR DESCRIPTION
The event is now moved to play area *before* paying the cost, not after. This means that if the cost is not successfully paid (can happen with Price of Freedom, thank you tests), the card must be moved back, but aside from that, I don't think there are any new complications. This change is kinda deep in the system though, so I'd appreciate a second pair of eyes on this.

Doing this allows us to effectively undo ae4c08a, which fixed #3004, so I did, fixing #4012 . Was there any other reason you changed Chacon's watch from resolving an ability to triggering an event, @danhut ?