### PR TITLE
Fix for additional-abilities on icebreakers

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1002,7 +1002,8 @@
                                           (use-mu (:memoryunits target)))}}}
 
    "Eater"
-   (auto-icebreaker {:abilities [(break-sub 1 1 "All" {:additional-ability (effect (max-access 0))
+   (auto-icebreaker {:abilities [(break-sub 1 1 "All" {:additional-ability {:msg (msg "access not more than 0 cards for the remainder of this run")
+                                                                            :effect (effect (max-access 0))}
                                                        :label "break 1 subroutine and access 0 cards"})
                                  (strength-pump 1 1)]})
 

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1069,9 +1069,10 @@
 
    "Faerie"
    (auto-icebreaker {:abilities [(break-sub 0 1 "Sentry"
-                                            {:additional-ability (effect (update! (assoc-in card [:special :faerie-used] true)))})
+                                            {:additional-ability {:effect (effect (update! (assoc-in card [:special :faerie-used] true)))}})
                                  (strength-pump 1 1)]
                      :events {:pass-ice {:req (req (get-in card [:special :faerie-used]))
+                                         :msg (msg "trash " (:title card))
                                          :effect (effect (trash card))}}})
 
    "False Echo"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -524,7 +524,7 @@
 
    "Brahman"
    (auto-icebreaker {:abilities [(break-sub 1 2 "All"
-                                            {:additional-ability (effect (update! (assoc-in card [:special :brahman-used] true)))})
+                                            {:additional-ability {:effect (effect (update! (assoc-in card [:special :brahman-used] true)))}})
                                  (strength-pump 2 1)]
                      :events (let [put-back {:req (req (get-in card [:special :brahman-used]))
                                              :player :runner ; Needed for when the run is ended by the Corp

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2100,8 +2100,8 @@
 
    "Snowball"
    (auto-icebreaker {:abilities [(break-sub 1 1 "Barrier"
-                                            {:repeatable false
-                                             :additional-ability (effect (pump card 1 :all-run))})
+                                            {:additional-ability {:msg "gain +1 strength for the remainder of the run"
+                                                                  :effect (effect (pump card 1 :all-run))}})
                                  (strength-pump 1 1)]})
 
    "Spike"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -725,13 +725,16 @@
    (break-and-enter "Code Gate")
 
    "Crypsis"
-   (auto-icebreaker {:abilities [(break-sub 1 1 "All" {:additional-ability (effect (update! (assoc card :crypsis-broke true)))})
+   (auto-icebreaker {:abilities [(break-sub 1 1 "All" {:additional-ability {:effect (effect (update! (assoc card :crypsis-broke true)))}})
                                  (strength-pump 1 1)
                                  {:cost [:click 1]
                                   :msg "place 1 virus counter"
                                   :effect (effect (add-counter card :virus 1))}]
                      :events (let [encounter-ends-effect
                                    {:req (req (:crypsis-broke card))
+                                    :msg (msg (if (pos? (get-counters card :virus))
+                                                (str "remove a virus token from " (:title card))
+                                                (str "trash " (:title card))))
                                     :effect (req ((:effect breaker-auto-pump) state side eid card targets)
                                                  (if (pos? (get-counters card :virus))
                                                    (add-counter state side card :virus -1)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2271,7 +2271,7 @@
 
    "Tycoon"
    (auto-icebreaker {:abilities [(break-sub 1 2 "Barrier"
-                                            {:additional-ability (effect (update! (assoc-in card [:special :tycoon-used] true)))})
+                                            {:additional-ability {:effect (effect (update! (assoc-in card [:special :tycoon-used] true)))}})
                                  (strength-pump 2 3)]
                      :events (let [give-credits {:req (req (get-in card [:special :tycoon-used]))
                                                  :msg "give the Corp 2 [Credits]"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -402,7 +402,8 @@
                 (dotimes [n times-pump]
                   (resolve-ability state side (dissoc pump-ability :cost :msg) (get-card state card) nil))
                 (doseq [sub (remove :broken (:subroutines current-ice))]
-                  (break-subroutine! state (get-card state current-ice) sub))
+                  (break-subroutine! state (get-card state current-ice) sub)
+                  (continue-ability state side (:additional-ability break-ability) (get-card state card) nil))
                 (system-msg state side (if (pos? times-pump)
                                          (str (build-spend-msg async-result "increase")
                                               "the strength of " (:title card)
@@ -416,8 +417,7 @@
                                                 "the remaining "
                                                 "all ")
                                               unbroken-subs " subroutines on "
-                                              (:title current-ice))))
-                (continue-ability state side (:additional-ability break-ability) card nil)))))
+                                              (:title current-ice))))))))
 
 (defn play-copy-ability
   "Play an ability from another card's definition."

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -403,7 +403,8 @@
                   (resolve-ability state side (dissoc pump-ability :cost :msg) (get-card state card) nil))
                 (doseq [sub (remove :broken (:subroutines current-ice))]
                   (break-subroutine! state (get-card state current-ice) sub)
-                  (continue-ability state side (:additional-ability break-ability) (get-card state card) nil))
+                  (resolve-ability state side (make-eid state {:source card :source-type :ability})
+                                   (:additional-ability break-ability) (get-card state card) nil))
                 (system-msg state side (if (pos? times-pump)
                                          (str (build-spend-msg async-result "increase")
                                               "the strength of " (:title card)

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -306,16 +306,16 @@
                                (wait-for (resolve-ability state side (make-eid state {:source-type :ability})
                                                           (break-subroutines-pay ice cost broken-subs args) card nil)
                                          (doseq [sub broken-subs]
-                                           (break-subroutine! state (get-card state ice) sub))
+                                           (break-subroutine! state (get-card state ice) sub)
+                                           (continue-ability state side (:additional-ability args) card nil))
                                          (let [ice (get-card state ice)
                                                card (get-card state card)]
-                                           (if (and (not early-exit)
-                                                    (:repeatable args)
-                                                    (seq broken-subs)
-                                                    (pos? (count (unbroken-subroutines-choice ice)))
-                                                    (can-pay? state side eid (get-card state card) nil cost))
-                                             (continue-ability state side (break-subroutines ice cost n args) card nil)
-                                             (continue-ability state side (:additional-ability args) card nil)))))))})))
+                                           (when (and (not early-exit)
+                                                      (:repeatable args)
+                                                      (seq broken-subs)
+                                                      (pos? (count (unbroken-subroutines-choice ice)))
+                                                      (can-pay? state side eid (get-card state card) nil cost))
+                                             (continue-ability state side (break-subroutines ice cost n args) card nil)))))))})))
 
 (defn break-sub
   "Creates a break subroutine ability.

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -307,9 +307,9 @@
                                                           (break-subroutines-pay ice cost broken-subs args) card nil)
                                          (doseq [sub broken-subs]
                                            (break-subroutine! state (get-card state ice) sub)
-                                           (continue-ability state side (assoc (:additional-ability args)
-                                                                              :eid (make-eid state {:source-type :ability}))
-                                                             card nil))
+                                           (resolve-ability state side (make-eid state {:source card :source-type :ability})
+                                                            (:additional-ability args)
+                                                            card nil))
                                          (let [ice (get-card state ice)
                                                card (get-card state card)]
                                            (if (and (not early-exit)

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -315,7 +315,7 @@
                                                     (pos? (count (unbroken-subroutines-choice ice)))
                                                     (can-pay? state side eid (get-card state card) nil cost))
                                              (continue-ability state side (break-subroutines ice cost n args) card nil)
-                                             (continue-ability state side {:effect (:additional-ability args)} card nil)))))))})))
+                                             (continue-ability state side (:additional-ability args) card nil)))))))})))
 
 (defn break-sub
   "Creates a break subroutine ability.
@@ -336,6 +336,7 @@
                               (or (= subtype "All")
                                   (has-subtype? current-ice subtype))
                               true)))))
