### PR TITLE
Naive reset card per turn when card moves between zones

### DIFF
--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -2,7 +2,7 @@
 
 (declare active? all-installed all-active-installed cards card-init deactivate
          card-flag? gain lose get-card-hosted handle-end-run hardware? ice? is-type?
-         make-eid program? register-events remove-from-host remove-icon reset-card
+         make-eid program? register-events remove-from-host remove-icon make-card
          resource? rezzed? toast toast-check-mu trash trigger-event
          update-breaker-strength update-hosted! update-ice-strength unregister-events
          use-mu)
@@ -152,6 +152,12 @@
                      moved-card)]
     moved-card))
 
+(defn reset-card
+  "Resets a card back to its original state - retaining any data in the :persistent key"
+  ([state side {:keys [title cid persistent]}]
+   (swap! state update-in [:per-turn] dissoc cid)
+   (update! state side (assoc (make-card (server-card title) cid) :persistent persistent))))
+
 (defn move
   "Moves the given card to the given new zone."
   ([state side card to] (move state side card to nil))
@@ -190,7 +196,7 @@
              (move-zone-fn state side (make-eid state) moved-card card))
            (trigger-event state side :card-moved card (assoc moved-card :move-to-side side))
            ;; Default a card when moved to inactive zones (except :persistent key)
-           (when (#{:discard :hand :deck :rfg} to)
+           (when (#{:discard :hand :deck :rfg :scored} to)
              (reset-card state side moved-card)
              (when-let [icon-card (get-in moved-card [:icon :card])]
                ;; Remove icon and icon-card keys

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -404,7 +404,6 @@
    (if card
      (let [cdef (card-def card)
            moved-card (move state (to-keyword (:side card)) card :discard {:keep-server-alive keep-server-alive})]
-       (swap! state update-in [:per-turn] dissoc (:cid moved-card))
        (swap! state update-in [:trash :trash-list] dissoc oid)
        (if-let [trash-effect (:trash-effect cdef)]
          (if (and (not disabled)

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -129,11 +129,6 @@
       (assoc :cid cid :implementation (card-implemented card))
       (dissoc :setname :text :_id :influence :number :influencelimit :factioncost))))
 
-(defn reset-card
-  "Resets a card back to its original state - retaining any data in the :persistent key"
-  ([state side {:keys [title cid persistent]}]
-   (update! state side (assoc (make-card (server-card title) cid) :persistent persistent))))
-
 (defn create-deck
   "Creates a shuffled draw deck (R&D/Stack) from the given list of cards.
   Loads card data from the server-card map if available."

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2774,7 +2774,26 @@
         (click-card state :runner "Gordian Blade")
         (is (= (- credits (- cost (quot cost 2))) (:credit (get-runner))) "Runner should only pay half for Gordian Blade"))
       (take-credits state :runner)
-      (is (= "Gordian Blade" (:title (get-program state 0))) "Kabonesa Wu shouldn't rfg card bounced and reinstalled with Rejig"))))
+      (is (= "Gordian Blade" (:title (get-program state 0))) "Kabonesa Wu shouldn't rfg card bounced and reinstalled with Rejig")))
+  (testing "Uninstalling and reinstalling should allow once per turn effects again. Issue #4217"
+    (do-game
+      (new-game {:options {:start-as :runner}
+                 :corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["Rejig" "Stargate"]
+                          :credits 100}})
+      (play-from-hand state :runner "Stargate")
+      (let [stargate (get-program state 0)]
+        (card-ability state :runner stargate 0)
+        (run-successful state)
+        (click-prompt state :runner "Hedge Fund")
+        (play-from-hand state :runner "Rejig")
+        (click-card state :runner "Stargate")
+        (click-card state :runner "Stargate"))
+      (let [stargate (get-program state 0)]
+        (card-ability state :runner stargate 0)
+        (run-successful state)
+        (click-prompt state :runner "Hedge Fund")))))
 
 (deftest reshape
   ;; Reshape - Swap 2 pieces of unrezzed ICE


### PR DESCRIPTION
The reason Scavenge worked is cuz `trash` was dissoc'ing the cid of the trashed card from `:once :per-turn`. Move that into `reset-card` so it happens whenever any card is moved to a non-remote server zone, and we're golden.

Fixes #4217 