### PR TITLE
Card fixes

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1006,11 +1006,12 @@
    (let [sub {:label "Draw a card or gain 1 [Credits]"
               :prompt "Choose one:"
               :choices ["Gain 1 [Credits]" "Draw 1 card"]
+              :msg (req (if (= target "Gain 1 [Credits]")
+                          "gain 1 [Credits]"
+                          "draw 1 card"))
               :effect (req (if (= target "Gain 1 [Credits]")
-                                  (do (gain-credits state :corp 1)
-                                      (system-msg state side "gains 1 [Credits] with Errand Boy"))
-                                  (do (draw state :corp eid 1 nil)
-                                      (system-msg state side "draws 1 card with Errand Boy"))))}]
+                                   (gain-credits state :corp 1)
+                                   (draw state :corp eid 1 nil)))}]
      {:subroutines [sub sub sub]})
 
    "Excalibur"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2160,7 +2160,8 @@
                                    (system-msg (str "adds " (:title target) " to the top of the Runner's Stack")))}]}
 
    "Pachinko"
-   {:subroutines [end-the-run-if-tagged]}
+   {:subroutines [end-the-run-if-tagged
+                  end-the-run-if-tagged]}
 
    "Paper Wall"
    {:implementation "Trash on break is manual"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1003,9 +1003,15 @@
                   end-the-run]}
 
    "Errand Boy"
-   {:subroutines [(gain-credits-sub 1)
-                  {:msg "draw 1 card"
-                   :effect (effect (draw eid 1 nil))}]}
+   (let [sub {:label "Draw a card or gain 1 [Credits]"
+              :prompt "Choose one:"
+              :choices ["Gain 1 [Credits]" "Draw 1 card"]
+              :effect (req (if (= target "Gain 1 [Credits]")
+                                  (do (gain-credits state :corp 1)
+                                      (system-msg state side "gains 1 [Credits] with Errand Boy"))
+                                  (do (draw state :corp eid 1 nil)
+                                      (system-msg state side "draws 1 card with Errand Boy"))))}]
+     {:subroutines [sub sub sub]})
 
    "Excalibur"
    {:subroutines [{:label "The Runner cannot make another run this turn"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -135,6 +135,7 @@
                  :req (req (and (:run @state) (not (rezzed? current-ice)) (can-rez? state side current-ice {:ignore-unique true})))
                  :prompt "Choose another server and redirect the run to its outermost position"
                  :choices (req (cancellable (remove #{(-> @state :run :server central->name)} servers)))
+                 :label "Trash a piece of ice to choose another server- the runner is now running that server"
                  :msg (msg "trash the approached ICE. The Runner is now running on " target)
                  :effect (req (let [dest (server->zone state target)]
                                 (trash state side current-ice)
@@ -296,6 +297,7 @@
    {:flags {:corp-phase-12 (req (and (not (:disabled card))
                                      (some rezzed? (all-installed state :corp))))}
     :abilities [{:choices {:req rezzed?}
+                 :label "Add 1 rezzed card to HQ and gain credits equal to its rez cost"
                  :effect (req (trigger-event state side :pre-rez-cost target)
                               (let [cost (rez-cost state side target)]
                                 (gain-credits state side cost)
@@ -1285,6 +1287,7 @@
                                     (trash-resource-bonus state side -2)
                                     (update! state side (-> card (assoc :sync-front true
                                                                         :code "09001"))))))
+                 :label "Flip this identity"
                  :msg (msg "flip their ID")}]
     :leave-play (req (if (:sync-front card)
                        (tag-remove-bonus state side 1)
@@ -1309,6 +1312,7 @@
    {:flags {:corp-phase-12 (req (and (not (:disabled (get-card state card)))
                                      (not-last-turn? state :runner :successful-run)))}
     :abilities [{:msg (msg "place 1 advancement token on " (card-str state target))
+                 :label "Place 1 advancement token on a card if the Runner did not make a successful run last turn"
                  :choices {:req installed?}
                  :req (req (and (:corp-phase-12 @state) (not-last-turn? state :runner :successful-run)))
                  :once :per-turn


### PR DESCRIPTION
- **Pachinko** had only 1 sub instead of 2

- **Errand Boy** had only 1 sub programmed, and letting all subs fire gave the Corp 1 card and 1 credit

- **Blue Sun**, **Tennin Institute**, **Sync**, and **AgInfusion** have been given ability labels