+      :additional-ability (:additional-ability args)
       :break n
       :breaks subtype
       :break-cost cost

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -307,19 +307,23 @@
                                                           (break-subroutines-pay ice cost broken-subs args) card nil)
                                          (doseq [sub broken-subs]
                                            (break-subroutine! state (get-card state ice) sub)
-                                           (continue-ability state side (:additional-ability args) card nil))
+                                           (continue-ability state side (assoc (:additional-ability args)
+                                                                              :eid (make-eid state {:source-type :ability}))
+                                                             card nil))
                                          (let [ice (get-card state ice)
                                                card (get-card state card)]
-                                           (when (and (not early-exit)
-                                                      (:repeatable args)
-                                                      (seq broken-subs)
-                                                      (pos? (count (unbroken-subroutines-choice ice)))
-                                                      (can-pay? state side eid (get-card state card) nil cost))
-                                             (continue-ability state side (break-subroutines ice cost n args) card nil)))))))})))
+                                           (if (and (not early-exit)
+                                                    (:repeatable args)
+                                                    (seq broken-subs)
+                                                    (pos? (count (unbroken-subroutines-choice ice)))
+                                                    (can-pay? state side eid (get-card state card) nil cost))
+                                             (continue-ability state side (break-subroutines ice cost n args) card nil)
+                                             (effect-completed state side eid)))))))})))
 
 (defn break-sub
   "Creates a break subroutine ability.
-  If n = 0 then any number of subs are broken."
+  If n = 0 then any number of subs are broken.
+  :additional-ability is a non-async ability that is called after using the break ability."
   ([cost n] (break-sub cost n nil nil))
   ([cost n subtype] (break-sub cost n subtype nil))
   ([cost n subtype args]

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -685,51 +685,71 @@
 
 (deftest crypsis
   ;; Crypsis - Loses a virus counter after encountering ice it broke
-  (do-game
-    (new-game {:corp {:deck ["Ice Wall"]}
-               :runner {:deck [(qty "Crypsis" 2)]}})
-    (play-from-hand state :corp "Ice Wall" "Archives")
-    (take-credits state :corp)
-    (core/gain state :runner :credit 100)
-    (play-from-hand state :runner "Crypsis")
-    (let [crypsis (get-program state 0)]
-      (card-ability state :runner crypsis 2)
-      (is (= 1 (get-counters (refresh crypsis) :virus))
-          "Crypsis has 1 virus counter")
-      (run-on state "Archives")
-      (core/rez state :corp (get-ice state :archives 0))
-      (card-ability state :runner (refresh crypsis) 1) ; Match strength
-      (card-ability state :runner (refresh crypsis) 0) ; Break
-      (click-prompt state :runner "End the run")
-      (is (= 1 (get-counters (refresh crypsis) :virus))
-          "Crypsis has 1 virus counter")
-      (run-continue state)
-      (is (zero? (get-counters (refresh crypsis) :virus))
-          "Crypsis has 0 virus counters")
-      (run-jack-out state)
-      (is (zero? (get-counters (refresh crypsis) :virus))
-          "Crypsis has 0 virus counters")
-      (run-on state "Archives")
-      (card-ability state :runner (refresh crypsis) 1) ; Match strength
-      (card-ability state :runner (refresh crypsis) 0) ; Break
-      (click-prompt state :runner "End the run")
-      (is (zero? (get-counters (refresh crypsis) :virus))
-          "Crypsis has 0 virus counters")
-      (run-jack-out state)
-      (is (= "Crypsis" (:title (first (:discard (get-runner)))))
-          "Crypsis was trashed"))
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (play-from-hand state :runner "Crypsis")
-    (let [crypsis (get-program state 0)]
-      (run-on state "Archives")
-      (card-ability state :runner (refresh crypsis) 1) ; Match strength
-      (card-ability state :runner (refresh crypsis) 0) ; Break
-      (click-prompt state :runner "End the run")
-      (is (zero? (get-counters (refresh crypsis) :virus))
-          "Crypsis has 0 virus counters")
-      (run-jack-out state)
-      (is (= 2 (count (:discard (get-runner)))) "Crypsis was trashed"))))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck ["Ice Wall"]}
+                 :runner {:deck [(qty "Crypsis" 2)]}})
+      (play-from-hand state :corp "Ice Wall" "Archives")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 100)
+      (play-from-hand state :runner "Crypsis")
+      (let [crypsis (get-program state 0)]
+        (card-ability state :runner crypsis 2)
+        (is (= 1 (get-counters (refresh crypsis) :virus))
+            "Crypsis has 1 virus counter")
+        (run-on state "Archives")
+        (core/rez state :corp (get-ice state :archives 0))
+        (card-ability state :runner (refresh crypsis) 1) ; Match strength
+        (card-ability state :runner (refresh crypsis) 0) ; Break
+        (click-prompt state :runner "End the run")
+        (is (= 1 (get-counters (refresh crypsis) :virus))
+            "Crypsis has 1 virus counter")
+        (run-continue state)
+        (is (zero? (get-counters (refresh crypsis) :virus))
+            "Crypsis has 0 virus counters")
+        (run-jack-out state)
+        (is (zero? (get-counters (refresh crypsis) :virus))
+            "Crypsis has 0 virus counters")
+        (run-on state "Archives")
+        (card-ability state :runner (refresh crypsis) 1) ; Match strength
+        (card-ability state :runner (refresh crypsis) 0) ; Break
+        (click-prompt state :runner "End the run")
+        (is (zero? (get-counters (refresh crypsis) :virus))
+            "Crypsis has 0 virus counters")
+        (run-jack-out state)
+        (is (= "Crypsis" (:title (first (:discard (get-runner)))))
+            "Crypsis was trashed"))
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Crypsis")
+      (let [crypsis (get-program state 0)]
+        (run-on state "Archives")
+        (card-ability state :runner (refresh crypsis) 1) ; Match strength
+        (card-ability state :runner (refresh crypsis) 0) ; Break
+        (click-prompt state :runner "End the run")
+        (is (zero? (get-counters (refresh crypsis) :virus))
+            "Crypsis has 0 virus counters")
+        (run-jack-out state)
+        (is (= 2 (count (:discard (get-runner)))) "Crypsis was trashed"))))
+  (testing "Working with auto-pump-and-break"
+    (do-game
+      (new-game {:corp {:deck ["Ice Wall"]}
+                 :runner {:deck [(qty "Crypsis" 2)]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 100)
+      (play-from-hand state :runner "Crypsis")
+      (let [crypsis (get-program state 0)
+            iw (get-ice state :hq 0)]
+        (card-ability state :runner crypsis 2)
+        (is (= 1 (get-counters (refresh crypsis) :virus))
+            "Crypsis has 1 virus counter")
+        (run-on state "HQ")
+        (core/rez state :corp (refresh iw))
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh crypsis)})
+        (run-continue state)
+        (is (= 0 (get-counters (refresh crypsis) :virus))
+            "Used up virus token on Crypsis")))))
 
 (deftest cyber-cypher
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -2696,7 +2696,23 @@
         (is (= credits (:credit (get-corp))) "Corp doesn't gain credits until encounter is over")
         (card-ability state :corp (refresh nisei) 0)
         (is (= (+ credits 2) (:credit (get-corp))) "Corp gains 2 credits from Tycoon being used after Nisei MK II fires")
-        (is (= 1 (:current-strength (refresh tycoon))) "Tycoon strength back down to 1.")))))
+        (is (= 1 (:current-strength (refresh tycoon))) "Tycoon strength back down to 1."))))
+  ;; Issue #4423: Tycoon no longer working automatically
+  (testing "Tycoon pays out on auto-pump-and-break"
+    (do-game
+      (new-game {:corp {:deck ["Markus 1.0"]}
+                 :runner {:deck ["Tycoon"]}})
+      (play-from-hand state :corp "Markus 1.0" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Tycoon")
+      (let [tycoon (get-program state 0)
+            credits (:credit (get-corp))]
+        (run-on state "HQ")
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh tycoon)})
+        (is (= credits (:credit (get-corp))) "Corp doesn't gain credits until encounter is over")
+        (run-continue state)
+        (is (= (+ credits 2) (:credit (get-corp))) "Corp gains 2 credits from Tycoon being used")))))
 
 (deftest upya
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1040,23 +1040,36 @@
     (is (not (:run @state)) "Run ended")))
 
 (deftest faerie
-  ;; Faerie - trash after encounter is over, not before.
-  (do-game
-    (new-game {:corp {:deck ["Caduceus"]}
-               :runner {:deck ["Faerie"]}})
-    (play-from-hand state :corp "Caduceus" "Archives")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Faerie")
-    (let [fae (get-program state 0)]
-      (run-on state :archives)
-      (core/rez state :corp (get-ice state :archives 0))
-      (card-ability state :runner fae 1)
-      (card-ability state :runner fae 0)
-      (click-prompt state :runner "Trace 3 - Gain 3 [Credits]")
-      (click-prompt state :runner "Trace 2 - End the run")
-      (is (refresh fae) "Faerie not trashed until encounter over")
-      (run-continue state)
-      (is (find-card "Faerie" (:discard (get-runner))) "Faerie trashed"))))
+  (testing "Trash after encounter is over, not before"
+    (do-game
+      (new-game {:corp {:deck ["Caduceus"]}
+                 :runner {:deck ["Faerie"]}})
+      (play-from-hand state :corp "Caduceus" "Archives")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Faerie")
+      (let [fae (get-program state 0)]
+        (run-on state :archives)
+        (core/rez state :corp (get-ice state :archives 0))
+        (card-ability state :runner fae 1)
+        (card-ability state :runner fae 0)
+        (click-prompt state :runner "Trace 3 - Gain 3 [Credits]")
+        (click-prompt state :runner "Trace 2 - End the run")
+        (is (refresh fae) "Faerie not trashed until encounter over")
+        (run-continue state)
+        (is (find-card "Faerie" (:discard (get-runner))) "Faerie trashed"))))
+  (testing "Works with auto-pump-and-break"
+    (do-game
+      (new-game {:corp {:deck ["Caduceus"]}
+                 :runner {:deck ["Faerie"]}})
+      (play-from-hand state :corp "Caduceus" "Archives")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Faerie")
+      (let [fae (get-program state 0)]
+        (run-on state :archives)
+        (core/rez state :corp (get-ice state :archives 0))
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh fae)})
+        (run-continue state)
+        (is (find-card "Faerie" (:discard (get-runner))) "Faerie trashed")))))
 
 (deftest false-echo
   ;; False Echo - choice for Corp

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -388,7 +388,26 @@
         (card-ability state :corp (refresh nisei) 0) ; Nisei Token
         (is (= 0 (count (:deck (get-runner)))) "Stack is empty.")
         (click-card state :runner brah)
-        (is (= 1 (count (:deck (get-runner)))) "Brahman on top of Stack now.")))))
+        (is (= 1 (count (:deck (get-runner)))) "Brahman on top of Stack now."))))
+  (testing "Works with dynamic ability"
+    (do-game
+      (new-game {:runner {:deck ["Brahman" "Paricia"]}
+                 :corp {:deck ["Spiderweb"]}})
+      (play-from-hand state :corp "Spiderweb" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Brahman")
+      (play-from-hand state :runner "Paricia")
+      (core/gain state :runner :credit 1)
+      (let [brah (get-program state 0)
+            par (get-program state 1)
+            spi (get-ice state :hq 0)]
+        (run-on state :hq)
+        (core/rez state :corp spi)
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh brah)})
+        (run-continue state)
+        (is (= 0 (count (:deck (get-runner)))) "Stack is empty.")
+        (click-card state :runner par)
+        (is (= 1 (count (:deck (get-runner)))) "Paricia on top of Stack now.")))))
 
 (deftest bukhgalter
   ;; Bukhgalter ability

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -2541,41 +2541,58 @@
       (is (empty? (get-in @state [:runner :prompt])) "No option to jack out"))))
 
 (deftest snowball
-  ;; Snowball - Strength boost until end of run when used to break a subroutine
-  (do-game
-    (new-game {:corp {:deck ["Spiderweb" "Fire Wall" "Hedge Fund"]}
-               :runner {:deck ["Snowball"]}})
-    (play-from-hand state :corp "Hedge Fund")
-    (play-from-hand state :corp "Fire Wall" "HQ")
-    (play-from-hand state :corp "Spiderweb" "HQ")
-    (take-credits state :corp)
-    (core/gain state :runner :credit 10)
-    (play-from-hand state :runner "Snowball")
-    (let [sp (get-ice state :hq 1)
-          fw (get-ice state :hq 0)
-          snow (get-program state 0)]
-      (run-on state "HQ")
-      (core/rez state :corp sp)
-      (core/rez state :corp fw)
-      (card-ability state :runner snow 1) ; match strength
-      (is (= 2 (:current-strength (refresh snow))))
-      (card-ability state :runner snow 0) ; strength matched, break a sub
-      (click-prompt state :runner "End the run")
-      (card-ability state :runner snow 0) ; break a sub
-      (click-prompt state :runner "End the run")
-      (is (= 4 (:current-strength (refresh snow))) "Broke 2 subs, gained 2 more strength")
-      (run-continue state)
-      (is (= 3 (:current-strength (refresh snow))) "Has +2 strength until end of run; lost 1 per-encounter boost")
-      (card-ability state :runner snow 1)
-      (card-ability state :runner snow 1) ; match strength
-      (is (= 5 (:current-strength (refresh snow))) "Matched strength, gained 2")
-      (card-ability state :runner snow 0) ; strength matched, break a sub
-      (click-prompt state :runner "End the run")
-      (is (= 6 (:current-strength (refresh snow))) "Broke 1 sub, gained 1 more strength")
-      (run-continue state)
-      (is (= 4 (:current-strength (refresh snow))) "+3 until-end-of-run strength")
-      (run-jack-out state)
-      (is (= 1 (:current-strength (refresh snow))) "Back to default strength"))))
+  (testing "Strength boost until end of run when used to break a subroutine"
+    (do-game
+      (new-game {:corp {:deck ["Spiderweb" "Fire Wall" "Hedge Fund"]}
+                 :runner {:deck ["Snowball"]}})
+      (play-from-hand state :corp "Hedge Fund")
+      (play-from-hand state :corp "Fire Wall" "HQ")
+      (play-from-hand state :corp "Spiderweb" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Snowball")
+      (let [sp (get-ice state :hq 1)
+            fw (get-ice state :hq 0)
+            snow (get-program state 0)]
+        (run-on state "HQ")
+        (core/rez state :corp sp)
+        (core/rez state :corp fw)
+        (card-ability state :runner snow 1) ; match strength
+        (is (= 2 (:current-strength (refresh snow))))
+        (card-ability state :runner snow 0) ; strength matched, break a sub
+        (click-prompt state :runner "End the run")
+        (click-prompt state :runner "End the run")
+        (click-prompt state :runner "End the run")
+        (is (= 5 (:current-strength (refresh snow))) "Broke 3 subs, gained 3 more strength")
+        (run-continue state)
+        (is (= 4 (:current-strength (refresh snow))) "Has +3 strength until end of run; lost 1 per-encounter boost")
+        (card-ability state :runner snow 1) ; match strength
+        (is (= 5 (:current-strength (refresh snow))) "Matched strength, gained 1")
+        (card-ability state :runner snow 0) ; strength matched, break a sub
+        (click-prompt state :runner "End the run")
+        (is (= 6 (:current-strength (refresh snow))) "Broke 1 sub, gained 1 more strength")
+        (run-continue state)
+        (is (= 5 (:current-strength (refresh snow))) "+4 until-end-of-run strength")
+        (run-jack-out state)
+        (is (= 1 (:current-strength (refresh snow))) "Back to default strength"))))
+  (testing "Strength boost until end of run when used to break a subroutine"
+    (do-game
+      (new-game {:corp {:deck ["Spiderweb" "Hedge Fund"]}
+                 :runner {:deck ["Snowball"]}})
+      (play-from-hand state :corp "Hedge Fund")
+      (play-from-hand state :corp "Spiderweb" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Snowball")
+      (let [sp (get-ice state :hq 0)
+            snow (get-program state 0)]
+        (run-on state "HQ")
+        (core/rez state :corp sp)
+        (is (= 1 (:current-strength (refresh snow))) "Snowball starts at 1 strength")
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh snow)})
+        (is (= 5 (:current-strength (refresh snow))) "Snowball was pumped once and gained 3 strength from breaking")
+        (run-continue state)
+        (is (= 4 (:current-strength (refresh snow))) "+3 until-end-of-run strength")))))
 
 (deftest stargate
   ;; Stargate - once per turn Keyhole which doesn't shuffle

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1000,6 +1000,24 @@
         (is (= 2 (:credit (get-runner))) "1cr to use Djinn ability")
         (is (= 2 (:click (get-runner))) "1click to use Djinn ability")))))
 
