### PR TITLE
Fix Hernando Cortez/Blue Sun interaction by adding additional costs to rez

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -220,14 +220,12 @@
    "Cortez Chip"
    {:abilities [{:prompt "Select a piece of ICE"
                  :choices {:req ice?}
-                 :effect (req (let [ice target]
-                                (update! state side (assoc card :cortez-target ice))
-                                (trash state side (get-card state card) {:cause :ability-cost})
-                                (system-msg state side
-                                            (str "trashes Cortez Chip to increase the rez cost of " (card-str state ice)
-                                                 " by 2 [Credits] until the end of the turn"))))}]
+                 :msg (msg "trashes Cortez Chip to increase the rez cost of " (card-str state target)
+                           " by 2 [Credits] until the end of the turn")
+                 :effect (effect (update! (assoc card :cortez-target target))
+                                 (trash (get-card state card) {:cause :ability-cost}))}]
     :trash-effect {:effect (effect (register-events {:pre-rez {:req (req (= (:cid target) (:cid (:cortez-target card))))
-                                                               :effect (effect (rez-cost-bonus 2))}
+                                                               :effect (effect (rez-additional-cost-bonus [:credit 2]))}
                                                      :runner-turn-ends {:effect (effect (unregister-events card))}
                                                      :corp-turn-ends {:effect (effect (unregister-events card))}}
                                                     (get-card state card)))}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -268,14 +268,14 @@
 
    "Blue Sun: Powering the Future"
    {:flags {:corp-phase-12 (req (and (not (:disabled card))
-                                     (some #(rezzed? %) (all-installed state :corp))))}
-    :abilities [{:choices {:req #(:rezzed %)}
+                                     (some rezzed? (all-installed state :corp))))}
+    :abilities [{:choices {:req rezzed?}
                  :effect (req (trigger-event state side :pre-rez-cost target)
                               (let [cost (rez-cost state side target)]
                                 (gain-credits state side cost)
                                 (move state side target :hand)
                                 (system-msg state side (str "adds " (:title target) " to HQ and gains " cost " [Credits]"))
-                                (swap! state update-in [:bonus] dissoc :cost)))}]}
+                                (swap! state update-in [:bonus] dissoc :cost :rez)))}]}
 
    "Boris \"Syfr\" Kovac: Crafty Veteran"
    {:events {:pre-start-game {:effect draft-points-target}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -982,7 +982,8 @@
 
    "Hernando Cortez"
    {:events {:pre-rez-cost {:req (req (and (>= (:credit corp) 10) (ice? target)))
-                            :effect (effect (rez-cost-bonus (count-num-subroutines target)))
+                            :effect (effect (rez-additional-cost-bonus
+                                              [:credit (count-num-subroutines target)]))
                             :msg (msg "increase the rez cost by " (count-num-subroutines target) " [Credit]")}}}
 
    "Human First"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -430,10 +430,14 @@
                                                                   :cached-bonus curr-bonus})))))}))
                  (let [cdef (card-def card)
                        cost (rez-cost state side card)
-                       costs (concat (when-not ignore-cost [:credit cost])
+                       additional-costs (concat (:additional-cost cdef)
+                                                (:additional-cost card)
+                                                (get-rez-additional-cost-bonus state side))
+                       costs (concat (when-not ignore-cost
+                                       [:credit cost])
                                      (when (and (not= ignore-cost :all-costs)
                                                 (not (:disabled card)))
-                                       (:additional-cost cdef)))]
+                                       additional-costs))]
                    (when-let [cost-str (apply pay state side card costs)]
                      ;; Deregister the derezzed-events before rezzing card
                      (when (:derezzed-events cdef)
@@ -464,7 +468,7 @@
                      (swap! state update-in [:stats :corp :cards :rezzed] (fnil inc 0))
                      (trigger-event-sync state side eid :rez card)))))
            (effect-completed state side eid))
