### PR TITLE
Reveal Spent Credits refactor, Trace clean up

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1262,10 +1262,10 @@
    {:flags {:rd-reveal (req true)}
     :access
     {:psi {:req (req (not installed))
-           :not-equal {:msg (msg "prevent it from being stolen")
-                       :effect (effect (register-run-flag! card :can-steal
-                                                           (fn [_ _ c] (not= (:cid c) (:cid card))))
-                                       ;; TODO: investigate why this is needed??
+           :not-equal {:msg "prevent it from being stolen"
+                       :effect (effect (register-run-flag!
+                                         card :can-steal
+                                         (fn [_ _ c] (not= (:cid c) (:cid card))))
                                        (effect-completed eid))}}}}
 
    "Timely Public Release"
@@ -1294,7 +1294,7 @@
                                                         (if (and run
                                                                  (= (zone->name (first (:server run)))
                                                                     chosen-server))
-                                                          (let [curr-pos (get-in @state [:run :position])] 
+                                                          (let [curr-pos (get-in @state [:run :position])]
                                                             (if (>= curr-pos (Integer/parseInt target))
                                                               (swap! state assoc-in [:run :position] (inc curr-pos))))))})
                                         card nil))})

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -702,10 +702,13 @@
                  :effect (req (host state side card target))}]}
 
    "Fumiko Yamamori"
-   {:events {:psi-game-done {:req (req (not= (first targets) (second targets)))
-                             :async true
-                             :msg "do 1 meat damage"
-                             :effect (effect (damage eid :meat 1 {:card card}))}}}
+   {:events {:reveal-spent-credits
+             {:async true
+              :req (req (and (some? (first targets))
+                             (some? (second targets))
+                             (not= (first targets) (second targets))))
+              :msg "do 1 meat damage"
+              :effect (effect (damage eid :meat 1 {:card card}))}}}
 
    "Gene Splicer"
    {:advanceable :always
@@ -773,9 +776,11 @@
                  :effect (effect (damage eid :net 1 {:card card}))}]}
 
    "Hyoubu Research Facility"
-   {:events {:psi-bet-corp {:once :per-turn
-                            :msg (msg "gain " target " [Credits]")
-                            :effect (effect (gain-credits :corp target))}}}
+   {:events {:reveal-spent-credits
+             {:req (req (some? (first targets)))
+              :once :per-turn
+              :msg (msg "gain " target " [Credits]")
+              :effect (effect (gain-credits :corp target))}}}
 
    "Ibrahim Salem"
    (let [trash-ability (fn [card-type]
@@ -1390,11 +1395,19 @@
                                               {:card card}))})
 
    "Psychic Field"
-   (let [ab {:psi {:req (req installed)
-                   :not-equal {:msg (msg "do " (count (:hand runner)) " net damage")
-                               :async true
-                               :effect (effect (damage eid :net (count (:hand runner)) {:card card}))}}}]
-     {:expose ab :access ab})
+   (let [ab {:async true
+             :req (req installed)
+             :effect (req (let [hand (count (:hand runner))
+                                message (str "do " hand " net damage")]
+                            (continue-ability
+                              state side
+                              {:psi {:not-equal
+                                     {:msg message
+                                      :async true
+                                      :effect (effect (damage eid :net hand {:card card}))}}}
+                              card nil)))}]
+     {:expose ab
+      :access ab})
 
    "Public Support"
    {:effect (effect (add-counter card :power 3))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -102,7 +102,7 @@
    {:label (str "Psi Game - " label-neq " / " label-eq)
     :msg (str "start a psi game (" label-neq " / " label-eq ")")
     :psi {:not-equal neq-ability
-          :equal     eq-ability}}))
+          :equal eq-ability}}))
 
 (def take-bad-pub
   "Bad pub on rez effect."
@@ -226,7 +226,8 @@
   {"Aiki"
    {:subroutines [(do-psi {:label "Runner draws 2 cards"
                            :msg "make the Runner draw 2 cards"
-                           :effect (effect (draw :runner 2))})
+                           :effect (effect (draw :runner 2)
+                                           (effect-completed eid))})
                   (do-net-damage 1)]}
 
    "Aimor"
