### PR TITLE
Refactor access prompts, forced trashing, and access abilities

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -500,7 +500,7 @@
                                                        c)))}
                       card nil))
     :events {:run-ends nil}
-    :interactions {:trash-ability
+    :interactions {:access-ability
                    {:label "[Demolition Run]: Trash card"
                     :msg (msg "trash " (:title target) " at no cost")
                     :async true

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -410,11 +410,9 @@
                               :effect (req (draw state side eid 1 nil))}}}
 
    "Freedom Khumalo: Crypto-Anarchist"
-   {:flags {:slow-trash (req true)}
-    :interactions
-    {:trash-ability
-     {:interactive (req true)
-      :async true
+   {:interactions
+    {:access-ability
+     {:async true
       :once :per-turn
       :label "[Freedom]: Trash card"
       :req (req (and (not (:disabled card))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1294,17 +1294,15 @@
                                   :effect (effect (host target card))}]})
 
    "Imp"
-   {:flags {:slow-trash (req (pos? (get-counters card :virus)))}
-    :data {:counter {:virus 2}}
-    :interactions {:trash-ability {:interactive (req true)
-                                   :label "[Imp]: Trash card"
-                                   :req (req (and (not (get-in @state [:per-turn (:cid card)]))
-                                                  (pos? (get-counters card :virus))))
-                                   :counter-cost [:virus 1]
-                                   :msg (msg "trash " (:title target) " at no cost")
-                                   :once :per-turn
-                                   :async true
-                                   :effect (effect (trash-no-cost eid target))}}}
+   {:data {:counter {:virus 2}}
+    :interactions {:access-ability {:label "[Imp]: Trash card"
+                                    :req (req (and (not (get-in @state [:per-turn (:cid card)]))
+                                                   (pos? (get-counters card :virus))))
+                                    :counter-cost [:virus 1]
+                                    :msg (msg "trash " (:title target) " at no cost")
+                                    :once :per-turn
+                                    :async true
+                                    :effect (effect (trash-no-cost eid target))}}}
 
    "Incubator"
    {:events {:runner-turn-begins {:effect (effect (add-counter card :virus 1))}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1891,6 +1891,7 @@
     {:access-ability
      {:label "[Salsette Slums]: Remove card from game"
       :req (req (and (not (get-in @state [:per-turn (:cid card)]))
+                     (:trash target)
                      (can-pay? state :runner {:source card :source-type :ability}
                                card (:title target) [:credit (trash-cost state side target)])))
       :once :per-turn

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -837,22 +837,7 @@
                                   card nil)))}]}
 
    "Mumbad Virtual Tour"
-   {:implementation "Only forces trash if runner has no Imps and enough credits in the credit pool"
-    :flags {:must-trash (req (when installed
-                               true))}
-    :access {:req (req installed)
-             :effect (req (let [trash-cost (trash-cost state side card)
-                                no-salsette (remove #(= (:title %) "Salsette Slums") (all-active state :runner))
-                                slow-trash (any-flag-fn? state :runner :slow-trash true no-salsette)]
-                            (if (and (can-pay? state :runner eid card nil :credit trash-cost)
-                                     (not slow-trash))
-                              (do (toast state :runner "You have been forced to trash Mumbad Virtual Tour" "info")
-                                  (swap! state assoc-in [:runner :register :force-trash] true))
-                              (toast state :runner
-                                     (str "You must trash Mumbad Virtual Tour, if able, using any available means "
-                                          "(Whizzard, Imp, Ghost Runner, Net Celebrity...)")))))}
-    :trash-effect {:when-inactive true
-                   :effect (req (swap! state assoc-in [:runner :register :force-trash] false))}}
+   {:flags {:must-trash (req (when installed true))}}
 
    "Mwanza City Grid"
    (let [gain-creds-and-clear {:req (req (= (:from-server target)

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -259,7 +259,7 @@
                      (if (= :corp side) "R&D" "the stack"))))))
 
 (defn pay-trash-from-hand
-  "Randomly trash a card from hand as part of a cost"
+  "Trash a card from hand as part of a cost"
   [state side eid amount]
   (let [select-fn #(and ((if (= :corp side) corp? runner?) %)
                         (in-hand? %))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -2633,13 +2633,10 @@
 (deftest salsette-slums
   ;; Salsette Slums - Once per turn, when the trash cost of a card is paid, optionally remove from the game
   (do-game
-    (new-game {:corp {:deck ["Hostile Infrastructure" "Tech Startup" "Thomas Haas"
-                             (qty "Hedge Fund" 3)]}
+    (new-game {:corp {:hand ["Hostile Infrastructure" "Tech Startup" "Thomas Haas"]
+                      :deck [(qty "Hedge Fund" 3)]}
                :runner {:deck [(qty "Salsette Slums" 2) (qty "Sure Gamble" 3)]}})
     ;; Use Hostile Infrastructure to ensure on-trash effects don't fire.
-    (core/move state :corp (find-card "Hostile Infrastructure" (:deck (get-corp))) :hand)
-    (core/move state :corp (find-card "Tech Startup" (:deck (get-corp))) :hand)
-    (core/move state :corp (find-card "Thomas Haas" (:deck (get-corp))) :hand)
     (play-from-hand state :corp "Tech Startup" "New remote")
     (play-from-hand state :corp "Hostile Infrastructure" "New remote")
     (play-from-hand state :corp "Thomas Haas" "New remote")
@@ -2648,54 +2645,29 @@
     (play-from-hand state :runner "Salsette Slums")
     (core/gain state :runner :credit 2)
     (core/gain state :runner :click 4)
-    (let [ts1 (get-content state :remote1 0)
-          hostile2 (get-content state :remote2 0)
-          th3 (get-content state :remote3 0)
-          salsette1 (get-resource state 0)
-          salsette2 (get-resource state 1)]
+    (let [ts (get-content state :remote1 0)
+          hostile (get-content state :remote2 0)]
       (is (= 3 (count (:hand (get-runner)))) "Runner started this part with three cards in hand")
-      (core/rez state :corp hostile2)
+      (core/rez state :corp hostile)
       (run-empty-server state "Server 1")
       (is (seq (:prompt (get-runner))) "Prompting to trash.")
-      (card-ability state :runner salsette1 0)
+      (click-prompt state :runner "[Salsette Slums]: Remove card from game")
       (is (empty? (:prompt (get-runner))) "All prompts done")
       (is (= 3 (count (:hand (get-runner)))) "On-trash ability of other Hostile didn't fire")
-      (is (= (:cid ts1) (:cid (last (:rfg (get-corp))))) "Tech Startup was removed from game")
+      (is (= (:cid ts) (:cid (last (:rfg (get-corp))))) "Tech Startup was removed from game")
       (is (= 2 (:credit (get-runner))) "Runner paid the trash cost.")
       (is (not (:run @state)) "Run is over")
       (run-empty-server state :remote2)
       (is (seq (:prompt (get-runner))) "Prompting to trash")
-      ;; Only able to use the ability once per turn
-      (card-ability state :runner salsette1 0)
-      (is (seq (:prompt (get-runner))) "Still prompting to trash")
-      (is (:run @state) "Run is still occurring")
-      ;; Can't use the ability if you can't afford to trash
-      (card-ability state :runner salsette2 0)
-      (is (seq (:prompt (get-runner))) "Still prompting to trash")
+      (is (= ["No action"] (->> (get-runner) :prompt first :choices)) "Can't prompt to trash as can't afford trash cost")
       (is (:run @state) "Run is still occurring")
       (click-prompt state :runner "No action")
-      ;; Test the "oops I forgot" ability (runner feels bad that they forgot to use Slums when a Hostile is out)
       (run-empty-server state :remote3)
-      (click-prompt state :runner "Pay 1 [Credits] to trash")
-      ;; Can only use that first Slums once
-      (card-ability state :runner salsette1 1)
-      (is (empty? (:prompt (get-runner))) "Not prompting the runner")
-      (is (not= (:cid th3) (:cid (last (:rfg (get-corp))))) "Card was not removed from the game")
-      (card-ability state :runner salsette2 1)
-      (is (seq (:prompt (get-runner))) "Prompting the runner to choose a card")
-      (click-card state :runner (find-card "Thomas Haas" (:discard (get-corp))))
-      (is (= (:cid th3) (:cid (last (:rfg (get-corp))))) "Card was removed from the game"))
-    ;; Set things up so we can trash the Hostile and then make sure we can't "oops I forgot on a later turn"
-    (core/gain state :runner :credit 5)
-    (run-empty-server state :remote2)
-    (click-prompt state :runner "Pay 5 [Credits] to trash")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (let [salsette1 (get-resource state 0)
-          hostile2 (get-content state :remote2 0)]
-      (card-ability state :runner salsette1 1)
-      (click-card state :runner (find-card "Hostile Infrastructure" (:discard (get-corp))))
-      (is (not= (:cid hostile2) (:cid (last (:rfg (get-corp))))) "Did not remove card from game"))))
+      (is (seq (:prompt (get-runner))) "Prompting to trash")
+      (is (= ["[Salsette Slums]: Remove card from game" "Pay 1 [Credits] to trash" "No action"]
+             (->> (get-runner) :prompt first :choices)) "Second Salsette Slums can be used")
+      (click-prompt state :runner "[Salsette Slums]: Remove card from game")
+      (is (= 2 (count (:rfg (get-corp)))) "Two cards should be RFG now"))))
 
 (deftest scrubber
   ;; Scrubber

--- a/test/clj/game_test/macros.clj
+++ b/test/clj/game_test/macros.clj
@@ -23,9 +23,10 @@
          ~'prompt-fmt (fn [side#]
                         (let [prompt# (~'prompt-map side#)
                               choices# (:choices prompt#)
-                              choices# (if (sequential? choices#)
-                                         choices#
-                                         [choices#])
+                              choices# (cond
+                                         (nil? choices#) nil
+                                         (sequential? choices#) choices#
+                                         :else [choices#])
                               prompt-type# (:prompt-type prompt#)]
                           (str (side-str side#) ": " (:msg prompt# "") "\n"
                                "Type: " (if (some? prompt-type#) prompt-type# "nil") "\n"


### PR DESCRIPTION
Looking at Mumbad Virtual Tour, I realized there was a really simple way to write it, which lead me down a rabbit hole of cleaning up both `access-non-agenda` and `access-agenda`.

### Changelog
* Change the key from `:trash-abilities` to `:access-abilities`, as cards like Salsette Slums aren't trash abilities
* Refactor `access-non-agenda` to be much simpler and properly handle early exiting
* Clean up the two different kinds of forced trashing, making them stricter and more accurate
* Rewrite Mumbad Virtual Tour to be simpler, removing all references to `:slow-trash`
* Clean up Neutralize All Threats to remove flag after access instead of leaving it applied
* Clean up a bunch of relevant tests