### PR TITLE
Some quick fixes (Liquidation, RNG Key, Psychographics)

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -896,7 +896,7 @@
 
    "Liquidation"
    {:async true
-    :req (req (some #(rezzed? %) (all-installed state :corp)))
+    :req (req (some #(and (rezzed? %) (not (is-type? % "Agenda"))) (all-installed state :corp)))
     :effect (req (let [n (count (filter #(not (is-type? % "Agenda")) (all-active-installed state :corp)))]
                    (continue-ability state side
                      {:prompt "Select any number of rezzed cards to trash"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -896,6 +896,7 @@
 
    "Liquidation"
    {:async true
+    :req (req (some #(rezzed? %) (all-installed state :corp)))
     :effect (req (let [n (count (filter #(not (is-type? % "Agenda")) (all-active-installed state :corp)))]
                    (continue-ability state side
                      {:prompt "Select any number of rezzed cards to trash"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1187,16 +1187,19 @@
 
    "Psychographics"
    {:req (req tagged)
-    :choices :credit
-    :prompt "How many credits?"
     :async true
-    :effect (req (let [c (min target (count-tags state))]
-                   (continue-ability state side
-                                     {:msg (msg "place " c " advancement tokens on "
-                                                (card-str state target))
-                                      :choices {:req can-be-advanced?}
-                                      :effect (effect (add-prop target :advance-counter c {:placed true}))}
-                                     card nil)))}
+    :prompt "Pay how many credits?"
+    :choices {:number (req (count-tags state))}
+    :effect (req (let [c target]
+                   (when (can-pay? state side (:title card) :credit c)
+                     (pay state :corp card :credit c)
+                     (continue-ability
+                       state side
+                       {:msg (msg "place " c " advancement token" (when-not (= c 1) "s") " on "
+                                  (card-str state target))
+                        :choices {:req can-be-advanced?}
+                        :effect (effect (add-prop target :advance-counter c {:placed true}))}
+                       card nil))))}
 
     "Psychokinesis"
     (letfn [(choose-card [state cards]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1195,8 +1195,7 @@
                      (pay state :corp card :credit c)
                      (continue-ability
                        state side
-                       {:msg (msg "place " c " advancement token" (when-not (= c 1) "s") " on "
-                                  (card-str state target))
+                       {:msg (msg "place " (quantify c " advancement token") " on " (card-str state target))
                         :choices {:req can-be-advanced?}
                         :effect (effect (add-prop target :advance-counter c {:placed true}))}
                        card nil))))}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -872,7 +872,7 @@
    "RNG Key"
    {:events {:pre-access-card {:req (req (get-in card [:special :rng-guess]))
                                :async true
-                               :msg (msg "to reveal " (:title target))
+                               :msg (msg "reveal " (:title target))
                                :effect (req (if-let [guess (get-in card [:special :rng-guess])]
                                               (if (installed? target)
                                                 ;; Do not trigger on installed cards (can't "reveal" an installed card per UFAQ)


### PR DESCRIPTION
Psychographics rewritten so that you can't pay 5 credits to place 3 advancement tokens because the runner has 3 tags.