### PR TITLE
Fix as-trashed-agenda to correctly increment Maw's no-trash-or-steal register

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -63,9 +63,11 @@
      (move state :runner (assoc (deactivate state side card) :agendapoints n) :scored options)
      ; allow force option in case of Blacklist/News Team
      (move state :runner (assoc (deactivate state side card) :agendapoints n :zone [:discard]) :scored options))
+   (no-trash-or-steal state)
+   (system-msg state :runner (str "adds " (:title card) " to their score area as an agenda worth " (quantify n "agenda point")))
    (wait-for (trigger-event-sync state side :as-agenda (assoc card :as-agenda-side side :as-agenda-points n))
-             (do (gain-agenda-point state side n)
-                 (effect-completed state side eid)))))
+             (gain-agenda-point state side n)
+             (effect-completed state side eid))))
 
 ;; Card definitions
 (def card-definitions
@@ -1316,9 +1318,7 @@
                                 :prompt "Take 2 tags or add News Team to your score area as an agenda worth -1 agenda point?"
                                 :choices ["Take 2 tags" "Add News Team to score area"]
                                 :effect (req (if (= target "Add News Team to score area")
-                                               (do (system-msg state :runner (str "adds News Team to their score area as an agenda worth -1 agenda point"))
-                                                   (trigger-event state side :no-trash card)
-                                                   (as-trashed-agenda state :runner eid card -1 {:force true}))
+                                               (as-trashed-agenda state :runner eid card -1 {:force true})
                                                (do (system-msg state :runner (str "takes 2 tags from News Team"))
                                                    (gain-tags state :runner eid 2))))}
                                card targets))}}
@@ -1799,11 +1799,9 @@
                                             :choices [(str "Take " dmg " net damage") "Add Shi.Kyū to score area"]
                                             :async true
                                             :effect (req (if (= target "Add Shi.Kyū to score area")
-                                                           (do (system-msg state :runner (str "adds Shi.Kyū to their score area as as an agenda worth -1 agenda point"))
-                                                               (trigger-event state side :no-trash card)
-                                                               (as-trashed-agenda state :runner eid card -1 {:force true}))
-                                                           (do (damage state :corp eid :net dmg {:card card})
-                                                               (system-msg state :runner (str "takes " dmg " net damage from Shi.Kyū")))))}
+                                                           (as-trashed-agenda state :runner eid card -1 {:force true})
+                                                           (do (system-msg state :runner (str "takes " dmg " net damage from Shi.Kyū"))
+                                                               (damage state :corp eid :net dmg {:card card}))))}
                                            card targets)))}
                          :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
                        card targets))}}

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -66,6 +66,10 @@
   [state side n]
   (swap! state update-in [:runner :next-run-credit] (fnil + 0 0) n))
 
