### PR TITLE
Fixed Ash prematurely ending the run. Added regression test.

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -57,7 +57,9 @@
                                                         (swap! state update-in [:run :run-effect]
                                                                #(assoc % :replace-access
                                                                        {:mandatory true
-                                                                        :effect (effect (access-card ash))
+                                                                        :async true
+                                                                        :effect (req (wait-for (access-card state :runner ash)
+                                                                                               (effect-completed state side eid)))
                                                                         :card ash})))))}}}}}
 
    "Awakening Center"

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -80,19 +80,38 @@
 
 (deftest ash-2x3zb9cy
   ;; Ash 2X3ZB9CY
-  (do-game
-    (new-game {:corp {:deck ["Ash 2X3ZB9CY" (qty "Ice Wall" 10)]}})
-    (starting-hand state :corp ["Ash 2X3ZB9CY" "Ice Wall"])
-    (play-from-hand state :corp "Ash 2X3ZB9CY" "HQ")
-    (take-credits state :corp)
-    (let [ash (get-content state :hq 0)]
-      (core/rez state :corp ash)
-      (run-empty-server state "HQ")
-      (click-prompt state :corp "0")
-      (click-prompt state :runner "0")
-      (is (= "Ash 2X3ZB9CY" (-> (get-runner) :prompt first :card :title)) "Should access Ash")
-      (click-prompt state :runner "Pay 3 [Credits] to trash")
-      (is (not (:run @state)) "Accessing Ash then ends the run"))))
+  (testing "Ash 2X3ZB9CY"
+    (do-game
+     (new-game {:corp {:deck ["Ash 2X3ZB9CY" (qty "Ice Wall" 10)]}})
+     (starting-hand state :corp ["Ash 2X3ZB9CY" "Ice Wall"])
+     (play-from-hand state :corp "Ash 2X3ZB9CY" "HQ")
+     (take-credits state :corp)
+     (let [ash (get-content state :hq 0)]
+       (core/rez state :corp ash)
+       (run-empty-server state "HQ")
+       (click-prompt state :corp "0")
+       (click-prompt state :runner "0")
+       (is (= "Ash 2X3ZB9CY" (-> (get-runner) :prompt first :card :title)) "Should access Ash")
+       (click-prompt state :runner "Pay 3 [Credits] to trash")
+       (is (not (:run @state)) "Accessing Ash then ends the run"))))
+  (testing "Ash+Dirty Laundry interaction"
+    (do-game
+     (new-game {:corp {:deck ["Ash 2X3ZB9CY"]}
+                :runner {:deck ["Dirty Laundry"]}})
+     (play-from-hand state :corp "Ash 2X3ZB9CY" "New remote")
+     (core/rez state :corp (get-content state :remote1 0))
+     (take-credits state :corp)
+     (play-from-hand state :runner "Dirty Laundry")
+     (click-prompt state :runner "Server 1")
+     (is (:credit (get-runner) 3) "Runner has 1 credit")
+     (run-successful state)
+     (click-prompt state :corp "0")
+     (click-prompt state :runner "0")
+     (is (:credit (get-runner) 3) "Runner still has 3 credits")
+     (is (:run @state) "Run is not over")
+     (click-prompt state :runner "Pay 3 [Credits] to trash")
+     (is (:credit (get-runner) 5) "Runner got their laundry money")
+     (is (not (:run @state)) "Run not over"))))
 
 (deftest awakening-center
   ;; Awakening Center


### PR DESCRIPTION
Fixes #3995. This one I'm actually puzzled hasn't become an issue before, to be honest, because as far as I can tell the run seems to instantly end when the Ash trash prompt comes up. 