### PR TITLE
Keep Events/Operations in Play Area until fully resolved

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -253,8 +253,8 @@
                          :end-effect (effect (clear-wait-prompt :runner))}}
                        card nil)))]
      {:events [{:event :play-event
-                :req (req (and (first-event? state :runner :run)
-                               (has-subtype? target "Run")
+                :req (req (and (has-subtype? target "Run")
+                               (first-event? state :runner :play-event #(has-subtype? (first %) "Run"))
                                (not (used-this-turn? (:cid card) state))))
                 :async true
                 :effect (ability "playing a run event")}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -12,62 +12,60 @@
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer :all]))
 
-(defn- run-event
-  ([] (run-event nil))
-  ([run-ability] (run-event nil run-ability))
-  ([cdef run-ability] (run-event cdef run-ability nil))
-  ([cdef run-ability pre-run-effect]
-   (run-event cdef run-ability pre-run-effect nil))
-  ([cdef run-ability pre-run-effect post-run-effect]
-   (merge {:prompt "Choose a server"
-           :makes-run true
-           :choices (req runnable-servers)
-           :effect (effect ((or pre-run-effect (effect)) eid card targets)
-                           (make-run target run-ability card)
-                           ((or post-run-effect (effect)) eid card targets))}
-          cdef)))
-
 (defn- cutlery
-  [_subtype]
-  ;; Subtype does nothing currently, but might be used if trashing is properly implemented
-  {:implementation "Ice trash is manual, always enables Reprisals"
+  [subtype]
+  {:implementation "Ice trash is manual"
    :async true
    :makes-run true
-   :effect (req (continue-ability state :runner
-                                  (run-event nil nil nil
-                                             (req (swap! state assoc-in [:runner :register :trashed-card] true)))
-                                  card nil))})
+   :prompt "Choose a server:"
+   :choices (req runnable-servers)
+   :effect (effect (toast "Click this card to trash the passed ice")
+                   (make-run eid target nil card))
+   :abilities [{:label (str "Trash " subtype " ice")
+                :once :per-run
+                :req (req (and run
+                               (has-subtype? (nth run-ices run-position) subtype)
+                               (rezzed? (nth run-ices run-position))))
+                :async true
+                :msg (msg "trash " (card-str state (nth run-ices run-position)))
+                :effect (effect (trash eid (nth run-ices run-position) nil))}]})
 
 ;; Card definitions
 (def card-definitions
   {"Account Siphon"
    {:req (req hq-runnable)
     :makes-run true
-    :effect (effect (make-run :hq {:req (req (= target :hq))
-                                   :replace-access
-                                   {:msg (msg "force the Corp to lose " (min 5 (:credit corp))
-                                              " [Credits], gain " (* 2 (min 5 (:credit corp)))
-                                              " [Credits] and take 2 tags")
-                                    :async true
-                                    :effect (req (wait-for (gain-tags state :runner 2)
-                                                           (do (gain-credits state :runner (* 2 (min 5 (:credit corp))))
-                                                               (lose-credits state :corp (min 5 (:credit corp)))
-                                                               (effect-completed state side eid))))}}
-                              card))}
+    :async true
+    :effect (effect (make-run
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       {:msg (msg "force the Corp to lose " (min 5 (:credit corp))
+                                  " [Credits], gain " (* 2 (min 5 (:credit corp)))
+                                  " [Credits] and take 2 tags")
+                        :async true
+                        :effect (req (wait-for (gain-tags state :runner 2)
+                                               (gain-credits state :runner (* 2 (min 5 (:credit corp))))
+                                               (lose-credits state :corp (min 5 (:credit corp)))
+                                               (effect-completed state side eid)))}}
+                      card))}
 
    "Always Have a Backup Plan"
-   (letfn [(run-again [server]
-             {:optional {:prompt "Run again?"
-                         :msg (msg "to make a run on " (zone->name server) ", ignoring additional costs")
-                         :yes-ability {:effect (effect (make-run eid server nil card {:ignore-costs true}))}}})]
-     {:prompt "Choose a server"
-      :choices (req runnable-servers)
-      :async true
-      :makes-run true
-      :msg (msg "make a run on " target)
-      :effect (req (let [run-server (server->zone state target)]
-                     (wait-for (make-run state side (make-eid state) target nil card nil)
-                               (continue-ability state side (run-again run-server) card nil))))})
+   {:implementation "Bypass is manual"
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :async true
+    :makes-run true
+    :msg (msg "make a run on " target)
+    :effect (req (wait-for (make-run state side target nil card)
+                           (let [card (get-card state card)]
+                             (if (:run-again card)
+                               (make-run state side eid target nil card {:ignore-costs true})
+                               (effect-completed state side eid)))))
+    :events [{:event :unsuccessful-run-ends
+              :optional {:req (req (not (:run-again card)))
+                         :prompt "Make another run on the same server?"
+                         :yes-ability {:effect (effect (update! (assoc card :run-again true)))}}}]}
 
    "Amped Up"
    {:msg "gain [Click][Click][Click] and suffer 1 brain damage"
@@ -113,22 +111,28 @@
                      (continue-ability state side runner-facedown card nil)))})
 
    "Because I Can"
