### PR TITLE
Fix Runner Rezzing/Derezzing Corp Cards, Don't Auto-Open Ice Ability Windows

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -140,7 +140,8 @@
     (f (if (= "exception" type) (build-exception-msg msg (:last-error @game-state)) msg))
     (send-command "toast")))
 
-(defn action-list [{:keys [type zone rezzed advanceable advance-counter advancementcost current-cost] :as card}]
+(defn action-list
+  [{:keys [type zone rezzed advanceable advance-counter advancementcost current-cost] :as card}]
   (-> []
       (#(if (or (and (= type "Agenda")
                      (#{"servers" "onhost"} (first zone)))
@@ -168,7 +169,7 @@
         (or (< 1 c)
             (pos? (+ (count corp-abilities)
                      (count runner-abilities)))
-            (some #{"rez derez" "advance"} actions)
+            (some #{"rez" "derez" "advance"} actions)
             (and (= type "ICE")
                  (not (:run @game-state)))
             (and (corp? card)


### PR DESCRIPTION
Lots of folks have reached out to say that having the Ice ability window open automatically with no method to close is cumbersome, so I'm reverting that functionality to how it used to be: you have to click on a piece of ice to see the subroutines list now.

This also includes a fix for my typo that let runners rez and derez corp cards.

Closes #4398 
Closes #4381 
Closes #4400 