### PR TITLE
Fix labels on icebreakers, clean up icebreaker impls

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -381,7 +381,7 @@
                     (if-let [subtype (:breaks ability)]
                       (or (= subtype "All")
                           (has-subtype? current-ice subtype))
-                      true))
+                      false))
         break-ability (some #(when (can-break %) %) (:abilities (card-def card)))
         subs-broken-at-once (when break-ability
                               (:break break-ability 1))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -164,7 +164,7 @@
     (case cost-type
       :credit (str amount " [Credits]")
       :click (->> "[Click]" repeat (take amount) (apply str))
-      :trash "[Trash]"
+      :trash "[trash]"
       :forfeit (str "forfeit " (quantify amount "Agenda"))
       :forfeit-self "forfeit this Agenda"
       :tag (str "remove " (quantify amount "tag"))
@@ -211,8 +211,13 @@
                        (capitalize (:msg ability)))
                   "")
         cost (:cost ability)]
-    (if (and (seq cost) (not (string/blank? label)))
-      (str (build-cost-label cost) ": " label)
+    (cond
+      (and (seq cost)
+           (not (string/blank? label)))
+      (str (build-cost-label cost) ": " (capitalize label))
+      (not (string/blank? label))
+      (capitalize label)
+      :else
       label)))
 
 (defn cost->string

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -421,24 +421,25 @@
                                                           (card-init state side c {:resolve-effect false
                                                                                    :init-data true}))]
                                      (when-not no-msg
-                                       (runner-install-message state side (:title card) cost-str params))
-
+                                       (runner-install-message state side (:title installed-card) cost-str params))
                                      (play-sfx state side "install-runner")
-                                     (when (and (program? card)
+                                     (when (and (program? installed-card)
                                                 (not facedown)
                                                 (not no-mu))
                                        ;; Use up mu from program not installed facedown
-                                       (use-mu state (:memoryunits card))
+                                       (use-mu state (:memoryunits installed-card))
                                        (toast-check-mu state))
-                                     (handle-virus-counter-flag state side installed-card)
-                                     (when (and (not facedown) (resource? card))
+                                     (handle-virus-counter-flag state side (get-card state installed-card))
+                                     (when (and (not facedown)
+                                                (resource? card))
                                        (swap! state assoc-in [:runner :register :installed-resource] true))
-                                     (when (and (not facedown) (has-subtype? c "Icebreaker"))
-                                       (update-breaker-strength state side c))
+                                     (when (and (not facedown)
+                                                (has-subtype? installed-card "Icebreaker"))
+                                       (update-breaker-strength state side installed-card))
                                      (trigger-event-simult state side eid :runner-install
                                                            (when-not facedown
-                                                             {:card-ability (card-as-handler installed-card)})
-                                                           installed-card))
+                                                             {:card-ability (card-as-handler (get-card state installed-card))})
+                                                           (get-card state installed-card)))
                                    (effect-completed state side eid)))
                        (effect-completed state side eid)))
                    (clear-install-cost-bonus state side)))


### PR DESCRIPTION
Because of a quirk of the `auto-pump-and-break` function, the labels on icebreaker abilities weren't being properly generated, which, combined with quite a few misses on my part, meant that most every new `break-sub` or `pump-strength` ability I wrote didn't have the correct label.

By fixing the label issue and refactoring a number of icebreaker suite functions, icebreakers should now correctly display ability labels with the cost bundled in.

Closes #4380 
Closes #4392 