### PR TITLE
Change draw to use move

### DIFF
--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -119,9 +119,8 @@
                        (not (pos? draws-after-prevent))
                        (not (pos? deck-count)))
                  (effect-completed state side eid)
-                 (let [drawn (zone :hand (take draws-after-prevent (get-in @state [side :deck])))]
-                   (swap! state update-in [side :hand] #(concat % drawn))
-                   (swap! state update-in [side :deck] (partial drop draws-after-prevent))
+                 (let [to-draw (take draws-after-prevent (get-in @state [side :deck]))
+                       drawn (doall (for [card to-draw] (move state side card :hand)))]
                    (swap! state assoc-in [side :register :most-recent-drawn] drawn)
                    (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % draws-after-prevent) 0))
                    (swap! state update-in [:stats side :gain :card] (fnil + 0) n)


### PR DESCRIPTION
Currently, `draw` directly moves the given number of cards directly from the deck to the hand, merely changing their zone.  This makes it very hard to watch for card movement, as you have to duplicate your efforts either by let-binding an ability and assigning it to many events (easy to forget some) or by directly writing out the ability on each event (DRY).

This changes `draw` to call `move` the given number of times, which is slower, yes, but also handles all of the edge cases where a card's data isn't be set correctly by any outside ability. And by using `move`, we get the benefit of calling `card-move` for every card drawn, giving us the chance to react in an ability.