### PR TITLE
Add option to flip order of runner cards when playing as corp

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -62,6 +62,7 @@
   (swap! app-state assoc-in [:options :background] (:background @s))
   (swap! app-state assoc-in [:options :show-alt-art] (:show-alt-art @s))
   (swap! app-state assoc-in [:options :stacked-servers] (:stacked-servers @s))
+  (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
   (swap! app-state assoc-in [:options :blocked-users] (:blocked-users @s))
   (swap! app-state assoc-in [:options :alt-arts] (:alt-arts @s))
   (swap! app-state assoc-in [:options :gamestats] (:gamestats @s))
@@ -70,6 +71,7 @@
   (.setItem js/localStorage "lobby_sounds" (:lobby-sounds @s))
   (.setItem js/localStorage "sounds_volume" (:volume @s))
   (.setItem js/localStorage "stacked-servers" (:stacked-servers @s))
+  (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
   (post-options url (partial post-response s)))
 
 (defn add-user-to-block-list
@@ -134,6 +136,7 @@
                    :show-alt-art (get-in @app-state [:options :show-alt-art])
                    :all-art-select ""
                    :stacked-servers (get-in @app-state [:options :stacked-servers])
+                   :runner-board-order (get-in @app-state [:options :runner-board-order])
                    :gamestats (get-in @app-state [:options :gamestats])
                    :deckstats (get-in @app-state [:options :deckstats])
                    :blocked-users (sort (get-in @app-state [:options :blocked-users]))})]
@@ -177,13 +180,20 @@
                     :disabled (not (or (:sounds @s) (:lobby-sounds @s)))}]]]
 
          [:section
-          [:h3 "Server Stacking"]
+          [:h3 "Layout options"]
           [:div
            [:label [:input {:type "checkbox"
                             :value true
                             :checked (:stacked-servers @s)
                             :on-change #(swap! s assoc-in [:stacked-servers] (.. % -target -checked))}]
-            "Server stacking is on by default"]]]
+            "Server stacking is on by default"]]
+
+          [:div
+           [:label [:input {:type "checkbox"
+                            :value true
+                            :checked (:runner-board-order @s)
+                            :on-change #(swap! s assoc-in [:runner-board-order] (.. % -target -checked))}]
+            "Runner rig layout is jnet-classic (Top to bottom: Programs, Hardware, Resources)"]]]
 
          [:section
           [:h3  "Game board background"]

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -14,6 +14,7 @@
            :options (merge {:background "lobby-bg"
                             :show-alt-art true
                             :stacked-servers (= (get-local-value "stacked-servers" "true") "true")
+                            :runner-board-order (= (get-local-value "runner-board-order" "true") "true")
                             :deckstats "always"
                             :gamestats "always"
                             :sounds (= (get-local-value "sounds" "true") "true")

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -112,8 +112,11 @@
   (ws/ws-send! [:netrunner/mute-spectators {:gameid-str (:gameid @game-state)
                                             :mute-state mute-state}]))
 
-(defn stack-servers [ss-state]
-  (swap! app-state assoc-in [:options :stacked-servers] ss-state))
+(defn stack-servers []
+  (swap! app-state update-in [:options :stacked-servers] not))
+
+(defn flip-runner-board []
+  (swap! app-state update-in [:options :runner-board-order] not))
 
 (defn concede []
   (ws/ws-send! [:netrunner/concede {:gameid-str (:gameid @game-state)}]))
@@ -1180,11 +1183,15 @@
         centrals [:div.runner-centrals
                     [discard-view-runner player-side discard]
                     [deck-view :runner player-side identity deck]
-                    [identity-view identity]]]
+                    [identity-view identity]]
+        runner-f (if (and (not is-me)
+                          (not (get-in @app-state [:options :runner-board-order])))
+                   reverse
+                   seq)]
     [:div.runner-board {:class (if is-me "me" "opponent")}
      (when-not is-me centrals)
      (doall
-       (for [zone [:program :hardware :resource :facedown]]
+       (for [zone (runner-f [:program :hardware :resource :facedown])]
          ^{:key zone}
          [:div
           (doall (for [c (zone @rig)]

--- a/src/cljs/nr/main.cljs
+++ b/src/cljs/nr/main.cljs
@@ -9,7 +9,7 @@
             [nr.cardbrowser :refer [card-browser]]
             [nr.chat :refer [chat]]
             [nr.deckbuilder :refer [deck-builder]]
-            [nr.gameboard :refer [concede gameboard game-state mute-spectators stack-servers]]
+            [nr.gameboard :refer [concede gameboard game-state mute-spectators stack-servers flip-runner-board]]
             [nr.gamelobby :refer [filter-blocked-games game-lobby leave-game player-view]]
             [nr.help :refer [help]]
             [nr.news :refer [news news-state]]
@@ -63,8 +63,11 @@
             (when is-player
               [:a.mute-button {:on-click #(mute-spectators (not (:mute-spectators game)))}
                (if (:mute-spectators game) "Unmute spectators" "Mute spectators")])
-            [:a.stack-servers-button {:on-click #(stack-servers (not (get-in @app-state [:options :stacked-servers] false)))}
-             (if (get-in @app-state [:options :stacked-servers]) "Unstack servers" "Stack servers")]]))
+            [:a.stack-servers-button {:on-click #(stack-servers)}
+             (if (get-in @app-state [:options :stacked-servers]) "Unstack servers" "Stack servers")]
+            (when (= :corp (:side @game-state))
+              [:a.stack-servers-button {:on-click #(flip-runner-board)}
+               (if (get-in @app-state [:options :runner-board-order]) "Rig layout: IRL" "Rig layout: jnet")])]))
        (when (not (nil? @gameid))
          [:div.float-right [:a {:on-click #(leave-game)} "Leave game"]]))
      (when-let [game (some #(when (= @gameid (:gameid %)) %) @games)]


### PR DESCRIPTION
How it is now:
![image](https://user-images.githubusercontent.com/603677/65799959-56648f00-e143-11e9-99f2-b6c6a47ac1af.png)
Here's how it'd be toggled:
![image](https://user-images.githubusercontent.com/603677/65799972-5ebcca00-e143-11e9-9f85-d3d0a0ecbf78.png)
