### PR TITLE
Fix :keyword error in prompt-fmt

### DIFF
--- a/test/clj/game_test/macros.clj
+++ b/test/clj/game_test/macros.clj
@@ -22,11 +22,13 @@
          ~'prompt-titles (fn [side#] (map #(:title %) (:choices (~'prompt-map side#))))
          ~'prompt-fmt (fn [side#]
                         (let [prompt# (~'prompt-map side#)
-                              choices# (:choices prompt#)
+                              choices# (if (keyword? choices#)
+                                         [choices#]
+                                         (seq choices#))
                               prompt-type# (:prompt-type prompt#)]
                           (str (side-str side#) ": " (:msg prompt# "") "\n"
                                "Type: " (if (some? prompt-type#) prompt-type# "nil") "\n"
-                               (join "\n" (map #(str "[ " (or (:title %) %) " ]") choices#)) "\n")))]
+                               (join "\n" (map #(str "[ " (or (:title %) % "nil") " ]") choices#)) "\n")))]
      ~@body))
 
 (defmacro deftest-pending [name & body]

--- a/test/clj/game_test/macros.clj
+++ b/test/clj/game_test/macros.clj
@@ -22,6 +22,7 @@
          ~'prompt-titles (fn [side#] (map #(:title %) (:choices (~'prompt-map side#))))
          ~'prompt-fmt (fn [side#]
                         (let [prompt# (~'prompt-map side#)
+                              choices# (:choices prompt#)
                               choices# (if (keyword? choices#)
                                          [choices#]
                                          (seq choices#))


### PR DESCRIPTION
When using `prompt-fmt` in tests to see what the current prompt is, if the current prompt `:choice` is `:credits`, `:choices` wouldn't be a seq, it'd just be the keyword `:credits`, which would throw.