### PR TITLE
WIP: Make end-turn effects fire on both turns

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2015,7 +2015,7 @@
                                                           (fn [coll]
                                                             (remove-once #(= (:cid %) (:cid target)) coll)))
                                     {:cause :ability-cost})
-                             (runner-install state side (dissoc target :facedown))))}]}
+                             (runner-install state side eid (dissoc target :facedown) nil)))}]}
 
    "Symmetrical Visage"
    {:events {:runner-click-draw {:req (req (genetics-trigger? state side :runner-click-draw))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -113,7 +113,9 @@
                    deck-count (count (get-in @state [side :deck]))]
                (when (and (= side :corp) (> draws-after-prevent deck-count))
                  (win-decked state))
-               (when-not (and (= side active-player) (get-in @state [side :register :cannot-draw]))
+               (if (and (= side active-player)
+                        (get-in @state [side :register :cannot-draw]))
+                 (effect-completed state side eid)
                  (let [drawn (zone :hand (take draws-after-prevent (get-in @state [side :deck])))]
                    (swap! state update-in [side :hand] #(concat % drawn))
                    (swap! state update-in [side :deck] (partial drop draws-after-prevent))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -276,8 +276,10 @@
      (wait-for
        (trigger-event-sync state side (if (= side :runner) :runner-turn-ends :corp-turn-ends))
        (do (trigger-event state side (if (= side :runner) :post-runner-turn-ends :post-corp-turn-ends))
-           (doseq [a (get-in @state [side :register :end-turn])]
-             (resolve-ability state side (:ability a) (:card a) (:targets a)))
+           (doseq [side [:corp :runner]]
+             (doseq [a (get-in @state [side :register :end-turn])]
+               (resolve-ability state side (:eid a) (:ability a) (:card a) (:targets a)))
+             (swap! state dissoc-in [side :register :end-turn]))
            (swap! state assoc-in [side :register-last-turn] (-> @state side :register))
            (doseq [card (all-active-installed state :runner)]
              ;; Clear :installed :this-turn as turn has ended


### PR DESCRIPTION
This is a small change but potentially large: Now `:end-turn` effects in card defs will fire on whichever turn it's registered, not on the card side's next turn. Additionally, all of those effects are removed immediately after firing.

Fixes #4106