### PR TITLE
Add error-checking function wrapping all-cards, fix small bugs

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -224,7 +224,7 @@
                                " resolve.") "info"))})
 
 (defn get-autoresolve
-  "Returns a 5-fn intended for use in the :autoresolve of an optional ability. Function returns 'Yes', 'No' or nil 
+  "Returns a 5-fn intended for use in the :autoresolve of an optional ability. Function returns 'Yes', 'No' or nil
   depending on whether card has [:special toggle-kw] set to :always, :never or something else.
   If a function is passed in, instead call that on [:special toggle-kw] and return the result."
   ([toggle-kw] (get-autoresolve toggle-kw {:always "Yes" :never "No"}))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]))
 
 (defn ice-boost-agenda [subtype]
   (letfn [(count-ice [corp]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]))
 
 ;;; Asset-specific helpers
 (defn installed-access-trigger
@@ -1830,7 +1829,8 @@
                  :prompt "Select two pieces of ICE to swap positions"
                  :choices {:req #(and (installed? %)
                                       (ice? %))
-                           :max 2}
+                           :max 2
+                           :all true}
                  :effect (req (when (= (count targets) 2)
                                 (swap-ice state side (first targets) (second targets))))
                  :msg (msg "swap the positions of "

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]))
 
 (defn- run-event
   ([] (run-event nil))
@@ -1658,7 +1657,7 @@
                                            (= (:faction runner-identity) (:faction %))
                                            (not (is-draft-id? %))
                                            (not= (:title runner-identity) (:title %)))
-                        swappable-ids (filter is-swappable (vals @all-cards))]
+                        swappable-ids (filter is-swappable (server-cards))]
                     (cancellable swappable-ids :sorted)))
     :effect (req
               (let [old-runner-identity (:identity runner)]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]))
 
 ;; Card definitions
 (def card-definitions

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]))
 
 ;;;; Helper functions specific for ICE
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? has-subtype?]]))
 
 ;;; Helper functions for Draft cards
 (def draft-points-target
@@ -108,7 +107,7 @@
               :async true
               :effect (req (show-wait-prompt state :corp "Runner to choose starting directives")
                            (let [is-directive? #(has-subtype? % "Directive")
-                                 directives (filter is-directive? (vals @all-cards))
+                                 directives (filter is-directive? (server-cards))
                                  directives (map make-card directives)
                                  directives (zone :play-area directives)]
                              ;; Add directives to :play-area - assumed to be empty
@@ -472,7 +471,7 @@
                                                         (effect-completed eid))
                                  :effect (effect (rez-cost-bonus -4)
                                                  (clear-wait-prompt :runner)
-                                                 (rez eid target))}
+                                                 (rez eid target nil))}
                                 card nil))}}}
 
    "Haas-Bioroid: Engineering the Future"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags has-subtype?]]))
 
 ;; Card definitions
 (def card-definitions
@@ -1732,22 +1731,22 @@
                :play-event gaincr}})
 
    "The All-Seeing I"
-   (let [trash-all-resources {:player :runner
-                              :effect (req (trash-cards state side (filter #(is-type? % "Resource") (all-active-installed state :runner))))
-                              :msg (msg "trash all resources")}]
+   (let [trash-all-resources
+         {:msg "trash all resources"
+          :effect (effect (trash-cards :corp eid (filter resource? (all-active-installed state :runner)) nil))}]
      {:req (req tagged)
       :async true
       :effect (effect
                 (continue-ability
-                  (if-not (zero? (:bad-publicity corp)) ;; If corp's bad-pub is 0
-                    {:optional {:player :runner
-                                :prompt "Remove 1 bad publicity from the corp to prevent all resources from being trashed?"
-                                :yes-ability {:effect (effect (lose :corp :bad-publicity 1))
-                                              :player :corp
-                                              :msg (msg "lose 1 bad publicity, preventing all resources from being trashed")}
-                                :no-ability trash-all-resources}}
+                  (if (pos? (:bad-publicity corp 0))
+                    {:optional
+                     {:player :runner
+                      :prompt "Remove 1 bad publicity to prevent all resources from being trashed?"
+                      :yes-ability {:msg "remove 1 bad publicity, preventing all resources from being trashed"
+                                    :effect (effect (lose :bad-publicity 1))}
+                      :no-ability trash-all-resources}}
                     trash-all-resources)
-                  card targets))})
+                  card nil))})
 
    "Threat Assessment"
    {:req (req (last-turn? state :runner :trashed-card))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability when-let*]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? has-subtype?]]))
 
 (defn get-strength
   [card]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? count-tags INFINITY has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? count-tags INFINITY has-subtype?]]))
 
 (defn- genetics-trigger?
   "Returns true if Genetics card should trigger - does not work with Adjusted Chronotype"
@@ -684,8 +683,8 @@
                  :runner-trash (trash-event :runner-trash)})})
 
    "DJ Fenris"
