### PR TITLE
Rewrite Sandburg, add events to pay-credits

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -253,8 +253,8 @@
                                    remainder-str
                                    (when (and card-strs remainder-str)
                                      " from their credit pool"))]
-                  (deduct state side [:credit remainder])
-                  (swap! state update-in [:stats side :spent :credit] (fnil + 0) target-count)
+                  (lose state side :credit remainder)
+                  (swap! state update-in [:stats side :spent :credit] (fnil + 0) (- target-count remainder))
                   (let [cards (filter #(has-subtype? % "Stealth") (map :card (vals selected-cards)))]
                     (wait-for (trigger-stealth-cards state side cards)
                               ; Now we trigger all of the :counter-added events we'd neglected previously

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1679,17 +1679,15 @@
                                    card nil))}]}
 
    "Sandburg"
-   {:effect (req (add-watch state :sandburg
-                            (fn [k ref old new]
-                              (let [credit (get-in new [:corp :credit])]
-                                (when (not= (get-in old [:corp :credit]) credit)
-                                  (update-all-ice ref side)))))
-                 (update-all-ice state side))
-    :events {:pre-ice-strength {:req (req (and (ice? target)
+   {:effect (effect (update-all-ice))
+    :events {:corp-gain {:req (req (= :credit (first target)))
+                         :effect (effect (update-all-ice))}
+             :corp-lose {:req (req (= :credit (first target)))
+                         :effect (effect (update-all-ice))}
+             :pre-ice-strength {:req (req (and (ice? target)
                                                (>= (:credit corp) 10)))
                                 :effect (effect (ice-strength-bonus (quot (:credit corp) 5) target))}}
-    :leave-play (req (remove-watch state :sandburg)
-                     (update-all-ice state side))}
+    :leave-play (effect (update-all-ice))}
 
    "Sealed Vault"
    {:abilities [{:label "Store any number of [Credits] on Sealed Vault"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1798,7 +1798,7 @@
               :async true
               :effect (req (let [correct-guess ((if (= target "Even") even? odd?) spent)]
                              (clear-wait-prompt state :runner)
-                             (deduct state :runner [:credit spent])
+                             (lose state :runner :credit spent)
                              (system-msg state :runner (str "spends " spent " [Credit]"))
                              (system-msg state :corp (str (if correct-guess " " " in")
                                                           "correctly guesses " (lower-case target)))
@@ -1976,7 +1976,7 @@
               :choices choices
               :async true
               :effect (req (clear-wait-prompt state :runner)
-                           (deduct state :runner [:credit spent])
+                           (lose state :runner :credit spent)
                            (system-msg state :runner (str "spends " spent " [Credit]"))
                            (system-msg state :corp (str " guesses " target " [Credit]"))
                            (wait-for (trigger-event-simult state side :reveal-spent-credits nil nil spent)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -114,8 +114,8 @@
                                          (effect-completed state :runner eid)))}}}
 
    "Adjusted Chronotype"
-   {:events {:runner-loss {:req (req (and (some #{:click} target)
-                                          (let [click-losses (count (filter #(= :click %) (mapcat first (turn-events state side :runner-loss))))]
+   {:events {:runner-lose {:req (req (and (some #{:click} target)
+                                          (let [click-losses (count (filter #(= :click %) (mapcat first (turn-events state side :runner-lose))))]
                                             (or (= 1 click-losses)
                                                 (and (= 2 click-losses)
                                                      (has-flag? state side :persistent :genetics-trigger-twice))))))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1116,7 +1116,7 @@
                                                :prompt "How many credits to spend?"
                                                :effect (req (clear-wait-prompt state :runner)
                                                             (let [spent (str->int target)]
-                                                              (deduct state :corp [:credit spent])
+                                                              (lose state :corp :credit spent)
                                                               (add-counter state :corp card :power spent)
                                                               (system-msg state :corp (str "places " (quantify spent "power counter") " on Reduced Service"))
                                                               (effect-completed state side eid)))}

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -50,7 +50,7 @@
   [state side args]
   (when (pay state side nil :click 1 {:action :corp-click-credit})
     (system-msg state side "spends [Click] to gain 1 [Credits]")
-    (gain-credits state side 1 (keyword (str (name side) "-click-credit")))
+    (gain-credits state side 1 (if (= :corp side) :corp-click-credit :runner-click-credit))
     (swap! state update-in [:stats side :click :credit] (fnil inc 0))
     (trigger-event state side (if (= side :corp) :corp-click-credit :runner-click-credit))
     (play-sfx state side "click-credit")))

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -3470,33 +3470,59 @@
 
 (deftest sandburg
   ;; Sandburg - +1 strength to all ICE for every 5c when Corp has over 10c
-  (do-game
-    (new-game {:corp {:deck ["Sandburg" (qty "Ice Wall" 2) (qty "Hedge Fund" 3)]}})
-    (core/gain state :corp :click 3 :credit 3)
-    (play-from-hand state :corp "Sandburg" "New remote")
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Ice Wall" "R&D")
-    (let [sb (get-content state :remote1 0)
-          iwall1 (get-ice state :hq 0)
-          iwall2 (get-ice state :rd 0)]
-      (core/rez state :corp iwall1)
-      (core/rez state :corp iwall2)
-      (core/rez state :corp sb)
-      (is (= 6 (:credit (get-corp))))
-      (play-from-hand state :corp "Hedge Fund")
-      (is (= 10 (:credit (get-corp))))
-      (is (= 3 (:current-strength (refresh iwall1))) "Strength boosted by 2")
-      (is (= 3 (:current-strength (refresh iwall2))) "Strength boosted by 2")
-      (play-from-hand state :corp "Hedge Fund")
-      (play-from-hand state :corp "Hedge Fund")
-      (is (= 18 (:credit (get-corp))))
-      (is (= 4 (:current-strength (refresh iwall1))) "Strength boosted by 3")
-      (is (= 4 (:current-strength (refresh iwall2))) "Strength boosted by 3")
-      (take-credits state :corp)
-      (run-empty-server state "Server 1")
-      (click-prompt state :runner "Pay 4 [Credits] to trash")
-      (is (= 1 (:current-strength (refresh iwall1))) "Strength back to default")
-      (is (= 1 (:current-strength (refresh iwall2))) "Strength back to default"))))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Sandburg" (qty "Ice Wall" 2) (qty "Hedge Fund" 3)]}})
+      (core/gain state :corp :click 3 :credit 3)
+      (play-from-hand state :corp "Sandburg" "New remote")
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Ice Wall" "R&D")
+      (let [sb (get-content state :remote1 0)
+            iwall1 (get-ice state :hq 0)
+            iwall2 (get-ice state :rd 0)]
+        (core/rez state :corp iwall1)
+        (core/rez state :corp iwall2)
+        (core/rez state :corp sb)
+        (is (= 6 (:credit (get-corp))))
+        (play-from-hand state :corp "Hedge Fund")
+        (is (= 10 (:credit (get-corp))))
+        (is (= 3 (:current-strength (refresh iwall1))) "Strength boosted by 2")
+        (is (= 3 (:current-strength (refresh iwall2))) "Strength boosted by 2")
+        (play-from-hand state :corp "Hedge Fund")
+        (play-from-hand state :corp "Hedge Fund")
+        (is (= 18 (:credit (get-corp))))
+        (is (= 4 (:current-strength (refresh iwall1))) "Strength boosted by 3")
+        (is (= 4 (:current-strength (refresh iwall2))) "Strength boosted by 3")
+        (take-credits state :corp)
+        (run-empty-server state "Server 1")
+        (click-prompt state :runner "Pay 4 [Credits] to trash")
+        (is (= 1 (:current-strength (refresh iwall1))) "Strength back to default")
+        (is (= 1 (:current-strength (refresh iwall2))) "Strength back to default"))))
+  (testing "Changes on rez"
+    (do-game
+      (new-game {:corp {:hand ["Sandburg" (qty "Ice Wall" 2) "Mlinzi" "Hedge Fund"]
+                        :deck [(qty "Hedge Fund" 3)]
+                        :credits 10}})
+      (core/gain state :corp :click 10)
+      (play-from-hand state :corp "Sandburg" "New remote")
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Ice Wall" "R&D")
+      (play-from-hand state :corp "Mlinzi" "Archives")
+      (let [sb (get-content state :remote1 0)
+            iwall1 (get-ice state :hq 0)
+            iwall2 (get-ice state :rd 0)
+            mlinzi (get-ice state :archives 0)]
+        (core/rez state :corp iwall1)
+        (core/rez state :corp iwall2)
+        (core/rez state :corp sb)
+        (is (= 8 (:credit (get-corp))))
+        (play-from-hand state :corp "Hedge Fund")
+        (is (= 3 (:current-strength (refresh iwall1))) "Strength boosted by 2")
+        (is (= 12 (:credit (get-corp))))
+        (core/rez state :corp mlinzi)
+        (is (= 5 (:credit (get-corp))))
+        (is (= 1 (:current-strength (refresh iwall1))) "Strength back to base")))))
 
 (deftest sealed-vault
   ;; Sealed Vault - Store credits for 1c, retrieve credits by trashing or spending click


### PR DESCRIPTION
Rewrites Sandburg to not rely on `watch`, which really shouldn't be used anywhere in the engine. Changes the `deduct` calls in `pay-credits` to be `lose` calls, which allows us to watch for credit changes in a generic way: `:X-gain` and `:X-lose`. Removes references to `deduct` outside of `game.core`, as it's an implementation-level function. Much better to use `gain` and `lose`, or the more specific functions (`gain-bad-publicity`, etc).

I pulled the bulk of this plus further work from #4434 

Closes #4516 