-   (run-event
-     {:choices (req (filter #(can-run-server? state %) remotes))}
-     {:req (req (is-remote? target))
-      :replace-access {:msg "shuffle all cards in the server into R&D"
-                       :effect (req (doseq [c (:content run-server)]
-                                      (move state :corp c :deck))
-                                    (shuffle! state :corp :deck))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (filter #(can-run-server? state %) remotes))
+    :effect (effect (make-run
+                      eid target
+                      {:req (req (is-remote? target))
+                       :replace-access
+                       {:msg "shuffle all cards in the server into R&D"
+                        :effect (req (doseq [c (:content run-server)]
+                                       (move state :corp c :deck))
+                                     (shuffle! state :corp :deck))}}
+                      card))}
 
    "Black Hat"
    {:trace {:base 4
-            :unsuccessful {:effect (effect (register-events (assoc card :zone '(:discard))))}}
-    :events [{:event :pre-access
-              :req (req (#{:hq :rd} target))
-              :effect (effect (access-bonus target 2))}
-             {:event :runner-turn-ends
-              :effect (effect (unregister-events card))}]}
+            :unsuccessful
+            {:effect (effect (register-events
+                               card [{:event :pre-access
+                                      :duration :end-of-turn
+                                      :req (req (#{:hq :rd} target))
+                                      :effect (effect (access-bonus target 2))}]))}}}
 
    "Blueberry!™ Diesel"
    {:async true
@@ -145,21 +149,25 @@
                  (draw state :runner eid 2 nil))}
 
    "Blackmail"
-   (run-event
-     {:req (req (has-bad-pub? state))
-      :msg "prevent ICE from being rezzed during this run"}
-     nil
-     (effect (register-run-flag!
-               card
-               :can-rez
-               (fn [state side card]
-                 (if (ice? card)
-                   ((constantly false)
-                    (toast state :corp "Cannot rez ICE on this run due to Blackmail"))
-                   true)))))
+   {:async true
+    :makes-run true
+    :req (req (has-bad-pub? state))
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :msg "prevent ICE from being rezzed during this run"
+    :effect (effect (register-run-flag!
+                      card
+                      :can-rez
+                      (fn [state side card]
+                        (if (ice? card)
+                          ((constantly false)
+                           (toast state :corp "Cannot rez ICE on this run due to Blackmail"))
+                          true)))
+                    (make-run eid target nil card))}
 
    "Bribery"
    {:implementation "ICE chosen for cost increase is specified at start of run, not on approach"
+    :async true
     :makes-run true
     :prompt "How many credits?"
     :choices :credit
@@ -168,8 +176,9 @@
                       (let [bribery-x target]
                         {:prompt "Choose a server"
                          :choices (req runnable-servers)
-                         :effect (req (make-run state side target nil card)
-                                      (let [run-ices (get-in @state (concat [:corp :servers] (:server (:run @state)) [:ices]))
+                         :async true
+                         :effect (req (let [server (unknown->kw target)
+                                            run-ices (get-in @state (concat [:corp :servers] [server] [:ices]))
                                             foremost-ice (last (remove rezzed? run-ices))]
                                         (register-floating-effect
                                           state side card
@@ -184,7 +193,8 @@
                                             :duration :end-of-run
                                             :req (req (and (same-card? foremost-ice target)
                                                            (not (get-in @state [:per-run (:cid card)]))))
-                                            :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}])))})
+                                            :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}])
+                                        (make-run state side eid target nil card)))})
                       card nil))}
 
    "Brute-Force-Hack"
@@ -225,16 +235,15 @@
     :effect (effect (gain-credits 1) (draw eid 2 nil))}
 
    "By Any Means"
-   {:effect (effect (register-events card))
-    :events [{:event :access
+   {:events [{:event :access
               :duration :end-of-turn
               :req (req (not (in-discard? target)))
               :interactive (req true)
               :async true
               :msg (msg "trash " (:title target) " at no cost and suffer 1 meat damage")
               :effect (req (wait-for (trash state side (assoc target :seen true) nil)
-                                     (do (swap! state assoc-in [:runner :register :trashed-card] true)
-                                         (damage state :runner eid :meat 1 {:unboostable true}))))}]}
+                                     (swap! state assoc-in [:runner :register :trashed-card] true)
+                                     (damage state :runner eid :meat 1 {:unboostable true})))}]}
 
    "Calling in Favors"
    {:msg (msg "gain " (count (filter #(and (has-subtype? % "Connection") (resource? %))
@@ -262,12 +271,10 @@
                     (system-msg (str "prevents the rezzing of " (card-str state target)
                                      " for the rest of this turn via Careful Planning"))
                     (register-events
-                      (assoc card :zone '(:discard))
+                      card
                       [{:event :runner-turn-ends
-                        :effect (effect (remove-icon card target)
-                                        (unregister-events
-                                          card
-                                          {:events [{:event :runner-turn-ends}]}))}])
+                        :duration :end-of-turn
+                        :effect (effect (remove-icon card target))}])
                     (register-turn-flag! card :can-rez
                                          (fn [state side card]
                                            (if (same-card? card target)
@@ -277,11 +284,12 @@
 
    "CBI Raid"
    (letfn [(cbi-final [chosen original]
-             {:prompt (str "The top cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
+             {:prompt (str "The top cards of R&D will be " (join  ", " (map :title chosen)) ".")
               :choices ["Done" "Start over"]
               :async true
               :effect (req (if (= target "Done")
-                             (do (doseq [c (reverse chosen)] (move state :corp c :deck {:front true}))
+                             (do (doseq [c (reverse chosen)]
+                                   (move state :corp c :deck {:front true}))
                                  (clear-wait-prompt state :runner)
                                  (effect-completed state side eid))
                              (continue-ability state side (cbi-choice original '() (count original) original)
@@ -298,24 +306,27 @@
      {:req (req hq-runnable)
       :async true
       :makes-run true
-      :effect (effect (make-run :hq {:replace-access
-                                     {:msg "force the Corp to add all cards in HQ to the top of R&D"
-                                      :async true
-                                      :mandatory true
-                                      :effect (req (show-wait-prompt state :runner "Corp to add all cards in HQ to the top of R&D")
-                                                   (let [from (:hand corp)]
-                                                     (if (pos? (count from))
-                                                       (continue-ability state :corp (cbi-choice from '() (count from) from) card nil)
-                                                       (do (clear-wait-prompt state :runner)
-                                                           (effect-completed state side eid)))))}}
-                                card))})
+      :effect (effect (make-run
+                        eid :hq
+                        {:replace-access
+                         {:msg "force the Corp to add all cards in HQ to the top of R&D"
+                          :async true
+                          :mandatory true
+                          :effect (req (show-wait-prompt state :runner "Corp to add all cards in HQ to the top of R&D")
+                                       (let [from (:hand corp)]
+                                         (if (pos? (count from))
+                                           (continue-ability state :corp (cbi-choice from '() (count from) from) card nil)
+                                           (do (clear-wait-prompt state :runner)
+                                               (effect-completed state side eid)))))}}
+                        card))})
 
    "Code Siphon"
    {:req (req rd-runnable)
+    :async true
     :makes-run true
-    :effect
-    (effect
-      (make-run :rd
+    :effect (effect
+              (make-run
+                eid :rd
                 {:replace-access
                  (let [rd-ice (fn [state] (* -3 (count (get-in @state [:corp :servers :rd :ices]))))]
                    {:async true
@@ -335,25 +346,20 @@
                 card))}
 
    "Cold Read"
-   (let [end-effect {:prompt "Choose a program that was used during the run to trash "
-                     :choices {:req program?}
-                     :msg (msg "trash " (:title target))
-                     :effect (effect (trash target {:unpreventable true}))}]
-     {:async true
-      :prompt "Choose a server"
-      :recurring 4
-      :makes-run true
-      :choices (req runnable-servers)
-      :effect (req (let [c (move state side (assoc card :zone '(:discard)) :play-area {:force true})]
-                     (card-init state side c {:resolve-effect false})
-                     (update! state side (assoc (get-card state c) :cold-read-active true))
-                     (make-run state side (make-eid state) target
-                               {:end-run {:async true
-                                          :effect (effect (trash card)
-                                                          (continue-ability :runner end-effect nil nil))}}
-                               (assoc c :cold-read-active true))))
-      :interactions {:pay-credits {:req (req (:cold-read-active card))
-                                   :type :recurring}}})
+   {:implementation "Used programs restriction not enforced"
+    :async true
+    :prompt "Choose a server"
+    :data {:counter {:credit 4}}
+    :makes-run true
+    :choices (req runnable-servers)
+    :effect (effect (make-run eid target nil card))
+    :interactions {:pay-credits {:type :credit}}
+    :events [{:event :run-ends
+              :prompt "Choose a program that was used during the run to trash "
+              :choices {:req program?}
+              :msg (msg "trash " (:title target))
+              :async true
+              :effect (effect (trash eid target {:unpreventable true}))}]}
 
    "Compile"
    (letfn [(compile-fn [where]
@@ -372,6 +378,7 @@
       :choices (req runnable-servers)
       :async true
       :makes-run true
+      :effect (effect (make-run eid target nil card))
       :abilities [{:label "Install a program using Compile"
                    :prompt "Install a program from your Stack or Heap?"
                    :choices ["Stack" "Heap"]
@@ -379,18 +386,12 @@
                    :effect (effect (continue-ability
                                      (compile-fn (if (= "Stack" target) :deck :discard))
                                      card nil))}]
-      :effect (effect (make-run target nil card)
-                      (prompt! card (str "Click Compile in the Temporary Zone to install a Program") ["OK"] {})
-                      (continue-ability
-                        {:effect (effect (card-init (move state side (last (:discard runner)) :play-area) {:resolve-effect false}))}
-                        card nil))
       :events [{:event :run-ends
-                :effect
-                (req (when-let [compile-installed (some #(when (get-in % [:special :compile-installed]) %) (all-installed state :runner))]
-                       (system-msg state side (str "moved " (:title compile-installed) " to the bottom of the Stack at the end of the run from Compile"))
-                       (move state :runner compile-installed :deck))
-                  (unregister-events state side card)
-                  (trash state side card))}]})
+                :effect (req (when-let [compile-installed (some #(when (get-in % [:special :compile-installed]) %)
+                                                                (all-installed state :runner))]
+                               (system-msg state side (str "moved " (:title compile-installed)
+                                                           " to the bottom of the Stack at the end of the run from Compile"))
+                               (move state :runner compile-installed :deck)))}]})
 
    "Contaminate"
    {:effect (req (resolve-ability
@@ -420,8 +421,7 @@
    {:prompt "Choose a server"
     :choices (req runnable-servers)
     :makes-run true
-    :effect (effect (make-run target nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (make-run eid target nil card))
     :events [{:event :pre-access-card
               :once :per-run
               :async true
@@ -429,7 +429,7 @@
               :effect (req (let [c target
                                  cost (:cost c)
                                  title (:title c)]
-                             (if (can-pay? state :corp eid card nil :credit cost)
+                             (if (can-pay? state :corp eid card nil [:credit cost])
                                (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent the trash")
                                    (continue-ability
                                      state :corp
@@ -446,9 +446,7 @@
                                                                     (trash eid (assoc c :seen true) nil))}}}
                                      card nil))
                                (do (system-msg state side (str "uses Credit Crash to trash " title " at no cost"))
-                                   (trash state side eid (assoc c :seen true) nil)))))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+                                   (trash state side eid (assoc c :seen true) nil)))))}]}
 
    "Credit Kiting"
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
@@ -470,52 +468,86 @@
     :effect (req (let [serv target]
                    (continue-ability
                      state :corp
-                     {:optional
-                      {:prompt (msg "Rez a piece of ICE protecting " serv "?")
-                       :yes-ability {:prompt (msg "Select a piece of ICE protecting " serv " to rez")
-                                     :player :corp
-                                     :choices {:req #(and (not (:rezzed %))
-                                                          (= (last (:zone %)) :ices))}
-                                     :effect (req (rez state :corp target nil))}
-                       :no-ability {:effect (effect (make-run eid serv nil card))
-                                    :msg (msg "make a run on " serv " during which no ICE can be rezzed")}}}
+                     (if (seq (filter #(and (installed? %)
+                                            (not (rezzed? %))
+                                            (ice? %)
+                                            (can-pay? state side eid card nil
+                                                      [:credit (rez-cost state side %)]))
+                                      (all-installed state :corp)))
+                       {:optional
+                        {:prompt (msg "Rez a piece of ICE protecting " serv "?")
+                         :yes-ability {:async true
+                                       :prompt (msg "Select a piece of ICE protecting " serv " to rez")
+                                       :player :corp
+                                       :choices {:req #(and (installed? %)
+                                                            (not (rezzed? %))
+                                                            (ice? %)
+                                                            (can-pay? state side eid card nil
+                                                                      [:credit (rez-cost state side %)]))}
+                                       :effect (effect (rez :corp eid target nil))
+                                       :cancel-effect
+                                       (effect (register-run-flag!
+                                                 card
+                                                 :can-rez
+                                                 (fn [state side card]
+                                                   (if (ice? card)
+                                                     ((constantly false)
+                                                      (toast state :corp "Cannot rez ICE on this run due to Cyber Threat"))
+                                                     true)))
+                                               (make-run eid serv nil card))}
+                         :no-ability {:async true
+                                      :effect (effect (register-run-flag!
+                                                        card
+                                                        :can-rez
+                                                        (fn [state side card]
+                                                          (if (ice? card)
+                                                            ((constantly false)
+                                                             (toast state :corp "Cannot rez ICE on this run due to Cyber Threat"))
+                                                            true)))
+                                                      (make-run eid serv nil card))
+                                      :msg (msg "make a run on " serv " during which no ICE can be rezzed")}}}
+                       {:async true
+                        :effect (effect (register-run-flag!
+                                          card
+                                          :can-rez
+                                          (fn [state side card]
+                                            (if (ice? card)
+                                              ((constantly false)
+                                               (toast state :corp "Cannot rez ICE on this run due to Cyber Threat"))
+                                              true)))
+                                        (make-run eid serv nil card))
+                        :msg (msg "make a run on " serv " during which no ICE can be rezzed")})
                      card nil)))}
 
    "Data Breach"
-   {:req (req rd-runnable)
-    :async true
+   {:async true
     :makes-run true
-    :effect (req (let [db-eid (make-eid state)
-                       events (:events (card-def card))]
-                   (register-events
-                     state side (assoc card :zone '(:discard))
-                     [(assoc (first events) :eid db-eid)])
-                   (wait-for (make-run state side db-eid :rd nil card)
-                             (let [card (get-card state (assoc card :zone '(:discard)))]
-                               (unregister-events state side card)
-                               (when (:run-again card)
-                                 (make-run state side db-eid :rd nil card))
-                               (update! state side (dissoc card :run-again))))))
+    :req (req rd-runnable)
+    :effect (req (wait-for (make-run state side :rd nil card)
+                           (let [card (get-card state card)]
+                             (if (:run-again card)
+                               (make-run state side eid :rd nil card)
+                               (effect-completed state side eid)))))
     :events [{:event :successful-run-ends
-              :optional {:req (req (= [:rd] (:server target)))
+              :optional {:req (req (and (not (:run-again card))
+                                        (= [:rd] (:server target))))
                          :prompt "Make another run on R&D?"
                          :yes-ability {:effect (effect (clear-wait-prompt :corp)
                                                        (update! (assoc card :run-again true)))}}}]}
 
    "Day Job"
    {:additional-cost [:click 3]
-    :msg "gain 10 [Credits]" :effect (effect (gain-credits 10))}
+    :msg "gain 10 [Credits]"
+    :effect (effect (gain-credits 10))}
 
    "Deep Data Mining"
-   {:req (req rd-runnable)
+   {:async true
     :makes-run true
-    :effect (effect (make-run :rd nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :req (req rd-runnable)
+    :effect (effect (make-run eid :rd nil card))
     :events [{:event :successful-run
               :silent (req true)
-              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}]}
 
    "Déjà Vu"
    {:prompt "Choose a card to add to Grip" :choices (req (cancellable (:discard runner) :sorted))
@@ -534,16 +566,8 @@
     :prompt "Choose a server"
     :choices ["HQ" "R&D"]
     :makes-run true
-    :effect (effect (make-run target nil card)
-                    (resolve-ability
-                      {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
-                                      (card-init state side c {:resolve-effect false})
-                                      (register-events
-                                        state side c
-                                        [{:event :run-ends
-                                          :effect (effect (trash c))}])))}
-                      card nil))
-    :events [{:event :run-ends}]
+    :async true
+    :effect (effect (make-run eid target nil card nil))
     :interactions {:access-ability
                    {:label "Trash card"
                     :msg (msg "trash " (:title target) " at no cost")
@@ -560,7 +584,8 @@
                :msg "remove 1 tag"}
               {:prompt "Select 1 piece of ice to expose"
                :msg "expose 1 ice and make a run"
-               :choices {:req #(and (installed? %) (ice? %))}
+               :choices {:req #(and (installed? %)
+                                    (ice? %))}
                :async true
                :effect (req (wait-for (expose state side target)
                                       (continue-ability
@@ -590,36 +615,28 @@
     :choices (req runnable-servers)
     :async true
     :makes-run true
+    :effect (effect (make-run eid target nil card))
     :abilities [{:label "Install a program using Diana's Hunt?"
                  :async true
-                 :effect (effect (resolve-ability
-                                   {:prompt "Choose a program in your Grip to install"
-                                    :choices {:req #(and (program? %)
-                                                         (runner-can-install? state side % false)
-                                                         (in-hand? %))}
-                                    :msg (msg "install " (:title target))
-                                    :effect (req (let [diana-card (assoc-in target [:special :diana-installed] true)]
-                                                   (runner-install state side (make-eid state {:source card :source-type :runner-install}) diana-card {:ignore-all-cost true})
-                                                   (swap! state update :diana #(conj % diana-card))))}
-                                   card nil))}]
-    :effect (effect (make-run target nil card)
-                    (prompt! card (str "Click Diana's Hunt in the Temporary Zone to install a Program") ["OK"] {})
-                    (resolve-ability
-                      {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
-                                      (card-init state side c {:resolve-effect false})
-                                      (register-events
-                                        state side c
-                                        [{:event :run-ends
-                                          :effect (req (let [hunt (:diana @state)]
-                                                         (doseq [c hunt]
-                                                           (let [installed (find-cid (:cid c) (all-installed state side))]
-                                                             (when (get-in installed [:special :diana-installed])
-                                                               (system-msg state side (str "trashes " (:title c) " at the end of the run from Diana's Hunt"))
-                                                               (trash state side installed {:unpreventable true}))))
-                                                         (swap! state dissoc :diana)
-                                                         (unregister-events state side card {:event :run-ends})
-                                                         (trash state side c)))}])))}
-                      card nil))}
+                 :effect
+                 (effect
+                   (continue-ability
+                     {:prompt "Choose a program in your grip to install"
+                      :choices {:req #(and (in-hand? %)
+                                           (program? %)
+                                           (runner-can-install? state side % false)
+                                           (can-pay? state side eid card nil [:credit (install-cost state side %)]))}
+                      :msg (msg "install " (:title target) ", ignoring all costs")
+                      :effect (req (let [diana-card (assoc-in target [:special :diana-installed] true)]
+                                     (update! state side (update-in card [:special :diana] conj diana-card))
+                                     (runner-install state side eid diana-card {:ignore-all-cost true})))}
+                     card nil))}]
+    :events [{:event :run-ends
+              :effect (req (doseq [c (get-in card [:special :diana])]
+                             (let [installed (find-cid (:cid c) (all-installed state side))]
+                               (when (get-in installed [:special :diana-installed])
+                                 (system-msg state side (str "trashes " (:title c) " at the end of the run from Diana's Hunt"))
+                                 (trash state side installed {:unpreventable true})))))}]}
 
    "Diesel"
    {:msg "draw 3 cards"
@@ -627,59 +644,70 @@
     :effect (effect (draw eid 3 nil))}
 
    "Direct Access"
-   (let [maybe-reshuffle {:optional {:autoresolve (get-autoresolve :auto-reshuffle)
-                                     :prompt "Shuffle Direct Access into the Stack?"
-                                     :yes-ability {:msg (msg "shuffles Direct Access into the Stack")
-                                                   :effect (effect (move (get-card state card) :deck)
-                                                                   (shuffle! :deck)
-                                                                   (effect-completed eid))}
-                                     :no-ability {:effect (effect (trash eid (get-card state card) {:unpreventable true :suppress-event true}))}}}]
-     {:effect (req (doseq [s [:corp :runner]]
-                     (disable-identity state s))
-                   (continue-ability state side
-                                     {:prompt "Choose a server"
-                                      :choices (req runnable-servers)
-                                      :async true
-                                      :effect (req (let [c (move state side (find-latest state card) :play-area)]
-                                                     (card-init state side c {:resolve-effect false})
-                                                     (wait-for (make-run state side (make-eid state) target nil card)
-                                                               (doseq [s [:corp :runner]]
-                                                                 (enable-identity state s))
-                                                               (continue-ability state side maybe-reshuffle c nil))))}
-                                     card nil))
-      :abilities [(set-autoresolve :auto-reshuffle "reshuffle")]})
+   {:async true
+    :makes-run true
+    :effect (req (doseq [s [:corp :runner]]
+                   (disable-identity state s))
+                 (continue-ability
+                   state side
+                   {:prompt "Choose a server"
+                    :choices (req runnable-servers)
+                    :async true
+                    :effect (effect (make-run eid target nil card))}
+                   card nil))
+    :abilities [(set-autoresolve :auto-reshuffle "reshuffle")]
+    :events [{:event :run-ends
+              :async true
+              :effect (req (doseq [s [:corp :runner]]
+                             (enable-identity state s))
+                           (continue-ability
+                             state :runner
+                             {:optional
+                              {:autoresolve (get-autoresolve :auto-reshuffle)
+                               :prompt "Shuffle Direct Access into the Stack?"
+                               :yes-ability
+                               {:msg (msg "shuffles Direct Access into the Stack")
+                                :effect (effect (move (get-card state card) :deck)
+                                                (shuffle! :deck)
+                                                (unregister-events card))}}}
+                             card nil))}]}
 
    "Dirty Laundry"
-   (run-event
-     {:end-run {:req (req (:successful run))
-                :msg "gain 5 [Credits]"
-                :effect (effect (gain-credits :runner 5))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (make-run eid target nil card))
+    :events [{:event :successful-run-ends
+              :silent (req true)
+              :msg "gain 5 [Credits]"
+              :effect (effect (gain-credits :runner 5))}]}
 
    "Diversion of Funds"
    {:req (req hq-runnable)
-    :effect (effect (make-run :hq
-                              {:req (req (= target :hq))
-                               :replace-access
-                               (let [five-or-all (fn [corp] (min 5 (:credit corp)))]
-                                 {:msg (msg "force the Corp to lose " (five-or-all corp)
-                                            "[Credits], and gain " (five-or-all corp) "[Credits]")
-                                  :effect (effect (lose-credits :corp (five-or-all corp))
-                                                  (gain-credits :runner (five-or-all corp)))})}
-                              card))}
+    :async true
+    :makes-run true
+    :effect (effect (make-run
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       (let [five-or-all (fn [corp] (min 5 (:credit corp)))]
+                         {:msg (msg "force the Corp to lose " (five-or-all corp)
+                                    "[Credits], and gain " (five-or-all corp) "[Credits]")
+                          :effect (effect (lose-credits :corp (five-or-all corp))
+                                          (gain-credits :runner (five-or-all corp)))})}
+                      card))}
 
    "Divide and Conquer"
    {:req (req archives-runnable)
     :makes-run true
     :async true
-    :effect (effect (make-run :archives nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (make-run eid :archives nil card))
     :events [{:event :end-access-phase
               :async true
               :req (req (= :archives (:from-server target)))
               :effect (req (wait-for (do-access state side [:hq] {:no-root true})
-                                     (do-access state side eid [:rd] {:no-root true})))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+                                     (do-access state side eid [:rd] {:no-root true})))}]}
 
    "Drive By"
    {:choices {:req #(let [topmost (get-nested-host %)]
@@ -699,38 +727,49 @@
                              (effect-completed state side eid))))}
 
    "Early Bird"
-   (run-event
-     {:msg (msg "make a run on " target " and gain [Click]")}
-     nil
-     (effect (gain :click 1)))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :msg (msg "make a run on " target " and gain [Click]")
+    :effect (effect (gain :click 1)
+                    (make-run eid target nil card))}
 
    "Easy Mark"
-   {:msg "gain 3 [Credits]" :effect (effect (gain-credits 3))}
+   {:msg "gain 3 [Credits]"
+    :effect (effect (gain-credits 3))}
 
    "Embezzle"
-   (letfn [(name-string [cards]
-             (join " and " (map :title cards)))] ; either 'card' or 'card1 and card2'
-     {:req (req hq-runnable)
-      :effect (effect
-                (make-run :hq {:req (req (= target :hq))
-                               :replace-access
-                               {:mandatory true
-                                :msg (msg "reveal 2 cards from HQ and trash all "
-                                          target (when (not= "ICE" (:type target)) "s"))
-                                :prompt "Choose a card type"
-                                :choices ["Asset" "Upgrade" "Operation" "ICE"]
-                                :effect (req (let [chosen-type target
-                                                   cards-to-reveal (take 2 (shuffle (:hand corp)))
-                                                   cards-to-trash (filter #(is-type? % chosen-type) cards-to-reveal)]
-                                               (system-msg state side (str " reveals " (name-string cards-to-reveal) " from HQ"))
-                                               (reveal state side cards-to-reveal)
-                                               (when (seq cards-to-trash)
-                                                 (system-msg state side (str " trashes " (name-string cards-to-trash)
-                                                                             " from HQ and gain " (* 4 (count cards-to-trash)) "[Credits]"))
-                                                 (doseq [c cards-to-trash]
-                                                   (trash state :runner (assoc c :seen true)))
-                                                 (gain-credits state :runner (* 4 (count cards-to-trash))))))}}
-                          card))})
+   {:async true
+    :makes-run true
+    :req (req hq-runnable)
+    :effect
+    (effect
+      (make-run eid :hq
+                {:req (req (= target :hq))
+                 :replace-access
+                 {:mandatory true
+                  :prompt "Choose a card type"
+                  :choices ["Asset" "Upgrade" "Operation" "ICE"]
+                  :msg (msg "reveal 2 cards from HQ and trash all "
+                            target (when (not= "ICE" (:type target)) "s"))
+                  :effect (req (let [cards-to-reveal (take 2 (shuffle (:hand corp)))
+                                     cards-to-trash (filter #(is-type? % target) cards-to-reveal)
+                                     credits (* 4 (count cards-to-trash))]
+                                 (system-msg state side
+                                             (str "uses Embezzle to reveal "
+                                                  (join " and " (map :title cards-to-reveal))
+                                                  " from HQ"))
+                                 (reveal state side cards-to-reveal)
+                                 (when (pos? credits)
+                                   (system-msg state side
+                                               (str " uses Embezzle to trash "
+                                                    (join " and " (map :title cards-to-trash))
+                                                    " from HQ and gain "
+                                                    credits " [Credits]"))
+                                   (trash-cards state :runner (map #(assoc % :seen true) cards-to-trash))
+                                   (gain-credits state :runner credits))))}}
+                card))}
 
    "Emergency Shutdown"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
@@ -792,22 +831,31 @@
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
                    (some #{:rd} (:successful-run runner-reg))
                    (some #{:archives} (:successful-run runner-reg))))
-    :effect (req (swap! state update-in [:runner :extra-turns] (fnil inc 0))
-                 (move state side (first (:play-area runner)) :rfg))
-    :msg "take an additional turn after this one"}
+    :rfg-instead-of-trashing true
+    :msg "take an additional turn after this one"
+    :effect (req (swap! state update-in [:runner :extra-turns] (fnil inc 0)))}
 
    "Escher"
-   (letfn [(es [] {:prompt "Select two pieces of ICE to swap positions"
-                   :choices {:req #(and (installed? %) (ice? %)) :max 2}
+   (letfn [(es [] {:async true
+                   :prompt "Select two pieces of ICE to swap positions"
+                   :choices {:req #(and (installed? %)
+                                        (ice? %))
+                             :max 2}
                    :effect (req (if (= (count targets) 2)
                                   (do (swap-ice state side (first targets) (second targets))
-                                      (resolve-ability state side (es) card nil))
-                                  (system-msg state side "has finished rearranging ICE")))})]
-     {:req (req hq-runnable)
-      :effect (effect (make-run :hq {:replace-access
-                                     {:mandatory true
-                                      :msg "rearrange installed ICE"
-                                      :effect (effect (resolve-ability (es) card nil))}} card))})
+                                      (continue-ability state side (es) card nil))
+                                  (do (system-msg state side "has finished rearranging ICE")
+                                      (effect-completed state side eid))))})]
+     {:async true
+      :makes-run true
+      :req (req hq-runnable)
+      :effect (effect (make-run eid :hq
+                                {:replace-access
+                                 {:mandatory true
+                                  :async true
+                                  :msg "rearrange installed ICE"
+                                  :effect (effect (continue-ability (es) card nil))}}
+                                card))})
 
    "Eureka!"
    {:effect (req (let [topcard (first (:deck runner))
@@ -854,25 +902,31 @@
                    (derez state side c)))}
 
    "Exploratory Romp"
-   (run-event
-     {:replace-access
-      {:prompt "Advancements to remove from a card in or protecting this server?"
-       :choices ["0" "1" "2" "3"]
-       :async true
-       :mandatory true
-       :effect (req (let [c (str->int target)]
-                      (show-wait-prompt state :corp "Runner to remove advancements")
-                      (continue-ability
-                        state side
-                        {:choices {:req #(and (contains? % :advance-counter)
-                                              (= (first (:server run)) (second (:zone %))))}
-                         :msg (msg "remove " (quantify c "advancement token")
-                                   " from " (card-str state target))
-                         :effect (req (let [to-remove (min c (get-counters target :advancement))]
-                                        (add-prop state :corp target :advance-counter (- to-remove))
-                                        (clear-wait-prompt state :corp)
-                                        (effect-completed state side eid)))}
-                        card nil)))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (make-run
+                      eid target
+                      {:replace-access
+                       {:prompt "Advancements to remove from a card in or protecting this server?"
+                        :choices ["0" "1" "2" "3"]
+                        :async true
+                        :mandatory true
+                        :effect (req (let [c (str->int target)]
+                                       (show-wait-prompt state :corp "Runner to remove advancements")
+                                       (continue-ability
+                                         state side
+                                         {:choices {:req #(and (contains? % :advance-counter)
+                                                               (= (first (:server run)) (second (:zone %))))}
+                                          :msg (msg "remove " (quantify c "advancement token")
+                                                    " from " (card-str state target))
+                                          :effect (req (let [to-remove (min c (get-counters target :advancement))]
+                                                         (add-prop state :corp target :advance-counter (- to-remove))
+                                                         (clear-wait-prompt state :corp)
+                                                         (effect-completed state side eid)))}
+                                         card nil)))}}
+                      card))}
 
    "Express Delivery"
    {:prompt "Choose a card to add to your Grip" :choices (req (take 4 (:deck runner)))
@@ -905,42 +959,38 @@
                 card nil))}
 
    "Fear the Masses"
-   {:req (req hq-runnable)
+   {:async true
+    :makes-run true
+    :req (req hq-runnable)
     :effect (effect
               (make-run
-                :hq {:req (req (= target :hq))
-                     :replace-access
-                     {:async true
-                      :mandatory true
-                      :msg "force the Corp to trash the top card of R&D"
-                      :effect (req (mill state :corp)
-                                   (let [n (count (filter #(= (:title card) (:title %)) (:hand runner)))]
-                                     (if (pos? n)
-                                       (continue-ability
-                                         state side
-                                         {:prompt "Reveal how many copies of Fear the Masses?"
-                                          :choices {:number (req n)}
-                                          :effect (req (when (pos? target)
-                                                         (mill state :corp target)
-                                                         (system-msg
-                                                           state side
-                                                           (str "reveals " target " copies of Fear the Masses,"
-                                                                " forcing the Corp to trash " target " cards"
-                                                                " from the top of R&D"))))}
-                                         card nil)
-                                       (effect-completed state side eid))))}}
+                eid :hq
+                {:req (req (= target :hq))
+                 :replace-access
+                 {:async true
+                  :mandatory true
+                  :msg "force the Corp to trash the top card of R&D"
+                  :effect (effect (mill :corp)
+                                  (continue-ability
+                                    {:prompt "Reveal how many copies of Fear the Masses?"
+                                     :choices {:req #(and (in-hand? %)
+                                                          (same-card? :title card %))}
+                                     :msg (msg "reveal " (count targets) " copies of Fear the Masses,"
+                                               " forcing the Corp to trash " (count targets)
+                                               " additional cards from the top of R&D")
+                                     :effect (effect (reveal targets)
+                                                     (mill :corp (count targets)))}
+                                    card nil))}}
                 card))}
 
    "Feint"
-   {:req (req hq-runnable)
-    :implementation "Bypass is manual"
-    :effect (effect (make-run :hq nil card)
-                    (register-events (assoc card :zone '(:discard))))
-    ;; Don't need a msg since game will print that card access is prevented
+   {:implementation "Bypass is manual"
+    :async true
+    :makes-run true
+    :req (req hq-runnable)
+    :effect (effect (make-run eid :hq nil card))
     :events [{:event :successful-run
-              :effect (effect (prevent-access))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (prevent-access))}]}
 
    "Fisk Investment Seminar"
    {:msg "make each player draw 3 cards"
@@ -982,37 +1032,43 @@
    "Frantic Coding"
    {:async true
     :effect
-    (req (let [top-ten (take 10 (:deck runner))]
-           (prompt! state :runner card (str "The top 10 cards of the Stack are "
-                                            (join ", " (map :title top-ten))) ["OK"] {})
-           (continue-ability
-             state side
-             {:prompt "Install a program?"
-              :choices (concat
-                         (->> top-ten
-                              (filter #(and (program? %)
-                                            (can-pay? state side eid card nil
-                                                      [:credit (install-cost state side % {:cost-bonus -5})])))
-                              (sort-by :title)
-                              (into []))
-                         ["No install"])
-              :async true
-              :effect (req (if (not= target "No install")
-                             (let [number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck))
-                                   to-trash (remove #(same-card? % target) top-ten)]
-                               (wait-for (runner-install state side (make-eid state {:source card :source-type :runner-install})
-                                                         target {:cost-bonus -5})
-                                         (if (= number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck)))
-                                           (do (system-msg state side (str "trashes " (join ", " (map :title to-trash))))
-                                               (doseq [c to-trash]
-                                                 (trash state side c {:unpreventable true}))
-                                               (effect-completed state side eid))
-                                           (do (system-msg state side "does not have to trash cards because the stack was shuffled")
-                                               (effect-completed state side eid)))))
-                             (do (doseq [c top-ten]
-                                   (trash state side c {:unpreventable true}))
-                                 (system-msg state side (str "trashes " (join ", " (map :title top-ten)))))))}
-             card nil)))}
+    (effect
+      (continue-ability
+        (let [top-ten (take 10 (:deck runner))]
+          {:prompt (str "The top 10 cards of the stack are " (join ", " (map :title top-ten)) ".")
+           :choices ["OK"]
+           :async true
+           :effect
+           (effect
+             (continue-ability
+               {:prompt "Install a program?"
+                :choices (concat
+                           (->> top-ten
+                                (filter #(and (program? %)
+                                              (can-pay? state side eid card nil
+                                                        [:credit (install-cost state side % {:cost-bonus -5})])))
+                                (sort-by :title)
+                                (into []))
+                           ["No install"])
+                :async true
+                :effect (req (if (not= target "No install")
+                               (let [number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck))
+                                     to-trash (remove #(same-card? % target) top-ten)]
+                                 (wait-for (runner-install state side (make-eid state {:source card :source-type :runner-install})
+                                                           target {:cost-bonus -5})
+                                           (if (= number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck)))
+                                             (do (system-msg state side (str "trashes " (join ", " (map :title to-trash))))
+                                                 (doseq [c to-trash]
+                                                   (trash state side c {:unpreventable true}))
+                                                 (effect-completed state side eid))
+                                             (do (system-msg state side "does not have to trash cards because the stack was shuffled")
+                                                 (effect-completed state side eid)))))
+                               (do (doseq [c top-ten]
+                                     (trash state side c {:unpreventable true}))
+                                   (system-msg state side (str "trashes " (join ", " (map :title top-ten))))
+                                   (effect-completed state side eid))))}
+               card nil))})
+        card nil))}
 
    "\"Freedom Through Equality\""
    {:events [{:event :agenda-stolen
@@ -1039,7 +1095,7 @@
    (let [corp-choose {:show-discard true
                       :async true
                       :player :corp
-                      :prompt (msg "Select 5 cards from Archives to add to HQ")
+                      :prompt "Select 5 cards from Archives to add to HQ"
                       :choices {:max 5
                                 :all true
                                 :req #(and (corp? %)
@@ -1052,30 +1108,22 @@
                                          (str (when-not (empty? seen) " and ")
                                               (quantify m "unseen card")))
                                        " into HQ, then trash 5 cards")))
-                      :effect (req (wait-for
-                                     (resolve-ability state side
-                                                      {:effect (req (doseq [c targets]
-                                                                      (move state side c :hand)))}
-                                                      card targets)
-                                     (continue-ability state side
-                                                       {:async true
-                                                        :effect (req (doseq [c (take 5 (shuffle (:hand corp)))]
-                                                                       (trash state :corp c))
-                                                                     (clear-wait-prompt state :runner)
-                                                                     (effect-completed state :runner eid))}
-                                                       card nil)))}
+                      :effect (req (doseq [c targets]
+                                     (move state side c :hand))
+                                   (trash-cards state :corp eid (take 5 (shuffle (:hand (:corp @state))))))}
          access-effect {:mandatory true
                         :async true
-                        :req (req (>= (count (:discard corp)) 5))
+                        :req (req (<= 5 (count (:discard corp))))
                         :effect (req (show-wait-prompt
                                        state :runner
-                                       "Corp to choose which cards to pick up from Archives") ;; For some reason it just shows successful-run-trigger-message, but this works!?
-                                     (continue-ability state side
-                                                       corp-choose
-                                                       card nil))}]
+                                       "Corp to choose which cards to pick up from Archives")
+                                     (wait-for (resolve-ability state side corp-choose card nil)
+                                               (clear-wait-prompt state :runner)
+                                               (effect-completed state side eid)))}]
      {:req (req archives-runnable)
+      :async true
       :makes-run true
-      :effect (effect (make-run :archives
+      :effect (effect (make-run eid :archives
                                 {:req (req (= target :archives))
                                  :replace-access access-effect}
                                 card))})
@@ -1095,13 +1143,17 @@
                         :value [:randomly-trash-from-hand 1]}]}
 
    "High-Stakes Job"
-   (run-event
-     {:choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
-                          bad-zones (keys (filter (complement unrezzed-ice) (get-in @state [:corp :servers])))]
-                      (zones->sorted-names (remove (set bad-zones) (get-runnable-zones state side eid card nil)))))}
-     {:end-run {:req (req (:successful run))
-                :msg "gain 12 [Credits]"
-                :effect (effect (gain-credits :runner 12))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
+                        bad-zones (keys (filter (complement unrezzed-ice) (get-in @state [:corp :servers])))]
+                    (zones->sorted-names (remove (set bad-zones) (get-runnable-zones state side eid card nil)))))
+    :effect (effect (make-run eid target nil card))
+    :events [{:event :successful-run-ends
+              :silent (req true)
+              :msg "gain 12 [Credits]"
+              :effect (effect (gain-credits :runner 12))}]}
 
    "Hostage"
    {:prompt "Choose a Connection"
@@ -1122,14 +1174,16 @@
                      card nil))}
 
    "Hot Pursuit"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
-    :effect (effect (make-run :hq {:req (req (= target :hq))
-                                   :successful-run {:async true
-                                                    :msg "gain 9 [Credits] and take 1 tag"
-                                                    :effect (req (wait-for (gain-tags state :runner 1)
-                                                                           (gain-credits state :runner 9)
-                                                                           (effect-completed state side eid)))}} card))}
+    :req (req hq-runnable)
+    :effect (effect (make-run eid :hq nil card))
+    :events [{:event :successful-run
+              :async true
+              :msg "gain 9 [Credits] and take 1 tag"
+              :effect (req (wait-for (gain-tags state :runner 1)
+                                     (gain-credits state :runner 9)
+                                     (effect-completed state side eid)))}]}
 
    "Isolation"
    {:additional-cost [:resource 1]
@@ -1145,9 +1199,10 @@
                    :effect (effect (draw :runner eid 3 nil)) :msg "draw 3 cards"}}
 
    "Immolation Script"
-   {:req (req archives-runnable)
-    :effect (effect (make-run :archives nil card)
-                    (register-events (assoc card :zone '(:discard))))
+   {:async true
+    :makes-run true
+    :req (req archives-runnable)
+    :effect (effect (make-run eid :archives nil card))
     :events [{:event :pre-access
               :async true
               :req (req (and (= target :archives)
@@ -1155,41 +1210,32 @@
                              (not-empty (clojure.set/intersection
                                           (into #{} (map :title (filter ice? (:discard corp))))
                                           (into #{} (map :title (filter rezzed? (all-installed state :corp))))))))
-              :effect (req (continue-ability
-                             state side
-                             {:async true
-                              :prompt "Choose a piece of ICE in Archives"
-                              :choices (req (filter ice? (:discard corp)))
-                              :effect (req (let [icename (:title target)]
-                                             (continue-ability
-                                               state side
-                                               {:async true
-                                                :prompt (msg "Select a rezzed copy of " icename " to trash")
-                                                :choices {:req #(and (ice? %)
-                                                                     (rezzed? %)
-                                                                     (= (:title %) icename))}
-                                                :msg (msg "trash " (card-str state target))
-                                                :effect (req (trash state :corp target)
-                                                             (unregister-events state side card)
-                                                             (effect-completed state side eid))}
-                                               card nil)))}
-                             card nil))}]}
+              :prompt "Choose a piece of ICE in Archives"
+              :choices (req (filter ice? (:discard corp)))
+              :effect (effect (continue-ability
+                                (let [ice target]
+                                  {:async true
+                                   :prompt (msg "Select a rezzed copy of " (:title ice) " to trash")
+                                   :choices {:req #(and (ice? %)
+                                                        (rezzed? %)
+                                                        (same-card? :title % ice))}
+                                   :msg (msg "trash " (card-str state target))
+                                   :effect (effect (trash eid target nil))})
+                                card nil))}]}
 
    "In the Groove"
-   {:effect (req (register-events state side (dissoc card :zone)))
-    :events [{:event :runner-turn-ends
-              :effect (effect (unregister-events card))}
-             {:event :runner-install
+   {:events [{:event :runner-install
+              :duration :end-of-turn
               :req (req (<= 1 (:cost target)))
               :interactive (req (has-subtype? target "Cybernetic"))
               :async true
               :prompt "What to get from In the Groove?"
               :choices ["Draw 1 card" "Gain 1 [Credits]"]
+              :msg (msg (lower-case target))
               :effect (req (if (= target "Draw 1 card")
                              (draw state side eid 1 nil)
                              (do (gain-credits state side 1)
-                                 (effect-completed state side eid))))
-              :msg (msg (lower-case target))}]}
+                                 (effect-completed state side eid))))}]}
 
    "Independent Thinking"
    (letfn [(cards-to-draw [targets]
@@ -1207,8 +1253,9 @@
    "Indexing"
    {:req (req rd-runnable)
     :async true
+    :makes-run true
     :effect (effect (make-run
-                      :rd
+                      eid :rd
                       {:req (req (= target :rd))
                        :replace-access
                        {:msg "rearrange the top 5 cards of R&D"
@@ -1280,9 +1327,12 @@
                                                     card nil))}
                                  card nil))
                            (effect-completed state side eid)))}]
-       {:req (req hq-runnable)
-        :effect (effect (make-run :hq {:req (req (= target :hq))
-                                       :replace-access access-effect}
+       {:async true
+        :makes-run true
+        :req (req hq-runnable)
+        :effect (effect (make-run eid :hq
+                                  {:req (req (= target :hq))
+                                   :replace-access access-effect}
                                   card))}))
 
    "Inject"
@@ -1295,22 +1345,27 @@
                          (system-msg state side (str "adds " (:title c) " to Grip"))))))}
 
    "Injection Attack"
-   (run-event
-     {:async true}
-     nil
-     nil
-     (effect (continue-ability
-               {:prompt "Select an icebreaker"
-                :choices {:req #(and (installed? %)
-                                     (has-subtype? % "Icebreaker"))}
-                :effect (effect (pump target 2 :end-of-run))}
-               card nil)))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (continue-ability
+                      (let [server target]
+                        {:async true
+                         :prompt "Select an icebreaker"
+                         :choices {:req #(and (installed? %)
+                                              (has-subtype? % "Icebreaker"))}
+                         :effect (effect (pump target 2 :end-of-run)
+                                         (make-run eid server nil card))})
+                      card nil))}
 
    "Inside Job"
    {:implementation "Bypass is manual"
+    :async true
+    :makes-run true
     :prompt "Choose a server"
     :choices (req runnable-servers)
-    :effect (effect (make-run target nil card))}
+    :effect (effect (make-run eid target nil card))}
 
    "Insight"
    {:async true
@@ -1378,12 +1433,12 @@
                                   :effect (effect (effect-completed
                                                     (make-result eid [(str->int (first (split target #" ")))
                                                                       (min 6 (str->int (nth (split target #" ") 2)))])))}))]
-     {:req (req rd-runnable)
-      :async true
-      :effect (req
+     {:async true
+      :makes-run true
+      :req (req rd-runnable)
+      :effect (effect
                 (make-run
-                  state side
-                  :rd
+                  eid :rd
                   {:req (req (= target :rd))
                    :replace-access
                    {:async true
@@ -1428,9 +1483,11 @@
 
    "Labor Rights"
    {:req (req (pos? (+ (count (:deck runner)) (count (:discard runner)))))
+    :rfg-instead-of-trashing true
+    :async true
     :effect (req (let [mill-count (min 3 (count (:deck runner)))]
                    (mill state :runner :runner mill-count)
-                   (system-msg state :runner (str "trashes the top " (quantify mill-count "card") " of their Stack"))
+                   (system-msg state :runner (str "trashes the top " (quantify mill-count "card") " of their stack"))
                    (let [heap-count (min 3 (count (get-in @state [:runner :discard])))]
                      (continue-ability
                        state side
@@ -1448,120 +1505,114 @@
                                                                     " from their Heap into their Stack, and draws 1 card"))
                                      (shuffle! state :runner :deck)
                                      (wait-for (draw state :runner 1 nil)
-                                               (move state side (find-latest state card) :rfg)
-                                               (system-msg state :runner "removes Labor Rights from the game")
                                                (effect-completed state side eid)))}
                        card nil))))}
 
    "Lawyer Up"
    {:msg "remove 2 tags and draw 3 cards"
     :async true
-    :effect (req (wait-for (draw state side 3 nil) (lose-tags state side eid 2)))}
+    :effect (req (wait-for (draw state side 3 nil)
+                           (lose-tags state side eid 2)))}
 
    "Lean and Mean"
-   {:prompt "Choose a server"
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
     :choices (req runnable-servers)
-    :async true
-    :msg (msg "make a run on " target (when (< (count (filter program? (all-active-installed state :runner))) 4)
+    :msg (msg "make a run on " target (when (<= (count (filter program? (all-active-installed state :runner))) 3)
                                         ", adding +2 strength to all icebreakers"))
-    :effect (req (when (< (count (filter program? (all-active-installed state :runner))) 4)
+    :effect (req (when (<= (count (filter program? (all-active-installed state :runner))) 3)
                    (pump-all-icebreakers state side 2 :end-of-run))
-                 (make-run state side (make-eid state) target nil card))}
+                 (make-run state side eid target nil card))}
 
    "Leave No Trace"
    (letfn [(get-rezzed-cids [ice]
              (map :cid (filter #(and (rezzed? %)
                                      (ice? %))
                                ice)))]
-     {:prompt "Choose a server"
+     {:async true
+      :makes-run true
+      :prompt "Choose a server"
       :msg "make a run and derez any ICE that are rezzed during this run"
       :choices (req runnable-servers)
-      :async true
-      :effect (req
-                (let [old-ice-cids (get-rezzed-cids (all-installed state :corp))]
-                  (swap! state assoc :lnt old-ice-cids)
-                  (register-events state side (assoc card :zone '(:discard)))
-                  (make-run state side (make-eid state) target nil card)))
+      :effect (req (let [old-ice-cids (get-rezzed-cids (all-installed state :corp))]
+                     (update! state side (assoc-in card [:special :leave-no-trace] old-ice-cids))
+                     (make-run state side eid target nil (get-card state card))))
       :events [{:event :run-ends
                 :effect (req (let [new (set (get-rezzed-cids (all-installed state :corp)))
-                                   old (set (:lnt @state))
+                                   old (set (get-in (get-card state card) [:special :leave-no-trace]))
                                    diff-cid (seq (clojure.set/difference new old))
                                    diff (map #(find-cid % (all-installed state :corp)) diff-cid)]
                                (doseq [ice diff]
                                  (derez state :runner ice))
                                (when-not (empty? diff)
-                                 (system-msg state side (str "derezzes " (join ", " (map :title diff)) " via Leave No Trace")))
-                               (swap! state dissoc :lnt)
-                               (unregister-events state side card)))}]})
+                                 (system-msg state side (str "uses Leave No Trace to derez " (join ", " (map :title diff)))))))}]})
 
    "Legwork"
-   {:req (req hq-runnable)
-    :effect (effect (make-run :hq nil card)
-                    (register-events (assoc card :zone '(:discard))))
+   {:async true
+    :makes-run true
+    :req (req hq-runnable)
+    :effect (effect (make-run eid :hq nil card))
     :events [{:event :successful-run
               :silent (req true)
-              :effect (effect (access-bonus :hq 2))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (access-bonus :hq 2))}]}
 
    "Leverage"
-   {:req (req (some #{:hq} (:successful-run runner-reg)))
-    :player :corp
-    :prompt "Take 2 bad publicity?"
-    :yes-ability {:player :corp
-                  :msg "takes 2 bad publicity"
-                  :effect (effect (gain-bad-publicity :corp 2))}
-    :no-ability {:player :runner
-                 :msg "is immune to damage until the beginning of the Runner's next turn"
-                 :effect (effect
-                           (register-events
-                             (assoc card :zone '(:discard))
-                             [{:event :pre-damage
-                               :effect (effect (damage-prevent :net Integer/MAX_VALUE)
-                                               (damage-prevent :meat Integer/MAX_VALUE)
-                                               (damage-prevent :brain Integer/MAX_VALUE))}
-                              {:event :runner-turn-begins
-                               :effect (effect (unregister-events
-                                                 card
-                                                 {:events [{:event :runner-turn-begins}
-                                                           {:event :pre-damage}]}))}]))}}
+   {:optional
+    {:req (req (some #{:hq} (:successful-run runner-reg)))
+     :player :corp
+     :prompt "Take 2 bad publicity?"
+     :yes-ability {:player :corp
+                   :msg "takes 2 bad publicity"
+                   :effect (effect (gain-bad-publicity :corp 2))}
+     :no-ability {:player :runner
+                  :msg "is immune to damage until the beginning of the Runner's next turn"
+                  :effect (effect
+                            (register-events
+                              card
+                              [{:event :pre-damage
+                                :duration :until-runner-turn-begins
+                                :effect (effect (damage-prevent :net Integer/MAX_VALUE)
+                                                (damage-prevent :meat Integer/MAX_VALUE)
+                                                (damage-prevent :brain Integer/MAX_VALUE))}
+                               {:event :runner-turn-begins
+                                :duration :until-runner-turn-begins
+                                :effect (effect (unregister-floating-events :until-runner-turn-begins))}]))}}}
 
    "Levy AR Lab Access"
    {:msg "shuffle their Grip and Heap into their Stack and draw 5 cards"
+    :rfg-instead-of-trashing true
     :async true
-    :effect (req (shuffle-into-deck state :runner :hand :discard)
-                 (wait-for (draw state :runner 5 nil)
-                           (move state side (first (:play-area runner)) :rfg)
-                           (effect-completed state side eid)))}
+    :effect (effect (shuffle-into-deck :hand :discard)
+                    (draw eid 5 nil))}
 
    "Lucky Find"
    {:msg "gain 9 [Credits]"
     :effect (effect (gain-credits 9))}
 
    "Mad Dash"
-   {:prompt "Choose a server"
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
     :choices (req runnable-servers)
-    :async true
-    :effect (effect (make-run target nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (make-run eid target nil card))
     :events [{:event :agenda-stolen
               :silent (req true)
               :effect (effect (update! (assoc card :steal true)))}
              {:event :run-ends
               :async true
               :effect (req (if (:steal card)
-                             (wait-for (as-agenda state :runner (get-card state card) 1)
-                                       (system-msg state :runner
-                                                   (str "adds Mad Dash to their score area as an agenda worth 1 agenda point")))
+                             (do (system-msg state :runner
+                                             (str "adds Mad Dash to their score area as an agenda worth 1 agenda point"))
+                                 (as-agenda state :runner eid (get-card state card) 1))
                              (do (system-msg state :runner
                                              (str "suffers 1 meat damage from Mad Dash"))
-                                 (damage state side eid :meat 1 {:card card})))
-                           (unregister-events state side card))}]}
+                                 (damage state side eid :meat 1 {:card card}))))}]}
 
    "Making an Entrance"
    (letfn [(entrance-trash [cards]
              {:prompt "Choose a card to trash"
-              :choices (cons "None" cards)
+              :choices (concat cards ["None"])
               :async true
               :msg (req (when (not= target "None") (str "trash " (:title target))))
               :effect (req (if (= target "None")
@@ -1580,13 +1631,17 @@
                      (continue-ability state side (entrance-trash from) card nil)))})
 
    "Marathon"
-   (run-event
-     {:choices (req (filter #(can-run-server? state %) remotes))}
-     {:end-run {:effect (req (prevent-run-on-server state card (:server run))
-                             (when (:successful run)
-                               (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
-                               (gain state :runner :click 1)
-                               (move state :runner (assoc card :zone [:discard]) :hand)))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (filter #(can-run-server? state %) remotes))
+    :effect (effect (make-run eid target nil card))
+    :events [{:event :run-ends
+              :effect (req (prevent-run-on-server state card (:server run))
+                           (when (:successful run)
+                             (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
+                             (gain state :runner :click 1)
+                             (move state :runner card :hand)))}]}
 
    "Mars for Martians"
    (letfn [(count-clan [state] (count (filter #(and (has-subtype? % "Clan") (resource? %))
@@ -1608,10 +1663,10 @@
 
    "Mining Accident"
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
+    :rfg-instead-of-trashing true
     :async true
     :msg "make the Corp pay 5 [Credits] or take 1 bad publicity"
-    :effect (effect (move (first (:play-area runner)) :rfg)
-                    (show-wait-prompt :runner "Corp to choose to pay or take bad publicity")
+    :effect (effect (show-wait-prompt :runner "Corp to choose to pay or take bad publicity")
                     (continue-ability
                       {:player :corp
                        :async true
@@ -1632,28 +1687,20 @@
    "Möbius"
    {:req (req rd-runnable)
     :async true
-    :effect (req (let [mob-eid (make-eid state)
-                       events (:events (card-def card))]
-                   (register-events
-                     state side (assoc card :zone '(:discard))
-                     [(assoc (second events) :eid mob-eid)])
-                   (wait-for (make-run state side mob-eid :rd nil card)
-                             (let [card (get-card state (assoc card :zone '(:discard)))]
-                               (unregister-events state side card)
-                               (when (:run-again card)
-                                 (update! state side (dissoc card :run-again))
-                                 (register-events
-                                   state side card
-                                   [{:event :successful-run
-                                     :req (req (= target :rd))
-                                     :msg "gain 4 [Credits]"
-                                     :effect (effect (gain-credits 4))}])
-                                 (wait-for (make-run state side (make-eid state mob-eid) :rd nil card)
-                                           (unregister-events state side card)))))))
-    :events [{:event :successful-run}
+    :effect (req (wait-for (make-run state side :rd nil card)
+                           (let [card (get-card state card)]
+                             (if (:run-again card)
+                               (make-run state side eid :rd nil card)
+                               (effect-completed state side eid)))))
+    :events [{:event :successful-run
+              :req (req (and (:run-again card)
+                             (= target :rd)))
+              :msg "gain 4 [Credits]"
+              :effect (effect (gain-credits 4))}
              {:event :successful-run-ends
               :interactive (req true)
-              :optional {:req (req (= [:rd] (:server target)))
+              :optional {:req (req (and (not (:run-again card))
+                                        (= [:rd] (:server target))))
                          :prompt "Make another run on R&D?"
                          :yes-ability {:effect (effect (clear-wait-prompt :corp)
                                                        (update! (assoc card :run-again true)))}}}]}
@@ -1710,7 +1757,7 @@
     :prompt "Choose a resource to host On the Lam"
     :choices {:req #(and (resource? %)
                          (installed? %))}
-    :effect (effect (host target (assoc card :zone [:discard] :installed true))
+    :effect (effect (host target (assoc card :installed true))
                     (card-init (find-latest state card) {:resolve-effect false})
                     (system-msg (str "hosts On the Lam on " (:title target))))
     :interactions {:prevent [{:type #{:net :brain :meat :tag}
@@ -1752,14 +1799,18 @@
                                         (ashes-recur (count (filter #(= "Out of the Ashes" (:title %))
                                                                     (:discard runner))))
                                         card nil))}]]
-     (run-event
-       {:move-zone (req (if (= [:discard] (:zone card))
-                          (register-events state side (assoc card :zone [:discard]) ashes-flag)
-                          (unregister-events state side card {:events [{:event :runner-phase-12}]})))}
-       nil))
+     {:async true
+      :makes-run true
+      :prompt "Choose a server"
+      :choices (req runnable-servers)
+      :effect (effect (make-run eid target nil card))
+      :move-zone (req (if (in-discard? card)
+                        (register-events state side (assoc card :zone [:discard]) ashes-flag)
+                        (unregister-events state side card {:events [{:event :runner-phase-12}]})))})
 
    "Paper Tripping"
-   {:msg "remove all tags" :effect (effect (lose-tags :all))}
+   {:msg "remove all tags"
+    :effect (effect (lose-tags :all))}
 
    "Peace in Our Time"
    {:req (req (not (:scored-agenda corp-reg)))
@@ -1780,33 +1831,37 @@
    (let [update-agenda-points (fn [state side target amount]
                                 (set-prop state side (get-card state target) :agendapoints (+ amount (:agendapoints (get-card state target))))
                                 (gain-agenda-point state side amount))]
-     {:req (req archives-runnable)
-      :events [{:event :purge
-                :effect (effect (trash card {:cause :purge}))}]
-      :trash-effect {:effect (req (let [current-side (get-scoring-owner state {:cid (:agenda-cid card)})]
-                                    (update-agenda-points state current-side (find-cid (:agenda-cid card) (get-in @state [current-side :scored])) 1)))}
+     {:async true
       :makes-run true
+      :req (req archives-runnable)
       :effect (effect (make-run
-                        :archives
+                        eid :archives
                         {:req (req (= target :archives))
                          :replace-access
-                         {:prompt "Select an agenda to host Political Graffiti"
-                          :mandatory true
+                         {:mandatory true
+                          :prompt "Select an agenda to host Political Graffiti"
                           :choices {:req #(in-corp-scored? state side %)}
                           :msg (msg "host Political Graffiti on " (:title target) " as a hosted condition counter")
                           :effect (req (host state :runner (get-card state target)
                                              ; keep host cid in :agenda-cid because `trash` will clear :host
-                                             (assoc card :zone [:discard] :installed true :agenda-cid (:cid (get-card state target))))
-                                       (update-agenda-points state :corp target -1))}} card))})
+                                             (assoc card :installed true :agenda-cid (:cid (get-card state target))))
+                                       (update-agenda-points state :corp target -1))}}
+                        card))
+      :events [{:event :purge
+                :effect (effect (trash card {:cause :purge}))}]
+      :trash-effect {:effect (req (let [current-side (get-scoring-owner state {:cid (:agenda-cid card)})]
+                                    (update-agenda-points state current-side
+                                                          (find-cid (:agenda-cid card) (get-in @state [current-side :scored]))
+                                                          1)))}})
 
    "Populist Rally"
    {:req (req (seq (filter #(has-subtype? % "Seedy") (all-active-installed state :runner))))
     :msg "give the Corp 1 fewer [Click] to spend on their next turn"
-    :effect (effect (lose :corp :click-per-turn 1)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (lose :corp :click-per-turn 1))
     :events [{:event :corp-turn-ends
+              :duration :until-corp-turn-ends
               :effect (effect (gain :corp :click-per-turn 1)
-                              (unregister-events card))}]}
+                              (unregister-floating-events :until-corp-turn-ends))}]}
 
    "Power Nap"
    {:effect (effect (gain-credits (+ 2 (count (filter #(has-subtype? % "Double")
@@ -1814,19 +1869,41 @@
     :msg (msg "gain " (+ 2 (count (filter #(has-subtype? % "Double") (:discard runner)))) " [Credits]")}
 
    "Power to the People"
-   {:effect (effect (register-events
-                      (assoc card :zone '(:discard))
-                      [{:event :pre-steal-cost
-                        :once :per-turn
-                        :effect (effect (gain-credits 7))
-                        :msg "gain 7 [Credits]"}
-                       {:event :runner-turn-ends
-                        :effect (effect (unregister-events card {:event :pre-steal-cost}))}]))
-    :events [{:event :pre-steal-cost}
-             {:event :runner-turn-ends}]}
+   {:events [{:event :pre-steal-cost
+              :duration :end-of-turn
+              :once :per-turn
+              :msg "gain 7 [Credits]"
+              :effect (effect (gain-credits 7))}]}
 
    "Prey"
-   (run-event {:implementation "Ice trash is manual"} nil)
+   {:implementation "Ice trash is manual"
+    :async true
+    :makes-run true
+    :prompt "Choose a server:"
+    :choices (req runnable-servers)
+    :effect (effect (toast "Click this card to trash the passed ice")
+                    (make-run eid target nil card))
+    :abilities [{:label "Trash previous ice"
+                 :once :per-run
+                 :req (req (let [last-ice (nth run-ices run-position)]
+                             (and run
+                                (rezzed? last-ice)
+                                (<= (get-strength last-ice) (count (all-installed state :runner))))))
+                 :async true
+                 :msg (msg "trash " (card-str state (nth run-ices run-position)))
+                 :effect
+                 (effect
+                   (show-wait-prompt :corp "Runner to use Prey")
+                   (continue-ability
+                     (let [strength (get-strength (nth run-ices run-position))]
+                       {:prompt (str "Select " strength " installed cards")
+                        :choices {:req #(and (runner? %)
+                                             (installed? %))
+                                  :max strength
+                                  :all true}
+                        :effect (effect (clear-wait-prompt :runner)
+                                        (trash eid (nth run-ices run-position) nil))})
+                     card nil))}]}
 
    "Process Automation"
    {:msg "gain 2 [Credits] and draw 1 card"
@@ -1910,6 +1987,7 @@
    "Rebirth"
    {:msg "change identities"
     :prompt "Choose an identity to become"
+    :rfg-instead-of-trashing true
     :choices (req (let [is-draft-id? #(.startsWith (:code %) "00")
                         runner-identity (:identity runner)
                         is-swappable #(and (= "Identity" (:type %))
@@ -1922,7 +2000,6 @@
                    ;; Handle hosted cards (Ayla) - Part 1
                    (doseq [c (:hosted old-runner-identity)]
                      (move state side c :temp-hosted))
-                   (move state side (last (:discard runner)) :rfg)
                    (disable-identity state side)
                    ;; Manually reduce the runner's link by old link
                    (lose state :runner :link (:baselink old-runner-identity))
@@ -1943,32 +2020,38 @@
    "Reboot"
    (letfn [(install-cards [state side eid card to-install titles]
              (if-let [f (first to-install)]
-               (wait-for (runner-install state :runner (make-eid state {:source card :source-type :runner-install}) f {:facedown true :no-msg true})
+               (wait-for (runner-install state :runner f {:facedown true :no-msg true})
                          (install-cards state side eid card (rest to-install) titles))
                (do
                  (move state side (find-latest state card) :rfg)
                  (system-msg state :runner (str "uses Reboot to install " (join ", " titles) " facedown"))
                  (effect-completed state side eid))))]
-     {:req (req archives-runnable)
+     {:async true
       :makes-run true
+      :rfg-instead-of-trashing true
+      :req (req archives-runnable)
       :effect (effect
                 (make-run
-                  :archives
+                  eid :archives
                   {:req (req (= target :archives))
                    :replace-access
-                   {:prompt "Choose up to five cards to install"
+                   {:mandatory true
+                    :async true
+                    :prompt "Choose up to five cards to install"
                     :show-discard true
                     :choices {:max 5
-                              :req #(and (in-discard? %) (runner? %) (not (same-card? % card)))}
-                    :mandatory true
-                    :async true
-                    :cancel-effect (req (move state side (find-latest state card) :rfg)
-                                        (effect-completed state side eid))
-                    :effect (req (install-cards state side eid card targets (map :title targets)))}}
+                              :req #(and (in-discard? %)
+                                         (runner? %))}
+                    :effect (effect (install-cards eid card targets (map :title targets)))}}
                   card))})
 
    "Recon"
-   (run-event)
+   {:implementation "Jack out is manual"
+    :async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (make-run eid target nil card))}
 
    "Rejig"
    (let [valid-target? (fn [card] (and (runner? card)
@@ -2004,16 +2087,19 @@
                    (swap-ice state side (first targets) (second targets))))}
 
    "Retrieval Run"
-   {:req (req archives-runnable)
+   {:async true
     :makes-run true
+    :req (req archives-runnable)
     :effect (effect (make-run
-                      :archives
+                      eid :archives
                       {:req (req (= target :archives))
                        :replace-access
-                       {:prompt "Choose a program to install"
+                       {:async true
+                        :prompt "Choose a program to install"
                         :msg (msg "install " (:title target))
                         :choices (req (filter program? (:discard runner)))
-                        :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:ignore-all-cost true}))}}
+                        :effect (effect (runner-install (assoc eid :source card :source-type :runner-install)
+                                                        target {:ignore-all-cost true}))}}
                       card))}
 
    "Rigged Results"
@@ -2037,10 +2123,11 @@
                                        (continue-ability state :runner (choose-ice) card nil)
                                        (effect-completed state side eid))))})
            (choose-ice []
-             {:prompt "Select a piece of ICE to bypass"
+             {:async true
+              :prompt "Select a piece of ICE to bypass"
               :choices {:req ice?}
-              :msg (msg "bypass " (card-str state target))
-              :effect (effect (make-run (second (:zone target))))})]
+              :msg (msg "make a run and bypass " (card-str state target))
+              :effect (effect (make-run eid (second (:zone target)) nil card))})]
      {:async true
       :effect (req (show-wait-prompt state :corp "Runner to spend credits")
                 (let [all-amounts (range (min 3 (inc (get-in @state [:runner :credit]))))
@@ -2051,39 +2138,38 @@
                   (continue-ability state side (runner-choice choices) card nil)))})
 
    "Rip Deal"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
-    :effect (effect
-              (make-run
-                :hq {:req (req (= target :hq))
-                     :replace-access
-                     {:async true
-                      :effect
-                      (req (let [n (min (-> corp :hand count) (access-count state side :hq-access))
-                                 heap (-> runner :discard count (- 1))]
-                             (move state side (find-cid (:cid card) (:discard runner)) :rfg)
-                             (if (pos? heap)
-                               (continue-ability
-                                 state side
-                                 {:show-discard true
-                                  :prompt (str "Choose " (quantify (min n heap) "card") " to move from the Heap to your Grip")
-                                  :async true
-                                  :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
-                                  :choices {:max (min n heap)
-                                            :all true
-                                            :req #(and (runner? %)
-                                                       (in-discard? %))}
-                                  :effect (req (doseq [c targets]
-                                                 (move state side c :hand))
-                                               (do-access state side eid (:server run) {:hq-root-only true}))}
-                                 card nil)
-                               (continue-ability
-                                 state side
-                                 {:async true
-                                  :msg (msg "take no cards from their Heap to their Grip")
-                                  :effect (req (do-access state side eid (:server run) {:hq-root-only true}))}
-                                 card nil))))}}
-                card))}
+    :rfg-instead-of-trashing true
+    :req (req hq-runnable)
+    :effect
+    (effect (make-run
+              eid :hq
+              {:req (req (= target :hq))
+               :replace-access
+               {:async true
+                :effect
+                (effect
+                  (continue-ability
+                    (let [n (min (-> corp :hand count) (access-count state side :hq-access))
+                          heap (count (:discard runner))]
+                      (if (pos? heap)
+                        {:show-discard true
+                         :prompt (str "Choose " (quantify (min n heap) "card") " to move from the Heap to your Grip")
+                         :async true
+                         :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
+                         :choices {:max (min n heap)
+                                   :all true
+                                   :req #(and (runner? %)
+                                              (in-discard? %))}
+                         :effect (req (doseq [c targets]
+                                        (move state side c :hand))
+                                      (do-access state side eid (:server run) {:hq-root-only true}))}
+                        {:async true
+                         :msg (msg "take no cards from their Heap to their Grip")
+                         :effect (req (do-access state side eid (:server run) {:hq-root-only true}))}))
+                    card nil))}}
+              card nil))}
 
    "Rumor Mill"
    (letfn [(eligible? [card] (and (:uniqueness card)
@@ -2103,23 +2189,43 @@
                 :effect (effect (disable-card :corp target))}]})
 
    "Run Amok"
-   {:implementation "Ice trash is manual"
-    :prompt "Choose a server"
-    :choices (req runnable-servers)
-    :makes-run true
-    :effect (effect (make-run target {:end-run {:msg " trash 1 piece of ICE that was rezzed during the run"}} card))}
+   (letfn [(get-rezzed-cids [ice]
+             (map :cid (filter #(and (rezzed? %)
+                                     (ice? %))
+                               ice)))]
+     {:prompt "Choose a server"
+      :choices (req runnable-servers)
+      :makes-run true
+      :effect (effect (update! (assoc-in card [:special :run-amok] (get-rezzed-cids (all-installed state :corp))))
+                      (make-run eid target nil (get-card state card)))
+      :events [{:event :run-ends
+                :async true
+                :effect (req (let [new (set (get-rezzed-cids (all-installed state :corp)))
+                                   old (set (get-in (get-card state card) [:special :run-amok]))
+                                   diff-cid (seq (clojure.set/difference new old))
+                                   diff (map #(find-cid % (all-installed state :corp)) diff-cid)]
+                               (continue-ability
+                                 state side
+                                 (when (seq diff)
+                                   {:async true
+                                    :prompt "Select an ice to trash"
+                                    :choices {:req #(some (partial same-card? %) diff)
+                                              :all true}
+                                    :effect (effect (trash eid target nil))})
+                                 card nil)))}]})
 
    "Running Interference"
-   (run-event
-     nil
-     nil
-     nil
-     (effect (register-floating-effect
-               card
-               {:type :rez-additional-cost
-                :duration :end-of-run
-                :req (req (ice? target))
-                :value (req [:credit (:cost target)])})))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (register-floating-effect
+                      card
+                      {:type :rez-additional-cost
+                       :duration :end-of-run
+                       :req (req (ice? target))
+                       :value (req [:credit (:cost target)])})
+                    (make-run eid target nil card))}
 
    "Satellite Uplink"
    {:choices {:max 2 :req installed?}
@@ -2165,31 +2271,37 @@
               :effect (effect (update! (dissoc-in card [:special :scrubbed-target])))}]}
 
    "Showing Off"
-   {:req (req rd-runnable)
+   {:async true
     :makes-run true
+    :req (req rd-runnable)
     :effect (effect (make-run
-                      :rd
+                      eid :rd
                       {:replace-access
                        {:msg "access cards from the bottom of R&D"
                         :mandatory true
                         :async true
-                        :effect (effect (register-events (assoc card :zone '(:discard)))
-                                        (do-access eid (:server run)))}} card))
+                        :effect (effect (do-access eid (:server run)))}}
+                      card))
     :events [{:event :pre-access
               :silent (req true)
               :effect (req (swap! state assoc-in [:runner :rd-access-fn] reverse))}
              {:event :run-ends
-              :effect (req (swap! state assoc-in [:runner :rd-access-fn] seq)
-                           (unregister-events state side card))}]}
+              :effect (req (swap! state assoc-in [:runner :rd-access-fn] seq))}]}
 
    "Singularity"
-   (run-event
-     {:choices (req (filter #(can-run-server? state %) remotes))}
-     {:req (req (is-remote? target))
-      :replace-access {:mandatory true
-                       :msg "trash all cards in the server at no cost"
-                       :effect (req (doseq [c (:content run-server)]
-                                      (trash state side c)))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (filter #(can-run-server? state %) remotes))
+    :effect (effect (make-run
+                      eid target
+                      {:req (req (is-remote? target))
+                       :replace-access
+                       {:mandatory true
+                        :async true
+                        :msg "trash all cards in the server at no cost"
+                        :effect (effect (trash-cards eid (:content run-server)))}}
+                      card))}
 
    "Social Engineering"
    {:prompt "Select an unrezzed piece of ICE"
@@ -2203,17 +2315,18 @@
                                      card
                                      [{:event :rez
                                        :duration :end-of-turn
-                                       :req (req (= target ice))
+                                       :req (req (same-card? target ice))
                                        :msg (msg "gain " (rez-cost state side (get-card state target)) " [Credits]")
                                        :effect (effect (gain-credits :runner (rez-cost state side (get-card state target))))}]))})
                 card nil))}
 
    "Spear Phishing"
    {:implementation "Bypass is manual"
+    :async true
+    :makes-run true
     :prompt "Choose a server"
     :choices (req runnable-servers)
-    :makes-run true
-    :effect (effect (make-run target nil card))}
+    :effect (effect (make-run eid target nil card))}
 
    "Spec Work"
    {:async true
@@ -2236,7 +2349,9 @@
    "Spot the Prey"
    {:prompt "Select 1 non-ICE card to expose"
     :msg "expose 1 card and make a run"
-    :choices {:req #(and (installed? %) (not (ice? %)) (corp? %))}
+    :choices {:req #(and (installed? %)
+                         (not (ice? %))
+                         (corp? %))}
     :async true
     :makes-run true
     :effect (req (wait-for (expose state side target)
@@ -2249,12 +2364,16 @@
                              card nil)))}
 
    "Stimhack"
-   (run-event
-     nil
-     {:end-run {:msg "take 1 brain damage"
-                :effect (effect (damage eid :brain 1 {:unpreventable true
-                                                      :card card}))}}
-     (effect (gain-next-run-credits 9)))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (gain-next-run-credits 9)
+                    (make-run eid target nil card))
+    :events [{:event :run-ends
+              :msg "take 1 brain damage"
+              :effect (effect (damage eid :brain 1 {:unpreventable true
+                                                    :card card}))}]}
 
    "Sure Gamble"
    {:msg "gain 9 [Credits]"
@@ -2296,8 +2415,7 @@
               :effect (effect (lose-credits :corp 1))}]}
 
    "System Seizure"
-   {:effect (req (register-events state side (assoc card :zone '(:discard))))
-    :events [{:event :pump-breaker
+   {:events [{:event :pump-breaker
               :once :per-turn
               :effect (req (let [last-pump (assoc (last (:effects @state)) :duration :end-of-run)]
                              (swap! state assoc :effects
@@ -2305,104 +2423,106 @@
                                          butlast
                                          (into [])
                                          (#(conj % last-pump)))))
-                           (update-breaker-strength state side target))}]
-    :move-zone (req (when (= [:discard] (:zone card))
-                      (unregister-events state side card)))}
+                           (update-breaker-strength state side target))}]}
 
    "Test Run"
-   (let [move-ability {:req (req (seq (filter #(get-in % [:special :test-run]) (all-active-installed state :runner))))
-                       :effect (req (doseq [program (filter #(get-in % [:special :test-run]) (all-active-installed state :runner))]
-                                      (move state side program :deck {:front true})
-                                      (system-msg state side (str "move " (:title program) " to the top of the Stack"))))}]
-     {:events [(assoc move-ability :event :corp-turn-ends)
-               (assoc move-ability :event :runner-turn-ends)]
-      :prompt "Install a program from your Stack or Heap?"
-      :choices ["Stack" "Heap"]
-      :msg (msg "install a program from their " target)
-      :effect (effect (register-events (assoc card :zone '(:discard)))
-                      (continue-ability
-                        (let [where target]
-                          {:prompt "Choose a program to install"
-                           :choices (req (cancellable
-                                           (filter program? ((if (= where "Heap") :discard :deck) runner))))
-                           :effect (effect (trigger-event :searched-stack nil)
-                                           (shuffle! :deck)
-                                           (runner-install (assoc eid :source card :source-type :runner-install)
-                                                           (assoc-in target [:special :test-run] true)
-                                                           {:ignore-all-cost true}))})
-                        card nil))})
+   {:prompt "Install a program from your Stack or Heap?"
+    :choices ["Stack" "Heap"]
+    :msg (msg "install a program from their " target)
+    :effect (effect
+              (continue-ability
+                (let [where target]
+                  {:prompt "Choose a program to install"
+                   :choices (req (cancellable
+                                   (filter program? ((if (= where "Heap") :discard :deck) runner))))
+                   :effect (effect (trigger-event :searched-stack nil)
+                                   (shuffle! :deck)
+                                   (register-events
+                                     card
+                                     (let [program target]
+                                       [{:event :runner-turn-ends
+                                         :duration :end-of-turn
+                                         :req (req (let [program (find-cid (:cid program) (all-installed state :runner))]
+                                                     (get-in program [:special :test-run])))
+                                         :msg (msg "move " (:title program) " to the top of the stack")
+                                         :effect (effect (move (find-cid (:cid program) (all-installed state :runner))
+                                                               :deck {:front true}))}]))
+                                   (runner-install (assoc eid :source card :source-type :runner-install)
+                                                   (assoc-in target [:special :test-run] true)
+                                                   {:ignore-all-cost true}))})
+                card nil))}
 
    "The Maker's Eye"
    {:req (req rd-runnable)
     :makes-run true
-    :effect (effect (make-run :rd nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :async true
+    :effect (effect (make-run eid :rd nil card))
     :events [{:event :successful-run
               :silent (req true)
               :req (req (= target :rd))
-              :effect (effect (access-bonus :rd 2))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (access-bonus :rd 2))}]}
 
    "The Noble Path"
    {:async true
-    :effect (req (doseq [c (:hand runner)]
-                   (trash state side c))
-                 (register-events
-                   state side card
-                   [{:event :pre-damage
-                     :duration :end-of-run
-                     :effect (effect (damage-prevent :net Integer/MAX_VALUE)
-                                     (damage-prevent :meat Integer/MAX_VALUE)
-                                     (damage-prevent :brain Integer/MAX_VALUE))}])
-                 (continue-ability
-                   state side
-                   {:prompt "Choose a server"
-                    :choices (req runnable-servers)
-                    :msg (msg "trash their Grip and make a run on " target ", preventing all damage")
-                    :effect (effect (make-run target nil card))}
-                   card nil))}
+    :makes-run true
+    :effect (req (wait-for (trash-cards state side eid (:hand runner) nil)
+                    (continue-ability
+                      state side
+                      {:async true
+                       :prompt "Choose a server"
+                       :choices (req runnable-servers)
+                       :msg (msg "trash their Grip and make a run on " target ", preventing all damage")
+                       :effect (effect (make-run eid target nil card))}
+                      card nil)))
+    :events [{:event :pre-damage
+              :duration :end-of-run
+              :effect (effect (damage-prevent :net Integer/MAX_VALUE)
+                              (damage-prevent :meat Integer/MAX_VALUE)
+                              (damage-prevent :brain Integer/MAX_VALUE))}]}
 
    "The Price of Freedom"
    {:additional-cost [:connection 1]
     :msg "prevent the Corp from advancing cards during their next turn"
-    :effect (effect (register-events (assoc card :zone '(:rfg)))
-                    (move (first (:play-area runner)) :rfg))
+    :rfg-instead-of-trashing true
     :events [{:event :corp-turn-begins
+              :duration :until-start-of-runner-turn
               :effect (effect (register-turn-flag!
                                 card :can-advance
                                 (fn [state side card]
                                   ((constantly false)
                                    (toast state :corp "Cannot advance cards this turn due to The Price of Freedom." "warning"))))
-                              (unregister-events card))}]}
+                              ;; This is a hack
+                              (unregister-floating-events :until-start-of-runner-turn))}]}
 
    "Three Steps Ahead"
-   {:effect (effect (register-events
-                      (assoc card :zone '(:discard))
-                      [{:event :runner-turn-ends
-                        :msg (msg "gain " (* 2 (count (:successful-run runner-reg))) " [Credits]")
-                        :effect (effect (gain-credits (* 2 (count (:successful-run runner-reg))))
-                                        (unregister-events card {:events [{:event :runner-turn-ends}]}))}]))}
+   {:events [{:event :runner-turn-ends
+              :duration :end-of-turn
+              :msg (msg "gain " (* 2 (count (:successful-run runner-reg))) " [Credits]")
+              :effect (effect (gain-credits (* 2 (count (:successful-run runner-reg)))))}]}
 
    "Tinkering"
-   {:prompt "Select a piece of ICE"
-    :choices {:req #(and (= (last (:zone %)) :ices) (ice? %))}
-    :effect (req (let [ice target
-                       serv (zone->name (second (:zone ice)))
-                       stypes (:subtype ice)]
-                   (resolve-ability
-                     state :runner
-                     {:msg (msg "make " (card-str state ice) " gain Sentry, Code Gate, and Barrier until the end of the turn")
-                      :effect (effect (update! (assoc ice :subtype (combine-subtypes true (:subtype ice) "Sentry" "Code Gate" "Barrier")))
-                                      (update-ice-strength (get-card state ice))
-                                      (add-icon card (get-card state ice) "T" "green")
-                                      (register-events
-                                        (assoc card :zone '(:discard))
-                                        [{:event :runner-turn-ends
-                                          :effect (effect (remove-icon card (get-card state ice))
-                                                          (update! (assoc (get-card state ice) :subtype stypes))
-                                                          (unregister-events card {:events [{:event :runner-turn-ends}]}))}]))}
-                     card nil)))}
+   {:req (req (some #(and (ice? %)
+                          (installed? %))
+                    (all-installed state :corp)))
+    :prompt "Select a piece of ICE"
+    :choices {:req #(and (installed? %)
+                         (ice? %))}
+    :msg (msg "make " (card-str state target) " gain Sentry, Code Gate, and Barrier until the end of the turn")
+    :effect (effect (update! (assoc target :subtype (combine-subtypes true (:subtype target) "Sentry" "Code Gate" "Barrier")))
+                    (update! (assoc-in (get-card state target) [:special :tinkering] true))
+                    (update-all-ice)
+                    (add-icon card (get-card state target) "T" "green")
+                    (register-events
+                      card
+                      (let [ice (get-card state target)
+                            stypes (:subtype target)]
+                        [{:event :runner-turn-ends
+                          :duration :end-of-turn
+                          :req (req (get-in (get-card state ice) [:special :tinkering]))
+                          :effect (effect (remove-icon card (get-card state ice))
+                                          (update! (assoc (get-card state ice) :subtype stypes))
+                                          (update! (dissoc-in (get-card state ice) [:special :tinkering]))
+                                          (update-all-ice))}])))}
 
    "Trade-In"
    ;; Basically a hack. Ideally the additional cost cause the cost trash to be passed in as targets
@@ -2449,53 +2569,56 @@
     :leave-play (effect (clear-turn-flag! card :can-install-ice))}
 
    "Vamp"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
+    :req (req hq-runnable)
     :effect (effect (make-run
-                      :hq {:req (req (= target :hq))
-                           :replace-access
-                           {:async true
-                            :prompt "How many [Credits]?"
-                            :choices :credit
-                            :msg (msg "take 1 tag and make the Corp lose " target " [Credits]")
-                            :effect (effect (lose-credits :corp target)
-                                            (gain-tags eid 1))}} card))}
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       {:async true
+                        :prompt "How many [Credits]?"
+                        :choices :credit
+                        :msg (msg "take 1 tag and make the Corp lose " target " [Credits]")
+                        :effect (effect (lose-credits :corp target)
+                                        (gain-tags eid 1))}}
+                      card))}
 
    "Wanton Destruction"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
+    :req (req hq-runnable)
     :effect (effect (make-run
-                      :hq {:req (req (= target :hq))
-                           :replace-access
-                           {:msg (msg "force the Corp to discard " target " cards from HQ at random")
-                            :prompt "How many [Click] do you want to spend?"
-                            :choices (req (map str (range 1 (inc (:click runner)))))
-                            :effect (req (let [n (str->int target)]
-                                           (when (pay state :runner card :click n)
-                                             (trash-cards state :corp (take n (shuffle (:hand corp)))))))}} card))}
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       {:msg (msg "force the Corp to discard " target " cards from HQ at random")
+                        :prompt "How many [Click] do you want to spend?"
+                        :choices (req (map str (range 1 (inc (:click runner)))))
+                        :effect (req (let [n (str->int target)]
+                                       (wait-for (pay-sync state :runner card :click n)
+                                                 (trash-cards state :corp eid (take n (shuffle (:hand corp)))))))}}
+                      card))}
 
    "Watch the World Burn"
-   (letfn [(rfg-card-event [burn-name]
+   (letfn [(rfg-card-event [burned-card]
              [{:event :pre-access-card
-               :req (req (= (:title target) burn-name))
-               :msg (msg (str "uses the previously played Watch the World Burn to remove " burn-name " from the game"))
-               :effect (req (move state :corp target :rfg))}])]
-     {:makes-run true
+               :duration :end-of-game
+               :req (req (same-card? :title burned-card target))
+               :msg (msg (str "remove " (:title burned-card) " from the game"))
+               :effect (effect (move :corp target :rfg))}])]
+     {:async true
+      :makes-run true
       :prompt "Choose a server"
       :choices (req (filter #(can-run-server? state %) remotes))
-      :effect (effect (make-run target nil card)
-                      (register-events (dissoc card :zone)))
+      :effect (effect (make-run eid target nil card))
       :events [{:event :pre-access-card
                 :req (req (and (not= (:type target) "Agenda")
-                               (get-in @state [:run :successful])))
+                               (:successful run)))
                 :once :per-run
-                :effect (req (let [t (:title target)]
-                               (system-msg state :runner (str "to remove " t " from the game, and watch for other copies of " t " to burn"))
-                               (move state :corp target :rfg)
-                               ;; in the below, the new :cid ensures that when unregister-events is called, the rfg-card-event is left alone
-                               (register-events state side (dissoc (assoc card :cid (make-cid)) :zone) (rfg-card-event t))))}
-               {:event :run-ends
-                :effect (effect (unregister-events (dissoc card :zone)))}]})
+                :msg (msg "remove " (:title target) " from the game, and watch for other copies of " (:title target) " to burn")
+                :effect (effect (move :corp target :rfg)
+                                (register-events card (rfg-card-event target)))}]})
 
    "White Hat"
    (letfn [(finish-choice [choices]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -31,28 +31,26 @@
                    card nil))}
 
    "Accelerated Diagnostics"
-   (letfn [(ad [i n adcard]
-             {:prompt "Select an operation to play"
-              :choices {:req #(and (corp? %)
-                                   (operation? %)
-                                   (in-play-area? %))}
-              :msg (msg "play " (:title target))
-              :async true
-              :effect (req (wait-for (play-instant state side target {:no-additional-cost true})
-                                     (if (and (not (get-in @state [:corp :register :terminal])) (< i n))
-                                       (continue-ability state side (ad (inc i) n adcard) adcard nil)
-                                       (effect-completed state side eid))))})]
+   (letfn [(ad [st si e c cards]
+             (when-let [cards (filterv #(and (operation? %)
+                                             (can-pay? st si e c nil [:credit (play-cost st si %)]))
+                                       cards)]
+               {:async true
+                :prompt "Select an operation to play"
+                :choices (cancellable cards)
+                :msg (msg "play " (:title target))
+                :effect (req (wait-for (play-instant state side target {:no-additional-cost true})
+                                       (let [cards (filterv #(not (same-card? % target)) cards)]
+                                         (continue-ability state side (ad state side eid card cards) card nil))))}))]
      {:async true
-      :implementation "Corp has to manually cards back to R&D to correctly play a draw operation"
-      :effect (req (let [n (count (filter operation?
-                                          (take 3 (:deck corp))))]
-                     (continue-ability state side
-                                       {:msg "look at the top 3 cards of R&D"
-                                        :async true
-                                        :effect (req (doseq [c (take 3 (:deck corp))]
-                                                       (move state side c :play-area))
-                                                     (continue-ability state side (ad 1 n card) card nil))}
-                                       card nil)))})
+      :effect
+      (effect
+        (continue-ability
+          (let [top (take 3 (:deck corp))]
+            {:prompt (str "The top 3 cards of R&D are " (join ", " (map :title top)) ".")
+             :choices ["OK"]
+             :effect (effect (continue-ability (ad state side eid card top) card nil))})
+          card nil))})
 
    "Ad Blitz"
    (let [abhelp (fn ab [n total]
@@ -74,7 +72,8 @@
       :effect (effect (continue-ability (abhelp 1 target) card nil))})
 
    "Aggressive Negotiation"
-   {:req (req (:scored-agenda corp-reg)) :prompt "Choose a card"
+   {:req (req (:scored-agenda corp-reg))
+    :prompt "Choose a card"
     :choices (req (cancellable (:deck corp) :sorted))
     :effect (effect (move target :hand)
                     (shuffle! :deck))
@@ -82,20 +81,23 @@
 
    "An Offer You Can't Refuse"
    {:async true
-    :prompt "Choose a server" :choices ["Archives" "R&D" "HQ"]
+    :prompt "Choose a server"
+    :choices ["Archives" "R&D" "HQ"]
     :effect (req (let [serv target]
                    (show-wait-prompt state :corp (str "Runner to decide on running " target))
                    (continue-ability
                      state side
                      {:optional
-                      {:prompt (msg "Make a run on " serv "?") :player :runner
-                       :yes-ability {:msg (msg "let the Runner make a run on " serv)
+                      {:prompt (str "Make a run on " serv "?")
+                       :player :runner
+                       :yes-ability {:msg (str "let the Runner make a run on " serv)
+                                     :async true
                                      :effect (effect (clear-wait-prompt :corp)
                                                      (make-run eid serv nil card))}
                        :no-ability {:async true
+                                    :msg "add it to their score area as an agenda worth 1 agenda point"
                                     :effect (req (clear-wait-prompt state :corp)
-                                                 (as-agenda state :corp eid (some #(when (same-card? card %) %) (:discard corp)) 1))
-                                    :msg "add it to their score area as an agenda worth 1 agenda point"}}}
+                                                 (as-agenda state :corp eid card 1))}}}
                      card nil)))}
 
    "Anonymous Tip"
@@ -269,7 +271,7 @@
                          (not (rezzed? %)))}
     :msg (msg "rez " (card-str state target {:visible true}) " at no cost")
     :effect (effect (rez target {:ignore-cost :all-costs})
-                    (host (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))}
+                    (host (get-card state target) (assoc card :seen true :condition true)))}
 
    "Biotic Labor"
    {:msg "gain [Click][Click]"
@@ -303,26 +305,25 @@
    {:choices {:req #(and (agenda? %)
                          (in-hand? %))}
     :async true
-    :effect (req (let [agenda target]
-                   (continue-ability
-                     state side {:prompt (str "Choose a server to install " (:title agenda))
-                                 :choices (installable-servers state agenda)
-                                 :effect (req (corp-install state side agenda target {:install-state :face-up})
-                                              ; find where the agenda ended up and host on it
-                                              (let [agenda (some #(when (same-card? % agenda) %)
-                                                                 (all-installed state :corp))]
-                                                ; the operation ends up in :discard when it is played; to host it,
-                                                ; we need (host) to look for it in discard.
-                                                (host state side agenda (assoc card
-                                                                               :zone [:discard]
-                                                                               :seen true
-                                                                               :installed true))
-                                                (system-msg state side (str "hosts Casting Call on " (:title agenda)))))}
-                     card nil)))
+    :effect (effect
+              (continue-ability
+                (let [agenda target]
+                  {:prompt (str "Choose a server to install " (:title agenda))
+                   :choices (installable-servers state agenda)
+                   :effect (req (corp-install state side agenda target {:install-state :face-up})
+                                ; find where the agenda ended up and host on it
+                                (let [agenda (some #(when (same-card? % agenda) %)
+                                                   (all-installed state :corp))]
+                                  (host state side agenda (assoc card
+                                                                 :seen true
+                                                                 :installed true))
+                                  (system-msg state side (str "hosts Casting Call on " (:title agenda)))))})
+                card nil))
     :events [{:event :access
-              :req (req (same-card? target (:host card)))
               :async true
-              :effect (effect (gain-tags :runner eid 2)) :msg "give the Runner 2 tags"}]}
+              :req (req (same-card? target (:host card)))
+              :msg "give the Runner 2 tags"
+              :effect (effect (gain-tags :runner eid 2))}]}
 
    "Celebrity Gift"
    {:choices {:max 5
@@ -410,13 +411,14 @@
     :effect (effect (purge))}
 
    "Death and Taxes"
-   (let [gain-cred-effect {:msg "gain 1 [Credits]"
-                           :effect (effect (gain-credits :corp 1))}]
-     {:implementation "Credit gain mandatory to save on wait-prompts, adjust credits manually if credit not wanted."
-      :events [(assoc gain-cred-effect :event :runner-install)
-               (assoc gain-cred-effect
-                      :event :runner-trash
-                      :req (req (installed? target)))]})
+   {:implementation "Credit gain mandatory to save on wait-prompts, adjust credits manually if credit not wanted."
+    :events [{:event :runner-install
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits :corp 1))}
+             {:event :runner-trash
+              :req (req (installed? target))
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits :corp 1))}]}
 
    "Dedication Ceremony"
    {:prompt "Select a faceup card"
@@ -478,7 +480,7 @@
 
    "Distract the Masses"
    (let [shuffle-two {:async true
-                      :effect (effect (rfg-and-shuffle-rd-effect eid (find-cid (:cid card) (:discard corp)) 2 nil))}
+                      :effect (effect (shuffle-into-rd-effect eid card 2 false))}
          trash-from-hq {:async true
                         :prompt "Select up to 2 cards in HQ to trash"
                         :choices {:max 2
@@ -488,8 +490,9 @@
                         :effect (req (wait-for
                                        (trash-cards state side targets nil)
                                        (continue-ability state side shuffle-two card nil)))
-                        :cancel-effect (req (continue-ability state side shuffle-two card nil))}]
+                        :cancel-effect (effect (continue-ability shuffle-two card nil))}]
      {:async true
+      :rfg-instead-of-trashing true
       :msg "give The Runner 2 [Credits]"
       :effect (effect (gain-credits :runner 2)
                       (continue-ability trash-from-hq card nil))})
@@ -548,7 +551,7 @@
       :msg (msg "give " (card-str state target {:visible false}) " additional text")
       :effect (req (add-extra-sub! state :corp (get-card state target) new-sub (:cid card))
                    (update-ice-strength state side target)
-                   (host state side (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))
+                   (host state side (get-card state target) (assoc card :seen true :condition true)))
       :leave-play (req (remove-extra-subs! state :corp (:cid card) (:host card)))
       :events [{:event :rez
                 :req (req (same-card? target (:host card)))
@@ -792,8 +795,8 @@
                                         card nil))})
 
    "Game Changer"
-   {:effect (req (gain state side :click (count (:scored runner)))
-                 (move state side (first (:play-area corp)) :rfg))}
+   {:rfg-instead-of-trashing true
+    :effect (effect (gain :click (count (:scored runner))))}
 
    "Game Over"
    {:req (req (last-turn? state :runner :stole-agenda))
@@ -836,8 +839,9 @@
    "Genotyping"
    {:async true
     :msg "trash the top 2 cards of R&D"
+    :rfg-instead-of-trashing true
     :effect (effect (mill :corp 2)
-                    (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) 4 false))}
+                    (shuffle-into-rd-effect eid card 4 false))}
 
    "Green Level Clearance"
    {:msg "gain 3 [Credits] and draw 1 card"
@@ -858,15 +862,16 @@
                         :async true
                         :prompt "Access card? (If not, add Hangeki to your score area worth -1 agenda point)"
                         :yes-ability
-                        {:effect (req (clear-wait-prompt state :corp)
+                        {:async true
+                         :effect (req (clear-wait-prompt state :corp)
                                       (wait-for (access-card state side target)
-                                                (move state :corp (find-latest state card) :rfg)
-                                                (system-msg state :corp "removes Hangeki from the game")
+                                                (update! state side (assoc card :rfg-instead-of-trashing true))
                                                 (effect-completed state side eid)))}
                         :no-ability
-                        {:msg "add it to the Runner's score area as an agenda worth -1 agenda point"
+                        {:async true
+                         :msg "add it to the Runner's score area as an agenda worth -1 agenda point"
                          :effect (effect (clear-wait-prompt :corp)
-                                         (as-agenda :runner eid (find-latest state card) -1))}}}
+                                         (as-agenda :runner eid card -1))}}}
                       card targets))}
 
    "Hard-Hitting News"
