### PR TITLE
Refactor card and icon rendering

### DIFF
--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -178,7 +178,7 @@
   (when (and (number? value)
              (pos? value))
     (case attr
-      :credit (str value " [$]")
+      :credit (str value " [credit]")
       :click (->> "[Click]" repeat (take value) (apply str))
       :forfeit (str value " Agenda" (when (> value 1) "s"))
       :net (str value " net damage")

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -8,7 +8,7 @@
             [nr.account :refer [alt-art-name]]
             [nr.ajax :refer [GET]]
             [nr.utils :refer [toastr-options banned-span restricted-span rotated-span
-                              influence-dots slug->format format->slug]]
+                              influence-dots slug->format format->slug render-icons]]
             [reagent.core :as r]))
 
 (def cards-channel (chan))
@@ -99,37 +99,6 @@
   [only-version cards]
   (reduce (partial expand-alts only-version) () (reverse cards)))
 
-(defn add-symbols [card-text]
-  (-> (if (nil? card-text) "" card-text)
-      (make-span "\\[Credits\\]" "credit")
-      (make-span "\\[Credit\\]" "credit")
-      (make-span "\\[Click\\]" "click")
-      (make-span "\\[Subroutine\\]" "subroutine")
-      (make-span "\\[Recurring Credits\\]" "recurring-credit")
-      (make-span "\\[recurring-credit\\]" "recurring-credit")
-      (make-span "1\\[Memory Unit\\]" "mu1")
-      (make-span "2\\[Memory Unit\\]" "mu2")
-      (make-span "3\\[Memory Unit\\]" "mu3")
-      (make-span "\\[Memory Unit\\]" "mu")
-      (make-span "1\\[mu\\]" "mu1")
-      (make-span "2\\[mu\\]" "mu2")
-      (make-span "3\\[mu\\]" "mu3")
-      (make-span "\\[mu\\]" "mu")
-      (make-span "\\[Link\\]" "link")
-      (make-span "\\[Trash\\]" "trash")
-      (make-span "\\[adam\\]" "adam")
-      (make-span "\\[anarch\\]" "anarch")
-      (make-span "\\[apex\\]" "apex")
-      (make-span "\\[criminal\\]" "criminal")
-      (make-span "\\[hb\\]" "haas-bioroid")
-      (make-span "\\[haas-bioroid\\]" "haas-bioroid")
-      (make-span "\\[jinteki\\]" "jinteki")
-      (make-span "\\[nbn\\]" "nbn")
-      (make-span "\\[shaper\\]" "shaper")
-      (make-span "\\[sunny\\]" "sunny")
-      (make-span "\\[weyland\\]" "weyland-consortium")
-      (make-span "\\[weyland-consortium\\]" "weyland-consortium")))
-
 (defn non-game-toast
   "Display a toast warning with the specified message."
   [msg type options]
@@ -213,7 +182,7 @@
    [:div.text
     [:p [:span.type (str (:type card))] (if (empty? (:subtype card))
                                           "" (str ": " (:subtype card)))]
-    [:pre {:dangerouslySetInnerHTML #js {:__html (add-symbols (:text card))}}]
+    [:pre (render-icons (:text (first (filter #(= (:title %) (:title card)) @all-cards))))]
 
     [:div.formats
      (doall (for [[k name] (-> slug->format butlast)]

--- a/src/cljs/nr/chat.cljs
+++ b/src/cljs/nr/chat.cljs
@@ -5,8 +5,8 @@
             [nr.ajax :refer [GET PUT]]
             [nr.appstate :refer [app-state]]
             [nr.auth :refer [avatar authenticated] :as auth]
-            [nr.gameboard :refer [card-preview-mouse-over card-preview-mouse-out get-message-parts create-span card-zoom] :as gameboard]
-            [nr.utils :refer [toastr-options]]
+            [nr.gameboard :refer [card-preview-mouse-over card-preview-mouse-out card-zoom] :as gameboard]
+            [nr.utils :refer [toastr-options render-icons-and-cards]]
             [nr.ws :as ws]
             [reagent.core :as r]))
 
@@ -187,10 +187,7 @@
        [:div
         {:on-mouse-over #(card-preview-mouse-over % (:zoom-ch @s))
          :on-mouse-out  #(card-preview-mouse-out % (:zoom-ch @s))}
-        (let [parts (get-message-parts (:msg message))]
-          (doall (map-indexed
-            (fn [i item]
-              (when (not-empty item) (create-span item))) parts)))]]])))
+        (render-icons-and-cards (:msg message))]]])))
 
 (defn fetch-all-messages []
   (doseq [channel (keys (:channels @app-state))]

--- a/src/cljs/nr/chat.cljs
+++ b/src/cljs/nr/chat.cljs
@@ -6,7 +6,7 @@
             [nr.appstate :refer [app-state]]
             [nr.auth :refer [avatar authenticated] :as auth]
             [nr.gameboard :refer [card-preview-mouse-over card-preview-mouse-out card-zoom] :as gameboard]
-            [nr.utils :refer [toastr-options render-icons-and-cards]]
+            [nr.utils :refer [toastr-options render-message]]
             [nr.ws :as ws]
             [reagent.core :as r]))
 