-         (swap! state update-in [:bonus] dissoc :cost))
+         (swap! state update-in [:bonus] dissoc :cost :rez))
        (effect-completed state side eid)))))
 
 (defn derez

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -335,6 +335,14 @@
 (defn get-rez-cost-bonus [state side]
   (get-in @state [:bonus :cost] 0))
 
+(defn rez-additional-cost-bonus
+  [state side n]
+  (swap! state update-in [:bonus :rez :additional-cost] #(merge-costs (concat % n))))
+
+(defn get-rez-additional-cost-bonus
+  [state side]
+  (get-in @state [:bonus :rez :additional-cost]))
+
 (defn rez-cost [state side {:keys [cost] :as card}]
   (when-not (nil? cost)
     (-> (if-let [rezfun (:rez-cost-bonus (card-def card))]

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -1,7 +1,7 @@
 (in-ns 'game.core)
 
 (declare forfeit prompt! toast damage mill installed? is-type? is-scored? system-msg
-         facedown? make-result)
+         facedown? make-result discard-from-hand)
 
 (defn deduct
   "Deduct the value from the player's attribute."
@@ -52,17 +52,19 @@
       (flag-stops-pay? state side cost-type)
       computer-says-no
 
-      (not (or (#{:memory :net-damage} cost-type)
-               (and (= cost-type :forfeit) (>= (- (count (get-in @state [side :scored])) amount) 0))
-               (and (= cost-type :mill) (>= (- (count (get-in @state [side :deck])) amount) 0))
-               (and (= cost-type :tag) (>= (- (get-in @state [:runner :tag :base]) amount) 0))
-               (and (= cost-type :ice) (>= (- (count (filter (every-pred rezzed? ice?) (all-installed state :corp))) amount) 0))
-               (and (= cost-type :hardware) (>= (- (count (get-in @state [:runner :rig :hardware])) amount) 0))
-               (and (= cost-type :program) (>= (- (count (get-in @state [:runner :rig :program])) amount) 0))
-               (and (= cost-type :connection) (>= (- (count (filter #(has-subtype? % "Connection")
-                                                                    (all-active-installed state :runner))) amount) 0))
-               (and (= cost-type :shuffle-installed-to-stack) (>= (- (count (all-installed state :runner)) amount) 0))
-               (>= (- (get-in @state [side cost-type] -1) amount) 0)))
+      (not (or (#{:memory :net-damage :meat-damage :brain-damage} cost-type)
+               (and (= cost-type :forfeit) (<= 0 (- (count (get-in @state [side :scored])) amount)))
+               (and (= cost-type :mill) (<= 0 (- (count (get-in @state [side :deck])) amount)))
+               (and (= cost-type :discard) (<= 0 (- (count (get-in @state [side :hand])) amount)))
+               (and (= cost-type :tag) (<= 0 (- (get-in @state [:runner :tag :base]) amount)))
+               (and (= cost-type :ice) (<= 0 (- (count (filter (every-pred rezzed? ice?) (all-installed state :corp))) amount)))
+               (and (= cost-type :hardware) (<= 0 (- (count (get-in @state [:runner :rig :hardware])) amount)))
+               (and (= cost-type :program) (<= 0 (- (count (get-in @state [:runner :rig :program])) amount)))
+               (and (= cost-type :connection)
+                    (<= 0 (- (count (filter #(has-subtype? % "Connection") (all-active-installed state :runner))) amount)))
+               (and (= cost-type :shuffle-installed-to-stack) (<= 0 (- (count (all-installed state :runner)) amount)))
+               (and (#{:credit :click} cost-type)
+                    (<= 0 (- (get-in @state [side cost-type] -1) amount)))))
       computer-says-no)))
 
 (defn add-default-to-costs
@@ -224,6 +226,7 @@
      :tag (complete-with-result state side eid (deduct state :runner cost))
      :net-damage (pay-damage state side eid :net (second cost))
      :mill (complete-with-result state side eid (mill state side (second cost)))
+     :discard (complete-with-result state side eid (discard-from-hand state side (second cost)))
 
      ;; Shuffle installed runner cards into the stack (eg Degree Mill)
      :shuffle-installed-to-stack (pay-shuffle-installed-to-stack state side eid card (second cost))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -255,7 +255,7 @@
               (pay-sync-next state side eid (next costs) card action (conj msgs async-result)))))
 
 (defn pay-sync
-  "Same as pay, but awaitable. "
+  "Same as pay, but awaitable."
   [state side eid card & args]
   (let [raw-costs (not-empty (remove map? args))
         action (not-empty (filter map? args))]

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -614,11 +614,20 @@
   (trigger-event state side :purge))
 
 (defn mill
-  "Force the discard of n cards by trashing them."
+  "Force the discard of n cards from the deck by trashing them"
   ([state side] (mill state side side 1))
   ([state side n] (mill state side side n))
   ([state from-side to-side n]
    (let [milltargets (take n (get-in @state [to-side :deck]))]
+     (doseq [card milltargets]
+       (trash-no-cost state from-side (make-eid state) card :seen false :unpreventable true)))))
+
+(defn discard-from-hand
+  "Force the discard of n cards from the hand by trashing them"
+  ([state side] (discard-from-hand state side side 1))
+  ([state side n] (discard-from-hand state side side 1))
+  ([state from-side to-side n]
+   (let [milltargets (take n (get-in @state [to-side :hand]))]
      (doseq [card milltargets]
        (trash-no-cost state from-side (make-eid state) card :seen false :unpreventable true)))))
 

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -365,6 +365,33 @@
       (core/rez state :corp iw2)
       (is (core/rezzed? (refresh iw2)) "Final Ice Wall is rezzed"))))
 
+(deftest brute-force-hack
+  ;; Brute-Force-Hack
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 10)]
+                      :hand ["Ice Wall" "Tollbooth"]
+                      :credits 10}
+               :runner {:hand [(qty "Brute-Force-Hack" 2) "Xanadu"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Tollbooth" "HQ")
+    (take-credits state :corp)
+    (core/gain state :runner :click 10)
+    (let [iw (get-ice state :hq 0)
+          tb (get-ice state :hq 1)]
+      (core/rez state :corp iw)
+      (core/rez state :corp tb)
+      (play-from-hand state :runner "Brute-Force-Hack")
+      (click-prompt state :runner "1")
+      (click-card state :runner "Tollbooth")
+      (is (core/rezzed? (refresh tb)) "Runner doesn't have enough money to derez Tollbooth")
+      (click-card state :runner iw)
+      (is (not (core/rezzed? (refresh iw))) "Runner can derez Ice Wall")
+      (play-from-hand state :runner "Xanadu")
+      (core/gain state :runner :credit 7)
+      (is (= (:cost tb) (:credit (get-runner))) "Gain enough credits to derez Tollbooth normally")
+      (play-from-hand state :runner "Brute-Force-Hack")
+      (is (empty? (:prompt (get-runner))) "Runner can't play Brute-Force-Hack when only available ice is too expensive"))))
+
 (deftest by-any-means
   ;; By Any Means
   (testing "Full test"

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -1460,23 +1460,29 @@
   ;; Make sure it is not active when hosted on Peddler
   (do-game
     (new-game {:corp {:deck [(qty "Jeeves Model Bioroids" 2)
-                             (qty "Jackson Howard" 2)]}
-               :runner {:deck ["Street Peddler"
-                               (qty "Hacktivist Meeting" 3)]}})
+                             (qty "Jackson Howard" 2)]
+                      :hand ["Jeeves Model Bioroids" "Jackson Howard" "Sundew"]
+                      :credits 10}
+               :runner {:hand ["Hacktivist Meeting"]}})
     (take-credits state :corp)
     (starting-hand state :runner ["Street Peddler" "Hacktivist Meeting"])
     (play-from-hand state :runner "Street Peddler")
     (take-credits state :runner)
     (play-from-hand state :corp "Jeeves Model Bioroids" "New remote")
     (play-from-hand state :corp "Jackson Howard" "New remote")
+    (play-from-hand state :corp "Sundew" "New remote")
     (let [jeeves (get-content state :remote1 0)
-          jackson (get-content state :remote2 0)]
+          jackson (get-content state :remote2 0)
+          sundew (get-content state :remote3 0)]
       (core/rez state :corp jeeves)
       (is (zero? (count (:discard (get-corp)))) "Nothing discarded to rez Jeeves - Hacktivist not active")
       (take-credits state :corp)
       (play-from-hand state :runner "Hacktivist Meeting")
       (core/rez state :corp jackson)
-      (is (= 1 (count (:discard (get-corp)))) "Card discarded to rez Jackson - Hacktivist active"))))
+      (is (= 1 (count (:discard (get-corp)))) "Card discarded to rez Jackson - Hacktivist active")
+      (core/rez state :corp sundew)
+      (is (not (core/rezzed? (refresh sundew))) "Sundew is not rezzed as corp has no cards in hand")
+      (is (= "Unable to pay for Sundew." (-> @state :corp :toast first :msg)) "Corp gets the correct toast"))))
 
 (deftest high-stakes-job
   ;; High Stakes Job - run on server with at least 1 piece of unrezzed ice, gains 12 credits if successful

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1299,7 +1299,25 @@
         (is (second-last-log-contains? state "increase the rez cost by 0 \\[Credit\\]") "Hernando Cortez use was logged")
         (core/rez state :corp next-silver)
         (is (= 7 (:credit (get-corp))) "Paid 3 to rez NEXT Silver")
-        (is (second-last-log-contains? state "increase the rez cost by 0 \\[Credit\\]") "Hernando Cortez use was logged")))))
+        (is (second-last-log-contains? state "increase the rez cost by 0 \\[Credit\\]") "Hernando Cortez use was logged"))))
+  (testing "interactions with non-rez abilities, such as Blue Sun. Issue #4000"
+    (do-game
+      (new-game {:corp {:id "Blue Sun: Powering the Future"
+                        :deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]
+                        :credits 15}
+                 :runner {:hand ["Hernando Cortez"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Hernando Cortez")
+      (let [iw (get-ice state :hq 0)
+            credits (:credit (get-corp))]
+        (core/rez state :corp iw)
+        (is (= (- credits 2) (:credit (get-corp))) "Corp should pay an addition 1 to rez Ice Wall")
+        (take-credits state :runner)
+        (card-ability state :corp (:identity (get-corp)) 0)
+        (click-card state :corp iw)
+        (is (= (dec credits) (:credit (get-corp))) "Corp should only gain 1 back when using Blue Sun's ability")))))
 
 (deftest ice-carver
   ;; Ice Carver - lower ice strength on encounter


### PR DESCRIPTION
This adds `rez-additional-cost-bonus`, which allows for adding additional costs to rezzing something, side-stepping the issue that plagued the Hernando Cortez/Blue Sun interaction: when we rely on `:pre-rez-cost` to determine rez cost, we have to be sure that none of our bonuses are actually additional costs.

Cards rewritten/refactored to better handle additional costs:
* Bribery
* Hacktivist Meeting
* Running Interference
* Blackguard
* Cortez Chip
* Blue Sun
* Hernando Cortez

Closes #1244 
Closes #1249
Closes #4000
Closes #4058