### PR TITLE
Block single player games

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -251,6 +251,7 @@
             (.println *err* (with-out-str
                               (clojure.stacktrace/print-stack-trace
                                 (Exception. "Error in a text prompt") 25)))
+            (.println *err* (str "Current choice: " choice))
             (.println *err* (str "Current prompt: " prompt))))))))
 
 (defn select

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -77,6 +77,7 @@
     client-id                           :client-id}]
   (when-let [{:keys [players gameid started] :as game} (lobby/game-for-client client-id)]
     (when (and (lobby/first-player? client-id gameid)
+               (= 2 (count players))
                (not started))
       (let [strip-deck (fn [player] (-> player
                                         (update-in [:deck] #(select-keys % [:_id :identity]))


### PR DESCRIPTION
Currently starting a game with only one player throws an error when we attempt to find the non-existent player's identity.