-   (let [is-draft-id? #(.startsWith (:code %) "00")
-         sorted-id-list (fn [runner] (->> (vals @all-cards)
+   (let [is-draft-id? #(starts-with? (:code %) "00")
+         sorted-id-list (fn [runner] (->> (server-cards)
                                           (filter #(and (is-type? % "Identity")
                                                         (has-subtype? % "g-mod")
                                                         (not= (-> runner :identity :faction)

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -4,8 +4,7 @@
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [jinteki.utils :refer [str->int other-side is-tagged? has-subtype?]]
-            [jinteki.cards :refer [all-cards]]))
+            [jinteki.utils :refer [str->int other-side is-tagged? has-subtype?]]))
 
 ;; Card definitions
 (def card-definitions

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -196,7 +196,7 @@
          (prompt! state s card prompt {:number n :default d} ab args))
        (:card-title choices)
        (let [card-titles (sort (map :title (filter #((:card-title choices) state side (make-eid state) nil [%])
-                                                   (vals @all-cards))))
+                                                   (server-cards))))
              choices (assoc choices :autocomplete card-titles)
              args (assoc args :prompt-type :card-title)]
          (prompt! state s card prompt choices ab args))

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -181,7 +181,7 @@
   [state side {:keys [choice card] :as args}]
   (let [servercard (get-card state card)
         card (if (not= (:title card) (:title servercard))
-               (@all-cards (:title card))
+               (server-card (:title card))
                servercard)
         prompt (first (get-in @state [side :prompt]))
         choices (:choices prompt)]
@@ -214,7 +214,7 @@
       (:card-title choices)
       (if (string? choice)
         (let [title-fn (:card-title choices)
-              found (some #(when (= (lower-case choice) (lower-case (:title % ""))) %) (vals @all-cards))]
+              found (some #(when (= (lower-case choice) (lower-case (:title % ""))) %) (server-cards))]
           (if found
             (if (title-fn state side (make-eid state) (:card prompt) [found])
               (do (when-let [effect-prompt (:effect prompt)]
@@ -405,10 +405,10 @@
    (let [card (if no-get-card
                 card
                 (get-card state card))
-         altcost (when-not no-get-card
+         altcost (when (and card (not no-get-card))
                    (:alternative-cost (card-def card)))]
      (when cached-bonus (rez-cost-bonus state side cached-bonus))
-     (if (or force (can-rez? state side card))
+     (if (and card (or force (can-rez? state side card)))
        (do
          (trigger-event state side :pre-rez card)
          (if (or (#{"Asset" "ICE" "Upgrade"} (:type card))

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -21,7 +21,7 @@
 (defn remove-from-host
   "Removes a card from its host."
   [state side {:keys [cid] :as card}]
-  (let [host-card (get-card state (:host card))]
+  (when-let [host-card (get-card state (:host card))]
     (update-hosted! state side (update-in host-card [:hosted] (fn [coll] (remove-once #(= (:cid %) cid) coll))))
     (when-let [hosted-lost (:hosted-lost (card-def host-card))]
       (hosted-lost state side (make-eid state) (get-card state host-card) (dissoc card :host)))))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -428,7 +428,8 @@
                                        [:rig (if facedown :facedown (to-keyword (:type card)))]))
                              c (assoc c :installed true :new true)
                              installed-card (if facedown
-                                              (update! state side c)
+                                              (do (update! state side c)
+                                                  (find-latest state c))
                                               (card-init state side c {:resolve-effect false
                                                                        :init-data true}))]
                          (when-not no-msg

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -1,5 +1,6 @@
 (ns game.utils
-  (:require [clojure.string :refer [split-lines split join]]))
+  (:require [clojure.string :refer [split-lines split join]]
+            [jinteki.cards :refer [all-cards]]))
 
 (declare pluralize)
 
@@ -7,6 +8,17 @@
 
 (defn make-cid []
   (swap! cid inc))
+
+(defn server-card
+  [title]
+  (let [card (get @all-cards title)]
+    (if (and title card)
+      card
+      (.println *err* (str "Tried to select server-card for " title)))))
+
+(defn server-cards
+  []
+  (vals @jinteki.cards/all-cards))
 
 (defn abs [n] (max n (- n)))
 

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -5,7 +5,7 @@
             [clojure.test :refer :all]
             [hawk.core :as hawk]
             [game.core :as core]
-            [game.utils :as utils]
+            [game.utils :as utils :refer [make-cid server-card]]
             [jinteki.cards :refer [all-cards]]
             [jinteki.utils :as jutils]))
 
@@ -71,7 +71,7 @@
 
 (defn card-vec->card-map
   [[card amt]]
-  (let [loaded-card (if (string? card) (@all-cards card) card)]
+  (let [loaded-card (if (string? card) (server-card card) card)]
     (when-not loaded-card
       (throw (Exception. (str card " not found in @all-cards"))))
     {:card loaded-card
@@ -94,7 +94,7 @@
                     (transform (qty "Hedge Fund" 3)))
           :hand (flatten (:hand corp))
           :discard (flatten (:discard corp))
-          :identity (@all-cards
+          :identity (server-card
                       (or (:id corp)
                           "Custom Biotics: Engineered for Success"))
           :credits (:credits corp)
@@ -105,7 +105,7 @@
                       (transform (qty "Sure Gamble" 3)))
             :hand (flatten (:hand runner))
             :discard (flatten (:discard runner))
-            :identity (@all-cards
+            :identity (server-card
                         (or (:id runner)
                             "The Professor: Keeper of Knowledge"))
             :credits (:credits runner)

--- a/test/clj/game_test/utils.clj
+++ b/test/clj/game_test/utils.clj
@@ -2,8 +2,7 @@
   (:require [game.core :as core]
             [game.utils :as utils :refer [side-str]]
             [clojure.test :refer :all]
-            [clojure.string :refer [lower-case split]]
-            [jinteki.cards :refer [all-cards]]))
+            [clojure.string :refer [lower-case split]]))
 
 ;;; helper functions for prompt interaction
 (defn assert-prompt [state side]


### PR DESCRIPTION
This has a couple small bug fixes (found by changing the `println *err*` calls in `card-def` to be `throw (Exception.`), and a pretty fundamental change:

`@all-cards` is now accessible through two separate functions: `server-card` and `server-cards`.

* The first works just like calling `(get @all-cards title)` or more frequently `(@all-cards title)` except that it checks that both `title` and the resulting `card` are not `nil` before returning. If either is `nil`, an error message is printed to `*err*` along with the `title` argument.
* The second works just like calling `(vals @all-cards)`: it returns an array of all card objects that can be iterated over as necessary.

I made this change for a couple reasons:
1) When we're directly accessing the data from `all-cards`, we have no way of verifying what we're passing in or getting back is good data. This isn't great but it's a small step towards that verification (research spec for this purpose?).
2) The longer we use this, the harder it will be to change if we ever decide to stop storing the card data in an atom (such as moving to a more fine-grained database system). Using a wrapping function allows us to abstract out the actual data.
3) We have _a lot_ of ways of doing the exact same thing in this engine, and unifying an important engine function in single accessor will have long-term benefits even if we never run into 1) or 2).

I hope to move the front-end over to this in a future commit, but that's a whole other beast, lol.