+(deftest eater
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck [(qty "Ice Wall" 2)]}
+                 :runner {:deck [(qty "Eater" 2)]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 100)
+      (play-from-hand state :runner "Eater")
+      (let [eater (get-program state 0)
+            iw (get-ice state :hq 0)]
+        (run-on state "HQ")
+        (core/rez state :corp (refresh iw))
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh eater)})
+        (run-continue state)
+        (run-successful state)
+        (is (empty? (:prompt (get-runner))) "No prompt for accessing cards")))))
+
 (deftest equivocation
   ;; Equivocation - interactions with other successful-run events.
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -2575,7 +2575,7 @@
         (is (= 5 (:current-strength (refresh snow))) "+4 until-end-of-run strength")
         (run-jack-out state)
         (is (= 1 (:current-strength (refresh snow))) "Back to default strength"))))
-  (testing "Strength boost until end of run when used to break a subroutine"
+  (testing "Strength boost until end of run when using dynamic auto-pump-and-break ability"
     (do-game
       (new-game {:corp {:deck ["Spiderweb" "Hedge Fund"]}
                  :runner {:deck ["Snowball"]}})


### PR DESCRIPTION
The `:additional-ability` on a `break-sub` is now called multiple times during breaking.

Closes #4429, closes #4423, and fixes Brahman, Crypsis, Eater and Snowball which was not found by the community :wink: .