### PR TITLE
Fix simultaneous ability reqs, Handle Asa/419

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -71,16 +71,16 @@
    {:effect (effect (gain-credits 3))
     :msg (msg "gain 3 [Credits]")
     :abilities [{:label "[Trash]: Install a non-agenda card from HQ"
-                 :effect (effect (trash card {:cause :ability-cost})
-                                 (corp-install target nil))
-                 :msg (msg (corp-install-msg target))
+                 :async true
                  :prompt "Select a non-agenda card to install from HQ"
-                 :priority true
                  :req (req (not (:run @state)))
                  :choices {:req #(and (not (is-type? % "Operation"))
                                       (not (is-type? % "Agenda"))
                                       (= (:zone %) [:hand])
-                                      (= (:side %) "Corp"))}}]}
+                                      (= (:side %) "Corp"))}
+                 :msg (msg (corp-install-msg target))
+                 :effect (req (wait-for (trash state side card {:cause :ability-cost})
+                                        (corp-install state side eid target nil nil)))}]}
 
    "Aggressive Secretary"
    (advance-ambush 2 {:req (req (pos? (get-counters (get-card state card) :advancement)))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -55,7 +55,7 @@
                                        (if (not (can-pay? state :corp nil :credit 1))
                                          (do
                                            (toast state :corp "Cannot afford to pay 1 credit to block card exposure" "info")
-                                           (expose state side eid itarget))
+                                           (expose state :runner eid itarget))
                                          (do
                                            (show-wait-prompt state :runner "Corp decision")
                                            (continue-ability
@@ -65,7 +65,7 @@
                                                :player :corp
                                                :no-ability
                                                {:async true
-                                                :effect (req (expose state side eid itarget)
+                                                :effect (req (expose state :runner eid itarget)
                                                              (clear-wait-prompt state :runner))}
                                                :yes-ability
                                                {:effect (req (pay state :corp card [:credit 1])
@@ -865,9 +865,9 @@
 
    "New Angeles Sol: Your News"
    (let [nasol {:optional
-                {:prompt "Play a Current?" :player :corp
-                 :req (req (not (empty? (filter #(has-subtype? % "Current")
-                                                (concat (:hand corp) (:discard corp))))))
+                {:prompt "Play a Current?"
+                 :player :corp
+                 :req (req (some #(has-subtype? % "Current") (concat (:hand corp) (:discard corp))))
                  :yes-ability {:prompt "Select a Current to play from HQ or Archives"
                                :show-discard true
                                :async true
@@ -876,7 +876,8 @@
                                                     (#{[:hand] [:discard]} (:zone %)))}
                                :msg (msg "play a current from " (name-zone "Corp" (:zone target)))
                                :effect (effect (play-instant eid target))}}}]
-     {:events {:agenda-scored nasol :agenda-stolen nasol}})
+     {:events {:agenda-scored nasol
+               :agenda-stolen nasol}})
 
    "NEXT Design: Guarding the Net"
    (let [ndhelper (fn nd [n] {:prompt (msg "When finished, click NEXT Design: Guarding the Net to draw back up to 5 cards in HQ. "

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -13,7 +13,7 @@
   [card]
   (if-let [title (:title card)]
     (get cards title)
-    (.println *err* "Tried to select card def for non-existent card")))
+    (throw (Exception. "Tried to select card def for non-existent card"))))
 
 (defn find-cid
   "Return a card with specific :cid from given sequence"

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -13,7 +13,7 @@
   [card]
   (if-let [title (:title card)]
     (get cards title)
-    (throw (Exception. "Tried to select card def for non-existent card"))))
+    (.println *err* "Tried to select card def for non-existent card")))
 
 (defn find-cid
   "Return a card with specific :cid from given sequence"

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -180,8 +180,8 @@
                        ;; prepare the list of the given player's handlers for this event.
                        ;; Gather all registered handlers from the state, then append the card-ability if appropriate,
                        ;; then filter to remove suppressed handlers and those whose req is false.
-                       ;; This is essentially "step 1" as described here:
-                       ;; http://ancur.wikia.com/wiki/User_blog:Jakodrako/Ability_Types_and_Resolution_Primer#Conditional_Abilities
+                       ;; This is essentially Phase 9.3 and 9.6.7a of CR 1.1:
+                       ;; http://nisei.net/files/Comprehensive_Rules_1.1.pdf
                        (let [abis (filter (partial is-player player-side) (get-in @state [:events event]))
                              abis (if (= player-side (get-side card-ability))
                                     (cons card-ability abis)

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -59,9 +59,10 @@
         is-active-player #(= (:active-player @state) (get-side %))]
 
     (let [handlers (sort-by (complement is-active-player) (get-in @state [:events event]))
-          handlers (filter #(and (not (apply trigger-suppress state side event (cons (:card %) targets)))
-                                 (can-trigger? state side (:ability %) (get-card state (:card %)) targets))
-                           handlers)]
+          handlers (doall
+                     (filter #(and (not (apply trigger-suppress state side event (cons (:card %) targets)))
+                                   (can-trigger? state side (:ability %) (get-card state (:card %)) targets))
+                             handlers))]
       (wait-for (apply trigger-event-sync-next state side handlers event targets)
                 (effect-completed state side eid)))))
 
@@ -75,23 +76,24 @@
   [state side eid event handlers cancel-fn event-targets]
   (if (not-empty handlers)
     (letfn [;; Allow resolution as long as there is no cancel-fn, or if the cancel-fn returns false.
-            (should-continue [state handlers] (and (< 1 (count handlers))
-                                                   (not (and cancel-fn (cancel-fn state)))))
-
+            (should-continue [state handlers]
+              (and (< 1 (count handlers))
+                   (not (and cancel-fn (cancel-fn state)))))
             (choose-handler [handlers]
-              (let [non-silent (filter #(not (and (:silent (:ability %))
-                                                  (let [ans ((:silent (:ability %)) state side (make-eid state) (:card %) event-targets)]
-                                                    ans)))
+              (let [non-silent (filter #(let [silent-fn (:silent (:ability %))]
+                                          (not (and silent-fn
+                                                    (silent-fn state side (make-eid state) (:card %) event-targets))))
                                        handlers)
-                    cards (map :card non-silent)
-                    titles (map :title cards)
+                    titles (map (comp :title :card) non-silent)
                     interactive (filter #(let [interactive-fn (:interactive (:ability %))]
-                                          (and interactive-fn (interactive-fn state side (make-eid state) (:card %) event-targets)))
+                                           (and interactive-fn
+                                                (interactive-fn state side (make-eid state) (:card %) event-targets)))
                                         handlers)]
                 ;; If there is only 1 non-silent ability, resolve that then recurse on the rest
                 (if (or (= 1 (count handlers)) (empty? interactive) (= 1 (count non-silent)))
-                  (let [to-resolve
-                        (if (= 1 (count non-silent)) (first non-silent) (first handlers))
+                  (let [to-resolve (if (= 1 (count non-silent))
+                                     (first non-silent)
+                                     (first handlers))
                         ability-to-resolve (dissoc (:ability to-resolve) :req)
                         card-to-resolve (:card to-resolve)
                         others (if (= 1 (count non-silent))
@@ -170,39 +172,39 @@
          get-ability-side #(-> % :ability :side)
          active-player (:active-player @state)
          opponent (other-side active-player)
-         is-player (fn [player ability] (or (= player (get-side ability)) (= player (get-ability-side ability))))
-
-         ;; prepare the list of the given player's handlers for this event.
-         ;; gather all registered handlers from the state, then append the card-ability if appropriate, then
-         ;; filter to remove suppressed handlers and those whose req is false.
-         ;; this is essentially "step 1" as described here:
-         ;; http://ancur.wikia.com/wiki/User_blog:Jakodrako/Ability_Types_and_Resolution_Primer#Conditional_Abilities
-         get-handlers (fn [player-side]
-                        (let [abis (filter (partial is-player player-side) (get-in @state [:events event]))
-                              abis (if (= player-side (get-side card-ability))
-                                     (cons card-ability abis)
-                                     abis)]
-                          (filter #(and (not (apply trigger-suppress state side event (cons (:card %) targets)))
-                                        (can-trigger? state side (:ability %) (get-card state (:card %)) targets))
-                                  abis)))
-         active-player-events (get-handlers active-player)
-         opponent-events (get-handlers opponent)]
+         is-player (fn [player ability] (or (= player (get-side ability)) (= player (get-ability-side ability))))]
      ; let active player activate their events first
-     (wait-for
-       (resolve-ability state side first-ability nil nil)
-       (do (show-wait-prompt state opponent (str (side-str active-player) " to resolve " (event-title event) " triggers")
-                             {:priority -1})
-           (wait-for
-             (trigger-event-simult-player state side event active-player-events cancel-fn targets)
-             (do (when after-active-player
-                   (resolve-ability state side after-active-player nil nil))
-                 (clear-wait-prompt state opponent)
-                 (show-wait-prompt state active-player
-                                   (str (side-str opponent) " to resolve " (event-title event) " triggers")
+     (wait-for (resolve-ability state side first-ability nil nil)
+               (let [get-handlers
+                     (fn [player-side]
+                       ;; prepare the list of the given player's handlers for this event.
+                       ;; Gather all registered handlers from the state, then append the card-ability if appropriate,
+                       ;; then filter to remove suppressed handlers and those whose req is false.
+                       ;; This is essentially "step 1" as described here:
+                       ;; http://ancur.wikia.com/wiki/User_blog:Jakodrako/Ability_Types_and_Resolution_Primer#Conditional_Abilities
+                       (let [abis (filter (partial is-player player-side) (get-in @state [:events event]))
+                             abis (if (= player-side (get-side card-ability))
+                                    (cons card-ability abis)
+                                    abis)]
+                         (doall
+                           (filter #(and (not (apply trigger-suppress state side event (cons (:card %) targets)))
+                                         (can-trigger? state side (:ability %) (get-card state (:card %)) targets))
+                                   abis))))
+                     active-player-events (get-handlers active-player)
+                     opponent-events (get-handlers opponent)]
+                 (show-wait-prompt state opponent
+                                   (str (side-str active-player) " to resolve " (event-title event) " triggers")
                                    {:priority -1})
-                 (wait-for (trigger-event-simult-player state opponent event opponent-events cancel-fn targets)
-                           (do (clear-wait-prompt state active-player)
-                               (effect-completed state side eid))))))))))
+                 (wait-for (trigger-event-simult-player state side event active-player-events cancel-fn targets)
+                           (when after-active-player
+                             (resolve-ability state side after-active-player nil nil))
+                           (clear-wait-prompt state opponent)
+                           (show-wait-prompt state active-player
+                                             (str (side-str opponent) " to resolve " (event-title event) " triggers")
+                                             {:priority -1})
+                           (wait-for (trigger-event-simult-player state opponent event opponent-events cancel-fn targets)
+                                     (clear-wait-prompt state active-player)
+                                     (effect-completed state side eid))))))))
 
 
 ; Functions for registering trigger suppression events.

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -173,7 +173,6 @@
          active-player (:active-player @state)
          opponent (other-side active-player)
          is-player (fn [player ability] (or (= player (get-side ability)) (= player (get-ability-side ability))))]
-     ; let active player activate their events first
      (wait-for (resolve-ability state side first-ability nil nil)
                (let [get-handlers
                      (fn [player-side]
@@ -195,6 +194,7 @@
                  (show-wait-prompt state opponent
                                    (str (side-str active-player) " to resolve " (event-title event) " triggers")
                                    {:priority -1})
+                 ; let active player activate their events first
                  (wait-for (trigger-event-simult-player state side event active-player-events cancel-fn targets)
                            (when after-active-player
                              (resolve-ability state side after-active-player nil nil))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -228,7 +228,7 @@
       ;; Check to see if a second agenda/asset was installed.
       (wait-for (corp-install-asset-agenda state side moved-card dest-zone server)
                 (letfn [(event [state side eid _]
-                          (trigger-event-sync state side eid :corp-install (get-card state moved-card)))]
+                          (trigger-event-simult state side eid :corp-install nil (get-card state moved-card)))]
                   (case install-state
                     ;; Ignore all costs. Pass eid to rez.
                     :rezzed-no-cost
@@ -279,7 +279,7 @@
       (wait-for (pay-sync state side card end-cost {:action action})
                 (if-let [cost-str async-result]
                   (if (= server "New remote")
-                    (wait-for (trigger-event-sync state side :server-created card)
+                    (wait-for (trigger-event-simult state side :server-created nil card)
                               (corp-install-continue state side eid card server args slot cost-str))
                     (corp-install-continue state side eid card server args slot cost-str))
                   (end-fn)))
@@ -317,7 +317,7 @@
            dest-zone (get-in @state (cons :corp slot))]
        ;; trigger :pre-corp-install before computing install costs so that
        ;; event handlers may adjust the cost.
-       (wait-for (trigger-event-sync state side :pre-corp-install card {:server server :dest-zone dest-zone})
+       (wait-for (trigger-event-simult state side :pre-corp-install nil card {:server server :dest-zone dest-zone})
                  (corp-install-pay state side eid card server args slot))))))
 
 

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -1662,8 +1662,7 @@
     (click-prompt state :runner "Pay 4 net damage to steal")
     (is (= 4 (count (:discard (get-runner)))) "Runner paid 4 net damage")
     (is (= :runner (:winner @state)) "Runner wins")
-    (is (= "Agenda" (:reason @state)) "Win condition reports agenda points")
-    (is (last-log-contains? state "wins the game") "PE did not fire")))
+    (is (= "Agenda" (:reason @state)) "Win condition reports agenda points")))
 
 (deftest paper-trail
   ;; Paper Trail

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -73,7 +73,37 @@
         (click-prompt state :runner "Yes")
         (click-prompt state :corp "Yes")
         (is (= 1 (- corp-credits (:credit (get-corp)))) "Should lose 1 credit from 419 ability")
-        (is (zero? (- runner-credits (:credit (get-runner)))) "Should not gain any credits from Ixodidae")))))
+        (is (zero? (- runner-credits (:credit (get-runner)))) "Should not gain any credits from Ixodidae"))))
+  (testing "419 vs Asa Group double install, Corp's turn"
+    (do-game
+      (new-game {:corp {:id "Asa Group: Security Through Vigilance"
+                        :deck [(qty "Hedge Fund" 5)]
+                        :hand ["PAD Campaign" "Ice Wall"]}
+                 :runner {:id "419: Amoral Scammer"}})
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (click-card state :corp "Ice Wall")
+      (click-prompt state :runner "Yes")
+      (click-prompt state :corp "No")
+      (let [log (-> @state :log last :text)]
+        (is (= log "Runner exposes PAD Campaign in Server 1.")))))
+  (testing "419 vs Asa Group double install, Runner's turn"
+    (do-game
+      (new-game {:corp {:id "Asa Group: Security Through Vigilance"
+                        :deck [(qty "Hedge Fund" 5)]
+                        :hand ["PAD Campaign" "Ice Wall" "Advanced Assembly Lines"]}
+                 :runner {:id "419: Amoral Scammer"}})
+      (play-from-hand state :corp "Advanced Assembly Lines" "New remote")
+      (click-prompt state :corp "Done")
+      (click-prompt state :runner "No")
+      (take-credits state :corp)
+      (card-ability state :corp (get-content state :remote1 0) 0)
+      (click-card state :corp "PAD Campaign")
+      (click-prompt state :corp "New remote")
+      (click-prompt state :runner "Yes")
+      (click-prompt state :corp "No")
+      (let [log (-> @state :log last :text)]
+        (is (= log "Runner exposes PAD Campaign in Server 2.")))
+      (is (prompt-is-type? state :corp :select) "Corp should still have select prompt"))))
 
 (deftest acme-consulting-the-truth-you-need
   (testing "Tag gain when rezzing outermost ice"
@@ -369,16 +399,7 @@
         (click-card state :corp pup)
         (click-prompt state :corp "New remote")
         (is (empty? (:prompt (get-corp))) "No more prompts")
-        (is (= 6 (count (:servers (get-corp)))) "There are six servers, including centrals"))))
-  (testing "don't allow installation of operations"
-    (do-game
-      (new-game {:corp {:id "Asa Group: Security Through Vigilance"
-                        :deck ["Pup" "BOOM!" "Urban Renewal"]}})
-      (play-from-hand state :corp "Pup" "New remote")
-      (click-card state :corp (find-card "BOOM!" (:hand (get-corp))))
-      (is (empty? (get-content state :remote1)) "Asa Group installed an event in a server")
-      (click-card state :corp (find-card "Urban Renewal" (:hand (get-corp))))
-      (is (= "Urban Renewal" (:title (get-content state :remote1 0))) "Asa Group can install an asset in a remote"))))
+        (is (= 6 (count (:servers (get-corp)))) "There are six servers, including centrals")))))
 
 (deftest ayla-bios-rahim-simulant-specialist
   ;; Ayla - choose & use cards for NVRAM

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -121,11 +121,11 @@
   (let [state (core/init-game
                 {:gameid 1
                  :players [{:side "Corp"
-                            :user "player1"
+                            :user {:username "Corp"}
                             :deck {:identity (:identity corp)
                                    :cards (:deck corp)}}
                            {:side "Runner"
-                            :user "player2"
+                            :user {:username "Runner"}
                             :deck {:identity (:identity runner)
                                    :cards (:deck runner)}}]})]
     (when-not dont-start-game


### PR DESCRIPTION
In trying to fix the Asa/419 bug, I found out that when we generate event-handlers in `trigger-event-sync` and `trigger-event-simult`, because they use `filter`, the LazySeq is built but not realized. This means the event-handler `:req`s weren't being checked until they were being consumed. Thus, 419 wouldn't trigger because by the time we'd gotten to resolving the `opponent-events`, Asa's ability had executed twice and `first-event?` would return false.

Solution 1) Wrap the filter in a `doall` call, which forces evaluation.

HOWEVER, this breaks how we handle currents! Because currents are trashed in the `:first-ability` called when an agenda is scored or stolen, and New Angeles Sol can play the current that was just trashed by the runner stealing an agenda, when we would check Sol's `:req` to see if a current existed to be played, it wasn't in the trash yet.

Solution 2) Move generating (and thus `:req` checking) the active and opponent event handlers to happen _after_ we've resolved the `:first-ability`.

Closes #3590.