@@ -505,7 +506,8 @@
                                                  #(assoc % :position (count (get-in corp (conj dest :ices)))
                                                            :server (rest dest))))
                                         (move state side card
-                                              (conj (server->zone state target) :ices)))})]}
+                                              (conj (server->zone state target) :ices))
+                                        (effect-completed state side eid))})]}
 
    "Bulwark"
    {:effect take-bad-pub
@@ -558,8 +560,8 @@
                    :effect (effect (gain-credits :runner 2)
                                    (gain-credits :corp 2))}
                   (do-psi {:label "Do 1 net damage for each card in the Runner's grip"
-                           :effect (effect (damage eid :net (count (get-in @state [:runner :hand])) {:card card}))
-                           :msg (msg (str "do " (count (get-in @state [:runner :hand])) " net damage"))})]}
+                           :msg (msg "do " (count (get-in @state [:runner :hand])) " net damage")
+                           :effect (effect (damage eid :net (count (get-in @state [:runner :hand])) {:card card}))})]}
 
    "Chimera"
    (let [turn-end-ability {:effect (effect (derez :corp card)
@@ -625,7 +627,7 @@
                                      (card-str state target) " and end the run")
                            :choices {:req installed?}
                            :effect (effect (add-prop target :advance-counter 1 {:placed true})
-                                           (end-run))})]}
+                                           (end-run eid))})]}
 
    "Cobra"
    {:subroutines [trash-program (do-net-damage 2)]}
@@ -1422,7 +1424,10 @@
    "Mamba"
    {:abilities [(power-counter-ability (do-net-damage 1))]
     :subroutines [(do-net-damage 1)
-                  (do-psi add-power-counter)]}
+                  (do-psi {:label "Add 1 power counter"
+                           :msg "add 1 power counter"
+                           :effect (effect (add-counter card :power 1)
+                                           (effect-completed eid))})]}
 
    "Marker"
    {:subroutines [{:label "Give the next ICE encountered \"End the run\" for the remainder of the run"
@@ -1527,12 +1532,10 @@
 
    "Mganga"
    {:subroutines [(do-psi {:label "do 2 net damage"
-                           :async true
                            :player :corp
                            :effect (req (wait-for (damage state :corp :net 2 {:card card})
                                                   (trash state :corp eid card nil)))}
                           {:label "do 1 net damage"
-                           :async true
                            :player :corp
                            :effect (req (wait-for (damage state :corp :net 1 {:card card})
                                                   (trash state :corp eid card nil)))})]}
@@ -1546,7 +1549,8 @@
                            :effect (req (let [dest (server->zone state target)]
                                           (swap! state update-in [:run]
                                                  #(assoc % :position (count (get-in corp (conj dest :ices)))
-                                                           :server (rest dest)))))})]
+                                                           :server (rest dest))))
+                                        (effect-completed state side eid))})]
     :runner-abilities [{:label "Add an installed card to the bottom of your Stack"
                         :prompt "Choose one of your installed cards"
                         :choices {:req #(and (installed? %)
@@ -2163,7 +2167,9 @@
     :subroutines [(trace-ability 3 add-power-counter)]}
 
    "Snowflake"
-   {:subroutines [(do-psi end-the-run)]}
+   {:subroutines [(do-psi {:label "End the run"
+                           :msg "end the run"
+                           :effect (effect (end-run eid))})]}
 
    "Special Offer"
    {:subroutines [{:label "Gain 5 [Credits] and trash Special Offer"
@@ -2360,14 +2366,14 @@
    {:implementation "\"Resolve a subroutine...\" subroutine is not implemented"
     :subroutines [(do-psi {:label "Make the Runner lose 2 [Credits]"
                            :msg "make the Runner lose 2 [Credits]"
-                           :effect (effect (lose-credits :runner 2))})
+                           :effect (effect (lose-credits :runner 2)
+                                           (effect-completed eid))})
                   {:msg "resolve a subroutine on a piece of rezzed psi ICE"}]}
 
    "Uroboros"
    {:subroutines [(trace-ability 4 {:label "Prevent the Runner from making another run"
                                     :msg "prevent the Runner from making another run"
                                     :effect (effect (register-turn-flag! card :can-run nil))})
-
                   (trace-ability 4 end-the-run)]}
 
    "Vanilla"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -890,7 +890,11 @@
                                 (swap! state dissoc :turn-events))}]})
 
    "Nisei Division: The Next Generation"
