### PR TITLE
Add summon command to add a card to your hand outside of the game

### DIFF
--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -275,8 +275,16 @@
     identity
     {:priority 10}))
 
+(defn command-summon
+  [state side args]
+  (let [s-card (server-card (string/join " " args))
+        card (when (and s-card (card-is? s-card :side side))
+               (build-card s-card))]
+    (when card
+      (swap! state update-in [side :hand] #(concat % (zone :hand [card]))))))
+
 (defn parse-command [text]
-  (let [[command & args] (split text #" ");"
+  (let [[command & args] (split text #" ")
         value (if-let [n (string->num (first args))] n 1)
         num   (if-let [n (-> args first (safe-split #"#") second string->num)] (dec n) 0)]
     (when (<= (count args) 2)
@@ -348,6 +356,7 @@
                                            :choices {:req (fn [t] (card-is? t :side %2))}}
                                           {:title "/rfg command"} nil)
           "/roll"       #(command-roll %1 %2 value)
+          "/summon"     #(command-summon %1 %2 args)
           "/swap-ice"   #(when (= %2 :corp)
                            (resolve-ability
                              %1 %2

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -130,16 +130,20 @@
       (assoc :cid cid :implementation (card-implemented card))
       (dissoc :setname :text :_id :influence :number :influencelimit :factioncost))))
 
+(defn build-card
+  [card]
+  (let [server-card (or (server-card (:title card)) card)
+        c (assoc (make-card server-card) :art (:art card))]
+    (if-let [init (:init (card-def c))]
+      (merge c init)
+      c)))
+
 (defn create-deck
   "Creates a shuffled draw deck (R&D/Stack) from the given list of cards.
   Loads card data from the server-card map if available."
   ([deck] (create-deck deck nil))
   ([deck user]
-   (shuffle (mapcat #(map (fn [card]
-                            (let [server-card (or (server-card (:title card)) card)
-                                  c (assoc (make-card server-card) :art (:art card))]
-                              (if-let [init (:init (card-def c))] (merge c init) c)))
-                          (repeat (:qty %) (assoc (:card %) :art (:art %))))
+   (shuffle (mapcat #(map build-card (repeat (:qty %) (assoc (:card %) :art (:art %))))
                     (shuffle (vec (:cards deck)))))))
 
 (defn make-rid


### PR DESCRIPTION
Playtesters asked for this. You use it by saying `/summon X` where X is a card title, with the proper capitalization: `/summon Hedge Fund` will put a new copy of Hedge Fund into your hand if you're Corp, but not if you're Runner. `/summon hedge fund` will not put any cards into your hand regardless.