### PR TITLE
Refactor resolve-ability for readability and potential expansion

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1485,11 +1485,11 @@
                          :effect (effect (mill :corp :runner (adv4? state card)))}}})
 
    "Unorthodox Predictions"
-   {:async false
-    :implementation "Prevention of subroutine breaking is not enforced"
+   {:implementation "Prevention of subroutine breaking is not enforced"
     :prompt "Choose an ICE type for Unorthodox Predictions"
     :choices ["Barrier" "Code Gate" "Sentry"]
-    :msg (msg "prevent subroutines on " target " ICE from being broken until next turn.")}
+    :msg (msg "prevent subroutines on " target " ICE from being broken until next turn.")
+    :effect (effect (effect-completed eid))}
 
    "Utopia Fragment"
    {:events {:pre-steal-cost {:req (req (pos? (get-counters target :advancement)))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -598,7 +598,7 @@
 (defn- pay-sync-next
   [state side eid costs card action msgs]
   (if (empty? costs)
-    (effect-completed state side (make-result eid msgs))
+    (complete-with-result state side eid msgs)
     (wait-for (cost-handler state side (make-eid state eid) card action costs (first costs))
               (pay-sync-next state side eid (next costs) card action (conj msgs async-result)))))
 
@@ -612,7 +612,7 @@
                 (complete-with-result state side eid (->> async-result
                                                           (filter some?)
                                                           (join " and "))))
-      (effect-completed state side (make-result eid nil)))))
+      (complete-with-result state side eid nil))))
 
 (defn gain [state side & args]
   (doseq [[type amount] (partition 2 args)]

--- a/src/clj/game/core/eid.clj
+++ b/src/clj/game/core/eid.clj
@@ -24,17 +24,20 @@
 
 (defn effect-completed
   [state side eid]
-  (doseq [handler (get-in @state [:effect-completed (:eid eid)])]
-    (handler state side eid))
-  (swap! state update-in [:effect-completed] dissoc (:eid eid)))
+  (let [results
+        (reduce (fn [result handler]
+                  (conj result (handler state side eid)))
+                []
+                (get-in @state [:effect-completed (:eid eid)]))]
+    (swap! state update-in [:effect-completed] dissoc (:eid eid))
+    results))
 
 (defn make-result
   [eid result]
   (assoc eid :result result))
 
 (defn complete-with-result
-  "Calls `effect-complete` with `make-result` and also returns the argument.
-  Helper function for cost-handler"
+  "Calls `effect-complete` with `make-result` and also returns the argument"
   [state side eid result]
   (effect-completed state side (make-result eid result))
   result)


### PR DESCRIPTION
# Overview
The `resolve-ability` system is a weird mix of conditional logic and dropping return values. This reads poorly and behaves inconsistently. This cleans it up to only take the necessary paths and always return the output.

# Reasoning
The core engine is stateful, but Clojure is not and we lose a lot of valuable information when we needlessly discard the return data from expressions. It's slower and less clear what exactly is happening when all of the `check-psi`-style functions are called, even tho only one of them will result in an ability being resolved. Especially with `complete-ability` being called at the end regardless, meaning that if the ability is async at all it would only return `nil`.

Additionally, `effect-completed` used `doseq` and then called `swap!` in the final position, returning the entirety of the unwrapped `state`.

# Changes
* Rewrite `resolve-ability-eid` to always take a single path
* Add additional helper functions for choices, async abilities, and non-async abilities
* Rewrite `do-ability` to always take a single path
* Use `complete-with-result` in `pay-sync` instead of using the long-form.
* Rewrite `effect-completed` to reduce over the handlers, `conj`ing the results together and returning those results after performing the `swap!`

### To Do
I experimented with returning all values from `effect-completed` and `complete-with-result`, passing that back to `resolve-ability`, but decided to worry about that in another PR. I have plans for continuous abilities and gathering results that doesn't rely on the `eid` system, as it's not built for it at all.