### PR TITLE
Fix SDS program selection (steal and score)

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1239,7 +1239,7 @@
    "SDS Drone Deployment"
    {:steal-cost-bonus (req [:program 1])
     :effect (req (show-wait-prompt state :runner "Corp to use SDS Drone Deployment")
-                 (if (seq (get-in @state [:runner :rig :program]))
+                 (if (seq (all-installed-runner-type state :program))
                    (continue-ability
                      state side
                      {:prompt "Select a program to trash"

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -2,7 +2,7 @@
 
 (declare forfeit prompt! toast damage mill installed? is-type? is-scored? system-msg
          facedown? make-result unknown->kw discard-from-hand card-str trash trash-cards
-         complete-with-result)
+         complete-with-result all-installed-runner-type)
 
 (defn deduct
   "Deduct the value from the player's attribute."
@@ -59,9 +59,9 @@
                (and (= cost-type :discard) (<= 0 (- (count (get-in @state [side :hand])) amount)))
                (and (= cost-type :tag) (<= 0 (- (get-in @state [:runner :tag :base]) amount)))
                (and (= cost-type :ice) (<= 0 (- (count (filter (every-pred rezzed? ice?) (all-installed state :corp))) amount)))
-               (and (= cost-type :hardware) (<= 0 (- (count (get-in @state [:runner :rig :hardware])) amount)))
-               (and (= cost-type :program) (<= 0 (- (count (get-in @state [:runner :rig :program])) amount)))
-               (and (= cost-type :resource) (<= 0 (- (count (get-in @state [:runner :rig :resource])) amount)))
+               (and (= cost-type :hardware) (<= 0 (- (count (all-installed-runner-type state :hardware)) amount)))
+               (and (= cost-type :program) (<= 0 (- (count (all-installed-runner-type state :program)) amount)))
+               (and (= cost-type :resource) (<= 0 (- (count (all-installed-runner-type state :resource)) amount)))
                (and (= cost-type :connection)
                     (<= 0 (- (count (filter #(has-subtype? % "Connection") (all-active-installed state :runner))) amount)))
                (and (= cost-type :shuffle-installed-to-stack) (<= 0 (- (count (all-installed state :runner)) amount)))

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -131,6 +131,11 @@
   [state]
   (concat (all-installed state :corp) (all-installed state :runner)))
 
+(defn all-installed-runner-type
+  "Returns a list of all installed, non-facedown runner cards of the requested type."
+  [state card-type]
+  (filter (every-pred #(is-type? % card-type) (complement facedown?)) (all-installed state :runner)))
+
 (defn number-of-virus-counters
   "Returns number of actual virus counters (excluding virtual counters from Hivemind)"
   [state]


### PR DESCRIPTION
Closes #4147 (which was the bug on score). Also fixes a bug on steal, where trash would not happen, if all installed programs were hosted on other cards.

Closes #4140