### PR TITLE
Remove :slow-X-access flags

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -460,8 +460,7 @@
                               :effect (effect (gain-credits 2))}}}
 
    "Gagarin Deep Space: Expanding the Horizon"
-   {:flags {:slow-remote-access (req (not (:disabled card)))}
-    :events {:pre-access-card {:req (req (is-remote? (second (:zone target))))
+   {:events {:pre-access-card {:req (req (is-remote? (second (:zone target))))
                                :effect (effect (access-cost-bonus [:credit 1]))
                                :msg "make the Runner spend 1 [Credits] to access"}}}
 
@@ -809,11 +808,12 @@
    "Leela Patel: Trained Pragmatist"
    (let [leela {:interactive (req true)
                 :prompt "Select an unrezzed card to return to HQ"
-                :choices {:req #(and (not (rezzed? %)) (installed? %) (corp? %))}
+                :choices {:req #(and (not (rezzed? %))
+                                     (installed? %)
+                                     (corp? %))}
                 :msg (msg "add " (card-str state target) " to HQ")
                 :effect (effect (move :corp target :hand))}]
-     {:flags {:slow-hq-access (req true)}
-      :events {:agenda-scored leela
+     {:events {:agenda-scored leela
                :agenda-stolen leela}})
 
    "Liza Talking Thunder: Prominent Legislator"

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -871,13 +871,11 @@
     (play-from-hand state :corp "PAD Campaign" "New remote")
     (take-credits state :corp)
     (run-empty-server state :remote1)
-    (click-card state :runner (get-content state :remote1 0))
     (click-prompt state :runner "Pay to access")
     (is (zero? (:credit (get-runner))) "Paid 1 credit to access")
     (click-prompt state :runner "No action") ; Dismiss trash prompt
     (is (last-log-contains? state "PAD Campaign") "Accessed card name was logged")
     (run-empty-server state :remote1)
-    (click-card state :runner (get-content state :remote1 0))
     (click-prompt state :runner "OK") ; Could not afford message dismissed
     (is (empty? (:prompt (get-runner))) "Runner cannot access so no trash prompt")
     (is (not (last-log-contains? state "PAD Campaign")) "No card name was logged")

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1307,7 +1307,6 @@
         (run-empty-server state "Server 1")
         (changes-val-macro 0 (:credit (get-runner))
                            "Used 1 credit from Fencer Fueno"
-                           (click-card state :runner pad)
                            (click-prompt state :runner "Pay to access")
                            (click-card state :runner ff) ; pay Gagarin credit
                            (click-prompt state :runner "Pay 4 [Credits] to trash")


### PR DESCRIPTION
Only used with Leela and Gagarin, as there were potential interactions related to credits that had to be accessible in between. Now, we have the pay-credits prompts, so these are no longer needed. Only change is removal of a single "Card from hand" or "Select card to access" prompt when there's only 1 card possible to access.