### PR TITLE
Simple hack/fix for Bankroll

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -441,7 +441,8 @@
 
    "Bankroll"
    {:implementation "Bankroll gains credits automatically."
-    :events {:successful-run {:effect (effect (add-counter card :credit 1)
+    :events {:successful-run {:req (req (not= "Jak Sinclair" (get-in run [:run-effect :card :title]))) ;; TODO: dirty hack
+                              :effect (effect (add-counter card :credit 1)
                                               (system-msg "places 1 [Credit] on Bankroll"))}}
     :abilities [{:label "Take all credits from Bankroll"
                  :async true

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -241,15 +241,17 @@
       (is (= 4 (:credit (get-runner))) "-5 from Baba, -1 from Sharpshooter played into Rig, -5 from Yog"))))
 
 (deftest bankroll
-  ;; Bankroll
+  ;; Bankroll - Includes check for Issue #4334
   (do-game
-    (new-game {:runner {:deck ["Bankroll"]}})
+    (new-game {:runner {:deck ["Bankroll" "Jak Sinclair"]}})
     (take-credits state :corp)
     (play-from-hand state :runner "Bankroll")
+    (play-from-hand state :runner "Jak Sinclair")
     (is (= 3 (core/available-mu state)) "Bankroll uses up 1 MU")
-    (is (= 4 (:credit (get-runner))) "Bankroll cost 1 to install")
+    (is (= 1 (:credit (get-runner))) "Bankroll cost 1 to install")
     (let [bankroll (get-program state 0)
-          hosted-credits #(get-counters (refresh bankroll) :credit)]
+          hosted-credits #(get-counters (refresh bankroll) :credit)
+          credits (:credit (get-runner))]
       (is (zero? (hosted-credits)) "No counters on Bankroll on install")
       (run-empty-server state "Archives")
       (is (= 1 (hosted-credits)) "One credit counter on Bankroll after one successful run")
@@ -257,8 +259,15 @@
       (is (= 2 (hosted-credits)) "Two credit counter on Bankroll after two successful runs")
       (run-empty-server state "HQ")
       (is (= 3 (hosted-credits)) "Three credit counter on Bankroll after three successful runs")
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (core/end-phase-12 state :runner nil)
+      (click-prompt state :runner "Yes")
+      (click-prompt state :runner "R&D")
+      (run-successful state)
+      (is (= 3 (hosted-credits)) "Jak Sinclair didn't trigger Bankroll")
       (card-ability state :runner bankroll 0)
-      (is (= (+ 4 3) (:credit (get-runner))) "Gained 3 credits when trashing Bankroll")
+      (is (= (+ 3 credits) (:credit (get-runner))) "Gained 3 credits when trashing Bankroll")
       (is (= 1 (-> (get-runner) :discard count)) "Bankroll was trashed"))))
 
 (deftest berserker


### PR DESCRIPTION
Bankroll won't fire when Jak Sinclair initiates the run. This is a bad fix, but the best I've got while we don't have any sort of "can't use programs" system set up.

Closes #4334