### PR TITLE
Fix Utae, Gravedigger, Errand Boy, Daily Quest, Adonis Campaign

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -169,8 +169,8 @@
 (defn trash-on-empty
   "Used in :event maps for effects like Daily Casts"
   [counter-type]
-  {:counter-added {:req (req (same-card? card target)
-                             (not (pos? (get-counters card counter-type))))
+  {:counter-added {:req (req (and (same-card? card target)
+                                  (not (pos? (get-counters card counter-type)))))
                    :async true
                    :effect (effect (system-msg (str "trashes " (:title card)))
                                    (trash eid card {:unpreventable true}))}})

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1004,7 +1004,8 @@
 
    "Errand Boy"
    {:subroutines [(gain-credits-sub 1)
-                  {:msg "draw 1 card" :effect (effect (draw))}]}
+                  {:msg "draw 1 card"
+                   :effect (effect (draw eid 1 nil))}]}
 
    "Excalibur"
    {:subroutines [{:label "The Runner cannot make another run this turn"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1181,8 +1181,10 @@
                                   (break-subroutine! state (get-card state current-ice) sub))))}]}
 
    "Gravedigger"
-   {:events (let [e {:req (req (and (installed? target) (= (:side target) "Corp")))
-                     :effect (effect (add-counter :runner card :virus 1))}]
+   {:events (let [e {:req (req (and (installed? target)
+                                    (corp? target)))
+                     :msg (msg "place 1 virus counter on " (:title card))
+                     :effect (effect (add-counter :runner card :virus 1 nil))}]
               {:runner-trash e
                :corp-trash e})
     :abilities [{:cost [:click 1 :virus 1]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1047,7 +1047,7 @@
                                  :type :credit}}}
 
    "Globalsec Security Clearance"
-   {:req (req (> (:link runner) 1))
+   {:req (req (< 1 (:link runner)))
     :flags {:runner-phase-12 (req true)}
     :abilities [{:msg "lose [Click] and look at the top card of R&D"
                  :once :per-turn

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -210,8 +210,9 @@
 (defn add-prop
   "Adds the given value n to the existing value associated with the key in the card.
   Example: (add-prop ... card :counter 1) adds one power/virus counter. Triggers events."
-  ([state side card key n] (add-prop state side card key n nil))
-  ([state side card key n {:keys [placed] :as args}]
+  ([state side card key n] (add-prop state side (make-eid state) card key n nil))
+  ([state side card key n args] (add-prop state side (make-eid state) card key n args))
+  ([state side eid card key n {:keys [placed] :as args}]
    (let [updated-card (if (has-subtype? card "Virus")
                         (assoc card :added-virus-counter true)
                         card)]
@@ -219,10 +220,9 @@
      (if (= key :advance-counter)
        (do (when (and (ice? updated-card) (rezzed? updated-card)) (update-ice-strength state side updated-card))
            (if-not placed
-             (trigger-event state side :advance (get-card state updated-card))
-             (trigger-event state side :advancement-placed (get-card state updated-card))))
-       (let [eid (make-eid state {:source card :source-type :add-prop})]
-         (trigger-event-sync state side eid :counter-added (get-card state updated-card)))))))
+             (trigger-event-sync state side eid :advance (get-card state updated-card))
+             (trigger-event-sync state side eid :advancement-placed (get-card state updated-card))))
+       (trigger-event-sync state side eid :counter-added (get-card state updated-card))))))
 
 (defn set-prop
   "Like add-prop, but sets multiple keys to corresponding values without triggering events.
@@ -232,17 +232,17 @@
 
 (defn add-counter
   "Adds n counters of the specified type to a card"
-  ([state side card type n] (add-counter state side card type n nil))
-  ([state side card type n {:keys [placed] :as args}]
+  ([state side card type n] (add-counter state side (make-eid state) card type n nil))
+  ([state side card type n args] (add-counter state side (make-eid state) card type n args))
+  ([state side eid card type n {:keys [placed] :as args}]
    (let [updated-card (if (= type :virus)
                         (assoc card :added-virus-counter true)
                         card)]
      (update! state side (update-in updated-card [:counter type] #(+ (or % 0) n)))
      (if (= type :advancement)
        ;; if advancement counter use existing system
-       (add-prop state side card :advance-counter n args)
-       (let [eid (make-eid state {:source card :source-type :add-prop})]
-         (trigger-event-sync state side (make-eid state) :counter-added (get-card state updated-card)))))))
+       (add-prop state side eid card :advance-counter n args)
+       (trigger-event-sync state side eid :counter-added (get-card state updated-card))))))
 
 ;;; Deck-related functions
 (defn shuffle!

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -168,7 +168,7 @@
         (or (< 1 c)
             (pos? (+ (count corp-abilities)
                      (count runner-abilities)))
-            (some #{"derez" "advance"} actions)
+            (some #{"rez derez" "advance"} actions)
             (and (= type "ICE")
                  (not (:run @game-state)))
             (and (corp? card)
@@ -643,7 +643,6 @@
 (defn card-abilities [card c-state abilities subroutines]
   (let [actions (action-list card)
         dynabi-count (count (filter :dynamic abilities))
-        cur-ice (current-ice)
         show-all (or (:abilities @c-state)
                      (and (= :corp (get-side @game-state))
                           (= card (current-ice))

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -2750,25 +2750,31 @@
     (let [utae (get-program state 0)]
       (run-on state "HQ")
       (core/rez state :corp (get-ice state :hq 0))
-      (card-ability state :runner utae 2)
-      (card-ability state :runner utae 0)
-      (click-prompt state :runner "2")
-      (click-prompt state :runner "Force the Runner to lose 1 [Click] if able")
-      (click-prompt state :runner "End the run")
-      (is (= 5 (:credit (get-runner))))
-      (card-ability state :runner utae 0)
-      (is (empty? (:prompt (get-runner))) "Can only use ability once per run")
-      (card-ability state :runner utae 1)
-      (is (= 5 (:credit (get-runner))) "Cannot use this ability without 3 installed virtual resources")
+      (let [credits (:credit (get-runner))]
+        (card-ability state :runner utae 2)
+        (is (= (dec credits) (:credit (get-runner)))))
+      (let [credits (:credit (get-runner))]
+        (card-ability state :runner utae 0)
+        (click-prompt state :runner "2")
+        (click-prompt state :runner "Force the Runner to lose 1 [Click] if able")
+        (click-prompt state :runner "End the run")
+        (is (= (- credits 2) (:credit (get-runner)))))
+      (let [credits (:credit (get-runner))]
+        (card-ability state :runner utae 0)
+        (is (empty? (:prompt (get-runner))) "Can only use ability once per run")
+        (card-ability state :runner utae 1)
+        (is (= credits (:credit (get-runner))) "Cannot use this ability without 3 installed virtual resources"))
       (run-jack-out state)
       (core/gain state :runner :click 2)
       (dotimes [_ 3]
         (play-from-hand state :runner "Logic Bomb"))
       (run-on state "HQ")
       (card-ability state :runner utae 2)
-      (card-ability state :runner utae 1)
-      (click-prompt state :runner "End the run")
-      (click-prompt state :runner "Done")
+      (let [credits (:credit (get-runner))]
+        (card-ability state :runner utae 1)
+        (click-prompt state :runner "End the run")
+        (click-prompt state :runner "Done")
+        (is (= (dec credits) (:credit (get-runner)))))
       (is (= 3 (:credit (get-runner))) "Able to use ability now"))))
 
 (deftest wyrm


### PR DESCRIPTION
* Converted `add-prop` and `add-counter` to be fully async.
* Give Daily Quest an ability so it can be used in corp-phase-12.
* Fix Errand Boy to call `draw` properly.
* Refactor Rex Campaign.
* Fix `trash-on-empty` bug in `:req` clause.

Closes #4379 