### PR TITLE
Fix CtM to only fire when the first Corp card is trashed

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -894,8 +894,9 @@
    "NBN: Controlling the Message"
    {:events {:runner-trash
              {:async true
-              :req (req (and (= 1 (count (filter #(-> % first installed?) (turn-events state side :runner-trash))))
-                             (card-is? target :side :corp)
+              :req (req (and (= 1 (count (filter #(and (installed? (first %)) (corp? (first %)))
+                                                 (turn-events state side :runner-trash))))
+                             (corp? target)
                              (installed? target)))
               :effect (req (show-wait-prompt state :runner "Corp to use NBN: Controlling the Message")
                            (continue-ability

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -603,7 +603,9 @@
                                             {:runner-turn-ends install-prompt}
                                             (assoc card :zone [:discard]))))]
      {:data {:counter {:credit 3}}
-      :flags {:drip-economy true}
+      :flags {:drip-economy true
+              :runner-turn-draw (req (= 1 (get-counters (get-card state card) :credit)))
+              :runner-phase-12 (req (= 1 (get-counters (get-card state card) :credit)))}
       :abilities [ability]
       :move-zone heap-event
       :events {:runner-turn-begins ability

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1715,7 +1715,31 @@
       (click-prompt state :runner "Pay 2 [Credits] to trash")
       (is (empty? (:prompt (get-corp))) "CtM shouldn't fire")
       (is (empty? (:prompt (get-runner))) "Runner shouldn't have prompt")
-      (is (zero? (count-tags state)) "Runner took 1 unpreventable tag"))))
+      (is (zero? (count-tags state)) "Runner took 1 unpreventable tag")))
+ (testing "Trace should fire on first trash of a Corp card after a Runner card is trashed"
+    (do-game
+      (new-game {:corp {:id "NBN: Controlling the Message"
+                        :deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Launch Campaign" 3)]}
+                 :runner {:deck ["Sure Gamble"]
+                          :hand ["Crowdfunding"]}})
+      (play-from-hand state :corp "Launch Campaign" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Crowdfunding")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (is (zero? (count (:hand (get-runner)))))
+      (core/end-phase-12 state :runner nil)
+      (is (zero? (count (get-resource state))))
+      (is (= 1 (count (:hand (get-runner)))))
+      (run-empty-server state "Server 1")
+      (click-prompt state :runner "Pay 2 [Credits] to trash")
+      (is (seq (:prompt (get-corp))) "Corp should have a Trace prompt")
+      (click-prompt state :corp "No"))))
 
 (deftest new-angeles-sol-your-news
   ;; New Angeles Sol - interaction with runner stealing agendas

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -569,22 +569,15 @@
         (is (empty? (:discard (get-runner))) "No cards in discard")
         (take-credits state :runner)
         (take-credits state :corp)
+        (core/end-phase-12 state :runner nil)
         (is (= 19 (:credit (get-runner))))
         (is (empty? (:deck (get-runner))) "No cards in deck")
         (is (= 1 (count (:hand (get-runner)))) "1 card in hand")
         (is (= 1 (count (:discard (get-runner)))) "1 card in discard")
-        (is (nil? (get-resource state 0)) "Crowdfunding not installed")
-        (run-empty-server state :archives)
-        (run-empty-server state :archives)
-        (run-empty-server state :archives)
-        (take-credits state :runner)
-        (click-prompt state :runner "Yes")
-        (is (empty? (:discard (get-runner))) "Crowdfunding not in discard")
-        (is (= 1 (count (get-resource state))) "Crowdfunding reinstalled"))))
+        (is (nil? (get-resource state 0)) "Crowdfunding not installed"))))
   (testing "Install from heap"
     (do-game
-      (new-game {:runner {:deck ["Crowdfunding"]}})
-      (core/move state :runner (find-card "Crowdfunding" (:hand (get-runner))) :discard)
+      (new-game {:runner {:discard ["Crowdfunding"]}})
       (take-credits state :corp)
       (take-credits state :runner)
       (is (empty? (:prompt (get-runner))) "No install prompt if no runs")
@@ -602,8 +595,7 @@
     (do-game
       (new-game {:corp {:hand ["Scarcity of Resources"]
                         :deck [(qty "Hedge Fund" 5)]}
-                 :runner {:deck ["Crowdfunding"]}})
-      (core/move state :runner (find-card "Crowdfunding" (:hand (get-runner))) :discard)
+                 :runner {:discard ["Crowdfunding"]}})
       (play-from-hand state :corp "Scarcity of Resources")
       (take-credits state :corp)
       (run-empty-server state :archives)
@@ -617,8 +609,7 @@
       (do-game
         (new-game {:corp {:hand ["Ice Wall"]
                           :deck [(qty "Hedge Fund" 5)]}
-                   :runner {:deck ["Crowdfunding"]}})
-        (core/move state :runner (find-card "Crowdfunding" (:hand (get-runner))) :discard)
+                   :runner {:discard ["Crowdfunding"]}})
         (play-from-hand state :corp "Ice Wall" "HQ")
         (take-credits state :corp)
         (let [iw (get-ice state :hq 0)]

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -137,9 +137,14 @@
         (when-let [hand (seq (:hand side-map))]
           (starting-hand state side hand))
         (when (seq (:discard side-map))
-          (doseq [card (:discard side-map)]
+          (doseq [ctitle (:discard side-map)]
             (core/move state side
-                       (find-card card (get-in @state [side :deck])) :discard)))
+                       (or (find-card ctitle (get-in @state [side :deck]))
+                           ;; This is necessary as a :discard card will only end up in
+                           ;; the hand when we're not already using (starting-hand)
+                           (when (empty? (:hand side-map))
+                             (find-card ctitle (get-in @state [side :hand]))))
+                       :discard)))
         (when (:credits side-map)
           (swap! state assoc-in [side :credit] (:credits side-map)))))
     ;; These are side independent so they happen ouside the loop


### PR DESCRIPTION
Also make Crowdfunding pay attention to runner-phase-12 when it's down to 1 counter, pausing for ordered usage as necessary.

Also fix subtle bug with `:discard` vector in tests.