### PR TITLE
Fix damage selection abilities, make Chronos Protocol and Complete Image work togethr

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1223,7 +1223,8 @@
                                            (do (system-msg state :runner "trashes Respirocytes as it reached 3 power counters")
                                                (trash state side eid card {:unpreventable true}))
                                            (effect-completed state side eid))))}]
-     {:effect (effect (damage eid :meat 1 {:unboostable true :card card}))
+     {:async true
+      :effect (effect (damage eid :meat 1 {:unboostable true :card card}))
       :msg "suffer 1 meat damage"
       :events {:runner-hand-change {:req (req (and (zero? target)
                                                    (first-event? state side :runner-hand-change #(zero? (first %)))))
@@ -1438,7 +1439,12 @@
                                  :type :recurring}}}
 
    "Titanium Ribs"
-   {:events
+   {:async true
+    :effect (effect (enable-runner-damage-choice)
+                    (system-msg (str "suffers 2 meat damage from installing Titanium Ribs"))
+                    (damage eid :meat 2 {:unboostable true :card card}))
+    :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-runner))
+    :events
     {:pre-resolve-damage
      {:async true
       :req (req (and (pos? (last targets))
@@ -1446,37 +1452,26 @@
                      (not (get-in @state [:damage :damage-replace]))))
       :effect (req (let [dtype target
                          src (second targets)
-                         dmg (last targets)]
-                     (when (> dmg (count (:hand runner)))
-                       (flatline state))
-                     (when (= dtype :brain)
-                       (swap! state update-in [:runner :brain-damage] #(+ % dmg))
-                       (swap! state update-in [:runner :hand-size :mod] #(- % dmg)))
+                         dmg (last targets)
+                         hand (:hand runner)]
                      (show-wait-prompt state :corp "Runner to use Titanium Ribs to choose cards to be trashed")
-                     (wait-for (resolve-ability
-                                 state side
-                                 {:async true
-                                  :prompt (msg "Select " dmg " cards to trash for the " (name dtype) " damage")
-                                  :player :runner
-                                  :choices {:max dmg
-                                            :all true
-                                            :req #(and (in-hand? %)
-                                                       (runner? %))}
-                                  :msg (msg "trash " (join ", " (map :title targets)))
-                                  :effect (req (clear-wait-prompt state :corp)
-                                               (doseq [c targets]
-                                                 (trash state side c {:cause dtype :unpreventable true}))
-                                               (trigger-event state side :damage-chosen)
-                                               (damage-defer state side dtype 0)
-                                               (effect-completed state side eid))}
-                                 card nil)
-                               (trigger-event-sync state side eid :damage dtype src dmg))))}
-     :damage-chosen {:effect (effect (enable-runner-damage-choice))}}
-    :async true
-    :effect (effect (enable-runner-damage-choice)
-                    (system-msg (str "suffers 2 meat damage from installing Titanium Ribs"))
-                    (damage eid :meat 2 {:unboostable true :card card}))
-    :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-runner))}
+                     (continue-ability
+                       state :runner
+                       (if (< (count hand) dmg)
+                         {:async true
+                          :effect (req (clear-wait-prompt state :corp)
+                                       (chosen-damage state :runner hand)
+                                       (effect-completed state side eid))}
+                         {:prompt (msg "Select " dmg " cards to trash for the " (name dtype) " damage")
+                          :choices {:max dmg
+                                    :all true
+                                    :req #(and (in-hand? %)
+                                               (runner? %))}
+                          :msg (msg "trash " (join ", " (map :title targets)))
+                          :effect (req (clear-wait-prompt state :corp)
+                                       (chosen-damage state :runner targets)
+                                       (effect-completed state side eid))})
+                         card nil)))}}}
 
    "Top Hat"
    (letfn [(ability [n]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -370,18 +370,21 @@
               :prompt "Name a Runner card"
               :choices {:card-title (req (and (runner? target)
                                               (not (identity? target))))}
-              :effect (effect (system-msg (str "uses Complete Image to name " target))
-                              (continue-ability (damage-ability) card targets))})
+              :msg (msg "name " target)
+              :effect (effect (continue-ability (damage-ability) card targets))})
            (damage-ability []
              {:async true
               :msg "do 1 net damage"
               :effect (req (wait-for (damage state side :net 1 {:card card})
-                                     (when-let* [should-continue (not (:winner @state))
-                                                 cards (some #(when (same-card? (second %) card) (last %))
-                                                             (turn-events state :corp :damage))
-                                                 dmg (some #(when (= (:title %) target) %) cards)]
-                                       (continue-ability state side (name-a-card) card nil))))})]
-     {:async true
+                                     (let [should-continue (not (:winner @state))
+                                           cards (some #(when (same-card? (second %) card) (last %))
+                                                       (turn-events state :corp :damage))
+                                           dmg (some #(when (= (:title %) target) %) cards)]
+                                       (continue-ability state side (when (and should-continue dmg)
+                                                                      (name-a-card))
+                                                         card nil))))})]
+     {:implementation "Doesn't work with Chronos Protocol: Selective Mind-mapping"
+      :async true
       :req (req (and (last-turn? state :runner :successful-run)
                      (<= 3 (:agenda-point runner))))
       :effect (effect (continue-ability (name-a-card) card nil))})

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1258,7 +1258,6 @@
                      (pos? (last targets))
                      (can-pay? state :corp eid card nil [:credit 2])))
       :effect (req (swap! state assoc-in [:damage :damage-replace] true)
-                   (damage-defer state side :net (last targets))
                    (show-wait-prompt state :runner "Corp to use Tori Hanzō")
                    (continue-ability
                      state side

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -2346,21 +2346,21 @@
         (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards"))))
   (testing "With Respirocytes"
     (do-game
-      (new-game {:runner {:deck ["Zer0" "Titanium Ribs" "Respirocytes"(qty "Sure Gamble" 7)]}})
-      (starting-hand state :runner ["Zer0" "Titanium Ribs" "Respirocytes" "Sure Gamble" "Sure Gamble" "Sure Gamble" "Sure Gamble"])
+      (new-game {:runner {:deck [(qty "Clone Chip" 5)]
+                          :hand ["Zer0" "Titanium Ribs" "Respirocytes"
+                                 "Sure Gamble" "Easy Mark" "Zamba" "Corroder"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Zer0")
       (play-from-hand state :runner "Titanium Ribs")
-      (click-card state :runner (second (:hand (get-runner))))
-      (click-card state :runner (nth (:hand (get-runner)) 2))
+      (click-card state :runner "Sure Gamble")
+      (click-card state :runner "Easy Mark")
       (play-from-hand state :runner "Respirocytes")
-      (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))
-      ;; Now 1 Gamble in hand
+      (click-card state :runner "Zamba")
       (is (= 3 (:credit (get-runner))) "Runner has 3 credits")
       (let  [z (get-hardware state 0)]
         (card-ability state :runner z 0)
         (is (= 3 (:credit (get-runner))) "Zer0 has not yet resolved because Ribs prompt is open")
         (is (= 1 (count (:hand (get-runner)))) "Zer0 has not yet resolved because Ribs prompt is open")
-        (click-card state :runner (first (:hand (get-runner))))
+        (click-card state :runner "Corroder")
         (is (= 4 (:credit (get-runner))) "Runner has 4 credits")
         (is (= 3 (count (:hand (get-runner)))) "Runner has 3 cards")))))

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -411,7 +411,33 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (play-from-hand state :corp "Complete Image")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't be able to play Complete Image"))))
+      (is (empty? (:prompt (get-corp))) "Corp shouldn't be able to play Complete Image")))
+  (testing "Interaction with Chronos Protocol"
+    (do-game
+      (new-game {:corp {:id "Chronos Protocol: Selective Mind-mapping"
+                        :deck [(qty "Hedge Fund" 5)]
+                        :hand ["Complete Image" "Priority Requisition"]}
+                 :runner {:hand [(qty "Sure Gamble" 5)]}})
+      (play-from-hand state :corp "Priority Requisition" "New remote")
+      (take-credits state :corp)
+      (run-on state :remote1)
+      (run-successful state)
+      (click-prompt state :runner "Steal")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Complete Image")
+      (is (-> (get-runner) :discard count zero?) "Runner's heap should be empty")
+      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (is (seq (:prompt (get-corp))) "Corp guessed right so should have another choice")
+      (click-prompt state :corp "Yes") ;; Chronos Protocol
+      (click-prompt state :corp "Sure Gamble") ;; Chronos Protocol
+      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (is (seq (:prompt (get-corp))) "Even when the runner has no cards in hand, Corp must choose again")
+      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (click-prompt state :corp "Sure Gamble") ;; Complete Image
+      (is (empty? (:prompt (get-corp))) "Runner is flatlined so no more choices")
+      (is (= 5 (-> (get-runner) :discard count)) "Runner's heap should have 5 cards"))))
 
 (deftest consulting-visit
   ;; Consulting Visit - Only show single copies of operations corp can afford as choices. Play chosen operation


### PR DESCRIPTION
Instead of using the "deferred damage" system as before, a given damage selection ability adds to a `chosen-damage` list, which is then selected first and the leftover damage (if there's any) is selected from the runner's hand at random (as it should be). This is much simpler overall and will make other similar effects easy to handle.

Also fixes some async bugs related to damage!

Closes #4084 