### PR TITLE
Refactor cards to use card property utilities

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -39,7 +39,7 @@
              (if (pos? i)
                {:async true
                 :prompt "Select a piece of ICE from the Temporary Zone to install"
-                :choices {:req #(and (= (:side %) "Corp")
+                :choices {:req #(and (corp? %)
                                      (ice? %)
                                      (= (:zone %) [:play-area]))}
                 :effect (req (wait-for (corp-install state side target nil
@@ -440,7 +440,7 @@
    (letfn [(install-ability [server-name n]
              {:prompt "Select a card to install"
               :show-discard true
-              :choices {:req #(and (= (:side %) "Corp")
+              :choices {:req #(and (corp? %)
                                    (not (operation? %))
                                    (#{[:hand] [:discard]} (:zone %)))}
               :effect (req (corp-install state side target server-name {:ignore-all-cost true})
@@ -654,7 +654,7 @@
                                      (is-scored? state :corp card)))}
     :abilities [{:prompt "Select a card to add to the bottom of R&D"
                  :show-discard true
-                 :choices {:req #(and (= (:side %) "Corp")
+                 :choices {:req #(and (corp? %)
                                       (= (:zone %) [:discard]))}
                  :effect (effect (move target :deck))
                  :msg (msg "add "
@@ -789,7 +789,7 @@
     :show-discard true
     :choices {:req #(and (#{"Asset" "Upgrade"} (:type %))
                          (#{[:hand] [:discard]} (:zone %))
-                         (= (:side %) "Corp"))}
+                         (corp? %))}
     :msg (msg "install and rez " (:title target) ", ignoring all costs")
     :effect (effect (corp-install eid target nil {:install-state :rezzed-no-cost}))}
 
@@ -887,7 +887,7 @@
                :yes-ability {:prompt "Select a card to install"
                              :choices {:req #(and (not (operation? %))
                                                   (not (ice? %))
-                                                  (= (:side %) "Corp")
+                                                  (corp? %)
                                                   (in-hand? %))}
                              :msg (msg "install a card from HQ"
                                        (when (>= (get-counters (get-card state card) :advancement) 5)
@@ -993,7 +993,7 @@
                         {:prompt (msg "Select " (trash-count-str card) " installed cards to trash")
                          :choices {:max (min (- (get-counters card :advancement) 4)
                                              (count (all-installed state :runner)))
-                                   :req #(and (= (:side %) "Runner")
+                                   :req #(and (runner? %)
                                               (:installed %))}
                          :effect (effect (trash-cards targets)
                                          (system-msg (str "trashes " (join ", " (map :title targets))))
@@ -1036,7 +1036,7 @@
                  :prompt "Choose a card in Archives to add to HQ"
                  :show-discard true
                  :choices {:req #(and (in-discard? %)
-                                      (= (:side %) "Corp"))}
+                                      (corp? %))}
                  :req (req (pos? (get-counters card :agenda)))
                  :msg (msg "add "
                            (if (:seen target)
@@ -1063,7 +1063,7 @@
            (choose-swap [to-swap]
              {:prompt (str "Select a card in HQ to swap with " (:title to-swap))
               :choices {:not-self true
-                        :req #(and (= "Corp" (:side %))
+                        :req #(and (corp? %)
                                    (in-hand? %)
                                    (if (ice? to-swap)
                                      (ice? %)
@@ -1355,7 +1355,7 @@
    (letfn [(sft [n max] {:prompt "Select a card in HQ to install with Successful Field Test"
                          :priority -1
                          :async true
-                         :choices {:req #(and (= (:side %) "Corp")
+                         :choices {:req #(and (corp? %)
                                               (not (operation? %))
                                               (in-hand? %))}
                          :effect (req (wait-for

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -994,7 +994,7 @@
                          :choices {:max (min (- (get-counters card :advancement) 4)
                                              (count (all-installed state :runner)))
                                    :req #(and (runner? %)
-                                              (:installed %))}
+                                              (installed? %))}
                          :effect (effect (trash-cards targets)
                                          (system-msg (str "trashes " (join ", " (map :title targets))))
                                          (gain-bad-publicity :corp 1))}

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -41,7 +41,7 @@
                 :prompt "Select a piece of ICE from the Temporary Zone to install"
                 :choices {:req #(and (corp? %)
                                      (ice? %)
-                                     (= (:zone %) [:play-area]))}
+                                     (in-play-area? %))}
                 :effect (req (wait-for (corp-install state side target nil
                                                      {:ignore-all-cost true :install-state :rezzed-no-cost})
                                        (let [card (get-card state card)]
@@ -655,7 +655,7 @@
     :abilities [{:prompt "Select a card to add to the bottom of R&D"
                  :show-discard true
                  :choices {:req #(and (corp? %)
-                                      (= (:zone %) [:discard]))}
+                                      (in-discard? %))}
                  :effect (effect (move target :deck))
                  :msg (msg "add "
                            (if (:seen target)

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -108,7 +108,7 @@
    "AR-Enhanced Security"
    {:events {:runner-trash {:once :per-turn
                             :async true
-                            :req (req (some #(card-is? % :side :corp) targets))
+                            :req (req (some corp? targets))
                             :msg "give the Runner a tag for trashing a Corp card"
                             :effect (effect (gain-tags eid 1))}}}
 
@@ -411,7 +411,7 @@
                              (continue-ability
                                state :corp
                                {:prompt (msg "Select " (access-count state side :hq-access) " cards in HQ for the Runner to access")
-                                :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
+                                :choices {:req #(and (in-hand? %) (corp? %))
                                           :max (req (access-count state side :hq-access))}
                                 :effect (effect (clear-wait-prompt :runner)
                                                 (continue-ability

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -429,7 +429,7 @@
                                                   state side
                                                   {:prompt "Move to where?"
                                                    :choices {:req #(and (ice? %)
-                                                                        (not= (:cid from-ice) (:cid %))
+                                                                        (not (same-card? from-ice %))
                                                                         (can-be-advanced? %))}
                                                    :effect (effect (add-prop :corp target :advance-counter 1)
                                                                    (add-prop :corp from-ice :advance-counter -1)
@@ -528,7 +528,7 @@
                                          {:prompt (str "Select " (quantify dbs "card") " to add to the bottom of R&D")
                                           :msg (msg "add " (quantify dbs "card") " to the bottom of R&D")
                                           :choices {:max dbs
-                                                    :req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
+                                                    :req #(some (fn [c] (same-card? c %)) drawn)}
                                           :effect (req (doseq [c targets]
                                                          (move state side c :deck)))}
                                          card targets)
@@ -1241,7 +1241,7 @@
     :implementation "Errata from FAQ 3.1: should be unique"}
 
    "Nanoetching Matrix"
-   {:events {:runner-trash {:req (req (= (:cid card) (:cid target)))
+   {:events {:runner-trash {:req (req (same-card? card target))
                             :effect (effect (show-wait-prompt :runner "Corp to use Nanoetching Matrix")
                                             (continue-ability
                                               :corp
@@ -1554,7 +1554,7 @@
                                 (resolve-ability
                                   state side
                                   {:prompt "Choose a card in HQ that you just drew to swap for a card of the same type in Archives"
-                                   :choices {:req #(some (fn [c] (= (:cid c) (:cid %))) drawn)}
+                                   :choices {:req #(some (fn [c] (same-card? c %)) drawn)}
                                    :effect (req (let [hqcard target
                                                       t (:type hqcard)]
                                                   (resolve-ability
@@ -1572,7 +1572,7 @@
                                                                     (reveal state side hqcard)
                                                                     (swap! state assoc-in [:corp :discard] newarch)
                                                                     (swap! state update-in [:corp :hand]
-                                                                           (fn [coll] (remove-once #(= (:cid %) (:cid hqcard)) coll)))
+                                                                           (fn [coll] (remove-once #(same-card? % hqcard) coll)))
                                                                     (move state side target :hand)))}
                                                    card nil)))}
                                  card nil)))}]}
@@ -2001,7 +2001,7 @@
 
    "The Board"
    (let [the-board {:req (req (and (= :runner (:as-agenda-side target))
-                                   (not= (:cid target) (:cid card))))
+                                   (not (same-card? target card))))
                     :effect (effect (lose :runner :agenda-point 1))}]
      {:effect (effect (lose :runner :agenda-point (count (:scored runner))))
       :leave-play (effect (gain :runner :agenda-point (count (:scored runner))))
@@ -2054,7 +2054,7 @@
                                           state side
                                           {:effect (req (swap! state assoc-in (cons :corp (:zone card)) newcont)
                                                         (swap! state update-in [:corp :hand]
-                                                               (fn [coll] (remove-once #(= (:cid %) (:cid newcard)) coll)))
+                                                               (fn [coll] (remove-once #(same-card? % newcard) coll)))
                                                         (trigger-event state side :corp-install newcard)
                                                         (move state side card :hand))} card nil)
                                         (resolve-prompt state :runner {:choice "No action"})

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -151,7 +151,7 @@
                          :yes-ability {:trace {:base (effect (advancement-cost agenda))
                                                :successful
                                                {:choices {:req #(and (installed? %)
-                                                                     (card-is? % :side :runner))}
+                                                                     (runner? %))}
                                                 :label "add an installed card to the Grip"
                                                 :msg (msg "add " (:title target) " to the Runner's Grip")
                                                 :effect (effect (move :runner target :hand true))}}}}})]
@@ -820,15 +820,15 @@
 
    "Hostile Infrastructure"
    {:events {:runner-trash {:async true
-                            :req (req (some #(card-is? % :side :corp) targets))
-                            :msg (msg (str "do " (count (filter #(card-is? % :side :corp) targets))
+                            :req (req (some corp? targets))
+                            :msg (msg (str "do " (count (filter corp? targets))
                                            " net damage"))
                             :effect (req (letfn [(do-damage [t]
                                                    (if-not (empty? t)
                                                      (wait-for (damage state side :net 1 {:card card})
                                                                (do-damage (rest t)))
                                                      (effect-completed state side eid)))]
-                                           (do-damage (filter #(card-is? % :side :corp) targets))))}}
+                                           (do-damage (filter corp? targets))))}}
     :abilities [{:msg "do 1 net damage"
                  :async true
                  :effect (effect (damage eid :net 1 {:card card}))}]}
@@ -1218,7 +1218,7 @@
                                 (str "Select "
                                      (if (> mus 1) "a card " (str mus " cards "))
                                      "in Archives to shuffle into R&D")))
-                 :choices {:req #(and (card-is? % :side :corp)
+                 :choices {:req #(and (corp? %)
                                       (= (:zone %) [:discard]))
                            :max (req (count (filter #(and (= "10019" (:code %))
                                                           (rezzed? %))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -77,7 +77,7 @@
                  :choices {:req #(and (not (operation? %))
                                       (not (agenda? %))
                                       (= (:zone %) [:hand])
-                                      (= (:side %) "Corp"))}
+                                      (corp? %))}
                  :msg (msg (corp-install-msg target))
                  :effect (req (wait-for (trash state side card {:cause :ability-cost})
                                         (corp-install state side eid target nil nil)))}]}
@@ -229,7 +229,7 @@
                  :prompt "Select a card in HQ to install"
                  :choices {:req #(and (not (operation? %))
                                       (in-hand? %)
-                                      (= (:side %) "Corp"))}
+                                      (corp? %))}
                  :effect (effect (trash card {:cause :ability-cost})
                                  (corp-install target nil))
                  :msg (msg (corp-install-msg target))}]}
@@ -747,7 +747,7 @@
                  :prompt "Select an asset or agenda to install"
                  :choices {:req #(and (or (asset? %) (agenda? %))
                                       (in-hand? %)
-                                      (= (:side %) "Corp"))}
+                                      (corp? %))}
                  :msg "install and host an asset or agenda"
                  :effect (req (corp-install state side target card))}
                 {:label "Install a previously-installed asset or agenda on Full Immersion RecStudio (fixes only)"
@@ -755,7 +755,7 @@
                  :prompt "Select an installed asset or agenda to host on Full Immersion RecStudio"
                  :choices {:req #(and (or (asset? %) (agenda? %))
                                       (installed? %)
-                                      (= (:side %) "Corp"))}
+                                      (corp? %))}
                  :msg "install and host an asset or agenda"
                  :effect (req (host state side card target))}]}
 
@@ -1066,7 +1066,7 @@
      {:effect (effect (update! (assoc card :malia-target target))
                       (disable-card :runner target))
       :msg (msg (str "blank the text box of " (card-str state target)))
-      :choices {:req #(and (= "Runner" (:side %))
+      :choices {:req #(and (runner? %)
                            (installed? %)
                            (resource? %)
                            (not (has-subtype? % "Virtual")))}
@@ -1309,7 +1309,7 @@
                                         :player :corp
                                         :cost [:credit 3]
                                         :choices {:req #(and (installed? %)
-                                                             (= (:side %) "Runner"))
+                                                             (runner? %))
                                                   :max cnt}
                                         :msg (msg "shuffle " (join ", " (map :title targets)) " into the stack")
                                         :effect (req (doseq [c targets]
@@ -1359,7 +1359,7 @@
                                 {:prompt "Choose a card in HQ to put on top of R&D"
                                  :async true
                                  :choices {:req #(and (in-hand? %)
-                                                      (= (:side %) "Corp"))}
+                                                      (corp? %))}
                                  :msg "add 1 card from HQ to the top of R&D"
                                  :effect (effect (move target :deck {:front true})
                                                  (effect-completed eid))}
@@ -1561,7 +1561,7 @@
                                                     state side
                                                     {:show-discard true
                                                      :prompt (msg "Choose an " t " in Archives to reveal and swap into HQ for " (:title hqcard))
-                                                     :choices {:req #(and (= (:side %) "Corp")
+                                                     :choices {:req #(and (corp? %)
                                                                           (= (:type %) t)
                                                                           (= (:zone %) [:discard]))}
                                                      :msg (msg "lose [Click], reveal " (:title hqcard) " from HQ, and swap it for " (:title target) " from Archives")
@@ -1736,7 +1736,7 @@
                  :effect (effect (draw 3)
                                  (resolve-ability
                                    {:prompt "Select a card in HQ to add to the bottom of R&D"
-                                    :choices {:req #(and (= (:side %) "Corp")
+                                    :choices {:req #(and (corp? %)
                                                          (in-hand? %))}
                                     :msg "add 1 card from HQ to the bottom of R&D"
                                     :effect (effect (move target :deck))}
@@ -1929,7 +1929,7 @@
                              :interactive (req true)
                              :async true
                              :choices {:req #(and (not (operation? %))
-                                                  (= (:side %) "Corp")
+                                                  (corp? %)
                                                   (#{[:hand] [:discard]} (:zone %)))}
                              :msg (msg (corp-install-msg target))
                              :effect (effect (corp-install eid target nil {:ignore-install-cost true}))}}}
@@ -2136,14 +2136,14 @@
                  :effect (req (show-wait-prompt state :runner "Corp to use Whampoa Reclamation")
                               (wait-for (resolve-ability state side
                                                          {:prompt "Choose a card in HQ to trash"
-                                                          :choices {:req #(and (in-hand? %) (= (:side %) "Corp"))}
+                                                          :choices {:req #(and (in-hand? %) (corp? %))}
                                                           :effect (effect (trash target))}
                                                          card nil)
                                         (continue-ability
                                           state side
                                           {:prompt "Select a card in Archives to add to the bottom of R&D"
                                            :show-discard true
-                                           :choices {:req #(and (in-discard? %) (= (:side %) "Corp"))}
+                                           :choices {:req #(and (in-discard? %) (corp? %))}
                                            :msg (msg "trash 1 card from HQ and add "
                                                      (if (:seen target) (:title target) "a card") " from Archives to the bottom of R&D")
                                            :effect (effect (move target :deck)
@@ -2157,7 +2157,7 @@
                  :prompt "Select an asset to install on Worlds Plaza"
                  :choices {:req #(and (asset? %)
                                       (in-hand? %)
-                                      (= (:side %) "Corp"))}
+                                      (corp? %))}
                  :msg (msg "host " (:title target))
                  :effect (req (corp-install state side target card) ;; install target onto card
                               (rez-cost-bonus state side -2)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -76,7 +76,7 @@
                  :req (req (not (:run @state)))
                  :choices {:req #(and (not (operation? %))
                                       (not (agenda? %))
-                                      (= (:zone %) [:hand])
+                                      (in-hand? %)
                                       (corp? %))}
                  :msg (msg (corp-install-msg target))
                  :effect (req (wait-for (trash state side card {:cause :ability-cost})
@@ -356,7 +356,7 @@
                                     :once :per-turn
                                     :show-discard true
                                     :choices {:req #(and (operation? %)
-                                                         (= (:zone %) [:discard]))}
+                                                         (in-discard? %))}
                                     :msg (msg "add "
                                               (if (:seen target)
                                                 (:title target)
@@ -1219,7 +1219,7 @@
                                      (if (> mus 1) "a card " (str mus " cards "))
                                      "in Archives to shuffle into R&D")))
                  :choices {:req #(and (corp? %)
-                                      (= (:zone %) [:discard]))
+                                      (in-discard? %))
                            :max (req (count (filter #(and (= "10019" (:code %))
                                                           (rezzed? %))
                                                     (all-installed state :corp))))}
@@ -1563,7 +1563,7 @@
                                                      :prompt (msg "Choose an " t " in Archives to reveal and swap into HQ for " (:title hqcard))
                                                      :choices {:req #(and (corp? %)
                                                                           (= (:type %) t)
-                                                                          (= (:zone %) [:discard]))}
+                                                                          (in-discard? %))}
                                                      :msg (msg "lose [Click], reveal " (:title hqcard) " from HQ, and swap it for " (:title target) " from Archives")
                                                      :effect (req (let [swappedcard (assoc hqcard :zone [:discard])
                                                                         archndx (ice-index state target)

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -308,7 +308,7 @@
 
    "Cold Read"
    (let [end-effect {:prompt "Choose a program that was used during the run to trash "
-                     :choices {:req #(card-is? % :type "Program")}
+                     :choices {:req program?}
                      :msg (msg "trash " (:title target))
                      :effect (effect (trash target {:unpreventable true}))}]
      {:async true
@@ -1201,7 +1201,7 @@
                                  state :corp
                                  {:async true
                                   :prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
-                                  :choices {:req #(and (in-hand? %) (card-is? % :side :corp))
+                                  :choices {:req #(and (in-hand? %) (corp? %))
                                             :max (req (dec (count (:hand corp))))}
                                   :effect (effect (clear-wait-prompt :runner)
                                                   (show-wait-prompt :corp "Runner to select a pile")
@@ -1889,7 +1889,7 @@
    (run-event)
 
    "Rejig"
-   (let [valid-target? (fn [card] (and (card-is? card :side :runner)
+   (let [valid-target? (fn [card] (and (runner? card)
                                        (or (program? card)
                                            (hardware? card))))
          pick-up {:async true
@@ -2000,8 +2000,8 @@
 
    "Rumor Mill"
    (letfn [(eligible? [card] (and (:uniqueness card)
-                                  (or (card-is? card :type "Asset")
-                                      (card-is? card :type "Upgrade"))
+                                  (or (asset? card)
+                                      (upgrade? card))
                                   (not (has-subtype? card "Region"))))
            (rumor [state] (filter eligible? (concat (all-installed state :corp)
                                                     (get-in @state [:corp :hand])

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -252,7 +252,7 @@
                                      (assoc card :zone '(:discard)))
                     (register-turn-flag! card :can-rez
                                          (fn [state side card]
-                                           (if (= (:cid card) (:cid target))
+                                           (if (same-card? card target)
                                              ((constantly false)
                                                (toast state :corp "Cannot rez the rest of this turn due to Careful Planning"))
                                              true))))}
@@ -943,7 +943,7 @@
                                                    {:effect (effect (update! (assoc card :shuffle-occurred true)))}}
                                                   (assoc card :zone '(:discard)))
                                  (install-cost-bonus state side [:credit -5])
-                                 (let [to-trash (remove #(= (:cid %) (:cid target)) topten)]
+                                 (let [to-trash (remove #(same-card? % target) topten)]
                                    (wait-for (runner-install state side target nil)
                                              (let [card (get-card state (assoc card :zone '(:discard)))]
                                                (if (not (:shuffle-occurred card))
@@ -1877,7 +1877,7 @@
                    {:prompt "Choose up to five cards to install"
                     :show-discard true
                     :choices {:max 5
-                              :req #(and (in-discard? %) (runner? %) (not= (:cid %) (:cid card)))}
+                              :req #(and (in-discard? %) (runner? %) (not (same-card? % card)))}
                     :mandatory true
                     :async true
                     :cancel-effect (req (move state side (find-latest state card) :rfg)
@@ -2210,7 +2210,7 @@
                                                (run-flag? state side (second targets) :system-seizure))
                                           (not (get-in @state [:per-turn (:cid card)]))))
                             :effect (req (update! state side (update-in (second targets) [:pump :all-run] (fnil #(+ % (first targets)) 0)))
-                                         (register-run-flag! state side card :system-seizure (fn [_ _ c] (= (:cid c) (:cid (second targets)))))
+                                         (register-run-flag! state side card :system-seizure (fn [_ _ c] (same-card? c (second targets))))
                                          (update-breaker-strength state side (second targets))
                                          (swap! state assoc-in [:per-turn (:cid card)] targets))}}
     :move-zone (req (when (= [:discard] (:zone card))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -363,7 +363,7 @@
                    state side
                    {:msg (msg "place 3 virus tokens on " (:title target))
                     :choices {:req #(and (installed? %)
-                                         (= (:side %) "Runner")
+                                         (runner? %)
                                          (zero? (get-virus-counters state %)))}
                     :effect (req (add-counter state :runner target :virus 3))}
                    card nil))}
@@ -983,7 +983,7 @@
                       :prompt (msg "Select 5 cards from Archives to add to HQ")
                       :choices {:max 5
                                 :all true
-                                :req #(and (= (:side %) "Corp")
+                                :req #(and (corp? %)
                                            (= (:zone %) [:discard]))}
                       :msg (msg "move "
                                 (let [seen (filter :seen targets)
@@ -1090,8 +1090,8 @@
               :req (req (and (= target :archives)
                              ;; don't prompt unless there's at least 1 rezzed ICE matching one in Archives
                              (not-empty (clojure.set/intersection
-                                          (into #{} (map :title (filter #(ice? %) (:discard corp))))
-                                          (into #{} (map :title (filter #(rezzed? %) (all-installed state :corp))))))))
+                                          (into #{} (map :title (filter ice? (:discard corp))))
+                                          (into #{} (map :title (filter rezzed? (all-installed state :corp))))))))
               :effect (req (continue-ability
                              state side
                              {:async true
@@ -1135,7 +1135,7 @@
       :prompt "Choose up to 5 installed cards to trash with Independent Thinking"
       :choices {:max 5
                 :req #(and (installed? %)
-                        (= (:side %) "Runner"))}
+                        (runner? %))}
       :effect (req (wait-for (trash-cards state side targets nil)
                              (draw state :runner eid (cards-to-draw targets) nil)))
       :msg (msg "trash " (join ", " (map :title targets)) " and draw " (quantify (cards-to-draw targets) "card"))})
@@ -1373,7 +1373,7 @@
                         :choices {:max heap-count
                                   :all true
                                   :not-self true
-                                  :req #(and (= (:side %) "Runner")
+                                  :req #(and (runner? %)
                                              (in-discard? %))}
                         :effect (req (doseq [c targets]
                                        (move state side c :deck))
@@ -1877,7 +1877,7 @@
                    {:prompt "Choose up to five cards to install"
                     :show-discard true
                     :choices {:max 5
-                              :req #(and (in-discard? %) (= (:side %) "Runner") (not= (:cid %) (:cid card)))}
+                              :req #(and (in-discard? %) (runner? %) (not= (:cid %) (:cid card)))}
                     :mandatory true
                     :async true
                     :cancel-effect (req (move state side (find-latest state card) :rfg)
@@ -1984,7 +1984,7 @@
                                   :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
                                   :choices {:max (min n heap)
                                             :all true
-                                            :req #(and (= (:side %) "Runner")
+                                            :req #(and (runner? %)
                                                        (in-discard? %))}
                                   :effect (req (doseq [c targets]
                                                  (move state side c :hand))
@@ -2146,7 +2146,7 @@
    "Spot the Prey"
    {:prompt "Select 1 non-ICE card to expose"
     :msg "expose 1 card and make a run"
-    :choices {:req #(and (installed? %) (not (ice? %)) (= (:side %) "Corp"))}
+    :choices {:req #(and (installed? %) (not (ice? %)) (corp? %))}
     :async true
     :effect (req (wait-for (expose state side target)
                            (continue-ability
@@ -2191,7 +2191,7 @@
                                         state :corp
                                         {:prompt "Choose 2 cards to discard"
                                          :choices {:max 2
-                                                   :req #(and (in-hand? %) (= (:side %) "Corp"))}
+                                                   :req #(and (in-hand? %) (corp? %))}
                                          :effect (effect (trash-cards :corp targets)
                                                          (clear-wait-prompt state :runner)
                                                          (system-msg :corp "discards 2 cards from SYN Attack"))}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -984,7 +984,7 @@
                       :choices {:max 5
                                 :all true
                                 :req #(and (corp? %)
-                                           (= (:zone %) [:discard]))}
+                                           (in-discard? %))}
                       :msg (msg "move "
                                 (let [seen (filter :seen targets)
                                       m (count  (remove :seen targets))]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -611,7 +611,7 @@
     :interactions {:prevent [{:type #{:net :brain :meat}
                               :req (req true)}]}
     :abilities [{:msg (msg "prevent 1 damage, trashing a facedown " (:title target))
-                 :choices {:req #(and (runner? %) (:installed %))}
+                 :choices {:req #(and (runner? %) (installed? %))}
                  :priority 50
                  :effect (effect (trash target {:unpreventable true})
                                  (damage-prevent :brain 1)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -71,7 +71,7 @@
 
    "Autoscripter"
    {:events {:runner-install {:silent (req true)
-                              :req (req (and (is-type? target "Program")
+                              :req (req (and (program? target)
                                              ;; only trigger on Runner's turn
                                              (= (:active-player @state) :runner)
                                              ;; only trigger when playing a Program from grip
@@ -80,7 +80,7 @@
                                              ;; which translates to just one case of playing a Program in turn-events
                                              (first-event? state :runner :runner-install
                                                            (fn [[card _]] (and (some #{:hand} (:previous-zone card))
-                                                                               (is-type? card "Program"))))))
+                                                                               (program? card))))))
                               :msg "gain [Click]"
                               :effect (effect (gain :click 1))}
              :unsuccessful-run {:effect (effect (trash card)
@@ -211,7 +211,7 @@
                  :show-discard true
                  :req (req (and (not (seq (get-in @state [:runner :locked :discard])))
                                 (not (install-locked? state side))))
-                 :choices {:req #(and (is-type? % "Program")
+                 :choices {:req #(and (program? %)
                                       (= (:zone %) [:discard]))}
                  :effect (req (when (>= (:credit runner) (:cost target))
                                 (runner-install state side target)
@@ -226,7 +226,7 @@
                                        (update! state side (assoc card :comet-event true)))}}
     :abilities [{:req (req (:comet-event card))
                  :prompt "Select an Event in your Grip to play"
-                 :choices {:req #(and (is-type? % "Event")
+                 :choices {:req #(and (event? %)
                                       (in-hand? %))}
                  :msg (msg "play " (:title target))
                  :effect (effect (play-instant target)
@@ -479,14 +479,14 @@
                    :req (req (empty? (:hosted card)))
                    :cost [:click 1]
                    :prompt "Select a program in your Grip to install on Flame-out"
-                   :choices {:req #(and (is-type? % "Program")
+                   :choices {:req #(and (program? %)
                                         (in-hand? %))}
                    :effect (effect (runner-install target {:host-card card})
                                    (update! (assoc-in (get-card state card) [:special :flame-out] (:cid target))))}
                   {:label "Host an installed program on Flame-out"
                    :req (req (empty? (:hosted card)))
                    :prompt "Select an installed program to host on Flame-out"
-                   :choices {:req #(and (is-type? % "Program")
+                   :choices {:req #(and (program? %)
                                         (installed? %))}
                    :msg (msg "host " (:title target))
                    :effect (req (->> target
@@ -656,7 +656,7 @@
                          :yes-ability {:prompt "Select an installed virus program for Knobkierie to add a virus counter to"
                                        :choices {:req #(and (installed? %)
                                                             (has-subtype? % "Virus")
-                                                            (is-type? % "Program"))}
+                                                            (program? %))}
                                        :msg (msg "place 1 virus counter on " (:title target))
                                        :effect (effect (add-counter target :virus 1))}}}}
     :abilities [(set-autoresolve :auto-add "Knobkierie")]}
@@ -830,7 +830,7 @@
 
    "Monolith"
    (let [mhelper (fn mh [n] {:prompt "Select a program to install"
-                             :choices {:req #(and (is-type? % "Program")
+                             :choices {:req #(and (program? %)
                                                   (in-hand? %))}
                              :effect (req (install-cost-bonus state side [:credit -4])
                                           (runner-install state side target nil)
@@ -842,7 +842,7 @@
       :effect (effect (resolve-ability (mhelper 1) card nil))
       :abilities [{:msg (msg "prevent 1 brain or net damage by trashing " (:title target))
                    :priority 50
-                   :choices {:req #(and (is-type? % "Program")
+                   :choices {:req #(and (program? %)
                                         (in-hand? %))}
                    :prompt "Choose a program to trash from your Grip"
                    :effect (effect (trash target)
@@ -870,7 +870,7 @@
                                   state side
                                   {:cost [:click 1]
                                    :prompt "Select a program in your Grip to install on NetChip"
-                                   :choices {:req #(and (is-type? % "Program")
+                                   :choices {:req #(and (program? %)
                                                         (runner-can-install? state side % false)
                                                         (<= (:memoryunits %) n)
                                                         (in-hand? %))}
@@ -886,7 +886,7 @@
                                 (resolve-ability
                                   state side
                                   {:prompt "Select an installed program to host on NetChip"
-                                   :choices {:req #(and (is-type? % "Program")
+                                   :choices {:req #(and (program? %)
                                                         (<= (:memoryunits %) n)
                                                         (installed? %))}
                                    :msg (msg "host " (:title target))
@@ -924,7 +924,7 @@
                  :req (req (empty? (:hosted card)))
                  :cost [:click 1]
                  :prompt "Select a program of 1[Memory Unit] or less to install on Omni-drive from your grip"
-                 :choices {:req #(and (is-type? % "Program")
+                 :choices {:req #(and (program? %)
                                       (<= (:memoryunits %) 1)
                                       (in-hand? %))}
                  :msg (msg "host " (:title target))
@@ -932,7 +932,7 @@
                                  (update! (assoc (get-card state card) :Omnidrive-prog (:cid target))))}
                 {:label "Host an installed program of 1[Memory Unit] or less on Omni-drive"
                  :prompt "Select an installed program of 1[Memory Unit] or less to host on Omni-drive"
-                 :choices {:req #(and (is-type? % "Program")
+                 :choices {:req #(and (program? %)
                                       (<= (:memoryunits %) 1)
                                       (installed? %))}
                  :msg (msg "host " (:title target))
@@ -1181,7 +1181,7 @@
 
    "Replicator"
    (letfn [(hardware-and-in-deck? [target runner]
-             (and (is-type? target "Hardware")
+             (and (hardware? target)
                   (some #(= (:title %) (:title target)) (:deck runner))))]
      {:events {:runner-install
                {:interactive (req (hardware-and-in-deck? target runner))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -32,7 +32,7 @@
    {:implementation "Click Adjusted Matrix to use ability."
     :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
     :prompt "Choose Icebreaker on which to install Adjusted Matrix"
-    :choices {:req #(and (= (:side %) "Runner") (has-subtype? % "Icebreaker") (installed? %))}
+    :choices {:req #(and (runner? %) (has-subtype? % "Icebreaker") (installed? %))}
     :msg (msg "host it on " (card-str state target))
     :effect (effect (update! (assoc target :subtype (combine-subtypes false (-> target :subtype) "AI")))
                     (host (get-card state target) (get-card state card)))
@@ -121,7 +121,7 @@
    {:abilities [{:label "Host up to 3 cards from your Grip facedown"
                  :cost [:click 1] :msg "host up to 3 cards from their Grip facedown"
                  :choices {:max 3
-                           :req #(and (= (:side %) "Runner")
+                           :req #(and (runner? %)
                                       (in-hand? %))}
                  :effect (req (doseq [c targets]
                                 (host state side (get-card state card) c {:facedown true})))}
@@ -166,7 +166,7 @@
                                   state side
                                   {:prompt "Select any number of cards to trash from your Grip"
                                    :choices {:max handsize
-                                             :req #(and (= (:side %) "Runner")
+                                             :req #(and (runner? %)
                                                         (in-hand? %))}
                                    :effect (req (let [trashed (count targets)
                                                       remaining (- handsize trashed)]
@@ -611,7 +611,7 @@
     :interactions {:prevent [{:type #{:net :brain :meat}
                               :req (req true)}]}
     :abilities [{:msg (msg "prevent 1 damage, trashing a facedown " (:title target))
-                 :choices {:req #(and (= (:side %) "Runner") (:installed %))}
+                 :choices {:req #(and (runner? %) (:installed %))}
                  :priority 50
                  :effect (effect (trash target {:unpreventable true})
                                  (damage-prevent :brain 1)
@@ -994,7 +994,7 @@
                                {:prompt (str "Trash a card to lower the " cost-type " cost of " (:title playing) " by 2 [Credits].")
                                 :priority 2
                                 :choices {:req #(and (in-hand? %)
-                                                     (= "Runner" (:side %))
+                                                     (runner? %)
                                                      (not (same-card? % playing)))}
                                 :msg (msg "trash " (:title target) " to lower the " cost-type " cost of "
                                           (:title playing) " by 2 [Credits]")
@@ -1433,7 +1433,7 @@
                                   :choices {:max dmg
                                             :all true
                                             :req #(and (in-hand? %)
-                                                       (= (:side %) "Runner"))}
+                                                       (runner? %))}
                                   :msg (msg "trash " (join ", " (map :title targets)))
                                   :effect (req (clear-wait-prompt state :corp)
                                                (doseq [c targets]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -212,7 +212,7 @@
                  :req (req (and (not (seq (get-in @state [:runner :locked :discard])))
                                 (not (install-locked? state side))))
                  :choices {:req #(and (program? %)
-                                      (= (:zone %) [:discard]))}
+                                      (in-discard? %))}
                  :effect (req (when (>= (:credit runner) (:cost target))
                                 (runner-install state side target)
                                 (trash state side card {:cause :ability-cost})

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -315,7 +315,7 @@
    {:in-play [:memory 1]
     :events {:pre-trash {:effect (effect (trash-cost-bonus -1))}
              :runner-trash {:once :per-turn
-                            :req (req (card-is? target :side :corp))
+                            :req (req (corp? target))
                             :msg "gain 1 [Credits]"
                             :effect (effect (gain-credits 1))}}}
 
@@ -557,8 +557,8 @@
       :effect (effect (toast "Tip: You can toggle automatically adding virus counters by clicking Friday Chip."))
       :events {:runner-turn-begins ability
                :runner-trash {:async true
-                              :req (req (some #(card-is? % :side :corp) targets))
-                              :effect (req (let [amt-trashed (count (filter #(card-is? % :side :corp) targets))
+                              :req (req (some corp? targets))
+                              :effect (req (let [amt-trashed (count (filter corp? targets))
                                                  sing-ab {:optional {:prompt "Place a virus counter on Friday Chip?"
                                                                      :autoresolve (get-autoresolve :auto-accept)
                                                                      :yes-ability {:effect (effect (system-msg
@@ -705,7 +705,7 @@
    "Lucky Charm"
    {:interactions {:prevent [{:type #{:end-run}
                               :req (req (and (some #{:hq} (:successful-run runner-reg))
-                                             (card-is? (:card-cause target) :side :corp)))}]}
+                                             (corp? (:card-cause target))))}]}
     :abilities [{:msg "prevent the run from ending"
                  :req (req (some #{:hq} (:successful-run runner-reg)))
                  :effect (effect (end-run-prevent)
@@ -718,7 +718,7 @@
                  :async true
                  :effect (effect (draw :runner eid 1 nil))}]
     :events {:runner-trash {:once :per-turn
-                            :req (req (and (card-is? target :side :corp)
+                            :req (req (and (corp? target)
                                            (:access @state)
                                            (:trash target)))
                             :effect (effect (system-msg (str "places " (:trash target) " power counters on Mâché"))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -349,7 +349,7 @@
                    :priority true
                    :choices {:req #(and (not (operation? %))
                                         (#{[:hand] [:discard]} (:zone %))
-                                        (= (:side %) "Corp"))}
+                                        (corp? %))}
                    :effect (effect (corp-install target nil))
                    :msg (msg (corp-install-msg target))}]}
 
@@ -698,7 +698,7 @@
                    :priority true
                    :choices {:req #(and (not (operation? %))
                                         (= (:zone %) [:discard])
-                                        (= (:side %) "Corp"))}
+                                        (corp? %))}
                    :msg (msg (corp-install-msg target))
                    :effect (effect (corp-install target nil))}]
     :strength-bonus (req (if (= (second (:zone card)) :archives) 3 0))}
@@ -752,7 +752,7 @@
                                  (resolve-ability state side
                                                   {:prompt (msg "Choose " n " cards in your Grip to add to the top of the Stack (first card targeted will be topmost)")
                                                    :choices {:max n :all true
-                                                             :req #(and (in-hand? %) (= (:side %) "Runner"))}
+                                                             :req #(and (in-hand? %) (runner? %))}
                                                    :effect (req (doseq [c targets]
                                                                   (move state :runner c :deck {:front true}))
                                                                 (system-msg state :runner (str "adds " n " cards from their Grip to the top of the Stack")))}
@@ -986,7 +986,7 @@
                :effect (effect (draw eid target nil))}
          reveal-and-shuffle {:prompt "Reveal and shuffle up to 3 agendas"
                              :show-discard true
-                             :choices {:req #(and (= "Corp" (:side %))
+                             :choices {:req #(and (corp? %)
                                                   (or (= [:discard] (:zone %))
                                                       (= [:hand] (:zone %)))
                                                   (agenda? %))
@@ -1324,7 +1324,7 @@
                    :req (req (>= (count (all-installed state :runner)) 2))
                    :async true
                    :prompt "Select 2 installed Runner cards"
-                   :choices {:req #(and (= (:side %) "Runner")
+                   :choices {:req #(and (runner? %)
                                         (installed? %))
                              :max 2
                              :all true}
@@ -1666,7 +1666,7 @@
     :runner-abilities [{:label "Add an installed card to the bottom of your Stack"
                         :prompt "Choose one of your installed cards"
                         :choices {:req #(and (installed? %)
-                                             (= (:side %) "Runner"))}
+                                             (runner? %))}
                         :effect (effect (move target :deck)
                                         (system-msg :runner (str "adds " (:title target) " to the bottom of their Stack")))}]}
 
@@ -1696,7 +1696,7 @@
                                           (resolve-ability
                                             state side
                                             {:prompt "Choose 1 card in HQ to shuffle into R&D"
-                                             :choices {:req #(and (in-hand? %) (= (:side %) "Corp"))}
+                                             :choices {:req #(and (in-hand? %) (corp? %))}
                                              :msg "shuffle 1 card in HQ into R&D"
                                              :effect (effect (move target :deck)
                                                              (shuffle! :deck))}
@@ -1810,7 +1810,7 @@
                    :label "Trash 1 installed Runner card"
                    :msg (msg "trash " (:title target))
                    :choices {:req #(and (installed? %)
-                                        (= (:side %) "Runner"))}
+                                        (runner? %))}
                    :async true
                    :effect (req (trash state side eid target {:cause :subroutine}))}]}
 
@@ -1826,7 +1826,7 @@
                    :priority true
                    :choices {:req #(and (not (operation? %))
                                         (in-hand? %)
-                                        (= (:side %) "Corp"))}
+                                        (corp? %))}
                    :effect (effect (corp-install target nil))
                    :msg (msg (corp-install-msg target))}]}
 
@@ -1841,7 +1841,7 @@
                   {:label "Add up to X cards from Archives to HQ"
                    :prompt "Select cards to add to HQ"
                    :show-discard  true
-                   :choices {:req #(and (= "Corp" (:side %))
+                   :choices {:req #(and (corp? %)
                                         (= [:discard] (:zone %)))
                              :max (req (next-ice-count corp))}
                    :effect (req (doseq [c targets]
@@ -1856,7 +1856,7 @@
                              " to HQ")}
                   {:label "Shuffle up to X cards from HQ into R&D"
                    :prompt "Select cards to shuffle into R&D"
-                   :choices {:req #(and (= "Corp" (:side %))
+                   :choices {:req #(and (corp? %)
                                         (= [:hand] (:zone %)))
                              :max (req (next-ice-count corp))}
                    :effect (req (doseq [c targets]
@@ -1903,7 +1903,7 @@
                    :label "Place 3 advancement tokens on installed card"
                    :msg "place 3 advancement tokens on installed card"
                    :prompt "Choose an installed Corp card"
-                   :choices {:req #(and (= (:side %) "Corp")
+                   :choices {:req #(and (corp? %)
                                         (installed? %))}
                    :effect (req (let [c target
                                       title (if (:rezzed c)
@@ -2162,7 +2162,7 @@
                    :req (req (not-empty (all-installed state :runner)))
                    :effect (effect (show-wait-prompt :runner "Corp to select Sandman target")
                                    (resolve-ability {:choices {:req #(and (installed? %)
-                                                                          (= (:side %) "Runner"))}
+                                                                          (runner? %))}
                                                      :msg (msg "to add " (:title target) " to the grip")
                                                      :effect (effect (clear-wait-prompt :runner)
                                                                      (move :runner target :hand true))
@@ -2386,7 +2386,7 @@
                    :effect (effect (draw))}
                   {:req (req (pos? (count (:hand corp))))
                    :prompt "Choose a card in HQ to move to the top of R&D"
-                   :choices {:req #(and (in-hand? %) (= (:side %) "Corp"))}
+                   :choices {:req #(and (in-hand? %) (corp? %))}
                    :msg "add 1 card in HQ to the top of R&D"
                    :effect (effect (move target :deck {:front true}))}]}
 
@@ -2459,7 +2459,7 @@
                    :label "Trash 1 installed Runner card"
                    :msg (msg "trash " (:title target))
                    :choices {:req #(and (installed? %)
-                                        (= (:side %) "Runner"))}
+                                        (runner? %))}
                    :async true
                    :effect (req (trash state side eid target {:cause :subroutine}))}
                   (trace-ability 6 {:label "The Runner cannot steal or trash Corp cards for the remainder of this run"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -312,7 +312,7 @@
                      :effect (effect (show-wait-prompt :runner "Corp to select Archangel target")
                                      (continue-ability
                                        {:choices {:req #(and (installed? %)
-                                                             (card-is? % :side :runner))}
+                                                             (runner? %))}
                                         :label "Add 1 installed card to the Runner's Grip"
                                         :msg "add 1 installed card to the Runner's Grip"
                                         :effect (effect (clear-wait-prompt :runner)
@@ -1515,11 +1515,11 @@
       :effect (req (let [magnet card]
                      (wait-for (resolve-ability
                                  state side
-                                 {:req (req (some #(some (fn [h] (card-is? h :type "Program")) (:hosted %))
+                                 {:req (req (some #(some program? (:hosted %))
                                                   (remove-once #(= (:cid %) (:cid magnet))
                                                                (filter ice? (all-installed state corp)))))
                                   :prompt "Select a Program to host on Magnet"
-                                  :choices {:req #(and (card-is? % :type "Program")
+                                  :choices {:req #(and (program? %)
                                                        (ice? (:host %))
                                                        (not= (:cid (:host %)) (:cid magnet)))}
                                   :effect (effect (host card target))}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -336,7 +336,7 @@
                    :priority true
                    :activatemsg "uses Architect to look at the top 5 cards of R&D"
                    :req (req (and (not (string? target))
-                                  (not (is-type? target "Operation"))))
+                                  (not (operation? target))))
                    :not-distinct true
                    :choices (req (conj (take 5 (:deck corp)) "No install"))
                    :effect (effect (system-msg (str "chooses the card in position "
@@ -347,7 +347,7 @@
                    :prompt "Select a card to install from Archives or HQ"
                    :show-discard true
                    :priority true
-                   :choices {:req #(and (not (is-type? % "Operation"))
+                   :choices {:req #(and (not (operation? %))
                                         (#{[:hand] [:discard]} (:zone %))
                                         (= (:side %) "Corp"))}
                    :effect (effect (corp-install target nil))
@@ -404,7 +404,7 @@
    {:subroutines [end-the-run]}
 
    "Blockchain"
-   (letfn [(sub-count [corp] (int (/ (count (filter #(and (is-type? % "Operation")
+   (letfn [(sub-count [corp] (int (/ (count (filter #(and (operation? %)
                                                           (has-subtype? % "Transaction")
                                                           (:seen %))
                                                     (:discard corp)))
@@ -425,7 +425,7 @@
 
    "Bloodletter"
    {:subroutines [{:label "Runner trashes 1 program or top 2 cards of their Stack"
-                   :effect (req (if (empty? (filter #(is-type? % "Program") (all-active-installed state :runner)))
+                   :effect (req (if (empty? (filter program? (all-active-installed state :runner)))
                                   (do (mill state :runner 2)
                                       (system-msg state :runner (str "trashes the top 2 cards of their Stack")))
                                   (do (show-wait-prompt state :corp "Runner to choose an option for Bloodletter")
@@ -660,7 +660,7 @@
                                               {:prompt "Choose a resource to trash"
                                                :msg (msg "trash " (:title target))
                                                :choices {:req #(and (installed? %)
-                                                                    (is-type? % "Resource"))}
+                                                                    (resource? %))}
                                                :cancel-effect (req (effect-completed state side eid))
                                                :effect (effect (trash target {:cause :subroutine}))}
                                               card nil)
@@ -696,7 +696,7 @@
                    :prompt "Select a card to install from Archives"
                    :show-discard true
                    :priority true
-                   :choices {:req #(and (not (is-type? % "Operation"))
+                   :choices {:req #(and (not (operation? %))
                                         (= (:zone %) [:discard])
                                         (= (:side %) "Corp"))}
                    :msg (msg (corp-install-msg target))
@@ -932,7 +932,7 @@
                                     :effect (effect (continue-ability
                                                       {:prompt "Select a piece of hardware to trash"
                                                        :label "Trash a piece of hardware"
-                                                       :choices {:req #(is-type? % "Hardware")}
+                                                       :choices {:req hardware?}
                                                        :msg (msg "trash " (:title target))
                                                        :effect (req (wait-for
                                                                       (trash state side target {:cause :subroutine})
@@ -989,7 +989,7 @@
                              :choices {:req #(and (= "Corp" (:side %))
                                                   (or (= [:discard] (:zone %))
                                                       (= [:hand] (:zone %)))
-                                                  (is-type? % "Agenda"))
+                                                  (agenda? %))
                                        :max (req 3)}
                              :effect (req (reveal state side targets)
                                           (doseq [c targets]
@@ -1044,7 +1044,7 @@
                    :prompt "Choose a program that is not a decoder, fracter or killer"
                    :msg (msg "trash " (:title target))
                    :choices {:req #(and (installed? %)
-                                        (is-type? % "Program")
+                                        (program? %)
                                         (not (has-subtype? % "Decoder"))
                                         (not (has-subtype? % "Fracter"))
                                         (not (has-subtype? % "Killer")))}
@@ -1824,7 +1824,7 @@
    {:subroutines [{:label "Install a card from HQ, paying all costs"
                    :prompt "Choose a card in HQ to install"
                    :priority true
-                   :choices {:req #(and (not (is-type? % "Operation"))
+                   :choices {:req #(and (not (operation? %))
                                         (in-hand? %)
                                         (= (:side %) "Corp"))}
                    :effect (effect (corp-install target nil))
@@ -1868,7 +1868,7 @@
    "NEXT Silver"
    {:abilities [{:label "Gain subroutines"
                  :msg (msg "gain "
-                           (count (filter #(and (is-type? % "ICE")
+                           (count (filter #(and (ice? %)
                                                 (has-subtype? % "NEXT"))
                                           (all-active-installed state :corp)))
                            " subroutines")}]
@@ -1931,7 +1931,7 @@
 
    "Owl"
    {:subroutines [{:choices {:req #(and (installed? %)
-                                        (is-type? % "Program"))}
+                                        (program? %))}
                    :label "Add installed program to the top of the Runner's Stack"
                    :msg "add an installed program to the top of the Runner's Stack"
                    :effect (effect (move :runner target :deck {:front true})
@@ -2174,7 +2174,7 @@
     :subroutines [trash-program]
     :access {:async true
              :req (req (and (not= (first (:zone card)) :discard)
-                            (some #(is-type? % "Program") (all-active-installed state :runner))))
+                            (some program? (all-active-installed state :runner))))
              :effect (effect (show-wait-prompt :corp "Runner to decide to break Sapper subroutine")
                              (continue-ability
                                :runner {:optional
@@ -2221,7 +2221,7 @@
 
    "Sherlock 1.0"
    {:subroutines [(trace-ability 4 {:choices {:req #(and (installed? %)
-                                                         (is-type? % "Program"))}
+                                                         (program? %))}
                                     :label "Add an installed program to the top of the Runner's Stack"
                                     :msg (msg "add " (:title target) " to the top of the Runner's Stack")
                                     :effect (effect (move :runner target :deck {:front true}))})]
@@ -2229,7 +2229,7 @@
 
    "Sherlock 2.0"
    {:subroutines [(trace-ability 4 {:choices {:req #(and (installed? %)
-                                                         (is-type? % "Program"))}
+                                                         (program? %))}
                                     :label "Add an installed program to the bottom of the Runner's Stack"
                                     :msg (msg "add " (:title target) " to the bottom of the Runner's Stack")
                                     :effect (effect (move :runner target :deck))})
@@ -2368,7 +2368,7 @@
                    :label "Trash an AI program"
                    :effect (effect (trash target))
                    :choices {:req #(and (installed? %)
-                                        (is-type? % "Program")
+                                        (program? %)
                                         (has-subtype? % "AI"))}}]}
 
    "SYNC BRE"
@@ -2429,7 +2429,7 @@
                    :msg (msg "trash " (:title target))
                    :async true
                    :choices {:req #(and (installed? %)
-                                        (is-type? % "Resource"))}
+                                        (resource? %))}
                    :effect (effect (trash target {:reason :subroutine}))}]}
 
    "TL;DR"
@@ -2450,8 +2450,7 @@
 
    "Tour Guide"
    {:abilities [{:label "Gain subroutines"
-                 :msg (msg "gain " (count (filter #(is-type? % "Asset")
-                                                  (all-active-installed state :corp))) " subroutines")}]
+                 :msg (msg "gain " (count (filter asset? (all-active-installed state :corp))) " subroutines")}]
     :subroutines [end-the-run]}
 
    "Trebuchet"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -697,7 +697,7 @@
                    :show-discard true
                    :priority true
                    :choices {:req #(and (not (operation? %))
-                                        (= (:zone %) [:discard])
+                                        (in-discard? %)
                                         (corp? %))}
                    :msg (msg (corp-install-msg target))
                    :effect (effect (corp-install target nil))}]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -117,7 +117,7 @@
                                                 :choices {:max 3
                                                           :all true
                                                           :req #(and (runner? %)
-                                                                     (= (:zone %) [:play-area]))}
+                                                                     (in-play-area? %))}
                                                 :effect (req (doseq [c targets]
                                                                (runner-install state side c {:ignore-all-cost true
                                                                                              :custom-message (str "starts with " (:title c) " in play")}))
@@ -243,7 +243,7 @@
                               :choices {:max 4
                                         :all true
                                         :req #(and (runner? %)
-                                                   (= (:zone %) [:play-area]))}
+                                                   (in-play-area? %))}
                               :effect (req (doseq [c targets]
                                              (host state side (get-card state card) c {:facedown true}))
                                            (doseq [c (get-in @state [:runner :play-area])]
@@ -1255,7 +1255,7 @@
                              (has-most-faction? state :corp "Haas-Bioroid")
                              (pos? (count (:discard corp)))))
               :prompt "Select a card in Archives to shuffle into R&D"
-              :choices {:req #(and (corp? %) (= (:zone %) [:discard]))}
+              :choices {:req #(and (corp? %) (in-discard? %))}
               :player :corp :show-discard true :priority true
               :msg (msg "shuffle " (if (:seen target) (:title target) "a card")
                         " into R&D")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -91,7 +91,7 @@
                                              (rezzed? current-ice))
                                     (activate state card true)))}
                :rez {:effect (req (when (and (outermost? run-position run-ices)
-                                             (= (:cid current-ice) (:cid target)))
+                                             (same-card? current-ice target))
                                     (activate state card true)))}
                :derez {:effect (req (when (outermost? run-position run-ices)
                                       (activate state card false)))}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -807,7 +807,7 @@
    "Leela Patel: Trained Pragmatist"
    (let [leela {:interactive (req true)
                 :prompt "Select an unrezzed card to return to HQ"
-                :choices {:req #(and (not (rezzed? %)) (installed? %) (card-is? % :side :corp))}
+                :choices {:req #(and (not (rezzed? %)) (installed? %) (corp? %))}
                 :msg (msg "add " (card-str state target) " to HQ")
                 :effect (effect (move :corp target :hand))}]
      {:flags {:slow-hq-access (req true)}
@@ -1255,7 +1255,7 @@
                              (has-most-faction? state :corp "Haas-Bioroid")
                              (pos? (count (:discard corp)))))
               :prompt "Select a card in Archives to shuffle into R&D"
-              :choices {:req #(and (card-is? % :side :corp) (= (:zone %) [:discard]))}
+              :choices {:req #(and (corp? %) (= (:zone %) [:discard]))}
               :player :corp :show-discard true :priority true
               :msg (msg "shuffle " (if (:seen target) (:title target) "a card")
                         " into R&D")
@@ -1381,7 +1381,7 @@
    "Wyvern: Chemically Enhanced"
    {:events {:pre-start-game {:effect draft-points-target}
              :runner-trash {:req (req (and (has-most-faction? state :runner "Anarch")
-                                           (card-is? target :side :corp)
+                                           (corp? target)
                                            (pos? (count (:discard runner)))))
                             :msg (msg "shuffle " (:title (last (:discard runner))) " into their Stack")
                             :effect (effect (move :runner (last (:discard runner)) :deck)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -116,7 +116,7 @@
                                                {:prompt (str "Choose 3 starting directives")
                                                 :choices {:max 3
                                                           :all true
-                                                          :req #(and (= (:side %) "Runner")
+                                                          :req #(and (runner? %)
                                                                      (= (:zone %) [:play-area]))}
                                                 :effect (req (doseq [c targets]
                                                                (runner-install state side c {:ignore-all-cost true
@@ -172,7 +172,7 @@
                   :label "Install a card facedown (start of turn)"
                   :once :per-turn
                   :choices {:max 1
-                            :req #(and (= (:side %) "Runner")
+                            :req #(and (runner? %)
                                        (in-hand? %))}
                   :req (req (and (pos? (count (:hand runner)))
                                  (:runner-phase-12 @state)))
@@ -213,7 +213,7 @@
                                                "piece of ice")
                                              " in HQ to install with Asa Group: Security Through Vigilance (optional)")
                                 :choices {:req #(and (in-hand? %)
-                                                     (= (:side %) "Corp")
+                                                     (corp? %)
                                                      (corp-installable-type? %)
                                                      (not (agenda? %))
                                                      (or (is-remote? z)
@@ -242,7 +242,7 @@
                               :async true
                               :choices {:max 4
                                         :all true
-                                        :req #(and (= (:side %) "Runner")
+                                        :req #(and (runner? %)
                                                    (= (:zone %) [:play-area]))}
                               :effect (req (doseq [c targets]
                                              (host state side (get-card state card) c {:facedown true}))
@@ -631,7 +631,7 @@
                              (continue-ability
                                state side
                                {:prompt "Select a card to place advancement tokens on with Jemison Astronautics: Sacrifice. Audacity. Success."
-                                :choices {:req #(and (installed? %) (= (:side %) "Corp"))}
+                                :choices {:req #(and (installed? %) (corp? %))}
                                 :msg (msg "place " p " advancement tokens on " (card-str state target))
                                 :cancel-effect (effect (clear-wait-prompt :runner))
                                 :effect (effect (add-prop :corp target :advance-counter p {:placed true})
@@ -946,7 +946,7 @@
                                :show-discard true
                                :async true
                                :choices {:req #(and (has-subtype? % "Current")
-                                                    (= (:side %) "Corp")
+                                                    (corp? %)
                                                     (#{[:hand] [:discard]} (:zone %)))}
                                :msg (msg "play a current from " (name-zone "Corp" (:zone target)))
                                :effect (effect (play-instant eid target))}}}]
@@ -956,7 +956,7 @@
    "NEXT Design: Guarding the Net"
    (let [ndhelper (fn nd [n] {:prompt (msg "When finished, click NEXT Design: Guarding the Net to draw back up to 5 cards in HQ. "
                                            "Select a piece of ICE in HQ to install:")
-                              :choices {:req #(and (= (:side %) "Corp")
+                              :choices {:req #(and (corp? %)
                                                    (ice? %)
                                                    (in-hand? %))}
                               :effect (req (corp-install state side target nil)
@@ -1091,7 +1091,7 @@
                    :cost [:click 1 :credit 1]
                    :prompt "Select a card to install from HQ"
                    :choices {:req #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))
-                                     (= (:side %) "Corp")
+                                     (corp? %)
                                      (in-hand? %))}
                    :msg (msg "install a card in a remote server and place 1 advancement token on it")
                    :effect (effect (continue-ability (install-card target) card nil))}]})
@@ -1102,7 +1102,7 @@
                  :once :per-turn
                  :prompt "Select a card to add to the top of R&D"
                  :show-discard true
-                 :choices {:req #(and (= (:side %) "Corp") (in-discard? %))}
+                 :choices {:req #(and (corp? %) (in-discard? %))}
                  :effect (effect (move target :deck {:front true}))
                  :msg (msg "add " (if (:seen target) (:title target) "a card") " to the top of R&D")}]}
 
@@ -1219,7 +1219,7 @@
                                  :prompt "Select 2 cards in your Heap"
                                  :show-discard true
                                  :choices {:max 2 :req #(and (in-discard? %)
-                                                             (= (:side %) "Runner")
+                                                             (runner? %)
                                                              (not= (-> @state :run :run-effect :card :cid) (:cid %)))}
                                  :cancel-effect (req (effect-completed state side eid))
                                  :effect (req (let [c1 (first targets)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -358,8 +358,8 @@
    (letfn [(name-a-card []
              {:async true
               :prompt "Name a Runner card"
-              :choices {:card-title (req (and (card-is? target :side "Runner")
-                                              (not (card-is? target :type "Identity"))))}
+              :choices {:card-title (req (and (runner? target)
+                                              (not (identity? target))))}
               :effect (effect (system-msg (str "uses Complete Image to name " target))
                               (continue-ability (damage-ability) card targets))})
            (damage-ability []
@@ -407,9 +407,9 @@
 
    "Dedication Ceremony"
    {:prompt "Select a faceup card"
-    :choices {:req #(or (and (card-is? % :side :corp)
+    :choices {:req #(or (and (corp? %)
                              (:rezzed %))
-                        (and (card-is? % :side :runner)
+                        (and (runner? %)
                              (or (installed? %)
                                  (:host %))
                              (not (facedown? %))))}
@@ -543,7 +543,7 @@
                               {:prompt "Select an installed card not matching the faction of the Runner's identity"
                                :choices {:req #(and (installed? %)
                                                     (not= f (:faction %))
-                                                    (card-is? % :side :runner))}
+                                                    (runner? %))}
                                :msg (msg "trash " (:title target))
                                :effect (effect (trash target))}
                               card nil)))}}}
@@ -864,7 +864,7 @@
    "Hatchet Job"
    {:trace {:base 5
             :successful {:choices {:req #(and (installed? %)
-                                              (card-is? % :side :runner)
+                                              (runner? %)
                                               (not (has-subtype? % "Virtual")))}
                          :msg "add an installed non-virtual card to the Runner's grip"
                          :effect (effect (move :runner target :hand true))}}}
@@ -1611,8 +1611,8 @@
 
    "Salem's Hospitality"
    {:prompt "Name a Runner card"
-    :choices {:card-title (req (and (card-is? target :side "Runner")
-                                    (not (card-is? target :type "Identity"))))}
+    :choices {:card-title (req (and (runner? target)
+                                    (not (identity? target))))}
     :effect (req (system-msg state side
                              (str "uses Salem's Hospitality to reveal the Runner's Grip ( "
                                   (join ", " (map :title (sort-by :title (:hand runner))))
@@ -1891,8 +1891,8 @@
                  :effect (effect (gain-credits :corp 10))
                  :msg (msg "gain 10 [Credits] from " (:marketing-target card))}]
      {:prompt "Name a Runner card"
-      :choices {:card-title (req (and (card-is? target :side "Runner")
-                                      (not (card-is? target :type "Identity"))))}
+      :choices {:card-title (req (and (runner? target)
+                                      (not (identity? target))))}
       :effect (effect (update! (assoc card :marketing-target target))
                       (system-msg (str "uses Targeted Marketing to name " target)))
       :events {:runner-install gaincr

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -29,7 +29,7 @@
              {:prompt "Select an operation to play"
               :choices {:req #(and (corp? %)
                                    (operation? %)
-                                   (= (:zone %) [:play-area]))}
+                                   (in-play-area? %))}
               :msg (msg "play " (:title target))
               :async true
               :effect (req (wait-for (play-instant state side target {:no-additional-cost true})
@@ -55,7 +55,7 @@
                    :choices {:req #(and (corp? %)
                                         (has-subtype? % "Advertisement")
                                         (or (in-hand? %)
-                                            (= (:zone %) [:discard])))}
+                                            (in-discard? %)))}
                    :effect (req (wait-for
                                   (corp-install state side target nil {:install-state :rezzed})
                                   (if (< n total)
@@ -106,7 +106,7 @@
                       :show-discard true
                       :choices {:req #(and (not= (:cid %) cid)
                                            (corp? %)
-                                           (= (:zone %) [:discard]))}
+                                           (in-discard? %))}
                       :effect (effect (move target :hand)
                                       (system-msg (str "adds " (if (:seen target) (:title target) "an unseen card") " to HQ")))}
                      card nil)))}
@@ -1359,7 +1359,7 @@
     :show-discard true
     :choices {:req #(and (corp? %)
                          (not= (:title %) "Reclamation Order")
-                         (= (:zone %) [:discard]))}
+                         (in-discard? %))}
     :msg (msg "name " (:title target))
     :effect (req (let [title (:title target)
                        cards (filter #(= title (:title %)) (:discard corp))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -887,7 +887,7 @@
    {:req (req (last-turn? state :runner :trashed-card))
     :trace {:base 2
             :label "Trace 2 - Trash 2 installed non-program cards or take 1 bad publicity"
-            :successful {:choices {:max (req (min 2 (count (filter #(or (:facedown %)
+            :successful {:choices {:max (req (min 2 (count (filter #(or (facedown? %)
                                                                         (not (program? %)))
                                                                    (concat (all-installed state :corp)
                                                                            (all-installed state :runner))))))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -27,7 +27,7 @@
    "Accelerated Diagnostics"
    (letfn [(ad [i n adcard]
              {:prompt "Select an operation to play"
-              :choices {:req #(and (= (:side %) "Corp")
+              :choices {:req #(and (corp? %)
                                    (operation? %)
                                    (= (:zone %) [:play-area]))}
               :msg (msg "play " (:title target))
@@ -52,7 +52,7 @@
    (let [abhelp (fn ab [n total]
                   {:prompt "Select an Advertisement to install and rez" :show-discard true
                    :async true
-                   :choices {:req #(and (= (:side %) "Corp")
+                   :choices {:req #(and (corp? %)
                                         (has-subtype? % "Advertisement")
                                         (or (in-hand? %)
                                             (= (:zone %) [:discard])))}
@@ -105,7 +105,7 @@
                      {:prompt "Select a card from Archives to add to HQ"
                       :show-discard true
                       :choices {:req #(and (not= (:cid %) cid)
-                                           (= (:side %) "Corp")
+                                           (corp? %)
                                            (= (:zone %) [:discard]))}
                       :effect (effect (move target :hand)
                                       (system-msg (str "adds " (if (:seen target) (:title target) "an unseen card") " to HQ")))}
@@ -128,7 +128,7 @@
                              state side
                              {:prompt "Choose up to 2 agendas in HQ or Archives"
                               :choices {:max 2
-                                        :req #(and (= (:side %) "Corp")
+                                        :req #(and (corp? %)
                                                    (agenda? %)
                                                    (or (in-hand? %)
                                                        (in-discard? %)))}
@@ -287,7 +287,7 @@
     :effect (effect (damage eid :meat 7 {:card card}))}
 
    "Building Blocks"
-   {:choices {:req #(and (= (:side %) "Corp")
+   {:choices {:req #(and (corp? %)
                          (has-subtype? % "Barrier")
                          (in-hand? %))}
     :async true
@@ -319,7 +319,7 @@
 
    "Celebrity Gift"
    {:choices {:max 5
-              :req #(and (= (:side %) "Corp")
+              :req #(and (corp? %)
                          (in-hand? %))}
     :msg (msg "reveal " (join ", " (map :title (sort-by :title targets))) " and gain " (* 2 (count targets)) " [Credits]")
     :effect (effect (reveal targets) (gain-credits (* 2 (count targets))))}
@@ -439,7 +439,7 @@
          trash-from-hq {:async true
                         :prompt "Select up to 2 cards in HQ to trash"
                         :choices {:max 2
-                                  :req #(and (= (:side %) "Corp")
+                                  :req #(and (corp? %)
                                              (in-hand? %))}
                         :msg (msg "trash " (quantify (count targets) "card") " from HQ")
                         :effect (req (wait-for
@@ -474,7 +474,7 @@
                      {:async true
                       :prompt "Select a card to rez"
                       :choices {:req #(and (installed? %)
-                                           (= (:side %) "Corp")
+                                           (corp? %)
                                            (not (rezzed? %))
                                            (not (agenda? %)))}
                       :effect (effect (rez-cost-bonus discount)
@@ -594,7 +594,7 @@
                install-cards (fn install-cards
                                [server n]
                                {:prompt "Select a card to install"
-                                :choices {:req #(and (= (:side %) "Corp")
+                                :choices {:req #(and (corp? %)
                                                      (not (operation? %))
                                                      (in-hand? %)
                                                      (seq (filter (fn [c] (= server c)) (corp-install-list state %))))}
@@ -710,7 +710,7 @@
                               :priority -1
                               :async true
                               :show-discard true
-                              :choices {:req #(and (= (:side %) "Corp")
+                              :choices {:req #(and (corp? %)
                                                    (not (operation? %))
                                                    (in-discard? %))}
                               :effect (req (wait-for
@@ -805,7 +805,7 @@
    {:req (req (last-turn? state :runner :trashed-card))
     :async true
     :prompt "Choose an installed Corp card"
-    :choices {:req #(and (= (:side %) "Corp")
+    :choices {:req #(and (corp? %)
                          (installed? %))}
     :effect (effect (show-wait-prompt :corp "Runner to resolve Hangeki")
                     (continue-ability
@@ -905,7 +905,7 @@
     :effect (req (wait-for (draw state side 3 nil)
                            (continue-ability state side
                                              {:prompt "Select a card in HQ to put on top of R&D"
-                                              :choices {:req #(and (= (:side %) "Corp")
+                                              :choices {:req #(and (corp? %)
                                                                    (in-hand? %))}
                                               :msg "draw 3 cards and add 1 card from HQ to the top of R&D"
                                               :effect (effect (move target :deck {:front true}))}
@@ -921,7 +921,7 @@
    "Housekeeping"
    {:events {:runner-install {:player :runner
                               :prompt "Select a card from your Grip to trash for Housekeeping" :once :per-turn
-                              :choices {:req #(and (= (:side %) "Runner")
+                              :choices {:req #(and (runner? %)
                                                    (in-hand? %))}
                               :msg (msg "force the Runner to trash " (:title target) " from their Grip")
                               :effect (effect (trash target {:unpreventable true}))}}}
@@ -939,7 +939,7 @@
     :show-discard true
     :not-distinct true
     :choices {:req #(and (not (operation? %))
-                         (= (:side %) "Corp")
+                         (corp? %)
                          (#{[:hand] [:discard]} (:zone %)))}
     :effect (effect (corp-install target nil {:ignore-install-cost true}))
     :msg (msg (corp-install-msg target))}
@@ -1000,7 +1000,7 @@
     :effect (effect (gain-credits 4)
                     (continue-ability {:player :corp
                                        :prompt "Select a card to install"
-                                       :choices {:req #(and (= (:side %) "Corp")
+                                       :choices {:req #(and (corp? %)
                                                             (not (operation? %))
                                                             (in-hand? %))}
                                        :async true
@@ -1077,7 +1077,7 @@
    {:req (req (not-empty (filter #(has-subtype? % "Connection")
                                  (all-active-installed state :runner))))
     :prompt "Choose a connection to host MCA Informant on"
-    :choices {:req #(and (= (:side %) "Runner")
+    :choices {:req #(and (runner? %)
                          (has-subtype? % "Connection")
                          (installed? %))}
     :msg (msg "host it on " (card-str state target) ". The Runner has an additional tag")
@@ -1110,7 +1110,7 @@
    "Mushin No Shin"
    {:prompt "Select a card to install from HQ"
     :choices {:req #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))
-                         (= (:side %) "Corp")
+                         (corp? %)
                          (in-hand? %))}
     :effect (req (corp-install state side (assoc target :advance-counter 3) "New remote")
                  (effect-completed state side eid)
@@ -1290,7 +1290,7 @@
               :effect (effect (corp-install (assoc chosen :advance-counter 3) target {:ignore-all-cost true}))})]
      {:async true
       :prompt "Choose a piece of ICE in HQ to install"
-      :choices {:req #(and (in-hand? %) (= (:side %) "Corp") (ice? %))}
+      :choices {:req #(and (in-hand? %) (corp? %) (ice? %))}
       :msg "install an ICE from HQ and place 3 advancements on it"
       :cancel-effect (req (effect-completed state side eid))
       :effect (effect (continue-ability (install-card target) card nil))})
@@ -1357,7 +1357,7 @@
    "Reclamation Order"
    {:prompt "Select a card from Archives"
     :show-discard true
-    :choices {:req #(and (= (:side %) "Corp")
+    :choices {:req #(and (corp? %)
                          (not= (:title %) "Reclamation Order")
                          (= (:zone %) [:discard]))}
     :msg (msg "name " (:title target))
@@ -1464,7 +1464,7 @@
    (letfn [(replant [n]
              {:prompt "Select a card to install with Replanting"
               :async true
-              :choices {:req #(and (= (:side %) "Corp")
+              :choices {:req #(and (corp? %)
                                    (not (operation? %))
                                    (in-hand? %))}
               :effect (req (wait-for (corp-install state side target nil {:ignore-all-cost true})
@@ -1473,7 +1473,7 @@
                                        (effect-completed state side eid))))})]
      {:async true
       :prompt "Select an installed card to add to HQ"
-      :choices {:req #(and (= (:side %) "Corp")
+      :choices {:req #(and (corp? %)
                            (installed? %))}
       :msg (msg "add " (card-str state target) " to HQ, then install 2 cards ignoring all costs")
       :effect (req (move state side target :hand)
@@ -1486,7 +1486,7 @@
                        :priority -1
                        :async true
                        :show-discard true
-                       :choices {:req #(and (= (:side %) "Corp")
+                       :choices {:req #(and (corp? %)
                                             (not (operation? %))
                                             (in-discard? %))}
                        :effect (req (wait-for
@@ -1523,7 +1523,7 @@
                      state side
                      {:prompt (msg "Select up to " n " cards in HQ to trash with Reuse")
                       :choices {:max n
-                                :req #(and (= (:side %) "Corp")
+                                :req #(and (corp? %)
                                            (in-hand? %))}
                       :msg (msg (let [m (count targets)]
                                   (str "trash " (quantify m "card")
@@ -1552,7 +1552,7 @@
 
    "Rework"
    {:prompt "Select a card from HQ to shuffle into R&D"
-    :choices {:req #(and (= (:side %) "Corp")
+    :choices {:req #(and (corp? %)
                          (in-hand? %))}
     :msg "shuffle a card from HQ into R&D"
     :effect (effect (move target :deck)
@@ -1672,7 +1672,7 @@
    {:req (req tagged)
     :prompt "Select two installed Runner cards"
     :choices {:req #(and (installed? %)
-                         (= "Runner" (:side %)))
+                         (runner? %))
               :max 2}
     :msg (msg (str "move " (join ", " (map :title targets)) " to the Runner's grip"))
     :effect (req (doseq [c targets]
@@ -1693,7 +1693,7 @@
    "Shipment from MirrorMorph"
    (let [shelper (fn sh [n] {:prompt "Select a card to install with Shipment from MirrorMorph"
                              :async true
-                             :choices {:req #(and (= (:side %) "Corp")
+                             :choices {:req #(and (corp? %)
                                                   (not (operation? %))
                                                   (in-hand? %))}
                              :effect (req (wait-for
@@ -1719,7 +1719,7 @@
    "Shipment from Tennin"
    {:async true
     :req (req (not-last-turn? state :runner :successful-run))
-    :choices {:req #(and (installed? %) (= (:side %) "Corp"))}
+    :choices {:req #(and (installed? %) (corp? %))}
     :msg (msg "place 2 advancement tokens on " (card-str state target))
     :effect (effect (add-prop target :advance-counter 2 {:placed true}))}
 
@@ -1763,7 +1763,7 @@
    "Special Report"
    {:prompt "Select any number of cards in HQ to shuffle into R&D"
     :choices {:max (req (count (:hand corp)))
-              :req #(and (= (:side %) "Corp")
+              :req #(and (corp? %)
                          (in-hand? %))}
     :msg (msg "shuffle " (count targets) " cards in HQ into R&D and draw " (count targets) " cards")
     :async true
@@ -1805,7 +1805,7 @@
    "Subcontract"
    (letfn [(sc [i sccard]
              {:prompt "Select an operation in HQ to play"
-              :choices {:req #(and (= (:side %) "Corp")
+              :choices {:req #(and (corp? %)
                                    (operation? %)
                                    (in-hand? %))}
               :async true
@@ -1919,7 +1919,7 @@
    "Threat Assessment"
    {:req (req (last-turn? state :runner :trashed-card))
     :prompt "Select an installed Runner card"
-    :choices {:req #(and (= (:side %) "Runner") (installed? %))}
+    :choices {:req #(and (runner? %) (installed? %))}
     :async true
     :effect (req (let [chosen target]
                    (show-wait-prompt state side "Runner to resolve Threat Assessment")
@@ -2026,7 +2026,7 @@
                  (wait-for (draw state side 4 nil)
                            (continue-ability state side
                                              {:prompt "Choose a card in HQ to install"
-                                              :choices {:req #(and (in-hand? %) (= (:side %) "Corp") (not (operation? %)))}
+                                              :choices {:req #(and (in-hand? %) (corp? %) (not (operation? %)))}
                                               :msg "gain 10 [Credits], draw 4 cards, and install 1 card from HQ"
                                               :cancel-effect (req (effect-completed state side eid))
                                               :effect (effect (corp-install target nil))}
@@ -2039,7 +2039,7 @@
                                       (has-subtype? % "Connection"))
                                 (all-active-installed state :runner)))))
     :prompt "Choose a connection to trash"
-    :choices {:req #(and (= (:side %) "Runner")
+    :choices {:req #(and (runner? %)
                          (resource? %)
                          (has-subtype? % "Connection")
                          (installed? %))}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -180,12 +180,12 @@
                                                   (card-init state side hosted {:resolve-effect false
                                                                                 :init-data true}))
                                                 (let [devavec (get-in @state [:runner :rig :program])
-                                                      devaindex (first (keep-indexed #(when (= (:cid %2) (:cid card)) %1) devavec))
+                                                      devaindex (first (keep-indexed #(when (same-card? %2 card) %1) devavec))
                                                       newdeva (assoc target :zone (:zone card) :installed true)
                                                       newvec (apply conj (subvec devavec 0 devaindex) newdeva (subvec devavec devaindex))]
                                                   (lose state :runner :memory (:memoryunits card))
                                                   (swap! state assoc-in [:runner :rig :program] newvec)
-                                                  (swap! state update-in [:runner :hand] (fn [coll] (remove-once #(= (:cid %) (:cid target)) coll)))
+                                                  (swap! state update-in [:runner :hand] (fn [coll] (remove-once #(same-card? % target) coll)))
                                                   (card-init state side newdeva {:resolve-effect false
                                                                                  :init-data true})))
                                               (move state side card :hand))}]}))
@@ -391,7 +391,7 @@
     :effect (effect (add-counter card :power target))
     :abilities [(break-sub 1 1)]
     :strength-bonus (req (get-counters card :power))
-    :events {:counter-added {:req (req (= (:cid target) (:cid card)))
+    :events {:counter-added {:req (req (same-card? target card))
                              :effect (effect (update-breaker-strength card))}}}
 
    "Au Revoir"
@@ -411,7 +411,7 @@
                                        (get-in @state [:run :did-access])))
                         :effect (effect (add-counter card :virus 1))}
              :expose {:effect (effect (add-counter card :virus 1))}
-             :counter-added {:req (req (= (:cid target) (:cid card)))
+             :counter-added {:req (req (same-card? target card))
                              :effect (effect (update-breaker-strength card))}}}
 
    "Aurora"
@@ -585,7 +585,7 @@
              :pre-advancement-cost {:req (req (>= (get-virus-counters state card) 3))
                                     :effect (effect (advancement-cost-bonus 1))}
              :counter-added
-             {:req (req (or (= (:title target) "Hivemind") (= (:cid target) (:cid card))))
+             {:req (req (or (= (:title target) "Hivemind") (same-card? target card)))
               :effect (effect (update-all-advancement-costs))}
              :purge {:effect (effect (update-all-advancement-costs))}}}
 
@@ -813,7 +813,7 @@
               {:successful-run {:silent (req true)
                                 :effect (effect (add-counter card :virus 1))
                                 :req (req (#{:hq :rd :archives} target))}
-               :pre-ice-strength {:req (req (and (= (:cid target) (:cid current-ice))
+               :pre-ice-strength {:req (req (and (same-card? target current-ice)
                                                  (:datasucker-count card)))
                                   :effect (req (let [c (:datasucker-count (get-card state card))]
                                                  (ice-strength-bonus state side (- c) target)))}
@@ -1246,7 +1246,7 @@
      {:data {:counter {:virus 1}}
       :effect update-programs
       :trash-effect {:effect update-programs}
-      :events {:counter-added {:req (req (= (:cid target) (:cid card)))
+      :events {:counter-added {:req (req (same-card? target card))
                                :effect update-programs}}
       :abilities [{:req (req (pos? (get-counters card :virus)))
                    :priority true
@@ -1692,13 +1692,13 @@
     :events {:runner-turn-begins
              {:effect (req (add-counter state side card :virus 1))}
              :counter-added
-             {:req (req (or (= (:title target) "Hivemind") (= (:cid target) (:cid card))))
+             {:req (req (or (= (:title target) "Hivemind") (same-card? target card)))
               :effect (effect (update-ice-strength (:host card)))}
              :pre-ice-strength
-             {:req (req (= (:cid target) (:cid (:host card))))
+             {:req (req (same-card? target (:host card)))
               :effect (effect (ice-strength-bonus (- (get-virus-counters state card)) target))}
              :ice-strength-changed
-             {:req (req (and (= (:cid target) (:cid (:host card)))
+             {:req (req (and (same-card? target (:host card))
                              (not (card-flag? (:host card) :untrashable-while-rezzed true))
                              (<= (:current-strength target) 0)))
               :effect (req (unregister-events state side card)
@@ -2359,7 +2359,7 @@
                                                ((:effect breaker-auto-pump) state side eid card targets))
                                    wy {:effect (effect (update! (dissoc card :wyrm-count))
                                                        (auto-pump eid (get-card state card) targets))}]
-                               {:pre-ice-strength {:req (req (and (= (:cid target) (:cid current-ice))
+                               {:pre-ice-strength {:req (req (and (same-card? target current-ice)
                                                                   (:wyrm-count card)))
                                                    :effect (req (let [c (:wyrm-count (get-card state card))]
                                                                   (ice-strength-bonus state side (- c) target)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1009,7 +1009,7 @@
    "Endless Hunger"
    {:abilities [{:label "Trash 1 installed card to break 1 \"End the run.\" subroutine"
                  :prompt "Select a card to trash for Endless Hunger"
-                 :choices {:req #(and (= (:side %) "Runner") (:installed %))}
+                 :choices {:req #(and (runner? %) (:installed %))}
                  :msg (msg "trash " (:title target)
                            " and break 1 \"[Subroutine] End the run.\" subroutine")
                  :effect (effect (trash target {:unpreventable true}))}]}
@@ -1231,7 +1231,7 @@
                               (resolve-ability
                                 state :corp
                                 {:prompt "Choose a card to trash"
-                                 :choices (req (filter #(= (:side %) "Corp") (:hand corp)))
+                                 :choices (req (filter corp? (:hand corp)))
                                  :effect (effect (trash target)
                                                  (clear-wait-prompt :runner))}
                                 card nil))}]}
@@ -2234,7 +2234,7 @@
                              {:show-discard true
                               :choices {:max (min (get-counters card :power) (count (:discard runner)))
                                         :all true
-                                        :req #(and (= (:side %) "Runner")
+                                        :req #(and (runner? %)
                                                    (in-discard? %))}
                               :msg (msg "shuffle " (join ", " (map :title targets))
                                         " into their Stack")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -193,7 +193,7 @@
 (defn- conspiracy
   "Install-from-heap breakers"
   [title ice-type abilities]
-  (let [install-prompt {:req (req (and (= (:zone card) [:discard])
+  (let [install-prompt {:req (req (and (in-discard? card)
                                        (rezzed? current-ice)
                                        (has-subtype? current-ice ice-type)
                                        (not (install-locked? state :runner))))
@@ -209,7 +209,7 @@
                                                       ;; to prevent multiple copies from prompting multiple times.
                                                       :no-ability {:effect (req (swap! state assoc-in [:run :register :conspiracy (:cid current-ice)] true))}}}
                                           card targets))}
-        heap-event (req (when (= (:zone card) [:discard])
+        heap-event (req (when (in-discard? card)
                           (unregister-events state side card)
                           (register-events state side
                                            {:rez install-prompt

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1009,7 +1009,7 @@
    "Endless Hunger"
    {:abilities [{:label "Trash 1 installed card to break 1 \"End the run.\" subroutine"
                  :prompt "Select a card to trash for Endless Hunger"
-                 :choices {:req #(and (runner? %) (:installed %))}
+                 :choices {:req #(and (runner? %) (installed? %))}
                  :msg (msg "trash " (:title target)
                            " and break 1 \"[Subroutine] End the run.\" subroutine")
                  :effect (effect (trash target {:unpreventable true}))}]}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -637,8 +637,8 @@
 
    "Consume"
    {:events {:runner-trash {:async true
-                            :req (req (some #(card-is? % :side :corp) targets))
-                            :effect (req (let [amt-trashed (count (filter #(card-is? % :side :corp) targets))
+                            :req (req (some corp? targets))
+                            :effect (req (let [amt-trashed (count (filter corp? targets))
                                                sing-ab {:optional {:prompt "Place a virus counter on Consume?"
                                                                    :autoresolve (get-autoresolve :auto-accept)
                                                                    :yes-ability {:effect (effect (add-counter :runner card :virus 1))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -526,7 +526,7 @@
                                                   (register-turn-flag!
                                                     state side card :can-rez
                                                     (fn [state side card]
-                                                      (if (= (:cid card) (:cid c))
+                                                      (if (same-card? card c)
                                                         ((constantly false)
                                                          (toast state :corp "Cannot rez the rest of this turn due to Councilman"))
                                                         true)))
@@ -723,7 +723,7 @@
                                                          (update! (dissoc card :dean-target))
                                                          (update-breaker-strength (:dean-target card)))}]
                                {:run-ends dean
-                                :pre-breaker-strength {:req (req (= (:cid target)(:cid (:dean-target card))))
+                                :pre-breaker-strength {:req (req (same-card? target (:dean-target card)))
                                                        :effect (effect (breaker-strength-bonus (count (:hand runner))))}}) card))}}
 
    "Decoy"
@@ -1121,7 +1121,7 @@
 
    "Ice Carver"
    {:events {:pre-ice-strength
-             {:req (req (and (= (:cid target) (:cid current-ice)) (:rezzed target)))
+             {:req (req (and (same-card? target current-ice) (:rezzed target)))
               :effect (effect (ice-strength-bonus -1 target))}}}
 
    "Inside Man"
@@ -1420,7 +1420,7 @@
                                             state side
                                             {:prompt "Select 1 card to add to the bottom of the Stack"
                                              :choices {:req #(and (in-hand? %)
-                                                                  (some (fn [c] (= (:cid c) (:cid %))) drawn))}
+                                                                  (some (fn [c] (same-card? c %)) drawn))}
                                              :msg (msg "add 1 card to the bottom of the Stack")
                                              :effect (req (move state side target :deck))}
                                             card nil)
@@ -1550,7 +1550,7 @@
                  :msg (msg "host " (:title target) " and draw 1 card")
                  :async true
                  :effect (effect (host card target) (draw eid 1 nil))}]
-    :events {:runner-install {:req (req (= (:cid card) (:cid (:host target))))
+    :events {:runner-install {:req (req (same-card? card (:host target)))
                               :async true
                               :effect (effect (draw eid 1 nil))}}}
 
@@ -1927,7 +1927,7 @@
                              ((toast state :runner "Can only use a copy of Salsette Slums once per turn.") false)))
                  :effect (effect (resolve-ability
                                    {; only allow targeting cards that were trashed this turn -- not perfect, but good enough?
-                                    :choices {:req #(some (fn [c] (= (:cid %) (:cid c)))
+                                    :choices {:req #(some (fn [c] (same-card? % c))
                                                           (map first (turn-events state side :runner-trash)))}
                                     :msg (msg "remove " (:title target) " from the game")
                                     :effect (req (deactivate state side target)
@@ -2050,7 +2050,7 @@
                              (install-cost-bonus state side [:credit -1])
                              (trash state side (update-in card [:hosted]
                                                           (fn [coll]
-                                                            (remove-once #(= (:cid %) (:cid target)) coll)))
+                                                            (remove-once #(same-card? % target) coll)))
                                     {:cause :ability-cost})
                              (runner-install state side eid (dissoc target :facedown) nil)))}]}
 
@@ -2221,7 +2221,7 @@
                                                         (update! (dissoc card :hai-target))
                                                         (update-breaker-strength (:hai-target card)))}]
                                {:runner-turn-ends hai :corp-turn-ends hai
-                                :pre-breaker-strength {:req (req (= (:cid target)(:cid (:hai-target card))))
+                                :pre-breaker-strength {:req (req (same-card? target (:hai-target card)))
                                                        :effect (effect (breaker-strength-bonus 2))}}) card))}}
 
    "The Nihilist"
@@ -2290,7 +2290,7 @@
                                                       (assoc :supplier-installed (:cid target))
                                                       (update-in [:hosted]
                                                                  (fn [coll]
-                                                                   (remove-once #(= (:cid %) (:cid target)) coll)))))))}]
+                                                                   (remove-once #(same-card? % target) coll)))))))}]
      {:flags {:drip-economy true}  ; not technically drip economy, but has an interaction with Drug Dealer
       :abilities [{:label "Host a resource or piece of hardware" :cost [:click 1]
                    :prompt "Select a card to host on The Supplier"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -120,9 +120,9 @@
     :abilities [{:effect (req (resolve-ability
                                 state side
                                 {:msg (msg "trash " (:title target) " and gain 3 [Credits]")
-                                 :choices {:req #(and (card-is? % :side :runner)
+                                 :choices {:req #(and (runner? %)
                                                       (installed? %)
-                                                      (not (card-is? % :cid (:cid card))))}
+                                                      (not (same-card? % card)))}
                                  :effect (effect (gain-credits 3)
                                                  (trash target {:unpreventable true}))}
                                 card nil))}]}
@@ -2445,8 +2445,8 @@
      {:events {:successful-run {:optional {:autoresolve (get-autoresolve :auto-name-agenda)
                                            :prompt "Trash Whistleblower to name an agenda?"
                                            :yes-ability {:prompt "Name an agenda"
-                                                         :choices {:card-title (req (and (card-is? target :side "Corp")
-                                                                                         (card-is? target :type "Agenda")))}
+                                                         :choices {:card-title (req (and (corp? target)
+                                                                                         (agenda? target)))}
                                                          :effect (effect (system-msg (str "trashes " (:title card)
                                                                                           " to name " (:title target)))
                                                                          (register-events (steal-events target)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -586,7 +586,7 @@
                                                                       " and draws 1 card")))
                                      (draw state :runner eid 1 nil))
                                  (effect-completed state side eid)))}
-         install-prompt {:req (req (and (= (:zone card) [:discard])
+         install-prompt {:req (req (and (in-discard? card)
                                         (not (install-locked? state :runner))))
                          :async true
                          :effect (req (continue-ability
@@ -601,7 +601,7 @@
                                                     ;; to prevent multiple copies from prompting multiple times.
                                                     :no-ability {:effect (req (swap! state assoc-in [:runner :register :crowdfunding-prompt] true))}}}
                                         card nil))}
-         heap-event (req (when (= (:zone card) [:discard])
+         heap-event (req (when (in-discard? card)
                            (unregister-events state side card)
                            (register-events state side
                                             {:runner-turn-ends install-prompt}
@@ -1960,7 +1960,7 @@
                  :msg (msg "play " (:title target))
                  :show-discard true
                  :choices {:req #(and (event? %)
-                                      (= (:zone %) [:discard]))}
+                                      (in-discard? %))}
                  :effect (effect (trash card {:cause :ability-cost}) (play-instant target))}]}
 
    "Scrubber"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -202,7 +202,7 @@
                  :prompt "Select a facedown installed card"
                  :choices {:req #(and (facedown? %)
                                       (installed? %)
-                                      (= "Runner" (:side %)))}
+                                      (runner? %))}
                  :effect (req (if (or (event? target)
                                       (and (has-subtype? target "Console")
                                            (some #(has-subtype? % "Console") (all-active-installed state :runner))))
@@ -350,7 +350,7 @@
                                         (resolve-ability state side
                                                          {:prompt "Choose a card in your Grip to shuffle back into your Stack"
                                                           :choices {:req #(and (in-hand? %)
-                                                                               (= (:side %) "Runner"))}
+                                                                               (runner? %))}
                                                           :effect (effect (move target :deck)
                                                                           (shuffle! :deck))}
                                                          card nil)))}]}
@@ -362,7 +362,7 @@
                  :once :per-turn
                  :prompt "Choose a card in the Heap to remove from the game and gain 2 [Credits]"
                  :show-discard true
-                 :choices {:req #(and (in-discard? %) (= (:side %) "Runner"))}
+                 :choices {:req #(and (in-discard? %) (runner? %))}
                  :msg (msg "remove " (:title target) " from the game and gain 2 [Credits]")
                  :effect (effect (gain-credits 2)
                                  (move target :rfg))}]}
@@ -983,7 +983,7 @@
 
    "First Responders"
    {:abilities [{:cost [:credit 2]
-                 :req (req (some #(= (:side %) "Corp") (map second (turn-events state :runner :damage))))
+                 :req (req (some corp? (map second (turn-events state :runner :damage))))
                  :msg "draw 1 card"
                  :async true
                  :effect (effect (draw eid 1 nil))}]}
@@ -1430,7 +1430,7 @@
    {:effect (req (resolve-ability
                    state :corp
                    {:prompt "Select a card to derez"
-                    :choices {:req #(and (= (:side %) "Corp")
+                    :choices {:req #(and (corp? %)
                                          (not (agenda? %))
                                          (:rezzed %))}
                     :effect (req (derez state side target))}
@@ -1687,7 +1687,7 @@
                    :prompt "Select a card to host on Personal Workshop"
                    :choices {:req #(and (#{"Program" "Hardware"} (:type %))
                                         (in-hand? %)
-                                        (= (:side %) "Runner"))}
+                                        (runner? %))}
                    :effect (req (if (zero? (:cost target))
                                   (runner-install state side target)
                                   (host state side card
@@ -2277,7 +2277,7 @@
                   :req (req (some #(can-pay? state side eid card nil (modified-install-cost state side % [:credit -2]))
                                   (:hosted card)))
                   :choices {:req #(and (= "The Supplier" (:title (:host %)))
-                                       (= "Runner" (:side %)))}
+                                       (runner? %))}
                   :once :per-turn
                   :effect (req
                             (runner-can-install? state side target nil)
@@ -2337,7 +2337,7 @@
    "Thunder Art Gallery"
    (let [first-event-check (fn [state fn1 fn2] (and (fn1 state :runner :runner-lose-tag #(= :runner (second %)))
                                                     (fn2 state :runner :runner-prevent (fn [t] (seq (filter #(some #{:tag} %) t))))))
-         ability {:choices {:req #(and (= "Runner" (:side %))
+         ability {:choices {:req #(and (runner? %)
                                        (in-hand? %)
                                        (not (event? %)))}
                   :async true

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -50,7 +50,7 @@
          {:prompt "Select a card to install with Arella Salvatore"
           :choices {:req #(and (corp-installable-type? %)
                                (in-hand? %)
-                               (= (:side %) "Corp"))}
+                               (corp? %))}
           :async true
           :cancel-effect (req (effect-completed state side eid))
           :effect (req (wait-for (corp-install state :corp target nil {:ignore-all-cost true :display-message false})
@@ -115,7 +115,7 @@
    (letfn [(dome [dcard]
              {:prompt "Select a card to add to HQ"
               :async true
-              :choices {:req #(and (= (:side %) "Corp")
+              :choices {:req #(and (corp? %)
                                    (= (:zone %) [:play-area]))}
               :msg "move a card to HQ"
               :effect (effect (move target :hand)
@@ -123,7 +123,7 @@
            (put [dcard]
              {:prompt "Select first card to put back onto R&D"
               :async true
-              :choices {:req #(and (= (:side %) "Corp")
+              :choices {:req #(and (corp? %)
                                    (= (:zone %) [:play-area]))}
               :msg "move remaining cards back to R&D"
               :effect (effect (move target :deck {:front true})
@@ -324,7 +324,7 @@
    (letfn [(choose-swap [to-swap]
              {:prompt (str "Select a card to swap with " (:title to-swap))
               :choices {:not-self true
-                        :req #(and (= "Corp" (:side %))
+                        :req #(and (corp? %)
                                    (#{"Asset" "Agenda" "Upgrade"} (:type %))
                                    (or (in-hand? %) ; agenda, asset or upgrade from HQ
                                        (and (installed? %) ; card installed in a server
@@ -367,7 +367,7 @@
                  :effect (effect (resolve-ability
                                    {:show-discard true
                                     :choices {:max (get-counters card :advancement)
-                                              :req #(and (= (:side %) "Corp")
+                                              :req #(and (corp? %)
                                                          (not (:seen %))
                                                          (= (:zone %) [:discard]))}
                                     :msg (msg "add " (count targets) " facedown cards in Archives to HQ")
@@ -380,7 +380,7 @@
    (letfn [(dhq [n i]
              {:req (req (pos? i))
               :prompt "Select a card in HQ to add to the bottom of R&D"
-              :choices {:req #(and (= (:side %) "Corp")
+              :choices {:req #(and (corp? %)
                                    (in-hand? %))}
               :async true
               :msg "add a card to the bottom of R&D"
@@ -541,7 +541,7 @@
                                   state side
                                   {:prompt "Choose a card in HQ to trash"
                                    :choices {:req #(and (in-hand? %)
-                                                        (= (:side %) "Corp"))}
+                                                        (corp? %))}
                                    :msg "trash a card from HQ and give all ice protecting this server +2 strength until the end of the run"
                                    :effect (effect (clear-wait-prompt :runner)
                                                    (trash eid target nil))}
@@ -1337,7 +1337,7 @@
               :async true
               :player :runner
               :priority 2
-              :choices {:req #(and (installed? %) (= (:side %) "Runner"))}
+              :choices {:req #(and (installed? %) (runner? %))}
               :effect (req (system-msg state side (str "trashes " (card-str state target) " due to Warroid Tracker"))
                            (trash state side target {:unpreventable true})
                            (if (> n t)

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -116,7 +116,7 @@
              {:prompt "Select a card to add to HQ"
               :async true
               :choices {:req #(and (corp? %)
-                                   (= (:zone %) [:play-area]))}
+                                   (in-play-area? %))}
               :msg "move a card to HQ"
               :effect (effect (move target :hand)
                               (continue-ability (put dcard) dcard nil))})
@@ -124,7 +124,7 @@
              {:prompt "Select first card to put back onto R&D"
               :async true
               :choices {:req #(and (corp? %)
-                                   (= (:zone %) [:play-area]))}
+                                   (in-play-area? %))}
               :msg "move remaining cards back to R&D"
               :effect (effect (move target :deck {:front true})
                               (move (first (get-in @state [:corp :play-area])) :deck {:front true})
@@ -369,7 +369,7 @@
                                     :choices {:max (get-counters card :advancement)
                                               :req #(and (corp? %)
                                                          (not (:seen %))
-                                                         (= (:zone %) [:discard]))}
+                                                         (in-discard? %))}
                                     :msg (msg "add " (count targets) " facedown cards in Archives to HQ")
                                     :effect (req (doseq [c targets]
                                                    (move state side c :hand)))}

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -211,6 +211,16 @@
   [card]
   (= (:zone card) [:discard]))
 
+(defn in-deck?
+  "Checks if the specified card is in the draw deck."
+  [card]
+  (= (:zone card) [:deck]))
+
+(defn in-play-area?
+  "Checks if the specified card is in the play area."
+  [card]
+  (= (:zone card) [:play-area]))
+
 (defn is-scored?
   "Checks if the specified card is in the scored area of the specified player."
   [state side card]
@@ -220,11 +230,6 @@
   "Checks if the specified card is able to be used for a when-scored text ability"
   [card]
   (not (:not-when-scored (card-def card))))
-
-(defn in-deck?
-  "Checks if the specified card is in the draw deck."
-  [card]
-  (= (:zone card) [:deck]))
 
 (defn facedown?
   "Checks if the specified card is facedown."

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -302,10 +302,10 @@
   [{:keys [zone] :as card}]
   (or (is-type? card "Identity")
       (= zone [:current])
-      (and (card-is? card :side :corp)
+      (and (corp? card)
            (installed? card)
            (rezzed? card))
-      (and (card-is? card :side :runner)
+      (and (runner? card)
            (installed? card)
            (not (facedown? card)))))
 
@@ -432,7 +432,7 @@
     ;; public runner cards: in hand and :openhand is true;
     ;; or installed/hosted and not facedown;
     ;; or scored or current or in heap
-    (or (card-is? card :side :corp)
+    (or (corp? card)
         (and (:openhand (:runner @state)) (in-hand? card))
         (and (or (installed? card) (:host card)) (not (facedown? card)))
         (#{:scored :discard :current} (last zone)))
@@ -440,7 +440,7 @@
     ;; or installed and rezzed;
     ;; or in :discard and :seen
     ;; or scored or current
-    (or (card-is? card :side :runner)
+    (or (runner? card)
         (and (:openhand (:corp @state)) (in-hand? card))
         (and (or (installed? card) (:host card))
              (or (is-type? card "Operation") (rezzed? card)))

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -1,5 +1,7 @@
 (in-ns 'game.core)
 
+(declare runner? corp?)
+
 (defn get-nested-host
   "Recursively searches upward to find the 'root' card of a hosting chain."
   [card]
@@ -75,8 +77,8 @@
        ;; events should be registered for: runner cards that are installed; corp cards that are Operations, or are installed and rezzed
        (when (or (is-type? target "Operation")
                  (and (is-type? target "Event") (not facedown))
-                 (and installed (card-is? target :side :runner))
-                 (and installed (card-is? target :side :corp) (:rezzed target)))
+                 (and installed (runner? target))
+                 (and installed (corp? target) (:rezzed target)))
          (when-let [events (:events tdef)]
            (register-events state side events c))
          (when (or (:recurring tdef)

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -85,7 +85,7 @@
   in/protecting a server, facedown, or hosted."
   ([state card] (card-str state card nil))
   ([state {:keys [zone host title facedown] :as card} {:keys [visible] :as args}]
-  (str (if (card-is? card :side :corp)
+  (str (if (corp? card)
          ; Corp card messages
          (str (if (or (rezzed? card) visible) title (if (ice? card) "ICE" "a card"))
               ; Hosted cards do not need "in server 1" messages, host has them
@@ -140,7 +140,7 @@
                         counter-type (cond (= 1 (count existing)) (first (keys existing))
                                      (can-be-advanced? target) :advance-counter
                                      (and (is-type? target "Agenda") (is-scored? state side target)) :agenda
-                                     (and (card-is? target :side :runner) (has-subtype? target "Virus")) :virus)
+                                     (and (runner? target) (has-subtype? target "Virus")) :virus)
                         advance (= :advance-counter counter-type)]
                     (cond
                       advance


### PR DESCRIPTION
This is a good step towards enforcing Separation of Concerns and very loosely/lightly Law of Demeter. and Loose Coupling.

Directly touching objects for their properties makes it hard for use to change how we structure our objects in the future, so this affords us a lot of flexibility.