### PR TITLE
Brahman full implementation

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -858,7 +858,10 @@
 
    "Net-Ready Eyes"
    {:effect (effect (damage eid :meat 2 {:unboostable true :card card})) :msg "suffer 2 meat damage"
-    :events {:run {:choices {:req #(and (installed? %)
+    :events {:run {:req (req (some #(and (program? %)
+                                         (has-subtype? % "Icebreaker"))
+                                   (all-active-installed state :runner)))
+                   :choices {:req #(and (installed? %)
                                         (has-subtype? % "Icebreaker"))}
                    :msg (msg "give " (:title target) " +1 strength")
                    :effect (effect (pump target 1 :all-run))}}}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -544,8 +544,7 @@
                                                                   (not (facedown? %))
                                                                   (not (has-subtype? % "Virus")))}
                                              :msg (msg "add " (:title target) " to the top of the Stack")
-                                             :effect (effect (resolve-ability eid breaker-auto-pump card nil)
-                                                             (update! (dissoc-in card [:special :brahman-used]))
+                                             :effect (effect (update! (dissoc-in card [:special :brahman-used]))
                                                              (move target :deck {:front true}))}]
                                {:pass-ice put-back
                                 :run-ends put-back})})
@@ -2279,8 +2278,7 @@
                                  (strength-pump 2 3)]
                      :events (let [give-credits {:req (req (get-in card [:special :tycoon-used]))
                                                  :msg "give the Corp 2 [Credits]"
-                                                 :effect (effect (resolve-ability eid breaker-auto-pump card nil)
-                                                                 (update! (dissoc-in card [:special :tycoon-used]))
+                                                 :effect (effect (update! (dissoc-in card [:special :tycoon-used]))
                                                                  (gain-credits :corp 2))}]
                                {:pass-ice give-credits
                                 :run-ends give-credits})})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -534,9 +534,19 @@
 
    "Brahman"
    (auto-icebreaker ["All"]
-                    {:implementation "Adding non-virus program to top of Stack is manual"
-                     :abilities [(break-sub 1 2 "ICE")
-                                 (strength-pump 2 1)]})
+                    {:abilities [(break-sub 1 2 "ICE" (effect (update! (assoc-in card [:special :brahman-used] true))))
+                                 (strength-pump 2 1)]
+                     :events (let [put-back {:req (req (get-in card [:special :brahman-used]))
+                                             :prompt "Choose a non-virus program to put on top of your stack."
+                                             :choices {:req #(and (installed? %)
+                                                                  (program? %)
+                                                                  (not (facedown? %))
+                                                                  (not (has-subtype? % "Virus")))}
+                                             :msg (msg "add " (:title target) " to the top of the Stack")
+                                             :effect (effect (update! (dissoc-in card [:special :brahman-used]))
+                                                             (move target :deck {:front true}))}]
+                               {:pass-ice put-back
+                                :run-ends put-back})})
 
    "Breach"
    (central-breaker "Barrier"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -537,13 +537,15 @@
                     {:abilities [(break-sub 1 2 "ICE" (effect (update! (assoc-in card [:special :brahman-used] true))))
                                  (strength-pump 2 1)]
                      :events (let [put-back {:req (req (get-in card [:special :brahman-used]))
+                                             :player :runner ; Needed for when the run is ended by the Corp
                                              :prompt "Choose a non-virus program to put on top of your stack."
                                              :choices {:req #(and (installed? %)
                                                                   (program? %)
                                                                   (not (facedown? %))
                                                                   (not (has-subtype? % "Virus")))}
                                              :msg (msg "add " (:title target) " to the top of the Stack")
-                                             :effect (effect (update! (dissoc-in card [:special :brahman-used]))
+                                             :effect (effect (resolve-ability eid breaker-auto-pump card nil)
+                                                             (update! (dissoc-in card [:special :brahman-used]))
                                                              (move target :deck {:front true}))}]
                                {:pass-ice put-back
                                 :run-ends put-back})})
