### PR TITLE
Clean up Director Haas Pet Project and agenda scoring messaging

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -449,9 +449,10 @@
                                                (install-ability (last (get-remote-names state)) (inc n))
                                                card nil)
                              (effect-completed state side eid)))
-              :msg (msg (if (pos? n)
-                          (corp-install-msg target)
-                          "create a new remote server, installing cards from HQ or Archives, ignoring all install costs"))})]
+              :msg (msg (corp-install-msg target)
+                        (when (zero? n)
+                          ", creating a new remote server")
+                        ", ignoring all install costs")})]
      {:optional {:prompt "Install cards in a new remote server?"
                  :yes-ability (install-ability "New remote" 0)}})
 

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -529,6 +529,7 @@
                        c (card-init state :corp moved-card {:resolve-effect false
                                                             :init-data true})
                        points (get-agenda-points state :corp c)]
+                   (system-msg state :corp (str "scores " (:title c) " and gains " (quantify points "agenda point")))
                    (trigger-event-simult state :corp eid :agenda-scored
                                          {:first-ability {:effect (req (when-let [current (first (get-in @state [:runner :current]))]
                                                                          ;; TODO: Make this use remove-old-current
@@ -541,8 +542,6 @@
                                           :after-active-player {:effect (req (let [c (get-card state c)
                                                                                    points (or (get-agenda-points state :corp c) points)]
                                                                                (set-prop state :corp (get-card state moved-card) :advance-counter 0)
-                                                                               (system-msg state :corp (str "scores " (:title c) " and gains "
-                                                                                                            (quantify points "agenda point")))
                                                                                (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
                                                                                (swap! state dissoc-in [:corp :disable-id])
                                                                                (gain-agenda-point state :corp points)

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -346,7 +346,7 @@
           nil)))))
 
 (defn corp-install-msg
-  "Gets a message describing where a card has been installed from. Example: Interns. "
+  "Gets a message describing where a card has been installed from. Example: Interns."
   [card]
   (str "install " (if (:seen card) (:title card) "an unseen card") " from " (name-zone :corp (:zone card))))
 

--- a/test/clj/game_test/cards/agendas.clj
+++ b/test/clj/game_test/cards/agendas.clj
@@ -650,18 +650,16 @@
 (deftest director-haas-pet-project
   ;; Director Haas' Pet Project
   (do-game
-    (new-game {:corp {:deck ["Director Haas' Pet Project"
-                             "Adonis Campaign"
-                             "Strongbox"
-                             "Eli 1.0"
-                             (qty "Hedge Fund" 5)]}})
-    (starting-hand state :corp ["Director Haas' Pet Project" "Adonis Campaign" "Strongbox"])
-    (core/move state :corp (find-card "Eli 1.0" (:deck (get-corp))) :discard)
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Strongbox"
+                             "Director Haas' Pet Project"
+                             "Adonis Campaign"]
+                      :discard ["Eli 1.0"]}})
     (play-and-score state "Director Haas' Pet Project")
     (click-prompt state :corp "Yes")
-    (click-card state :corp (find-card "Adonis Campaign" (:hand (get-corp))))
-    (click-card state :corp (find-card "Strongbox" (:hand (get-corp))))
-    (click-card state :corp (find-card "Eli 1.0" (:discard (get-corp))))))
+    (click-card state :corp "Adonis Campaign")
+    (click-card state :corp "Strongbox")
+    (click-card state :corp "Eli 1.0")))
 
 (deftest divested-trust
   ;; Divested Trust


### PR DESCRIPTION
I moved the "Corp scores X" message to before the trigger event, because it should really be printed before anything else happens. We can tweak it later if need be.

Fixes #4232