### PR TITLE
Refactor pay-discard

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1032,7 +1032,7 @@
 
    "Hacktivist Meeting"
    {:events {:pre-rez-cost {:req (req (not (ice? target)))
-                            :effect (effect (rez-additional-cost-bonus [:discard 1]))}}}
+                            :effect (effect (rez-additional-cost-bonus [:randomly-trash-from-hand 1]))}}}
 
    "High-Stakes Job"
    (run-event

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1086,16 +1086,12 @@
 
    "Faust"
    {:abilities [{:label "Trash 1 card from Grip to break 1 subroutine"
-                 :prompt "Select a card from your grip to trash for Faust"
-                 :choices {:req in-hand?}
-                 :msg (msg "trash " (:title target) " and break 1 subroutine")
-                 :effect (effect (trash target {:unpreventable true}))}
+                 :cost [:trash-from-hand 1]
+                 :msg (msg "break 1 subroutine")}
                 {:label "Trash 1 card from Grip to add 2 strength"
-                 :prompt "Select a card from your grip to trash for Faust"
-                 :choices {:req in-hand?}
-                 :msg (msg "trash " (:title target) " and add 2 strength")
-                 :effect (effect (trash target {:unpreventable true})
-                                 (pump card 2))}]}
+                 :cost [:trash-from-hand 1]
+                 :msg (msg "add 2 strength")
+                 :effect (effect (pump card 2))}]}
 
    "Fawkes"
    {:implementation "Stealth credit restriction not enforced"

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -813,6 +813,15 @@
       (is (= 2 (count (:discard (get-runner)))) "False Echo trashed"))))
 
 (deftest faust
+  (testing "Basic test: Break by discarding"
+    (do-game
+      (new-game {:runner {:deck ["Faust" (qty "Sure Gamble" 3)]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Faust")
+      (let [faust (get-program state 0)]
+        (card-ability state :runner faust 0)
+        (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))
+        (is (= 1 (count (:discard (get-runner)))) "1 card trashed"))))
   (testing "Basic test: Pump by discarding"
     (do-game
       (new-game {:runner {:deck ["Faust" (qty "Sure Gamble" 3)]}})


### PR DESCRIPTION
Rename `pay-discard` to `pay-randomly-trash-from-hand`, add `pay-trash-from-hand`, rewrite Faust to use `pay-trash-from-hand`, add a test for it.

Closes #4263 