### PR TITLE
Fix Psi, trace, and optional ability handling

### DIFF
--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -142,21 +142,39 @@
   "Checks if there is an optional ability to resolve"
   [state side {:keys [eid optional] :as ability} card targets]
   (if (can-trigger? state side optional card targets)
-    (optional-ability state (or (:player optional) side) eid card (:prompt optional) optional targets)
+    (resolve-ability
+      state side
+      (-> ability
+          (dissoc :optional)
+          (assoc :async true
+                 :effect (req (optional-ability state (or (:player optional) side) eid card (:prompt optional) optional targets))))
+      card targets)
     (effect-completed state side eid)))
 
 (defn- check-psi
   "Checks if a psi-game is to be resolved"
   [state side {:keys [eid psi] :as ability} card targets]
   (if (can-trigger? state side psi card targets)
-    (psi-game state side eid card psi)
+    (resolve-ability
+      state side
+      (-> ability
+          (dissoc :psi)
+          (assoc :async true
+                 :effect (effect (psi-game eid card psi))))
+      card targets)
     (effect-completed state side eid)))
 
 (defn- check-trace
   "Checks if there is a trace to resolve"
   [state side {:keys [eid trace] :as ability} card targets]
   (if (can-trigger? state side ability card targets)
-    (init-trace state side eid card trace)
+    (resolve-ability
+      state side
+      (-> ability
+          (dissoc :trace)
+          (assoc :async true
+                 :effect (effect (init-trace eid card trace))))
+      card targets)
     (effect-completed state side eid)))
 
 (defn- check-prompt

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -1769,7 +1769,7 @@
   (do-game
     (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                       :hand ["Peeping Tom"]}
-               :runner {:hand ["Corroder" (qty "Sure Gamble" 5)]}})
+               :runner {:hand ["Corroder" (qty "Sure Gamble" 4)]}})
     (play-from-hand state :corp "Peeping Tom" "HQ")
     (take-credits state :corp)
     (play-from-hand state :runner "Corroder")

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1173,6 +1173,27 @@
 
 (deftest marcus-batty
   ;; Marcus Batty
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Marcus Batty" "Ice Wall"]
+                        :credits 10}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Marcus Batty" "HQ")
+      (let [iw (get-ice state :hq 0)
+            mb (get-content state :hq 0)]
+        (core/rez state :corp mb)
+        (core/rez state :corp iw)
+        (take-credits state :corp)
+        (run-on state "HQ")
+        (card-ability state :corp mb 0)
+        (is (= :psi (:prompt-type (prompt-map :corp))))
+        (click-prompt state :corp "1 [Credits]")
+        (click-prompt state :runner "0 [Credits]")
+        (click-card state :corp iw)
+        (click-prompt state :corp "End the run")
+        (is (not (:run @state)) "Run has ended")
+        (is (nil? (refresh mb)) "Marcus Batty is trashed"))))
   (testing "Simultaneous Interaction with Security Nexus"
     (do-game
       (new-game {:corp {:deck ["Marcus Batty" "Enigma"]}


### PR DESCRIPTION
This was a real silly mistake, but I don't feel that bad about it because the old functionality was so weird: it'd queue up whichever of the "special" abilities was in the map, and then still hit the `do-ability` clause and pay all the costs, lol. Terrible.

Closes #4419 