### PR TITLE
Remove has?

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1146,7 +1146,7 @@
                    :prompt "Choose an icebreaker to trash"
                    :msg (msg "trash " (:title target))
                    :choices {:req #(and (installed? %)
-                                        (has? % :subtype "Icebreaker"))}
+                                        (has-subtype? % "Icebreaker"))}
                    :effect (effect (trash target {:cause :subroutine})
                                    (clear-wait-prompt :runner))}]}
 
@@ -1497,12 +1497,12 @@
                                     :prompt "Choose a virus to trash"
                                     :msg (msg "trash " (:title target))
                                     :choices {:req #(and (installed? %)
-                                                         (has? % :subtype "Virus"))}
+                                                         (has-subtype? % "Virus"))}
                                     :effect (effect (trash target {:cause :subroutine})
                                                     (clear-wait-prompt :runner))})
                   (trace-ability 2 {:label "Remove a virus in the Heap from the game"
                                     :prompt "Choose a virus in the Heap to remove from the game"
-                                    :choices (req (cancellable (filter #(has? % :subtype "Virus") (:discard runner)) :sorted))
+                                    :choices (req (cancellable (filter #(has-subtype? % "Virus") (:discard runner)) :sorted))
                                     :msg (msg "remove " (:title target) " from the game")
                                     :effect (effect (move :runner target :rfg))})
                   (trace-ability 1 end-the-run)]}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -759,7 +759,7 @@
     :choices ["Hardware" "Program" "Resource"]
     :effect (req (let [type target
                        trashtargets (filter #(and (is-type? % type)
-                                                  (not (has? % :subtype "Icebreaker")))
+                                                  (not (has-subtype? % "Icebreaker")))
                                             (all-active-installed state :runner))
                        numtargets (count trashtargets)
                        typemsg (str (when (= type "Program") "non-Icebreaker ") type
@@ -775,7 +775,7 @@
                         :choices {:max (req (min numtargets (quot (:credit runner) 3)))
                                   :req #(and (installed? %)
                                              (is-type? % type)
-                                             (not (has? % :subtype "Icebreaker")))}
+                                             (not (has-subtype? % "Icebreaker")))}
                         :effect (req (pay state :runner card :credit (* 3 (count targets)))
                                      (system-msg
                                        state :runner

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1369,11 +1369,11 @@
                                                           (ice? %)
                                                           (can-host? %)
                                                           (installed? %)
-                                                          (not-any? (fn [c] (has? c :subtype "Caïssa")) (:hosted %)))
+                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
                                                      (and (ice? %)
                                                           (installed? %)
                                                           (can-host? %)
-                                                          (not-any? (fn [c] (has? c :subtype "Caïssa")) (:hosted %))))}
+                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
                                    :msg (msg "host it on " (card-str state target))
                                    :effect (effect (host target card))} card nil)))}
                 {:cost [:credit 2]
@@ -1956,11 +1956,11 @@
                                                           (= (last (:zone %)) :ices)
                                                           (ice? %)
                                                           (can-host? %)
-                                                          (not-any? (fn [c] (has? c :subtype "Caïssa")) (:hosted %)))
+                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
                                                      (and (ice? %)
                                                           (can-host? %)
                                                           (= (last (:zone %)) :ices)
-                                                          (not-any? (fn [c] (has? c :subtype "Caïssa")) (:hosted %))))}
+                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
                                    :msg (msg "host it on " (card-str state target))
                                    :effect (effect (host target card))} card nil)))}]
     :events {:pre-rez-cost {:req (req (= (:zone (:host card)) (:zone target)))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1641,7 +1641,7 @@
                                 :effect (effect (continue-ability
                                                   (pphelper (:title target)
                                                             (->> (:deck runner)
-                                                                 (filter #(has? % :title (:title target)))
+                                                                 (filter #(= (:title %) (:title target)))
                                                                  (vec)))
                                                   card nil))}}})
 

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -41,12 +41,6 @@
   (let [[head tail] (split-with (complement pred) coll)]
     (vec (concat head (rest tail)))))
 
-(defn has?
-  "Checks the string property of the card to see if it contains the given value"
-  [card property value]
-  (when-let [p (property card)]
-    (> (.indexOf p value) -1)))
-
 (defn card-is?
   "Checks the property of the card to see if it is equal to the given value,
   as either a string or a keyword"

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -2175,14 +2175,14 @@
         (core/rez state :corp wend)
         (is (= 4 (:current-strength (refresh wend))) "Wendigo at normal 4 strength")
         (core/advance state :corp {:card (refresh wend)})
-        (is (true? (utils/has? (refresh wend) :subtype "Barrier")) "Wendigo gained Barrier")
-        (is (false? (utils/has? (refresh wend) :subtype "Code Gate")) "Wendigo lost Code Gate")
+        (is (has-subtype? (refresh wend) "Barrier") "Wendigo gained Barrier")
+        (is (not (has-subtype? (refresh wend) "Code Gate")) "Wendigo lost Code Gate")
         (is (= 5 (:current-strength (refresh wend))) "Wendigo boosted to 5 strength by scored Superior Cyberwalls")
         (play-from-hand state :corp "Shipment from SanSan")
         (click-prompt state :corp "1")
         (click-card state :corp wend)
-        (is (false? (utils/has? (refresh wend) :subtype "Barrier")) "Wendigo lost Barrier")
-        (is (true? (utils/has? (refresh wend) :subtype "Code Gate")) "Wendigo gained Code Gate")
+        (is (not (has-subtype? (refresh wend) "Barrier")) "Wendigo lost Barrier")
+        (is (has-subtype? (refresh wend) "Code Gate") "Wendigo gained Code Gate")
         (is (= 4 (:current-strength (refresh wend))) "Wendigo returned to normal 4 strength")))))
 
 (deftest wraparound

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1464,9 +1464,9 @@
       (click-card state :runner iwall)
       (click-prompt state :runner "Code Gate")
       (is (= 2 (:click (get-runner))) "Click charged")
-      (is (true? (utils/has? (refresh iwall) :subtype "Code Gate")) "Ice Wall gained Code Gate")
+      (is (has-subtype? (refresh iwall) "Code Gate") "Ice Wall gained Code Gate")
       (run-empty-server state "Archives")
-      (is (false? (utils/has? (refresh iwall) :subtype "Code Gate")) "Ice Wall lost Code Gate at the end of the run"))))
+      (is (not (has-subtype? (refresh iwall) "Code Gate")) "Ice Wall lost Code Gate at the end of the run"))))
 
 (deftest paperclip
   ;; Paperclip - prompt to install on encounter, but not if another is installed
@@ -1682,9 +1682,9 @@
       (core/rez state :corp iw)
       (card-ability state :runner pelangi 0)
       (click-prompt state :runner "Code Gate")
-      (is (utils/has? (refresh iw) :subtype "Code Gate") "Ice Wall gained Code Gate")
+      (is (has-subtype? (refresh iw) "Code Gate") "Ice Wall gained Code Gate")
       (run-continue state)
-      (is (not (utils/has? (refresh iw) :subtype "Code Gate")) "Ice Wall lost Code Gate at the end of the run"))))
+      (is (not (has-subtype? (refresh iw) "Code Gate")) "Ice Wall lost Code Gate at the end of the run"))))
 
 (deftest peregrine
   ;; Peregrine - 2c to return to grip and derez an encountered code gate


### PR DESCRIPTION
There's no reason for this function to exist when `has-subtype?` exists.