### PR TITLE
Stacking of similar servers

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -61,6 +61,7 @@
   (swap! app-state assoc-in [:options :sounds-volume] (:volume @s))
   (swap! app-state assoc-in [:options :background] (:background @s))
   (swap! app-state assoc-in [:options :show-alt-art] (:show-alt-art @s))
+  (swap! app-state assoc-in [:options :stacked-servers] (:stacked-servers @s))
   (swap! app-state assoc-in [:options :blocked-users] (:blocked-users @s))
   (swap! app-state assoc-in [:options :alt-arts] (:alt-arts @s))
   (swap! app-state assoc-in [:options :gamestats] (:gamestats @s))
@@ -68,6 +69,7 @@
   (.setItem js/localStorage "sounds" (:sounds @s))
   (.setItem js/localStorage "lobby_sounds" (:lobby-sounds @s))
   (.setItem js/localStorage "sounds_volume" (:volume @s))
+  (.setItem js/localStorage "stacked-servers" (:stacked-servers @s))
   (post-options url (partial post-response s)))
 
 (defn add-user-to-block-list
@@ -131,6 +133,7 @@
                    :volume (get-in @app-state [:options :sounds-volume])
                    :show-alt-art (get-in @app-state [:options :show-alt-art])
                    :all-art-select ""
+                   :stacked-servers (get-in @app-state [:options :stacked-servers])
                    :gamestats (get-in @app-state [:options :gamestats])
                    :deckstats (get-in @app-state [:options :deckstats])
                    :blocked-users (sort (get-in @app-state [:options :blocked-users]))})]
@@ -172,6 +175,15 @@
                     :on-change #(swap! s assoc-in [:volume] (.. % -target -value))
                     :value (or (:volume @s) 50)
                     :disabled (not (or (:sounds @s) (:lobby-sounds @s)))}]]]
