### PR TITLE
Filter pending abilities whose cards have become inactive

### DIFF
--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -84,7 +84,8 @@
               (and (< 1 (count handlers))
                    (not (and cancel-fn (cancel-fn state)))))
             (choose-handler [handlers]
-              (let [non-silent (filter #(let [silent-fn (:silent (:ability %))]
+              (let [handlers (filter #(get-card state (:card %)) handlers)
+                    non-silent (filter #(let [silent-fn (:silent (:ability %))]
                                           (not (and silent-fn
                                                     (silent-fn state side (make-eid state) (:card %) event-targets))))
                                        handlers)

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -209,11 +209,12 @@
         (is (= "Adonis Campaign" (:title (get-content state :remote4 0)))
             "Adonis installed by Team Sponsorship")
         (is (nil? (find-card "Adonis Campaign" (:discard (get-corp)))) "No Adonis in discard"))))
-  (testing "with Gang Sign. Issue #4487"
+  (testing "with Gang Sign and Leela. Issue #4487"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                         :hand ["Amani Senai" "Hostile Takeover" "Hostile Takeover"]}
-                 :runner {:hand ["Gang Sign"]}})
+                 :runner {:id "Leela Patel: Trained Pragmatist"
+                          :hand ["Gang Sign"]}})
       (play-from-hand state :corp "Amani Senai" "New remote")
       (core/rez state :corp (get-content state :remote1 0))
       (take-credits state :corp)
@@ -225,6 +226,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (click-card state :corp "Gang Sign")
+      (click-prompt state :runner "Done") ; Leela trigger, no Gang Sign prompt
       (is (empty? (:prompt (get-runner))) "Runner doesn't get an access prompt"))))
 
 (deftest anson-rose


### PR DESCRIPTION
Turns out, we weren't rechecking that the source of a pending ability was active when choosing what to resolve. This was only seen when choosing between simultaneous abilities, because we checked `get-card` in the case of 1 or less interactive abilities being iterated over.

Closes #4487 