### PR TITLE
Make Thoth act like Authenticator/Data raven

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2672,6 +2672,7 @@
 
    "Thoth"
    {:implementation "Encounter effect is manual"
+    :abilities [(give-tags 1)]
     :runner-abilities [{:label "Take 1 tag"
                         :async true
                         :effect (req (system-msg state :runner "takes 1 tag on encountering Thoth")


### PR DESCRIPTION
Adds the 'give-tags' ability to thoth, so the corp can give the runner a tag like they can with data raven/authenticator.

I tested this on my machine and it seems to work fine.