### PR TITLE
Combine trash and trash-cards

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -612,8 +612,7 @@
                                                    :effect (effect (move (get-card state card) :deck)
                                                                    (shuffle! :deck)
                                                                    (effect-completed eid))}
-                                     :no-ability {:effect (effect (trash (get-card state card) {:unpreventable true :suppress-event true})
-                                                                  (effect-completed eid))}}}]
+                                     :no-ability {:effect (effect (trash eid (get-card state card) {:unpreventable true :suppress-event true}))}}}]
      {:effect (req (doseq [s [:corp :runner]]
                      (disable-identity state s))
                    (continue-ability state side


### PR DESCRIPTION
* Adds `cause` to `trash-cards` call, so `(second targets)` still refers to the cause.
* Changes `trash` to call `trash-cards` with its inputs, wrapping the single card in a list.
* Removes the restriction on triggering `:X-trash` on currents.
* Renames `resolve-trash-end` to just `resolve-trash`, for clarity.

Closes #4472 