### PR TITLE
Add prompt-is functions to assert-expr defmethod

### DIFF
--- a/test/clj/game_test/utils.clj
+++ b/test/clj/game_test/utils.clj
@@ -5,17 +5,15 @@
             [clojure.string :refer [lower-case split]]))
 
 ;;; helper functions for prompt interaction
-(defn assert-prompt [state side]
-  (let [prompt (-> @state side :prompt)]
-    (is (first prompt) (str "Expected an open " (side-str side) " prompt"))
-    (first (seq prompt))))
+(defn get-prompt [state side]
+  (-> @state side :prompt seq first))
 
 (defn prompt-is-type? [state side prompt-type]
-  (let [prompt (-> @state side :prompt first)]
+  (when-let [prompt (get-prompt state side)]
     (= prompt-type (:prompt-type prompt))))
 
 (defn prompt-is-card? [state side card]
-  (when-let [prompt (assert-prompt state side)]
+  (when-let [prompt (get-prompt state side)]
     (and (:cid card)
          (-> prompt :card :cid)
          (= (:cid card) (-> prompt :card :cid)))))
@@ -28,7 +26,7 @@
 (defn click-card
   "Resolves a 'select prompt' by clicking a card. Takes a card map or a card name."
   [state side card]
-  (let [prompt (assert-prompt state side)]
+  (when-let [prompt (get-prompt state side)]
     (cond
       ;; Card and prompt types are correct
       (and (prompt-is-type? state side :select)
@@ -63,31 +61,32 @@
 (defn click-prompt
   "Clicks a button in a prompt. {choice} is a string or map only, no numbers."
   [state side choice]
-  (let [prompt (assert-prompt state side)
+  (let [prompt (get-prompt state side)
         choices (:choices prompt)]
-    (cond
-      ;; Integer prompts
-      (or (= choices :credit)
-          (:counter choices)
-          (:number choices))
-      (when-not (core/resolve-prompt state side {:choice (Integer/parseInt choice)})
-        (is (number? (Integer/parseInt choice))
-            (expect-type "number string" choice)))
+    (when prompt
+      (cond
+        ;; Integer prompts
+        (or (= choices :credit)
+            (:counter choices)
+            (:number choices))
+        (when-not (core/resolve-prompt state side {:choice (Integer/parseInt choice)})
+          (is (number? (Integer/parseInt choice))
+              (expect-type "number string" choice)))
 
-      ;; List of card titles for auto-completion
-      (:card-title choices)
-      (when-not (core/resolve-prompt state side {:choice choice})
-        (is (or (map? choice)
-                (string? choice))
-            (expect-type "card string or map" choice)))
+        ;; List of card titles for auto-completion
+        (:card-title choices)
+        (when-not (core/resolve-prompt state side {:choice choice})
+          (is (or (map? choice)
+                  (string? choice))
+              (expect-type "card string or map" choice)))
 
-      ;; Default text prompt
-      :else
-      (when-not (core/resolve-prompt state side {(if (string? choice) :choice :card) choice})
-        (is (= choice (first choices))
-            (str (side-str side) " expected to click [ "
-                 (if (string? choice) choice (:title choice ""))
-                 " ] but couldn't find it. Current prompt is: \n" prompt))))))
+        ;; Default text prompt
+        :else
+        (when-not (core/resolve-prompt state side {(if (string? choice) :choice :card) choice})
+          (is (= choice (first choices))
+              (str (side-str side) " expected to click [ "
+                   (if (string? choice) choice (:title choice ""))
+                   " ] but couldn't find it. Current prompt is: \n" prompt)))))))
 
 (defn last-log-contains?
   [state content]
@@ -125,3 +124,30 @@
         :message ~msg})
      found#))
 
+(defmethod assert-expr 'prompt-is-type?
+  [msg form]
+  `(let [state# ~(nth form 1)
+         side# ~(nth form 2)
+         given-type# ~(nth form 3)
+         prompt-type# (-> @state# side# :prompt :prompt-type)
+         found# ~form]
+     (do-report
+       {:type (if found# :pass :fail)
+        :actual prompt-type#
+        :expected given-type#
+        :message ~msg})
+     found#))
+
+(defmethod assert-expr 'prompt-is-card?
+  [msg form]
+  `(let [state# ~(nth form 1)
+         side# ~(nth form 2)
+         card# ~(nth form 3)
+         prompt-card# (-> @state# side# :prompt :card)
+         found# ~form]
+     (do-report
+       {:type (if found# :pass :fail)
+        :actual prompt-card#
+        :expected card#
+        :message ~msg})
+     found#))


### PR DESCRIPTION
Based on the phenomenal cosmic power of #4136, I've applied the same technique to the two `prompt-is-X?` functions, rendering their errors much more readable.