### PR TITLE
Namespace eid-related functions

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1,5 +1,6 @@
 (ns game.cards.agendas
   (:require [game.core :refer :all]
+            [game.core.eid :refer [effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1,5 +1,6 @@
 (ns game.cards.assets
   (:require [game.core :refer :all]
+            [game.core.eid :refer [effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1,5 +1,6 @@
 (ns game.cards.events
   (:require [game.core :refer :all]
+            [game.core.eid :refer [make-eid make-result effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1,5 +1,6 @@
 (ns game.cards.hardware
   (:require [game.core :refer :all]
+            [game.core.eid :refer [make-eid make-result effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1,5 +1,6 @@
 (ns game.cards.ice
   (:require [game.core :refer :all]
+            [game.core.eid :refer [make-eid effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability when-let*]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1,5 +1,6 @@
 (ns game.cards.identities
   (:require [game.core :refer :all]
+            [game.core.eid :refer [effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1,5 +1,6 @@
 (ns game.cards.operations
   (:require [game.core :refer :all]
+            [game.core.eid :refer [make-eid make-result effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability when-let*]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1,5 +1,6 @@
 (ns game.cards.programs
   (:require [game.core :refer :all]
+            [game.core.eid :refer [effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability when-let*]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1,5 +1,6 @@
 (ns game.cards.resources
   (:require [game.core :refer :all]
+            [game.core.eid :refer [make-eid effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1,5 +1,6 @@
 (ns game.cards.upgrades
   (:require [game.core :refer :all]
+            [game.core.eid :refer [effect-completed]]
             [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
             [clojure.string :refer [split-lines split join lower-case includes? starts-with?]]

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -1,6 +1,7 @@
 (ns game.core
   (:require [game.utils :refer :all]
             [game.macros :refer [effect req msg wait-for continue-ability]]
+            [game.core.eid :refer [make-eid make-result register-effect-completed effect-completed complete-with-result]]
             [clj-time.core :as t]
             [clojure.string :as string :refer [split-lines split join lower-case includes? starts-with?]]
             [clojure.java.io :as io]

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -2,7 +2,7 @@
 
 (declare active? all-installed all-active-installed cards card-init deactivate
          card-flag? gain lose get-card-hosted handle-end-run hardware? ice? is-type?
-         make-eid program? register-events remove-from-host remove-icon make-card
+         program? register-events remove-from-host remove-icon make-card
          resource? rezzed? toast toast-check-mu trash trigger-event
          update-breaker-strength update-hosted! update-ice-strength unregister-events
          use-mu)

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -1,8 +1,8 @@
 (in-ns 'game.core)
 
 (declare forfeit prompt! toast damage mill installed? is-type? is-scored? system-msg
-         facedown? make-result unknown->kw discard-from-hand card-str trash trash-cards
-         complete-with-result all-installed-runner-type pick-credit-providing-cards all-active
+         facedown? unknown->kw discard-from-hand card-str trash trash-cards
+         all-installed-runner-type pick-credit-providing-cards all-active
          eligible-pay-credit-cards corp? runner? in-hand?)
 
 (defn deduct
@@ -170,13 +170,6 @@
              (interpose " and ")
              (apply str))]
     (capitalize cost-string)))
-
-(defn- complete-with-result
-  "Calls `effect-complete` with `make-result` and also returns the argument.
-  Helper function for cost-handler"
-  [state side eid result]
-  (effect-completed state side (make-result eid result))
-  result)
 
 (defn pay-forfeit
   "Forfeit agenda as part of paying for a card or ability

--- a/src/clj/game/core/eid.clj
+++ b/src/clj/game/core/eid.clj
@@ -1,0 +1,29 @@
+(ns game.core.eid)
+
+(defn make-eid
+  ([state] (make-eid state nil))
+  ([state {:keys [source source-type]}]
+   (merge {:eid (:eid (swap! state update-in [:eid] inc))}
+          (when source {:source source})
+          (when source-type {:source-type source-type}))))
+
+(defn register-effect-completed
+  [state side eid effect]
+  (swap! state update-in [:effect-completed (:eid eid)] #(conj % effect)))
+
+(defn effect-completed
+  [state side eid]
+  (doseq [handler (get-in @state [:effect-completed (:eid eid)])]
+    (handler state side eid))
+  (swap! state update-in [:effect-completed] dissoc (:eid eid)))
+
+(defn make-result
+  [eid result]
+  (assoc eid :result result))
+
+(defn complete-with-result
+  "Calls `effect-complete` with `make-result` and also returns the argument.
+  Helper function for cost-handler"
+  [state side eid result]
+  (effect-completed state side (make-result eid result))
+  result)

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -1,8 +1,8 @@
 (in-ns 'game.core)
 
-(declare can-trigger? card-def clear-wait-prompt effect-completed event-title get-card
+(declare can-trigger? card-def clear-wait-prompt event-title get-card
          get-nested-host get-remote-names get-runnable-zones get-zones installed?
-         make-eid register-effect-completed register-suppress resolve-ability
+         register-suppress resolve-ability
          show-wait-prompt trigger-suppress unregister-suppress)
 
 ; Functions for registering and dispatching events.
@@ -298,14 +298,3 @@
   "Returns true if this is the first trash of an owned installed card this turn by this side"
   [state side]
   (= 1 (count (filter #(= (:side (first %)) (side-str side)) (get-installed-trashed state side)))))
-
-;;; Effect completion triggers
-(defn register-effect-completed
-  [state side eid effect]
-  (swap! state update-in [:effect-completed (:eid eid)] #(conj % effect)))
-
-(defn effect-completed
-  [state side eid]
-  (doseq [handler (get-in @state [:effect-completed (:eid eid)])]
-    (handler state side eid))
-  (swap! state update-in [:effect-completed] dissoc (:eid eid)))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -2,7 +2,7 @@
 
 (declare can-run? can-trash? card-init card-str cards-can-prevent? close-access-prompt enforce-msg
          gain-agenda-point get-prevent-list get-agenda-points in-corp-scored? installed? is-type? play-sfx
-         prevent-draw make-result remove-old-current show-prompt system-say system-msg steal-trigger-events
+         prevent-draw remove-old-current show-prompt system-say system-msg steal-trigger-events
          trash-cards untrashable-while-rezzed? update-all-ice untrashable-while-resources? win win-decked)
 
 ;;;; Functions for applying core Netrunner game rules.

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -147,17 +147,6 @@
   [state]
   (get-in (swap! state update-in [:rid] inc) [:rid]))
 
-(defn make-eid
-  ([state] (make-eid state nil))
-  ([state {:keys [source source-type]}]
-   (merge {:eid (:eid (swap! state update-in [:eid] inc))}
-          (when source {:source source})
-          (when source-type {:source-type source-type}))))
-
-(defn make-result
-  [eid result]
-  (assoc eid :result result))
-
 (defn mulligan
   "Mulligan starting hand."
   [state side args]

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -93,8 +93,8 @@
          totake (if (= 'apply (first action)) 4 3)
          th (nth action totake)]
      `(let [~'use-eid# (and (map? ~th) (:eid ~th))
-            ~'new-eid# (if ~'use-eid# ~th (game.core/make-eid ~'state))]
-        (~'register-effect-completed ~'state ~'side ~'new-eid# ~reqmac)
+            ~'new-eid# (if ~'use-eid# ~th (game.core.eid/make-eid ~'state))]
+        (~'game.core.eid/register-effect-completed ~'state ~'side ~'new-eid# ~reqmac)
         (if ~'use-eid#
           ~(concat (take totake action) (list 'new-eid#) (drop (inc totake) action))
           ~(concat (take totake action) (list 'new-eid#) (drop totake action)))))))


### PR DESCRIPTION
Instead of doing a monolith PR like #4251, I've decided to go one file or group of functions at a time, cleaning and moving as I go. I hope to have these PRs be relatively short-lived, and iterate quickly. This is PR 1 of XX.

In this PR, I've moved the `eid` creation and manipulation-related functions into a single namespace, and then imported only the needed functions into each other namespace. I view this as the highest point on the call graph. Everything should need these, these functions should need no others.