### PR TITLE
Fix Personal Evolution/Employee Strike interaction, other stuff

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -458,25 +458,29 @@
    "Divested Trust"
    {:events
     {:agenda-stolen
-     {:interactive (req true)
-      :req (req (not (:winner @state)))
-      :effect (req (let [stolen-agenda target
-                         title (:title stolen-agenda)
-                         prompt (str "Forfeit Divested Trust to add " title
-                                     " to HQ and gain 5[Credits]?")
-                         message (str "add " title " to HQ and gain 5 [Credits]")]
-                     (show-wait-prompt state :runner "Corp to use Divested Trust")
-                     (continue-ability
-                       state side
-                       {:optional
-                        {:prompt prompt
-                         :yes-ability {:msg message
-                                       :effect (effect (forfeit card)
-                                                       (move stolen-agenda :hand)
-                                                       (gain-agenda-point :runner (- (:agendapoints stolen-agenda)))
-                                                       (gain-credits 5))}
-                         :end-effect (effect (clear-wait-prompt :runner))}}
-                       card nil)))}}}
+     {:async true
+      :interactive (req true)
+      :effect (req (if (:winner @state)
+                     (effect-completed state side eid)
+                     (let [stolen-agenda target
+                           title (:title stolen-agenda)
+                           prompt (str "Forfeit Divested Trust to add " title
+                                       " to HQ and gain 5[Credits]?")
+                           message (str "add " title " to HQ and gain 5 [Credits]")]
+                       (show-wait-prompt state :runner "Corp to use Divested Trust")
+                       (continue-ability
+                         state side
+                         {:optional
+                          {:prompt prompt
+                           :yes-ability
+                           {:msg message
+                            :effect (effect (forfeit card)
+                                            (move stolen-agenda :hand)
+                                            (gain-agenda-point :runner (- (:agendapoints stolen-agenda)))
+                                            (gain-credits 5)
+                                            (effect-completed eid))}
+                           :end-effect (effect (clear-wait-prompt :runner))}}
+                         card nil))))}}}
 
    "Domestic Sleepers"
    {:agendapoints-runner (req 0)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -937,7 +937,7 @@
    (let [nasol {:optional
                 {:prompt "Play a Current?"
                  :player :corp
-                 :req (req (some #(has-subtype? % "Current") (concat (:hand corp) (:discard corp))))
+                 :req (req (some #(has-subtype? % "Current") (concat (:hand corp) (:discard corp) (:current corp))))
                  :yes-ability {:prompt "Select a Current to play from HQ or Archives"
                                :show-discard true
                                :async true

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -540,28 +540,10 @@
                               card nil)))}}}
 
    "Enhanced Login Protocol"
-   (letfn [(elp-activated [state]
-             (get-in @state [:corp :register :elp-activated] false))
-           (add-effect [state side]
-             (swap! state assoc-in [:corp :register :elp-activated] true)
-             (click-run-cost-bonus state side [:click 1]))
-           (remove-effect [state side]
-             (click-run-cost-bonus state side [:click -1])
-             (swap! state update-in [:corp :register] dissoc :elp-activated))]
-     {:effect (req (when (and (= :runner (:active-player @state))
-                              (not (:made-click-run runner-reg)))
-                     (add-effect state side)
-                     (system-msg state side (str "uses Enhanced Login Protocol to add an additional cost of [Click]"
-                                                 " to make the first run not through a card ability this turn"))))
-      :events {:runner-turn-begins {:msg "add an additional cost of [Click] to make the first run not through a card ability this turn"
-                                    :effect (effect (add-effect))}
-               :runner-turn-ends {:req (req (elp-activated state))
-                                  :effect (effect (remove-effect))}
-               :run-ends {:req (req (and (elp-activated state)
-                                         (:made-click-run runner-reg)))
-                          :effect (effect (remove-effect))}}
-      :leave-play (req (when (elp-activated state)
-                         (remove-effect state side)))})
+   {:msg "uses Enhanced Login Protocol to add an additional cost of [Click] to make the first run not through a card ability this turn"
+    :events {:pre-init-run {:req (req (and (first-event? state side :pre-init-run #(= :click-run (second %)))
+                                           (= :click-run (second targets))))
+                            :effect (effect (run-additional-cost-bonus [:click 1]))}}}
 
    "Exchange of Information"
    {:req (req (and tagged
@@ -1674,26 +1656,9 @@
                    (move state :runner c :hand)))}
 
    "Service Outage"
-   (letfn [(so-activated [state]
-             (get-in @state [:corp :register :so-activated] false))
-           (add-effect [state side]
-             (swap! state assoc-in [:corp :register :so-activated] true)
-             (run-cost-bonus state side [:credit 1]))
-           (remove-effect [state side]
-             (run-cost-bonus state side [:credit -1])
-             (swap! state update-in [:corp :register] dissoc :so-activated))]
-     {:msg "add a cost of 1 [Credit] for the Runner to make the first run each turn"
-      :effect (req (when (and (= :runner (:active-player @state))
-                              (empty? (:made-run runner-reg)))
-                     (add-effect state side)))
-      :events {:runner-turn-begins {:msg "add an additional cost of 1 [Credit] to make the first run this turn"
-                                    :effect (effect (add-effect))}
-               :runner-turn-ends {:req (req (so-activated state))
-                                  :effect (effect (remove-effect))}
-               :run-ends {:req (req (so-activated state))
-                          :effect (effect (remove-effect))}}
-      :leave-play (req (when (so-activated state)
-                         (remove-effect state side)))})
+   {:msg "add a cost of 1 [Credit] for the Runner to make the first run each turn"
+    :events {:pre-init-run {:req (req (first-event? state side :pre-init-run))
+                            :effect (effect (run-additional-cost-bonus [:credit 1]))}}}
 
    "Shipment from Kaguya"
    {:choices {:max 2 :req can-be-advanced?}

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -265,7 +265,7 @@
   (let [cost (:cost ability)]
     (when (or (nil? cost)
               (if (has-subtype? card "Run")
-                (apply can-pay? state side (:title card) cost (get-in @state [:bonus :run-cost]))
+                (apply can-pay? state side (:title card) cost (run-costs state side card))
                 (apply can-pay? state side (:title card) cost)))
       (when-let [activatemsg (:activatemsg ability)]
         (system-msg state side activatemsg))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -367,18 +367,16 @@
         (+ (get-rez-cost-bonus state side))
         (max 0))))
 
-(defn run-cost-bonus [state side n]
-  (swap! state update-in [:bonus :run-cost] #(merge-costs (concat % n))))
-
-(defn click-run-cost-bonus [state side & n]
-  (swap! state update-in [:bonus :click-run-cost] #(merge-costs (concat % n))))
+(defn run-additional-cost-bonus
+  [state side & n]
+  (swap! state update-in [:bonus :run-cost :additional-cost] #(merge-costs (concat % n))))
 
 (defn run-costs
   "Get a list of all costs required to run a server, including additional costs. If card is :click-run, assume run is made by spending a click, and include the assumed click in the cost list."
   [state server card]
   (let [server (unknown->kw server)
-        click-run-cost (when (= card :click-run) (concat (get-in @state [:bonus :click-run-cost]) [:click 1]))
-        global-costs (get-in @state [:bonus :run-cost])
+        click-run-cost (when (= card :click-run) [:click 1])
+        global-costs (get-in @state [:bonus :run-cost :additional-cost])
         server-costs (get-in @state [:corp :servers server :additional-cost])]
     (merge-costs (concat click-run-cost global-costs server-costs))))
 

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -14,8 +14,9 @@
   ([state side server run-effect card] (make-run state side (make-eid state) server run-effect card nil))
   ([state side eid server run-effect card] (make-run state side eid server run-effect card nil))
   ([state side eid server run-effect card {:keys [ignore-costs] :as args}]
-   (wait-for (trigger-event-simult state :runner :pre-init-run nil server)
+   (wait-for (trigger-event-simult state :runner :pre-init-run nil server card)
              (let [all-run-costs (when-not ignore-costs (run-costs state server card))]
+               (swap! state update-in [:bonus] dissoc :run-cost)
                (if (and (can-run? state :runner)
                         (can-run-server? state server)
                         (can-pay? state :runner "a run" all-run-costs))

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1208,16 +1208,28 @@
       (is (= 3 (count (:deck (get-corp)))) "R&D ended with 3 cards"))))
 
 (deftest jinteki-personal-evolution
-  ;; Personal Evolution - Prevent runner from running on remotes unless they first run on a central
-  (do-game
-    (new-game {:corp {:id "Jinteki: Personal Evolution"
-                      :deck [(qty "Braintrust" 6)]}
-               :runner {:deck [(qty "Sure Gamble" 3)]}})
-    (play-from-hand state :corp "Braintrust" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state "Server 1")
-    (click-prompt state :runner "Steal")
-    (is (= 2 (count (:hand (get-runner)))) "Runner took 1 net damage from steal")))
+  ;; Personal Evolution - Take 1 net when an agenda is scored or stolen
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:id "Jinteki: Personal Evolution"
+                        :deck [(qty "Braintrust" 6)]}
+                 :runner {:hand [(qty "Sure Gamble" 3)]}})
+      (play-from-hand state :corp "Braintrust" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (click-prompt state :runner "Steal")
+      (is (= 2 (count (:hand (get-runner)))) "Runner took 1 net damage from steal")))
+  (testing "Interaction with Employee Striek. Issue #4124"
+    (do-game
+      (new-game {:corp {:id "Jinteki: Personal Evolution"
+                        :deck [(qty "Braintrust" 6)]}
+                 :runner {:hand ["Employee Strike" (qty "Sure Gamble" 3)]}})
+      (play-from-hand state :corp "Braintrust" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Employee Strike")
+      (run-empty-server state "Server 1")
+      (click-prompt state :runner "Steal")
+      (is (= 3 (count (:hand (get-runner)))) "Runner took 0 net damage from steal"))))
 
 (deftest jinteki-potential-unleashed
   ;; Potential Unleashed - when the runner takes at least one net damage, mill 1 from their deck
@@ -1249,7 +1261,7 @@
       (take-credits state :corp)
       (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
       (run-empty-server state "HQ")
-      (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")))
+      (is (core/can-run-server? state "Server 1") "Runner can run on remotes")))
   (testing "interaction with Employee Strike. Issue #1313 and #1956."
     (do-game
       (new-game {:corp {:id "Jinteki: Replicating Perfection"
@@ -1259,7 +1271,7 @@
       (take-credits state :corp)
       (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals")
       (play-from-hand state :runner "Employee Strike")
-      (is (boolean (core/can-run-server? state "Server 1")) "Runner can run on remotes")
+      (is (core/can-run-server? state "Server 1") "Runner can run on remotes")
       (play-from-hand state :runner "Scrubbed")
       (is (not (core/can-run-server? state "Server 1")) "Runner can only run on centrals"))))
 


### PR DESCRIPTION
My #4070 PR was a good step but moving reqs to after the `first-ability` firing was a bad idea as Employee Strike's effect should last until it's trashed, past when abilities are checked. I moved that back to where it should be, but that resulted in New Angeles Sol breaking again. I considered ripping the req from NAS out, as it shouldn't necessary check before firing, but it's more work than necessary so instead I've just expanded it to look for an existing Corp current as well.

I also changed the req on Divested Trust to look for the winner after it's fired, instead of in the req, because the req will check before the agenda is moved into either score area.

I also rewrote run-cost bonus generating and Enhanced Login Protocol/Service Outage, so instead of applying a bonus during a turn, it only applies the bonus at the start of a run, which is automatically cleared out by `make-run`.

Fixes #4124