### PR TITLE
Fix message when runner trashes entire hand

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -441,7 +441,7 @@
                     (if (= :runner side) "their grip" "HQ")
                     (when (and (= :runner side)
                                (pos? (count cards)))
-                      (str " (" (map :title cards) ")")))))))
+                      (str " (" (join ", " (map :title cards)) ")")))))))
 
 (defn pay-trash-program-from-grip
   [state side eid amount]


### PR DESCRIPTION
This fix adds the cards names trashed when the runner trashes their hand instead of the name of a clojure datastructure.

Fixes https://github.com/mtgred/netrunner/issues/4496

Before fix:
<img width="174" alt="Screenshot 2019-09-17 at 17 57 07" src="https://user-images.githubusercontent.com/661871/65059249-f10be380-d975-11e9-8270-8e0a2e3f1840.png">

After fix:
<img width="177" alt="Screenshot 2019-09-17 at 18 02 54" src="https://user-images.githubusercontent.com/661871/65059265-fa954b80-d975-11e9-84cd-84148781bcae.png">
