### PR TITLE
Clean up last-log-contains? failure reports

### DIFF
--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -328,42 +328,6 @@
    (dotimes [_ n]
      (core/advance state :corp {:card (core/get-card state card)}))))
 
-(defn last-log-contains?
-  [state content]
-  (some? (re-find (re-pattern content)
-                  (-> @state :log last :text))))
-
-(defn second-last-log-contains?
-  [state content]
-  (some? (re-find (re-pattern content)
-                  (-> @state :log butlast last :text))))
-
-(defmethod assert-expr 'last-log-contains?
-  [msg form]
-  `(let [state# ~(nth form 1)
-         content# ~(nth form 2)
-         log# (-> @state# :log last :text)
-         found# ~form]
-     (do-report
-       {:type (if found# :pass :fail)
-        :actual log#
-        :expected content#
-        :message ~msg})
-     found#))
-
-(defmethod assert-expr 'second-last-log-contains?
-  [msg form]
-  `(let [state# ~(nth form 1)
-         content# ~(nth form 2)
-         log# (-> @state# :log butlast last :text)
-         found# ~form]
-     (do-report
-       {:type (if found# :pass :fail)
-        :actual log#
-        :expected content#
-        :message ~msg})
-     found#))
-
 (defn trash-from-hand
   "Trash specified card from hand of specified side"
   [state side title]

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -338,6 +338,32 @@
   (some? (re-find (re-pattern content)
                   (-> @state :log butlast last :text))))
 
+(defmethod assert-expr 'last-log-contains?
+  [msg form]
+  `(let [state# ~(nth form 1)
+         content# ~(nth form 2)
+         log# (-> @state# :log last :text)
+         found# ~form]
+     (do-report
+       {:type (if found# :pass :fail)
+        :actual log#
+        :expected content#
+        :message ~msg})
+     found#))
+
+(defmethod assert-expr 'second-last-log-contains?
+  [msg form]
+  `(let [state# ~(nth form 1)
+         content# ~(nth form 2)
+         log# (-> @state# :log butlast last :text)
+         found# ~form]
+     (do-report
+       {:type (if found# :pass :fail)
+        :actual log#
+        :expected content#
+        :message ~msg})
+     found#))
+
 (defn trash-from-hand
   "Trash specified card from hand of specified side"
   [state side title]

--- a/test/clj/game_test/utils.clj
+++ b/test/clj/game_test/utils.clj
@@ -88,3 +88,40 @@
             (str (side-str side) " expected to click [ "
                  (if (string? choice) choice (:title choice ""))
                  " ] but couldn't find it. Current prompt is: \n" prompt))))))
+
+(defn last-log-contains?
+  [state content]
+  (some? (re-find (re-pattern content)
+                  (-> @state :log last :text))))
+
+(defn second-last-log-contains?
+  [state content]
+  (some? (re-find (re-pattern content)
+                  (-> @state :log butlast last :text))))
+
+(defmethod assert-expr 'last-log-contains?
+  [msg form]
+  `(let [state# ~(nth form 1)
+         content# ~(nth form 2)
+         log# (-> @state# :log last :text)
+         found# ~form]
+     (do-report
+       {:type (if found# :pass :fail)
+        :actual log#
+        :expected content#
+        :message ~msg})
+     found#))
+
+(defmethod assert-expr 'second-last-log-contains?
+  [msg form]
+  `(let [state# ~(nth form 1)
+         content# ~(nth form 2)
+         log# (-> @state# :log butlast last :text)
+         found# ~form]
+     (do-report
+       {:type (if found# :pass :fail)
+        :actual log#
+        :expected content#
+        :message ~msg})
+     found#))
+


### PR DESCRIPTION
Right now, when `last-log-contains?` and `second-last-log-contains?` fail, they print the full contents of `state` to the output because of the way the testing macro `is` works by default. To fix this issue, I've added two `assert-expr` methods which pivot off `last-log-contains?` and `second-last-log-contains?`, allowing for pretty-printing the failure and handling future issues.