### PR TITLE
Forced-to-trash only checks credit pool

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -129,8 +129,8 @@
     (let [card (assoc c :seen true)
           card-name (:title card)
           trash-cost (trash-cost state side c)
-          can-pay (when trash-cost (or (can-pay? state :runner nil :credit trash-cost)
-                                       (can-pay-with-recurring? state :runner trash-cost)))]
+          can-pay (when trash-cost (can-pay? state :runner nil :credit trash-cost))
+          pay-with-recurring (when trash-cost (can-pay-with-recurring? state :runner trash-cost))]
       ;; Show the option to pay to trash the card.
       (when-not (and (is-type? card "Operation")
                      ;; Don't show the option if Edward Kim's auto-trash flag is true.
@@ -141,7 +141,7 @@
                                        (concat (all-active state :runner)
                                                (get-in @state [:runner :play-area])))
                 ability-strs (map #(get-in (card-def %) [:interactions :trash-ability :label]) trash-ab-cards)
-                trash-cost-str (when can-pay
+                trash-cost-str (when (or can-pay pay-with-recurring)
                                  [(str "Pay " trash-cost " [Credits] to trash")])
                 ;; If the runner is forced to trash this card (Neutralize All Threats)
                 forced-to-trash? (and (or can-pay
@@ -152,14 +152,13 @@
                             (str trash-cost " [Credits] to trash " card-name " from " (name-zone :corp (:zone card))))
                 pay-str (when can-pay
                           (str (if forced-to-trash? "is forced to pay " "pays ") trash-msg))
-                prompt-str (str "You accessed " card-name ".")
                 no-action-str (when-not forced-to-trash?
                                 ["No action"])
                 choices (vec (concat ability-strs trash-cost-str no-action-str))]
             (continue-ability
               state :runner
               {:async true
-               :prompt prompt-str
+               :prompt (str "You accessed " card-name ".")
                :choices choices
                :effect (req (cond
                               (= target "No action")

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1149,13 +1149,15 @@
   (testing "not forced to trash when credits below 5"
     (do-game
       (new-game {:corp {:deck [(qty "Mumbad Virtual Tour" 3)]}
-                 :runner {:deck ["Cache"]}})
+                 :runner {:deck ["Daily Casts"]}})
       (play-from-hand state :corp "Mumbad Virtual Tour" "New remote")
       (take-credits state :corp)
-      (play-from-hand state :runner "Cache")
-      (is (= 4 (:credit (get-runner))) "Runner paid install costs")
+      (play-from-hand state :runner "Daily Casts")
+      (is (= 2 (:credit (get-runner))) "Runner paid install costs")
       (run-empty-server state "Server 1")
-      (is (= ["No action"] (-> (get-runner) :prompt first :choices)) "Can't trash"))))
+      (is (= ["Pay 5 [Credits] to trash" "No action"]
+             (-> (get-runner) :prompt first :choices))
+          "Runner is given the choice, as we don't know if they can afford it or not"))))
 
 (deftest mwanza-city-grid
   ;; Mwanza City Grid - runner accesses 3 additional cards, gain 2C for each card accessed


### PR DESCRIPTION
Currently, `forced-to-trash` in `access-non-agenda` relies on `can-pay`, which is true if the runner can pay with credits in pool OR with credits in pool + credits on cards. This falls apart when cards like Daily Casts don't have usable credits. To fix this, I've separated `can-pay` into two different checks, the first that checks credits in pool and the second that checks credits in pool + credits on cards. This allows us to say `force-to-trash` is true _only if_ the runner has enough credits in pool to afford it. The runner will still get the `Pay X to trash` prompt if they have enough credits in pool + credits on cards, just in case, but `No action` won't be removed unless they have enough credits in pool only.

Fixes #3653. 

also, lol at me for writing "I'll take a look!" on my birthday, 9 months ago.