@@ -187,7 +187,7 @@
        [:div
         {:on-mouse-over #(card-preview-mouse-over % (:zoom-ch @s))
          :on-mouse-out  #(card-preview-mouse-out % (:zoom-ch @s))}
-        (render-icons-and-cards (:msg message))]]])))
+        (render-message (:msg message))]]])))
 
 (defn fetch-all-messages []
   (doseq [channel (keys (:channels @app-state))]

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -7,7 +7,6 @@
             [jinteki.cards :refer [all-cards]]
             [nr.appstate :refer [app-state]]
             [nr.auth :refer [avatar] :as auth]
-            [nr.cardbrowser :refer [add-symbols] :as cb]
             [nr.utils :refer [influence-dot map-longest toastr-options render-icons render-icons-and-cards]]
             [nr.ws :as ws]
             [reagent.core :as r]))
@@ -630,7 +629,7 @@
      [:div.text
       [:p [:span.type (str (:type card))] (if (empty? (:subtype card))
                                             "" (str ": " (:subtype card)))]
-      [:pre {:dangerouslySetInnerHTML #js {:__html (add-symbols (:text card))}}]]
+      [:pre (render-icons (:text (first (filter #(= (:title %) (:title card)) @all-cards))))]]
      (when-let [url (image-url card)]
        [:img {:src url :alt (:title card) :onLoad #(-> % .-target js/$ .show)}])]))
 
@@ -640,8 +639,8 @@
      (fn [i ab]
        [:div {:key i
               :on-click #(do (send-command "runner-ability" {:card card
-                                                             :ability i}))
-              :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}])
+                                                             :ability i}))}
+        (render-icons (str (ability-costs ab) (:label ab)))])
      runner-abilities)
    (when (> (count subroutines) 1)
      [:div {:on-click #(send-command "system-msg"
@@ -652,8 +651,8 @@
        [:div {:key i
               :on-click #(send-command "system-msg"
                                        {:msg (str "indicates to fire the \"" (:label sub)
-                                                  "\" subroutine on " title)})
-              :dangerouslySetInnerHTML #js {:__html (add-symbols (str "Let fire: \"" (:label sub) "\""))}}])
+                                                  "\" subroutine on " title)})}
+        (render-icons (str "Let fire: \"" (:label sub) "\""))])
      subroutines)])
 
 (defn corp-abs [card c-state corp-abilities]
@@ -662,7 +661,8 @@
        (fn [i ab]
          [:div {:on-click #(do (send-command "corp-ability" {:card card
                                                              :ability i}))
-                :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}])
+                }
+          (render-icons (str (ability-costs ab) (:label ab)))])
        corp-abilities)])
 
 (defn server-menu [card c-state remotes type zone]
@@ -697,18 +697,18 @@
            (if (:dynamic ab)
              [:div {:key i
                     :on-click #(do (send-command "dynamic-ability" (assoc (select-keys ab [:dynamic :source :index])
-                                                                     :card card)))
-                    :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}]
+                                                                     :card card)))}
+              (render-icons (str (ability-costs ab) (:label ab)))]
              [:div {:key i
                     :on-click #(do (send-command "ability" {:card card
-                                                            :ability (- i dynabi-count)}))
-                    :dangerouslySetInnerHTML #js {:__html (add-symbols (str (ability-costs ab) (:label ab)))}}]))
+                                                            :ability (- i dynabi-count)}))}
+              (render-icons (str (ability-costs ab) (:label ab)))]))
          abilities)
        (map-indexed
          (fn [i sub]
            [:div {:key i
-                  :on-click #(do (send-command "subroutine" {:card card :subroutine i}))
-                  :dangerouslySetInnerHTML #js {:__html (add-symbols (str "[Subroutine]" (:label sub)))}}])
+                  :on-click #(do (send-command "subroutine" {:card card :subroutine i}))}
+            (render-icons (str "[Subroutine]" (:label sub)))])
          subroutines)])))
 
 (defn card-view [{:keys [zone code type abilities counter advance-counter advancementcost current-cost subtype

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -563,7 +563,9 @@
      [:div.text
       [:p [:span.type (str (:type card))] (if (empty? (:subtype card))
                                             "" (str ": " (:subtype card)))]
-      [:pre (render-icons (:text (first (filter #(= (:title %) (:title card)) @all-cards))))]]
+      [:pre (letfn [(card-by-title [title]
+                      (some #(when (= (:title %) title) %) @all-cards))]
+             (render-icons (:text (card-by-title (:title card)))))]]
      (when-let [url (image-url card)]
        [:img {:src url :alt (:title card) :onLoad #(-> % .-target js/$ .show)}])]))
 

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -7,7 +7,7 @@
             [jinteki.cards :refer [all-cards]]
             [nr.appstate :refer [app-state]]
             [nr.auth :refer [avatar] :as auth]
-            [nr.utils :refer [influence-dot map-longest toastr-options render-icons render-icons-and-cards]]
+            [nr.utils :refer [influence-dot map-longest toastr-options render-icons render-message]]
             [nr.ws :as ws]
             [reagent.core :as r]))
 
@@ -354,12 +354,12 @@
                    (fn [i msg]
                      (when-not (and (= (:user msg) "__system__") (= (:text msg) "typing"))
                        (if (= (:user msg) "__system__")
-                         [:div.system {:key i} (render-icons-and-cards (:text msg))]
+                         [:div.system {:key i} (render-message (:text msg))]
                          [:div.message {:key i}
                           [avatar (:user msg) {:opts {:size 38}}]
                           [:div.content
                            [:div.username (get-in msg [:user :username])]
-                           [:div (render-icons-and-cards (:text msg))]]])))
+                           [:div (render-message (:text msg))]]])))
                    @log))]
          (when (seq (remove nil? (remove #{(get-in @app-state [:user :username])} @typing)))
            [:div [:p.typing (for [i (range 10)] ^{:key i} [:span " " influence-dot " "])]])
@@ -1319,7 +1319,7 @@
                          :on-mouse-out  #(card-preview-mouse-out % zoom-channel)}
        (if-let [prompt (first (:prompt @me))]
          [:div.panel.blue-shade
-          [:h4 (render-icons-and-cards (:msg prompt))]
+          [:h4 (render-message (:msg prompt))]
           (if-let [n (get-in prompt [:choices :number])]
             [:div
              [:div.credit-select
@@ -1394,7 +1394,7 @@
                                (if (string? c)
                                  [:button {:key i
                                            :on-click #(send-command "choice" {:choice c})}
-                                  (render-icons-and-cards c)]
+                                  (render-message c)]
                                  [:button {:key (:cid c)
                                            :class (when (:rotated c) :rotated)
                                            :on-click #(send-command "choice" {:card c}) :id {:code c}} (:title c)])))

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -594,8 +594,7 @@
      (map-indexed
        (fn [i ab]
          [:div {:on-click #(do (send-command "corp-ability" {:card card
-                                                             :ability i}))
-                }
+                                                             :ability i}))}
           (render-icons (str (ability-costs ab) (:label ab)))])
        corp-abilities)])
 

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -8,7 +8,7 @@
             [nr.appstate :refer [app-state]]
             [nr.auth :refer [avatar] :as auth]
             [nr.cardbrowser :refer [add-symbols] :as cb]
-            [nr.utils :refer [influence-dot map-longest toastr-options]]
+            [nr.utils :refer [influence-dot map-longest toastr-options render-icons render-icons-and-cards]]
             [nr.ws :as ws]
             [reagent.core :as r]))
 
@@ -421,15 +421,12 @@
                    (fn [i msg]
                      (when-not (and (= (:user msg) "__system__") (= (:text msg) "typing"))
                        (if (= (:user msg) "__system__")
-                         [:div.system {:key i} (map-indexed (fn [i item] [:<> {:key i} (create-span item)])
-                                                            (get-message-parts (:text msg)))]
+                         [:div.system {:key i} (render-icons-and-cards (:text msg))]
                          [:div.message {:key i}
                           [avatar (:user msg) {:opts {:size 38}}]
                           [:div.content
                            [:div.username (get-in msg [:user :username])]
-                           [:div (doall
-                                   (map-indexed (fn [i item] [:<> {:key i} (create-span item)])
-                                                (get-message-parts (:text msg))))]]])))
+                           [:div (render-icons-and-cards (:text msg))]]])))
                    @log))]
          (when (seq (remove nil? (remove #{(get-in @app-state [:user :username])} @typing)))
            [:div [:p.typing (for [i (range 10)] ^{:key i} [:span " " influence-dot " "])]])
@@ -1361,7 +1358,7 @@
              :reagent-render
              (fn [{:keys [sfx] :as cursor}]
               (let [_ @sfx]))}))) ;; make this component rebuild when sfx changes.
