### PR TITLE
Update http-kit to 2.4.0-alpha3 to support Java 11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [crypto-password "0.2.0"]
                  [binaryage/devtools "0.9.7"]
                  [digest "1.4.6"]
-                 [http-kit "2.3.0"]
+                 [http-kit "2.4.0-alpha3"]
                  [org.slf4j/slf4j-nop "1.7.12"]
                  [jwarwick/trello "0.3.3"]
                  [clj-time "0.14.2"]


### PR DESCRIPTION
As far as I can tell, our dependency on Java 8 goes away if we upgrade to this alpha version of http-kit. Don't know if we want to hold off till the official 2.4.0 though.