### PR TITLE
Always show "Fire unbroken subroutines" button

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -683,7 +683,7 @@
                 (render-icons (:label ab))]))
            abilities))
        (when (and show-all
-                  (pos? (count (remove #(or (:broken %) (:fired %)) subroutines))))
+                  (seq subroutines))
          [:div {:on-click #(send-command "unbroken-subroutines" {:card card})}
           "Fire unbroken subroutines"])
        (when (and show-all


### PR DESCRIPTION
Dirjel on netrunner discord shared this with me:
![image](https://user-images.githubusercontent.com/603677/62992745-a3ee9c00-be22-11e9-90d6-dbdd217bb478.png)

To fix this, let's just show the button all the time instead of being "clever".