-             
+
 
 (defn button-pane [{:keys [side active-player run end-turn runner-phase-12 corp-phase-12 corp runner me opponent] :as cursor}]
   (let [s (r/atom {})

--- a/src/cljs/nr/news.cljs
+++ b/src/cljs/nr/news.cljs
@@ -1,7 +1,7 @@
 (ns nr.news
   (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [nr.ajax :refer [GET]]
-            [nr.cardbrowser :refer [add-symbols] :as cb]
+            [nr.utils :refer [render-icons]]
             [nr.ws :refer [ws-send!]]
             [reagent.core :as r]))
 
@@ -18,4 +18,4 @@
           [:li.news-item
            {:key (:date d)}
            [:span.date (-> (:date d) js/Date. js/moment (.format "dddd MMM Do - HH:mm"))]
-           [:span.title {:dangerouslySetInnerHTML #js {:__html (cb/add-symbols (js/marked (:title d)))}}]]))]]))
+           [:span.title (render-icons (js/marked (:title d)))]]))]]))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -93,36 +93,41 @@
    "SOCR8" "socr8"
    "Casual" "casual"})
 
-(defn map-vals [function smap]
-  (into {} (map (fn [[k v]] [k (function v)]) smap)))
-
 (defn map-if [condition f s]
   (map #(if (condition %) (f %) %) s))
 
+(defn regex-escape [string]
+  (let [regex-escape-smap (zipmap ".*+?[](){}^$"
+                                  (map #(str "\\" %) esc-chars))]
+    (->> string
+         (replace regex-escape-smap)
+         (reduce str))))
+
 (def icon-smap
   (letfn [(span-of [icon] [:span {:class (str "anr-icon " icon)}])]
-  (map-vals span-of {"[credit]" "credit"
-                     "[credits]" "credit"
-                     "[c]" "credit"
-                     "[recurring credit]" "recurring-credit"
-                     "[recurring credits]" "recurring-credit"
-                     "[recurring-credit]" "recurring-credit"
-                     "[recurring-credits]" "recurring-credit"
-                     "[click]" "click"
-                     "[clicks]" "click"
-                     "1[memory unit]" "mu1"
-                     "1[mu]" "mu1"
-                     "2[memory unit]" "mu2"
-                     "2[mu]" "mu2"
-                     "3[memory unit]" "mu3"
-                     "3[mu]" "mu3"
-                     "[memory unit]" "mu"
-                     "[mu]" "mu"
-                     "[link]" "link"
-                     "[l]" "link"
-                     "[subroutine]" "subroutine"
-                     "[trash]" "trash"
-                     "[t]" "trash"})))
+    (->> {"[credit]" "credit"
+          "[credits]" "credit"
+          "[c]" "credit"
+          "[recurring credit]" "recurring-credit"
+          "[recurring credits]" "recurring-credit"
+          "[recurring-credit]" "recurring-credit"
+          "[recurring-credits]" "recurring-credit"
+          "[click]" "click"
+          "[clicks]" "click"
+          "1[memory unit]" "mu1"
+          "1[mu]" "mu1"
+          "2[memory unit]" "mu2"
+          "2[mu]" "mu2"
+          "3[memory unit]" "mu3"
+          "3[mu]" "mu3"
+          "[memory unit]" "mu"
+          "[mu]" "mu"
+          "[link]" "link"
+          "[l]" "link"
+          "[subroutine]" "subroutine"
+          "[trash]" "trash"
+          "[t]" "trash"}
+      (map (fn [[k v]] [(regex-escape k) (span-of v)])))))
 
 (defn card-smap-impl []
   (letfn [(unpack-card [[title cards]] [title (:code (first cards))])
@@ -144,16 +149,6 @@
 (defn into-fragment [text]
   [:<> text])
 
-(def regex-escape-smap
-  (let [esc-chars ".*+?[](){}^$"]
-    (zipmap esc-chars
-            (map #(str "\\" %) esc-chars))))
-
-(defn regex-escape [string]
-  (->> string
-       (replace regex-escape-smap)
-       (reduce str)))
-
 (defn padded-zip [pad s1 & sn]
   "Zip together any number of sequences of uneven lengths by padding out the
   shorter ones"
@@ -166,7 +161,7 @@
   "If element is a string, split that string on pattern boundaries and replace
   all patterns with the replacement"
   (if (string? element)
-    (let [pattern-regex (re-pattern (str "(?i)" (regex-escape pattern)))
+    (let [pattern-regex (re-pattern (str "(?i)" pattern))
           pop-if-nil #(if (nil? (last %)) (pop %) %)
           context (split element pattern-regex)
           match-count (count (re-seq pattern-regex element))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -157,6 +157,13 @@
 
 (def card-patterns (memoize card-patterns-impl))
 
+(def special-patterns
+  (letfn [(regex-of [icon-code] (re-pattern (str "(?i)" (regex-escape icon-code))))]
+    (->> {"[hr]" [:hr]
+          "[!]" [:div.smallwarning "!"]}
+      (map (fn [[k v]] [(regex-of k) v]))
+      (sort-by (comp count str first) >))))
+
 (defn padded-interleave [pad & seqs]
   "Interleave sequences of uneven lengths by padding out the shorter ones"
   (let [lazy-padded-seqs (map #(concat % (repeat pad)) seqs)
@@ -216,6 +223,10 @@
   "Render all cards in a given text or HTML fragment input"
   (render-input input (card-patterns)))
 
-(defn render-icons-and-cards [input]
-  "Render all icons and cards in a given text or HTML fragment input"
-  (render-icons (render-cards input)))
+(defn render-specials [input]
+  "Render all special codes in a given text or HTML fragment input"
+  (render-input input (special-patterns)))
+
+(defn render-message [input]
+  "Render icons, cards and special codes in a message"
+  (render-specials (render-icons (render-cards input))))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -93,10 +93,6 @@
    "SOCR8" "socr8"
    "Casual" "casual"})
 
-(defn map-if [condition f s]
-  "Map a function over elements of a sequence for which condition is true"
-  (map #(if (condition %) (f %) %) s))
-
 (defn regex-escape [string]
   "Escape characters in a string which have special meanings in regexes"
   (let [special-chars ".*+?[](){}^$"
@@ -198,7 +194,9 @@
   (let [counter (atom 0)
         set-next-key (fn [elem] (set-react-key (do (swap! counter inc) @counter) elem))]
     (->> (reduce replace-in-fragment fragment patterns)
-         (map-if vector? set-next-key)
+         (map #(if (vector? %)
+                 (set-next-key %)
+                 %))
          (into []))))
 
 (def render-fragment (memoize render-fragment-impl))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -145,7 +145,8 @@
           "[sunny]" "sunny"
           "[weyland]" "weyland-consortium"
           "[weyland-consortium]" "weyland-consortium"}
-      (map (fn [[k v]] [(regex-of k) (span-of v)])))))
+      (map (fn [[k v]] [(regex-of k) (span-of v)]))
+      (sort-by (comp count str first) >))))
 
 (defn card-patterns-impl []
   "A sequence of card pattern pairs consisting of a regex, used to match a card
@@ -155,15 +156,10 @@
     (->> @all-cards
          (filter #(not (:replaced_by %)))
          (map (juxt :title :code))
-         (map (fn [[k v]] [(regex-of k) (span-of k v)])))))
+         (map (fn [[k v]] [(regex-of k) (span-of k v)]))
+         (sort-by (comp count str first) >))))
 
 (def card-patterns (memoize card-patterns-impl))
-
-(defn ordered-keys-impl [smap]
-  "List the keys of a hashmap by length after stringifying them"
-  (sort-by (comp count str first) > smap))
-
-(def ordered-keys (memoize ordered-keys-impl))
 
 (defn padded-interleave [pad & seqs]
   "Interleave sequences of uneven lengths by padding out the shorter ones"
@@ -201,7 +197,7 @@
   optionally, card preview HTML"
   (let [counter (atom 0)
         set-next-key (fn [elem] (set-react-key (do (swap! counter inc) @counter) elem))]
-    (->> (reduce replace-in-fragment fragment (ordered-keys patterns))
+    (->> (reduce replace-in-fragment fragment patterns)
          (map-if vector? set-next-key)
          (into []))))
 

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -229,7 +229,7 @@
 
 (defn render-specials [input]
   "Render all special codes in a given text or HTML fragment input"
-  (render-input input (special-patterns)))
+  (render-input input special-patterns))
 
 (defn render-message [input]
   "Render icons, cards and special codes in a message"

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -97,8 +97,9 @@
   (map #(if (condition %) (f %) %) s))
 
 (defn regex-escape [string]
-  (let [regex-escape-smap (zipmap ".*+?[](){}^$"
-                                  (map #(str "\\" %) esc-chars))]
+  (let [special-chars ".*+?[](){}^$"
+        escaped-chars (map #(str "\\" %) special-chars)
+        regex-escape-smap (zipmap special-chars escaped-chars)]
     (->> string
          (replace regex-escape-smap)
          (reduce str))))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -178,9 +178,7 @@
           context (split element pattern-regex)
           match-count (count (re-seq pattern-regex element))
           replacements (repeat match-count replacement)]
-      (->> (if (empty? context)
-             [replacements]
-             (padded-interleave "" context replacements))
+      (->> (padded-interleave "" context replacements)
            (filter not-empty)))
     [element]))
 

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -210,4 +210,4 @@
       (card-smap)))
 
 (defn render-icons-and-cards [input]
-  (render-cards (render-icons input)))
+  (render-icons (render-cards input)))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -94,9 +94,11 @@
    "Casual" "casual"})
 
 (defn map-if [condition f s]
+  "Map a function over elements of a sequence for which condition is true"
   (map #(if (condition %) (f %) %) s))
 
 (defn regex-escape [string]
+  "Escape characters in a string which have special meanings in regexes"
   (let [special-chars ".*+?[](){}^$"
         escaped-chars (map #(str "\\" %) special-chars)
         regex-escape-smap (zipmap special-chars escaped-chars)]
@@ -105,6 +107,7 @@
          (reduce str))))
 
 (def icon-smap
+  "A map of case insensitive icon regexes to icon span fragments"
   (letfn [(span-of [icon] [:span {:class (str "anr-icon " icon)}])
           (regex-of [icon-code] (re-pattern (str "(?i)" (regex-escape icon-code))))]
     (->> {"[credit]" "credit"
@@ -144,6 +147,7 @@
       (map (fn [[k v]] [(regex-of k) (span-of v)])))))
 
 (defn card-smap-impl []
+  "A map of case sensitive card regexes to card span fragments"
   (letfn [(unpack-card [[title cards]] [title (:code (first cards))])
           (span-of [title code] [:span {:class "fake-link" :id code} title])
           (regex-of [card-title] (re-pattern (regex-escape card-title)))]
@@ -157,12 +161,10 @@
 (def card-smap (memoize card-smap-impl))
 
 (defn ordered-keys-impl [smap]
+  "List the keys of a hashmap by length after stringifying them"
   (sort-by (comp count str first) > smap))
 
 (def ordered-keys (memoize ordered-keys-impl))
-
-(defn into-fragment [text]
-  [:<> text])
 
 (defn padded-interleave [pad & seqs]
   "Interleave sequences of uneven lengths by padding out the shorter ones"
@@ -172,8 +174,9 @@
     (take (* max-len num-seqs) (apply interleave lazy-padded-seqs))))
 
 (defn replace-in-element [element [pattern replacement]]
-  "If element is a string, split that string on pattern boundaries and replace
-  all patterns with the replacement"
+  "Given a string element, split that string on pattern boundaries and replace
+  all patterns with a provided replacement. If element is not a string, return
+  it unmodified."
   (if (string? element)
     (let [context (split element pattern)
           match-count (count (re-seq pattern element))
@@ -188,6 +191,7 @@
   (reduce concat (map #(replace-in-element % substitution) fragment)))
 
 (defn set-react-key [n elem]
+  "Given a reagent-style HTML element, set the :key attribute of the element"
   (let [head (first elem)
         attr (if (map? (second elem)) (second elem) {})
         tail (if (map? (second elem)) (drop 2 elem) (drop 1 elem))]
@@ -213,10 +217,13 @@
       (render-fragment fragment replacement-smap))))
 
 (defn render-icons [input]
+  "Render all icons in a given text or HTML fragment input"
   (render-input input icon-smap))
 
 (defn render-cards [input]
+  "Render all cards in a given text or HTML fragment input"
   (render-input input (card-smap)))
 
 (defn render-icons-and-cards [input]
+  "Render all icons and cards in a given text or HTML fragment input"
   (render-icons (render-cards input)))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -149,13 +149,12 @@
 (defn into-fragment [text]
   [:<> text])
 
-(defn padded-zip [pad s1 & sn]
-  "Zip together any number of sequences of uneven lengths by padding out the
-  shorter ones"
-  (let [seqs (concat [s1] sn)
-        lazy-padded-seqs (map #(concat % (repeat pad)) seqs)
+(defn padded-interleave [pad & seqs]
+  "Interleave sequences of uneven lengths by padding out the shorter ones"
+  (let [lazy-padded-seqs (map #(concat % (repeat pad)) seqs)
+        num-seqs (count lazy-padded-seqs)
         max-len (reduce max (map count seqs))]
-    (apply map vector (map (partial take max-len) lazy-padded-seqs))))
+    (take (* max-len num-seqs) (apply interleave lazy-padded-seqs))))
 
 (defn replace-in-element [element [pattern replacement]]
   "If element is a string, split that string on pattern boundaries and replace
@@ -168,8 +167,7 @@
           replacements (repeat match-count replacement)]
       (->> (if (empty? context)
              [replacements]
-             (padded-zip "" context replacements))
-           (reduce concat)
+             (padded-interleave "" context replacements))
            (filter not-empty)))
     [element]))
 

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -207,15 +207,18 @@
 
 (def render-fragment (memoize render-fragment-impl))
 
+(defn render-input [input replacement-smap]
+  "Sanitize inputs into fragments before processing them with render-fragment"
+  (if (not (or (string? input) (vector? input)))
+    [:<>]
+    (let [fragment (if (string? input) [:<> input] input)]
+      (render-fragment fragment replacement-smap))))
+
 (defn render-icons [input]
-    (render-fragment
-      (if (string? input) [:<> input] input)
-      icon-smap))
+  (render-input input icon-smap))
 
 (defn render-cards [input]
-    (render-fragment
-      (if (string? input) [:<> input] input)
-      (card-smap)))
+  (render-input input (card-smap)))
 
 (defn render-icons-and-cards [input]
   (render-icons (render-cards input)))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -202,7 +202,6 @@
   (let [counter (atom 0)
         set-next-key (fn [elem] (set-react-key (do (swap! counter inc) @counter) elem))]
     (->> (reduce replace-in-fragment fragment (ordered-keys replacement-smap))
-         (replace replacement-smap)
          (map-if vector? set-next-key)
          (into []))))
 

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -148,13 +148,12 @@
 
 (defn card-smap-impl []
   "A map of case sensitive card regexes to card span fragments"
-  (letfn [(unpack-card [[title cards]] [title (:code (first cards))])
+  (letfn [(unpack-codes [card] [:title card :code card])
           (span-of [title code] [:span {:class "fake-link" :id code} title])
           (regex-of [card-title] (re-pattern (regex-escape card-title)))]
     (->> @all-cards
          (filter #(not (:replaced_by %)))
-         (group-by :title)
-         (map unpack-card)
+         (map unpack-codes)
          (map (fn [[k v]] [(regex-of k) (span-of k v)]))
          (into {}))))
 

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -176,21 +176,23 @@
   according to substitution"
   (reduce concat (map #(replace-in-element % substitution) fragment)))
 
-(defn set-key [n elem]
+(defn set-react-key [n elem]
   (let [head (first elem)
         attr (if (map? (second elem)) (second elem) {})
         tail (if (map? (second elem)) (drop 2 elem) (drop 1 elem))]
   (into [] (concat [head (merge attr {:key n})] tail))))
 
-(defn render-fragment [fragment replacement-smap]
+(defn render-fragment-impl [fragment replacement-smap]
   "Given a fragment, shallowly replaces text in the fragment with icon and,
   optionally, card preview HTML"
   (let [counter (atom 0)
-        set-next-key (fn [elem] (set-key (do (swap! counter inc) @counter) elem))]
+        set-next-key (fn [elem] (set-react-key (do (swap! counter inc) @counter) elem))]
     (->> (reduce replace-in-fragment fragment (ordered-keys replacement-smap))
          (replace replacement-smap)
          (map-if vector? set-next-key)
          (into []))))
+
+(def render-fragment (memoize render-fragment-impl))
 
 (defn render-icons [input]
     (render-fragment

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -125,13 +125,13 @@
                      "[t]" "trash"})))
 
 (defn card-smap-impl []
-  (letfn [(unpack-non-alt-code [[title cards]] [title (:code (first cards))])
+  (letfn [(unpack-card [[title cards]] [title (:code (first cards))])
           (span-of [title code] [:span {:class "fake-link" :id code} title])]
     (->> @all-cards
          (filter #(not (:replaced_by %)))
          (group-by :title)
-         (map unpack-non-alt-code)
-         (map (fn [[k v]] [(lower-case k) (span-of k v)]))
+         (map unpack-card)
+         (map (fn [[k v]] [(regex-escape k) (span-of k v)]))
          (into {}))))
 
 (def card-smap (memoize card-smap-impl))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -124,7 +124,7 @@
                      "[trash]" "trash"
                      "[t]" "trash"})))
 
-(def card-smap
+(defn card-smap-impl []
   (letfn [(unpack-non-alt-code [[title cards]] [title (:code (first cards))])
           (span-of [title code] [:span {:class "fake-link" :id code} title])]
     (->> @all-cards
@@ -134,7 +134,7 @@
          (map (fn [[k v]] [(lower-case k) (span-of k v)]))
          (into {}))))
 
-(def icon-and-card-smap (merge icon-smap card-smap))
+(def card-smap (memoize card-smap-impl))
 
 (defn ordered-keys-impl [smap]
   (sort-by (comp count first) > smap))
@@ -200,11 +200,14 @@
          (into []))))
 
 (defn render-icons [input]
-  (if (string? input)
-    (render-fragment [:<> input] icon-smap)
-    (render-fragment input icon-smap)))
+    (render-fragment
+      (if (string? input) [:<> input] input)
+      icon-smap))
+
+(defn render-cards [input]
+    (render-fragment
+      (if (string? input) [:<> input] input)
+      (card-smap)))
 
 (defn render-icons-and-cards [input]
-  (if (string? input)
-    (render-fragment [:<> input] icon-and-card-smap)
-    (render-fragment input icon-and-card-smap)))
+  (render-cards (render-icons input)))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -1,5 +1,5 @@
 (ns nr.utils
-  (:require [clojure.string :refer [join, lower-case, split] :as s]
+  (:require [clojure.string :refer [join lower-case split] :as s]
             [jinteki.cards :refer [all-cards]]))
 
 ;; Dot definitions

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -127,7 +127,19 @@
           "[l]" "link"
           "[subroutine]" "subroutine"
           "[trash]" "trash"
-          "[t]" "trash"}
+          "[t]" "trash"
+          "[adam]" "adam"
+          "[anarch]" "anarch"
+          "[apex]" "apex"
+          "[criminal]" "criminal"
+          "[hb]" "haas-bioroid"
+          "[haas-bioroid]" "haas-bioroid"
+          "[jinteki]" "jinteki"
+          "[nbn]" "nbn"
+          "[shaper]" "shaper"
+          "[sunny]" "sunny"
+          "[weyland]" "weyland-consortium"
+          "[weyland-consortium]" "weyland-consortium"}
       (map (fn [[k v]] [(regex-escape k) (span-of v)])))))
 
 (defn card-smap-impl []


### PR DESCRIPTION
Implement a new common functions engine for interspersing card and icon HTML into text strings containing card titles or icon short codes.

Previously most icon interpolation was handled by the `add-symbols` function, which produced stringified HTML which was then added to relevant DOM elements using `:dangerouslySetInnerHTML`. Because this method is unsafe for user-supplied input (as it would allow HTML injection) a different mechanism (largely accessed through the `create-span` function) was used by the log pane and global chat components This latter mechanism also inserts card previews.

The new functions use a common mechanism for both kinds of replacement based on regex -> replacement hashmaps (`card-smap` and `icon-smap`). Functionality provided by `add-symbols` is replaced with `render-icons`, and `create-span` is replaced by `render-icons-and-cards`. Both of these functions take a string or HTML fragment (in reagent's preferred vector form) and return another HTML fragment containing a mix of plain text and icon/card spans.

Fixes #4017