### PR TITLE
Fix Apocalypse-Calvin B4L3Y-Jinja City Grid interaction

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -269,7 +269,8 @@
    {:abilities [{:cost [:click 1]
                  :msg "draw 2 cards"
                  :once :per-turn
-                 :effect (effect (draw 2))}]
+                 :async true
+                 :effect (effect (draw eid 2 nil))}]
     :trash-effect {:req (req (= :servers (first (:previous-zone card))))
                    :async true
                    :effect (effect (show-wait-prompt :runner "Corp to use Calvin B4L3Y")
@@ -279,7 +280,7 @@
                                        :priority 1
                                        :player :corp
                                        :yes-ability {:msg "draw 2 cards"
-                                                     :effect (effect (draw :eid 2 nil))}
+                                                     :effect (effect (draw eid 2 nil))}
                                        :end-effect (effect (clear-wait-prompt :runner))}}
                                     card nil))}}
 

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -667,6 +667,7 @@
                            :once :per-turn
                            :once-key :jinja-city-grid-draw
                            :async true
+                           :req (req (not (find-cid (:cid card) (flatten (vals (get-in @state [:trash :trash-list]))))))
                            :effect (req (cond
                                           ;; If ice were drawn, do the full routine.
                                           (some ice? (:most-recent-drawn corp-reg))

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -225,29 +225,49 @@
         (is (:facedown (refresh logos)) "Logos is facedown")
         (is (zero? (get-in (get-runner) [:hand-size :mod])) "Hand-size reset with Logos and Origami facedown")
         (is (= 4 (core/available-mu state)) "Memory reset with Logos and Origami facedown"))))
-(testing "Turn Runner cards facedown without firing their trash effects"
-  (do-game
-    (new-game {:corp {:deck [(qty "Launch Campaign" 2) "Ice Wall"]}
-               :runner {:deck [(qty "Tri-maf Contact" 3) (qty "Apocalypse" 3)]}})
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Launch Campaign" "New remote")
-    (play-from-hand state :corp "Launch Campaign" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Tri-maf Contact")
-    (core/gain state :runner :click 2)
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (run-empty-server state "HQ")
-    (play-from-hand state :runner "Apocalypse")
-    (is (zero? (count (core/all-installed state :corp))) "All installed Corp cards trashed")
-    (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
-    (let [tmc (get-runner-facedown state 0)]
-      (is (:facedown (refresh tmc)) "Tri-maf Contact is facedown")
-      (is (= 3 (count (:hand (get-runner))))
-          "No meat damage dealt by Tri-maf's leave play effect")
-      (core/trash state :runner tmc)
-      (is (= 3 (count (:hand (get-runner))))
-          "No meat damage dealt by trashing facedown Tri-maf")))))
+  (testing "Turn Runner cards facedown without firing their trash effects"
+    (do-game
+      (new-game {:corp {:deck [(qty "Launch Campaign" 2) "Ice Wall"]}
+                 :runner {:deck [(qty "Tri-maf Contact" 3) (qty "Apocalypse" 3)]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Launch Campaign" "New remote")
+      (play-from-hand state :corp "Launch Campaign" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Tri-maf Contact")
+      (core/gain state :runner :click 2)
+      (run-empty-server state "Archives")
+      (run-empty-server state "R&D")
+      (run-empty-server state "HQ")
+      (play-from-hand state :runner "Apocalypse")
+      (is (zero? (count (core/all-installed state :corp))) "All installed Corp cards trashed")
+      (is (= 3 (count (:discard (get-corp)))) "3 Corp cards in Archives")
+      (let [tmc (get-runner-facedown state 0)]
+        (is (:facedown (refresh tmc)) "Tri-maf Contact is facedown")
+        (is (= 3 (count (:hand (get-runner))))
+            "No meat damage dealt by Tri-maf's leave play effect")
+        (core/trash state :runner tmc)
+        (is (= 3 (count (:hand (get-runner))))
+            "No meat damage dealt by trashing facedown Tri-maf"))))
+  (testing "Interaction with Calvin B4L3Y and Jinja City Grid. Issue #4201"
+    (do-game
+      (new-game {:corp {:deck [(qty "Ice Wall" 5)]
+                        :hand ["Calvin B4L3Y" "Jinja City Grid"]
+                        :credits 10}
+                 :runner {:hand ["Apocalypse"]}})
+      (play-from-hand state :corp "Jinja City Grid" "New remote")
+      (play-from-hand state :corp "Calvin B4L3Y" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (core/rez state :corp (get-content state :remote2 0))
+      (take-credits state :corp)
+      (run-empty-server state "Archives")
+      (run-empty-server state "R&D")
+      (click-prompt state :runner "No action")
+      (run-empty-server state "HQ")
+      (let [hand (count (:hand (get-corp)))]
+        (play-from-hand state :runner "Apocalypse")
+        (click-prompt state :corp "Yes")
+        (is (= (+ 2 hand) (count (:hand (get-corp)))) "Calvin Baley draws 2 cards")
+        (is (empty? (:prompt (get-corp))) "No Jinja City Grid")))))
 
 (deftest because-i-can
   ;; make a successful run on a remote to shuffle its contents into R&D


### PR DESCRIPTION
For this to be "properly" handled, we'd have to come up with a whole secondary "trash-cards" system that duplicates things like `move` and only calls the `corp-trash` and `runner-trash` events at the very end and somehow bundles all of the trashed cards together so they're recognized as trashed before events fire. That's way more than I'm up to doing at the moment, so this is a "quick" fix that will work across the board for now.

Closes #4201 