### PR TITLE
Blueberry Diesel should list multiples of a given card

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -122,6 +122,7 @@
    "Blueberry!™ Diesel"
    {:async true
     :prompt "Move a card to the bottom of the stack?"
+    :not-distinct true
     :choices (req (conj (vec (take 2 (:deck runner))) "No"))
     :effect (req (when-not (string? target)
                    (move state side target :deck))


### PR DESCRIPTION
Currently, Blueberry:tm: Diesel doesn't display duplicates. With this it now shows both cards even when they're the same.

Fixes #4132 