### PR TITLE
Break Sub Payment fix

### DIFF
--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -300,7 +300,8 @@
                                                           (break-subroutines-pay ice cost broken-subs args) card nil)
                                          (doseq [sub broken-subs]
                                            (break-subroutine! state (get-card state ice) sub))
-                                         (let [ice (get-card state ice)]
+                                         (let [ice (get-card state ice)
+                                               card (get-card state card)]
                                            (if (and (not early-exit)
                                                     (:repeatable args)
                                                     (seq broken-subs)


### PR DESCRIPTION
Wasn't updating the breaker reference after breaking and paying for breaking subs in `break-subroutine`.

Closes #4408 