### PR TITLE
Implement a lose-bad-publicity function

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -372,7 +372,8 @@
                :effect (effect (damage eid :meat (meat-damage state card) {:card card}))}})
 
    "Clone Retirement"
-   {:msg "remove 1 bad publicity" :effect (effect (lose :bad-publicity 1))
+   {:msg "remove 1 bad publicity"
+    :effect (effect (lose-bad-publicity 1))
     :silent (req true)
     :stolen {:msg "force the Corp to take 1 bad publicity"
              :effect (effect (gain-bad-publicity :corp 1))}}
@@ -1471,7 +1472,7 @@
    "Veterans Program"
    {:interactive (req true)
     :msg "lose 2 bad publicity"
-    :effect (effect (lose :bad-publicity 2))}
+    :effect (effect (lose-bad-publicity 2))}
 
    "Viral Weaponization"
    (let [dmg {:msg "do 1 net damage for each card in the grip"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -639,7 +639,8 @@
                  :effect (effect (rez target {:ignore-cost :all-costs}))}]}
 
    "Elizabeth Mills"
-   {:effect (effect (lose :bad-publicity 1)) :msg "remove 1 bad publicity"
+   {:effect (effect (lose-bad-publicity 1))
+    :msg "remove 1 bad publicity"
     :abilities [{:cost [:click 1] :label "Trash a location"
                  :msg (msg "trash " (:title target) " and take 1 bad publicity")
                  :choices {:req #(has-subtype? % "Location")}
@@ -715,7 +716,7 @@
     :abilities [{:label "Remove 1 bad publicity for each advancement token on Exposé"
                  :msg (msg "remove " (get-counters card :advancement) " bad publicity")
                  :effect (effect (trash card {:cause :ability-cost})
-                                 (lose :bad-publicity (get-counters card :advancement)))}]}
+                                 (lose-bad-publicity (get-counters card :advancement)))}]}
 
    "False Flag"
    (letfn [(tag-count [false-flag]
@@ -1649,7 +1650,7 @@
                                     :msg (msg (if (= target "Remove 1 bad publicity")
                                                 "remove 1 bad publicity" "gain 5 [Credits]"))
                                     :effect (req (if (= target "Remove 1 bad publicity")
-                                                   (lose state side :bad-publicity 1)
+                                                   (lose-bad-publicity state side 1)
                                                    (gain-credits state side 5)))}
                                    card targets)))}]
      {:effect (effect (add-counter card :power 3))
@@ -1682,7 +1683,7 @@
                                                :player :corp
                                                :prompt "Remove 1 bad publicity?"
                                                :yes-ability {:msg "remove 1 bad publicity"
-                                                             :effect (effect (lose :bad-publicity 1))}}}
+                                                             :effect (effect (lose-bad-publicity 1))}}}
                                    card nil))}]}
 
    "Sandburg"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1510,7 +1510,7 @@
                          (or (has-subtype? % "Clone")
                              (has-subtype? % "Executive")
                              (has-subtype? % "Sysop")))}
-    :effect (effect (lose :bad-publicity 2)
+    :effect (effect (lose-bad-publicity 2)
                     (trash eid target nil))}
 
    "Restructure"
@@ -1607,7 +1607,7 @@
                                            (:bad-publicity corp)))]
                    (system-msg state side (str "uses Sacrifice to lose " bp-lost " bad publicity and gain " bp-lost " [Credits]"))
                    (when (pos? bp-lost)
-                     (lose state side :bad-publicity bp-lost)
+                     (lose-bad-publicity state side bp-lost)
                      (gain-credits state side bp-lost))))}
 
    "Salem's Hospitality"
@@ -1912,7 +1912,7 @@
                      {:player :runner
                       :prompt "Remove 1 bad publicity to prevent all resources from being trashed?"
                       :yes-ability {:msg "remove 1 bad publicity, preventing all resources from being trashed"
-                                    :effect (effect (lose :bad-publicity 1))}
+                                    :effect (effect (lose-bad-publicity 1))}
                       :no-ability trash-all-resources}}
                     trash-all-resources)
                   card nil))})
@@ -2105,4 +2105,4 @@
 
    "Witness Tampering"
    {:msg "remove 2 bad publicity"
-    :effect (effect (lose :bad-publicity 2))}})
+    :effect (effect (lose-bad-publicity 2))}})

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -612,7 +612,7 @@
                                                               state :runner
                                                               "takes 1 tag to prevent Corp from removing 1 bad publicity"))}
                                  :no-ability {:msg "remove 1 bad publicity"
-                                              :effect (effect (lose :corp :bad-publicity 1))}
+                                              :effect (effect (lose-bad-publicity :corp 1))}
                                  :end-effect (effect (clear-wait-prompt :corp)
                                                      (effect-completed eid))}}
                                card nil))}}

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -387,6 +387,13 @@
                        {:priority 10}))
                  (resolve-bad-publicity state side eid n args))))))
 
+(defn lose-bad-publicity
+  ([state side n] (lose-bad-publicity state side (make-eid state) n))
+  ([state side eid n]
+   (if (= n :all)
+     (lose-bad-publicity state side eid (get-in @state [:corp :bad-publicity]))
+     (do (lose state :corp :bad-publicity n)
+         (trigger-event-sync state side eid :corp-lose-bad-publicity n side)))))
 
 ;;; Trashing
 (defn trash-resource-bonus


### PR DESCRIPTION
Modeled after lose-tags, this is for being able to wire abilities to losing bad publicity, namely Ireress automation (see #4265).