### PR TITLE
Add "implementation" notes to power-level errata'd cards

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1232,7 +1232,8 @@
                            " into R&D")
                  :effect (req (doseq [c targets]
                                 (move state side c :deck))
-                              (shuffle! state side :deck))}]}
+                              (shuffle! state side :deck))}]
+    :implementation "Errata from FAQ 3.1: should be unique"}
 
    "Nanoetching Matrix"
    {:events {:runner-trash {:req (req (= (:cid card) (:cid target)))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2424,7 +2424,8 @@
 
    "Wireless Net Pavilion"
    {:effect (effect (trash-resource-bonus -2))
-    :leave-play (effect (trash-resource-bonus 2))}
+    :leave-play (effect (trash-resource-bonus 2))
+    :implementation "Errata from FAQ 3.0.1: should be unique"}
 
    "Woman in the Red Dress"
    (let [ability {:msg (msg "reveal " (:title (first (:deck corp))) " on the top of R&D")


### PR DESCRIPTION
Astroscript is excluded as the image used already has "Limit 1 per deck"
added.

Fixes #4225