### PR TITLE
Fix Pelangi to allow choosing existing subtype

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1787,12 +1787,12 @@
                  :label "Make currently encountered ice gain a subtype"
                  :prompt "Choose an ICE subtype"
                  :choices (req (->> (server-cards)
-                                    (filter ice?)
-                                    (map :subtype)
-                                    (mapcat #(split % #" - "))
-                                    distinct
-                                    sort
-                                    (remove (->> current-ice :subtype (#(split % #" - ")) set))))
+                                    (reduce (fn [acc card]
+                                              (if (ice? card)
+                                                (apply conj acc (split (:subtype card) #" - "))
+                                                acc))
+                                            #{})
+                                    sort))
                  :msg (msg "make " (card-str state current-ice) " gain " target)
                  :effect (req (let [ice current-ice
                                     chosen-type target


### PR DESCRIPTION
I don't know exactly why #4227 is happening, but it is and I don't like it so here's a fix. This changes the list generation to be about twice as fast (single pass reduce with `conj` into a set), and it doesn't remove existing subtypes.