+(defn no-trash-or-steal
+  [state]
+  (swap! state update-in [:runner :register :no-trash-or-steal] (fnil inc 0)))
+
 (defn access-end
   "Trigger events involving the end of the access phase, including :no-trash and :post-access-card"
   [state side eid c]
@@ -78,7 +82,7 @@
   (when (and (get-card state c)
              ;; Don't increment :no-trash-or-steal if accessing a card in Archives
              (not= (:zone c) [:discard]))
-    (swap! state update-in [:runner :register :no-trash-or-steal] (fnil inc 0)))
+    (no-trash-or-steal state))
   (swap! state dissoc :access)
   (trigger-event-sync state side eid :post-access-card c))
 

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -2654,22 +2654,38 @@
 
 (deftest news-team
   ;; News Team - on access take 2 tags or take as agenda worth -1
-  (do-game
-    (new-game {:corp {:deck [(qty "News Team" 3) "Blacklist"]}})
-    (trash-from-hand state :corp "News Team")
-    (play-from-hand state :corp "Blacklist" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state :archives)
-    (click-prompt state :runner "Take 2 tags")
-    (is (= 2 (count-tags state)) "Runner has 2 tags")
-    (run-empty-server state :archives)
-    (click-prompt state :runner "Add News Team to score area")
-    (is (= 1 (count (:scored (get-runner)))) "News Team added to Runner score area")
-    (trash-from-hand state :corp "News Team")
-    (core/rez state :corp (get-content state :remote1 0))
-    (run-empty-server state :archives)
-    (click-prompt state :runner "Add News Team to score area")
-    (is (= 2 (count (:scored (get-runner)))) "News Team added to Runner score area with Blacklist rez")))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck [(qty "News Team" 3) "Blacklist"]}})
+      (trash-from-hand state :corp "News Team")
+      (play-from-hand state :corp "Blacklist" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state :archives)
+      (click-prompt state :runner "Take 2 tags")
+      (is (= 2 (count-tags state)) "Runner has 2 tags")
+      (run-empty-server state :archives)
+      (click-prompt state :runner "Add News Team to score area")
+      (is (= 1 (count (:scored (get-runner)))) "News Team added to Runner score area")
+      (trash-from-hand state :corp "News Team")
+      (core/rez state :corp (get-content state :remote1 0))
+      (run-empty-server state :archives)
+      (click-prompt state :runner "Add News Team to score area")
+      (is (= 2 (count (:scored (get-runner)))) "News Team added to Runner score area with Blacklist rez")))
+  (testing "interaction with Maw. Issue #4214"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Government Takeover" "News Team"]}
+                 :runner {:hand ["Maw"]
+                          :credits 10}})
+      (play-from-hand state :corp "News Team" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Maw")
+      (is (zero? (count (:discard (get-corp)))) "Corp has 0 cards in archives to start")
+      (run-empty-server state :remote1)
+      (click-prompt state :runner "Add News Team to score area")
+      (is (= 1 (count (:discard (get-corp)))) "Corp discards a card from hand")
+      (is (= "Government Takeover" (-> (get-corp) :discard first :title))
+          "Corp discards card from hand from Maw"))))
 
 (deftest ngo-front
   ;; NGO Front - full test
@@ -3553,25 +3569,43 @@
 
 (deftest shi-kyu
   ;; Shi.Kyū
-  (do-game
-    (new-game {:corp {:deck ["Shi.Kyū"]}
-               :runner {:deck [(qty "Sure Gamble" 5)]}})
-    (play-from-hand state :corp "Shi.Kyū" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state "Server 1")
-    (click-prompt state :corp "Yes")
-    (click-prompt state :corp "5")
-    (is (= "Take 5 net damage" (-> (prompt-map :runner) :choices first)))
-    (click-prompt state :runner "Take 5 net damage")
-    (click-prompt state :runner "No action")
-    (is (zero? (count (:hand (get-runner)))) "Runner took 5 net damage from Shi.Kyū")
-    (run-empty-server state "Server 1")
-    (click-prompt state :corp "Yes")
-    (click-prompt state :corp "2")
-    (is (= "Take 2 net damage" (-> (prompt-map :runner) :choices first)))
-    (click-prompt state :runner "Add Shi.Kyū to score area")
-    (is (empty? (prompt-map :runner)) "Runner shouldn't get the option to trash Shi.Kyū as it was added to agenda area")
-    (is (= -1 (:agenda-point (get-runner))) "Runner should be at -1 agenda points after adding Shi.Kyū to agenda area")))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck ["Shi.Kyū"]}
+                 :runner {:deck [(qty "Sure Gamble" 5)]}})
+      (play-from-hand state :corp "Shi.Kyū" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (click-prompt state :corp "Yes")
+      (click-prompt state :corp "5")
+      (is (= "Take 5 net damage" (-> (prompt-map :runner) :choices first)))
+      (click-prompt state :runner "Take 5 net damage")
+      (click-prompt state :runner "No action")
+      (is (zero? (count (:hand (get-runner)))) "Runner took 5 net damage from Shi.Kyū")
+      (run-empty-server state "Server 1")
+      (click-prompt state :corp "Yes")
+      (click-prompt state :corp "2")
+      (is (= "Take 2 net damage" (-> (prompt-map :runner) :choices first)))
+      (click-prompt state :runner "Add Shi.Kyū to score area")
+      (is (empty? (prompt-map :runner)) "Runner shouldn't get the option to trash Shi.Kyū as it was added to agenda area")
+      (is (= -1 (:agenda-point (get-runner))) "Runner should be at -1 agenda points after adding Shi.Kyū to agenda area")))
+  (testing "interaction with Maw. Issue #4214"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Government Takeover" "Shi.Kyū"]}
+                 :runner {:hand ["Maw"]
+                          :credits 10}})
+      (play-from-hand state :corp "Shi.Kyū" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Maw")
+      (is (zero? (count (:discard (get-corp)))) "Corp has 0 cards in archives to start")
+      (run-empty-server state :remote1)
+      (click-prompt state :corp "Yes")
+      (click-prompt state :corp "5")
+      (click-prompt state :runner "Add Shi.Kyū to score area")
+      (is (= 1 (count (:discard (get-corp)))) "Corp discards a card from hand")
+      (is (= "Government Takeover" (-> (get-corp) :discard first :title))
+          "Corp discards card from hand from Maw"))))
 
 (deftest shock
   ;; Shock! - do 1 net damage on access


### PR DESCRIPTION
Looks like this has been broken since last year! Yikes!

Closes #4214 