### PR TITLE
Added (local) timestamp to game board

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1483,6 +1483,11 @@
                   (pos? (:click @me)))
              #(send-command "credit")]]))])})))
 
+(defn starting-timestamp []
+  [:div
+   {:class ["panel" "blue-shade"]}
+   (str "Game start: " (.toLocaleTimeString (js/Date.)))])
+
 (defn gameboard []
   (let [run (r/cursor game-state [:run])
         side (r/cursor game-state [:side])
@@ -1586,7 +1591,8 @@
                     [play-area-view op-user "Temporary Zone" op-play-area]
                     [play-area-view me-user "Temporary Zone" me-play-area]
                     [rfg-view op-current "Current" false]
-                    [rfg-view me-current "Current" false]])
+                    [rfg-view me-current "Current" false]
+                    [starting-timestamp]])
                  (when-not (= @side :spectator)
                    [button-pane {:side me-side :active-player active-player :run run :end-turn end-turn
                                  :runner-phase-12 runner-phase-12 :corp-phase-12 corp-phase-12

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1586,13 +1586,13 @@
                        me-current (r/cursor game-state [me-side :current])
                        me-play-area (r/cursor game-state [me-side :play-area])]
                    [:div
+                    [starting-timestamp]
                     [rfg-view op-rfg "Removed from the game" true]
                     [rfg-view me-rfg "Removed from the game" true]
                     [play-area-view op-user "Temporary Zone" op-play-area]
                     [play-area-view me-user "Temporary Zone" me-play-area]
                     [rfg-view op-current "Current" false]
-                    [rfg-view me-current "Current" false]
-                    [starting-timestamp]])
+                    [rfg-view me-current "Current" false]])
                  (when-not (= @side :spectator)
                    [button-pane {:side me-side :active-player active-player :run run :end-turn end-turn
                                  :runner-phase-12 runner-phase-12 :corp-phase-12 corp-phase-12


### PR DESCRIPTION
The issue [2227](https://github.com/mtgred/netrunner/issues/2227) mentioned using GMT 0, but I opted for just providing a local time. I'd be glad to hear feedback on placement, GMT vs local, etc. 
![Screen Shot 2019-07-09 at 10 13 18 PM](https://user-images.githubusercontent.com/13421357/60937814-4b623700-a297-11e9-94dd-bddb8d887a5c.png)

Closes #2227 
