### PR TITLE
Clean up move-zone

### DIFF
--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -197,11 +197,8 @@
   "Moves all cards from one zone to another, as in Chronos Project."
   [state side server to]
   (when-not (seq (get-in @state [side :locked server]))
-    (let [from-zone (cons side (if (sequential? server) server [server]))
-          to-zone (cons side (if (sequential? to) to [to]))]
-      (swap! state assoc-in to-zone (concat (get-in @state to-zone)
-                                            (zone to (get-in @state from-zone))))
-      (swap! state assoc-in from-zone []))))
+    (doseq [card (get-in @state [side server])]
+      (move state side card to))))
 
 (defn add-prop
   "Adds the given value n to the existing value associated with the key in the card.


### PR DESCRIPTION
Using `zone` is a code-smell in this codebase. I really gotta look into removing it wholesale.