### PR TITLE
Fix button-pane incorrect assumption about data being passed in

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1229,7 +1229,7 @@
                [:div.start-hand
                 [:div {:class (when squeeze "squeeze")}
                  (doall (map-indexed
-                          (fn [i {title :title :as card}]
+                          (fn [i {:keys [title] :as card}]
                             [:div.start-card-frame {:style (when squeeze {:left     (* (/ 610 (dec (count @my-hand))) i)
                                                                           :position "absolute"})
                                                     :id    (str "startcard" i)
@@ -1241,10 +1241,9 @@
                                (when-let [url (image-url card)]
                                  [:div {:on-mouse-enter #(put! zoom-channel card)
                                         :on-mouse-leave #(put! zoom-channel false)}
-                                  [:img.start-card {:src url :alt title :onError #(-> % .-target js/$ .hide)}]
-                                  ])]]
-                             (js/setTimeout (fn [] (.add (.-classList (.querySelector js/document (str "#startcard" i))) "flip"))
-                                            (+ 1000 (* i 300)))])
+                                  [:img.start-card {:src url :alt title :onError #(-> % .-target js/$ .hide)}]])]]
+                             (when-let [elem (.querySelector js/document (str "#startcard" i))]
+                               (js/setTimeout #(.add (.-classList elem) "flip") (+ 1000 (* i 300))))])
                           @my-hand))]])
              [:div.mulligan
               (if (or (= :spectator @my-side) (and @my-keep @op-keep))

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1381,6 +1381,7 @@
                  [:button {:on-click #(send-command "choice"
                                                     {:choice (-> "#credit" js/$ .val str->int)})}
                   "OK"]])
+
               ;; otherwise choice of all present choices
               :else
               (map-indexed (fn [i c]
@@ -1389,7 +1390,7 @@
                                  [:button {:key i
                                            :on-click #(send-command "choice" {:choice c})}
                                   (render-message c)]
-                                 [:button {:key (:cid c)
+                                 [:button {:key (or (:cid c) i)
                                            :class (when (:rotated c) :rotated)
                                            :on-click #(send-command "choice" {:card c}) :id {:code c}} (:title c)])))
                            (:choices prompt))))]


### PR DESCRIPTION
Reported by @tolaasin, Rebirth was throwing an ugly React error in the console. Turns out, Rebirth didn't pass in card objects with `:cid` entries, so our `:key` logic failed.