### PR TITLE
Fix ETR effects marking successful runs as unsuccessful

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -865,12 +865,15 @@
 (defn- resolve-end-run
   "End this run, and set it as UNSUCCESSFUL"
   ([state side eid]
-   (let [run (:run @state)
-         server (first (get-in @state [:run :server]))]
-     (swap! state update-in [:runner :register :unsuccessful-run] #(conj % server))
-     (swap! state assoc-in [:run :unsuccessful] true)
-     (handle-end-run state side)
-     (trigger-event-sync state side eid :unsuccessful-run run))))
+   (if (get-in @state [:run :successful])
+     (do (handle-end-run state side)
+         (effect-completed state side eid))
+     (let [run (:run @state)
+           server (first (get-in @state [:run :server]))]
+       (swap! state update-in [:runner :register :unsuccessful-run] #(conj % server))
+       (swap! state assoc-in [:run :unsuccessful] true)
+       (handle-end-run state side)
+       (trigger-event-sync state side eid :unsuccessful-run run)))))
 
 (defn end-run
   "After checking for prevents, end this run, and set it as UNSUCCESSFUL."

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -823,28 +823,48 @@
 
 (deftest giordano-memorial-field
   ;; Giordano Memorial Field
-  (do-game
-    (new-game {:corp {:deck ["Giordano Memorial Field" "Hostile Takeover"]}
-               :runner {:deck [(qty "Fan Site" 3)]}})
-    (play-from-hand state :corp "Giordano Memorial Field" "New remote")
-    (core/rez state :corp (get-content state :remote1 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Fan Site")
-    (play-from-hand state :runner "Fan Site")
-    (play-from-hand state :runner "Fan Site")
-    (take-credits state :runner)
-    (play-and-score state "Hostile Takeover")
-    (take-credits state :corp)
-    (run-empty-server state "Server 1")
-    (let [credits (:credit (get-runner))]
-      (click-prompt state :runner "Pay 6 [Credits]")
-      (is (= (- credits 6) (:credit (get-runner))) "Runner pays 6 credits to not end the run"))
-    (click-prompt state :runner "No action")
-    (run-empty-server state "Server 1")
-    (is (= 1 (-> (get-runner) :prompt first :choices count)) "Runner should only get 1 choice")
-    (is (= "End the run" (-> (get-runner) :prompt first :choices first)) "Only choice should be End the run")
-    (click-prompt state :runner "End the run")
-    (is (not (:run @state)) "Run should be ended from Giordano Memorial Field ability")))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck ["Giordano Memorial Field" "Hostile Takeover"]}
+                 :runner {:deck [(qty "Fan Site" 3)]}})
+      (play-from-hand state :corp "Giordano Memorial Field" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Fan Site")
+      (play-from-hand state :runner "Fan Site")
+      (play-from-hand state :runner "Fan Site")
+      (take-credits state :runner)
+      (play-and-score state "Hostile Takeover")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (let [credits (:credit (get-runner))]
+        (click-prompt state :runner "Pay 6 [Credits]")
+        (is (= (- credits 6) (:credit (get-runner))) "Runner pays 6 credits to not end the run"))
+      (click-prompt state :runner "No action")
+      (run-empty-server state "Server 1")
+      (is (= 1 (-> (get-runner) :prompt first :choices count)) "Runner should only get 1 choice")
+      (is (= "End the run" (-> (get-runner) :prompt first :choices first)) "Only choice should be End the run")
+      (click-prompt state :runner "End the run")
+      (is (not (:run @state)) "Run should be ended from Giordano Memorial Field ability")))
+  (testing "Ending the run doesn't mark the run as unsuccessful. Issue #4223"
+    (do-game
+      (new-game {:corp {:hand ["Giordano Memorial Field" "Hostile Takeover"]}
+                 :runner {:hand [(qty "Fan Site" 2) "John Masanori"]
+                          :credit 10}})
+      (play-from-hand state :corp "Giordano Memorial Field" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "John Masanori")
+      (play-from-hand state :runner "Fan Site")
+      (play-from-hand state :runner "Fan Site")
+      (take-credits state :runner)
+      (play-and-score state "Hostile Takeover")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (is (zero? (count-tags state)))
+      (let [credits (:credit (get-runner))]
+        (click-prompt state :runner "End the run")
+        (is (zero? (count-tags state)) "Don't gain a tag from John Masanori")))))
 
 (deftest helheim-servers
   ;; Helheim Servers - Full test


### PR DESCRIPTION
Cards like Giordano can end the run after a run is considered `Successful`. This shouldn't mean that the run is now also considered `unsuccessful`, so the fix is to add a conditional in `resolve-end-run` to handle this.

Fixes #4223 