### PR TITLE
Generalize Showing Off

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2084,10 +2084,8 @@
                                                              card nil)
                                             (do-access state side eid (:server run))))}} card))
     :events {:pre-access {:silent (req true)
-                          :effect (req (swap! state assoc-in [:corp :deck]
-                                              (rseq (into [] (get-in @state [:corp :deck])))))}
-             :run-ends {:effect (req (swap! state assoc-in [:corp :deck]
-                                            (rseq (into [] (get-in @state [:corp :deck]))))
+                          :effect (req (swap! state assoc-in [:runner :rd-access-fn] reverse))}
+             :run-ends {:effect (req (swap! state assoc-in [:runner :rd-access-fn] seq)
                                      (unregister-events state side card))}}}
 
    "Singularity"

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -102,6 +102,7 @@
                 :hand-size {:base 5 :mod 0}
                 :agenda-point 0 :agenda-point-req 7
                 :hq-access 1 :rd-access 1
+                :rd-access-fn seq
                 :brain-damage 0
                 :keep false
                 :quote runner-quote}})))

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -3070,6 +3070,27 @@
       (is (zero? (:current-strength (refresh turing))) "Scrubbed reduces strength by 2")
       (run-successful state))))
 
+(deftest showing-off
+  ;; Showing Off
+  (do-game
+    (new-game {:corp {:hand [(qty "Hedge Fund" 5)]
+                      :deck ["Accelerated Beta Test" "Brainstorm" "Chiyashi"
+                               "DNA Tracker" "Excalibur" "Fire Wall"]}
+               :runner {:hand ["Showing Off"]}})
+      (core/move state :corp (find-card "Accelerated Beta Test" (:deck (get-corp))) :deck)
+      (core/move state :corp (find-card "Brainstorm" (:deck (get-corp))) :deck)
+      (core/move state :corp (find-card "Chiyashi" (:deck (get-corp))) :deck)
+      (core/move state :corp (find-card "DNA Tracker" (:deck (get-corp))) :deck)
+      (core/move state :corp (find-card "Excalibur" (:deck (get-corp))) :deck)
+      (core/move state :corp (find-card "Fire Wall" (:deck (get-corp))) :deck)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Showing Off")
+      (run-successful state)
+      (click-prompt state :runner "Replacement effect")
+      (is (= "You accessed Fire Wall." (-> (get-runner) :prompt first :msg)) "The accessed card is on the bottom of the deck")
+      (is (= "Accelerated Beta Test" (-> (get-corp) :deck first :title)) "The top of the deck is an entirely different card")
+      (click-prompt state :runner "No action")))
+
 (deftest singularity
   ;; Singularity - Run a remote; if successful, trash all contents at no cost
   (do-game


### PR DESCRIPTION
Instead of reversing the deck in-place, only reverse the deck when we're selecting cards to access! I'll whip up more tests tomorrow, but this should handle all outstanding bugs with Bacterial Programming, etc.

Closes #4258