### PR TITLE
Make Cards in Button Prompts hoverable

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1532,7 +1532,9 @@
                                   (render-message c)]
                                  [:button {:key (or (:cid c) i)
                                            :class (when (:rotated c) :rotated)
-                                           :on-click #(send-command "choice" {:card c}) :id {:code c}} (:title c)])))
+                                           :on-click #(send-command "choice" {:card c})
+                                           :id {:code c}}
+                                  (render-message (:title c))])))
                            (:choices prompt))))]
          (if @run
            (let [rs (:server @run)


### PR DESCRIPTION
Turns out we weren't wrapping a card's title in the `render-message` call, so it never generated the necessary hover info.

Closes #4186 