+
+         [:section
+          [:h3 "Server Stacking"]
+          [:div
+           [:label [:input {:type "checkbox"
+                            :value true
+                            :checked (:stacked-servers @s)
+                            :on-change #(swap! s assoc-in [:stacked-servers] (.. % -target -checked))}]
+            "Server stacking is on by default"]]]
 
          [:section
           [:h3  "Game board background"]

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -13,6 +13,7 @@
            :user (js->clj js/user :keywordize-keys true)
            :options (merge {:background "lobby-bg"
                             :show-alt-art true
+                            :stacked-servers false
                             :deckstats "always"
                             :gamestats "always"
                             :sounds (= (get-local-value "sounds" "true") "true")

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -13,7 +13,7 @@
            :user (js->clj js/user :keywordize-keys true)
            :options (merge {:background "lobby-bg"
                             :show-alt-art true
-                            :stacked-servers false
+                            :stacked-servers (= (get-local-value "stacked-servers" "true") "true")
                             :deckstats "always"
                             :gamestats "always"
                             :sounds (= (get-local-value "sounds" "true") "true")

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1104,7 +1104,8 @@
      (doall
        (for [server (reverse (get-remotes @servers))
              :let [num (remote->num (first server))
-                   similar-servers (filter #((compare-servers-for-stacking server) %) (get-remotes @servers))]
+                   similar-servers (filter #((compare-servers-for-stacking server) %) (get-remotes @servers))
+                   all-servers (conj similar-servers server)]
              :when (or (empty? similar-servers)                                     ; it is a normal server-view
                        (not (get-in @app-state [:options :stacked-servers] false))  ; we're not in stacked mode
                        ; otherwise only show one view for the stacked remote
@@ -1118,7 +1119,9 @@
            [stacked-view {:key num
                           :server (second server)
                           :similar-servers similar-servers
-                          :run (when (= server-type (str "remote" num)) @run)}
+                          :run (when
+                                 (some #(= server-type (str "remote" %)) (map #(remote->num (first %)) all-servers))
+                                 (= server-type (str "remote" num)) @run)}
             {:opts {:name (remote->name (first server))}}])))
      [server-view {:key "hq"
                    :server (:hq @servers)

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -752,8 +752,9 @@
 
 (defn label [cursor opts]
   (let [fn (or (get-in opts [:opts :fn]) count)
-        classes (conj (when (pos? (count cursor)) '("darkbg")) (get-in opts [:opts :classes]))]
-    [:div.header {:class (join " " classes)}
+        classes (str (when (pos? (count cursor)) "darkbg ")
+                     (get-in opts [:opts :classes]))]
+    [:div.header {:class classes}
      (str (get-in opts [:opts :name])
           (when (not (get-in opts [:opts :hide-cursor])) (str " (" (fn cursor) ")")))]))
 
@@ -1031,15 +1032,15 @@
       (when central-view
         central-view)
       (when (not-empty content)
-          (for [card content]
-            (let [is-first (= card (first content))
-                  flipped (not (:rezzed card))]
-              [:div.server-card {:key (:cid card)
-                                 :class (str (when central-view "central ")
-                                             (when (or central-view
-                                                       (and (< 1 (count content)) (not is-first)))
-                                               "shift"))}
-               [card-view card flipped]])))
+        (for [card content]
+          (let [is-first (= card (first content))
+                flipped (not (:rezzed card))]
+            [:div.server-card {:key (:cid card)
+                               :class (str (when central-view "central ")
+                                           (when (or central-view
+                                                     (and (< 1 (count content)) (not is-first)))
+                                             "shift"))}
+             [card-view card flipped]])))
       [label content (update-in opts [:opts] assoc :classes "server-label" :hide-cursor true)]]]))
 
 (defn stacked-label [cursor similar-servers opts]
@@ -1083,7 +1084,9 @@
   (fn [s2]
     (let [ss1 (second s1)
           ss2 (second s2)]
-      (and (not= s1 s2)
+      (and (= (-> ss1 :content first :normalizedtitle)
+              (-> ss2 :content first :normalizedtitle))
+           (not= s1 s2)
            (empty? (:ices ss1))
            (empty? (:ices ss2))
            (= 1 (count (:content ss1)))
@@ -1093,9 +1096,7 @@
            (-> ss1 :content first :rezzed)
            (-> ss2 :content first :rezzed)
            (-> ss1 :content first :hosted empty?)
-           (-> ss2 :content first :hosted empty?)
-           (= (-> ss1 :content first :normalizedtitle)
-              (-> ss2 :content first :normalizedtitle))))))
+           (-> ss2 :content first :hosted empty?)))))
 
 (defn board-view-corp [player-side identity deck discard servers run]
   (let [rs (:server @run)

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -3,7 +3,7 @@
   (:require [cljs.core.async :refer [chan put! <!] :as async]
             [clojure.string :refer [capitalize includes? join lower-case split]]
             [differ.core :as differ]
-            [game.core.card :refer [has-subtype?]]
+            [game.core.card :refer [has-subtype? asset?]]
             [jinteki.utils :refer [str->int is-tagged?] :as utils]
             [jinteki.cards :refer [all-cards]]
             [nr.appstate :refer [app-state]]
@@ -1092,6 +1092,8 @@
            (empty? (:ices ss2))
            (= 1 (count (:content ss1)))
            (= 1 (count (:content ss2)))
+           (-> ss1 :content first asset?)
+           (-> ss2 :content first asset?)
            (-> ss1 :content first :rezzed)
            (-> ss2 :content first :rezzed)
            (-> ss1 :content first :hosted empty?)

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -749,7 +749,7 @@
 
 (defn label [cursor opts]
   (let [fn (or (get-in opts [:opts :fn]) count)
-        classes (conj (when (> (count cursor) 0) '("darkbg")) (get-in opts [:opts :classes]))]
+        classes (conj (when (pos? (count cursor)) '("darkbg")) (get-in opts [:opts :classes]))]
     [:div.header {:class (join " " classes)}
      (str (get-in opts [:opts :name])
           (when (not (get-in opts [:opts :hide-cursor])) (str " (" (fn cursor) ")")))]))

--- a/src/cljs/nr/main.cljs
+++ b/src/cljs/nr/main.cljs
@@ -9,7 +9,7 @@
             [nr.cardbrowser :refer [card-browser]]
             [nr.chat :refer [chat]]
             [nr.deckbuilder :refer [deck-builder]]
-            [nr.gameboard :refer [concede gameboard game-state mute-spectators]]
+            [nr.gameboard :refer [concede gameboard game-state mute-spectators stack-servers]]
             [nr.gamelobby :refer [filter-blocked-games game-lobby leave-game player-view]]
             [nr.help :refer [help]]
             [nr.news :refer [news news-state]]
@@ -63,9 +63,8 @@
             (when is-player
               [:a.mute-button {:on-click #(mute-spectators (not (:mute-spectators game)))}
                (if (:mute-spectators game) "Unmute spectators" "Mute spectators")])
-            (when is-player
-              [:a.stack-servers-button {:on-click #(mute-spectators (not (:mute-spectators game)))}
-               (if (:stack-server game) "Unstack servers" "Stack servers")])]))
+            [:a.stack-servers-button {:on-click #(stack-servers (not (get-in @app-state [:options :stacked-servers] false)))}
+             (if (get-in @app-state [:options :stacked-servers]) "Unstack servers" "Stack servers")]]))
        (when (not (nil? @gameid))
          [:div.float-right [:a {:on-click #(leave-game)} "Leave game"]]))
      (when-let [game (some #(when (= @gameid (:gameid %)) %) @games)]

--- a/src/cljs/nr/main.cljs
+++ b/src/cljs/nr/main.cljs
@@ -62,7 +62,10 @@
             [:a.leave-button {:on-click #(leave-game)} "Leave game"]
             (when is-player
               [:a.mute-button {:on-click #(mute-spectators (not (:mute-spectators game)))}
-               (if (:mute-spectators game) "Unmute spectators" "Mute spectators")])]))
+               (if (:mute-spectators game) "Unmute spectators" "Mute spectators")])
+            (when is-player
+              [:a.stack-servers-button {:on-click #(mute-spectators (not (:mute-spectators game)))}
+               (if (:stack-server game) "Unstack servers" "Stack servers")])]))
        (when (not (nil? @gameid))
          [:div.float-right [:a {:on-click #(leave-game)} "Leave game"]]))
      (when-let [game (some #(when (= @gameid (:gameid %)) %) @games)]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -618,6 +618,9 @@ nav ul
   .mute-button
     margin-left: 12px
 
+  .stack-servers-button
+    margin-left: 12px
+
 // Auth
 
 #auth-forms, .reset-form

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1384,6 +1384,15 @@ nav ul
     text-shadow 1px 1px 2px black
     border-radius: 4px
 
+  .server-label
+    color: white
+    text-align: center
+    position: absolute
+    font-size: 105%
+    width: 100%
+    top: 100%
+    transform: translate(0, -100%)
+
   .card
     position: relative
     height: 84px


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1409906/61669768-904b8c00-ace1-11e9-8a22-3f34aa5b8d83.png)

### Goal
This change will allow a more compact display of asset servers. When there are multiple servers containing one copy of one asset each, these will be displayed stacked as if they were hosted on each other, with a label referring to the correct server numbers.

### Changelog
- Added option to stack similar servers. This is an opt-out feature, that you can disable in the settings.