### PR TITLE
Fix Cold Site Server/Reduced Service/Ruhr Valley bug

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -17,9 +17,11 @@
   NOTE: If card has an :effect or :leave-play, see function source for the things they need to do to ensure tracking works."
   [unit-costs cdef]
   (let [store-key [:special :current-added-cost]]
-       (letfn [(reset-cost [state card amt]
+       (letfn [(reset-cost [state card qty]
                  (swap! state update-in [:corp :servers (second (:zone card)) :additional-cost]
-                        #(merge-costs (concat % (vec (flatten (map (fn [x] [(first x) (* amt (second x))]) (partition 2 unit-costs))))))))
+                        #(merge-costs (concat % (mapv (fn [[cost-type amount]]
+                                                        [cost-type (* qty amount)])
+                                                      (partition 2 unit-costs))))))
                (recompute-cost [state card]
                  (let [change ((fnil - 0 0) (get-counters card :power) (get-in card store-key))]
                    (reset-cost state card change)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -148,9 +148,11 @@
                (same-side? s (:side card))
                (or (= last-zone :play-area)
                    (same-side? side (:side card))))
-      (let [move-card-to (partial move state s (dissoc c :seen :rezzed))
-            log-move (fn [verb & text] (system-msg state side (str verb " " label from-str
-                                                                   (when (seq text) (apply str " " text)))))]
+      (let [move-card-to (partial move state s c)
+            log-move (fn [verb & text]
+                       (system-msg state side (str verb " " label from-str
+                                                   (when (seq text)
+                                                     (apply str " " text)))))]
         (case server
           ("Heap" "Archives")
           (if (= :hand (first (:zone c)))
@@ -292,7 +294,7 @@
   (let [cost (:cost ability)]
     (when (or (nil? cost)
               (if (has-subtype? card "Run")
-                (can-pay? state side (make-eid state {:source card :source-type :ability}) card (:title card) cost (run-costs state side card))
+                (can-pay? state side (make-eid state {:source card :source-type :ability}) card (:title card) cost (run-costs state nil nil))
                 (can-pay? state side (make-eid state {:source card :source-type :ability}) card (:title card) cost)))
       (when-let [activatemsg (:activatemsg ability)]
         (system-msg state side activatemsg))

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -16,7 +16,7 @@
          permitted-zones (remove (set restricted-zones) zones)]
      (if ignore-costs
        permitted-zones
-       (filter #(can-pay? state :runner nil (run-costs state % true))
+       (filter #(can-pay? state :runner nil (run-costs state % nil))
                permitted-zones)))))
 
 (defn get-remotes [state]

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -6,6 +6,10 @@
          get-remote-names card-name can-access-loud can-steal?
          prevent-jack-out card-flag? can-run?)
 
+(defn clear-run-costs
+  [state]
+  (swap! state update-in [:bonus] dissoc :run-cost))
+
 ;;; Steps in the run sequence
 (defn make-run
   "Starts a run on the given server, with the given card as the cause. If card is nil, assume a click was spent."
@@ -14,9 +18,9 @@
   ([state side server run-effect card] (make-run state side (make-eid state) server run-effect card nil))
   ([state side eid server run-effect card] (make-run state side eid server run-effect card nil))
   ([state side eid server run-effect card {:keys [click-run ignore-costs] :as args}]
+   (clear-run-costs state)
    (wait-for (trigger-event-simult state :runner :pre-init-run nil server card args)
              (let [all-run-costs (when-not ignore-costs (run-costs state server args))]
-               (swap! state update-in [:bonus] dissoc :run-cost)
                (if (and (can-run? state :runner)
                         (can-run-server? state server)
                         (can-pay? state :runner (make-eid state eid) card "a run" all-run-costs))

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1881,21 +1881,7 @@
        (click-prompt state :runner "Pay 4 [Credits] to trash") ; pay to trash / 6 cr - 4 cr
        (is (= 1 (:click (get-runner))))
        (run-on state :hq)
-       (is (:run @state) "Runner got to run"))))
-  (testing "If runner cannot pay additional cost, server not shown as an option for run events or click to run button"
-    (do-game
-     (new-game {:corp {:deck ["Ruhr Valley"]}
-                :runner {:deck ["Dirty Laundry"]}})
-     (play-from-hand state :corp "Ruhr Valley" "HQ")
-     (take-credits state :corp)
-     (let [ruhr (get-content state :hq 0)]
-       (core/rez state :corp ruhr)
-       (core/gain state :runner :click -3)
-       (is (= 1 (:click (get-runner))))
-       (play-from-hand state :runner "Dirty Laundry")
-       (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner should only get choice of Archives or R&D")
-       (is (not (contains? (-> (get-runner) :prompt first :choices vec) "HQ"))
-           "Runner should only get choice of Archives or R&D")))))
+       (is (:run @state) "Runner got to run")))))
 
 (deftest ryon-knight
   ;; Ryon Knight - Trash during run to do 1 brain damage if Runner has no clicks remaining

--- a/test/clj/game_test/engine/costs.clj
+++ b/test/clj/game_test/engine/costs.clj
@@ -151,3 +151,19 @@
         (is (= 4 (count (remove :broken (:subroutines (refresh hive))))) "Only broken 1 sub")
         (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh cor)})
         (is (empty? (remove :broken (:subroutines (refresh hive)))) "Hive is now fully broken")))))
+
+(deftest run-additional-costs
+  (testing "If runner cannot pay additional cost, server not shown as an option for run events or click to run button"
+    (do-game
+     (new-game {:corp {:deck ["Ruhr Valley"]}
+                :runner {:deck ["Dirty Laundry"]}})
+     (play-from-hand state :corp "Ruhr Valley" "HQ")
+     (take-credits state :corp)
+     (let [ruhr (get-content state :hq 0)]
+       (core/rez state :corp ruhr)
+       (core/gain state :runner :click -3)
+       (is (= 1 (:click (get-runner))))
+       (play-from-hand state :runner "Dirty Laundry")
+       (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner should only get choice of Archives or R&D")
+       (is (not (contains? (-> (get-runner) :prompt first :choices vec) "HQ"))
+           "Runner should only get choice of Archives or R&D")))))


### PR DESCRIPTION
The issue is that `move-card` for some reason `dissoc`'d `:seen` and `:rezzed` from the card that was dragged, which breaks `:leave-play` effects.

I explored a number of other additional solutions, such as rewriting Cold Site Server (and the others) to watch `:pre-init-run` and rewriting how run costs are handled, but those would require significantly more work than this fix warrants.

Closes #4157 