-   {:events {:psi-game {:msg "gain 1 [Credits]" :effect (effect (gain-credits :corp 1))}}}
+   {:events {:reveal-spent-credits
+             {:req (req (and (some? (first targets))
+                             (some? (second targets))))
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits :corp 1))}}}
 
    "Noise: Hacker Extraordinaire"
    {:events {:runner-install {:msg "force the Corp to trash the top card of R&D"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -314,9 +314,10 @@
 
    "Cerebral Cast"
    {:req (req (last-turn? state :runner :successful-run))
-    :psi {:not-equal {:player :runner :prompt "Take 1 tag or 1 brain damage?"
-                      :choices ["1 tag" "1 brain damage"] :msg (msg "give the Runner " target)
-                      :async true
+    :psi {:not-equal {:player :runner
+                      :prompt "Take 1 tag or 1 brain damage?"
+                      :choices ["1 tag" "1 brain damage"]
+                      :msg (msg "give the Runner " target)
                       :effect (req (if (= target "1 tag")
                                      (gain-tags state :runner eid 1)
                                      (damage state side eid :brain 1 {:card card})))}}}
@@ -1878,7 +1879,8 @@
                       :choices {:req #(and (installed? %)
                                            (is-type? % "Resource"))}
                       :msg (msg "trash " (:title target))
-                      :effect (effect (trash target))}}}
+                      :effect (effect (trash target)
+                                      (effect-completed eid))}}}
 
    "Wake Up Call"
    {:req (req (last-turn? state :runner :trashed-card))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1700,9 +1700,8 @@
                      (continue-ability state side (sun serv) card nil)))})
 
    "Surveillance Sweep"
-   {:events {:run {:effect (req (swap! state assoc-in [:trace :player] :runner))}
-             :run-end {:effect (req (swap! state dissoc-in [:trace :player]))}}
-    :leave-play (req (swap! state dissoc-in [:trace :player]))}
+   {:events {:pre-init-trace {:req (req run)
+                              :effect (req (swap! state assoc-in [:trace :player] :runner))}}}
 
    "Sweeps Week"
    {:effect (effect (gain-credits (count (:hand runner))))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -210,13 +210,17 @@
    {:events {:pass-ice {:req (req (and this-server
                                        (= (:position run) 1))) ; trigger when last ice passed
                         :msg "start a Psi game"
-                        :psi {:not-equal {:msg "end the run" :effect (effect (end-run))}}}
+                        :psi {:not-equal {:msg "end the run"
+                                          :effect (effect (end-run eid))}}}
              :run {:req (req (and this-server
                                   (zero? (:position run)))) ; trigger on unprotected server
                    :msg "start a Psi game"
-                   :psi {:not-equal {:msg "end the run" :effect (effect (end-run))}}}}
-    :abilities [{:msg "start a Psi game"
-                 :psi {:not-equal {:msg "end the run" :effect (effect (end-run))}}}]}
+                   :psi {:not-equal {:msg "end the run"
+                                     :effect (effect (end-run eid))}}}}
+    :abilities [{:req (req this-server)
+                 :msg "start a Psi game"
+                 :psi {:not-equal {:msg "end the run"
+                                   :effect (effect (end-run eid))}}}]}
 
    "ChiLo City Grid"
    {:events {:successful-trace {:req (req this-server)
@@ -684,7 +688,7 @@
                                    :choices {:req #(and (ice? %)
                                                         (rezzed? %))}
                                    :msg (msg "resolve a subroutine on " (:title target))}}
