### PR TITLE
Allow triggering nil events

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1035,11 +1035,12 @@
    {:data {:counter {:credit 3}}
     :abilities [{:msg "gain 1 [Credits]"
                  :req (req (:run @state))
+                 :async true
                  :effect (req (add-counter state side card :credit -1)
                               (gain-credits state side 1)
-                              (trigger-event state side :spent-stealth-credit card)
-                              (when (not (pos? (get-counters (get-card state card) :credit)))
-                                (trash state :runner card {:unpreventable true})))}]
+                              (wait-for (trigger-event-sync state side :spent-stealth-credit card)
+                                        (when (not (pos? (get-counters (get-card state card) :credit)))
+                                          (trash state :runner card {:unpreventable true}))))}]
     :events (trash-on-empty :credit)
     ; See Net Mercur for why this implementation was chosen
     :interactions {:pay-credits {:req (req (:run @state))
@@ -1455,9 +1456,10 @@
 
    "Net Mercur"
    {:abilities [{:msg "gain 1 [Credits]"
+                 :async true
                  :effect (effect (add-counter card :credit -1)
-                                 (trigger-event :spent-stealth-credit card)
-                                 (gain-credits 1))}]
+                                 (gain-credits 1)
+                                 (trigger-event-sync eid :spent-stealth-credit card))}]
     :events {:spent-stealth-credit
              {:req (req (and (:run @state)
                              (has-subtype? target "Stealth")))
@@ -2382,9 +2384,10 @@
                                    (gain-tags state :runner eid 1))))}
                  card nil))
        {:msg "take 1 [Credits]"
+        :async true
         :effect (effect (add-counter card :credit -1)
-                        (trigger-event :spent-stealth-credit card)
-                        (gain-credits 1))})
+                        (gain-credits 1)
+                        (trigger-event-sync eid :spent-stealth-credit card))})
      :interactions {:pay-credits {:req (req (and (= :ability (:source-type eid))
                                                  (program? target)
                                                  run))

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -308,10 +308,12 @@
              ;; recurring credit abilities are not in the :abilities map and are implicit
              {:msg "take 1 [Recurring Credits]"
               :req (req (pos? (get-counters card :recurring)))
+              :async true
               :effect (req (add-prop state side card :rec-counter -1)
                            (gain state side :credit 1)
-                           (when (has-subtype? card "Stealth")
-                             (trigger-event state side :spent-stealth-credit card)))}
+                           (let [event (when (has-subtype? card "Stealth")
+                                         :spent-stealth-credit)]
+                             (trigger-event-sync state side eid event card)))}
              (get-in cdef [:abilities ability]))]
     (when-not (:disabled card)
       (do-play-ability state side card ab targets))))


### PR DESCRIPTION
In the event of a `nil` event, `effect-completed` will be called and the called `trigger-event` variation will be exited immediately.

This is to allow for conditionally triggering an event without having to split fork at every single later junction. Will make weaving `wait-for` through engine code much simpler and more readable.

To demonstrate how this will look, I refactored the existing `:spent-stealth-credits` calls to be awaitable (as they technically should be, cuz Net Mercur's handler is async (prompts yo)).