### PR TITLE
Remove unused arguments from effect-completed functions

### DIFF
--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -304,11 +304,11 @@
 
 ;;; Effect completion triggers
 (defn register-effect-completed
-  [state side eid card effect]
-  (swap! state update-in [:effect-completed (:eid eid)] #(conj % {:card card :effect effect})))
+  [state side eid effect]
+  (swap! state update-in [:effect-completed (:eid eid)] #(conj % effect)))
 
 (defn effect-completed
   [state side eid]
   (doseq [handler (get-in @state [:effect-completed (:eid eid)])]
-    ((:effect handler) state side eid nil nil))
+    (handler state side eid))
   (swap! state update-in [:effect-completed] dissoc (:eid eid)))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -85,7 +85,7 @@
 
 (defmacro wait-for
   ([action & expr]
-   (let [reqmac `(fn [state# side# eid# card# target#]
+   (let [reqmac `(fn [state# side# eid#]
                    (let [~'async-result (:result eid#)]
                      ~@expr))
    ;; this creates a five-argument function to be resolved later,
@@ -94,7 +94,7 @@
          th (nth action totake)]
      `(let [~'use-eid# (and (map? ~th) (:eid ~th))
             ~'new-eid# (if ~'use-eid# ~th (game.core/make-eid ~'state))]
-        (~'register-effect-completed ~'state ~'side ~'new-eid# ~(when (resolve 'card) ~'card) ~reqmac)
+        (~'register-effect-completed ~'state ~'side ~'new-eid# ~reqmac)
         (if ~'use-eid#
           ~(concat (take totake action) (list 'new-eid#) (drop (inc totake) action))
           ~(concat (take totake action) (list 'new-eid#) (drop totake action)))))))


### PR DESCRIPTION
After a discussion on slack with @ouroboros8 and @nealterrell, I thought I'd try this out, see what's possible.

Not necessarily the best way to go about this, but as a proof of concept, this is perfectly functional!