-                 :effect (effect (trash card))}]}
+                 :effect (effect (trash card {:cause :ability-cost}))}]}
 
    "Mason Bellamy"
    {:implementation "Manually triggered by Corp"

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -2682,8 +2682,8 @@
       (is (= 4 (-> (get-runner) :discard count)) "Project Junebug should do 4 net damage"))))
 
 (deftest psychic-field
+  ;; Psychic Field - Do 1 net damage for every card in Runner's hand when accessed/exposed
   (testing "Basic test"
-    ;; Psychic Field - Do 1 net damage for every card in Runner's hand when accessed/exposed
     (do-game
       (new-game {:corp {:deck [(qty "Psychic Field" 2)]}
                  :runner {:deck [(qty "Infiltration" 3) (qty "Sure Gamble" 3)]}})
@@ -2732,7 +2732,27 @@
       (click-prompt state :runner "1 [Credits]")
       (click-prompt state :runner "Pay 2 [Credits] to trash")
       (is (not (get-content state :remote1)) "Psychic Field trashed by Neutralize All Threats")
-      (is (= "Flatline" (:reason @state)) "Win condition reports flatline"))))
+      (is (= "Flatline" (:reason @state)) "Win condition reports flatline")))
+  (testing "Interaction with Fumiko Yamamori"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Psychic Field" "Fumiko Yamamori"]
+                        :credit 10}
+                 :runner {:hand [(qty "Sure Gamble" 2)]
+                          :credit 10}})
+      (play-from-hand state :corp "Psychic Field" "New remote")
+      (play-from-hand state :corp "Fumiko Yamamori" "New remote")
+      (let [field (get-content state :remote1 0)
+            fumiko (get-content state :remote2 0)]
+        (core/rez state :corp fumiko)
+        (take-credits state :corp)
+        (run-empty-server state :remote1)
+        (is (= 2 (count (:hand (get-runner)))))
+        (is (not (:winner @state)) "No one has won yet")
+        (click-prompt state :corp "2 [Credits]")
+        (click-prompt state :runner "0 [Credits]")
+        (is (= 2 (count (:discard (get-runner)))) "Suffered 2 net damage on expose and psi loss")
+        (is (= :corp (:winner @state)) "Corp wins because of 3 damage")))))
 
 (deftest public-support
   ;; Public support scoring and trashing

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2135,20 +2135,27 @@
   ;; Push Your Luck
   (testing "Corp guesses correctly"
     (do-game
-      (new-game {:runner {:deck ["Push Your Luck"]}})
+      (new-game {:runner {:hand ["Push Your Luck"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Push Your Luck")
-      (click-prompt state :corp "Odd")
       (click-prompt state :runner "3")
+      (click-prompt state :corp "Odd")
       (is (zero? (:credit (get-runner))) "Corp guessed correctly")))
   (testing "Corp guesses incorrectly"
     (do-game
-      (new-game {:runner {:deck ["Push Your Luck"]}})
+      (new-game {:runner {:hand ["Push Your Luck"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Push Your Luck")
-      (click-prompt state :corp "Even")
       (click-prompt state :runner "3")
-      (is (= 6 (:credit (get-runner))) "Corp guessed incorrectly"))))
+      (click-prompt state :corp "Even")
+      (is (= 6 (:credit (get-runner))) "Corp guessed incorrectly")))
+  (testing "Interaction with Government Investigations"
+    (do-game
+      (new-game {:runner {:hand ["Push Your Luck" "Government Investigations"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Government Investigations")
+      (play-from-hand state :runner "Push Your Luck")
+      (is (= '("0" "1" "3") (-> (get-runner) :prompt first :choices)) "Runner can't choose 2 because of Government Investigations"))))
 
 (deftest pushing-the-envelope
   ;; Run. Add 2 strength to each installer breaker.
@@ -2399,22 +2406,36 @@
 
 (deftest rigged-results
   ;; Rigged Results - success and failure
-  (do-game
-    (new-game {:corp {:deck ["Ice Wall"]}
-               :runner {:deck [(qty "Rigged Results" 3)]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Rigged Results")
-    (click-prompt state :runner "0")
-    (click-prompt state :corp "0")
-    (is (empty? (:prompt (get-runner))) "Rigged Results failed for runner")
-    (is (empty? (:prompt (get-corp))) "Rigged Results failed for runner")
-    (play-from-hand state :runner "Rigged Results")
-    (click-prompt state :runner "2")
-    (click-prompt state :corp "1")
-    (click-card state :runner (get-ice state :hq 0))
-    (is (= [:hq] (:server (:run @state))) "Runner is running on HQ")
-    (is (= 3 (:credit (get-runner))) "Rigged results spends credits")))
+  (testing "Corp guesses correctly"
+    (do-game
+      (new-game {:corp {:deck ["Ice Wall"]}
+                 :runner {:deck [(qty "Rigged Results" 3)]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Rigged Results")
+      (click-prompt state :runner "0")
+      (click-prompt state :corp "0")
+      (is (empty? (:prompt (get-runner))) "Rigged Results failed for runner")
+      (is (empty? (:prompt (get-corp))) "Rigged Results failed for runner")))
+  (testing "Corp guesses incorrectly"
+    (do-game
+      (new-game {:corp {:deck ["Ice Wall"]}
+                 :runner {:deck [(qty "Rigged Results" 3)]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Rigged Results")
+      (click-prompt state :runner "2")
+      (click-prompt state :corp "1")
+      (click-card state :runner (get-ice state :hq 0))
+      (is (= [:hq] (:server (:run @state))) "Runner is running on HQ")
+      (is (= 3 (:credit (get-runner))) "Rigged results spends credits")))
+  (testing "Interaction with Government Investigations"
+    (do-game
+      (new-game {:runner {:hand ["Rigged Results" "Government Investigations"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Government Investigations")
+      (play-from-hand state :runner "Rigged Results")
+      (is (= '("0" "1") (-> (get-runner) :prompt first :choices)) "Runner can't choose 2 because of Government Investigations"))))
 
 (deftest rip-deal
   ;; Rip Deal - replaces number of HQ accesses with heap retrieval

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1826,10 +1826,10 @@
   ;; Silhouette
   (testing "Expose trigger ability resolves completely before access. Issue #2173"
     (do-game
-      (new-game {:corp {:deck ["Psychic Field" (qty "Fetal AI" 10)]}
+      (new-game {:corp {:hand ["Psychic Field" "Fetal AI"]
+                        :deck [(qty "Sure Gamble" 10)]}
                  :runner {:id "Silhouette: Stealth Operative"
-                          :deck ["Feedback Filter" "Inside Job"]}})
-      (starting-hand state :corp ["Psychic Field" "Fetal AI"])
+                          :hand ["Feedback Filter" "Inside Job"]}})
       (play-from-hand state :corp "Psychic Field" "New remote")
       (take-credits state :corp)
       (play-from-hand state :runner "Feedback Filter")

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -2278,9 +2278,9 @@
         (run-successful state))))
   (testing "trace during run after stealing an agenda"
     (do-game
-      (new-game {:corp {:deck ["Surveillance Sweep" "Breaking News" "Forced Connection" "Data Raven"]}})
+      (new-game {:corp {:hand ["Surveillance Sweep" "Breaking News" "Forced Connection" "Data Raven"]
+                        :credits 20}})
       (core/gain state :corp :click 4)
-      (core/gain state :corp :credit 20)
       (play-from-hand state :corp "Surveillance Sweep")
       (play-from-hand state :corp "Breaking News" "New remote")
       (play-from-hand state :corp "Forced Connection" "Server 1")
@@ -2300,7 +2300,23 @@
         (click-card state :runner bn)
         (click-prompt state :runner "Steal")
         (click-card state :runner fc)
-        (is (prompt-is-type? state :runner :waiting) "After steal, Surveillance Sweep leaves play and Runner waits on Corp")))))
+        (is (prompt-is-type? state :runner :waiting) "After steal, Surveillance Sweep leaves play and Runner waits on Corp"))))
+  (testing "Interaction with Citadel Sanctuary and Sol"
+    (do-game
+      (new-game {:corp {:hand ["Hostile Takeover"]
+                        :discard ["Surveillance Sweep"]
+                        :id "New Angeles Sol: Your News"}
+                 :runner {:hand ["Citadel Sanctuary"]
+                          :tags 1}})
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Citadel Sanctuary")
+      (run-empty-server state :remote1)
+      (click-prompt state :runner "Steal")
+      (click-prompt state :corp "Yes")
+      (click-card state :corp "Surveillance Sweep")
+      (core/end-turn state :runner nil)
+      (is (prompt-is-type? state :runner :waiting) "Runner is waiting on Corp"))))
 
 (deftest targeted-marketing
   ;; Targeted Marketing

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -840,7 +840,7 @@
        (run-empty-server state :hq)
        (run-on state :remote1)
        (is (empty? (:prompt (get-runner))) "No Hired Help prompt")
-       (is (empty? (:discard (get-runner))) "No net damage done for successful run on R&D")))) 
+       (is (empty? (:discard (get-runner))) "No net damage done for successful run on R&D"))))
   (testing "Crisium Grid, fake agenda interactions"
     (do-game
      (new-game {:corp {:deck ["Hired Help" "Crisium Grid"]}

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -96,7 +96,8 @@
           :identity (@all-cards
                       (or (:id corp)
                           "Custom Biotics: Engineered for Success"))
-          :credits (:credits corp)}
+          :credits (:credits corp)
+          :bad-pub (:bad-pub corp)}
    :runner {:deck (or (transform (conj (:deck runner)
                                        (:hand runner)
                                        (:discard runner)))
@@ -106,7 +107,8 @@
             :identity (@all-cards
                         (or (:id runner)
                             "The Professor: Keeper of Knowledge"))
-            :credits (:credits runner)}
+            :credits (:credits runner)
+            :tags (:tags runner)}
    :mulligan (:mulligan options)
    :start-as (:start-as options)
    :dont-start-turn (:dont-start-turn options)
@@ -141,15 +143,15 @@
         (when (seq (:discard side-map))
           (doseq [card (:discard side-map)]
             (core/move state side
-                       (find-card (:card card) (get-in @state [side :deck])) :discard)))
+                       (find-card card (get-in @state [side :deck])) :discard)))
         (when (:credits side-map)
           (swap! state assoc-in [side :credit] (:credits side-map)))))
     (when (= start-as :runner) (take-credits state :corp))
     ;; These are side independent so they happen ouside the loop
-    (when (:bad-pub corp)
-      (swap! state assoc-in [:corp :bad-publicity] (:bad-pub corp)))
-    (when (:tags runner)
-      (swap! state assoc-in [:runner :tag] (:tags runner)))
+    (when-let [bad-pub (:bad-pub corp)]
+      (swap! state assoc-in [:corp :bad-publicity] bad-pub))
+    (when-let [tags (:tags runner)]
+      (swap! state assoc-in [:runner :tag :base] tags))
     state))
 
 (defn new-game


### PR DESCRIPTION
## Changelog

### Psi games

* `:psi-game` and `:psi-bet-X` and `:psi-game-done` have become the simult `:reveal-spent-credits` which provides two targets, how much the corp spent and how much the runner spent.
* I learned that Psi-games automatically wrap both `:equal` and `:not-equal` branches in `:async true`, so I went through and properly called `effect-completed eid` where it was missing. I don't know if this fixes any lingering bugs, but it's now consistent.
* Removed @nealterrell's TODO on The Future Perfect, lol.
* Refactored `req` clause of Fumiko Yamamori, Hyoubu Research Facility, and Nisei Division to use new `:reveal-spent-credits` event.
* Refactored Psychic Field to capture runner's hand size at time of access/expose, not after psi game. (Fixes issue with Fumiko when both are triggered at the same time with new timing system.)
* Rewrote Rigged Results and Push Your Luck to call `:reveal-spent-credits` with only the second target (runner spend) and to properly use a version of the Psi-game work flow. (Fixes issues with Government Investigations not disallowing runner from choosing 2 credits in those instances.)
* Added tests where appropriate.

### Traces

* Converted `:pre-init-trace`, `:successful-trace`, and `:unsuccessful-trace` to be awaitable/simult, which doesn't change anything immediately but could. No reason to not set ourselves up for success later.
* Cleaned up `:kicker` logic to properly call `effect-completed eid` at the end.
* "Fix" Surveillance Sweep (and probably other small bugs) by clearing `:trace` before every trace instead of conditionally removing `[:trace :player]` at the end of run. Now every trace starts from scratch and all trace modifications require triggering on `:pre-init-trace`.