@@ -2277,7 +2279,8 @@
                                  (strength-pump 2 3)]
                      :events (let [give-credits {:req (req (get-in card [:special :tycoon-used]))
                                                  :msg "give the Corp 2 [Credits]"
-                                                 :effect (effect (update! (dissoc-in card [:special :tycoon-used]))
+                                                 :effect (effect (resolve-ability eid breaker-auto-pump card nil)
+                                                                 (update! (dissoc-in card [:special :tycoon-used]))
                                                                  (gain-credits :corp 2))}]
                                {:pass-ice give-credits
                                 :run-ends give-credits})})

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -972,16 +972,16 @@
   [state side]
   (let [server (-> @state :run :server first)]
     (swap! state assoc-in [:run :ending] true)
-    (trigger-event state side :run-ends server)
-    (doseq [p (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
-      (update! state side (update-in (get-card state p) [:pump] dissoc :all-run))
-      (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
-      (update-breaker-strength state side p))
-    (let [run-effect (get-in @state [:run :run-effect])]
-      (if-let [end-run-effect (:end-run run-effect)]
-        (wait-for (resolve-ability state side end-run-effect (:card run-effect) [server])
-                  (run-cleanup-2 state side))
-        (run-cleanup-2 state side)))))
+    (wait-for (trigger-event-sync state side :run-ends server)
+              (doseq [p (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))]
+                (update! state side (update-in (get-card state p) [:pump] dissoc :all-run))
+                (update! state side (update-in (get-card state p) [:pump] dissoc :encounter))
+                (update-breaker-strength state side p))
+              (let [run-effect (get-in @state [:run :run-effect])]
+                (if-let [end-run-effect (:end-run run-effect)]
+                  (wait-for (resolve-ability state side end-run-effect (:card run-effect) [server])
+                            (run-cleanup-2 state side))
+                  (run-cleanup-2 state side))))))
 
 (defn handle-end-run
   "Initiate run resolution."

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -1204,21 +1204,31 @@
 
 (deftest net-ready-eyes
   ;; Net-Ready Eyes
-  (do-game
-    (new-game {:runner {:deck [(qty "Sure Gamble" 3) "Net-Ready Eyes" "Peacock"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Sure Gamble")
-    (play-from-hand state :runner "Peacock")
-    (play-from-hand state :runner "Net-Ready Eyes")
-    (is (= 3 (count (:discard (get-runner)))) "Took 2 damage on NRE install")
-    (run-on state "HQ")
-    (let [pea (get-program state 0)]
-      (click-card state :runner pea)
-      (is (= 3 (:current-strength (refresh pea))) "Peacock strength boosted")
-      (run-continue state)
-      (run-successful state)
-      (click-prompt state :runner "No action")
-      (is (= 2 (:current-strength (refresh pea))) "Peacock strength back to default"))))
+  (testing "Basic test"
+    (do-game
+      (new-game {:runner {:deck [(qty "Sure Gamble" 3) "Net-Ready Eyes" "Peacock"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Sure Gamble")
+      (play-from-hand state :runner "Peacock")
+      (play-from-hand state :runner "Net-Ready Eyes")
+      (is (= 3 (count (:discard (get-runner)))) "Took 2 damage on NRE install")
+      (run-on state "HQ")
+      (let [pea (get-program state 0)]
+        (click-card state :runner pea)
+        (is (= 3 (:current-strength (refresh pea))) "Peacock strength boosted")
+        (run-continue state)
+        (run-successful state)
+        (click-prompt state :runner "No action")
+        (is (= 2 (:current-strength (refresh pea))) "Peacock strength back to default"))))
+  (testing "Do not display prompt without an installed icebreaker"
+    (do-game
+      (new-game {:runner {:deck [(qty "Sure Gamble" 3) (qty "Net-Ready Eyes" 2)]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Sure Gamble")
+      (play-from-hand state :runner "Net-Ready Eyes")
+      (is (= 3 (count (:discard (get-runner)))) "Took 2 damage on NRE install")
+      (run-on state :hq)
+      (is (empty? (:prompt (get-runner))) "No NRE prompt"))))
 
 (deftest obelus
   ;; Obelus - Increase max hand size with tags, draw cards on first successful HQ/R&D run

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -282,12 +282,30 @@
         (run-on state :hq)
         (core/rez state :corp spi)
         (card-ability state :runner brah 0) ;break sub
-        (println (prompt-fmt :runner))
         (card-subroutine state :corp spi 0) ;ETR
-        (println (prompt-fmt :runner))
         (is (= 0 (count (:deck (get-runner)))) "Stack is empty.")
         (click-card state :runner par)
-        (is (= 1 (count (:deck (get-runner)))) "Paricia on top of Stack now.")))))
+        (is (= 1 (count (:deck (get-runner)))) "Paricia on top of Stack now."))))
+  (testing "Brahman works with Nisei tokens"
+    (do-game
+      (new-game {:corp {:deck ["Ice Wall" "Nisei MK II"]}
+                 :runner {:deck ["Brahman"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (play-and-score state "Nisei MK II")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Brahman")
+      (let [brah (get-program state 0)
+            iw (get-ice state :hq 0)
+            nisei (get-scored state :corp 0)]
+        (run-on state "HQ")
+        (core/rez state :corp iw)
+        (card-ability state :runner brah 0) ;break sub
+        (card-ability state :corp (refresh nisei) 0) ; Nisei Token
+        (is (= 0 (count (:deck (get-runner)))) "Stack is empty.")
+        (click-card state :runner brah)
+        (is (= 1 (count (:deck (get-runner)))) "Brahman on top of Stack now.")))))
+
 (deftest bukhgalter
   ;; Bukhgalter ability
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -243,6 +243,51 @@
       (card-ability state :runner berserker 0)
       (is (= 2 (core/get-strength (refresh berserker))) "Berserker gains 0 strength from Enigma (non-barrier)"))))
 
+(deftest brahman
+  ;; Brahman
+  (testing "Basic test"
+    (do-game
+      (new-game {:runner {:deck ["Brahman" "Paricia" "Cache"]}
+                 :corp {:deck ["Ice Wall"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Brahman")
+      (play-from-hand state :runner "Paricia")
+      (play-from-hand state :runner "Cache")
+      (core/gain state :runner :credit 1)
+      (let [brah (get-program state 0)
+            par (get-program state 1)
+            cache (get-program state 2)
+            iw (get-ice state :hq 0)]
+        (run-on state :hq)
+        (core/rez state :corp iw)
+        (card-ability state :runner brah 0) ;break sub
+        (run-continue state)
+        (is (= 0 (count (:deck (get-runner)))) "Stack is empty.")
+        (click-card state :runner cache)
+        (is (= 0 (count (:deck (get-runner)))) "Did not put Cache on top.")
+        (click-card state :runner par)
+        (is (= 1 (count (:deck (get-runner)))) "Paricia on top of Stack now."))))
+  (testing "Prompt on ETR"
+    (do-game
+      (new-game {:runner {:deck ["Brahman" "Paricia"]}
+                 :corp {:deck ["Spiderweb"]}})
+      (play-from-hand state :corp "Spiderweb" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Brahman")
+      (play-from-hand state :runner "Paricia")
+      (let [brah (get-program state 0)
+            par (get-program state 1)
+            spi (get-ice state :hq 0)]
+        (run-on state :hq)
+        (core/rez state :corp spi)
+        (card-ability state :runner brah 0) ;break sub
+        (println (prompt-fmt :runner))
+        (card-subroutine state :corp spi 0) ;ETR
+        (println (prompt-fmt :runner))
+        (is (= 0 (count (:deck (get-runner)))) "Stack is empty.")
+        (click-card state :runner par)
+        (is (= 1 (count (:deck (get-runner)))) "Paricia on top of Stack now.")))))
 (deftest bukhgalter
   ;; Bukhgalter ability
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -2373,9 +2373,12 @@
             credits (:credit (get-corp))]
         (run-on state "HQ")
         (card-ability state :runner tycoon 0)
+        (card-ability state :runner tycoon 1)
+        (is (= 4 (:current-strength (refresh tycoon))) "Tycoon strength pumped to 4.")
         (is (= credits (:credit (get-corp))) "Corp doesn't gain credits until encounter is over")
         (run-continue state)
-        (is (= (+ credits 2) (:credit (get-corp))) "Corp gains 2 credits from Tycoon being used"))))
+        (is (= (+ credits 2) (:credit (get-corp))) "Corp gains 2 credits from Tycoon being used")
+        (is (= 1 (:current-strength (refresh tycoon))) "Tycoon strength back down to 1."))))
   ;; Issue #4220: Tycoon doesn't fire if Corp ends run before ice is passed
   (testing "Tycoon gives 2c even if ICE wasn't passed"
     (do-game
@@ -2391,9 +2394,12 @@
             nisei (get-scored state :corp 0)]
         (run-on state "HQ")
         (card-ability state :runner tycoon 0)
+        (card-ability state :runner tycoon 1)
+        (is (= 4 (:current-strength (refresh tycoon))) "Tycoon strength pumped to 4.")
         (is (= credits (:credit (get-corp))) "Corp doesn't gain credits until encounter is over")
         (card-ability state :corp (refresh nisei) 0)
-        (is (= (+ credits 2) (:credit (get-corp))) "Corp gains 2 credits from Tycoon being used after Nisei MK II fires")))))
+        (is (= (+ credits 2) (:credit (get-corp))) "Corp gains 2 credits from Tycoon being used after Nisei MK II fires")
+        (is (= 1 (:current-strength (refresh tycoon))) "Tycoon strength back down to 1.")))))
 
 (deftest upya
   (do-game


### PR DESCRIPTION
### Changelog
- Feature: Net-Ready Eyes now only shows prompt, if an icebreaker is installed. Closes #4310.
- Feature: Putting back non-virus programs to the Stack is now implemented.

### ToDo
- [x] Figure out, why the event trigger on `:pass-ice` works, but `:run-ends` does not.