### PR TITLE
Only register card abilities when installing on faceup cards

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -176,7 +176,7 @@
                                        (in-hand? %))}
                   :req (req (and (pos? (count (:hand runner)))
                                  (:runner-phase-12 @state)))
-                  :effect (effect (runner-install target {:facedown true}))}]
+                  :effect (effect (runner-install eid target {:facedown true}))}]
      {:events {:runner-turn-begins ability}
       :flags {:runner-phase-12 (req true)}
       :abilities [ability]})

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -448,7 +448,8 @@
                          (when (and (not facedown) (has-subtype? c "Icebreaker"))
                            (update-breaker-strength state side c))
                          (trigger-event-simult state side eid :runner-install
-                                               {:card-ability (card-as-handler installed-card)}
+                                               (when-not facedown
+                                                 {:card-ability (card-as-handler installed-card)})
                                                installed-card))
                        (effect-completed state side eid))
                      (effect-completed state side eid)))

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -342,20 +342,30 @@
       (is (= 5 (:credit (get-corp))) "Palana does not gain credit from Andromeda's starting hand"))))
 
 (deftest apex-invasive-predator
-  ;; Apex - Allow facedown install of a second console. Issue #1326
-  (do-game
-    (new-game {:runner {:id "Apex: Invasive Predator"
-                        :deck [(qty "Heartbeat" 2)]}})
-    (take-credits state :corp)
-    (core/end-phase-12 state :runner nil)
-    (click-prompt state :runner "Done") ; no facedown install on turn 1
-    (play-from-hand state :runner "Heartbeat")
-    (is (= 1 (count (get-hardware state))))
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (core/end-phase-12 state :runner nil)
-    (click-card state :runner (find-card "Heartbeat" (:hand (get-runner))))
-    (is (= 1 (count (get-runner-facedown state))) "2nd console installed facedown")))
+  ;; Apex
+  (testing "Allow facedown install of a second console. Issue #1326"
+    (do-game
+      (new-game {:runner {:id "Apex: Invasive Predator"
+                          :deck [(qty "Heartbeat" 2)]}})
+      (take-credits state :corp)
+      (core/end-phase-12 state :runner nil)
+      (click-prompt state :runner "Done")
+      (play-from-hand state :runner "Heartbeat")
+      (is (= 1 (count (get-hardware state))))
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (core/end-phase-12 state :runner nil)
+      (click-card state :runner (find-card "Heartbeat" (:hand (get-runner))))
+      (is (= 1 (count (get-runner-facedown state))) "2nd console installed facedown")))
+  (testing "Don't fire events when installed facedown. Issue #4085"
+    (do-game
+      (new-game {:runner {:id "Apex: Invasive Predator"
+                          :deck ["Sure Gamble"]}})
+      (take-credits state :corp)
+      (core/end-phase-12 state :runner nil)
+      (let [credits (:credit (get-runner))]
+        (click-card state :runner "Sure Gamble")
+        (is (= credits (:credit (get-runner))))))))
 
 (deftest asa-group-security-through-vigilance
   (testing "Asa Group should not allow installing operations"


### PR DESCRIPTION
Missed when I tried to stop all `(card-def nil)` calls.

Fixes #4085