@@ -965,7 +970,8 @@
    "Housekeeping"
    {:events [{:event :runner-install
               :player :runner
-              :prompt "Select a card from your Grip to trash for Housekeeping" :once :per-turn
+              :once :per-turn
+              :prompt "Select a card from your Grip to trash for Housekeeping"
               :choices {:req #(and (runner? %)
                                    (in-hand? %))}
               :msg (msg "force the Runner to trash " (:title target) " from their Grip")
@@ -1074,8 +1080,8 @@
 
    "Load Testing"
    {:msg "make the Runner lose [Click] when their next turn begins"
-    :effect (effect (register-events (assoc card :zone '(:discard))))
     :events [{:event :runner-turn-begins
+              :duration :runner-turn-begins
               :msg "make the Runner lose [Click]"
               :effect (effect (lose :runner :click 1)
                               (unregister-events card))}]}
@@ -1130,21 +1136,23 @@
                          (has-subtype? % "Connection")
                          (installed? %))}
     :msg (msg "host it on " (card-str state target) ". The Runner has an additional tag")
-    :effect (req (host state side (get-card state target) (assoc card :zone [:discard] :seen true))
+    :effect (req (host state side (get-card state target) (assoc card :seen true))
                  (swap! state update-in [:runner :tag :additional] inc)
                  (trigger-event state :corp :runner-additional-tag-change 1))
     :leave-play (req (swap! state update-in [:runner :tag :additional] dec)
                      (trigger-event state :corp :runner-additional-tag-change 1)
                      (system-msg state :corp "trashes MCA Informant"))
     :runner-abilities [{:label "Trash MCA Informant host"
-                        :cost [:credit 2 :click 1]
+                        :cost [:click 1 :credit 2]
                         :req (req (= :runner side))
-                        :effect (effect (system-msg :runner (str "spends [Click] and 2 [Credits] to trash " (card-str state (:host card))))
+                        :effect (effect (system-msg :runner (str "spends [Click] and 2 [Credits] to trash "
+                                                                 (card-str state (:host card))))
                                         (trash :runner eid (get-card state (:host card)) nil))}]}
 
    "Medical Research Fundraiser"
    {:msg "gain 8 [Credits]. The Runner gains 3 [Credits]"
-    :effect (effect (gain-credits 8) (gain-credits :runner 3))}
+    :effect (effect (gain-credits 8)
+                    (gain-credits :runner 3))}
 
    "Midseason Replacements"
    {:req (req (last-turn? state :runner :stole-agenda))
@@ -1270,7 +1278,8 @@
 
    "Paywall Implementation"
    {:events [{:event :successful-run
-              :msg "gain 1 [Credits]" :effect (effect (gain-credits :corp 1))}]}
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits :corp 1))}]}
 
    "Peak Efficiency"
    {:msg (msg "gain " (reduce (fn [c server]
@@ -1334,7 +1343,9 @@
               :effect (effect (steal-cost-bonus [:credit 2]))}]}
 
    "Preemptive Action"
-   {:effect (effect (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) (min (count (:discard corp)) 3) true))}
+   {:async true
+    :rfg-instead-of-trashing true
+    :effect (effect (shuffle-into-rd-effect eid card 3 true))}
 
    "Priority Construction"
    (letfn [(install-card [chosen]
@@ -1614,25 +1625,24 @@
    "Riot Suppression"
    {:req (req (last-turn? state :runner :trashed-card))
     :async true
-    :effect (req (let [c card]
-                   (show-wait-prompt state :corp "Runner to decide if they will take 1 brain damage")
-                   (continue-ability
-                     state :runner
-                     {:optional
-                      {:prompt "Take 1 brain damage to prevent having 3 fewer clicks next turn?"
-                       :player :runner
-                       :end-effect (req (clear-wait-prompt state :corp)
-                                        (move state :corp (find-latest state c) :rfg))
-                       :yes-ability
-                       {:async true
-                        :effect (req (system-msg
-                                       state :runner
-                                       "suffers 1 brain damage to prevent losing 3[Click] to Riot Suppression")
-                                     (damage state :runner eid :brain 1 {:card card}))}
-                       :no-ability
-                       {:msg "give the runner 3 fewer [Click] next turn"
-                        :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil #(- % 3) 0)))}}}
-                     card nil)))}
+    :rfg-instead-of-trashing true
+    :effect (effect (show-wait-prompt :corp "Runner to decide if they will take 1 brain damage")
+                    (continue-ability
+                      (let [c card]
+                        {:optional
+                         {:prompt "Take 1 brain damage to prevent having 3 fewer clicks next turn?"
+                          :player :runner
+                          :end-effect (effect (clear-wait-prompt :corp))
+                          :yes-ability
+                          {:async true
+                           :effect (req (system-msg
+                                          state :runner
+                                          "suffers 1 brain damage to prevent losing 3[Click] to Riot Suppression")
+                                        (damage state :runner eid :brain 1 {:card card}))}
+                          :no-ability
+                          {:msg "give the runner 3 fewer [Click] next turn"
+                           :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil #(- % 3) 0)))}}})
+                      card nil))}
 
    "Rolling Brownout"
    {:msg "increase the play cost of operations and events by 1 [Credits]"
@@ -1644,9 +1654,10 @@
               :effect (effect (gain-credits :corp 1))}]}
 
    "Rover Algorithm"
-   {:choices {:req #(and (ice? %) (rezzed? %))}
+   {:choices {:req #(and (ice? %)
+                         (rezzed? %))}
     :msg (msg "host it as a condition counter on " (card-str state target))
-    :effect (effect (host target (assoc card :zone [:discard] :seen true :condition true))
+    :effect (effect (host target (assoc card :seen true :condition true))
                     (update-ice-strength (get-card state target)))
     :constant-effects [{:type :ice-strength
                         :req (req (same-card? target (:host card)))
@@ -1849,12 +1860,13 @@
      {:sub-effect {:label "End the run"
                    :msg "end the run"
                    :effect (effect (end-run eid card))}
-      :choices {:req #(and (ice? %) (rezzed? %))}
+      :choices {:req #(and (ice? %)
+                           (rezzed? %))}
       :msg (msg "make " (card-str state target) " gain Barrier and \"[Subroutine] End the run\"")
       :effect (req (update! state side (assoc target :subtype (combine-subtypes true (:subtype target) "Barrier")))
                    (add-extra-sub! state :corp (get-card state target) new-sub (:cid card))
                    (update-ice-strength state side target)
-                   (host state side (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))
+                   (host state side (get-card state target) (assoc card :seen true :condition true)))
       :leave-play (req (remove-extra-subs! state :corp (:cid card) (:host card)))
       :events [{:event :rez
                 :req (req (same-card? target (:host card)))
@@ -1877,33 +1889,30 @@
       :effect (effect (continue-ability (sc 1 card) card nil))})
 
    "Subliminal Messaging"
-   (letfn [(subliminal []
-             [{:event :corp-phase-12
-               :effect
-               (req (if (not-last-turn? state :runner :made-run)
-                      (do (resolve-ability state side
-                                           {:optional
-                                            {:prompt "Add Subliminal Messaging to HQ?"
-                                             :yes-ability {:effect (req (move state side card :hand)
-                                                                        (system-msg state side "adds Subliminal Messaging to HQ"))}
-                                             :no-ability {:effect (effect (register-events (assoc card :zone '(:discard)) (subliminal)))}}}
-                                           card nil)
-                          (unregister-events state side card))
-                      (do (unregister-events state side card)
-                          (resolve-ability state side
-                                           {:effect (effect (register-events (assoc card :zone '(:discard)) (subliminal)))}
-                                           card nil))))}])]
+   (let [subliminal [{:event :corp-phase-12
+                      :async true
+                      :effect
+                      (effect
+                        (continue-ability
+                          (when (not-last-turn? state :runner :made-run)
+                            {:optional
+                             {:prompt "Add Subliminal Messaging to HQ?"
+                              :yes-ability
+                              {:msg "add Subliminal Messaging to HQ"
+                               :effect (effect (move card :hand)
+                                               (unregister-events card {:events [{:event :corp-phase-12}]}))}}})
+                          card nil))}]]
      {:msg "gain 1 [Credits]"
       :effect (effect (gain-credits 1)
-                      (resolve-ability {:once :per-turn
-                                        :once-key :subliminal-messaging
-                                        :msg "gain [Click]"
-                                        :effect (effect (gain :corp :click 1))}
-                                       card nil))
-      :move-zone (req (if (= [:discard] (:zone card))
-                        (register-events state side (assoc card :zone '(:discard)) (subliminal))
-                        (unregister-events state side card)))
-      :events [{:event :corp-phase-12}]})
+                      (continue-ability
+                        {:once :per-turn
+                         :once-key :subliminal-messaging
+                         :msg "gain [Click]"
+                         :effect (effect (gain :corp :click 1))}
+                        card nil))
+      :move-zone (req (if (in-discard? card)
+                        (register-events state side (assoc card :zone '(:discard)) subliminal)
+                        (unregister-events state side card {:events [{:event :corp-phase-12}]})))})
 
    "Success"
    {:additional-cost [:forfeit]
@@ -1947,13 +1956,13 @@
     :msg (msg "gain " (count (:hand runner)) " [Credits]")}
 
    "Targeted Marketing"
-   (let [gaincr {:req (req (= (:title target) (:marketing-target card)))
+   (let [gaincr {:req (req (= (:title target) (get-in card [:special :marketing-target])))
                  :effect (effect (gain-credits :corp 10))
                  :msg (msg "gain 10 [Credits] from " (:marketing-target card))}]
      {:prompt "Name a Runner card"
       :choices {:card-title (req (and (runner? target)
                                       (not (identity? target))))}
-      :effect (effect (update! (assoc card :marketing-target target))
+      :effect (effect (update! (assoc-in card [:special :marketing-target] target))
                       (system-msg (str "uses Targeted Marketing to name " target)))
       :events [(assoc gaincr :event :runner-install)
                (assoc gaincr :event :play-event)]})
@@ -1979,25 +1988,26 @@
    "Threat Assessment"
    {:req (req (last-turn? state :runner :trashed-card))
     :prompt "Select an installed Runner card"
-    :choices {:req #(and (runner? %) (installed? %))}
+    :choices {:req #(and (runner? %)
+                         (installed? %))}
+    :rfg-instead-of-trashing true
     :async true
-    :effect (req (let [chosen target]
-                   (show-wait-prompt state side "Runner to resolve Threat Assessment")
-                   (continue-ability
-                     state :runner
-                     {:prompt (str "Add " (:title chosen) " to the top of the Stack or take 2 tags?")
-                      :choices [(str "Move " (:title chosen))
-                                "Take 2 tags"]
-                      :async true
-                      :effect (req (clear-wait-prompt state :corp)
-                                   (move state :corp (last (:discard corp)) :rfg)
-                                   (if (.startsWith target "Move")
-                                     (do (system-msg state side (str "chooses to move " (:title chosen) " to the Stack"))
-                                         (move state :runner chosen :deck {:front true})
-                                         (effect-completed state side eid))
-                                     (do (system-msg state side "chooses to take 2 tags")
-                                         (gain-tags state :runner eid 2))))}
-                     card nil)))}
+    :effect (effect (show-wait-prompt "Runner to resolve Threat Assessment")
+                    (continue-ability
+                      :runner
+                      (let [chosen target]
+                        {:prompt (str "Add " (:title chosen) " to the top of the Stack or take 2 tags?")
+                         :choices [(str "Move " (:title chosen))
+                                   "Take 2 tags"]
+                         :async true
+                         :effect (req (clear-wait-prompt state :corp)
+                                      (if (= target "Take 2 tags")
+                                        (do (system-msg state side "chooses to take 2 tags")
+                                            (gain-tags state :runner eid 2))
+                                        (do (system-msg state side (str "chooses to move " (:title chosen) " to the Stack"))
+                                            (move state :runner chosen :deck {:front true})
+                                            (effect-completed state side eid))))})
+                      card nil))}
 
    "Threat Level Alpha"
    {:trace {:base 1
@@ -2129,7 +2139,9 @@
    {:req (req (last-turn? state :runner :trashed-card))
     :prompt "Select a piece of hardware or non-virtual resource"
     :choices {:req #(or (hardware? %)
-                        (and (resource? %) (not (has-subtype? % "Virtual"))))}
+                        (and (resource? %)
+                             (not (has-subtype? % "Virtual"))))}
+    :rfg-instead-of-trashing true
     :async true
     :effect (effect (show-wait-prompt "Runner to resolve Wake Up Call")
                     (continue-ability
@@ -2141,7 +2153,6 @@
                                    "4 meat damage"]
                          :async true
                          :effect (req (clear-wait-prompt state :corp)
-                                      (move state :corp (last (:discard corp)) :rfg)
                                       (if (= target "4 meat damage")
                                         (do (system-msg state side "chooses to suffer meat damage")
                                             (damage state side eid :meat 4 {:card wake
@@ -2158,7 +2169,7 @@
       :msg (msg "give " (card-str state target) " \"[Subroutine] Do 1 brain damage\" before all its other subroutines")
       :sub-effect (do-brain-damage 1)
       :effect (req (add-extra-sub! state :corp target new-sub (:cid card) {:front true})
-                   (host state side (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))
+                   (host state side (get-card state target) (assoc card :seen true :condition true)))
       :leave-play (req (remove-extra-subs! state :corp (:host card) (:cid card)))
       :events [{:event :rez
                 :req (req (same-card? target (:host card)))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -203,8 +203,11 @@
                  :msg (msg "play " (:title target) " from Archives, ignoring all costs, and removes it from the game")
                  :choices (req (cancellable (filter #(and (operation? %)
                                                           (has-subtype? % "Transaction")) (:discard corp)) :sorted))
-                 :effect (effect (play-instant nil (assoc-in target [:special :rfg-when-trashed] true) {:ignore-cost true})
-                                 (move target :rfg))}]}
+                 :async true
+                 :effect (effect (play-instant eid (-> target
+                                                       (assoc :rfg-instead-of-trashing true)
+                                                       (assoc-in [:special :rfg-when-trashed] true))
+                                               {:ignore-cost true}))}]}
 
    "Calibration Testing"
    {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -526,7 +526,7 @@
   ([state side eid card n all?]
    (continue-ability state side
                     {:show-discard  true
-                     :choices {:max n
+                     :choices {:max (min (-> @state :corp :discard count) n)
                                :req #(and (corp? %)
                                           (in-discard? %))
                                :all all?}
@@ -542,10 +542,3 @@
                                   (shuffle! state side :deck))
                      :cancel-effect (req (shuffle! state side :deck))}
                     card nil)))
-
-(defn rfg-and-shuffle-rd-effect
-  ([state side card n] (rfg-and-shuffle-rd-effect state side (make-eid state) card n false))
-  ([state side card n all?] (rfg-and-shuffle-rd-effect state side (make-eid state) card n all?))
-  ([state side eid card n all?]
-   (move state side card :rfg)
-   (shuffle-into-rd-effect state side eid card n all?)))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -2594,17 +2594,17 @@
   ;; Paige Piper
   (testing "interaction with Frantic Coding. Issue #2190"
     (do-game
-      (new-game {:runner {:deck ["Paige Piper" (qty "Frantic Coding" 2) (qty "Sure Gamble" 3)
-                                 (qty "Gordian Blade" 2) "Ninja" (qty "Bank Job" 3) (qty "Indexing" 2)]}})
+      (new-game {:runner {:hand ["Paige Piper" "Frantic Coding" "Frantic Coding"]
+                          :deck [(qty "Sure Gamble" 3) (qty "Gordian Blade" 2)
+                                 "Ninja" (qty "Bank Job" 3) (qty "Indexing" 2)]}})
       (take-credits state :corp)
-      (starting-hand state :runner ["Paige Piper" "Frantic Coding" "Frantic Coding"])
       (play-from-hand state :runner "Paige Piper")
       (click-prompt state :runner "No")
       (take-credits state :runner) ; now 8 credits
       (take-credits state :corp)
       (play-from-hand state :runner "Frantic Coding")
       (click-prompt state :runner "OK")
-      (click-prompt state :runner (find-card "Gordian Blade" (:deck (get-runner))))
+      (click-prompt state :runner "Gordian Blade")
       (is (= 1 (count (get-program state))) "Installed Gordian Blade")
       (click-prompt state :runner "Yes")
       (click-prompt state :runner "0")
@@ -2613,7 +2613,7 @@
       ;; a second Frantic Coding will not trigger Paige (once per turn)
       (play-from-hand state :runner "Frantic Coding")
       (click-prompt state :runner "OK")
-      (click-prompt state :runner (find-card "Ninja" (:deck (get-runner))))
+      (click-prompt state :runner "Ninja")
       (is (= 2 (count (get-program state))) "Installed Ninja")
       (is (= 11 (count (:discard (get-runner)))) "11 cards in heap")
       (is (= 2 (:credit (get-runner))) "No charge to install Ninja"))))


### PR DESCRIPTION
Currently, we have to hack around the fact that an event/operation is "resolved" and the immediately put into the trash, even tho the card is supposed to stay in the play-area until it is fully resolved. Run events are the biggest offender here: we have to call `register-events` and then tag the card as in the discard, even tho when it's resolving it's not in the discard and we're not supposed to have access to it in the discard at all. This is a big issue with a lot of cards, so correcting this will go a long way to comprehensive and consistent handling of events/operations.