### PR TITLE
Keep Events/Operations in Play Area until fully resolved

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -253,8 +253,8 @@
                          :end-effect (effect (clear-wait-prompt :runner))}}
                        card nil)))]
      {:events [{:event :play-event
-                :req (req (and (first-event? state :runner :run)
-                               (has-subtype? target "Run")
+                :req (req (and (has-subtype? target "Run")
+                               (first-event? state :runner :play-event #(has-subtype? (first %) "Run"))
                                (not (used-this-turn? (:cid card) state))))
                 :async true
                 :effect (ability "playing a run event")}

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -12,62 +12,60 @@
             [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.utils :refer :all]))
 
-(defn- run-event
-  ([] (run-event nil))
-  ([run-ability] (run-event nil run-ability))
-  ([cdef run-ability] (run-event cdef run-ability nil))
-  ([cdef run-ability pre-run-effect]
-   (run-event cdef run-ability pre-run-effect nil))
-  ([cdef run-ability pre-run-effect post-run-effect]
-   (merge {:prompt "Choose a server"
-           :makes-run true
-           :choices (req runnable-servers)
-           :effect (effect ((or pre-run-effect (effect)) eid card targets)
-                           (make-run target run-ability card)
-                           ((or post-run-effect (effect)) eid card targets))}
-          cdef)))
-
 (defn- cutlery
-  [_subtype]
-  ;; Subtype does nothing currently, but might be used if trashing is properly implemented
-  {:implementation "Ice trash is manual, always enables Reprisals"
+  [subtype]
+  {:implementation "Ice trash is manual"
    :async true
    :makes-run true
-   :effect (req (continue-ability state :runner
-                                  (run-event nil nil nil
-                                             (req (swap! state assoc-in [:runner :register :trashed-card] true)))
-                                  card nil))})
+   :prompt "Choose a server:"
+   :choices (req runnable-servers)
+   :effect (effect (toast "Click this card to trash the passed ice")
+                   (make-run eid target nil card))
+   :abilities [{:label (str "Trash " subtype " ice")
+                :once :per-run
+                :req (req (and run
+                               (has-subtype? (nth run-ices run-position) subtype)
+                               (rezzed? (nth run-ices run-position))))
+                :async true
+                :msg (msg "trash " (card-str state (nth run-ices run-position)))
+                :effect (effect (trash eid (nth run-ices run-position) nil))}]})
 
 ;; Card definitions
 (def card-definitions
   {"Account Siphon"
    {:req (req hq-runnable)
     :makes-run true
-    :effect (effect (make-run :hq {:req (req (= target :hq))
-                                   :replace-access
-                                   {:msg (msg "force the Corp to lose " (min 5 (:credit corp))
-                                              " [Credits], gain " (* 2 (min 5 (:credit corp)))
-                                              " [Credits] and take 2 tags")
-                                    :async true
-                                    :effect (req (wait-for (gain-tags state :runner 2)
-                                                           (do (gain-credits state :runner (* 2 (min 5 (:credit corp))))
-                                                               (lose-credits state :corp (min 5 (:credit corp)))
-                                                               (effect-completed state side eid))))}}
-                              card))}
+    :async true
+    :effect (effect (make-run
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       {:msg (msg "force the Corp to lose " (min 5 (:credit corp))
+                                  " [Credits], gain " (* 2 (min 5 (:credit corp)))
+                                  " [Credits] and take 2 tags")
+                        :async true
+                        :effect (req (wait-for (gain-tags state :runner 2)
+                                               (gain-credits state :runner (* 2 (min 5 (:credit corp))))
+                                               (lose-credits state :corp (min 5 (:credit corp)))
+                                               (effect-completed state side eid)))}}
+                      card))}
 
    "Always Have a Backup Plan"
-   (letfn [(run-again [server]
-             {:optional {:prompt "Run again?"
-                         :msg (msg "to make a run on " (zone->name server) ", ignoring additional costs")
-                         :yes-ability {:effect (effect (make-run eid server nil card {:ignore-costs true}))}}})]
-     {:prompt "Choose a server"
-      :choices (req runnable-servers)
-      :async true
-      :makes-run true
-      :msg (msg "make a run on " target)
-      :effect (req (let [run-server (server->zone state target)]
-                     (wait-for (make-run state side (make-eid state) target nil card nil)
-                               (continue-ability state side (run-again run-server) card nil))))})
+   {:implementation "Bypass is manual"
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :async true
+    :makes-run true
+    :msg (msg "make a run on " target)
+    :effect (req (wait-for (make-run state side target nil card)
+                           (let [card (get-card state card)]
+                             (if (:run-again card)
+                               (make-run state side eid target nil card {:ignore-costs true})
+                               (effect-completed state side eid)))))
+    :events [{:event :unsuccessful-run-ends
+              :optional {:req (req (not (:run-again card)))
+                         :prompt "Make another run on the same server?"
+                         :yes-ability {:effect (effect (update! (assoc card :run-again true)))}}}]}
 
    "Amped Up"
    {:msg "gain [Click][Click][Click] and suffer 1 brain damage"
@@ -113,22 +111,28 @@
                      (continue-ability state side runner-facedown card nil)))})
 
    "Because I Can"
-   (run-event
-     {:choices (req (filter #(can-run-server? state %) remotes))}
-     {:req (req (is-remote? target))
-      :replace-access {:msg "shuffle all cards in the server into R&D"
-                       :effect (req (doseq [c (:content run-server)]
-                                      (move state :corp c :deck))
-                                    (shuffle! state :corp :deck))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (filter #(can-run-server? state %) remotes))
+    :effect (effect (make-run
+                      eid target
+                      {:req (req (is-remote? target))
+                       :replace-access
+                       {:msg "shuffle all cards in the server into R&D"
+                        :effect (req (doseq [c (:content run-server)]
+                                       (move state :corp c :deck))
+                                     (shuffle! state :corp :deck))}}
+                      card))}
 
    "Black Hat"
    {:trace {:base 4
-            :unsuccessful {:effect (effect (register-events (assoc card :zone '(:discard))))}}
-    :events [{:event :pre-access
-              :req (req (#{:hq :rd} target))
-              :effect (effect (access-bonus target 2))}
-             {:event :runner-turn-ends
-              :effect (effect (unregister-events card))}]}
+            :unsuccessful
+            {:effect (effect (register-events
+                               card [{:event :pre-access
+                                      :duration :end-of-turn
+                                      :req (req (#{:hq :rd} target))
+                                      :effect (effect (access-bonus target 2))}]))}}}
 
    "Blueberry!™ Diesel"
    {:async true
@@ -145,21 +149,25 @@
                  (draw state :runner eid 2 nil))}
 
    "Blackmail"
-   (run-event
-     {:req (req (has-bad-pub? state))
-      :msg "prevent ICE from being rezzed during this run"}
-     nil
-     (effect (register-run-flag!
-               card
-               :can-rez
-               (fn [state side card]
-                 (if (ice? card)
-                   ((constantly false)
-                    (toast state :corp "Cannot rez ICE on this run due to Blackmail"))
-                   true)))))
+   {:async true
+    :makes-run true
+    :req (req (has-bad-pub? state))
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :msg "prevent ICE from being rezzed during this run"
+    :effect (effect (register-run-flag!
+                      card
+                      :can-rez
+                      (fn [state side card]
+                        (if (ice? card)
+                          ((constantly false)
+                           (toast state :corp "Cannot rez ICE on this run due to Blackmail"))
+                          true)))
+                    (make-run eid target nil card))}
 
    "Bribery"
    {:implementation "ICE chosen for cost increase is specified at start of run, not on approach"
+    :async true
     :makes-run true
     :prompt "How many credits?"
     :choices :credit
@@ -168,8 +176,9 @@
                       (let [bribery-x target]
                         {:prompt "Choose a server"
                          :choices (req runnable-servers)
-                         :effect (req (make-run state side target nil card)
-                                      (let [run-ices (get-in @state (concat [:corp :servers] (:server (:run @state)) [:ices]))
+                         :async true
+                         :effect (req (let [server (unknown->kw target)
+                                            run-ices (get-in @state (concat [:corp :servers] [server] [:ices]))
                                             foremost-ice (last (remove rezzed? run-ices))]
                                         (register-floating-effect
                                           state side card
@@ -184,7 +193,8 @@
                                             :duration :end-of-run
                                             :req (req (and (same-card? foremost-ice target)
                                                            (not (get-in @state [:per-run (:cid card)]))))
-                                            :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}])))})
+                                            :effect (req (swap! state assoc-in [:per-run (:cid card)] true))}])
+                                        (make-run state side eid target nil card)))})
                       card nil))}
 
    "Brute-Force-Hack"
@@ -225,16 +235,15 @@
     :effect (effect (gain-credits 1) (draw eid 2 nil))}
 
    "By Any Means"
-   {:effect (effect (register-events card))
-    :events [{:event :access
+   {:events [{:event :access
               :duration :end-of-turn
               :req (req (not (in-discard? target)))
               :interactive (req true)
               :async true
               :msg (msg "trash " (:title target) " at no cost and suffer 1 meat damage")
               :effect (req (wait-for (trash state side (assoc target :seen true) nil)
-                                     (do (swap! state assoc-in [:runner :register :trashed-card] true)
-                                         (damage state :runner eid :meat 1 {:unboostable true}))))}]}
+                                     (swap! state assoc-in [:runner :register :trashed-card] true)
+                                     (damage state :runner eid :meat 1 {:unboostable true})))}]}
 
    "Calling in Favors"
    {:msg (msg "gain " (count (filter #(and (has-subtype? % "Connection") (resource? %))
@@ -262,12 +271,10 @@
                     (system-msg (str "prevents the rezzing of " (card-str state target)
                                      " for the rest of this turn via Careful Planning"))
                     (register-events
-                      (assoc card :zone '(:discard))
+                      card
                       [{:event :runner-turn-ends
-                        :effect (effect (remove-icon card target)
-                                        (unregister-events
-                                          card
-                                          {:events [{:event :runner-turn-ends}]}))}])
+                        :duration :end-of-turn
+                        :effect (effect (remove-icon card target))}])
                     (register-turn-flag! card :can-rez
                                          (fn [state side card]
                                            (if (same-card? card target)
@@ -277,11 +284,12 @@
 
    "CBI Raid"
    (letfn [(cbi-final [chosen original]
-             {:prompt (str "The top cards of R&D will be " (clojure.string/join  ", " (map :title chosen)) ".")
+             {:prompt (str "The top cards of R&D will be " (join  ", " (map :title chosen)) ".")
               :choices ["Done" "Start over"]
               :async true
               :effect (req (if (= target "Done")
-                             (do (doseq [c (reverse chosen)] (move state :corp c :deck {:front true}))
+                             (do (doseq [c (reverse chosen)]
+                                   (move state :corp c :deck {:front true}))
                                  (clear-wait-prompt state :runner)
                                  (effect-completed state side eid))
                              (continue-ability state side (cbi-choice original '() (count original) original)
@@ -298,24 +306,27 @@
      {:req (req hq-runnable)
       :async true
       :makes-run true
-      :effect (effect (make-run :hq {:replace-access
-                                     {:msg "force the Corp to add all cards in HQ to the top of R&D"
-                                      :async true
-                                      :mandatory true
-                                      :effect (req (show-wait-prompt state :runner "Corp to add all cards in HQ to the top of R&D")
-                                                   (let [from (:hand corp)]
-                                                     (if (pos? (count from))
-                                                       (continue-ability state :corp (cbi-choice from '() (count from) from) card nil)
-                                                       (do (clear-wait-prompt state :runner)
-                                                           (effect-completed state side eid)))))}}
-                                card))})
+      :effect (effect (make-run
+                        eid :hq
+                        {:replace-access
+                         {:msg "force the Corp to add all cards in HQ to the top of R&D"
+                          :async true
+                          :mandatory true
+                          :effect (req (show-wait-prompt state :runner "Corp to add all cards in HQ to the top of R&D")
+                                       (let [from (:hand corp)]
+                                         (if (pos? (count from))
+                                           (continue-ability state :corp (cbi-choice from '() (count from) from) card nil)
+                                           (do (clear-wait-prompt state :runner)
+                                               (effect-completed state side eid)))))}}
+                        card))})
 
    "Code Siphon"
    {:req (req rd-runnable)
+    :async true
     :makes-run true
-    :effect
-    (effect
-      (make-run :rd
+    :effect (effect
+              (make-run
+                eid :rd
                 {:replace-access
                  (let [rd-ice (fn [state] (* -3 (count (get-in @state [:corp :servers :rd :ices]))))]
                    {:async true
@@ -335,25 +346,20 @@
                 card))}
 
    "Cold Read"
-   (let [end-effect {:prompt "Choose a program that was used during the run to trash "
-                     :choices {:req program?}
-                     :msg (msg "trash " (:title target))
-                     :effect (effect (trash target {:unpreventable true}))}]
-     {:async true
-      :prompt "Choose a server"
-      :recurring 4
-      :makes-run true
-      :choices (req runnable-servers)
-      :effect (req (let [c (move state side (assoc card :zone '(:discard)) :play-area {:force true})]
-                     (card-init state side c {:resolve-effect false})
-                     (update! state side (assoc (get-card state c) :cold-read-active true))
-                     (make-run state side (make-eid state) target
-                               {:end-run {:async true
-                                          :effect (effect (trash card)
-                                                          (continue-ability :runner end-effect nil nil))}}
-                               (assoc c :cold-read-active true))))
-      :interactions {:pay-credits {:req (req (:cold-read-active card))
-                                   :type :recurring}}})
+   {:implementation "Used programs restriction not enforced"
+    :async true
+    :prompt "Choose a server"
+    :data {:counter {:credit 4}}
+    :makes-run true
+    :choices (req runnable-servers)
+    :effect (effect (make-run eid target nil card))
+    :interactions {:pay-credits {:type :credit}}
+    :events [{:event :run-ends
+              :prompt "Choose a program that was used during the run to trash "
+              :choices {:req program?}
+              :msg (msg "trash " (:title target))
+              :async true
+              :effect (effect (trash eid target {:unpreventable true}))}]}
 
    "Compile"
    (letfn [(compile-fn [where]
@@ -372,6 +378,7 @@
       :choices (req runnable-servers)
       :async true
       :makes-run true
+      :effect (effect (make-run eid target nil card))
       :abilities [{:label "Install a program using Compile"
                    :prompt "Install a program from your Stack or Heap?"
                    :choices ["Stack" "Heap"]
@@ -379,18 +386,12 @@
                    :effect (effect (continue-ability
                                      (compile-fn (if (= "Stack" target) :deck :discard))
                                      card nil))}]
-      :effect (effect (make-run target nil card)
-                      (prompt! card (str "Click Compile in the Temporary Zone to install a Program") ["OK"] {})
-                      (continue-ability
-                        {:effect (effect (card-init (move state side (last (:discard runner)) :play-area) {:resolve-effect false}))}
-                        card nil))
       :events [{:event :run-ends
-                :effect
-                (req (when-let [compile-installed (some #(when (get-in % [:special :compile-installed]) %) (all-installed state :runner))]
-                       (system-msg state side (str "moved " (:title compile-installed) " to the bottom of the Stack at the end of the run from Compile"))
-                       (move state :runner compile-installed :deck))
-                  (unregister-events state side card)
-                  (trash state side card))}]})
+                :effect (req (when-let [compile-installed (some #(when (get-in % [:special :compile-installed]) %)
+                                                                (all-installed state :runner))]
+                               (system-msg state side (str "moved " (:title compile-installed)
+                                                           " to the bottom of the Stack at the end of the run from Compile"))
+                               (move state :runner compile-installed :deck)))}]})
 
    "Contaminate"
    {:effect (req (resolve-ability
@@ -420,8 +421,7 @@
    {:prompt "Choose a server"
     :choices (req runnable-servers)
     :makes-run true
-    :effect (effect (make-run target nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (make-run eid target nil card))
     :events [{:event :pre-access-card
               :once :per-run
               :async true
@@ -429,7 +429,7 @@
               :effect (req (let [c target
                                  cost (:cost c)
                                  title (:title c)]
-                             (if (can-pay? state :corp eid card nil :credit cost)
+                             (if (can-pay? state :corp eid card nil [:credit cost])
                                (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent the trash")
                                    (continue-ability
                                      state :corp
@@ -446,9 +446,7 @@
                                                                     (trash eid (assoc c :seen true) nil))}}}
                                      card nil))
                                (do (system-msg state side (str "uses Credit Crash to trash " title " at no cost"))
-                                   (trash state side eid (assoc c :seen true) nil)))))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+                                   (trash state side eid (assoc c :seen true) nil)))))}]}
 
    "Credit Kiting"
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
@@ -470,52 +468,86 @@
     :effect (req (let [serv target]
                    (continue-ability
                      state :corp
-                     {:optional
-                      {:prompt (msg "Rez a piece of ICE protecting " serv "?")
-                       :yes-ability {:prompt (msg "Select a piece of ICE protecting " serv " to rez")
-                                     :player :corp
-                                     :choices {:req #(and (not (:rezzed %))
-                                                          (= (last (:zone %)) :ices))}
-                                     :effect (req (rez state :corp target nil))}
-                       :no-ability {:effect (effect (make-run eid serv nil card))
-                                    :msg (msg "make a run on " serv " during which no ICE can be rezzed")}}}
+                     (if (seq (filter #(and (installed? %)
+                                            (not (rezzed? %))
+                                            (ice? %)
+                                            (can-pay? state side eid card nil
+                                                      [:credit (rez-cost state side %)]))
+                                      (all-installed state :corp)))
+                       {:optional
+                        {:prompt (msg "Rez a piece of ICE protecting " serv "?")
+                         :yes-ability {:async true
+                                       :prompt (msg "Select a piece of ICE protecting " serv " to rez")
+                                       :player :corp
+                                       :choices {:req #(and (installed? %)
+                                                            (not (rezzed? %))
+                                                            (ice? %)
+                                                            (can-pay? state side eid card nil
+                                                                      [:credit (rez-cost state side %)]))}
+                                       :effect (effect (rez :corp eid target nil))
+                                       :cancel-effect
+                                       (effect (register-run-flag!
+                                                 card
+                                                 :can-rez
+                                                 (fn [state side card]
+                                                   (if (ice? card)
+                                                     ((constantly false)
+                                                      (toast state :corp "Cannot rez ICE on this run due to Cyber Threat"))
+                                                     true)))
+                                               (make-run eid serv nil card))}
+                         :no-ability {:async true
+                                      :effect (effect (register-run-flag!
+                                                        card
+                                                        :can-rez
+                                                        (fn [state side card]
+                                                          (if (ice? card)
+                                                            ((constantly false)
+                                                             (toast state :corp "Cannot rez ICE on this run due to Cyber Threat"))
+                                                            true)))
+                                                      (make-run eid serv nil card))
+                                      :msg (msg "make a run on " serv " during which no ICE can be rezzed")}}}
+                       {:async true
+                        :effect (effect (register-run-flag!
+                                          card
+                                          :can-rez
+                                          (fn [state side card]
+                                            (if (ice? card)
+                                              ((constantly false)
+                                               (toast state :corp "Cannot rez ICE on this run due to Cyber Threat"))
+                                              true)))
+                                        (make-run eid serv nil card))
+                        :msg (msg "make a run on " serv " during which no ICE can be rezzed")})
                      card nil)))}
 
    "Data Breach"
-   {:req (req rd-runnable)
-    :async true
+   {:async true
     :makes-run true
-    :effect (req (let [db-eid (make-eid state)
-                       events (:events (card-def card))]
-                   (register-events
-                     state side (assoc card :zone '(:discard))
-                     [(assoc (first events) :eid db-eid)])
-                   (wait-for (make-run state side db-eid :rd nil card)
-                             (let [card (get-card state (assoc card :zone '(:discard)))]
-                               (unregister-events state side card)
-                               (when (:run-again card)
-                                 (make-run state side db-eid :rd nil card))
-                               (update! state side (dissoc card :run-again))))))
+    :req (req rd-runnable)
+    :effect (req (wait-for (make-run state side :rd nil card)
+                           (let [card (get-card state card)]
+                             (if (:run-again card)
+                               (make-run state side eid :rd nil card)
+                               (effect-completed state side eid)))))
     :events [{:event :successful-run-ends
-              :optional {:req (req (= [:rd] (:server target)))
+              :optional {:req (req (and (not (:run-again card))
+                                        (= [:rd] (:server target))))
                          :prompt "Make another run on R&D?"
                          :yes-ability {:effect (effect (clear-wait-prompt :corp)
                                                        (update! (assoc card :run-again true)))}}}]}
 
    "Day Job"
    {:additional-cost [:click 3]
-    :msg "gain 10 [Credits]" :effect (effect (gain-credits 10))}
+    :msg "gain 10 [Credits]"
+    :effect (effect (gain-credits 10))}
 
    "Deep Data Mining"
-   {:req (req rd-runnable)
+   {:async true
     :makes-run true
-    :effect (effect (make-run :rd nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :req (req rd-runnable)
+    :effect (effect (make-run eid :rd nil card))
     :events [{:event :successful-run
               :silent (req true)
-              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}]}
 
    "Déjà Vu"
    {:prompt "Choose a card to add to Grip" :choices (req (cancellable (:discard runner) :sorted))
@@ -534,16 +566,8 @@
     :prompt "Choose a server"
     :choices ["HQ" "R&D"]
     :makes-run true
-    :effect (effect (make-run target nil card)
-                    (resolve-ability
-                      {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
-                                      (card-init state side c {:resolve-effect false})
-                                      (register-events
-                                        state side c
-                                        [{:event :run-ends
-                                          :effect (effect (trash c))}])))}
-                      card nil))
-    :events [{:event :run-ends}]
+    :async true
+    :effect (effect (make-run eid target nil card nil))
     :interactions {:access-ability
                    {:label "Trash card"
                     :msg (msg "trash " (:title target) " at no cost")
@@ -560,7 +584,8 @@
                :msg "remove 1 tag"}
               {:prompt "Select 1 piece of ice to expose"
                :msg "expose 1 ice and make a run"
-               :choices {:req #(and (installed? %) (ice? %))}
+               :choices {:req #(and (installed? %)
+                                    (ice? %))}
                :async true
                :effect (req (wait-for (expose state side target)
                                       (continue-ability
@@ -590,36 +615,28 @@
     :choices (req runnable-servers)
     :async true
     :makes-run true
+    :effect (effect (make-run eid target nil card))
     :abilities [{:label "Install a program using Diana's Hunt?"
                  :async true
-                 :effect (effect (resolve-ability
-                                   {:prompt "Choose a program in your Grip to install"
-                                    :choices {:req #(and (program? %)
-                                                         (runner-can-install? state side % false)
-                                                         (in-hand? %))}
-                                    :msg (msg "install " (:title target))
-                                    :effect (req (let [diana-card (assoc-in target [:special :diana-installed] true)]
-                                                   (runner-install state side (make-eid state {:source card :source-type :runner-install}) diana-card {:ignore-all-cost true})
-                                                   (swap! state update :diana #(conj % diana-card))))}
-                                   card nil))}]
-    :effect (effect (make-run target nil card)
-                    (prompt! card (str "Click Diana's Hunt in the Temporary Zone to install a Program") ["OK"] {})
-                    (resolve-ability
-                      {:effect (req (let [c (move state side (last (:discard runner)) :play-area)]
-                                      (card-init state side c {:resolve-effect false})
-                                      (register-events
-                                        state side c
-                                        [{:event :run-ends
-                                          :effect (req (let [hunt (:diana @state)]
-                                                         (doseq [c hunt]
-                                                           (let [installed (find-cid (:cid c) (all-installed state side))]
-                                                             (when (get-in installed [:special :diana-installed])
-                                                               (system-msg state side (str "trashes " (:title c) " at the end of the run from Diana's Hunt"))
-                                                               (trash state side installed {:unpreventable true}))))
-                                                         (swap! state dissoc :diana)
-                                                         (unregister-events state side card {:event :run-ends})
-                                                         (trash state side c)))}])))}
-                      card nil))}
+                 :effect
+                 (effect
+                   (continue-ability
+                     {:prompt "Choose a program in your grip to install"
+                      :choices {:req #(and (in-hand? %)
+                                           (program? %)
+                                           (runner-can-install? state side % false)
+                                           (can-pay? state side eid card nil [:credit (install-cost state side %)]))}
+                      :msg (msg "install " (:title target) ", ignoring all costs")
+                      :effect (req (let [diana-card (assoc-in target [:special :diana-installed] true)]
+                                     (update! state side (update-in card [:special :diana] conj diana-card))
+                                     (runner-install state side eid diana-card {:ignore-all-cost true})))}
+                     card nil))}]
+    :events [{:event :run-ends
+              :effect (req (doseq [c (get-in card [:special :diana])]
+                             (let [installed (find-cid (:cid c) (all-installed state side))]
+                               (when (get-in installed [:special :diana-installed])
+                                 (system-msg state side (str "trashes " (:title c) " at the end of the run from Diana's Hunt"))
+                                 (trash state side installed {:unpreventable true})))))}]}
 
    "Diesel"
    {:msg "draw 3 cards"
@@ -627,59 +644,70 @@
     :effect (effect (draw eid 3 nil))}
 
    "Direct Access"
-   (let [maybe-reshuffle {:optional {:autoresolve (get-autoresolve :auto-reshuffle)
-                                     :prompt "Shuffle Direct Access into the Stack?"
-                                     :yes-ability {:msg (msg "shuffles Direct Access into the Stack")
-                                                   :effect (effect (move (get-card state card) :deck)
-                                                                   (shuffle! :deck)
-                                                                   (effect-completed eid))}
-                                     :no-ability {:effect (effect (trash eid (get-card state card) {:unpreventable true :suppress-event true}))}}}]
-     {:effect (req (doseq [s [:corp :runner]]
-                     (disable-identity state s))
-                   (continue-ability state side
-                                     {:prompt "Choose a server"
-                                      :choices (req runnable-servers)
-                                      :async true
-                                      :effect (req (let [c (move state side (find-latest state card) :play-area)]
-                                                     (card-init state side c {:resolve-effect false})
-                                                     (wait-for (make-run state side (make-eid state) target nil card)
-                                                               (doseq [s [:corp :runner]]
-                                                                 (enable-identity state s))
-                                                               (continue-ability state side maybe-reshuffle c nil))))}
-                                     card nil))
-      :abilities [(set-autoresolve :auto-reshuffle "reshuffle")]})
+   {:async true
+    :makes-run true
+    :effect (req (doseq [s [:corp :runner]]
+                   (disable-identity state s))
+                 (continue-ability
+                   state side
+                   {:prompt "Choose a server"
+                    :choices (req runnable-servers)
+                    :async true
+                    :effect (effect (make-run eid target nil card))}
+                   card nil))
+    :abilities [(set-autoresolve :auto-reshuffle "reshuffle")]
+    :events [{:event :run-ends
+              :async true
+              :effect (req (doseq [s [:corp :runner]]
+                             (enable-identity state s))
+                           (continue-ability
+                             state :runner
+                             {:optional
+                              {:autoresolve (get-autoresolve :auto-reshuffle)
+                               :prompt "Shuffle Direct Access into the Stack?"
+                               :yes-ability
+                               {:msg (msg "shuffles Direct Access into the Stack")
+                                :effect (effect (move (get-card state card) :deck)
+                                                (shuffle! :deck)
+                                                (unregister-events card))}}}
+                             card nil))}]}
 
    "Dirty Laundry"
-   (run-event
-     {:end-run {:req (req (:successful run))
-                :msg "gain 5 [Credits]"
-                :effect (effect (gain-credits :runner 5))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (make-run eid target nil card))
+    :events [{:event :successful-run-ends
+              :silent (req true)
+              :msg "gain 5 [Credits]"
+              :effect (effect (gain-credits :runner 5))}]}
 
    "Diversion of Funds"
    {:req (req hq-runnable)
-    :effect (effect (make-run :hq
-                              {:req (req (= target :hq))
-                               :replace-access
-                               (let [five-or-all (fn [corp] (min 5 (:credit corp)))]
-                                 {:msg (msg "force the Corp to lose " (five-or-all corp)
-                                            "[Credits], and gain " (five-or-all corp) "[Credits]")
-                                  :effect (effect (lose-credits :corp (five-or-all corp))
-                                                  (gain-credits :runner (five-or-all corp)))})}
-                              card))}
+    :async true
+    :makes-run true
+    :effect (effect (make-run
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       (let [five-or-all (fn [corp] (min 5 (:credit corp)))]
+                         {:msg (msg "force the Corp to lose " (five-or-all corp)
+                                    "[Credits], and gain " (five-or-all corp) "[Credits]")
+                          :effect (effect (lose-credits :corp (five-or-all corp))
+                                          (gain-credits :runner (five-or-all corp)))})}
+                      card))}
 
    "Divide and Conquer"
    {:req (req archives-runnable)
     :makes-run true
     :async true
-    :effect (effect (make-run :archives nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (make-run eid :archives nil card))
     :events [{:event :end-access-phase
               :async true
               :req (req (= :archives (:from-server target)))
               :effect (req (wait-for (do-access state side [:hq] {:no-root true})
-                                     (do-access state side eid [:rd] {:no-root true})))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+                                     (do-access state side eid [:rd] {:no-root true})))}]}
 
    "Drive By"
    {:choices {:req #(let [topmost (get-nested-host %)]
@@ -699,38 +727,49 @@
                              (effect-completed state side eid))))}
 
    "Early Bird"
-   (run-event
-     {:msg (msg "make a run on " target " and gain [Click]")}
-     nil
-     (effect (gain :click 1)))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :msg (msg "make a run on " target " and gain [Click]")
+    :effect (effect (gain :click 1)
+                    (make-run eid target nil card))}
 
    "Easy Mark"
-   {:msg "gain 3 [Credits]" :effect (effect (gain-credits 3))}
+   {:msg "gain 3 [Credits]"
+    :effect (effect (gain-credits 3))}
 
    "Embezzle"
-   (letfn [(name-string [cards]
-             (join " and " (map :title cards)))] ; either 'card' or 'card1 and card2'
-     {:req (req hq-runnable)
-      :effect (effect
-                (make-run :hq {:req (req (= target :hq))
-                               :replace-access
-                               {:mandatory true
-                                :msg (msg "reveal 2 cards from HQ and trash all "
-                                          target (when (not= "ICE" (:type target)) "s"))
-                                :prompt "Choose a card type"
-                                :choices ["Asset" "Upgrade" "Operation" "ICE"]
-                                :effect (req (let [chosen-type target
-                                                   cards-to-reveal (take 2 (shuffle (:hand corp)))
-                                                   cards-to-trash (filter #(is-type? % chosen-type) cards-to-reveal)]
-                                               (system-msg state side (str " reveals " (name-string cards-to-reveal) " from HQ"))
-                                               (reveal state side cards-to-reveal)
-                                               (when (seq cards-to-trash)
-                                                 (system-msg state side (str " trashes " (name-string cards-to-trash)
-                                                                             " from HQ and gain " (* 4 (count cards-to-trash)) "[Credits]"))
-                                                 (doseq [c cards-to-trash]
-                                                   (trash state :runner (assoc c :seen true)))
-                                                 (gain-credits state :runner (* 4 (count cards-to-trash))))))}}
-                          card))})
+   {:async true
+    :makes-run true
+    :req (req hq-runnable)
+    :effect
+    (effect
+      (make-run eid :hq
+                {:req (req (= target :hq))
+                 :replace-access
+                 {:mandatory true
+                  :prompt "Choose a card type"
+                  :choices ["Asset" "Upgrade" "Operation" "ICE"]
+                  :msg (msg "reveal 2 cards from HQ and trash all "
+                            target (when (not= "ICE" (:type target)) "s"))
+                  :effect (req (let [cards-to-reveal (take 2 (shuffle (:hand corp)))
+                                     cards-to-trash (filter #(is-type? % target) cards-to-reveal)
+                                     credits (* 4 (count cards-to-trash))]
+                                 (system-msg state side
+                                             (str "uses Embezzle to reveal "
+                                                  (join " and " (map :title cards-to-reveal))
+                                                  " from HQ"))
+                                 (reveal state side cards-to-reveal)
+                                 (when (pos? credits)
+                                   (system-msg state side
+                                               (str " uses Embezzle to trash "
+                                                    (join " and " (map :title cards-to-trash))
+                                                    " from HQ and gain "
+                                                    credits " [Credits]"))
+                                   (trash-cards state :runner (map #(assoc % :seen true) cards-to-trash))
+                                   (gain-credits state :runner credits))))}}
+                card))}
 
    "Emergency Shutdown"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
@@ -792,22 +831,31 @@
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
                    (some #{:rd} (:successful-run runner-reg))
                    (some #{:archives} (:successful-run runner-reg))))
-    :effect (req (swap! state update-in [:runner :extra-turns] (fnil inc 0))
-                 (move state side (first (:play-area runner)) :rfg))
-    :msg "take an additional turn after this one"}
+    :rfg-instead-of-trashing true
+    :msg "take an additional turn after this one"
+    :effect (req (swap! state update-in [:runner :extra-turns] (fnil inc 0)))}
 
    "Escher"
-   (letfn [(es [] {:prompt "Select two pieces of ICE to swap positions"
-                   :choices {:req #(and (installed? %) (ice? %)) :max 2}
+   (letfn [(es [] {:async true
+                   :prompt "Select two pieces of ICE to swap positions"
+                   :choices {:req #(and (installed? %)
+                                        (ice? %))
+                             :max 2}
                    :effect (req (if (= (count targets) 2)
                                   (do (swap-ice state side (first targets) (second targets))
-                                      (resolve-ability state side (es) card nil))
-                                  (system-msg state side "has finished rearranging ICE")))})]
-     {:req (req hq-runnable)
-      :effect (effect (make-run :hq {:replace-access
-                                     {:mandatory true
-                                      :msg "rearrange installed ICE"
-                                      :effect (effect (resolve-ability (es) card nil))}} card))})
+                                      (continue-ability state side (es) card nil))
+                                  (do (system-msg state side "has finished rearranging ICE")
+                                      (effect-completed state side eid))))})]
+     {:async true
+      :makes-run true
+      :req (req hq-runnable)
+      :effect (effect (make-run eid :hq
+                                {:replace-access
+                                 {:mandatory true
+                                  :async true
+                                  :msg "rearrange installed ICE"
+                                  :effect (effect (continue-ability (es) card nil))}}
+                                card))})
 
    "Eureka!"
    {:effect (req (let [topcard (first (:deck runner))
@@ -854,25 +902,31 @@
                    (derez state side c)))}
 
    "Exploratory Romp"
-   (run-event
-     {:replace-access
-      {:prompt "Advancements to remove from a card in or protecting this server?"
-       :choices ["0" "1" "2" "3"]
-       :async true
-       :mandatory true
-       :effect (req (let [c (str->int target)]
-                      (show-wait-prompt state :corp "Runner to remove advancements")
-                      (continue-ability
-                        state side
-                        {:choices {:req #(and (contains? % :advance-counter)
-                                              (= (first (:server run)) (second (:zone %))))}
-                         :msg (msg "remove " (quantify c "advancement token")
-                                   " from " (card-str state target))
-                         :effect (req (let [to-remove (min c (get-counters target :advancement))]
-                                        (add-prop state :corp target :advance-counter (- to-remove))
-                                        (clear-wait-prompt state :corp)
-                                        (effect-completed state side eid)))}
-                        card nil)))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (make-run
+                      eid target
+                      {:replace-access
+                       {:prompt "Advancements to remove from a card in or protecting this server?"
+                        :choices ["0" "1" "2" "3"]
+                        :async true
+                        :mandatory true
+                        :effect (req (let [c (str->int target)]
+                                       (show-wait-prompt state :corp "Runner to remove advancements")
+                                       (continue-ability
+                                         state side
+                                         {:choices {:req #(and (contains? % :advance-counter)
+                                                               (= (first (:server run)) (second (:zone %))))}
+                                          :msg (msg "remove " (quantify c "advancement token")
+                                                    " from " (card-str state target))
+                                          :effect (req (let [to-remove (min c (get-counters target :advancement))]
+                                                         (add-prop state :corp target :advance-counter (- to-remove))
+                                                         (clear-wait-prompt state :corp)
+                                                         (effect-completed state side eid)))}
+                                         card nil)))}}
+                      card))}
 
    "Express Delivery"
    {:prompt "Choose a card to add to your Grip" :choices (req (take 4 (:deck runner)))
@@ -905,42 +959,38 @@
                 card nil))}
 
    "Fear the Masses"
-   {:req (req hq-runnable)
+   {:async true
+    :makes-run true
+    :req (req hq-runnable)
     :effect (effect
               (make-run
-                :hq {:req (req (= target :hq))
-                     :replace-access
-                     {:async true
-                      :mandatory true
-                      :msg "force the Corp to trash the top card of R&D"
-                      :effect (req (mill state :corp)
-                                   (let [n (count (filter #(= (:title card) (:title %)) (:hand runner)))]
-                                     (if (pos? n)
-                                       (continue-ability
-                                         state side
-                                         {:prompt "Reveal how many copies of Fear the Masses?"
-                                          :choices {:number (req n)}
-                                          :effect (req (when (pos? target)
-                                                         (mill state :corp target)
-                                                         (system-msg
-                                                           state side
-                                                           (str "reveals " target " copies of Fear the Masses,"
-                                                                " forcing the Corp to trash " target " cards"
-                                                                " from the top of R&D"))))}
-                                         card nil)
-                                       (effect-completed state side eid))))}}
+                eid :hq
+                {:req (req (= target :hq))
+                 :replace-access
+                 {:async true
+                  :mandatory true
+                  :msg "force the Corp to trash the top card of R&D"
+                  :effect (effect (mill :corp)
+                                  (continue-ability
+                                    {:prompt "Reveal how many copies of Fear the Masses?"
+                                     :choices {:req #(and (in-hand? %)
+                                                          (same-card? :title card %))}
+                                     :msg (msg "reveal " (count targets) " copies of Fear the Masses,"
+                                               " forcing the Corp to trash " (count targets)
+                                               " additional cards from the top of R&D")
+                                     :effect (effect (reveal targets)
+                                                     (mill :corp (count targets)))}
+                                    card nil))}}
                 card))}
 
    "Feint"
-   {:req (req hq-runnable)
-    :implementation "Bypass is manual"
-    :effect (effect (make-run :hq nil card)
-                    (register-events (assoc card :zone '(:discard))))
-    ;; Don't need a msg since game will print that card access is prevented
+   {:implementation "Bypass is manual"
+    :async true
+    :makes-run true
+    :req (req hq-runnable)
+    :effect (effect (make-run eid :hq nil card))
     :events [{:event :successful-run
-              :effect (effect (prevent-access))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (prevent-access))}]}
 
    "Fisk Investment Seminar"
    {:msg "make each player draw 3 cards"
@@ -982,37 +1032,43 @@
    "Frantic Coding"
    {:async true
     :effect
-    (req (let [top-ten (take 10 (:deck runner))]
-           (prompt! state :runner card (str "The top 10 cards of the Stack are "
-                                            (join ", " (map :title top-ten))) ["OK"] {})
-           (continue-ability
-             state side
-             {:prompt "Install a program?"
-              :choices (concat
-                         (->> top-ten
-                              (filter #(and (program? %)
-                                            (can-pay? state side eid card nil
-                                                      [:credit (install-cost state side % {:cost-bonus -5})])))
-                              (sort-by :title)
-                              (into []))
-                         ["No install"])
-              :async true
-              :effect (req (if (not= target "No install")
-                             (let [number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck))
-                                   to-trash (remove #(same-card? % target) top-ten)]
-                               (wait-for (runner-install state side (make-eid state {:source card :source-type :runner-install})
-                                                         target {:cost-bonus -5})
-                                         (if (= number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck)))
-                                           (do (system-msg state side (str "trashes " (join ", " (map :title to-trash))))
-                                               (doseq [c to-trash]
-                                                 (trash state side c {:unpreventable true}))
-                                               (effect-completed state side eid))
-                                           (do (system-msg state side "does not have to trash cards because the stack was shuffled")
-                                               (effect-completed state side eid)))))
-                             (do (doseq [c top-ten]
-                                   (trash state side c {:unpreventable true}))
-                                 (system-msg state side (str "trashes " (join ", " (map :title top-ten)))))))}
-             card nil)))}
+    (effect
+      (continue-ability
+        (let [top-ten (take 10 (:deck runner))]
+          {:prompt (str "The top 10 cards of the stack are " (join ", " (map :title top-ten)) ".")
+           :choices ["OK"]
+           :async true
+           :effect
+           (effect
+             (continue-ability
+               {:prompt "Install a program?"
+                :choices (concat
+                           (->> top-ten
+                                (filter #(and (program? %)
+                                              (can-pay? state side eid card nil
+                                                        [:credit (install-cost state side % {:cost-bonus -5})])))
+                                (sort-by :title)
+                                (into []))
+                           ["No install"])
+                :async true
+                :effect (req (if (not= target "No install")
+                               (let [number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck))
+                                     to-trash (remove #(same-card? % target) top-ten)]
+                                 (wait-for (runner-install state side (make-eid state {:source card :source-type :runner-install})
+                                                           target {:cost-bonus -5})
+                                           (if (= number-of-shuffles (count (turn-events state :runner :runner-shuffle-deck)))
+                                             (do (system-msg state side (str "trashes " (join ", " (map :title to-trash))))
+                                                 (doseq [c to-trash]
+                                                   (trash state side c {:unpreventable true}))
+                                                 (effect-completed state side eid))
+                                             (do (system-msg state side "does not have to trash cards because the stack was shuffled")
+                                                 (effect-completed state side eid)))))
+                               (do (doseq [c top-ten]
+                                     (trash state side c {:unpreventable true}))
+                                   (system-msg state side (str "trashes " (join ", " (map :title top-ten))))
+                                   (effect-completed state side eid))))}
+               card nil))})
+        card nil))}
 
    "\"Freedom Through Equality\""
    {:events [{:event :agenda-stolen
@@ -1039,7 +1095,7 @@
    (let [corp-choose {:show-discard true
                       :async true
                       :player :corp
-                      :prompt (msg "Select 5 cards from Archives to add to HQ")
+                      :prompt "Select 5 cards from Archives to add to HQ"
                       :choices {:max 5
                                 :all true
                                 :req #(and (corp? %)
@@ -1052,30 +1108,22 @@
                                          (str (when-not (empty? seen) " and ")
                                               (quantify m "unseen card")))
                                        " into HQ, then trash 5 cards")))
-                      :effect (req (wait-for
-                                     (resolve-ability state side
-                                                      {:effect (req (doseq [c targets]
-                                                                      (move state side c :hand)))}
-                                                      card targets)
-                                     (continue-ability state side
-                                                       {:async true
-                                                        :effect (req (doseq [c (take 5 (shuffle (:hand corp)))]
-                                                                       (trash state :corp c))
-                                                                     (clear-wait-prompt state :runner)
-                                                                     (effect-completed state :runner eid))}
-                                                       card nil)))}
+                      :effect (req (doseq [c targets]
+                                     (move state side c :hand))
+                                   (trash-cards state :corp eid (take 5 (shuffle (:hand (:corp @state))))))}
          access-effect {:mandatory true
                         :async true
-                        :req (req (>= (count (:discard corp)) 5))
+                        :req (req (<= 5 (count (:discard corp))))
                         :effect (req (show-wait-prompt
                                        state :runner
-                                       "Corp to choose which cards to pick up from Archives") ;; For some reason it just shows successful-run-trigger-message, but this works!?
-                                     (continue-ability state side
-                                                       corp-choose
-                                                       card nil))}]
+                                       "Corp to choose which cards to pick up from Archives")
+                                     (wait-for (resolve-ability state side corp-choose card nil)
+                                               (clear-wait-prompt state :runner)
+                                               (effect-completed state side eid)))}]
      {:req (req archives-runnable)
+      :async true
       :makes-run true
-      :effect (effect (make-run :archives
+      :effect (effect (make-run eid :archives
                                 {:req (req (= target :archives))
                                  :replace-access access-effect}
                                 card))})
@@ -1095,13 +1143,17 @@
                         :value [:randomly-trash-from-hand 1]}]}
 
    "High-Stakes Job"
-   (run-event
-     {:choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
-                          bad-zones (keys (filter (complement unrezzed-ice) (get-in @state [:corp :servers])))]
-                      (zones->sorted-names (remove (set bad-zones) (get-runnable-zones state side eid card nil)))))}
-     {:end-run {:req (req (:successful run))
-                :msg "gain 12 [Credits]"
-                :effect (effect (gain-credits :runner 12))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (let [unrezzed-ice #(seq (filter (complement rezzed?) (:ices (second %))))
+                        bad-zones (keys (filter (complement unrezzed-ice) (get-in @state [:corp :servers])))]
+                    (zones->sorted-names (remove (set bad-zones) (get-runnable-zones state side eid card nil)))))
+    :effect (effect (make-run eid target nil card))
+    :events [{:event :successful-run-ends
+              :silent (req true)
+              :msg "gain 12 [Credits]"
+              :effect (effect (gain-credits :runner 12))}]}
 
    "Hostage"
    {:prompt "Choose a Connection"
@@ -1122,14 +1174,16 @@
                      card nil))}
 
    "Hot Pursuit"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
-    :effect (effect (make-run :hq {:req (req (= target :hq))
-                                   :successful-run {:async true
-                                                    :msg "gain 9 [Credits] and take 1 tag"
-                                                    :effect (req (wait-for (gain-tags state :runner 1)
-                                                                           (gain-credits state :runner 9)
-                                                                           (effect-completed state side eid)))}} card))}
+    :req (req hq-runnable)
+    :effect (effect (make-run eid :hq nil card))
+    :events [{:event :successful-run
+              :async true
+              :msg "gain 9 [Credits] and take 1 tag"
+              :effect (req (wait-for (gain-tags state :runner 1)
+                                     (gain-credits state :runner 9)
+                                     (effect-completed state side eid)))}]}
 
    "Isolation"
    {:additional-cost [:resource 1]
@@ -1145,9 +1199,10 @@
                    :effect (effect (draw :runner eid 3 nil)) :msg "draw 3 cards"}}
 
    "Immolation Script"
-   {:req (req archives-runnable)
-    :effect (effect (make-run :archives nil card)
-                    (register-events (assoc card :zone '(:discard))))
+   {:async true
+    :makes-run true
+    :req (req archives-runnable)
+    :effect (effect (make-run eid :archives nil card))
     :events [{:event :pre-access
               :async true
               :req (req (and (= target :archives)
@@ -1155,41 +1210,32 @@
                              (not-empty (clojure.set/intersection
                                           (into #{} (map :title (filter ice? (:discard corp))))
                                           (into #{} (map :title (filter rezzed? (all-installed state :corp))))))))
-              :effect (req (continue-ability
-                             state side
-                             {:async true
-                              :prompt "Choose a piece of ICE in Archives"
-                              :choices (req (filter ice? (:discard corp)))
-                              :effect (req (let [icename (:title target)]
-                                             (continue-ability
-                                               state side
-                                               {:async true
-                                                :prompt (msg "Select a rezzed copy of " icename " to trash")
-                                                :choices {:req #(and (ice? %)
-                                                                     (rezzed? %)
-                                                                     (= (:title %) icename))}
-                                                :msg (msg "trash " (card-str state target))
-                                                :effect (req (trash state :corp target)
-                                                             (unregister-events state side card)
-                                                             (effect-completed state side eid))}
-                                               card nil)))}
-                             card nil))}]}
+              :prompt "Choose a piece of ICE in Archives"
+              :choices (req (filter ice? (:discard corp)))
+              :effect (effect (continue-ability
+                                (let [ice target]
+                                  {:async true
+                                   :prompt (msg "Select a rezzed copy of " (:title ice) " to trash")
+                                   :choices {:req #(and (ice? %)
+                                                        (rezzed? %)
+                                                        (same-card? :title % ice))}
+                                   :msg (msg "trash " (card-str state target))
+                                   :effect (effect (trash eid target nil))})
+                                card nil))}]}
 
    "In the Groove"
-   {:effect (req (register-events state side (dissoc card :zone)))
-    :events [{:event :runner-turn-ends
-              :effect (effect (unregister-events card))}
-             {:event :runner-install
+   {:events [{:event :runner-install
+              :duration :end-of-turn
               :req (req (<= 1 (:cost target)))
               :interactive (req (has-subtype? target "Cybernetic"))
               :async true
               :prompt "What to get from In the Groove?"
               :choices ["Draw 1 card" "Gain 1 [Credits]"]
+              :msg (msg (lower-case target))
               :effect (req (if (= target "Draw 1 card")
                              (draw state side eid 1 nil)
                              (do (gain-credits state side 1)
-                                 (effect-completed state side eid))))
-              :msg (msg (lower-case target))}]}
+                                 (effect-completed state side eid))))}]}
 
    "Independent Thinking"
    (letfn [(cards-to-draw [targets]
@@ -1207,8 +1253,9 @@
    "Indexing"
    {:req (req rd-runnable)
     :async true
+    :makes-run true
     :effect (effect (make-run
-                      :rd
+                      eid :rd
                       {:req (req (= target :rd))
                        :replace-access
                        {:msg "rearrange the top 5 cards of R&D"
@@ -1280,9 +1327,12 @@
                                                     card nil))}
                                  card nil))
                            (effect-completed state side eid)))}]
-       {:req (req hq-runnable)
-        :effect (effect (make-run :hq {:req (req (= target :hq))
-                                       :replace-access access-effect}
+       {:async true
+        :makes-run true
+        :req (req hq-runnable)
+        :effect (effect (make-run eid :hq
+                                  {:req (req (= target :hq))
+                                   :replace-access access-effect}
                                   card))}))
 
    "Inject"
@@ -1295,22 +1345,27 @@
                          (system-msg state side (str "adds " (:title c) " to Grip"))))))}
 
    "Injection Attack"
-   (run-event
-     {:async true}
-     nil
-     nil
-     (effect (continue-ability
-               {:prompt "Select an icebreaker"
-                :choices {:req #(and (installed? %)
-                                     (has-subtype? % "Icebreaker"))}
-                :effect (effect (pump target 2 :end-of-run))}
-               card nil)))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (continue-ability
+                      (let [server target]
+                        {:async true
+                         :prompt "Select an icebreaker"
+                         :choices {:req #(and (installed? %)
+                                              (has-subtype? % "Icebreaker"))}
+                         :effect (effect (pump target 2 :end-of-run)
+                                         (make-run eid server nil card))})
+                      card nil))}
 
    "Inside Job"
    {:implementation "Bypass is manual"
+    :async true
+    :makes-run true
     :prompt "Choose a server"
     :choices (req runnable-servers)
-    :effect (effect (make-run target nil card))}
+    :effect (effect (make-run eid target nil card))}
 
    "Insight"
    {:async true
@@ -1378,12 +1433,12 @@
                                   :effect (effect (effect-completed
                                                     (make-result eid [(str->int (first (split target #" ")))
                                                                       (min 6 (str->int (nth (split target #" ") 2)))])))}))]
-     {:req (req rd-runnable)
-      :async true
-      :effect (req
+     {:async true
+      :makes-run true
+      :req (req rd-runnable)
+      :effect (effect
                 (make-run
-                  state side
-                  :rd
+                  eid :rd
                   {:req (req (= target :rd))
                    :replace-access
                    {:async true
@@ -1428,9 +1483,11 @@
 
    "Labor Rights"
    {:req (req (pos? (+ (count (:deck runner)) (count (:discard runner)))))
+    :rfg-instead-of-trashing true
+    :async true
     :effect (req (let [mill-count (min 3 (count (:deck runner)))]
                    (mill state :runner :runner mill-count)
-                   (system-msg state :runner (str "trashes the top " (quantify mill-count "card") " of their Stack"))
+                   (system-msg state :runner (str "trashes the top " (quantify mill-count "card") " of their stack"))
                    (let [heap-count (min 3 (count (get-in @state [:runner :discard])))]
                      (continue-ability
                        state side
@@ -1448,120 +1505,114 @@
                                                                     " from their Heap into their Stack, and draws 1 card"))
                                      (shuffle! state :runner :deck)
                                      (wait-for (draw state :runner 1 nil)
-                                               (move state side (find-latest state card) :rfg)
-                                               (system-msg state :runner "removes Labor Rights from the game")
                                                (effect-completed state side eid)))}
                        card nil))))}
 
    "Lawyer Up"
    {:msg "remove 2 tags and draw 3 cards"
     :async true
-    :effect (req (wait-for (draw state side 3 nil) (lose-tags state side eid 2)))}
+    :effect (req (wait-for (draw state side 3 nil)
+                           (lose-tags state side eid 2)))}
 
    "Lean and Mean"
-   {:prompt "Choose a server"
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
     :choices (req runnable-servers)
-    :async true
-    :msg (msg "make a run on " target (when (< (count (filter program? (all-active-installed state :runner))) 4)
+    :msg (msg "make a run on " target (when (<= (count (filter program? (all-active-installed state :runner))) 3)
                                         ", adding +2 strength to all icebreakers"))
-    :effect (req (when (< (count (filter program? (all-active-installed state :runner))) 4)
+    :effect (req (when (<= (count (filter program? (all-active-installed state :runner))) 3)
                    (pump-all-icebreakers state side 2 :end-of-run))
-                 (make-run state side (make-eid state) target nil card))}
+                 (make-run state side eid target nil card))}
 
    "Leave No Trace"
    (letfn [(get-rezzed-cids [ice]
              (map :cid (filter #(and (rezzed? %)
                                      (ice? %))
                                ice)))]
-     {:prompt "Choose a server"
+     {:async true
+      :makes-run true
+      :prompt "Choose a server"
       :msg "make a run and derez any ICE that are rezzed during this run"
       :choices (req runnable-servers)
-      :async true
-      :effect (req
-                (let [old-ice-cids (get-rezzed-cids (all-installed state :corp))]
-                  (swap! state assoc :lnt old-ice-cids)
-                  (register-events state side (assoc card :zone '(:discard)))
-                  (make-run state side (make-eid state) target nil card)))
+      :effect (req (let [old-ice-cids (get-rezzed-cids (all-installed state :corp))]
+                     (update! state side (assoc-in card [:special :leave-no-trace] old-ice-cids))
+                     (make-run state side eid target nil (get-card state card))))
       :events [{:event :run-ends
                 :effect (req (let [new (set (get-rezzed-cids (all-installed state :corp)))
-                                   old (set (:lnt @state))
+                                   old (set (get-in (get-card state card) [:special :leave-no-trace]))
                                    diff-cid (seq (clojure.set/difference new old))
                                    diff (map #(find-cid % (all-installed state :corp)) diff-cid)]
                                (doseq [ice diff]
                                  (derez state :runner ice))
                                (when-not (empty? diff)
-                                 (system-msg state side (str "derezzes " (join ", " (map :title diff)) " via Leave No Trace")))
-                               (swap! state dissoc :lnt)
-                               (unregister-events state side card)))}]})
+                                 (system-msg state side (str "uses Leave No Trace to derez " (join ", " (map :title diff)))))))}]})
 
    "Legwork"
-   {:req (req hq-runnable)
-    :effect (effect (make-run :hq nil card)
-                    (register-events (assoc card :zone '(:discard))))
+   {:async true
+    :makes-run true
+    :req (req hq-runnable)
+    :effect (effect (make-run eid :hq nil card))
     :events [{:event :successful-run
               :silent (req true)
-              :effect (effect (access-bonus :hq 2))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (access-bonus :hq 2))}]}
 
    "Leverage"
-   {:req (req (some #{:hq} (:successful-run runner-reg)))
-    :player :corp
-    :prompt "Take 2 bad publicity?"
-    :yes-ability {:player :corp
-                  :msg "takes 2 bad publicity"
-                  :effect (effect (gain-bad-publicity :corp 2))}
-    :no-ability {:player :runner
-                 :msg "is immune to damage until the beginning of the Runner's next turn"
-                 :effect (effect
-                           (register-events
-                             (assoc card :zone '(:discard))
-                             [{:event :pre-damage
-                               :effect (effect (damage-prevent :net Integer/MAX_VALUE)
-                                               (damage-prevent :meat Integer/MAX_VALUE)
-                                               (damage-prevent :brain Integer/MAX_VALUE))}
-                              {:event :runner-turn-begins
-                               :effect (effect (unregister-events
-                                                 card
-                                                 {:events [{:event :runner-turn-begins}
-                                                           {:event :pre-damage}]}))}]))}}
+   {:optional
+    {:req (req (some #{:hq} (:successful-run runner-reg)))
+     :player :corp
+     :prompt "Take 2 bad publicity?"
+     :yes-ability {:player :corp
+                   :msg "takes 2 bad publicity"
+                   :effect (effect (gain-bad-publicity :corp 2))}
+     :no-ability {:player :runner
+                  :msg "is immune to damage until the beginning of the Runner's next turn"
+                  :effect (effect
+                            (register-events
+                              card
+                              [{:event :pre-damage
+                                :duration :until-runner-turn-begins
+                                :effect (effect (damage-prevent :net Integer/MAX_VALUE)
+                                                (damage-prevent :meat Integer/MAX_VALUE)
+                                                (damage-prevent :brain Integer/MAX_VALUE))}
+                               {:event :runner-turn-begins
+                                :duration :until-runner-turn-begins
+                                :effect (effect (unregister-floating-events :until-runner-turn-begins))}]))}}}
 
    "Levy AR Lab Access"
    {:msg "shuffle their Grip and Heap into their Stack and draw 5 cards"
+    :rfg-instead-of-trashing true
     :async true
-    :effect (req (shuffle-into-deck state :runner :hand :discard)
-                 (wait-for (draw state :runner 5 nil)
-                           (move state side (first (:play-area runner)) :rfg)
-                           (effect-completed state side eid)))}
+    :effect (effect (shuffle-into-deck :hand :discard)
+                    (draw eid 5 nil))}
 
    "Lucky Find"
    {:msg "gain 9 [Credits]"
     :effect (effect (gain-credits 9))}
 
    "Mad Dash"
-   {:prompt "Choose a server"
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
     :choices (req runnable-servers)
-    :async true
-    :effect (effect (make-run target nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (make-run eid target nil card))
     :events [{:event :agenda-stolen
               :silent (req true)
               :effect (effect (update! (assoc card :steal true)))}
              {:event :run-ends
               :async true
               :effect (req (if (:steal card)
-                             (wait-for (as-agenda state :runner (get-card state card) 1)
-                                       (system-msg state :runner
-                                                   (str "adds Mad Dash to their score area as an agenda worth 1 agenda point")))
+                             (do (system-msg state :runner
+                                             (str "adds Mad Dash to their score area as an agenda worth 1 agenda point"))
+                                 (as-agenda state :runner eid (get-card state card) 1))
                              (do (system-msg state :runner
                                              (str "suffers 1 meat damage from Mad Dash"))
-                                 (damage state side eid :meat 1 {:card card})))
-                           (unregister-events state side card))}]}
+                                 (damage state side eid :meat 1 {:card card}))))}]}
 
    "Making an Entrance"
    (letfn [(entrance-trash [cards]
              {:prompt "Choose a card to trash"
-              :choices (cons "None" cards)
+              :choices (concat cards ["None"])
               :async true
               :msg (req (when (not= target "None") (str "trash " (:title target))))
               :effect (req (if (= target "None")
@@ -1580,13 +1631,17 @@
                      (continue-ability state side (entrance-trash from) card nil)))})
 
    "Marathon"
-   (run-event
-     {:choices (req (filter #(can-run-server? state %) remotes))}
-     {:end-run {:effect (req (prevent-run-on-server state card (:server run))
-                             (when (:successful run)
-                               (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
-                               (gain state :runner :click 1)
-                               (move state :runner (assoc card :zone [:discard]) :hand)))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (filter #(can-run-server? state %) remotes))
+    :effect (effect (make-run eid target nil card))
+    :events [{:event :run-ends
+              :effect (req (prevent-run-on-server state card (:server run))
+                           (when (:successful run)
+                             (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
+                             (gain state :runner :click 1)
+                             (move state :runner card :hand)))}]}
 
    "Mars for Martians"
    (letfn [(count-clan [state] (count (filter #(and (has-subtype? % "Clan") (resource? %))
@@ -1608,10 +1663,10 @@
 
    "Mining Accident"
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
+    :rfg-instead-of-trashing true
     :async true
     :msg "make the Corp pay 5 [Credits] or take 1 bad publicity"
-    :effect (effect (move (first (:play-area runner)) :rfg)
-                    (show-wait-prompt :runner "Corp to choose to pay or take bad publicity")
+    :effect (effect (show-wait-prompt :runner "Corp to choose to pay or take bad publicity")
                     (continue-ability
                       {:player :corp
                        :async true
@@ -1632,28 +1687,20 @@
    "Möbius"
    {:req (req rd-runnable)
     :async true
-    :effect (req (let [mob-eid (make-eid state)
-                       events (:events (card-def card))]
-                   (register-events
-                     state side (assoc card :zone '(:discard))
-                     [(assoc (second events) :eid mob-eid)])
-                   (wait-for (make-run state side mob-eid :rd nil card)
-                             (let [card (get-card state (assoc card :zone '(:discard)))]
-                               (unregister-events state side card)
-                               (when (:run-again card)
-                                 (update! state side (dissoc card :run-again))
-                                 (register-events
-                                   state side card
-                                   [{:event :successful-run
-                                     :req (req (= target :rd))
-                                     :msg "gain 4 [Credits]"
-                                     :effect (effect (gain-credits 4))}])
-                                 (wait-for (make-run state side (make-eid state mob-eid) :rd nil card)
-                                           (unregister-events state side card)))))))
-    :events [{:event :successful-run}
+    :effect (req (wait-for (make-run state side :rd nil card)
+                           (let [card (get-card state card)]
+                             (if (:run-again card)
+                               (make-run state side eid :rd nil card)
+                               (effect-completed state side eid)))))
+    :events [{:event :successful-run
+              :req (req (and (:run-again card)
+                             (= target :rd)))
+              :msg "gain 4 [Credits]"
+              :effect (effect (gain-credits 4))}
              {:event :successful-run-ends
               :interactive (req true)
-              :optional {:req (req (= [:rd] (:server target)))
+              :optional {:req (req (and (not (:run-again card))
+                                        (= [:rd] (:server target))))
                          :prompt "Make another run on R&D?"
                          :yes-ability {:effect (effect (clear-wait-prompt :corp)
                                                        (update! (assoc card :run-again true)))}}}]}
@@ -1710,7 +1757,7 @@
     :prompt "Choose a resource to host On the Lam"
     :choices {:req #(and (resource? %)
                          (installed? %))}
-    :effect (effect (host target (assoc card :zone [:discard] :installed true))
+    :effect (effect (host target (assoc card :installed true))
                     (card-init (find-latest state card) {:resolve-effect false})
                     (system-msg (str "hosts On the Lam on " (:title target))))
     :interactions {:prevent [{:type #{:net :brain :meat :tag}
@@ -1752,14 +1799,18 @@
                                         (ashes-recur (count (filter #(= "Out of the Ashes" (:title %))
                                                                     (:discard runner))))
                                         card nil))}]]
-     (run-event
-       {:move-zone (req (if (= [:discard] (:zone card))
-                          (register-events state side (assoc card :zone [:discard]) ashes-flag)
-                          (unregister-events state side card {:events [{:event :runner-phase-12}]})))}
-       nil))
+     {:async true
+      :makes-run true
+      :prompt "Choose a server"
+      :choices (req runnable-servers)
+      :effect (effect (make-run eid target nil card))
+      :move-zone (req (if (in-discard? card)
+                        (register-events state side (assoc card :zone [:discard]) ashes-flag)
+                        (unregister-events state side card {:events [{:event :runner-phase-12}]})))})
 
    "Paper Tripping"
-   {:msg "remove all tags" :effect (effect (lose-tags :all))}
+   {:msg "remove all tags"
+    :effect (effect (lose-tags :all))}
 
    "Peace in Our Time"
    {:req (req (not (:scored-agenda corp-reg)))
@@ -1780,33 +1831,37 @@
    (let [update-agenda-points (fn [state side target amount]
                                 (set-prop state side (get-card state target) :agendapoints (+ amount (:agendapoints (get-card state target))))
                                 (gain-agenda-point state side amount))]
-     {:req (req archives-runnable)
-      :events [{:event :purge
-                :effect (effect (trash card {:cause :purge}))}]
-      :trash-effect {:effect (req (let [current-side (get-scoring-owner state {:cid (:agenda-cid card)})]
-                                    (update-agenda-points state current-side (find-cid (:agenda-cid card) (get-in @state [current-side :scored])) 1)))}
+     {:async true
       :makes-run true
+      :req (req archives-runnable)
       :effect (effect (make-run
-                        :archives
+                        eid :archives
                         {:req (req (= target :archives))
                          :replace-access
-                         {:prompt "Select an agenda to host Political Graffiti"
-                          :mandatory true
+                         {:mandatory true
+                          :prompt "Select an agenda to host Political Graffiti"
                           :choices {:req #(in-corp-scored? state side %)}
                           :msg (msg "host Political Graffiti on " (:title target) " as a hosted condition counter")
                           :effect (req (host state :runner (get-card state target)
                                              ; keep host cid in :agenda-cid because `trash` will clear :host
-                                             (assoc card :zone [:discard] :installed true :agenda-cid (:cid (get-card state target))))
-                                       (update-agenda-points state :corp target -1))}} card))})
+                                             (assoc card :installed true :agenda-cid (:cid (get-card state target))))
+                                       (update-agenda-points state :corp target -1))}}
+                        card))
+      :events [{:event :purge
+                :effect (effect (trash card {:cause :purge}))}]
+      :trash-effect {:effect (req (let [current-side (get-scoring-owner state {:cid (:agenda-cid card)})]
+                                    (update-agenda-points state current-side
+                                                          (find-cid (:agenda-cid card) (get-in @state [current-side :scored]))
+                                                          1)))}})
 
    "Populist Rally"
    {:req (req (seq (filter #(has-subtype? % "Seedy") (all-active-installed state :runner))))
     :msg "give the Corp 1 fewer [Click] to spend on their next turn"
-    :effect (effect (lose :corp :click-per-turn 1)
-                    (register-events (assoc card :zone '(:discard))))
+    :effect (effect (lose :corp :click-per-turn 1))
     :events [{:event :corp-turn-ends
+              :duration :until-corp-turn-ends
               :effect (effect (gain :corp :click-per-turn 1)
-                              (unregister-events card))}]}
+                              (unregister-floating-events :until-corp-turn-ends))}]}
 
    "Power Nap"
    {:effect (effect (gain-credits (+ 2 (count (filter #(has-subtype? % "Double")
@@ -1814,19 +1869,41 @@
     :msg (msg "gain " (+ 2 (count (filter #(has-subtype? % "Double") (:discard runner)))) " [Credits]")}
 
    "Power to the People"
-   {:effect (effect (register-events
-                      (assoc card :zone '(:discard))
-                      [{:event :pre-steal-cost
-                        :once :per-turn
-                        :effect (effect (gain-credits 7))
-                        :msg "gain 7 [Credits]"}
-                       {:event :runner-turn-ends
-                        :effect (effect (unregister-events card {:event :pre-steal-cost}))}]))
-    :events [{:event :pre-steal-cost}
-             {:event :runner-turn-ends}]}
+   {:events [{:event :pre-steal-cost
+              :duration :end-of-turn
+              :once :per-turn
+              :msg "gain 7 [Credits]"
+              :effect (effect (gain-credits 7))}]}
 
    "Prey"
-   (run-event {:implementation "Ice trash is manual"} nil)
+   {:implementation "Ice trash is manual"
+    :async true
+    :makes-run true
+    :prompt "Choose a server:"
+    :choices (req runnable-servers)
+    :effect (effect (toast "Click this card to trash the passed ice")
+                    (make-run eid target nil card))
+    :abilities [{:label "Trash previous ice"
+                 :once :per-run
+                 :req (req (let [last-ice (nth run-ices run-position)]
+                             (and run
+                                (rezzed? last-ice)
+                                (<= (get-strength last-ice) (count (all-installed state :runner))))))
+                 :async true
+                 :msg (msg "trash " (card-str state (nth run-ices run-position)))
+                 :effect
+                 (effect
+                   (show-wait-prompt :corp "Runner to use Prey")
+                   (continue-ability
+                     (let [strength (get-strength (nth run-ices run-position))]
+                       {:prompt (str "Select " strength " installed cards")
+                        :choices {:req #(and (runner? %)
+                                             (installed? %))
+                                  :max strength
+                                  :all true}
+                        :effect (effect (clear-wait-prompt :runner)
+                                        (trash eid (nth run-ices run-position) nil))})
+                     card nil))}]}
 
    "Process Automation"
    {:msg "gain 2 [Credits] and draw 1 card"
@@ -1910,6 +1987,7 @@
    "Rebirth"
    {:msg "change identities"
     :prompt "Choose an identity to become"
+    :rfg-instead-of-trashing true
     :choices (req (let [is-draft-id? #(.startsWith (:code %) "00")
                         runner-identity (:identity runner)
                         is-swappable #(and (= "Identity" (:type %))
@@ -1922,7 +2000,6 @@
                    ;; Handle hosted cards (Ayla) - Part 1
                    (doseq [c (:hosted old-runner-identity)]
                      (move state side c :temp-hosted))
-                   (move state side (last (:discard runner)) :rfg)
                    (disable-identity state side)
                    ;; Manually reduce the runner's link by old link
                    (lose state :runner :link (:baselink old-runner-identity))
@@ -1943,32 +2020,38 @@
    "Reboot"
    (letfn [(install-cards [state side eid card to-install titles]
              (if-let [f (first to-install)]
-               (wait-for (runner-install state :runner (make-eid state {:source card :source-type :runner-install}) f {:facedown true :no-msg true})
+               (wait-for (runner-install state :runner f {:facedown true :no-msg true})
                          (install-cards state side eid card (rest to-install) titles))
                (do
                  (move state side (find-latest state card) :rfg)
                  (system-msg state :runner (str "uses Reboot to install " (join ", " titles) " facedown"))
                  (effect-completed state side eid))))]
-     {:req (req archives-runnable)
+     {:async true
       :makes-run true
+      :rfg-instead-of-trashing true
+      :req (req archives-runnable)
       :effect (effect
                 (make-run
-                  :archives
+                  eid :archives
                   {:req (req (= target :archives))
                    :replace-access
-                   {:prompt "Choose up to five cards to install"
+                   {:mandatory true
+                    :async true
+                    :prompt "Choose up to five cards to install"
                     :show-discard true
                     :choices {:max 5
-                              :req #(and (in-discard? %) (runner? %) (not (same-card? % card)))}
-                    :mandatory true
-                    :async true
-                    :cancel-effect (req (move state side (find-latest state card) :rfg)
-                                        (effect-completed state side eid))
-                    :effect (req (install-cards state side eid card targets (map :title targets)))}}
+                              :req #(and (in-discard? %)
+                                         (runner? %))}
+                    :effect (effect (install-cards eid card targets (map :title targets)))}}
                   card))})
 
    "Recon"
-   (run-event)
+   {:implementation "Jack out is manual"
+    :async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (make-run eid target nil card))}
 
    "Rejig"
    (let [valid-target? (fn [card] (and (runner? card)
@@ -2004,16 +2087,19 @@
                    (swap-ice state side (first targets) (second targets))))}
 
    "Retrieval Run"
-   {:req (req archives-runnable)
+   {:async true
     :makes-run true
+    :req (req archives-runnable)
     :effect (effect (make-run
-                      :archives
+                      eid :archives
                       {:req (req (= target :archives))
                        :replace-access
-                       {:prompt "Choose a program to install"
+                       {:async true
+                        :prompt "Choose a program to install"
                         :msg (msg "install " (:title target))
                         :choices (req (filter program? (:discard runner)))
-                        :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:ignore-all-cost true}))}}
+                        :effect (effect (runner-install (assoc eid :source card :source-type :runner-install)
+                                                        target {:ignore-all-cost true}))}}
                       card))}
 
    "Rigged Results"
@@ -2037,10 +2123,11 @@
                                        (continue-ability state :runner (choose-ice) card nil)
                                        (effect-completed state side eid))))})
            (choose-ice []
-             {:prompt "Select a piece of ICE to bypass"
+             {:async true
+              :prompt "Select a piece of ICE to bypass"
               :choices {:req ice?}
-              :msg (msg "bypass " (card-str state target))
-              :effect (effect (make-run (second (:zone target))))})]
+              :msg (msg "make a run and bypass " (card-str state target))
+              :effect (effect (make-run eid (second (:zone target)) nil card))})]
      {:async true
       :effect (req (show-wait-prompt state :corp "Runner to spend credits")
                 (let [all-amounts (range (min 3 (inc (get-in @state [:runner :credit]))))
@@ -2051,39 +2138,38 @@
                   (continue-ability state side (runner-choice choices) card nil)))})
 
    "Rip Deal"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
-    :effect (effect
-              (make-run
-                :hq {:req (req (= target :hq))
-                     :replace-access
-                     {:async true
-                      :effect
-                      (req (let [n (min (-> corp :hand count) (access-count state side :hq-access))
-                                 heap (-> runner :discard count (- 1))]
-                             (move state side (find-cid (:cid card) (:discard runner)) :rfg)
-                             (if (pos? heap)
-                               (continue-ability
-                                 state side
-                                 {:show-discard true
-                                  :prompt (str "Choose " (quantify (min n heap) "card") " to move from the Heap to your Grip")
-                                  :async true
-                                  :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
-                                  :choices {:max (min n heap)
-                                            :all true
-                                            :req #(and (runner? %)
-                                                       (in-discard? %))}
-                                  :effect (req (doseq [c targets]
-                                                 (move state side c :hand))
-                                               (do-access state side eid (:server run) {:hq-root-only true}))}
-                                 card nil)
-                               (continue-ability
-                                 state side
-                                 {:async true
-                                  :msg (msg "take no cards from their Heap to their Grip")
-                                  :effect (req (do-access state side eid (:server run) {:hq-root-only true}))}
-                                 card nil))))}}
-                card))}
+    :rfg-instead-of-trashing true
+    :req (req hq-runnable)
+    :effect
+    (effect (make-run
+              eid :hq
+              {:req (req (= target :hq))
+               :replace-access
+               {:async true
+                :effect
+                (effect
+                  (continue-ability
+                    (let [n (min (-> corp :hand count) (access-count state side :hq-access))
+                          heap (count (:discard runner))]
+                      (if (pos? heap)
+                        {:show-discard true
+                         :prompt (str "Choose " (quantify (min n heap) "card") " to move from the Heap to your Grip")
+                         :async true
+                         :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
+                         :choices {:max (min n heap)
+                                   :all true
+                                   :req #(and (runner? %)
+                                              (in-discard? %))}
+                         :effect (req (doseq [c targets]
+                                        (move state side c :hand))
+                                      (do-access state side eid (:server run) {:hq-root-only true}))}
+                        {:async true
+                         :msg (msg "take no cards from their Heap to their Grip")
+                         :effect (req (do-access state side eid (:server run) {:hq-root-only true}))}))
+                    card nil))}}
+              card nil))}
 
    "Rumor Mill"
    (letfn [(eligible? [card] (and (:uniqueness card)
@@ -2103,23 +2189,43 @@
                 :effect (effect (disable-card :corp target))}]})
 
    "Run Amok"
-   {:implementation "Ice trash is manual"
-    :prompt "Choose a server"
-    :choices (req runnable-servers)
-    :makes-run true
-    :effect (effect (make-run target {:end-run {:msg " trash 1 piece of ICE that was rezzed during the run"}} card))}
+   (letfn [(get-rezzed-cids [ice]
+             (map :cid (filter #(and (rezzed? %)
+                                     (ice? %))
+                               ice)))]
+     {:prompt "Choose a server"
+      :choices (req runnable-servers)
+      :makes-run true
+      :effect (effect (update! (assoc-in card [:special :run-amok] (get-rezzed-cids (all-installed state :corp))))
+                      (make-run eid target nil (get-card state card)))
+      :events [{:event :run-ends
+                :async true
+                :effect (req (let [new (set (get-rezzed-cids (all-installed state :corp)))
+                                   old (set (get-in (get-card state card) [:special :run-amok]))
+                                   diff-cid (seq (clojure.set/difference new old))
+                                   diff (map #(find-cid % (all-installed state :corp)) diff-cid)]
+                               (continue-ability
+                                 state side
+                                 (when (seq diff)
+                                   {:async true
+                                    :prompt "Select an ice to trash"
+                                    :choices {:req #(some (partial same-card? %) diff)
+                                              :all true}
+                                    :effect (effect (trash eid target nil))})
+                                 card nil)))}]})
 
    "Running Interference"
-   (run-event
-     nil
-     nil
-     nil
-     (effect (register-floating-effect
-               card
-               {:type :rez-additional-cost
-                :duration :end-of-run
-                :req (req (ice? target))
-                :value (req [:credit (:cost target)])})))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (register-floating-effect
+                      card
+                      {:type :rez-additional-cost
+                       :duration :end-of-run
+                       :req (req (ice? target))
+                       :value (req [:credit (:cost target)])})
+                    (make-run eid target nil card))}
 
    "Satellite Uplink"
    {:choices {:max 2 :req installed?}
@@ -2165,31 +2271,37 @@
               :effect (effect (update! (dissoc-in card [:special :scrubbed-target])))}]}
 
    "Showing Off"
-   {:req (req rd-runnable)
+   {:async true
     :makes-run true
+    :req (req rd-runnable)
     :effect (effect (make-run
-                      :rd
+                      eid :rd
                       {:replace-access
                        {:msg "access cards from the bottom of R&D"
                         :mandatory true
                         :async true
-                        :effect (effect (register-events (assoc card :zone '(:discard)))
-                                        (do-access eid (:server run)))}} card))
+                        :effect (effect (do-access eid (:server run)))}}
+                      card))
     :events [{:event :pre-access
               :silent (req true)
               :effect (req (swap! state assoc-in [:runner :rd-access-fn] reverse))}
              {:event :run-ends
-              :effect (req (swap! state assoc-in [:runner :rd-access-fn] seq)
-                           (unregister-events state side card))}]}
+              :effect (req (swap! state assoc-in [:runner :rd-access-fn] seq))}]}
 
    "Singularity"
-   (run-event
-     {:choices (req (filter #(can-run-server? state %) remotes))}
-     {:req (req (is-remote? target))
-      :replace-access {:mandatory true
-                       :msg "trash all cards in the server at no cost"
-                       :effect (req (doseq [c (:content run-server)]
-                                      (trash state side c)))}})
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req (filter #(can-run-server? state %) remotes))
+    :effect (effect (make-run
+                      eid target
+                      {:req (req (is-remote? target))
+                       :replace-access
+                       {:mandatory true
+                        :async true
+                        :msg "trash all cards in the server at no cost"
+                        :effect (effect (trash-cards eid (:content run-server)))}}
+                      card))}
 
    "Social Engineering"
    {:prompt "Select an unrezzed piece of ICE"
@@ -2203,17 +2315,18 @@
                                      card
                                      [{:event :rez
                                        :duration :end-of-turn
-                                       :req (req (= target ice))
+                                       :req (req (same-card? target ice))
                                        :msg (msg "gain " (rez-cost state side (get-card state target)) " [Credits]")
                                        :effect (effect (gain-credits :runner (rez-cost state side (get-card state target))))}]))})
                 card nil))}
 
    "Spear Phishing"
    {:implementation "Bypass is manual"
+    :async true
+    :makes-run true
     :prompt "Choose a server"
     :choices (req runnable-servers)
-    :makes-run true
-    :effect (effect (make-run target nil card))}
+    :effect (effect (make-run eid target nil card))}
 
    "Spec Work"
    {:async true
@@ -2236,7 +2349,9 @@
    "Spot the Prey"
    {:prompt "Select 1 non-ICE card to expose"
     :msg "expose 1 card and make a run"
-    :choices {:req #(and (installed? %) (not (ice? %)) (corp? %))}
+    :choices {:req #(and (installed? %)
+                         (not (ice? %))
+                         (corp? %))}
     :async true
     :makes-run true
     :effect (req (wait-for (expose state side target)
@@ -2249,12 +2364,16 @@
                              card nil)))}
 
    "Stimhack"
-   (run-event
-     nil
-     {:end-run {:msg "take 1 brain damage"
-                :effect (effect (damage eid :brain 1 {:unpreventable true
-                                                      :card card}))}}
-     (effect (gain-next-run-credits 9)))
+   {:async true
+    :makes-run true
+    :prompt "Choose a server"
+    :choices (req runnable-servers)
+    :effect (effect (gain-next-run-credits 9)
+                    (make-run eid target nil card))
+    :events [{:event :run-ends
+              :msg "take 1 brain damage"
+              :effect (effect (damage eid :brain 1 {:unpreventable true
+                                                    :card card}))}]}
 
    "Sure Gamble"
    {:msg "gain 9 [Credits]"
@@ -2296,8 +2415,7 @@
               :effect (effect (lose-credits :corp 1))}]}
 
    "System Seizure"
-   {:effect (req (register-events state side (assoc card :zone '(:discard))))
-    :events [{:event :pump-breaker
+   {:events [{:event :pump-breaker
               :once :per-turn
               :effect (req (let [last-pump (assoc (last (:effects @state)) :duration :end-of-run)]
                              (swap! state assoc :effects
@@ -2305,104 +2423,106 @@
                                          butlast
                                          (into [])
                                          (#(conj % last-pump)))))
-                           (update-breaker-strength state side target))}]
-    :move-zone (req (when (= [:discard] (:zone card))
-                      (unregister-events state side card)))}
+                           (update-breaker-strength state side target))}]}
 
    "Test Run"
-   (let [move-ability {:req (req (seq (filter #(get-in % [:special :test-run]) (all-active-installed state :runner))))
-                       :effect (req (doseq [program (filter #(get-in % [:special :test-run]) (all-active-installed state :runner))]
-                                      (move state side program :deck {:front true})
-                                      (system-msg state side (str "move " (:title program) " to the top of the Stack"))))}]
-     {:events [(assoc move-ability :event :corp-turn-ends)
-               (assoc move-ability :event :runner-turn-ends)]
-      :prompt "Install a program from your Stack or Heap?"
-      :choices ["Stack" "Heap"]
-      :msg (msg "install a program from their " target)
-      :effect (effect (register-events (assoc card :zone '(:discard)))
-                      (continue-ability
-                        (let [where target]
-                          {:prompt "Choose a program to install"
-                           :choices (req (cancellable
-                                           (filter program? ((if (= where "Heap") :discard :deck) runner))))
-                           :effect (effect (trigger-event :searched-stack nil)
-                                           (shuffle! :deck)
-                                           (runner-install (assoc eid :source card :source-type :runner-install)
-                                                           (assoc-in target [:special :test-run] true)
-                                                           {:ignore-all-cost true}))})
-                        card nil))})
+   {:prompt "Install a program from your Stack or Heap?"
+    :choices ["Stack" "Heap"]
+    :msg (msg "install a program from their " target)
+    :effect (effect
+              (continue-ability
+                (let [where target]
+                  {:prompt "Choose a program to install"
+                   :choices (req (cancellable
+                                   (filter program? ((if (= where "Heap") :discard :deck) runner))))
+                   :effect (effect (trigger-event :searched-stack nil)
+                                   (shuffle! :deck)
+                                   (register-events
+                                     card
+                                     (let [program target]
+                                       [{:event :runner-turn-ends
+                                         :duration :end-of-turn
+                                         :req (req (let [program (find-cid (:cid program) (all-installed state :runner))]
+                                                     (get-in program [:special :test-run])))
+                                         :msg (msg "move " (:title program) " to the top of the stack")
+                                         :effect (effect (move (find-cid (:cid program) (all-installed state :runner))
+                                                               :deck {:front true}))}]))
+                                   (runner-install (assoc eid :source card :source-type :runner-install)
+                                                   (assoc-in target [:special :test-run] true)
+                                                   {:ignore-all-cost true}))})
+                card nil))}
 
    "The Maker's Eye"
    {:req (req rd-runnable)
     :makes-run true
-    :effect (effect (make-run :rd nil card)
-                    (register-events (assoc card :zone '(:discard))))
+    :async true
+    :effect (effect (make-run eid :rd nil card))
     :events [{:event :successful-run
               :silent (req true)
               :req (req (= target :rd))
-              :effect (effect (access-bonus :rd 2))}
-             {:event :run-ends
-              :effect (effect (unregister-events card))}]}
+              :effect (effect (access-bonus :rd 2))}]}
 
    "The Noble Path"
    {:async true
-    :effect (req (doseq [c (:hand runner)]
-                   (trash state side c))
-                 (register-events
-                   state side card
-                   [{:event :pre-damage
-                     :duration :end-of-run
-                     :effect (effect (damage-prevent :net Integer/MAX_VALUE)
-                                     (damage-prevent :meat Integer/MAX_VALUE)
-                                     (damage-prevent :brain Integer/MAX_VALUE))}])
-                 (continue-ability
-                   state side
-                   {:prompt "Choose a server"
-                    :choices (req runnable-servers)
-                    :msg (msg "trash their Grip and make a run on " target ", preventing all damage")
-                    :effect (effect (make-run target nil card))}
-                   card nil))}
+    :makes-run true
+    :effect (req (wait-for (trash-cards state side eid (:hand runner) nil)
+                    (continue-ability
+                      state side
+                      {:async true
+                       :prompt "Choose a server"
+                       :choices (req runnable-servers)
+                       :msg (msg "trash their Grip and make a run on " target ", preventing all damage")
+                       :effect (effect (make-run eid target nil card))}
+                      card nil)))
+    :events [{:event :pre-damage
+              :duration :end-of-run
+              :effect (effect (damage-prevent :net Integer/MAX_VALUE)
+                              (damage-prevent :meat Integer/MAX_VALUE)
+                              (damage-prevent :brain Integer/MAX_VALUE))}]}
 
    "The Price of Freedom"
    {:additional-cost [:connection 1]
     :msg "prevent the Corp from advancing cards during their next turn"
-    :effect (effect (register-events (assoc card :zone '(:rfg)))
-                    (move (first (:play-area runner)) :rfg))
+    :rfg-instead-of-trashing true
     :events [{:event :corp-turn-begins
+              :duration :until-start-of-runner-turn
               :effect (effect (register-turn-flag!
                                 card :can-advance
                                 (fn [state side card]
                                   ((constantly false)
                                    (toast state :corp "Cannot advance cards this turn due to The Price of Freedom." "warning"))))
-                              (unregister-events card))}]}
+                              ;; This is a hack
+                              (unregister-floating-events :until-start-of-runner-turn))}]}
 
    "Three Steps Ahead"
-   {:effect (effect (register-events
-                      (assoc card :zone '(:discard))
-                      [{:event :runner-turn-ends
-                        :msg (msg "gain " (* 2 (count (:successful-run runner-reg))) " [Credits]")
-                        :effect (effect (gain-credits (* 2 (count (:successful-run runner-reg))))
-                                        (unregister-events card {:events [{:event :runner-turn-ends}]}))}]))}
+   {:events [{:event :runner-turn-ends
+              :duration :end-of-turn
+              :msg (msg "gain " (* 2 (count (:successful-run runner-reg))) " [Credits]")
+              :effect (effect (gain-credits (* 2 (count (:successful-run runner-reg)))))}]}
 
    "Tinkering"
-   {:prompt "Select a piece of ICE"
-    :choices {:req #(and (= (last (:zone %)) :ices) (ice? %))}
-    :effect (req (let [ice target
-                       serv (zone->name (second (:zone ice)))
-                       stypes (:subtype ice)]
-                   (resolve-ability
-                     state :runner
-                     {:msg (msg "make " (card-str state ice) " gain Sentry, Code Gate, and Barrier until the end of the turn")
-                      :effect (effect (update! (assoc ice :subtype (combine-subtypes true (:subtype ice) "Sentry" "Code Gate" "Barrier")))
-                                      (update-ice-strength (get-card state ice))
-                                      (add-icon card (get-card state ice) "T" "green")
-                                      (register-events
-                                        (assoc card :zone '(:discard))
-                                        [{:event :runner-turn-ends
-                                          :effect (effect (remove-icon card (get-card state ice))
-                                                          (update! (assoc (get-card state ice) :subtype stypes))
-                                                          (unregister-events card {:events [{:event :runner-turn-ends}]}))}]))}
-                     card nil)))}
+   {:req (req (some #(and (ice? %)
+                          (installed? %))
+                    (all-installed state :corp)))
+    :prompt "Select a piece of ICE"
+    :choices {:req #(and (installed? %)
+                         (ice? %))}
+    :msg (msg "make " (card-str state target) " gain Sentry, Code Gate, and Barrier until the end of the turn")
+    :effect (effect (update! (assoc target :subtype (combine-subtypes true (:subtype target) "Sentry" "Code Gate" "Barrier")))
+                    (update! (assoc-in (get-card state target) [:special :tinkering] true))
+                    (update-all-ice)
+                    (add-icon card (get-card state target) "T" "green")
+                    (register-events
+                      card
+                      (let [ice (get-card state target)
+                            stypes (:subtype target)]
+                        [{:event :runner-turn-ends
+                          :duration :end-of-turn
+                          :req (req (get-in (get-card state ice) [:special :tinkering]))
+                          :effect (effect (remove-icon card (get-card state ice))
+                                          (update! (assoc (get-card state ice) :subtype stypes))
+                                          (update! (dissoc-in (get-card state ice) [:special :tinkering]))
+                                          (update-all-ice))}])))}
 
    "Trade-In"
    ;; Basically a hack. Ideally the additional cost cause the cost trash to be passed in as targets
@@ -2449,53 +2569,56 @@
     :leave-play (effect (clear-turn-flag! card :can-install-ice))}
 
    "Vamp"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
+    :req (req hq-runnable)
     :effect (effect (make-run
-                      :hq {:req (req (= target :hq))
-                           :replace-access
-                           {:async true
-                            :prompt "How many [Credits]?"
-                            :choices :credit
-                            :msg (msg "take 1 tag and make the Corp lose " target " [Credits]")
-                            :effect (effect (lose-credits :corp target)
-                                            (gain-tags eid 1))}} card))}
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       {:async true
+                        :prompt "How many [Credits]?"
+                        :choices :credit
+                        :msg (msg "take 1 tag and make the Corp lose " target " [Credits]")
+                        :effect (effect (lose-credits :corp target)
+                                        (gain-tags eid 1))}}
+                      card))}
 
    "Wanton Destruction"
-   {:req (req hq-runnable)
+   {:async true
     :makes-run true
+    :req (req hq-runnable)
     :effect (effect (make-run
-                      :hq {:req (req (= target :hq))
-                           :replace-access
-                           {:msg (msg "force the Corp to discard " target " cards from HQ at random")
-                            :prompt "How many [Click] do you want to spend?"
-                            :choices (req (map str (range 1 (inc (:click runner)))))
-                            :effect (req (let [n (str->int target)]
-                                           (when (pay state :runner card :click n)
-                                             (trash-cards state :corp (take n (shuffle (:hand corp)))))))}} card))}
+                      eid :hq
+                      {:req (req (= target :hq))
+                       :replace-access
+                       {:msg (msg "force the Corp to discard " target " cards from HQ at random")
+                        :prompt "How many [Click] do you want to spend?"
+                        :choices (req (map str (range 1 (inc (:click runner)))))
+                        :effect (req (let [n (str->int target)]
+                                       (wait-for (pay-sync state :runner card :click n)
+                                                 (trash-cards state :corp eid (take n (shuffle (:hand corp)))))))}}
+                      card))}
 
    "Watch the World Burn"
-   (letfn [(rfg-card-event [burn-name]
+   (letfn [(rfg-card-event [burned-card]
              [{:event :pre-access-card
-               :req (req (= (:title target) burn-name))
-               :msg (msg (str "uses the previously played Watch the World Burn to remove " burn-name " from the game"))
-               :effect (req (move state :corp target :rfg))}])]
-     {:makes-run true
+               :duration :end-of-game
+               :req (req (same-card? :title burned-card target))
+               :msg (msg (str "remove " (:title burned-card) " from the game"))
+               :effect (effect (move :corp target :rfg))}])]
+     {:async true
+      :makes-run true
       :prompt "Choose a server"
       :choices (req (filter #(can-run-server? state %) remotes))
-      :effect (effect (make-run target nil card)
-                      (register-events (dissoc card :zone)))
+      :effect (effect (make-run eid target nil card))
       :events [{:event :pre-access-card
                 :req (req (and (not= (:type target) "Agenda")
-                               (get-in @state [:run :successful])))
+                               (:successful run)))
                 :once :per-run
-                :effect (req (let [t (:title target)]
-                               (system-msg state :runner (str "to remove " t " from the game, and watch for other copies of " t " to burn"))
-                               (move state :corp target :rfg)
-                               ;; in the below, the new :cid ensures that when unregister-events is called, the rfg-card-event is left alone
-                               (register-events state side (dissoc (assoc card :cid (make-cid)) :zone) (rfg-card-event t))))}
-               {:event :run-ends
-                :effect (effect (unregister-events (dissoc card :zone)))}]})
+                :msg (msg "remove " (:title target) " from the game, and watch for other copies of " (:title target) " to burn")
+                :effect (effect (move :corp target :rfg)
+                                (register-events card (rfg-card-event target)))}]})
 
    "White Hat"
    (letfn [(finish-choice [choices]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -31,28 +31,26 @@
                    card nil))}
 
    "Accelerated Diagnostics"
-   (letfn [(ad [i n adcard]
-             {:prompt "Select an operation to play"
-              :choices {:req #(and (corp? %)
-                                   (operation? %)
-                                   (in-play-area? %))}
-              :msg (msg "play " (:title target))
-              :async true
-              :effect (req (wait-for (play-instant state side target {:no-additional-cost true})
-                                     (if (and (not (get-in @state [:corp :register :terminal])) (< i n))
-                                       (continue-ability state side (ad (inc i) n adcard) adcard nil)
-                                       (effect-completed state side eid))))})]
+   (letfn [(ad [st si e c cards]
+             (when-let [cards (filterv #(and (operation? %)
+                                             (can-pay? st si e c nil [:credit (play-cost st si %)]))
+                                       cards)]
+               {:async true
+                :prompt "Select an operation to play"
+                :choices (cancellable cards)
+                :msg (msg "play " (:title target))
+                :effect (req (wait-for (play-instant state side target {:no-additional-cost true})
+                                       (let [cards (filterv #(not (same-card? % target)) cards)]
+                                         (continue-ability state side (ad state side eid card cards) card nil))))}))]
      {:async true
-      :implementation "Corp has to manually cards back to R&D to correctly play a draw operation"
-      :effect (req (let [n (count (filter operation?
-                                          (take 3 (:deck corp))))]
-                     (continue-ability state side
-                                       {:msg "look at the top 3 cards of R&D"
-                                        :async true
-                                        :effect (req (doseq [c (take 3 (:deck corp))]
-                                                       (move state side c :play-area))
-                                                     (continue-ability state side (ad 1 n card) card nil))}
-                                       card nil)))})
+      :effect
+      (effect
+        (continue-ability
+          (let [top (take 3 (:deck corp))]
+            {:prompt (str "The top 3 cards of R&D are " (join ", " (map :title top)) ".")
+             :choices ["OK"]
+             :effect (effect (continue-ability (ad state side eid card top) card nil))})
+          card nil))})
 
    "Ad Blitz"
    (let [abhelp (fn ab [n total]
@@ -74,7 +72,8 @@
       :effect (effect (continue-ability (abhelp 1 target) card nil))})
 
    "Aggressive Negotiation"
-   {:req (req (:scored-agenda corp-reg)) :prompt "Choose a card"
+   {:req (req (:scored-agenda corp-reg))
+    :prompt "Choose a card"
     :choices (req (cancellable (:deck corp) :sorted))
     :effect (effect (move target :hand)
                     (shuffle! :deck))
@@ -82,20 +81,23 @@
 
    "An Offer You Can't Refuse"
    {:async true
-    :prompt "Choose a server" :choices ["Archives" "R&D" "HQ"]
+    :prompt "Choose a server"
+    :choices ["Archives" "R&D" "HQ"]
     :effect (req (let [serv target]
                    (show-wait-prompt state :corp (str "Runner to decide on running " target))
                    (continue-ability
                      state side
                      {:optional
-                      {:prompt (msg "Make a run on " serv "?") :player :runner
-                       :yes-ability {:msg (msg "let the Runner make a run on " serv)
+                      {:prompt (str "Make a run on " serv "?")
+                       :player :runner
+                       :yes-ability {:msg (str "let the Runner make a run on " serv)
+                                     :async true
                                      :effect (effect (clear-wait-prompt :corp)
                                                      (make-run eid serv nil card))}
                        :no-ability {:async true
+                                    :msg "add it to their score area as an agenda worth 1 agenda point"
                                     :effect (req (clear-wait-prompt state :corp)
-                                                 (as-agenda state :corp eid (some #(when (same-card? card %) %) (:discard corp)) 1))
-                                    :msg "add it to their score area as an agenda worth 1 agenda point"}}}
+                                                 (as-agenda state :corp eid card 1))}}}
                      card nil)))}
 
    "Anonymous Tip"
@@ -269,7 +271,7 @@
                          (not (rezzed? %)))}
     :msg (msg "rez " (card-str state target {:visible true}) " at no cost")
     :effect (effect (rez target {:ignore-cost :all-costs})
-                    (host (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))}
+                    (host (get-card state target) (assoc card :seen true :condition true)))}
 
    "Biotic Labor"
    {:msg "gain [Click][Click]"
@@ -303,26 +305,25 @@
    {:choices {:req #(and (agenda? %)
                          (in-hand? %))}
     :async true
-    :effect (req (let [agenda target]
-                   (continue-ability
-                     state side {:prompt (str "Choose a server to install " (:title agenda))
-                                 :choices (installable-servers state agenda)
-                                 :effect (req (corp-install state side agenda target {:install-state :face-up})
-                                              ; find where the agenda ended up and host on it
-                                              (let [agenda (some #(when (same-card? % agenda) %)
-                                                                 (all-installed state :corp))]
-                                                ; the operation ends up in :discard when it is played; to host it,
-                                                ; we need (host) to look for it in discard.
-                                                (host state side agenda (assoc card
-                                                                               :zone [:discard]
-                                                                               :seen true
-                                                                               :installed true))
-                                                (system-msg state side (str "hosts Casting Call on " (:title agenda)))))}
-                     card nil)))
+    :effect (effect
+              (continue-ability
+                (let [agenda target]
+                  {:prompt (str "Choose a server to install " (:title agenda))
+                   :choices (installable-servers state agenda)
+                   :effect (req (corp-install state side agenda target {:install-state :face-up})
+                                ; find where the agenda ended up and host on it
+                                (let [agenda (some #(when (same-card? % agenda) %)
+                                                   (all-installed state :corp))]
+                                  (host state side agenda (assoc card
+                                                                 :seen true
+                                                                 :installed true))
+                                  (system-msg state side (str "hosts Casting Call on " (:title agenda)))))})
+                card nil))
     :events [{:event :access
-              :req (req (same-card? target (:host card)))
               :async true
-              :effect (effect (gain-tags :runner eid 2)) :msg "give the Runner 2 tags"}]}
+              :req (req (same-card? target (:host card)))
+              :msg "give the Runner 2 tags"
+              :effect (effect (gain-tags :runner eid 2))}]}
 
    "Celebrity Gift"
    {:choices {:max 5
@@ -410,13 +411,14 @@
     :effect (effect (purge))}
 
    "Death and Taxes"
-   (let [gain-cred-effect {:msg "gain 1 [Credits]"
-                           :effect (effect (gain-credits :corp 1))}]
-     {:implementation "Credit gain mandatory to save on wait-prompts, adjust credits manually if credit not wanted."
-      :events [(assoc gain-cred-effect :event :runner-install)
-               (assoc gain-cred-effect
-                      :event :runner-trash
-                      :req (req (installed? target)))]})
+   {:implementation "Credit gain mandatory to save on wait-prompts, adjust credits manually if credit not wanted."
+    :events [{:event :runner-install
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits :corp 1))}
+             {:event :runner-trash
+              :req (req (installed? target))
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits :corp 1))}]}
 
    "Dedication Ceremony"
    {:prompt "Select a faceup card"
@@ -478,7 +480,7 @@
 
    "Distract the Masses"
    (let [shuffle-two {:async true
-                      :effect (effect (rfg-and-shuffle-rd-effect eid (find-cid (:cid card) (:discard corp)) 2 nil))}
+                      :effect (effect (shuffle-into-rd-effect eid card 2 false))}
          trash-from-hq {:async true
                         :prompt "Select up to 2 cards in HQ to trash"
                         :choices {:max 2
@@ -488,8 +490,9 @@
                         :effect (req (wait-for
                                        (trash-cards state side targets nil)
                                        (continue-ability state side shuffle-two card nil)))
-                        :cancel-effect (req (continue-ability state side shuffle-two card nil))}]
+                        :cancel-effect (effect (continue-ability shuffle-two card nil))}]
      {:async true
+      :rfg-instead-of-trashing true
       :msg "give The Runner 2 [Credits]"
       :effect (effect (gain-credits :runner 2)
                       (continue-ability trash-from-hq card nil))})
@@ -548,7 +551,7 @@
       :msg (msg "give " (card-str state target {:visible false}) " additional text")
       :effect (req (add-extra-sub! state :corp (get-card state target) new-sub (:cid card))
                    (update-ice-strength state side target)
-                   (host state side (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))
+                   (host state side (get-card state target) (assoc card :seen true :condition true)))
       :leave-play (req (remove-extra-subs! state :corp (:cid card) (:host card)))
       :events [{:event :rez
                 :req (req (same-card? target (:host card)))
@@ -792,8 +795,8 @@
                                         card nil))})
 
    "Game Changer"
-   {:effect (req (gain state side :click (count (:scored runner)))
-                 (move state side (first (:play-area corp)) :rfg))}
+   {:rfg-instead-of-trashing true
+    :effect (effect (gain :click (count (:scored runner))))}
 
    "Game Over"
    {:req (req (last-turn? state :runner :stole-agenda))
@@ -836,8 +839,9 @@
    "Genotyping"
    {:async true
     :msg "trash the top 2 cards of R&D"
+    :rfg-instead-of-trashing true
     :effect (effect (mill :corp 2)
-                    (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) 4 false))}
+                    (shuffle-into-rd-effect eid card 4 false))}
 
    "Green Level Clearance"
    {:msg "gain 3 [Credits] and draw 1 card"
@@ -858,15 +862,16 @@
                         :async true
                         :prompt "Access card? (If not, add Hangeki to your score area worth -1 agenda point)"
                         :yes-ability
-                        {:effect (req (clear-wait-prompt state :corp)
+                        {:async true
+                         :effect (req (clear-wait-prompt state :corp)
                                       (wait-for (access-card state side target)
-                                                (move state :corp (find-latest state card) :rfg)
-                                                (system-msg state :corp "removes Hangeki from the game")
+                                                (update! state side (assoc card :rfg-instead-of-trashing true))
                                                 (effect-completed state side eid)))}
                         :no-ability
-                        {:msg "add it to the Runner's score area as an agenda worth -1 agenda point"
+                        {:async true
+                         :msg "add it to the Runner's score area as an agenda worth -1 agenda point"
                          :effect (effect (clear-wait-prompt :corp)
-                                         (as-agenda :runner eid (find-latest state card) -1))}}}
+                                         (as-agenda :runner eid card -1))}}}
                       card targets))}
 
    "Hard-Hitting News"
@@ -965,7 +970,8 @@
    "Housekeeping"
    {:events [{:event :runner-install
               :player :runner
-              :prompt "Select a card from your Grip to trash for Housekeeping" :once :per-turn
+              :once :per-turn
+              :prompt "Select a card from your Grip to trash for Housekeeping"
               :choices {:req #(and (runner? %)
                                    (in-hand? %))}
               :msg (msg "force the Runner to trash " (:title target) " from their Grip")
@@ -1074,8 +1080,8 @@
 
    "Load Testing"
    {:msg "make the Runner lose [Click] when their next turn begins"
-    :effect (effect (register-events (assoc card :zone '(:discard))))
     :events [{:event :runner-turn-begins
+              :duration :runner-turn-begins
               :msg "make the Runner lose [Click]"
               :effect (effect (lose :runner :click 1)
                               (unregister-events card))}]}
@@ -1130,21 +1136,23 @@
                          (has-subtype? % "Connection")
                          (installed? %))}
     :msg (msg "host it on " (card-str state target) ". The Runner has an additional tag")
-    :effect (req (host state side (get-card state target) (assoc card :zone [:discard] :seen true))
+    :effect (req (host state side (get-card state target) (assoc card :seen true))
                  (swap! state update-in [:runner :tag :additional] inc)
                  (trigger-event state :corp :runner-additional-tag-change 1))
     :leave-play (req (swap! state update-in [:runner :tag :additional] dec)
                      (trigger-event state :corp :runner-additional-tag-change 1)
                      (system-msg state :corp "trashes MCA Informant"))
     :runner-abilities [{:label "Trash MCA Informant host"
-                        :cost [:credit 2 :click 1]
+                        :cost [:click 1 :credit 2]
                         :req (req (= :runner side))
-                        :effect (effect (system-msg :runner (str "spends [Click] and 2 [Credits] to trash " (card-str state (:host card))))
+                        :effect (effect (system-msg :runner (str "spends [Click] and 2 [Credits] to trash "
+                                                                 (card-str state (:host card))))
                                         (trash :runner eid (get-card state (:host card)) nil))}]}
 
    "Medical Research Fundraiser"
    {:msg "gain 8 [Credits]. The Runner gains 3 [Credits]"
-    :effect (effect (gain-credits 8) (gain-credits :runner 3))}
+    :effect (effect (gain-credits 8)
+                    (gain-credits :runner 3))}
 
    "Midseason Replacements"
    {:req (req (last-turn? state :runner :stole-agenda))
@@ -1270,7 +1278,8 @@
 
    "Paywall Implementation"
    {:events [{:event :successful-run
-              :msg "gain 1 [Credits]" :effect (effect (gain-credits :corp 1))}]}
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits :corp 1))}]}
 
    "Peak Efficiency"
    {:msg (msg "gain " (reduce (fn [c server]
@@ -1334,7 +1343,9 @@
               :effect (effect (steal-cost-bonus [:credit 2]))}]}
 
    "Preemptive Action"
-   {:effect (effect (rfg-and-shuffle-rd-effect eid (first (:play-area corp)) (min (count (:discard corp)) 3) true))}
+   {:async true
+    :rfg-instead-of-trashing true
+    :effect (effect (shuffle-into-rd-effect eid card 3 true))}
 
    "Priority Construction"
    (letfn [(install-card [chosen]
@@ -1614,25 +1625,24 @@
    "Riot Suppression"
    {:req (req (last-turn? state :runner :trashed-card))
     :async true
-    :effect (req (let [c card]
-                   (show-wait-prompt state :corp "Runner to decide if they will take 1 brain damage")
-                   (continue-ability
-                     state :runner
-                     {:optional
-                      {:prompt "Take 1 brain damage to prevent having 3 fewer clicks next turn?"
-                       :player :runner
-                       :end-effect (req (clear-wait-prompt state :corp)
-                                        (move state :corp (find-latest state c) :rfg))
-                       :yes-ability
-                       {:async true
-                        :effect (req (system-msg
-                                       state :runner
-                                       "suffers 1 brain damage to prevent losing 3[Click] to Riot Suppression")
-                                     (damage state :runner eid :brain 1 {:card card}))}
-                       :no-ability
-                       {:msg "give the runner 3 fewer [Click] next turn"
-                        :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil #(- % 3) 0)))}}}
-                     card nil)))}
+    :rfg-instead-of-trashing true
+    :effect (effect (show-wait-prompt :corp "Runner to decide if they will take 1 brain damage")
+                    (continue-ability
+                      (let [c card]
+                        {:optional
+                         {:prompt "Take 1 brain damage to prevent having 3 fewer clicks next turn?"
+                          :player :runner
+                          :end-effect (effect (clear-wait-prompt :corp))
+                          :yes-ability
+                          {:async true
+                           :effect (req (system-msg
+                                          state :runner
+                                          "suffers 1 brain damage to prevent losing 3[Click] to Riot Suppression")
+                                        (damage state :runner eid :brain 1 {:card card}))}
+                          :no-ability
+                          {:msg "give the runner 3 fewer [Click] next turn"
+                           :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil #(- % 3) 0)))}}})
+                      card nil))}
 
    "Rolling Brownout"
    {:msg "increase the play cost of operations and events by 1 [Credits]"
@@ -1644,9 +1654,10 @@
               :effect (effect (gain-credits :corp 1))}]}
 
    "Rover Algorithm"
-   {:choices {:req #(and (ice? %) (rezzed? %))}
+   {:choices {:req #(and (ice? %)
+                         (rezzed? %))}
     :msg (msg "host it as a condition counter on " (card-str state target))
-    :effect (effect (host target (assoc card :zone [:discard] :seen true :condition true))
+    :effect (effect (host target (assoc card :seen true :condition true))
                     (update-ice-strength (get-card state target)))
     :constant-effects [{:type :ice-strength
                         :req (req (same-card? target (:host card)))
@@ -1849,12 +1860,13 @@
      {:sub-effect {:label "End the run"
                    :msg "end the run"
                    :effect (effect (end-run eid card))}
-      :choices {:req #(and (ice? %) (rezzed? %))}
+      :choices {:req #(and (ice? %)
+                           (rezzed? %))}
       :msg (msg "make " (card-str state target) " gain Barrier and \"[Subroutine] End the run\"")
       :effect (req (update! state side (assoc target :subtype (combine-subtypes true (:subtype target) "Barrier")))
                    (add-extra-sub! state :corp (get-card state target) new-sub (:cid card))
                    (update-ice-strength state side target)
-                   (host state side (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))
+                   (host state side (get-card state target) (assoc card :seen true :condition true)))
       :leave-play (req (remove-extra-subs! state :corp (:cid card) (:host card)))
       :events [{:event :rez
                 :req (req (same-card? target (:host card)))
@@ -1877,33 +1889,30 @@
       :effect (effect (continue-ability (sc 1 card) card nil))})
 
    "Subliminal Messaging"
-   (letfn [(subliminal []
-             [{:event :corp-phase-12
-               :effect
-               (req (if (not-last-turn? state :runner :made-run)
-                      (do (resolve-ability state side
-                                           {:optional
-                                            {:prompt "Add Subliminal Messaging to HQ?"
-                                             :yes-ability {:effect (req (move state side card :hand)
-                                                                        (system-msg state side "adds Subliminal Messaging to HQ"))}
-                                             :no-ability {:effect (effect (register-events (assoc card :zone '(:discard)) (subliminal)))}}}
-                                           card nil)
-                          (unregister-events state side card))
-                      (do (unregister-events state side card)
-                          (resolve-ability state side
-                                           {:effect (effect (register-events (assoc card :zone '(:discard)) (subliminal)))}
-                                           card nil))))}])]
+   (let [subliminal [{:event :corp-phase-12
+                      :async true
+                      :effect
+                      (effect
+                        (continue-ability
+                          (when (not-last-turn? state :runner :made-run)
+                            {:optional
+                             {:prompt "Add Subliminal Messaging to HQ?"
+                              :yes-ability
+                              {:msg "add Subliminal Messaging to HQ"
+                               :effect (effect (move card :hand)
+                                               (unregister-events card {:events [{:event :corp-phase-12}]}))}}})
+                          card nil))}]]
      {:msg "gain 1 [Credits]"
       :effect (effect (gain-credits 1)
-                      (resolve-ability {:once :per-turn
-                                        :once-key :subliminal-messaging
-                                        :msg "gain [Click]"
-                                        :effect (effect (gain :corp :click 1))}
-                                       card nil))
-      :move-zone (req (if (= [:discard] (:zone card))
-                        (register-events state side (assoc card :zone '(:discard)) (subliminal))
-                        (unregister-events state side card)))
-      :events [{:event :corp-phase-12}]})
+                      (continue-ability
+                        {:once :per-turn
+                         :once-key :subliminal-messaging
+                         :msg "gain [Click]"
+                         :effect (effect (gain :corp :click 1))}
+                        card nil))
+      :move-zone (req (if (in-discard? card)
+                        (register-events state side (assoc card :zone '(:discard)) subliminal)
+                        (unregister-events state side card {:events [{:event :corp-phase-12}]})))})
 
    "Success"
    {:additional-cost [:forfeit]
@@ -1947,13 +1956,13 @@
     :msg (msg "gain " (count (:hand runner)) " [Credits]")}
 
    "Targeted Marketing"
-   (let [gaincr {:req (req (= (:title target) (:marketing-target card)))
+   (let [gaincr {:req (req (= (:title target) (get-in card [:special :marketing-target])))
                  :effect (effect (gain-credits :corp 10))
                  :msg (msg "gain 10 [Credits] from " (:marketing-target card))}]
      {:prompt "Name a Runner card"
       :choices {:card-title (req (and (runner? target)
                                       (not (identity? target))))}
-      :effect (effect (update! (assoc card :marketing-target target))
+      :effect (effect (update! (assoc-in card [:special :marketing-target] target))
                       (system-msg (str "uses Targeted Marketing to name " target)))
       :events [(assoc gaincr :event :runner-install)
                (assoc gaincr :event :play-event)]})
@@ -1979,25 +1988,26 @@
    "Threat Assessment"
    {:req (req (last-turn? state :runner :trashed-card))
     :prompt "Select an installed Runner card"
-    :choices {:req #(and (runner? %) (installed? %))}
+    :choices {:req #(and (runner? %)
+                         (installed? %))}
+    :rfg-instead-of-trashing true
     :async true
-    :effect (req (let [chosen target]
-                   (show-wait-prompt state side "Runner to resolve Threat Assessment")
-                   (continue-ability
-                     state :runner
-                     {:prompt (str "Add " (:title chosen) " to the top of the Stack or take 2 tags?")
-                      :choices [(str "Move " (:title chosen))
-                                "Take 2 tags"]
-                      :async true
-                      :effect (req (clear-wait-prompt state :corp)
-                                   (move state :corp (last (:discard corp)) :rfg)
-                                   (if (.startsWith target "Move")
-                                     (do (system-msg state side (str "chooses to move " (:title chosen) " to the Stack"))
-                                         (move state :runner chosen :deck {:front true})
-                                         (effect-completed state side eid))
-                                     (do (system-msg state side "chooses to take 2 tags")
-                                         (gain-tags state :runner eid 2))))}
-                     card nil)))}
+    :effect (effect (show-wait-prompt "Runner to resolve Threat Assessment")
+                    (continue-ability
+                      :runner
+                      (let [chosen target]
+                        {:prompt (str "Add " (:title chosen) " to the top of the Stack or take 2 tags?")
+                         :choices [(str "Move " (:title chosen))
+                                   "Take 2 tags"]
+                         :async true
+                         :effect (req (clear-wait-prompt state :corp)
+                                      (if (= target "Take 2 tags")
+                                        (do (system-msg state side "chooses to take 2 tags")
+                                            (gain-tags state :runner eid 2))
+                                        (do (system-msg state side (str "chooses to move " (:title chosen) " to the Stack"))
+                                            (move state :runner chosen :deck {:front true})
+                                            (effect-completed state side eid))))})
+                      card nil))}
 
    "Threat Level Alpha"
    {:trace {:base 1
@@ -2129,7 +2139,9 @@
    {:req (req (last-turn? state :runner :trashed-card))
     :prompt "Select a piece of hardware or non-virtual resource"
     :choices {:req #(or (hardware? %)
-                        (and (resource? %) (not (has-subtype? % "Virtual"))))}
+                        (and (resource? %)
+                             (not (has-subtype? % "Virtual"))))}
+    :rfg-instead-of-trashing true
     :async true
     :effect (effect (show-wait-prompt "Runner to resolve Wake Up Call")
                     (continue-ability
@@ -2141,7 +2153,6 @@
                                    "4 meat damage"]
                          :async true
                          :effect (req (clear-wait-prompt state :corp)
-                                      (move state :corp (last (:discard corp)) :rfg)
                                       (if (= target "4 meat damage")
                                         (do (system-msg state side "chooses to suffer meat damage")
                                             (damage state side eid :meat 4 {:card wake
@@ -2158,7 +2169,7 @@
       :msg (msg "give " (card-str state target) " \"[Subroutine] Do 1 brain damage\" before all its other subroutines")
       :sub-effect (do-brain-damage 1)
       :effect (req (add-extra-sub! state :corp target new-sub (:cid card) {:front true})
-                   (host state side (get-card state target) (assoc card :zone [:discard] :seen true :condition true)))
+                   (host state side (get-card state target) (assoc card :seen true :condition true)))
       :leave-play (req (remove-extra-subs! state :corp (:host card) (:cid card)))
       :events [{:event :rez
                 :req (req (same-card? target (:host card)))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -203,8 +203,11 @@
                  :msg (msg "play " (:title target) " from Archives, ignoring all costs, and removes it from the game")
                  :choices (req (cancellable (filter #(and (operation? %)
                                                           (has-subtype? % "Transaction")) (:discard corp)) :sorted))
-                 :effect (effect (play-instant nil (assoc-in target [:special :rfg-when-trashed] true) {:ignore-cost true})
-                                 (move target :rfg))}]}
+                 :async true
+                 :effect (effect (play-instant eid (-> target
+                                                       (assoc :rfg-instead-of-trashing true)
+                                                       (assoc-in [:special :rfg-when-trashed] true))
+                                               {:ignore-cost true}))}]}
 
    "Calibration Testing"
    {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -526,7 +526,7 @@
   ([state side eid card n all?]
    (continue-ability state side
                     {:show-discard  true
-                     :choices {:max n
+                     :choices {:max (min (-> @state :corp :discard count) n)
                                :req #(and (corp? %)
                                           (in-discard? %))
                                :all all?}
@@ -542,10 +542,3 @@
                                   (shuffle! state side :deck))
                      :cancel-effect (req (shuffle! state side :deck))}
                     card nil)))
-
-(defn rfg-and-shuffle-rd-effect
-  ([state side card n] (rfg-and-shuffle-rd-effect state side (make-eid state) card n false))
-  ([state side card n all?] (rfg-and-shuffle-rd-effect state side (make-eid state) card n all?))
-  ([state side eid card n all?]
-   (move state side card :rfg)
-   (shuffle-into-rd-effect state side eid card n all?)))

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -258,11 +258,12 @@
   (when-let [current (first (get-in @state [current-side :current]))] ; trash old current
     (trigger-event state side :trash-current current)
     (unregister-constant-effects state side current)
-    (if (get-in current [:special :rfg-when-trashed])
-      (do (system-say state side (str (:title current) " is removed from the game."))
-          (move state (other-side side) current :rfg))
-      (do (system-say state side (str (:title current) " is trashed."))
-          (trash state (to-keyword (:side current)) current)))))
+    (let [current (get-card state current)]
+      (if (get-in current [:special :rfg-when-trashed])
+        (do (system-say state side (str (:title current) " is removed from the game."))
+            (move state (other-side side) current :rfg))
+        (do (system-say state side (str (:title current) " is trashed."))
+            (trash state (to-keyword (:side current)) current))))))
 
 ;;; Functions for icons associated with special cards - e.g. Femme Fatale
 (defn add-icon

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -156,6 +156,10 @@
   ([state side eid args]
    (turn-message state side true)
    (wait-for (trigger-event-simult state side (if (= side :corp) :corp-turn-begins :runner-turn-begins) nil nil)
+             (unregister-floating-effects state side :start-of-turn)
+             (unregister-floating-events state side :start-of-turn)
+             (unregister-floating-effects state side (if (= side :corp) :until-corp-turn-begins :until-runner-turn-begins))
+             (unregister-floating-events state side (if (= side :corp) :until-corp-turn-begins :until-runner-turn-begins))
              (when (= side :corp)
                (wait-for (draw state side 1 nil)
                          (trigger-event-simult state side eid :corp-mandatory-draw nil nil)))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -239,6 +239,8 @@
                (swap! state assoc-in [side :register-last-turn] (-> @state side :register))
                (unregister-floating-effects state side :end-of-turn)
                (unregister-floating-events state side :end-of-turn)
+               (unregister-floating-effects state side (if (= side :runner) :until-runner-turn-ends :until-corp-turn-ends))
+               (unregister-floating-events state side (if (= side :runner) :until-runner-turn-ends :until-corp-turn-ends))
                (doseq [card (all-active-installed state :runner)]
                  ;; Clear :installed :this-turn as turn has ended
                  (when (= :this-turn (installed? card))

--- a/src/clj/tasks/split_tests.clj
+++ b/src/clj/tasks/split_tests.clj
@@ -12,11 +12,14 @@
        sort
        (map slurp)))
 
+
 (defn extract-tests []
   (let [header (string/join
                  "\n"
                  ["(ns game-test.cards.%s.%s"
                   "  (:require [game.core :as core]"
+                  "            [game.core.card :refer :all]"
+                  "            [game.utils :as utils]"
                   "            [game-test.core :refer :all]"
                   "            [game-test.utils :refer :all]"
                   "            [game-test.macros :refer :all]"
@@ -58,6 +61,7 @@
                  "\n"
                  ["(ns game-test.cards.%s"
                   "  (:require [game.core :as core]"
+                  "            [game.core.card :refer :all]"
                   "            [game.utils :as utils]"
                   "            [game-test.core :refer :all]"
                   "            [game-test.utils :refer :all]"

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -962,7 +962,8 @@
            (map-indexed (fn [i card]
                           [:div.card-wrapper {:key i
                                               :style {:left (when (> size 1) (* (/ 128 size) i))}}
-                           (if (this-user? @user)
+                           (if (or (:seen card)
+                                   (this-user? @user))
                              [card-view card]
                              [facedown-card (:side card)])])
                         @cards))
@@ -1722,8 +1723,8 @@
                     [starting-timestamp]
                     [rfg-view op-rfg "Removed from the game" true]
                     [rfg-view me-rfg "Removed from the game" true]
-                    [play-area-view op-user "Temporary Zone" op-play-area]
-                    [play-area-view me-user "Temporary Zone" me-play-area]
+                    [play-area-view op-user "Play Area" op-play-area]
+                    [play-area-view me-user "Play Area" me-play-area]
                     [rfg-view op-current "Current" false]
                     [rfg-view me-current "Current" false]])
                  (when-not (= @side :spectator)

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -7,1120 +7,6 @@
             [game-test.macros :refer :all]
             [clojure.test :refer :all]))
 
-(deftest build-script
-  ;; Build Script
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck [(qty "Sure Gamble" 5)]
-                        :hand ["Build Script"]}})
-    (take-credits state :corp)
-    (let [credits (:credit (get-runner))
-          hand (dec (count (:hand (get-runner))))]
-      (play-from-hand state :runner "Build Script")
-      (is (= (inc credits) (:credit (get-runner))) "Gained 1 credit")
-      (is (= (+ 2 hand) (count (:hand (get-runner)))) "Drew 2 cards"))))
-
-(deftest calling-in-favors
-  ;; Calling in Favors
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand [(qty "Calling in Favors" 3) (qty "Aeneas Informant" 5) "Algo Trading"]}})
-    (take-credits state :corp)
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Calling in Favors")
-      (is (= credits (:credit (get-runner))) "Don't gain credits with nothing installed"))
-    (core/gain state :runner :click 10)
-    (dotimes [_ 5]
-      (play-from-hand state :runner "Aeneas Informant"))
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Calling in Favors")
-      (is (= (+ 5 credits) (:credit (get-runner))) "Gain 5 credits from 5 connections"))
-    (play-from-hand state :runner "Algo Trading")
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Calling in Favors")
-      (is (= (+ 5 credits) (:credit (get-runner))) "Gain 5 credits from 5 connections and 1 non-connection resource"))))
-
-(deftest career-fair
-  ;; Career Fair
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand [(qty "Career Fair" 2) "Caldera" "Beach Party"]
-                        :credits 0}})
-    (take-credits state :corp)
-    (is (zero? (:credit (get-runner))) "Start with 0 credits")
-    (play-from-hand state :runner "Career Fair")
-    (click-card state :runner "Caldera")
-    (is (= "Caldera" (:title (get-resource state 0))) "Caldera is installed for free")
-    (play-from-hand state :runner "Career Fair")
-    (click-card state :runner "Beach Party")
-    (is (= "Beach Party" (:title (get-resource state 1))) "Beach Party is installed for free")
-    (is (zero? (:credit (get-runner))) "Discount doesn't provide money")))
-
-(deftest code-siphon
-  ;; Code Siphon
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Ice Wall" 2)]}
-               :runner {:deck [(qty "Mass-Driver" 2)]
-                        :hand [(qty "Code Siphon" 2)]
-                        :credits 10}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Code Siphon")
-    (run-successful state)
-    (click-prompt state :runner "Code Siphon")
-    (let [credits (:credit (get-runner))
-          tags (count-tags state)]
-      (click-prompt state :runner "Mass-Driver")
-      (is (= "Mass-Driver" (:title (get-program state 0))) "Mass-Driver is installed")
-      (is (= (- credits 8) (:credit (get-runner))) "Runner pays full 8 for Mass-Driver")
-      (is (= (inc tags) (count-tags state)) "Gained 1 tag"))
-    (take-credits state :runner)
-    (play-from-hand state :corp "Ice Wall" "R&D")
-    (play-from-hand state :corp "Ice Wall" "R&D")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Code Siphon")
-    (run-continue state)
-    (run-continue state)
-    (run-successful state)
-    (is (= ["Code Siphon" "Access cards"] (-> (get-runner) :prompt first :choices))
-        "Replacement effect isn't mandatory")
-    (click-prompt state :runner "Code Siphon")
-    (let [credits (:credit (get-runner))]
-      (click-prompt state :runner "Mass-Driver")
-      (is (= "Mass-Driver" (:title (get-program state 1))) "Mass-Driver is installed")
-      (is (= (- credits 2) (:credit (get-runner))) "Runner pays discounted cost for Mass-Driver"))))
-
-(deftest credit-crash
-  ;; Credit Crash
-  (testing "Corp pays to keep"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-                 :runner {:hand ["Credit Crash"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Credit Crash")
-      (click-prompt state :runner "HQ")
-      (run-successful state)
-      (let [credits (:credit (get-corp))
-            discard (count (:discard (get-corp)))]
-        (click-prompt state :corp "Yes")
-        (is (= (- credits 5) (:credit (get-corp))) "Corp paid 5 credits to save Hedge Fund")
-        (is (= discard (count (:discard (get-corp)))) "Corp has no cards trashed"))
-      (click-prompt state :runner "No action")))
-  (testing "Corp doesn't pay to keep"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-                 :runner {:hand ["Credit Crash"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Credit Crash")
-      (click-prompt state :runner "HQ")
-      (run-successful state)
-      (let [credits (:credit (get-corp))
-            discard (count (:discard (get-corp)))]
-        (click-prompt state :corp "No")
-        (is (= credits (:credit (get-corp))) "Corp doesn't pay 5 credits to save Hedge Fund")
-        (is (= (inc discard) (count (:discard (get-corp)))) "Corp has 1 card trashed"))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompts"))))
-
-(deftest cyber-threat
-  ;; Cyber Threat
-  (testing "Corp rezzes a piece of ice"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Cyber Threat"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Cyber Threat")
-      (click-prompt state :runner "HQ")
-      (click-prompt state :corp "Yes")
-      (let [iw (get-ice state :hq 0)
-            credits (:credit (get-corp))]
-        (click-card state :corp "Ice Wall")
-        (is (rezzed? (refresh iw)) "Ice Wall is rezzed")
-        (is (= (dec credits) (:credit (get-corp))) "Corp paid to rez Ice Wall"))))
-  (testing "Corp doesn't rez a piece of ice"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Cyber Threat"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Cyber Threat")
-      (click-prompt state :runner "HQ")
-      (click-prompt state :corp "No")
-      (let [iw (get-ice state :hq 0)]
-        (is (:run @state) "Run has been initiated")
-        (core/rez state :corp iw)
-        (is (not (rezzed? (refresh iw))) "Corp can't rez ice this run")))))
-
-(deftest day-job
-  ;; Day Job
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Day Job"]}})
-    (take-credits state :corp)
-    (let [credits (:credit (get-runner))
-          clicks (:click (get-runner))]
-      (play-from-hand state :runner "Day Job")
-      (is (= (+ credits -2 10) (:credit (get-runner))) "Runner spends 2, gains 10")
-      (is (zero? (:click (get-runner))) "Runner loses 4 clicks"))))
-
-(deftest deep-data-mining
-  ;; Deep Data Mining
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hedge Fund"]}
-               :runner {:hand [(qty "Deep Data Mining" 2) "Magnum Opus"]
-                        :credits 15}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Deep Data Mining")
-    (run-successful state)
-    (dotimes [_ 5] ; 1 normal access, 4 extra accesses from DDM
-      (click-prompt state :runner "Card from deck")
-      (click-prompt state :runner "No action"))
-    (play-from-hand state :runner "Magnum Opus")
-    (play-from-hand state :runner "Deep Data Mining")
-    (run-successful state)
-    (dotimes [_ 3] ; 1 normal access, 2 extra accesses from DDM because Magnum Opus takes 2 MU
-      (click-prompt state :runner "Card from deck")
-      (click-prompt state :runner "No action"))
-    (is (empty? (:prompt (get-runner))) "No more accesses after 3")))
-
-(deftest diana-s-hunt
-  ;; Diana's Hunt
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall"]}
-               :runner {:hand ["Diana's Hunt" "Mass-Driver"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Diana's Hunt")
-    (click-prompt state :runner "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (card-ability state :runner (get-run-event state 0) 0)
-    (click-card state :runner "Mass-Driver")
-    (is (= "Mass-Driver" (:title (get-program state 0))) "Mass-Driver is installed")
-    (run-successful state)
-    (is (not (get-program state 0)) "Mass-Driver is uninstalled")
-    (is (= "Mass-Driver" (:title (get-discarded state :runner 0))) "Mass-Driver is in the heap")))
-
-(deftest diesel
-  ;; Diesel
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck [(qty "Sure Gamble" 5)]
-                        :hand ["Diesel"]}})
-    (take-credits state :corp)
-    (let [hand (count (:hand (get-runner)))]
-      (play-from-hand state :runner "Diesel")
-      (is (= (+ hand -1 3) (count (:hand (get-runner)))) "Runner plays Diesel and draws 3 cards"))))
-
-(deftest easy-mark
-  ;; Easy Mark
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Easy Mark"]}})
-    (take-credits state :corp)
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Easy Mark")
-      (is (= (+ 3 credits) (:credit (get-runner))) "Runner has gained 3 credits"))))
-
-(deftest emergency-shutdown
-  ;; Emergency Shutdown
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall"]}
-               :runner {:hand ["Emergency Shutdown"]}})
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (let [iw (get-ice state :remote1 0)]
-      (core/rez state :corp iw)
-      (is (rezzed? (refresh iw)) "Ice Wall is rezzed")
-      (take-credits state :corp)
-      (run-empty-server state :archives)
-      (play-from-hand state :runner "Emergency Shutdown")
-      (is (empty? (:prompt (get-runner))) "Runner has no derez prompt")
-      (run-empty-server state :hq)
-      (play-from-hand state :runner "Emergency Shutdown")
-      (is (seq (:prompt (get-runner))) "Runner has a derez prompt")
-      (click-card state :runner (refresh iw))
-      (is (not (rezzed? (refresh iw))) "Ice Wall is derezzed"))))
-
-(deftest en-passant
-  ;; En Passant
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Ice Wall" 2)]}
-               :runner {:hand [(qty "En Passant" 2)]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (take-credits state :corp)
-    (let [iw (get-ice state :hq 0)
-          iw2 (get-ice state :remote1 0)]
-      (run-on state :hq)
-      (run-continue state)
-      (run-successful state)
-      (play-from-hand state :runner "En Passant")
-      (click-card state :runner (refresh iw2))
-      (is (refresh iw2) "Ice Wall on the remote hasn't been trashed")
-      (core/rez state :corp iw)
-      (is (refresh iw) "Ice Wall on HQ hasn't been trashed as it's rezzed")
-      (core/derez state :corp iw)
-      (click-card state :runner (refresh iw))
-      (is (not (refresh iw)) "Ice Wall on HQ has been trashed")
-      (play-from-hand state :runner "En Passant")
-      (is (empty? (:prompt (get-runner))) "Runner has no prompt as En Passant can't be played"))))
-
-(deftest escher
-  ;; Escher
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall" "Enigma" "IP Block" "Data Raven"]
-                      :credits 20}
-               :runner {:hand ["Escher"]}})
-    (core/gain state :corp :click 1)
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Enigma" "New remote")
-    (play-from-hand state :corp "IP Block" "New remote")
-    (play-from-hand state :corp "Data Raven" "New remote")
-    (core/rez state :corp (get-ice state :remote1 0))
-    (core/rez state :corp (get-ice state :remote2 0))
-    (core/rez state :corp (get-ice state :remote3 0))
-    (core/rez state :corp (get-ice state :remote4 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Escher")
-    (is (= [:hq] (:server (:run @state))) "Run is on HQ")
-    (run-successful state)
-    (click-card state :runner "Ice Wall")
-    (click-card state :runner "IP Block")
-    (click-card state :runner "Enigma")
-    (click-card state :runner "Data Raven")
-    (click-prompt state :runner "Done")
-    (is (= "IP Block" (:title (get-ice state :remote1 0))) "IP Block has moved")
-    (is (= "Data Raven" (:title (get-ice state :remote2 0))) "Data Raven has moved")
-    (is (= "Ice Wall" (:title (get-ice state :remote3 0))) "Ice Wall has moved")
-    (is (= "Enigma" (:title (get-ice state :remote4 0))) "Enigma has moved")))
-
-(deftest executive-wiretaps
-  ;; Executive Wiretaps
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hostile Takeover" "PAD Campaign" "Ice Wall" "Hedge Fund" "Cayambe Grid"]}
-               :runner {:hand ["Executive Wiretaps"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Executive Wiretaps")
-    (is (last-log-contains? state (str "Runner uses Executive Wiretaps to reveal cards in HQ: "
-                                       "Cayambe Grid, Hedge Fund, Hostile Takeover, Ice Wall, PAD Campaign.")))))
-
-(deftest exploit
-  ;; Exploit
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall" "Enigma" "Hunter"]}
-               :runner {:hand ["Exploit"]}})
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Enigma" "New remote")
-    (play-from-hand state :corp "Hunter" "New remote")
-    (let [iw (get-ice state :remote1 0)
-          enigma (get-ice state :remote2 0)
-          hunter (get-ice state :remote3 0)]
-      (core/rez state :corp iw)
-      (core/rez state :corp enigma)
-      (core/rez state :corp hunter)
-      (take-credits state :corp)
-      (play-from-hand state :runner "Exploit")
-      (is (empty? (:prompt (get-runner))) "No prompt as runner has fulfilled req yet")
-      (run-empty-server state :archives)
-      (run-empty-server state :rd)
-      (click-prompt state :runner "No action")
-      (run-empty-server state :hq)
-      (play-from-hand state :runner "Exploit")
-      (is (= :select (-> (get-runner) :prompt first :prompt-type)) "Runner has Exploit select prompt")
-      (click-card state :runner (refresh iw))
-      (click-card state :runner (refresh enigma))
-      (click-card state :runner (refresh hunter))
-      (is (not (rezzed? (refresh iw))) "Ice Wall is derezzed")
-      (is (not (rezzed? (refresh enigma))) "Enigma is derezzed")
-      (is (not (rezzed? (refresh hunter))) "Hunter is derezzed"))))
-
-(deftest express-delivery
-  ;; Express Delivery
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck ["Easy Mark" "Sure Gamble" "Infiltration" "Magnum Opus"]
-                        :hand ["Express Delivery"]}})
-    (take-credits state :corp)
-    (let [num-shuffles (count (core/turn-events state :runner :runner-shuffle-deck))]
-      (play-from-hand state :runner "Express Delivery")
-      (is (= 4 (-> (get-runner) :prompt first :choices count)) "Runner sees 4 cards")
-      (click-prompt state :runner "Magnum Opus")
-      (is (= (inc num-shuffles) (count (core/turn-events state :runner :runner-shuffle-deck)))
-                "Runner should shuffle the stack")
-      (is (= ["Magnum Opus"] (map :title (:hand (get-runner)))) "Magnum Opus is in the hand"))))
-
-(deftest fear-the-masses
-  ;; Fear the Masses
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 50)]
-                      :hand [(qty "Hedge Fund" 5)]}
-               :runner {:hand [(qty "Fear the Masses" 6)]}})
-    (take-credits state :corp)
-    (let [discard (count (:discard (get-corp)))]
-      (play-from-hand state :runner "Fear the Masses")
-      (run-successful state)
-      (is (= (inc discard) (count (:discard (get-corp)))) "Corp trashes 1 card"))
-    (let [discard (count (:discard (get-corp)))]
-      (click-card state :runner (nth (:hand (get-runner)) 0))
-      (click-card state :runner (nth (:hand (get-runner)) 1))
-      (click-card state :runner (nth (:hand (get-runner)) 2))
-      (click-card state :runner (nth (:hand (get-runner)) 3))
-      (click-card state :runner (nth (:hand (get-runner)) 4))
-      (is (= (+ discard 5) (count (:discard (get-corp)))) "Corp trashes 5 additional card"))))
-
-(deftest fisk-investment-seminar
-  ;; Fisk Investment Seminar
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Hedge Fund" 5)]}
-               :runner {:deck [(qty "Sure Gamble" 5)]
-                        :hand ["Fisk Investment Seminar"]}})
-    (take-credits state :corp)
-    (let [c-hand (count (:hand (get-corp)))
-          r-hand (count (:hand (get-runner)))]
-      (play-from-hand state :runner "Fisk Investment Seminar")
-      (is (= (+ 3 c-hand (count (:hand (get-corp))))) "Corp draws 3 cards")
-      (is (= (+ 3 r-hand (count (:hand (get-runner))))) "Runner draws 3 cards"))))
-
-(deftest forged-activation-orders
-  ;; Forged Activation Orders
-  (testing "Corp chooses to trash the ice"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Forged Activation Orders"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Forged Activation Orders")
-      (click-card state :runner "Ice Wall")
-      (click-prompt state :corp "Trash")
-      (is (= "Ice Wall" (:title (get-discarded state :corp 0))) "Ice Wall is trashed")))
-  (testing "Corp chooses to rez the ice"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Forged Activation Orders"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Forged Activation Orders")
-      (click-card state :runner "Ice Wall")
-      (click-prompt state :corp "Rez")
-      (is (rezzed? (get-ice state :hq 0)) "Ice Wall is rezzed"))))
-
-(deftest forked
-  ;; Forked
-  (do-game
-    (new-game {:corp {:hand ["Hunter"]}
-               :runner {:hand ["Forked"]}})
-    (play-from-hand state :corp "Hunter" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Forked")
-    (click-prompt state :runner "HQ")
-    (run-continue state)
-    (card-ability state :runner (-> (get-runner) :play-area first) 0)
-    (is (= 1 (count (:discard (get-corp)))) "Hunter is trashed")
-    (run-successful state)))
-
-(deftest frame-job
-  ;; Frame Job
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hostile Takeover"]}
-               :runner {:hand ["Frame Job"]}})
-    (take-credits state :corp)
-    (run-empty-server state :hq)
-    (click-prompt state :runner "Steal")
-    (play-from-hand state :runner "Frame Job")
-    (let [bp (count-bad-pub state)]
-      (click-prompt state :runner "Hostile Takeover")
-      (is (= (inc bp) (count-bad-pub state)) "Corp gains 1 bp")
-      (is (not (get-scored state :runner 0)) "Hostile Takeover is forfeit"))))
-
-(deftest government-investigations
-  ;; Government Investigations
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Cerebral Cast"]}
-               :runner {:hand ["Government Investigations" "Push Your Luck"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Government Investigations")
-    (run-empty-server state :archives)
-    (take-credits state :runner)
-    (play-from-hand state :corp "Cerebral Cast")
-    (is (= ["Roll a d6" "0 [Credits]" "1 [Credits]"] (:choices (prompt-map :corp))))
-    (is (= ["Roll a d6" "0 [Credits]" "1 [Credits]"] (:choices (prompt-map :runner))))
-    (click-prompt state :corp "0 [Credits]")
-    (click-prompt state :runner "0 [Credits]")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Push Your Luck")
-    (is (= ["0" "1" "3" "4" "5"] (:choices (prompt-map :runner))) "Runner can't choose 2")))
-
-(deftest immolation-script
-  ;; Immolation Script
-  (testing "Basic test"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]
-                        :discard ["Ice Wall"]}
-                 :runner {:hand ["Immolation Script"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (core/rez state :corp (get-ice state :hq 0))
-      (take-credits state :corp)
-      (play-from-hand state :runner "Immolation Script")
-      (run-successful state)
-      (click-prompt state :runner "Ice Wall")
-      (click-card state :runner (get-ice state :hq 0))
-      (is (not (get-ice state :hq 0)) "Ice Wall is trashed")
-      (is (= 2 (count (:discard (get-corp)))) "2 cards in trash now")))
-  (testing "with no ice in archives"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Immolation Script"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (core/rez state :corp (get-ice state :hq 0))
-      (take-credits state :corp)
-      (play-from-hand state :runner "Immolation Script")
-      (run-successful state)
-      (is (empty? (prompt-map :runner)) "No prompt for runner")))
-  (testing "with no ice installed"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :discard ["Ice Wall"]}
-                 :runner {:hand ["Immolation Script"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Immolation Script")
-      (run-successful state)
-      (is (empty? (prompt-map :runner)) "No prompt for runner"))))
-
-(deftest infiltration
-  ;; Infiltration
-  (testing "Gain 2"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-                 :runner {:hand ["Infiltration"]}})
-      (take-credits state :corp)
-      (let [credits (:credit (get-runner))]
-        (play-from-hand state :runner "Infiltration")
-        (click-prompt state :runner "Gain 2 [Credits]")
-        (is (= (+ 2 credits) (:credit (get-runner))) "Runner gains 2"))))
-  (testing "Expose"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Infiltration"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Infiltration")
-      (click-prompt state :runner "Expose a card")
-      (click-card state :runner "Ice Wall")
-      (is (last-log-contains? state "Runner exposes Ice Wall protecting HQ at position 0")
-          "Infiltration properly exposes the ice"))))
-
-(deftest inside-job
-  ;; Inside Job
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall"]}
-               :runner {:hand ["Inside Job"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Inside Job")
-    (click-prompt state :runner "HQ")
-    (is (:run @state) "A run has been initiated")))
-
-(deftest itinerant-protesters
-  ;; Itinerant Protesters
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Itinerant Protesters"]}})
-    (take-credits state :corp)
-    (is (= 5 (hand-size :corp)) "Corp starts with handsize of 5")
-    (play-from-hand state :runner "Itinerant Protesters")
-    (core/gain state :corp :bad-publicity 1)
-    (is (= 4 (hand-size :corp)) "Corp's handsize is lowered by 1 for a bad publicity")
-    (core/gain state :corp :bad-publicity 3)
-    (is (= 1 (hand-size :corp)))))
-
-(deftest kraken
-  ;; Kraken
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hostile Takeover" "Ice Wall"]}
-               :runner {:hand ["Kraken"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Kraken")
-    (is (empty? (prompt-map :runner)) "No prompt as the runner hasn't stolen an agenda yet")
-    (run-empty-server state :hq)
-    (click-prompt state :runner "Steal")
-    (play-from-hand state :runner "Kraken")
-    (click-prompt state :runner "HQ")
-    (click-card state :corp (get-ice state :hq 0))
-    (is (not (get-ice state :hq 0)) "Ice Wall is trashed")))
-
-(deftest lean-and-mean
-  ;; Lean and Mean
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand [(qty "Lean and Mean" 3) (qty "Corroder" 5)]
-                        :credits 100}})
-    (take-credits state :corp)
-    (core/gain state :runner :click 10)
-    (testing "Duration and bonus"
-      (play-from-hand state :runner "Corroder")
-      (is (= 2 (core/get-strength (get-program state 0))) "Corroder starts with 2 str")
-      (play-from-hand state :runner "Lean and Mean")
-      (click-prompt state :runner "R&D")
-      (is (= 4 (core/get-strength (get-program state 0))) "Corroder gains 2 str from Lean and Mean")
-      (run-successful state)
-      (is (= 2 (core/get-strength (get-program state 0))) "Lean and Mean's str bonus goes away at run end"))
-    (testing "Bonus applies to multiple icebreakers"
-      (play-from-hand state :runner "Corroder")
-      (play-from-hand state :runner "Corroder")
-      (play-from-hand state :runner "Lean and Mean")
-      (click-prompt state :runner "R&D")
-      (is (= 4 (core/get-strength (get-program state 0))) "Corroder gains 2 str from Lean and Mean")
-      (is (= 4 (core/get-strength (get-program state 1))) "Corroder gains 2 str from Lean and Mean")
-      (is (= 4 (core/get-strength (get-program state 2))) "Corroder gains 2 str from Lean and Mean")
-      (run-successful state))
-    (testing "Bonus doesn't apply when there are too many programs installed"
-      (play-from-hand state :runner "Corroder")
-      (play-from-hand state :runner "Lean and Mean")
-      (click-prompt state :runner "R&D")
-      (is (= 4 (count (get-program state))) "4 programs installed")
-      (is (= 2 (core/get-strength (get-program state 0))) "Corroder doesn't gain any strength from Lean and Mean"))))
-
-(deftest legwork
-  ;; Legwork
-  (testing "Basic test"
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Hostile Takeover" 3)]}
-               :runner {:hand ["Legwork"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Legwork")
-    (run-successful state)
-    (dotimes [_ 3]
-      (click-prompt state :runner "Card from hand")
-      (click-prompt state :runner "Steal"))
-    (is (not (:run @state)) "Run has finished")))
-  (testing "Doesn't give bonus accesses when unsuccessful"
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Hostile Takeover" 3)]}
-               :runner {:hand ["Legwork"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Legwork")
-    (run-jack-out state)
-    (run-empty-server state :hq)
-    (click-prompt state :runner "Steal")
-    (is (not (:run @state)) "Run has finished"))))
-
-(deftest leverage
-  ;; Leverage
-  (testing "Corp takes bad publicity"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-                 :runner {:hand ["Leverage"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Leverage")
-      (is (empty? (prompt-map :corp)) "No prompt as runner didn't run HQ")
-      (run-empty-server state :hq)
-      (click-prompt state :runner "No action")
-      (is (zero? (count-bad-pub state)) "Corp has no bad pub")
-      (play-from-hand state :runner "Leverage")
-      (click-prompt state :corp "Yes")
-      (is (= 2 (count-bad-pub state)) "Corp gains 2 bad pub from Leverage")))
-  (testing "Corp doesn't take bad publicity"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["BOOM!"]}
-                 :runner {:hand ["Leverage"]}
-                 :tags 2})
-      (is (not (:winner @state)) "No winner is declared yet")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Leverage")
-      (is (empty? (prompt-map :corp)) "No prompt as runner didn't run HQ")
-      (run-empty-server state :hq)
-      (click-prompt state :runner "No action")
-      (play-from-hand state :runner "Leverage")
-      (click-prompt state :corp "No")
-      (take-credits state :runner)
-      (play-from-hand state :corp "BOOM!")
-      (is (not (:winner @state)) "Runner doesn't take any damage"))))
-
-(deftest levy-ar-lab-access
-  ;; Levy AR Lab Access
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck ["Magnum Opus"]
-                        :hand ["Levy AR Lab Access" "Easy Mark"]
-                        :discard [(qty "Sure Gamble" 3)]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Levy AR Lab Access")
-    (is (= 5 (count (:hand (get-runner)))) "Runner should draw 5 cards")
-    (is (zero? (count (:deck (get-runner)))) "Stack should be empty")
-    (is (zero? (count (:discard (get-runner)))) "Heap should be empty")
-    (is (= "Levy AR Lab Access" (:title (get-rfg state :runner 0))) "Levy should be rfg'd")))
-
-(deftest lucky-find
-  ;; Lucky Find
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Lucky Find"]}})
-    (take-credits state :corp)
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Lucky Find")
-      (is (= (+ credits -3 9) (:credit (get-runner))) "Runner should spend 3 and gain 9"))))
-
-(deftest marathon
-  ;; Marathon
-  (testing "Trashed on unsuccessful run"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Marathon"]}})
-      (play-from-hand state :corp "Ice Wall" "New remote")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Marathon")
-      (click-prompt state :runner "Server 1")
-      (run-jack-out state)
-      (is (= "Marathon" (-> (get-runner) :discard first :title)) "Marathon should be trashed")
-      (is (zero? (count (:hand (get-runner)))) "Marathon should not be in hand")))
-  (testing "Moved to hand on successful run"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall"]}
-                 :runner {:hand ["Marathon"]}})
-      (play-from-hand state :corp "Ice Wall" "New remote")
-      (take-credits state :corp)
-      (let [clicks (:click (get-runner))]
-        (play-from-hand state :runner "Marathon")
-        (click-prompt state :runner "Server 1")
-        (run-successful state)
-        (is (= "Marathon" (-> (get-runner) :hand first :title)) "Marathon should be in hand")
-        (is (= clicks (:click (get-runner))) "Runner should gain 1 click"))
-      (is (not (:run @state)) "Run has ended")
-      (run-on state "Server 1")
-      (is (not (:run @state)) "Run shouldn't be initiated on a Marathon'd server"))))
-
-(deftest mass-install
-  ;; Mass Install
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Mass Install" "Corroder" "Self-modifying Code" "Cloak"]
-                        :credits 10}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Mass Install")
-    (click-card state :runner "Corroder")
-    (is (= "Corroder" (:title (get-program state 0))) "Corroder should be installed")
-    (click-card state :runner "Self-modifying Code")
-    (is (= "Self-modifying Code" (:title (get-program state 1))) "SMC should be installed")
-    (click-card state :runner "Cloak")
-    (is (= "Cloak" (:title (get-program state 2))) "Cloak should be installed")
-    (is (empty? (prompt-map :runner)) "Runner should have no more prompts")))
-
-(deftest networking
-  ;; Networking
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Networking"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Networking")
-    (is (= "Networking" (-> (get-runner) :hand first :title)) "Networking shouldn't be played")
-    (core/gain-tags state :runner 4)
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Networking")
-      (is (= 3 (count-tags state)) "Runner should lose 1 tag")
-      (click-prompt state :runner "Yes")
-      (is (= (dec credits) (:credit (get-runner))) "Runner should spend 1 on Networking ability")
-      (is (zero? (count (:discard (get-runner)))) "Runner's discard should be empty")
-      (is (= "Networking" (-> (get-runner) :hand first :title))))
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Networking")
-      (is (= 2 (count-tags state)) "Runner should lose 1 tag")
-      (click-prompt state :runner "No")
-      (is (= credits (:credit (get-runner))) "Runner should spend 1 on Networking ability")
-      (is (= 1 (count (:discard (get-runner)))) "Runner's discard should be empty")
-      (is (= "Networking" (-> (get-runner) :discard first :title)) "Networking should be in heap"))))
-
-(deftest paper-tripping
-  ;; Paper Tripping
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Paper Tripping"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Paper Tripping")
-    (is (= "Paper Tripping" (-> (get-runner) :hand first :title)) "Paper Tripping shouldn't be played")
-    (core/gain-tags state :runner 100)
-    (play-from-hand state :runner "Paper Tripping")
-    (is (zero? (count-tags state)) "Runner should lose all tags")))
-
-(deftest planned-assault
-  ;; Planned Assault
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck ["Account Siphon"]
-                        :hand ["Planned Assault"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Planned Assault")
-    (is (not (:run @state)) "No run should be initiated yet")
-    (click-prompt state :runner "Account Siphon")
-    (is (:run @state) "A run should be initiated")
-    (run-successful state)
-    (is (= 2 (:click (get-runner))) "Runner should only spend 2 clicks on Planned Assault")))
-
-(deftest populist-rally
-  ;; Populist Rally
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Data Dealer" "Populist Rally"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Populist Rally")
-    (is (= ["Data Dealer" "Populist Rally"] (->> (get-runner) :hand (map :title) sort))
-        "Populist Rally shouldn't be played")
-    (play-from-hand state :runner "Data Dealer")
-    (play-from-hand state :runner "Populist Rally")
-    (take-credits state :runner)
-    (is (= 2 (:click (get-corp))) "Corp should gain only 2 clicks this turn")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (is (= 3 (:click (get-corp))) "Corp should gain 3 clicks as normal in later turns")))
-
-(deftest power-nap
-  ;; Power Nap
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand [(qty "Power Nap" 3)]}})
-    (take-credits state :corp)
-    (core/gain state :runner :click 2)
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Power Nap")
-      (is (= (+ credits 2) (:credit (get-runner))) "Runner should gain 2"))
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Power Nap")
-      (is (= (+ credits 3) (:credit (get-runner)))
-          "Runner should gain 3 for 1 double in heap"))
-    (let [credits (:credit (get-runner))]
-      (play-from-hand state :runner "Power Nap")
-      (is (= (+ credits 4) (:credit (get-runner)))
-          "Runner should gain 4 for 2 doubles in heap"))))
-
-(deftest prey
-  ;; Prey
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall" "Enigma"]}
-               :runner {:hand [(qty "Prey" 2) (qty "Clone Chip" 3)]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Enigma" "R&D")
-    (core/rez state :corp (get-ice state :hq 0))
-    (core/rez state :corp (get-ice state :rd 0))
-    (take-credits state :corp)
-    (core/gain state :runner :click 5)
-    (dotimes [_ 3]
-      (play-from-hand state :runner "Clone Chip"))
-    (play-from-hand state :runner "Prey")
-    (click-prompt state :runner "HQ")
-    (run-continue state)
-    (card-ability state :runner (-> (get-runner) :play-area first) 0)
-    (is (get-ice state :hq 0) "Ice Wall should not be trashed yet")
-    (click-card state :runner (get-hardware state 0))
-    (is (not (get-ice state :hq 0)) "Ice Wall should be trashed")
-    (run-successful state)
-    (play-from-hand state :runner "Prey")
-    (click-prompt state :runner "R&D")
-    (run-continue state)
-    (card-ability state :runner (-> (get-runner) :play-area first) 0)
-    (is (get-ice state :rd 0) "Enigma should not be trashed yet")
-    (click-card state :runner (get-hardware state 0))
-    (click-card state :runner (get-hardware state 1))
-    (is (not (get-ice state :rd 0)) "Enigma should be trashed")))
-
-(deftest process-automation
-  ;; Process Automation
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck [(qty "Sure Gamble" 5)]
-                        :hand ["Process Automation"]}})
-    (take-credits state :corp)
-    (let [credits (:credit (get-runner))
-          hand (dec (count (:hand (get-runner))))]
-      (play-from-hand state :runner "Process Automation")
-      (is (= (+ 2 credits) (:credit (get-runner))) "Should gain 2 credits")
-      (is (= (inc hand) (count (:hand (get-runner)))) "Should draw 1 card"))))
-
-(deftest quality-time
-  ;; Quality Time
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck [(qty "Sure Gamble" 5)]
-                        :hand ["Quality Time"]}})
-    (take-credits state :corp)
-    (is (= 1 (count (:hand (get-runner)))) "Runner should have 1 card in hand")
-    (play-from-hand state :runner "Quality Time")
-    (is (= 5 (count (:hand (get-runner)))) "Runner should draw 5 cards")))
-
-(deftest quest-completed
-  ;; Quest Completed
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hostile Takeover"]}
-               :runner {:hand ["Quest Completed"]}})
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (click-prompt state :runner "No action")
-    (run-empty-server state "HQ")
-    (play-from-hand state :runner "Quest Completed")
-    (click-card state :runner "Hostile Takeover")
-    (click-prompt state :runner "Steal")))
-
-(deftest recon
-  ;; Recon
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall"]}
-               :runner {:hand ["Recon"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Recon")
-    (click-prompt state :runner "HQ")
-    (is (:run @state) "A run has been initiated")))
-
-(deftest run-amok
-  ;; Run Amok
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall" "Enigma"]}
-               :runner {:hand ["Run Amok"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Enigma" "New remote")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Run Amok")
-    (click-prompt state :runner "Server 1")
-    (core/rez state :corp (get-ice state :remote1 0))
-    (run-successful state)
-    (click-card state :runner "Ice Wall")
-    (is (prompt-map :runner) "Prompt should still be active as Ice Wall wasn't rezzed this run")
-    (click-card state :runner "Enigma")
-    (is (empty? (prompt-map :runner)) "Enigma should be trashed")
-    (is (= "Enigma" (-> (get-corp) :discard first :title)) "Enigma should be trashed")))
-
-(deftest satellite-uplink
-  ;; Satellite Uplink
-  (testing "when exposing 2 cards"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall" "Hostile Takeover"]}
-                 :runner {:hand ["Satellite Uplink"]}})
-      (play-from-hand state :corp "Ice Wall" "New remote")
-      (play-from-hand state :corp "Hostile Takeover" "Server 1")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Satellite Uplink")
-      (click-card state :runner "Ice Wall")
-      (click-card state :runner "Hostile Takeover")))
-  (testing "when exposing 2 cards"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Ice Wall" "Hostile Takeover"]}
-                 :runner {:hand ["Satellite Uplink"]}})
-      (play-from-hand state :corp "Ice Wall" "New remote")
-      (play-from-hand state :corp "Hostile Takeover" "Server 1")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Satellite Uplink")
-      (click-card state :runner "Ice Wall")
-      (click-prompt state :runner "Done"))))
-
-(deftest scavenge
-  ;; Scavenge
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Scavenge" "Corroder"]
-                        :discard ["Mass-Driver"]
-                        :credits 10}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Corroder")
-    (play-from-hand state :runner "Scavenge")
-    (let [credits (:credit (get-runner))]
-      (click-card state :runner "Corroder")
-      (click-card state :runner "Mass-Driver")
-      (is (= "Mass-Driver" (:title (get-program state 0))) "Mass-Driver is now installed")
-      (is (= (+ credits 2 -8) (:credit (get-runner))) "Scavenge should give discount"))))
-
-(deftest social-engineering
-  ;; Social Engineering
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Fire Wall" "Ice Wall"]
-                      :credits 10}
-               :runner {:hand ["Social Engineering"]}})
-    (play-from-hand state :corp "Fire Wall" "HQ")
-    (play-from-hand state :corp "Ice Wall" "R&D")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Social Engineering")
-    (click-card state :runner "Fire Wall")
-    (let [credits (:credit (get-runner))]
-      (core/rez state :corp (get-ice state :rd 0))
-      (is (= credits (:credit (get-runner))) "Shouldn't gain credits from different ice rez")
-      (core/rez state :corp (get-ice state :hq 0))
-      (is (= (+ credits 5) (:credit (get-runner))) "Should gain credits from correct ice rez"))))
-
-(deftest spear-phishing
-  ;; Spear Phishing
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ice Wall"]}
-               :runner {:hand ["Spear Phishing"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Spear Phishing")
-    (click-prompt state :runner "HQ")
-    (is (:run @state) "A run has been initiated")))
-
-(deftest special-order
-  ;; Special Order
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck ["Corroder"]
-                        :hand ["Special Order"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Special Order")
-    (click-prompt state :runner "Corroder")
-    (is (= ["Corroder"] (->> (get-runner) :hand (map :title)))
-        "Corroder should be in the hand now")))
-
-(deftest spooned
-  ;; Spooned
-  (do-game
-    (new-game {:corp {:deck ["Enigma"]}
-               :runner {:deck ["Spooned"]}})
-    (play-from-hand state :corp "Enigma" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (take-credits state :corp)
-    (play-from-hand state :runner "Spooned")
-    (click-prompt state :runner "HQ")
-    (run-continue state)
-    (card-ability state :runner (-> (get-runner) :play-area first) 0)
-    (is (= 1 (count (:discard (get-corp)))) "Enigma is trashed")
-    (run-successful state)))
-
-(deftest spot-the-prey
-  ;; Spot the Prey
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hostile Takeover"]}
-               :runner {:hand ["Spot the Prey"]}})
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Spot the Prey")
-    (click-card state :runner "Hostile Takeover")
-    (is (last-log-contains? state "Runner exposes Hostile Takeover"))
-    (click-prompt state :runner "HQ")
-    (is (:run @state) "Run should be initiated")))
-
-(deftest syn-attack
-  ;; SYN Attack
-  (testing "and corp chooses to draw"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand [(qty "Hedge Fund" 5)]}
-                 :runner {:hand ["SYN Attack"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "SYN Attack")
-      (let [hand (count (:hand (get-corp)))]
-        (click-prompt state :corp "Draw 4")
-        (is (= (+ hand 4) (count (:hand (get-corp)))) "Corp should draw 4 cards"))))
-  (testing "and corp chooses to discard"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand [(qty "Hedge Fund" 5)]}
-                 :runner {:hand ["SYN Attack"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "SYN Attack")
-      (let [hand (count (:hand (get-corp)))]
-        (click-prompt state :corp "Discard 2")
-        (click-card state :corp (first (:hand (get-corp))))
-        (click-card state :corp (second (:hand (get-corp))))
-        (is (= (+ hand -2) (count (:hand (get-corp)))) "Corp should discard 2 cards")))))
-
-(deftest three-steps-ahead
-  ;; Three Steps Ahead
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Three Steps Ahead"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Three Steps Ahead")
-    (run-empty-server state "Archives")
-    (run-empty-server state "R&D")
-    (let [credits (:credit (get-runner))]
-      (run-empty-server state "HQ")
-      (click-prompt state :runner "No action")
-      (take-credits state :runner)
-      (is (= (+ credits 6) (:credit (get-runner))) "Runner should gain 6 for 3 successful runs"))))
-
-(deftest uninstall
-  ;; Uninstall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:hand [(qty "Uninstall" 2) "Corroder" "Clone Chip"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Corroder")
-    (play-from-hand state :runner "Clone Chip")
-    (play-from-hand state :runner "Uninstall")
-    (click-card state :runner "Corroder")
-    (play-from-hand state :runner "Uninstall")
-    (click-card state :runner "Clone Chip")
-    (is (= 2 (count (:hand (get-runner)))) "Runner has played 2 and picked up 2 cards")))
-
-(deftest wanton-destruction
-  ;; Wanton Destruction
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Hedge Fund" 5)]}
-               :runner {:hand ["Wanton Destruction"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Wanton Destruction")
-    (is (= [:hq] (:server (:run @state))) "Run should be on HQ")
-    (run-successful state)
-    (click-prompt state :runner "Wanton Destruction")
-    (is (zero? (count (:discard (get-corp)))) "Corp should have no cards in Archives")
-    (click-prompt state :runner "3")
-    (is (= 2 (count (:hand (get-corp)))) "Corp should discard 3 cards")
-    (is (= 3 (count (:discard (get-corp)))) "Corp should now have 3 cards in Archives")
-    (is (zero? (:click (get-runner))) "Runner should spend 3 clicks on ability")))
-
-(deftest windfall
-  ;; Windfall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
-               :runner {:deck ["Monolith"]
-                        :hand ["Windfall"]}})
-    (take-credits state :corp)
-    (let [num-shuffles (count (core/turn-events state :runner :runner-shuffle-deck))
-          credits (:credit (get-runner))]
-      (play-from-hand state :runner "Windfall")
-      (is (= (inc num-shuffles) (count (core/turn-events state :runner :runner-shuffle-deck)))
-          "Runner should shuffle the stack")
-      (is (= (+ credits 18) (:credit (get-runner))) "Runner should gain credits from trash")
-      (is (= "Monolith" (-> (get-runner) :discard first :title))
-          "Monolith should be trashed"))))
-
 (deftest account-siphon
   ;; Account Siphon
   (testing "Use ability"
@@ -1578,6 +464,19 @@
       (play-from-hand state :runner "Brute-Force-Hack")
       (is (empty? (:prompt (get-runner))) "Runner can't play Brute-Force-Hack when only available ice is too expensive"))))
 
+(deftest build-script
+  ;; Build Script
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck [(qty "Sure Gamble" 5)]
+                        :hand ["Build Script"]}})
+    (take-credits state :corp)
+    (let [credits (:credit (get-runner))
+          hand (dec (count (:hand (get-runner))))]
+      (play-from-hand state :runner "Build Script")
+      (is (= (inc credits) (:credit (get-runner))) "Gained 1 credit")
+      (is (= (+ 2 hand) (count (:hand (get-runner)))) "Drew 2 cards"))))
+
 (deftest by-any-means
   ;; By Any Means
   (testing "Full test"
@@ -1695,6 +594,42 @@
       (is (= 1 (count (:discard (get-corp)))) "Operation was trashed")
       (is (= 1 (count (:hand (get-runner)))) "Took 1 meat damage"))))
 
+(deftest calling-in-favors
+  ;; Calling in Favors
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Calling in Favors" 3) (qty "Aeneas Informant" 5) "Algo Trading"]}})
+    (take-credits state :corp)
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Calling in Favors")
+      (is (= credits (:credit (get-runner))) "Don't gain credits with nothing installed"))
+    (core/gain state :runner :click 10)
+    (dotimes [_ 5]
+      (play-from-hand state :runner "Aeneas Informant"))
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Calling in Favors")
+      (is (= (+ 5 credits) (:credit (get-runner))) "Gain 5 credits from 5 connections"))
+    (play-from-hand state :runner "Algo Trading")
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Calling in Favors")
+      (is (= (+ 5 credits) (:credit (get-runner))) "Gain 5 credits from 5 connections and 1 non-connection resource"))))
+
+(deftest career-fair
+  ;; Career Fair
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Career Fair" 2) "Caldera" "Beach Party"]
+                        :credits 0}})
+    (take-credits state :corp)
+    (is (zero? (:credit (get-runner))) "Start with 0 credits")
+    (play-from-hand state :runner "Career Fair")
+    (click-card state :runner "Caldera")
+    (is (= "Caldera" (:title (get-resource state 0))) "Caldera is installed for free")
+    (play-from-hand state :runner "Career Fair")
+    (click-card state :runner "Beach Party")
+    (is (= "Beach Party" (:title (get-resource state 1))) "Beach Party is installed for free")
+    (is (zero? (:credit (get-runner))) "Discount doesn't provide money")))
+
 (deftest careful-planning
   ;; Careful Planning - Prevent card in/protecting remote server from being rezzed this turn
   (do-game
@@ -1756,6 +691,40 @@
     (is (= "Quandary" (:title (second (rest (:deck (get-corp)))))))
     (is (= "Jackson Howard" (:title (second (rest (rest (:deck (get-corp))))))))
     (is (= "Global Food Initiative" (:title (second (rest (rest (rest (:deck (get-corp)))))))))))
+
+(deftest code-siphon
+  ;; Code Siphon
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Ice Wall" 2)]}
+               :runner {:deck [(qty "Mass-Driver" 2)]
+                        :hand [(qty "Code Siphon" 2)]
+                        :credits 10}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Code Siphon")
+    (run-successful state)
+    (click-prompt state :runner "Code Siphon")
+    (let [credits (:credit (get-runner))
+          tags (count-tags state)]
+      (click-prompt state :runner "Mass-Driver")
+      (is (= "Mass-Driver" (:title (get-program state 0))) "Mass-Driver is installed")
+      (is (= (- credits 8) (:credit (get-runner))) "Runner pays full 8 for Mass-Driver")
+      (is (= (inc tags) (count-tags state)) "Gained 1 tag"))
+    (take-credits state :runner)
+    (play-from-hand state :corp "Ice Wall" "R&D")
+    (play-from-hand state :corp "Ice Wall" "R&D")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Code Siphon")
+    (run-continue state)
+    (run-continue state)
+    (run-successful state)
+    (is (= ["Code Siphon" "Access cards"] (-> (get-runner) :prompt first :choices))
+        "Replacement effect isn't mandatory")
+    (click-prompt state :runner "Code Siphon")
+    (let [credits (:credit (get-runner))]
+      (click-prompt state :runner "Mass-Driver")
+      (is (= "Mass-Driver" (:title (get-program state 1))) "Mass-Driver is installed")
+      (is (= (- credits 2) (:credit (get-runner))) "Runner pays discounted cost for Mass-Driver"))))
 
 (deftest cold-read
   ;; Make a run, and place 4 on this card, which you may use only during this run.
@@ -1976,6 +945,37 @@
       (take-credits state :corp)
       (is (zero? (get-in (get-corp) [:bad-publicity :base])) "Corp has BP, didn't take 1 from Activist Support"))))
 
+(deftest credit-crash
+  ;; Credit Crash
+  (testing "Corp pays to keep"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["Credit Crash"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Credit Crash")
+      (click-prompt state :runner "HQ")
+      (run-successful state)
+      (let [credits (:credit (get-corp))
+            discard (count (:discard (get-corp)))]
+        (click-prompt state :corp "Yes")
+        (is (= (- credits 5) (:credit (get-corp))) "Corp paid 5 credits to save Hedge Fund")
+        (is (= discard (count (:discard (get-corp)))) "Corp has no cards trashed"))
+      (click-prompt state :runner "No action")))
+  (testing "Corp doesn't pay to keep"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["Credit Crash"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Credit Crash")
+      (click-prompt state :runner "HQ")
+      (run-successful state)
+      (let [credits (:credit (get-corp))
+            discard (count (:discard (get-corp)))]
+        (click-prompt state :corp "No")
+        (is (= credits (:credit (get-corp))) "Corp doesn't pay 5 credits to save Hedge Fund")
+        (is (= (inc discard) (count (:discard (get-corp)))) "Corp has 1 card trashed"))
+      (is (empty? (:prompt (get-runner))) "Runner has no access prompts"))))
+
 (deftest credit-kiting
   ;; Credit Kiting - After successful central run lower install cost by 8 and gain a tag
   (do-game
@@ -1997,6 +997,38 @@
         (click-card state :runner iw)
         (is (:icon (refresh iw)) "Ice Wall has an icon")))
     (is (= 1 (count-tags state)) "Runner gained a tag")))
+
+(deftest cyber-threat
+  ;; Cyber Threat
+  (testing "Corp rezzes a piece of ice"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Cyber Threat"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Cyber Threat")
+      (click-prompt state :runner "HQ")
+      (click-prompt state :corp "Yes")
+      (let [iw (get-ice state :hq 0)
+            credits (:credit (get-corp))]
+        (click-card state :corp "Ice Wall")
+        (is (rezzed? (refresh iw)) "Ice Wall is rezzed")
+        (is (= (dec credits) (:credit (get-corp))) "Corp paid to rez Ice Wall"))))
+  (testing "Corp doesn't rez a piece of ice"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Cyber Threat"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Cyber Threat")
+      (click-prompt state :runner "HQ")
+      (click-prompt state :corp "No")
+      (let [iw (get-ice state :hq 0)]
+        (is (:run @state) "Run has been initiated")
+        (core/rez state :corp iw)
+        (is (not (rezzed? (refresh iw))) "Corp can't rez ice this run")))))
 
 (deftest data-breach
   ;; Data Breach
@@ -2040,6 +1072,39 @@
       (is (= [:rd] (get-in @state [:run :server])) "Second Data Breach run on R&D triggered")
       (core/no-action state :corp nil)
       (run-successful state))))
+
+(deftest day-job
+  ;; Day Job
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Day Job"]}})
+    (take-credits state :corp)
+    (let [credits (:credit (get-runner))
+          clicks (:click (get-runner))]
+      (play-from-hand state :runner "Day Job")
+      (is (= (+ credits -2 10) (:credit (get-runner))) "Runner spends 2, gains 10")
+      (is (zero? (:click (get-runner))) "Runner loses 4 clicks"))))
+
+(deftest deep-data-mining
+  ;; Deep Data Mining
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hedge Fund"]}
+               :runner {:hand [(qty "Deep Data Mining" 2) "Magnum Opus"]
+                        :credits 15}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Deep Data Mining")
+    (run-successful state)
+    (dotimes [_ 5] ; 1 normal access, 4 extra accesses from DDM
+      (click-prompt state :runner "Card from deck")
+      (click-prompt state :runner "No action"))
+    (play-from-hand state :runner "Magnum Opus")
+    (play-from-hand state :runner "Deep Data Mining")
+    (run-successful state)
+    (dotimes [_ 3] ; 1 normal access, 2 extra accesses from DDM because Magnum Opus takes 2 MU
+      (click-prompt state :runner "Card from deck")
+      (click-prompt state :runner "No action"))
+    (is (empty? (:prompt (get-runner))) "No more accesses after 3")))
 
 (deftest deja-vu
   ;; Deja Vu - recur one non-virus or two virus cards
@@ -2118,6 +1183,35 @@
     (is (= 1 (count-tags state)) "Runner has 1 tag")
     (click-prompt state :runner "Remove 1 tag")
     (is (zero? (count-tags state)))))
+
+(deftest diana-s-hunt
+  ;; Diana's Hunt
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall"]}
+               :runner {:hand ["Diana's Hunt" "Mass-Driver"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Diana's Hunt")
+    (click-prompt state :runner "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (card-ability state :runner (get-run-event state 0) 0)
+    (click-card state :runner "Mass-Driver")
+    (is (= "Mass-Driver" (:title (get-program state 0))) "Mass-Driver is installed")
+    (run-successful state)
+    (is (not (get-program state 0)) "Mass-Driver is uninstalled")
+    (is (= "Mass-Driver" (:title (get-discarded state :runner 0))) "Mass-Driver is in the heap")))
+
+(deftest diesel
+  ;; Diesel
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck [(qty "Sure Gamble" 5)]
+                        :hand ["Diesel"]}})
+    (take-credits state :corp)
+    (let [hand (count (:hand (get-runner)))]
+      (play-from-hand state :runner "Diesel")
+      (is (= (+ hand -1 3) (count (:hand (get-runner)))) "Runner plays Diesel and draws 3 cards"))))
 
 (deftest direct-access
   ;; Direct Access - Make a run where both IDs are blank
@@ -2428,6 +1522,16 @@
     (click-prompt state :runner "Archives")
     (is (= 4 (:click (get-runner))) "Early Bird gains click")))
 
+(deftest easy-mark
+  ;; Easy Mark
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Easy Mark"]}})
+    (take-credits state :corp)
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Easy Mark")
+      (is (= (+ 3 credits) (:credit (get-runner))) "Runner has gained 3 credits"))))
+
 (deftest embezzle
   ;; Embezzle
   (testing "Basic test"
@@ -2451,6 +1555,26 @@
       (is (= 1 (count (:discard (get-corp)))) "HQ card trashed")
       (is (:seen (first (:discard (get-corp)))) "Trashed card is registered as seen")
       (is (= 8 (:credit (get-runner)))))))
+
+(deftest emergency-shutdown
+  ;; Emergency Shutdown
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall"]}
+               :runner {:hand ["Emergency Shutdown"]}})
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (let [iw (get-ice state :remote1 0)]
+      (core/rez state :corp iw)
+      (is (rezzed? (refresh iw)) "Ice Wall is rezzed")
+      (take-credits state :corp)
+      (run-empty-server state :archives)
+      (play-from-hand state :runner "Emergency Shutdown")
+      (is (empty? (:prompt (get-runner))) "Runner has no derez prompt")
+      (run-empty-server state :hq)
+      (play-from-hand state :runner "Emergency Shutdown")
+      (is (seq (:prompt (get-runner))) "Runner has a derez prompt")
+      (click-card state :runner (refresh iw))
+      (is (not (rezzed? (refresh iw))) "Ice Wall is derezzed"))))
 
 (deftest emergent-creativity
   ;; Emergent Creativty - Double, discard programs/hardware from grip, install from heap
@@ -2501,6 +1625,31 @@
       (is (= 3 (count (:discard (get-runner))))
           "Discard is 3 cards - 2 from Philotic, 1 EStrike.  Nothing from PU mill"))))
 
+(deftest en-passant
+  ;; En Passant
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Ice Wall" 2)]}
+               :runner {:hand [(qty "En Passant" 2)]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (take-credits state :corp)
+    (let [iw (get-ice state :hq 0)
+          iw2 (get-ice state :remote1 0)]
+      (run-on state :hq)
+      (run-continue state)
+      (run-successful state)
+      (play-from-hand state :runner "En Passant")
+      (click-card state :runner (refresh iw2))
+      (is (refresh iw2) "Ice Wall on the remote hasn't been trashed")
+      (core/rez state :corp iw)
+      (is (refresh iw) "Ice Wall on HQ hasn't been trashed as it's rezzed")
+      (core/derez state :corp iw)
+      (click-card state :runner (refresh iw))
+      (is (not (refresh iw)) "Ice Wall on HQ has been trashed")
+      (play-from-hand state :runner "En Passant")
+      (is (empty? (:prompt (get-runner))) "Runner has no prompt as En Passant can't be played"))))
+
 (deftest encore
   ;; Encore - Run all 3 central servers successfully to take another turn.  Remove Encore from game.
   (testing "Basic test"
@@ -2538,6 +1687,36 @@
       (take-credits state :runner)
       (is (= 13 (:credit (get-runner)))))))
 
+(deftest escher
+  ;; Escher
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall" "Enigma" "IP Block" "Data Raven"]
+                      :credits 20}
+               :runner {:hand ["Escher"]}})
+    (core/gain state :corp :click 1)
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (play-from-hand state :corp "Enigma" "New remote")
+    (play-from-hand state :corp "IP Block" "New remote")
+    (play-from-hand state :corp "Data Raven" "New remote")
+    (core/rez state :corp (get-ice state :remote1 0))
+    (core/rez state :corp (get-ice state :remote2 0))
+    (core/rez state :corp (get-ice state :remote3 0))
+    (core/rez state :corp (get-ice state :remote4 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Escher")
+    (is (= [:hq] (:server (:run @state))) "Run is on HQ")
+    (run-successful state)
+    (click-card state :runner "Ice Wall")
+    (click-card state :runner "IP Block")
+    (click-card state :runner "Enigma")
+    (click-card state :runner "Data Raven")
+    (click-prompt state :runner "Done")
+    (is (= "IP Block" (:title (get-ice state :remote1 0))) "IP Block has moved")
+    (is (= "Data Raven" (:title (get-ice state :remote2 0))) "Data Raven has moved")
+    (is (= "Ice Wall" (:title (get-ice state :remote3 0))) "Ice Wall has moved")
+    (is (= "Enigma" (:title (get-ice state :remote4 0))) "Enigma has moved")))
+
 (deftest eureka
   ;; Eureka! - Install the program but trash the event
   (do-game
@@ -2568,6 +1747,48 @@
     (is (= 2 (count (:discard (get-runner)))) "Two copies of EP in heap")
     (play-from-hand state :runner "Exclusive Party")
     (is (= 8 (:credit (get-runner))) "2 credits gained")))
+
+(deftest executive-wiretaps
+  ;; Executive Wiretaps
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hostile Takeover" "PAD Campaign" "Ice Wall" "Hedge Fund" "Cayambe Grid"]}
+               :runner {:hand ["Executive Wiretaps"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Executive Wiretaps")
+    (is (last-log-contains? state (str "Runner uses Executive Wiretaps to reveal cards in HQ: "
+                                       "Cayambe Grid, Hedge Fund, Hostile Takeover, Ice Wall, PAD Campaign.")))))
+
+(deftest exploit
+  ;; Exploit
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall" "Enigma" "Hunter"]}
+               :runner {:hand ["Exploit"]}})
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (play-from-hand state :corp "Enigma" "New remote")
+    (play-from-hand state :corp "Hunter" "New remote")
+    (let [iw (get-ice state :remote1 0)
+          enigma (get-ice state :remote2 0)
+          hunter (get-ice state :remote3 0)]
+      (core/rez state :corp iw)
+      (core/rez state :corp enigma)
+      (core/rez state :corp hunter)
+      (take-credits state :corp)
+      (play-from-hand state :runner "Exploit")
+      (is (empty? (:prompt (get-runner))) "No prompt as runner has fulfilled req yet")
+      (run-empty-server state :archives)
+      (run-empty-server state :rd)
+      (click-prompt state :runner "No action")
+      (run-empty-server state :hq)
+      (play-from-hand state :runner "Exploit")
+      (is (= :select (-> (get-runner) :prompt first :prompt-type)) "Runner has Exploit select prompt")
+      (click-card state :runner (refresh iw))
+      (click-card state :runner (refresh enigma))
+      (click-card state :runner (refresh hunter))
+      (is (not (rezzed? (refresh iw))) "Ice Wall is derezzed")
+      (is (not (rezzed? (refresh enigma))) "Enigma is derezzed")
+      (is (not (rezzed? (refresh hunter))) "Hunter is derezzed"))))
 
 (deftest exploratory-romp
   ;; Exploratory Romp - Remove advancements from card instead of accessing
@@ -2601,6 +1822,21 @@
         (click-card state :runner (refresh tg))
         (is (zero? (count-tags state)) "No tags, didn't access TGTBT")
         (is (zero? (get-counters (refresh tg) :advancement)) "Advancements removed")))))
+
+(deftest express-delivery
+  ;; Express Delivery
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck ["Easy Mark" "Sure Gamble" "Infiltration" "Magnum Opus"]
+                        :hand ["Express Delivery"]}})
+    (take-credits state :corp)
+    (let [num-shuffles (count (core/turn-events state :runner :runner-shuffle-deck))]
+      (play-from-hand state :runner "Express Delivery")
+      (is (= 4 (-> (get-runner) :prompt first :choices count)) "Runner sees 4 cards")
+      (click-prompt state :runner "Magnum Opus")
+      (is (= (inc num-shuffles) (count (core/turn-events state :runner :runner-shuffle-deck)))
+                "Runner should shuffle the stack")
+      (is (= ["Magnum Opus"] (map :title (:hand (get-runner)))) "Magnum Opus is in the hand"))))
 
 (deftest falsified-credentials
   ;; Falsified Credentials - Expose card in remote
@@ -2667,6 +1903,25 @@
         (click-prompt state :corp "Done")
         (is (= 8 (:credit (get-runner))) "A prevented expose does not")))))
 
+(deftest fear-the-masses
+  ;; Fear the Masses
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 50)]
+                      :hand [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Fear the Masses" 6)]}})
+    (take-credits state :corp)
+    (let [discard (count (:discard (get-corp)))]
+      (play-from-hand state :runner "Fear the Masses")
+      (run-successful state)
+      (is (= (inc discard) (count (:discard (get-corp)))) "Corp trashes 1 card"))
+    (let [discard (count (:discard (get-corp)))]
+      (click-card state :runner (nth (:hand (get-runner)) 0))
+      (click-card state :runner (nth (:hand (get-runner)) 1))
+      (click-card state :runner (nth (:hand (get-runner)) 2))
+      (click-card state :runner (nth (:hand (get-runner)) 3))
+      (click-card state :runner (nth (:hand (get-runner)) 4))
+      (is (= (+ discard 5) (count (:discard (get-corp)))) "Corp trashes 5 additional card"))))
+
 (deftest feint
   ;; Feint - bypass 2 pieces of ice on HQ, but access no cards
   (do-game
@@ -2676,6 +1931,75 @@
     (run-successful state)
     (click-prompt state :runner "OK")
     (is (not (:run @state)) "Run is over")))
+
+(deftest fisk-investment-seminar
+  ;; Fisk Investment Seminar
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Hedge Fund" 5)]}
+               :runner {:deck [(qty "Sure Gamble" 5)]
+                        :hand ["Fisk Investment Seminar"]}})
+    (take-credits state :corp)
+    (let [c-hand (count (:hand (get-corp)))
+          r-hand (count (:hand (get-runner)))]
+      (play-from-hand state :runner "Fisk Investment Seminar")
+      (is (= (+ 3 c-hand (count (:hand (get-corp))))) "Corp draws 3 cards")
+      (is (= (+ 3 r-hand (count (:hand (get-runner))))) "Runner draws 3 cards"))))
+
+(deftest forged-activation-orders
+  ;; Forged Activation Orders
+  (testing "Corp chooses to trash the ice"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Forged Activation Orders"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Forged Activation Orders")
+      (click-card state :runner "Ice Wall")
+      (click-prompt state :corp "Trash")
+      (is (= "Ice Wall" (:title (get-discarded state :corp 0))) "Ice Wall is trashed")))
+  (testing "Corp chooses to rez the ice"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Forged Activation Orders"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Forged Activation Orders")
+      (click-card state :runner "Ice Wall")
+      (click-prompt state :corp "Rez")
+      (is (rezzed? (get-ice state :hq 0)) "Ice Wall is rezzed"))))
+
+(deftest forked
+  ;; Forked
+  (do-game
+    (new-game {:corp {:hand ["Hunter"]}
+               :runner {:hand ["Forked"]}})
+    (play-from-hand state :corp "Hunter" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Forked")
+    (click-prompt state :runner "HQ")
+    (run-continue state)
+    (card-ability state :runner (-> (get-runner) :play-area first) 0)
+    (is (= 1 (count (:discard (get-corp)))) "Hunter is trashed")
+    (run-successful state)))
+
+(deftest frame-job
+  ;; Frame Job
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hostile Takeover"]}
+               :runner {:hand ["Frame Job"]}})
+    (take-credits state :corp)
+    (run-empty-server state :hq)
+    (click-prompt state :runner "Steal")
+    (play-from-hand state :runner "Frame Job")
+    (let [bp (count-bad-pub state)]
+      (click-prompt state :runner "Hostile Takeover")
+      (is (= (inc bp) (count-bad-pub state)) "Corp gains 1 bp")
+      (is (not (get-scored state :runner 0)) "Hostile Takeover is forfeit"))))
 
 (deftest frantic-coding
   ;; Frantic Coding - Install 1 program, other 9 cards are trashed
@@ -2807,6 +2131,25 @@
       (is (= 1 (count (filter :seen discard))) "There is 1 seen card in Archives"))
     (is (zero? (count (:hand (get-corp)))) "There are no cards in hand")))
 
+(deftest government-investigations
+  ;; Government Investigations
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Cerebral Cast"]}
+               :runner {:hand ["Government Investigations" "Push Your Luck"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Government Investigations")
+    (run-empty-server state :archives)
+    (take-credits state :runner)
+    (play-from-hand state :corp "Cerebral Cast")
+    (is (= ["Roll a d6" "0 [Credits]" "1 [Credits]"] (:choices (prompt-map :corp))))
+    (is (= ["Roll a d6" "0 [Credits]" "1 [Credits]"] (:choices (prompt-map :runner))))
+    (click-prompt state :corp "0 [Credits]")
+    (click-prompt state :runner "0 [Credits]")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Push Your Luck")
+    (is (= ["0" "1" "3" "4" "5"] (:choices (prompt-map :runner))) "Runner can't choose 2")))
+
 (deftest guinea-pig
   ;; Guinea Pig
   (do-game
@@ -2918,23 +2261,6 @@
     (click-prompt state :runner "No action")
     (is (not (:run @state)) "Run is finished")))
 
-(deftest isolation
-  ;; Isolation - A resource must be trashed, gain 7c
-  (do-game
-    (new-game {:runner {:deck ["Kati Jones" "Isolation"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Isolation")
-    (is (= 2 (count (get-in @state [:runner :hand]))) "Isolation could not be played because no resource is installed")
-    (is (zero? (count (get-resource state))) "Kati Jones is not installed")
-    (play-from-hand state :runner "Kati Jones")
-    (is (= 1 (count (get-resource state))) "Kati Jones was installed")
-    (let [kj (get-resource state 0)]
-      (play-from-hand state :runner "Isolation")
-      (click-card state :runner kj)
-      (is (zero? (count (get-resource state))) "Kati Jones was trashed")
-      (is (= 8 (:credit (get-runner))) "Gained 7 credits")
-      (is (= 2 (count (:discard (get-runner)))) "Kati Jones and Isolation are in the discard"))))
-
 (deftest i-ve-had-worse
   ;; I've Had Worse - Draw 3 cards when lost to net/meat damage; don't trigger if flatlined
   (testing "Basic test"
@@ -2973,6 +2299,44 @@
       (run-empty-server state "R&D")
       (play-from-hand state :runner "Apocalypse")
       (is (not= "Flatline" (:reason @state)) "Win condition does not report flatline"))))
+
+(deftest immolation-script
+  ;; Immolation Script
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]
+                        :discard ["Ice Wall"]}
+                 :runner {:hand ["Immolation Script"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Immolation Script")
+      (run-successful state)
+      (click-prompt state :runner "Ice Wall")
+      (click-card state :runner (get-ice state :hq 0))
+      (is (not (get-ice state :hq 0)) "Ice Wall is trashed")
+      (is (= 2 (count (:discard (get-corp)))) "2 cards in trash now")))
+  (testing "with no ice in archives"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Immolation Script"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Immolation Script")
+      (run-successful state)
+      (is (empty? (prompt-map :runner)) "No prompt for runner")))
+  (testing "with no ice installed"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :discard ["Ice Wall"]}
+                 :runner {:hand ["Immolation Script"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Immolation Script")
+      (run-successful state)
+      (is (empty? (prompt-map :runner)) "No prompt for runner"))))
 
 (deftest in-the-groove
   ;; In the Groove - whenever you install cost >0 stuff, draw or gain 1
@@ -3065,6 +2429,30 @@
     (is (= "Jackson Howard" (:title (second (rest (rest (:deck (get-corp))))))))
     (is (= "Global Food Initiative" (:title (second (rest (rest (rest (:deck (get-corp)))))))))))
 
+(deftest infiltration
+  ;; Infiltration
+  (testing "Gain 2"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["Infiltration"]}})
+      (take-credits state :corp)
+      (let [credits (:credit (get-runner))]
+        (play-from-hand state :runner "Infiltration")
+        (click-prompt state :runner "Gain 2 [Credits]")
+        (is (= (+ 2 credits) (:credit (get-runner))) "Runner gains 2"))))
+  (testing "Expose"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Infiltration"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Infiltration")
+      (click-prompt state :runner "Expose a card")
+      (click-card state :runner "Ice Wall")
+      (is (last-log-contains? state "Runner exposes Ice Wall protecting HQ at position 0")
+          "Infiltration properly exposes the ice"))))
+
 (deftest information-sifting
   (testing "Hudson interaction :max-access"
     (do-game
@@ -3120,6 +2508,19 @@
     (run-successful state)
     (is (= 2 (:current-strength (get-program state 0))) "Corroder reset to 2 strength")))
 
+(deftest inside-job
+  ;; Inside Job
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall"]}
+               :runner {:hand ["Inside Job"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Inside Job")
+    (click-prompt state :runner "HQ")
+    (is (:run @state) "A run has been initiated")))
+
 (deftest insight
   ;; Insight
   (do-game
@@ -3161,6 +2562,36 @@
       (play-from-hand state :runner "Interdiction")
       (core/rez state :corp jackson)
       (is (not (rezzed? (refresh jackson))) "Jackson is not rezzed"))))
+
+(deftest isolation
+  ;; Isolation - A resource must be trashed, gain 7c
+  (do-game
+    (new-game {:runner {:deck ["Kati Jones" "Isolation"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Isolation")
+    (is (= 2 (count (get-in @state [:runner :hand]))) "Isolation could not be played because no resource is installed")
+    (is (zero? (count (get-resource state))) "Kati Jones is not installed")
+    (play-from-hand state :runner "Kati Jones")
+    (is (= 1 (count (get-resource state))) "Kati Jones was installed")
+    (let [kj (get-resource state 0)]
+      (play-from-hand state :runner "Isolation")
+      (click-card state :runner kj)
+      (is (zero? (count (get-resource state))) "Kati Jones was trashed")
+      (is (= 8 (:credit (get-runner))) "Gained 7 credits")
+      (is (= 2 (count (:discard (get-runner)))) "Kati Jones and Isolation are in the discard"))))
+
+(deftest itinerant-protesters
+  ;; Itinerant Protesters
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Itinerant Protesters"]}})
+    (take-credits state :corp)
+    (is (= 5 (hand-size :corp)) "Corp starts with handsize of 5")
+    (play-from-hand state :runner "Itinerant Protesters")
+    (core/gain state :corp :bad-publicity 1)
+    (is (= 4 (hand-size :corp)) "Corp's handsize is lowered by 1 for a bad publicity")
+    (core/gain state :corp :bad-publicity 3)
+    (is (= 1 (hand-size :corp)))))
 
 (deftest khusyuk
   (testing "Basic functionality"
@@ -3340,6 +2771,23 @@
     (is (= 1 (count (:discard (get-corp)))) "Ice Wall is trashed")
     (run-successful state)))
 
+(deftest kraken
+  ;; Kraken
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hostile Takeover" "Ice Wall"]}
+               :runner {:hand ["Kraken"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Kraken")
+    (is (empty? (prompt-map :runner)) "No prompt as the runner hasn't stolen an agenda yet")
+    (run-empty-server state :hq)
+    (click-prompt state :runner "Steal")
+    (play-from-hand state :runner "Kraken")
+    (click-prompt state :runner "HQ")
+    (click-card state :corp (get-ice state :hq 0))
+    (is (not (get-ice state :hq 0)) "Ice Wall is trashed")))
+
 (deftest labor-rights
   ;; Labor Rights - trash 3 cards, shuffle 3 cards from heap->stack, draw 1 card, rfg Labor Rights
   (testing "Basic behavior"
@@ -3384,6 +2832,38 @@
     (is (= 3 (count (:hand (get-runner)))) "Drew 3 cards")
     (is (= 2 (:click (get-runner))) "Spent 2 clicks")
     (is (= 1 (count-tags state)) "Lost 2 tags")))
+
+(deftest lean-and-mean
+  ;; Lean and Mean
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Lean and Mean" 3) (qty "Corroder" 5)]
+                        :credits 100}})
+    (take-credits state :corp)
+    (core/gain state :runner :click 10)
+    (testing "Duration and bonus"
+      (play-from-hand state :runner "Corroder")
+      (is (= 2 (core/get-strength (get-program state 0))) "Corroder starts with 2 str")
+      (play-from-hand state :runner "Lean and Mean")
+      (click-prompt state :runner "R&D")
+      (is (= 4 (core/get-strength (get-program state 0))) "Corroder gains 2 str from Lean and Mean")
+      (run-successful state)
+      (is (= 2 (core/get-strength (get-program state 0))) "Lean and Mean's str bonus goes away at run end"))
+    (testing "Bonus applies to multiple icebreakers"
+      (play-from-hand state :runner "Corroder")
+      (play-from-hand state :runner "Corroder")
+      (play-from-hand state :runner "Lean and Mean")
+      (click-prompt state :runner "R&D")
+      (is (= 4 (core/get-strength (get-program state 0))) "Corroder gains 2 str from Lean and Mean")
+      (is (= 4 (core/get-strength (get-program state 1))) "Corroder gains 2 str from Lean and Mean")
+      (is (= 4 (core/get-strength (get-program state 2))) "Corroder gains 2 str from Lean and Mean")
+      (run-successful state))
+    (testing "Bonus doesn't apply when there are too many programs installed"
+      (play-from-hand state :runner "Corroder")
+      (play-from-hand state :runner "Lean and Mean")
+      (click-prompt state :runner "R&D")
+      (is (= 4 (count (get-program state))) "4 programs installed")
+      (is (= 2 (core/get-strength (get-program state 0))) "Corroder doesn't gain any strength from Lean and Mean"))))
 
 (deftest leave-no-trace
   ;; Leave No Trace should derez ICE that was rezzed during the run
@@ -3432,6 +2912,89 @@
         (is (= (+ credits 2) (:credit (get-runner))) "Keros should trigger off derez")
         (is (not (rezzed? (get-ice state :hq 0))) "Inner Ice Wall should not be rezzed")
         (is (rezzed? (get-ice state :hq 1)) "Outer Ice Wall should be rezzed still")))))
+
+(deftest legwork
+  ;; Legwork
+  (testing "Basic test"
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Hostile Takeover" 3)]}
+               :runner {:hand ["Legwork"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Legwork")
+    (run-successful state)
+    (dotimes [_ 3]
+      (click-prompt state :runner "Card from hand")
+      (click-prompt state :runner "Steal"))
+    (is (not (:run @state)) "Run has finished")))
+  (testing "Doesn't give bonus accesses when unsuccessful"
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Hostile Takeover" 3)]}
+               :runner {:hand ["Legwork"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Legwork")
+    (run-jack-out state)
+    (run-empty-server state :hq)
+    (click-prompt state :runner "Steal")
+    (is (not (:run @state)) "Run has finished"))))
+
+(deftest leverage
+  ;; Leverage
+  (testing "Corp takes bad publicity"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["Leverage"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Leverage")
+      (is (empty? (prompt-map :corp)) "No prompt as runner didn't run HQ")
+      (run-empty-server state :hq)
+      (click-prompt state :runner "No action")
+      (is (zero? (count-bad-pub state)) "Corp has no bad pub")
+      (play-from-hand state :runner "Leverage")
+      (click-prompt state :corp "Yes")
+      (is (= 2 (count-bad-pub state)) "Corp gains 2 bad pub from Leverage")))
+  (testing "Corp doesn't take bad publicity"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["BOOM!"]}
+                 :runner {:hand ["Leverage"]}
+                 :tags 2})
+      (is (not (:winner @state)) "No winner is declared yet")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Leverage")
+      (is (empty? (prompt-map :corp)) "No prompt as runner didn't run HQ")
+      (run-empty-server state :hq)
+      (click-prompt state :runner "No action")
+      (play-from-hand state :runner "Leverage")
+      (click-prompt state :corp "No")
+      (take-credits state :runner)
+      (play-from-hand state :corp "BOOM!")
+      (is (not (:winner @state)) "Runner doesn't take any damage"))))
+
+(deftest levy-ar-lab-access
+  ;; Levy AR Lab Access
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck ["Magnum Opus"]
+                        :hand ["Levy AR Lab Access" "Easy Mark"]
+                        :discard [(qty "Sure Gamble" 3)]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Levy AR Lab Access")
+    (is (= 5 (count (:hand (get-runner)))) "Runner should draw 5 cards")
+    (is (zero? (count (:deck (get-runner)))) "Stack should be empty")
+    (is (zero? (count (:discard (get-runner)))) "Heap should be empty")
+    (is (= "Levy AR Lab Access" (:title (get-rfg state :runner 0))) "Levy should be rfg'd")))
+
+(deftest lucky-find
+  ;; Lucky Find
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Lucky Find"]}})
+    (take-credits state :corp)
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Lucky Find")
+      (is (= (+ credits -3 9) (:credit (get-runner))) "Runner should spend 3 and gain 9"))))
 
 (deftest mad-dash
   ;; Mad Dash - Make a run. Move to score pile as 1 point if steal agenda.  Take 1 meat if not
@@ -3487,6 +3050,37 @@
     (play-from-hand state :runner "Making an Entrance")
     (is (= 1 (count (:hand (get-runner)))) "Can only play on first click")))
 
+(deftest marathon
+  ;; Marathon
+  (testing "Trashed on unsuccessful run"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Marathon"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Marathon")
+      (click-prompt state :runner "Server 1")
+      (run-jack-out state)
+      (is (= "Marathon" (-> (get-runner) :discard first :title)) "Marathon should be trashed")
+      (is (zero? (count (:hand (get-runner)))) "Marathon should not be in hand")))
+  (testing "Moved to hand on successful run"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:hand ["Marathon"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (take-credits state :corp)
+      (let [clicks (:click (get-runner))]
+        (play-from-hand state :runner "Marathon")
+        (click-prompt state :runner "Server 1")
+        (run-successful state)
+        (is (= "Marathon" (-> (get-runner) :hand first :title)) "Marathon should be in hand")
+        (is (= clicks (:click (get-runner))) "Runner should gain 1 click"))
+      (is (not (:run @state)) "Run has ended")
+      (run-on state "Server 1")
+      (is (not (:run @state)) "Run shouldn't be initiated on a Marathon'd server"))))
+
 (deftest mars-for-martians
   ;; Mars for Martians - Full test
   (do-game
@@ -3508,6 +3102,22 @@
     (play-from-hand state :runner "Mars for Martians")
     (is (= 3 (count (:hand (get-runner)))) "3 clan resources, +3 cards but -1 for playing Mars for Martians")
     (is (= 7 (:credit (get-runner))) "5 tags, +5 credits")))
+
+(deftest mass-install
+  ;; Mass Install
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Mass Install" "Corroder" "Self-modifying Code" "Cloak"]
+                        :credits 10}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Mass Install")
+    (click-card state :runner "Corroder")
+    (is (= "Corroder" (:title (get-program state 0))) "Corroder should be installed")
+    (click-card state :runner "Self-modifying Code")
+    (is (= "Self-modifying Code" (:title (get-program state 1))) "SMC should be installed")
+    (click-card state :runner "Cloak")
+    (is (= "Cloak" (:title (get-program state 2))) "Cloak should be installed")
+    (is (empty? (prompt-map :runner)) "Runner should have no more prompts")))
 
 (deftest mining-accident
   ;; Mining Accident
@@ -3599,6 +3209,30 @@
         (changes-val-macro 0 (:credit (get-runner))
                            "Used 1 credit from Net Celebrity"
                            (click-card state :runner nc))))))
+
+(deftest networking
+  ;; Networking
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Networking"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Networking")
+    (is (= "Networking" (-> (get-runner) :hand first :title)) "Networking shouldn't be played")
+    (core/gain-tags state :runner 4)
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Networking")
+      (is (= 3 (count-tags state)) "Runner should lose 1 tag")
+      (click-prompt state :runner "Yes")
+      (is (= (dec credits) (:credit (get-runner))) "Runner should spend 1 on Networking ability")
+      (is (zero? (count (:discard (get-runner)))) "Runner's discard should be empty")
+      (is (= "Networking" (-> (get-runner) :hand first :title))))
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Networking")
+      (is (= 2 (count-tags state)) "Runner should lose 1 tag")
+      (click-prompt state :runner "No")
+      (is (= credits (:credit (get-runner))) "Runner should spend 1 on Networking ability")
+      (is (= 1 (count (:discard (get-runner)))) "Runner's discard should be empty")
+      (is (= "Networking" (-> (get-runner) :discard first :title)) "Networking should be in heap"))))
 
 (deftest notoriety
   ;; Notoriety - Run all 3 central servers successfully and play to gain 1 agenda point
@@ -3716,6 +3350,18 @@
     (is (zero? (count (:discard (get-runner)))))
     (is (= 6 (count (:rfg (get-runner)))))))
 
+(deftest paper-tripping
+  ;; Paper Tripping
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Paper Tripping"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Paper Tripping")
+    (is (= "Paper Tripping" (-> (get-runner) :hand first :title)) "Paper Tripping shouldn't be played")
+    (core/gain-tags state :runner 100)
+    (play-from-hand state :runner "Paper Tripping")
+    (is (zero? (count-tags state)) "Runner should lose all tags")))
+
 (deftest peace-in-our-time
   ;; Peace in Our Time - runner gains 10, corp gains 5. No runs allowed during turn.
   (do-game
@@ -3728,6 +3374,20 @@
     (is (= 14 (:credit (get-runner))) "Runner gains 10 credits")
     (run-on state "HQ")
     (is (not (:run @state)) "Not allowed to make a run")))
+
+(deftest planned-assault
+  ;; Planned Assault
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck ["Account Siphon"]
+                        :hand ["Planned Assault"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Planned Assault")
+    (is (not (:run @state)) "No run should be initiated yet")
+    (click-prompt state :runner "Account Siphon")
+    (is (:run @state) "A run should be initiated")
+    (run-successful state)
+    (is (= 2 (:click (get-runner))) "Runner should only spend 2 clicks on Planned Assault")))
 
 (deftest political-graffiti
   ;; Political Graffiti - swapping with Turntable works / purging viruses restores points
@@ -3777,6 +3437,42 @@
       (is (zero? (:agenda-point (get-corp))) "Forfeiting agenda did not refund extra agenda points")
       (is (= 1 (count (:discard (get-runner)))) "Political Graffiti is in the Heap"))))
 
+(deftest populist-rally
+  ;; Populist Rally
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Data Dealer" "Populist Rally"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Populist Rally")
+    (is (= ["Data Dealer" "Populist Rally"] (->> (get-runner) :hand (map :title) sort))
+        "Populist Rally shouldn't be played")
+    (play-from-hand state :runner "Data Dealer")
+    (play-from-hand state :runner "Populist Rally")
+    (take-credits state :runner)
+    (is (= 2 (:click (get-corp))) "Corp should gain only 2 clicks this turn")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (is (= 3 (:click (get-corp))) "Corp should gain 3 clicks as normal in later turns")))
+
+(deftest power-nap
+  ;; Power Nap
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Power Nap" 3)]}})
+    (take-credits state :corp)
+    (core/gain state :runner :click 2)
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Power Nap")
+      (is (= (+ credits 2) (:credit (get-runner))) "Runner should gain 2"))
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Power Nap")
+      (is (= (+ credits 3) (:credit (get-runner)))
+          "Runner should gain 3 for 1 double in heap"))
+    (let [credits (:credit (get-runner))]
+      (play-from-hand state :runner "Power Nap")
+      (is (= (+ credits 4) (:credit (get-runner)))
+          "Runner should gain 4 for 2 doubles in heap"))))
+
 (deftest power-to-the-people
   ;; Power to the People - Gain 7c the first time you access an agenda
   (do-game
@@ -3795,6 +3491,50 @@
     (run-empty-server state "HQ")
     (click-prompt state :runner "Steal")
     (is (= 6 (:credit (get-runner))) "No credits gained from 2nd agenda access")))
+
+(deftest prey
+  ;; Prey
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall" "Enigma"]}
+               :runner {:hand [(qty "Prey" 2) (qty "Clone Chip" 3)]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Enigma" "R&D")
+    (core/rez state :corp (get-ice state :hq 0))
+    (core/rez state :corp (get-ice state :rd 0))
+    (take-credits state :corp)
+    (core/gain state :runner :click 5)
+    (dotimes [_ 3]
+      (play-from-hand state :runner "Clone Chip"))
+    (play-from-hand state :runner "Prey")
+    (click-prompt state :runner "HQ")
+    (run-continue state)
+    (card-ability state :runner (-> (get-runner) :play-area first) 0)
+    (is (get-ice state :hq 0) "Ice Wall should not be trashed yet")
+    (click-card state :runner (get-hardware state 0))
+    (is (not (get-ice state :hq 0)) "Ice Wall should be trashed")
+    (run-successful state)
+    (play-from-hand state :runner "Prey")
+    (click-prompt state :runner "R&D")
+    (run-continue state)
+    (card-ability state :runner (-> (get-runner) :play-area first) 0)
+    (is (get-ice state :rd 0) "Enigma should not be trashed yet")
+    (click-card state :runner (get-hardware state 0))
+    (click-card state :runner (get-hardware state 1))
+    (is (not (get-ice state :rd 0)) "Enigma should be trashed")))
+
+(deftest process-automation
+  ;; Process Automation
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck [(qty "Sure Gamble" 5)]
+                        :hand ["Process Automation"]}})
+    (take-credits state :corp)
+    (let [credits (:credit (get-runner))
+          hand (dec (count (:hand (get-runner))))]
+      (play-from-hand state :runner "Process Automation")
+      (is (= (+ 2 credits) (:credit (get-runner))) "Should gain 2 credits")
+      (is (= (inc hand) (count (:hand (get-runner)))) "Should draw 1 card"))))
 
 (deftest push-your-luck
   ;; Push Your Luck
@@ -3853,6 +3593,17 @@
       (is (zero? (:current-strength (refresh atman))) "Atman 0 current strength")
       (is (= 2 (:current-strength (refresh corr))) "Corroder 2 current strength"))))
 
+(deftest quality-time
+  ;; Quality Time
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck [(qty "Sure Gamble" 5)]
+                        :hand ["Quality Time"]}})
+    (take-credits state :corp)
+    (is (= 1 (count (:hand (get-runner)))) "Runner should have 1 card in hand")
+    (play-from-hand state :runner "Quality Time")
+    (is (= 5 (count (:hand (get-runner)))) "Runner should draw 5 cards")))
+
 (deftest queen-s-gambit
   ;; Check that Queen's Gambit prevents access of card #1542
   (do-game
@@ -3881,6 +3632,22 @@
       (is (core/can-access? state :runner (refresh pad)) "Can access PAD Campgain next turn")
       (click-prompt state :runner "Pay 4 [Credits] to trash")
       (is (= (- runner-creds 4) (:credit (get-runner))) "Paid 4 credits to trash PAD Campaign"))))
+
+(deftest quest-completed
+  ;; Quest Completed
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hostile Takeover"]}
+               :runner {:hand ["Quest Completed"]}})
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (click-prompt state :runner "No action")
+    (run-empty-server state "HQ")
+    (play-from-hand state :runner "Quest Completed")
+    (click-card state :runner "Hostile Takeover")
+    (click-prompt state :runner "Steal")))
 
 ;; rebirth
 (let [akiko "Akiko Nisei: Head Case"
@@ -4037,6 +3804,19 @@
     (is (= 3 (count (core/all-installed state :runner))) "Runner has no other cards installed")
     (is (empty? (:discard (get-runner))) "Runner has empty trash")
     (is (= 1 (count (:rfg (get-runner)))) "Runner has 1 card in RFG")))
+
+(deftest recon
+  ;; Recon
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall"]}
+               :runner {:hand ["Recon"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Recon")
+    (click-prompt state :runner "HQ")
+    (is (:run @state) "A run has been initiated")))
 
 (deftest rejig
   ;; Rejig
@@ -4283,6 +4063,26 @@
         (card-ability state :corp jeeves 0)
         (is (= 3 (:click (get-corp))) "Corp has 3 clicks - Jeeves working ok")))))
 
+(deftest run-amok
+  ;; Run Amok
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall" "Enigma"]}
+               :runner {:hand ["Run Amok"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Enigma" "New remote")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Run Amok")
+    (click-prompt state :runner "Server 1")
+    (core/rez state :corp (get-ice state :remote1 0))
+    (run-successful state)
+    (click-card state :runner "Ice Wall")
+    (is (prompt-map :runner) "Prompt should still be active as Ice Wall wasn't rezzed this run")
+    (click-card state :runner "Enigma")
+    (is (empty? (prompt-map :runner)) "Enigma should be trashed")
+    (is (= "Enigma" (-> (get-corp) :discard first :title)) "Enigma should be trashed")))
+
 (deftest running-interference
   ;; Running Interference
   (do-game
@@ -4310,6 +4110,47 @@
       (core/rez state :corp iw)
       (is (empty? (:prompt (get-corp))))
       (is (= (- credits (:cost iw)) (:credit (get-corp))) "Rezzing Ice Wall costs normal"))))
+
+(deftest satellite-uplink
+  ;; Satellite Uplink
+  (testing "when exposing 2 cards"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall" "Hostile Takeover"]}
+                 :runner {:hand ["Satellite Uplink"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Hostile Takeover" "Server 1")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Satellite Uplink")
+      (click-card state :runner "Ice Wall")
+      (click-card state :runner "Hostile Takeover")))
+  (testing "when exposing 2 cards"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall" "Hostile Takeover"]}
+                 :runner {:hand ["Satellite Uplink"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (play-from-hand state :corp "Hostile Takeover" "Server 1")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Satellite Uplink")
+      (click-card state :runner "Ice Wall")
+      (click-prompt state :runner "Done"))))
+
+(deftest scavenge
+  ;; Scavenge
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Scavenge" "Corroder"]
+                        :discard ["Mass-Driver"]
+                        :credits 10}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Corroder")
+    (play-from-hand state :runner "Scavenge")
+    (let [credits (:credit (get-runner))]
+      (click-card state :runner "Corroder")
+      (click-card state :runner "Mass-Driver")
+      (is (= "Mass-Driver" (:title (get-program state 0))) "Mass-Driver is now installed")
+      (is (= (+ credits 2 -8) (:credit (get-runner))) "Scavenge should give discount"))))
 
 (deftest scrubbed
   ;; First piece of ice encountered each turn has -2 Strength for remainder of the run
@@ -4373,6 +4214,37 @@
     (is (= 1 (:credit (get-runner))) "No credits paid for trashing")
     (is (nil? (get-in @state [:corp :servers :remote1 :content])) "Server 1 no longer exists")))
 
+(deftest social-engineering
+  ;; Social Engineering
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Fire Wall" "Ice Wall"]
+                      :credits 10}
+               :runner {:hand ["Social Engineering"]}})
+    (play-from-hand state :corp "Fire Wall" "HQ")
+    (play-from-hand state :corp "Ice Wall" "R&D")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Social Engineering")
+    (click-card state :runner "Fire Wall")
+    (let [credits (:credit (get-runner))]
+      (core/rez state :corp (get-ice state :rd 0))
+      (is (= credits (:credit (get-runner))) "Shouldn't gain credits from different ice rez")
+      (core/rez state :corp (get-ice state :hq 0))
+      (is (= (+ credits 5) (:credit (get-runner))) "Should gain credits from correct ice rez"))))
+
+(deftest spear-phishing
+  ;; Spear Phishing
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ice Wall"]}
+               :runner {:hand ["Spear Phishing"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Spear Phishing")
+    (click-prompt state :runner "HQ")
+    (is (:run @state) "A run has been initiated")))
+
 (deftest spec-work
   ;; Spec Work
   (do-game
@@ -4386,6 +4258,47 @@
     (click-card state :runner (get-program state 0))
     (is (= 7 (:credit (get-runner))) "+4 credits after paying for Spec Work")
     (is (= 2 (count (:hand (get-runner)))) "Drew 2 cards")))
+
+(deftest special-order
+  ;; Special Order
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck ["Corroder"]
+                        :hand ["Special Order"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Special Order")
+    (click-prompt state :runner "Corroder")
+    (is (= ["Corroder"] (->> (get-runner) :hand (map :title)))
+        "Corroder should be in the hand now")))
+
+(deftest spooned
+  ;; Spooned
+  (do-game
+    (new-game {:corp {:deck ["Enigma"]}
+               :runner {:deck ["Spooned"]}})
+    (play-from-hand state :corp "Enigma" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Spooned")
+    (click-prompt state :runner "HQ")
+    (run-continue state)
+    (card-ability state :runner (-> (get-runner) :play-area first) 0)
+    (is (= 1 (count (:discard (get-corp)))) "Enigma is trashed")
+    (run-successful state)))
+
+(deftest spot-the-prey
+  ;; Spot the Prey
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hostile Takeover"]}
+               :runner {:hand ["Spot the Prey"]}})
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Spot the Prey")
+    (click-card state :runner "Hostile Takeover")
+    (is (last-log-contains? state "Runner exposes Hostile Takeover"))
+    (click-prompt state :runner "HQ")
+    (is (:run @state) "Run should be initiated")))
 
 (deftest stimhack
   ;; Stimhack - Gain 9 temporary credits and take 1 brain damage after the run
@@ -4464,6 +4377,31 @@
         (play-from-hand state :runner "Surge")
         (click-card state :runner gd)
         (is (= 3 (get-counters (refresh gd) :virus)) "Surge does not trigger on Gorman Drip")))))
+
+(deftest syn-attack
+  ;; SYN Attack
+  (testing "and corp chooses to draw"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["SYN Attack"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "SYN Attack")
+      (let [hand (count (:hand (get-corp)))]
+        (click-prompt state :corp "Draw 4")
+        (is (= (+ hand 4) (count (:hand (get-corp)))) "Corp should draw 4 cards"))))
+  (testing "and corp chooses to discard"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["SYN Attack"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "SYN Attack")
+      (let [hand (count (:hand (get-corp)))]
+        (click-prompt state :corp "Discard 2")
+        (click-card state :corp (first (:hand (get-corp))))
+        (click-card state :corp (second (:hand (get-corp))))
+        (is (= (+ hand -2) (count (:hand (get-corp)))) "Corp should discard 2 cards")))))
 
 (deftest system-outage
   ;; When Corp draws 1+ cards, it loses 1 if it is not the first time he or she has drawn cards this turn
@@ -4659,6 +4597,21 @@
       (core/advance state :corp {:card (refresh napd)})
       (is (= 7 (:credit (get-corp))) "NAPD could be advanced (3 credits charged for advancing)"))))
 
+(deftest three-steps-ahead
+  ;; Three Steps Ahead
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Three Steps Ahead"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Three Steps Ahead")
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (let [credits (:credit (get-runner))]
+      (run-empty-server state "HQ")
+      (click-prompt state :runner "No action")
+      (take-credits state :runner)
+      (is (= (+ credits 6) (:credit (get-runner))) "Runner should gain 6 for 3 successful runs"))))
+
 (deftest tinkering
   ;; Tinkering - Add subtypes to ice
   (do-game
@@ -4739,6 +4692,20 @@
       (core/score state :corp {:card (refresh tg)})
       (is (= 3 (:agenda-point (get-corp))) "Took 5 advancements to score"))))
 
+(deftest uninstall
+  ;; Uninstall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:hand [(qty "Uninstall" 2) "Corroder" "Clone Chip"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Corroder")
+    (play-from-hand state :runner "Clone Chip")
+    (play-from-hand state :runner "Uninstall")
+    (click-card state :runner "Corroder")
+    (play-from-hand state :runner "Uninstall")
+    (click-card state :runner "Clone Chip")
+    (is (= 2 (count (:hand (get-runner)))) "Runner has played 2 and picked up 2 cards")))
+
 (deftest unscheduled-maintenance
   ;; Unscheduled Maintenance - prevent Corp from installing more than 1 ICE per turn
   (do-game
@@ -4771,6 +4738,23 @@
     (is (= 1 (count-tags state)) "Took 1 tag")
     (is (= 5 (:credit (get-runner))) "Paid 8 credits")
     (is (zero? (:credit (get-corp))) "Corp lost all 8 credits")))
+
+(deftest wanton-destruction
+  ;; Wanton Destruction
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Hedge Fund" 5)]}
+               :runner {:hand ["Wanton Destruction"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Wanton Destruction")
+    (is (= [:hq] (:server (:run @state))) "Run should be on HQ")
+    (run-successful state)
+    (click-prompt state :runner "Wanton Destruction")
+    (is (zero? (count (:discard (get-corp)))) "Corp should have no cards in Archives")
+    (click-prompt state :runner "3")
+    (is (= 2 (count (:hand (get-corp)))) "Corp should discard 3 cards")
+    (is (= 3 (count (:discard (get-corp)))) "Corp should now have 3 cards in Archives")
+    (is (zero? (:click (get-runner))) "Runner should spend 3 clicks on ability")))
 
 (deftest watch-the-world-burn
   ;; Watch the World Burn - run a remote to RFG the first card accessed
@@ -4857,3 +4841,19 @@
     (click-prompt state :runner (find-card "Ice Wall" (:hand (get-corp))))
     (click-prompt state :runner (find-card "Enigma" (:hand (get-corp))))
     (is (= #{"Ice Wall" "Enigma"} (->> (get-corp) :deck (map :title) (into #{}))))))
+
+(deftest windfall
+  ;; Windfall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]}
+               :runner {:deck ["Monolith"]
+                        :hand ["Windfall"]}})
+    (take-credits state :corp)
+    (let [num-shuffles (count (core/turn-events state :runner :runner-shuffle-deck))
+          credits (:credit (get-runner))]
+      (play-from-hand state :runner "Windfall")
+      (is (= (inc num-shuffles) (count (core/turn-events state :runner :runner-shuffle-deck)))
+          "Runner should shuffle the stack")
+      (is (= (+ credits 18) (:credit (get-runner))) "Runner should gain credits from trash")
+      (is (= "Monolith" (-> (get-runner) :discard first :title))
+          "Monolith should be trashed"))))

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -156,15 +156,6 @@
         (click-card state :runner "Ice Wall")
         (click-prompt state :corp "No")))))
 
-(deftest box-e
-  ;; Box-E - +2 MU, +2 max hand size
-  (do-game
-    (new-game {:runner {:deck ["Box-E"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Box-E")
-    (is (= 6 (core/available-mu state)))
-    (is (= 7 (hand-size :runner)))))
-
 (deftest bookmark
   ;; Bookmark
   (do-game
@@ -181,6 +172,15 @@
     (card-ability state :runner bm 2)
     (is (nil? (refresh bm)) "Bookmark is now trashed")
     (is (= 3 (count (:hand (get-runner)))) "Bookmark moved all hosted card into the grip"))))
+
+(deftest box-e
+  ;; Box-E - +2 MU, +2 max hand size
+  (do-game
+    (new-game {:runner {:deck ["Box-E"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Box-E")
+    (is (= 6 (core/available-mu state)))
+    (is (= 7 (hand-size :runner)))))
 
 (deftest brain-chip
   ;; Brain Chip handsize and memory limit
@@ -310,6 +310,14 @@
                            (card-ability state :runner co 1)
                            (click-card state :runner cyb))))))
 
+(deftest cybersolutions-mem-chip
+  ;; CyberSolutions Mem Chip- Gain 2 memory
+  (do-game
+    (new-game {:runner {:deck [(qty "CyberSolutions Mem Chip" 3)]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "CyberSolutions Mem Chip")
+    (is (= 6 (core/available-mu state)) "Gain 2 memory")))
+
 (deftest cybsoft-macrodrive
   ;; Cybsoft MacroDrive
   (testing "Pay-credits prompt"
@@ -322,14 +330,6 @@
         (changes-val-macro -1 (:credit (get-runner))
                            "Used 1 credit from Cybsoft MacroDrive"
                            (click-card state :runner cyb))))))
-
-(deftest cybersolutions-mem-chip
-  ;; CyberSolutions Mem Chip- Gain 2 memory
-  (do-game
-    (new-game {:runner {:deck [(qty "CyberSolutions Mem Chip" 3)]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "CyberSolutions Mem Chip")
-    (is (= 6 (core/available-mu state)) "Gain 2 memory")))
 
 (deftest daredevil
   ;; Daredevil
@@ -986,7 +986,6 @@
        (click-prompt state :runner "Done")
        (is (:run @state) "Run prevented from ending")))))
 
-
 (deftest mache
   ;; Mâché
   (testing "Basic test"
@@ -1551,19 +1550,6 @@
       (is (= 1 (count (:hand (get-runner)))) "All meat damage prevented")
       (is (empty? (get-hardware state)) "Plascrete depleted and trashed"))))
 
-(deftest public-terminal
-  ;; Public Terminal
-  (testing "Pay-credits prompt"
-    (do-game
-      (new-game {:runner {:deck ["Public Terminal" "Dirty Laundry"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Public Terminal")
-      (let [pt (get-hardware state 0)]
-        (changes-val-macro -1 (:credit (get-runner))
-                           "Used 1 credit from Public Terminal"
-                           (play-from-hand state :runner "Dirty Laundry")
-                           (click-card state :runner pt))))))
-
 (deftest prepaid-voicepad
   ;; Prepaid VoicePAD
   (testing "Pay-credits prompt"
@@ -1576,6 +1562,19 @@
                            "Used 1 credit from "
                            (play-from-hand state :runner "Dirty Laundry")
                            (click-card state :runner ppvp))))))
+
+(deftest public-terminal
+  ;; Public Terminal
+  (testing "Pay-credits prompt"
+    (do-game
+      (new-game {:runner {:deck ["Public Terminal" "Dirty Laundry"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Public Terminal")
+      (let [pt (get-hardware state 0)]
+        (changes-val-macro -1 (:credit (get-runner))
+                           "Used 1 credit from Public Terminal"
+                           (play-from-hand state :runner "Dirty Laundry")
+                           (click-card state :runner pt))))))
 
 (deftest rabbit-hole
   ;; Rabbit Hole - +1 link, optionally search Stack to install more copies

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -7,891 +7,6 @@
             [game-test.macros :refer :all]
             [clojure.test :refer :all]))
 
-(deftest ad-blitz
-  ;; Launch Campaign
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ad Blitz" "Launch Campaign"]
-                      :discard ["Pop-up Window"]}})
-    (play-from-hand state :corp "Ad Blitz")
-    (click-prompt state :corp "2")
-    (click-card state :corp "Launch Campaign")
-    (click-prompt state :corp "New remote")
-    (click-card state :corp "Pop-up Window")
-    (click-prompt state :corp "Server 1")
-    (is (zero? (count (:hand (get-corp)))) "Corp should have no cards in HQ")
-    (is (= ["Ad Blitz"] (->> (get-corp) :discard (map :title))) "Corp should have only Ad Blitz in Archives")))
-
-(deftest aggressive-negotiation
-  ;; Hostile Takeover
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Aggressive Negotiation" "Hostile Takeover"]}})
-    (play-from-hand state :corp "Aggressive Negotiation")
-    (is (empty? (:prompt (get-corp))) "Corp should have no prompt")
-    (play-and-score state "Hostile Takeover")
-    (play-from-hand state :corp "Aggressive Negotiation")
-    (click-prompt state :corp "Hedge Fund")
-    (is (= ["Hedge Fund"] (->> (get-corp) :hand (map :title))) "Hedge Fund is now in HQ")))
-
-(deftest anonymous-tip
-  ;; Anonymous Tip
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Anonymous Tip"]}})
-    (is (= 1 (count (:hand (get-corp)))) "Corp starts with 1 card in HQ")
-    (is (zero? (count (:discard (get-corp)))) "Corp starts with 0 cards in Archives")
-    (play-from-hand state :corp "Anonymous Tip")
-    (is (= 3 (count (:hand (get-corp)))) "Corp should draw 3 cards")
-    (is (= 1 (count (:discard (get-corp)))) "Corp has 1 card in Archives")))
-
-(deftest archived-memories
-  ;; Archived Memories
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Archived Memories"]
-                      :discard ["Hostile Takeover"]}})
-    (play-from-hand state :corp "Archived Memories")
-    (click-card state :corp "Hostile Takeover")
-    (is (= ["Hostile Takeover"] (->> (get-corp) :hand (map :title))) "Hostile Takeover should be in HQ")))
-
-(deftest ark-lockdown
-  ;; Ark Lockdown
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Ark Lockdown"]}
-               :runner {:hand ["Sure Gamble"]
-                        :discard [(qty "Sure Gamble" 2) "Corroder"]}})
-    (play-from-hand state :corp "Ark Lockdown")
-    (click-prompt state :corp "Sure Gamble")
-    (is (= ["Corroder"] (->> (get-runner) :discard (map :title))) "Both copies of Sure Gamble should be rfg")
-    (is (= ["Sure Gamble"] (->> (get-runner) :hand (map :title))) "Sure Gambles in hand should be around")
-    (is (= ["Sure Gamble" "Sure Gamble"] (->> (get-runner) :rfg (map :title))) "Two copies of Sure Gamble should be rfg'd")))
-
-(deftest audacity
-  ;; Audacity
-  (testing "requires 3 cards in hand to play"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand [(qty "Audacity" 2) "Ice Wall"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (play-from-hand state :corp "Audacity")
-      (is (empty? (:prompt (get-corp))) "Can't play Audacity with too few cards in HQ")))
-  (testing "when placing counters on 1 card"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand [(qty "Audacity" 3) "Ice Wall" "Hostile Takeover"]}})
-      (play-from-hand state :corp "Audacity")
-      (is (empty? (:prompt (get-corp))) "Can't play Audacity without an advanceable card")
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (play-from-hand state :corp "Audacity")
-      (click-card state :corp "Ice Wall")
-      (click-card state :corp "Ice Wall")
-      (is (= 2 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should have 2 counters")))
-  (testing "when placing counters on two cards"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand [(qty "Audacity" 3) "Ice Wall" "Hostile Takeover"]}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (play-from-hand state :corp "Hostile Takeover" "New remote")
-      (play-from-hand state :corp "Audacity")
-      (click-card state :corp "Ice Wall")
-      (click-card state :corp "Hostile Takeover")
-      (is (= 1 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should have 1 counter")
-      (is (= 1 (get-counters (get-content state :remote1 0) :advancement)) "Hostile Takeover should have 1 counter"))))
-
-(deftest back-channels
-  ;; Back Channels
-  (testing "trashing a card with no advancements"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Back Channels" "NGO Front"]}})
-      (play-from-hand state :corp "NGO Front" "New remote")
-      (let [credits (:credit (get-corp))]
-        (play-from-hand state :corp "Back Channels")
-        (click-card state :corp "NGO Front")
-        (is (= credits (:credit (get-corp))) "Corp should gain 0 credits"))))
-  (testing "trashing a card with some advancements"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Back Channels" "NGO Front"]}})
-      (play-from-hand state :corp "NGO Front" "New remote")
-      (core/set-prop state :corp (get-content state :remote1 0) :advance-counter 3)
-      (let [credits (:credit (get-corp))]
-        (play-from-hand state :corp "Back Channels")
-        (click-card state :corp "NGO Front")
-        (is (= (+ credits 9) (:credit (get-corp))) "Corp should gain 3 * 3 credits")))))
-
-(deftest bad-times
-  ;; Bad Times
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Bad Times"]}})
-      (is (= 4 (core/available-mu state)) "Runner should start with 4 MU")
-      (play-from-hand state :corp "Bad Times")
-      (is (= 4 (core/available-mu state)) "Corp can't play without a tag")
-      (core/gain-tags state :runner 1)
-      (play-from-hand state :corp "Bad Times")
-      (is (= 2 (core/available-mu state)) "Runner should lose 2 available MU")
-      (take-credits state :corp)
-      (is (= 4 (core/available-mu state)) "Runner should regain 2 available MU")))
-
-(deftest beanstalk-royalties
-  ;; Beanstalk Royalties
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Beanstalk Royalties"]}})
-    (let [credits (:credit (get-corp))]
-      (play-from-hand state :corp "Beanstalk Royalties")
-      (is (= (+ credits 3) (:credit (get-corp))) "Corp should gain 3"))))
-
-(deftest best-defense
-  ;; Best Defense
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Best Defense" 2)]}
-               :runner {:hand ["Dorm Computer" "Mass-Driver"]
-                        :credits 10}})
-    (play-from-hand state :corp "Best Defense")
-    (is (empty? (:prompt (get-corp))) "Corp can't play Best Defense without installed runner cards")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Dorm Computer")
-    (play-from-hand state :runner "Mass-Driver")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Best Defense")
-    (is (= "Choose a Runner card with an install cost of 0 or less to trash" (-> (get-corp) :prompt first :msg)))
-    (click-card state :corp "Mass-Driver")
-    (is (get-program state 0) "Mass-Driver should still be installed")
-    (click-card state :corp "Dorm Computer")
-    (is (not (get-hardware state 0)) "Dorm Computer should be trashed")
-    (core/gain-tags state :runner 8)
-    (play-from-hand state :corp "Best Defense")
-    (click-card state :corp "Mass-Driver")
-    (is (not (get-program state 0)) "Mass-Driver should still be installed")
-    (is (= 2 (count (:discard (get-runner)))) "2 cards should be in heap")))
-
-(deftest bioroid-efficiency-research
-  ;; Eli 1.0
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Bioroid Efficiency Research" "Eli 1.0"]}})
-    (play-from-hand state :corp "Eli 1.0" "HQ")
-    (play-from-hand state :corp "Bioroid Efficiency Research")
-    (let [credits (:credit (get-corp))]
-      (click-card state :corp "Eli 1.0")
-      (is (rezzed? (get-ice state :hq 0)) "Eli 1.0 should be rezzed")
-      (is (= credits (:credit (get-corp))) "Corp should spend no money to rez"))))
-
-(deftest boom
-  ;; BOOM!
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["BOOM!"]}
-               :runner {:hand [(qty "Sure Gamble" 10)]}})
-    (play-from-hand state :corp "BOOM!")
-    (is (= 1 (count (:hand (get-corp)))) "BOOM! should not be played as runner has no tags")
-    (core/gain-tags state :runner 2)
-    (is (zero? (count (:discard (get-runner)))) "Runner should have 0 cards in discard")
-    (play-from-hand state :corp "BOOM!")
-    (is (= 7 (count (:discard (get-runner)))) "Runner should take 7 damage")))
-
-(deftest celebrity-gift
-  ;; Ice Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Celebrity Gift" "NGO Front" "IPO" "PAD Campaign" "Hostile Takeover" "Ice Wall"]}})
-    (play-from-hand state :corp "Celebrity Gift")
-    (let [credits (:credit (get-corp))]
-      (click-card state :corp "NGO Front")
-      (click-card state :corp "IPO")
-      (click-card state :corp "PAD Campaign")
-      (click-card state :corp "Hostile Takeover")
-      (click-card state :corp "Ice Wall")
-      (is (= (+ credits 10 (:credit (get-corp)))) "Corp should gain 10 credits from 5 cards"))))
-
-(deftest clones-are-not-people
-  ;; Merger
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["\"Clones are not People\"" "Merger"]}})
-    (play-from-hand state :corp "\"Clones are not People\"")
-    (play-and-score state "Merger")
-    (is (= 2 (count (get-scored state :corp))) "Corp should have 2 cards in score area")))
-
-(deftest corporate-shuffle
-  ;; Ice Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Corporate Shuffle" (qty "Ice Wall" 2)]}})
-    (is (= 5 (count (:deck (get-corp)))) "Corp should start with 5 cards in deck")
-    (is (= 3 (count (:hand (get-corp)))) "Corp should have 3 cards in hand")
-    (play-from-hand state :corp "Corporate Shuffle")
-    (is (= 2 (count (:deck (get-corp)))) "Corp should have 3 cards in deck after draw")
-    (is (= 5 (count (:hand (get-corp)))) "Corp should draw up to 5 cards")
-    (is (= 1 (count (:discard (get-corp)))) "Corp should have 1 card in discard from playing")))
-
-(deftest cyberdex-trial
-  ;; Cyberdex Trial
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Cyberdex Trial"]}
-               :runner {:hand ["Datasucker"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Datasucker")
-    (core/add-counter state :runner (get-program state 0) :virus 2)
-    (take-credits state :runner)
-    (play-from-hand state :corp "Cyberdex Trial")
-    (is (zero? (get-counters (get-program state 0) :virus)) "Datasucker should have no virus countes left")))
-
-(deftest eavesdrop
-  ;; Ice Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Eavesdrop" "Ice Wall"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Eavesdrop")
-    (click-card state :corp "Ice Wall")
-    (is (= "Eavesdrop" (:title (first (:hosted (get-ice state :hq 0))))) "Eavesdrop is successfully hosted on Ice Wall")
-    (take-credits state :corp)
-    (run-on state :hq)
-    (core/rez state :corp (get-ice state :hq 0))
-    (card-ability state :corp (first (:hosted (get-ice state :hq 0))) 0)
-    (is (= :trace (:prompt-type (prompt-map :corp))) "Corp should initiate a trace")
-    (is (zero? (count-tags state)) "Runner should have no tags")
-    (click-prompt state :corp "0")
-    (click-prompt state :runner "0")
-    (is (= 1 (count-tags state)) "Runner should gain 1 tag from Eavesdrop ability")))
-
-(deftest enforced-curfew
-  ;; Hostile Takeover
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Enforced Curfew" "Hostile Takeover"]}})
-    (is (= 5 (core/hand-size state :runner)) "Runner should start with 5 max hand size")
-    (play-from-hand state :corp "Enforced Curfew")
-    (is (= 4 (core/hand-size state :runner)) "Runner should lose 1 hand size")
-    (take-credits state :corp)
-    (run-empty-server state :hq)
-    (click-prompt state :runner "Steal")
-    (is (= 5 (core/hand-size state :runner)) "Runner should go back to 5 hand size")))
-
-(deftest fast-track
-  ;; Fast Track
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5) "Hostile Takeover"]
-                      :hand ["Fast Track"]}})
-    (play-from-hand state :corp "Fast Track")
-    (click-prompt state :corp "Hostile Takeover")
-    (is (= ["Hostile Takeover"] (->> (get-corp) :hand (map :title))) "Hostile Takeover should now be in hand")))
-
-(deftest financial-collapse
-  ;; Financial Collapse
-  (testing "runner has no credits"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Financial Collapse"]}
-                 :runner {:hand ["Kati Jones" "Net Mercur"]}})
-      (play-from-hand state :corp "Financial Collapse")
-      (is (= ["Financial Collapse"] (->> (get-corp) :hand (map :title)))
-          "Financial Collapse shouldn't be playable without credit req")))
-  (testing "Runner has no installed resources"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Financial Collapse"]}
-                 :runner {:credits 6}})
-      (let [credits (:credit (get-runner))]
-        (play-from-hand state :corp "Financial Collapse")
-        (is (= credits (:credit (get-runner))) "Runner should lose no credits from no resources in play"))))
-  (testing "Runner has 2 installed resources and doesn't trash a resource"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Financial Collapse"]}
-                 :runner {:hand ["Kati Jones" "Net Mercur"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Kati Jones")
-      (play-from-hand state :runner "Net Mercur")
-      (core/gain-credits state :runner 6)
-      (take-credits state :runner)
-      (let [credits (:credit (get-runner))]
-        (play-from-hand state :corp "Financial Collapse")
-        (click-prompt state :runner "No")
-        (is (= (+ credits -4) (:credit (get-runner))) "Runner should lose 4 credits from 2 resources in play"))))
-  (testing "Runner has 2 installed resources and does trash a resource"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                        :hand ["Financial Collapse"]}
-                 :runner {:hand ["Kati Jones" "Net Mercur"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Kati Jones")
-      (play-from-hand state :runner "Net Mercur")
-      (core/gain-credits state :runner 6)
-      (take-credits state :runner)
-      (let [credits (:credit (get-runner))
-            kati (get-resource state 0)]
-        (play-from-hand state :corp "Financial Collapse")
-        (click-prompt state :runner "Yes")
-        (click-card state :runner "Kati Jones")
-        (is (not (refresh kati)) "Kati Jones should be trashed")
-        (is (= credits (:credit (get-runner))) "Runner should lose no credits")))))
-
-(deftest freelancer
-  ;; Freelancer
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Freelancer"]}
-               :runner {:hand ["Kati Jones" "Net Mercur"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Kati Jones")
-    (play-from-hand state :runner "Net Mercur")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Freelancer")
-    (is (= ["Freelancer" "Hedge Fund"] (->> (get-corp) :hand (map :title))) "Freelancer shouldn't be playable without a tag")
-    (core/gain-tags state :runner 1)
-    (play-from-hand state :corp "Freelancer")
-    (click-card state :corp "Kati Jones")
-    (click-card state :corp "Net Mercur")
-    (is (zero? (count (get-resource state))) "Runner should have no resources left in play")))
-
-(deftest friends-in-high-places
-  ;; Friends in High Places
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Friends in High Places"]
-                      :discard ["Ice Wall" "Hostile Takeover"]}})
-    (play-from-hand state :corp "Friends in High Places")
-    (click-card state :corp "Ice Wall")
-    (click-prompt state :corp "New remote")
-    (click-card state :corp "Hostile Takeover")
-    (click-prompt state :corp "Server 1")
-    (is (= "Ice Wall" (:title (get-ice state :remote1 0))) "Ice Wall should be installed")
-    (is (= "Hostile Takeover" (:title (get-content state :remote1 0))) "Hostile Takeover should be installed")))
-
-(deftest genotyping
-  ;; Genotyping
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Genotyping"]
-                      :discard ["Ice Wall" "Fire Wall" "Hostile Takeover" "Prisec"]}})
-    (play-from-hand state :corp "Genotyping")
-    (is (= 6 (count (:discard (get-corp)))) "Corp should trash top two cards to Genotyping")
-    (click-card state :corp "Ice Wall")
-    (click-card state :corp "Fire Wall")
-    (click-card state :corp "Hostile Takeover")
-    (click-card state :corp "Prisec")
-    (is (= ["Fire Wall" "Hedge Fund" "Hedge Fund" "Hedge Fund" "Hostile Takeover" "Ice Wall" "Prisec"]
-           (->> (get-corp) :deck (map :title) sort))
-        "All four chosen cards should be shuffled back into R&D")
-    (is (= ["Genotyping"] (->> (get-corp) :rfg (map :title))) "Genotyping should be rfg'd")))
-
-(deftest green-level-clearance
-  ;; Green Level Clearance
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Green Level Clearance"]}})
-    (play-from-hand state :corp "Green Level Clearance")
-    (is (= (+ 5 -1 +3) (:credit (get-corp))) "Corp should gain net 2 credits")
-    (is (= 1 (count (:hand (get-corp)))) "Corp should draw 1 card")))
-
-(deftest heritage-committee
-  ;; Hostile Takeover
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Heritage Committee" "Hostile Takeover"]}})
-    (play-from-hand state :corp "Heritage Committee")
-    (is (= 4 (count (:hand (get-corp)))) "Corp should draw 3 cards")
-    (click-card state :corp "Hostile Takeover")
-    (is (= "Hostile Takeover" (-> (get-corp) :deck first :title)) "Hostile Takeover should be moved to the top of R&D")))
-
-(deftest hunter-seeker
-  ;; Hostile Takeover
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hunter Seeker" "Hostile Takeover"]}
-               :runner {:hand ["Kati Jones"]}})
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Kati Jones")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Hunter Seeker")
-    (is (empty? (:prompt (get-corp))) "Corp should have no prompt without agenda stolen")
-    (take-credits state :corp)
-    (run-empty-server state :remote1)
-    (click-prompt state :runner "Steal")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Hunter Seeker")
-    (click-card state :corp "Kati Jones")
-    (is (not (get-resource state 0)) "Kati should be trashed")))
-
-(deftest interns
-  ;; Fire Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Interns" "Ice Wall" "Fire Wall"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Interns")
-    (click-card state :corp "Fire Wall")
-    (click-prompt state :corp "HQ")
-    (is (= 5 (:credit (get-corp))) "Installing second ice on HQ shouldn't cost anything")))
-
-(deftest liquidation
-  ;; Marilyn Campaign
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Liquidation" "PAD Campaign" "Launch Campaign" "Marilyn Campaign"]
-                      :credits 10}})
-    (core/gain state :corp :click 5)
-    (play-from-hand state :corp "PAD Campaign" "New remote")
-    (play-from-hand state :corp "Launch Campaign" "New remote")
-    (play-from-hand state :corp "Marilyn Campaign" "New remote")
-    (core/rez state :corp (get-content state :remote1 0))
-    (core/rez state :corp (get-content state :remote2 0))
-    (play-from-hand state :corp "Liquidation")
-    (let [credits (:credit (get-corp))]
-      (click-card state :corp "Marilyn Campaign")
-      (click-card state :corp "PAD Campaign")
-      (click-card state :corp "Launch Campaign")
-      (is (installed? (get-content state :remote3 0)) "Marilyn Campaign should still be installed")
-      (is (= (+ credits 6) (:credit (get-corp))) "Corp should gain 6 for 2 assets trashed"))))
-
-(deftest load-testing
-  ;; Load Testing
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Load Testing"]}})
-    (play-from-hand state :corp "Load Testing")
-    (take-credits state :corp)
-    (is (= 3 (:click (get-runner))) "Runner should lose 1 click start of turn")
-    (take-credits state :runner)
-    (take-credits state :corp)
-    (is (= 4 (:click (get-runner))) "Runner should gain 4 clicks per turn again")))
-
-(deftest localized-product-line
-  ;; Localized Product Line
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5) (qty "Hostile Takeover" 2)]
-                      :hand ["Localized Product Line"]}})
-    (play-from-hand state :corp "Localized Product Line")
-    (click-prompt state :corp "Hedge Fund")
-    (click-prompt state :corp "5")
-    (is (= 5 (count (:hand (get-corp)))) "Corp should have all 5 Hedge Funds in hand")))
-
-(deftest media-blitz
-  ;; Hostile Takeover
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Media Blitz" "Government Takeover" "Hostile Takeover"]}})
-    (play-from-hand state :corp "Government Takeover" "New remote")
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (take-credits state :corp)
-    (run-empty-server state :remote1)
-    (click-prompt state :runner "Steal")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Media Blitz")
-    (click-card state :corp "Government Takeover")
-    (let [credits (:credit (get-corp))]
-      (card-ability state :corp (first (:current (get-corp))) 0)
-      (is (= (+ credits 3) (:credit (get-corp))) "Corp should gain 3 from Media Blitz' GT ability"))
-    (take-credits state :corp)
-    (run-empty-server state :remote2)
-    (click-prompt state :runner "Steal")
-    (is (last-log-contains? state "Media Blitz is trashed") "Media Blitz should be trashed")))
-
-(deftest o-shortage
-  ;; O₂ Shortage
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "O₂ Shortage" 2)]
-                      :credits 10}
-               :runner {:hand [(qty "Sure Gamble" 2)]}})
-    (play-from-hand state :corp "O₂ Shortage")
-    (click-prompt state :runner "Yes")
-    (is (= 1 (count (:discard (get-runner)))) "Runner should discard a single card")
-    (play-from-hand state :corp "O₂ Shortage")
-    (let [clicks (:click (get-corp))]
-      (click-prompt state :runner "No")
-      (is (= (+ 2 clicks) (:click (get-corp))) "Corp should gain 2 clicks"))))
-
-(deftest observe-and-destroy
-  ;; Observe and Destroy
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Observe and Destroy"]}
-               :runner {:hand ["Kati Jones"]
-                        :credits 2
-                        :tags 1}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Kati Jones")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Observe and Destroy")
-    (click-card state :corp "Kati Jones")
-    (is (zero? (count-tags state)) "Runner should lose 1 tag")
-    (is (not (get-resource state 0)) "Kati should be trashed")))
-
-(deftest predictive-algorithm
-  ;; Hostile Takeover
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Predictive Algorithm" "Hostile Takeover"]}})
-    (play-from-hand state :corp "Predictive Algorithm")
-    (take-credits state :corp)
-    (run-empty-server state :hq)
-    (let [credits (:credit (get-runner))]
-      (is (= ["Pay to steal" "No action"] (:choices (prompt-map :runner))) "Runner has option to pay to steal")
-      (click-prompt state :runner "Pay to steal")
-      (is (= (+ credits -2) (:credit (get-runner))) "Runner should pay 2 to steal"))))
-
-(deftest priority-construction
-  ;; Ice Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Priority Construction" "Fire Wall" "Ice Wall"]}})
-    (play-from-hand state :corp "Fire Wall" "New remote")
-    (play-from-hand state :corp "Priority Construction")
-    (click-card state :corp "Ice Wall")
-    (let [credits (:credit (get-corp))]
-      (click-prompt state :corp "Server 1")
-      (is (= credits (:credit (get-corp))) "Installing another ice in an iced server shouldn't cost credits")
-      (is (= 3 (get-counters (get-ice state :remote1 1) :advancement)) "Ice Wall should be installed with 3 counters on it"))))
-
-(deftest product-recall
-  ;; Crisium Grid
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Product Recall" "Crisium Grid"]}})
-    (play-from-hand state :corp "Crisium Grid" "New remote")
-    (core/rez state :corp (get-content state :remote1 0))
-    (play-from-hand state :corp "Product Recall")
-    (let [credits (:credit (get-corp))]
-      (click-card state :corp "Crisium Grid")
-      (is (= (+ credits 5) (:credit (get-corp))) "Corp should gain 5 credits from trashing Crisium Grid"))))
-
-(deftest reclamation-order
-  ;; Reclamation Order
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Reclamation Order"]
-                      :discard [(qty "Ice Wall" 5) (qty "IPO" 3)]}})
-    (play-from-hand state :corp "Reclamation Order")
-    (click-card state :corp (find-card "IPO" (:discard (get-corp))))
-    (click-prompt state :corp "3")
-    (is (= 3 (count (:hand (get-corp)))) "Corp should have all 3 IPO in hand")
-    (is (= 6 (count (:discard (get-corp)))) "Corp should have 5 Ice Wall and 1 Reclamation Order in discard")))
-
-(deftest recruiting-trip
-  ;; Mason Bellamy
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5) "Keegan Lane" "Midori"
-                             "The Twins" "Arella Salvatore" "Mason Bellamy"]
-                      :hand ["Recruiting Trip"]}})
-    (play-from-hand state :corp "Recruiting Trip")
-    (click-prompt state :corp "5")
-    (click-prompt state :corp "Midori")
-    (click-prompt state :corp "The Twins")
-    (click-prompt state :corp "Arella Salvatore")
-    (click-prompt state :corp "Mason Bellamy")
-    (click-prompt state :corp "Keegan Lane")
-    (is (= 5 (count (:hand (get-corp)))) "Corp should have 5 cards in hand")))
-
-(deftest replanting
-  ;; Prisec
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Replanting" "Ice Wall" "Prisec"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Replanting")
-    (click-card state :corp "Ice Wall")
-    (click-card state :corp "Ice Wall")
-    (click-prompt state :corp "New remote")
-    (click-card state :corp "Prisec")
-    (click-prompt state :corp "Server 1")
-    (is (= "Ice Wall" (:title (get-ice state :remote1 0))) "Ice Wall has been moved")
-    (is (= "Prisec" (:title (get-content state :remote1 0))) "Prisec has been installed")))
-
-(deftest restore
-  ;; Fire Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Restore" "Fire Wall"]
-                      :discard [(qty "Ice Wall" 10)]}})
-    (play-from-hand state :corp "Fire Wall" "HQ")
-    (play-from-hand state :corp "Restore")
-    (click-card state :corp (find-card "Ice Wall" (:discard (get-corp))))
-    (let [credits (:credit (get-corp))]
-      (click-prompt state :corp "HQ")
-      (is (= (+ credits -2) (:credit (get-corp))) "Corp should pay for both install and rez cost"))
-    (is (= ["Restore"] (->> (get-corp) :discard (map :title))) "All other copies of Ice Wall should be rfg'd")))
-
-(deftest restoring-face
-  ;; Midori
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Restoring Face" "Midori"]
-                      :bad-pub 3}})
-    (play-from-hand state :corp "Midori" "New remote")
-    (play-from-hand state :corp "Restoring Face")
-    (click-card state :corp "Midori")
-    (is (= 1 (count-bad-pub state)) "Corp should lose 2 bad pub")
-    (is (= "Midori" (-> (get-corp) :discard first :title)) "Midori should be in Archives")))
-
-(deftest restructure
-  ;; Restructure
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Restructure"]
-                      :credits 10}})
-    (play-from-hand state :corp "Restructure")
-    (is (= 15 (:credit (get-corp))) "Corp should gain 5 credits")))
-
-(deftest rework
-  ;; Ice Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Rework" "Ice Wall"]}})
-    (play-from-hand state :corp "Rework")
-    (click-card state :corp "Ice Wall")
-    (is (zero? (count (:hand (get-corp)))) "Corp should have no cards in hand")
-    (is (find-card "Ice Wall" (:deck (get-corp))) "Corp should shuffle Ice Wall into deck")))
-
-(deftest rover-algorithm
-  ;; Enigma
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Rover Algorithm" "Enigma"]
-                      :credits 10}})
-    (play-from-hand state :corp "Enigma" "HQ")
-    (core/rez state :corp (get-ice state :hq 0))
-    (play-from-hand state :corp "Rover Algorithm")
-    (click-card state :corp "Enigma")
-    (take-credits state :corp)
-    (let [enigma (get-ice state :hq 0)
-          strength (core/get-strength (refresh enigma))]
-      (run-on state :hq)
-      (run-continue state)
-      (run-jack-out state)
-      (run-on state :hq)
-      (run-continue state)
-      (run-jack-out state)
-      (run-on state :hq)
-      (run-continue state)
-      (run-jack-out state)
-      (is (= (+ strength 3) (core/get-strength (refresh enigma))) "Enigma should gain 3 str from Rover Algorithm"))))
-
-(deftest scarcity-of-resources
-  ;; Scarcity of Resources
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Scarcity of Resources"]}
-               :runner {:hand ["Kati Jones"]}})
-    (play-from-hand state :corp "Scarcity of Resources")
-    (take-credits state :corp)
-    (let [credits (:credit (get-runner))
-          cost (:cost (find-card "Kati Jones" (:hand (get-runner))))]
-      (play-from-hand state :runner "Kati Jones")
-      (is (= (- credits (+ cost 2)) (:credit (get-runner))) "Runner should pay 2 extra for Kati Jones"))))
-
-(deftest shipment-from-kaguya
-  ;; NGO Front
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Shipment from Kaguya" "Ice Wall" "NGO Front"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "NGO Front" "New remote")
-    (play-from-hand state :corp "Shipment from Kaguya")
-    (click-card state :corp "Ice Wall")
-    (click-card state :corp "NGO Front")
-    (is (= 1 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should be advanced")
-    (is (= 1 (get-counters (get-content state :remote1 0) :advancement)) "NGO should be advanced")))
-
-(deftest shipment-from-mirrormorph
-  ;; Prisec
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Shipment from MirrorMorph" "Ice Wall" "PAD Campaign" "Prisec"]}})
-    (play-from-hand state :corp "Shipment from MirrorMorph")
-    (click-card state :corp "Ice Wall")
-    (click-prompt state :corp "New remote")
-    (click-card state :corp "PAD Campaign")
-    (click-prompt state :corp "Server 1")
-    (click-card state :corp "Prisec")
-    (click-prompt state :corp "Server 1")
-    (is (= "Ice Wall" (:title (get-ice state :remote1 0))) "Ice Wall should be installed")
-    (is (= "PAD Campaign" (:title (get-content state :remote1 0))) "PAD Campaign should be installed")
-    (is (= "Prisec" (:title (get-content state :remote1 1))) "Prisec should be installed")))
-
-(deftest shipment-from-tennin
-  ;; Ice Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Shipment from Tennin" "Ice Wall"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (take-credits state :corp)
-    (take-credits state :runner)
-    (play-from-hand state :corp "Shipment from Tennin")
-    (click-card state :corp "Ice Wall")
-    (is (= 2 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should be advanced")))
-
-(deftest shoot-the-moon
-  ;; Ice Wall
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Shoot the Moon" "Ice Wall"]}})
-    (play-from-hand state :corp "Ice Wall" "New remote")
-    (play-from-hand state :corp "Shoot the Moon")
-    (is (empty? (:prompt (get-corp))) "Shouldn't be able to play without runner being tagged")
-    (core/gain-tags state :runner 1)
-    (play-from-hand state :corp "Shoot the Moon")
-    (let [credits (:credit (get-corp))]
-      (click-card state :corp "Ice Wall")
-      (is (= credits (:credit (get-corp))) "Corp shouldn't pay anything to rez Ice Wall"))))
-
-(deftest special-report
-  ;; NGO Front
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Special Report" "Ice Wall" "IPO" "NGO Front"]}})
-    (play-from-hand state :corp "Special Report")
-    (click-card state :corp "Ice Wall")
-    (click-card state :corp "IPO")
-    (click-card state :corp "NGO Front")
-    (is (= 3 (count (:hand (get-corp)))) "corp should draw 3 cards")))
-
-(deftest standard-procedure
-  ;; Standard Procedure
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Standard Procedure"]}
-               :runner {:hand ["Sure Gamble" "Account Siphon" "Kati Jones" "Corroder"]}})
-    (play-from-hand state :corp "Standard Procedure")
-    (is (find-card "Standard Procedure" (:hand (get-corp))) "Corp shouldn't play anything as runner can't run")
-    (take-credits state :corp)
-    (run-empty-server state :archives)
-    (take-credits state :runner)
-    (play-from-hand state :corp "Standard Procedure")
-    (let [credits (:credit (get-corp))]
-      (click-prompt state :corp "Event")
-      (is (= (+ credits 4) (:credit (get-corp))) "Corp should gain 4 from 2 events in the grip"))))
-
-(deftest sunset
-  ;; Hunter
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Sunset" "Ice Wall" "Enigma" "Hunter"]}})
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "Enigma" "HQ")
-    (play-from-hand state :corp "Hunter" "HQ")
-    (core/gain state :corp :click 1)
-    (play-from-hand state :corp "Sunset")
-    (click-prompt state :corp "HQ")
-    (click-card state :corp "Ice Wall")
-    (click-card state :corp "Hunter")
-    (click-card state :corp "Ice Wall")
-    (click-card state :corp "Enigma")
-    (click-prompt state :corp "Done")
-    (is (= "Hunter" (:title (get-ice state :hq 0))) "Hunter should be in position 1")
-    (is (= "Ice Wall" (:title (get-ice state :hq 1))) "Ice Wall should be in position 2")
-    (is (= "Enigma" (:title (get-ice state :hq 2))) "Hunter should be in position 3")))
-
-(deftest sweeps-week
-  ;; Sweeps Week
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Sweeps Week" 2)]}
-               :runner {:deck [(qty "Sure Gamble" 5)]
-                        :hand ["Sure Gamble"]}})
-    (play-from-hand state :corp "Sweeps Week")
-    (is (= 5 (:credit (get-corp))) "Corp should spend 1 and gain 1 for 1 card in grip")
-    (dotimes [_ 5]
-      (core/move state :runner (find-card "Sure Gamble" (:deck (get-runner))) :hand))
-    (let [credits (:credit (get-corp))]
-      (play-from-hand state :corp "Sweeps Week")
-      (is (= (+ credits -1 (count (:hand (get-runner)))) (:credit (get-corp)))
-          "Corp should gain 5 for 6 cards in the grip"))))
-
-(deftest too-big-to-fail
-  ;; Too Big to Fail
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand [(qty "Too Big to Fail" 2)]}})
-    (let [credits (:credit (get-corp))]
-      (play-from-hand state :corp "Too Big to Fail")
-      (is (= 1 (count-bad-pub state)) "Corp should gain 1 bad pub")
-      (is (= (+ credits 7) (:credit (get-corp))) "Corp should gain 7 credits"))
-    (let [credits (:credit (get-corp))
-          bp (count-bad-pub state)]
-      (play-from-hand state :corp "Too Big to Fail")
-      (is (= bp (count-bad-pub state)) "Corp shouldn't gain any more bad pub")
-      (is (= credits (:credit (get-corp))) "Corp shouldn't gain any more as over 10 credits"))))
-
-(deftest traffic-accident
-  ;; Traffic Accident
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Traffic Accident"]}
-               :runner {:hand [(qty "Sure Gamble" 5)]}})
-    (play-from-hand state :corp "Traffic Accident")
-    (is (= 5 (count (:hand (get-runner)))) "Runner shouldn't take damage as they're not tagged")
-    (core/gain-tags state :runner 2)
-    (play-from-hand state :corp "Traffic Accident")
-    (is (= 3 (count (:hand (get-runner)))) "Runner should take 2 damage")))
-
-(deftest trick-of-light
-  ;; NGO Front
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Trick of Light" "Ice Wall" "NGO Front"]
-                      :credits 10}})
-    (core/gain state :corp :click 5)
-    (play-from-hand state :corp "Ice Wall" "HQ")
-    (play-from-hand state :corp "NGO Front" "New remote")
-    (let [ngo (get-content state :remote1 0)
-          iw (get-ice state :hq 0)]
-      (advance state (refresh ngo) 2)
-      (is (= 2 (get-counters (refresh ngo) :advancement)) "NGO Front should have 2 counters")
-      (play-from-hand state :corp "Trick of Light")
-      (click-card state :corp ngo)
-      (click-prompt state :corp "2")
-      (click-card state :corp "Ice Wall")
-      (is (= 2 (get-counters (refresh iw) :advancement)) "Ice Wall is now advanced")
-      (is (zero? (get-counters (refresh ngo) :advancement)) "NGO Front should have 0 counters"))))
-
-(deftest violet-level-clearance
-  ;; Violet Level Clearance
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Violet Level Clearance"]}})
-    (play-from-hand state :corp "Violet Level Clearance")
-    (is (= 8 (:credit (get-corp))) "Corp should gain 8 credits")
-    (is (= 4 (count (:hand (get-corp)))) "Corp should draw 4 cards")
-    (is (= 1 (count (:deck (get-corp)))) "Corp should draw 4 cards")))
-
-(deftest voter-intimidation
-  ;; Hostile Takeover
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Voter Intimidation" "Hostile Takeover"]}
-               :runner {:hand ["Kati Jones"]}})
-    (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Kati Jones")
-    (run-empty-server state :remote1)
-    (click-prompt state :runner "Steal")
-    (take-credits state :runner)
-    (play-from-hand state :corp "Voter Intimidation")
-    (click-prompt state :corp "1 [Credits]")
-    (click-prompt state :runner "0 [Credits]")
-    (click-card state :corp "Kati Jones")
-    (is (not (get-resource state 0)) "Kati Jones is trashed")))
-
-(deftest witness-tampering
-  ;; Witness Tampering
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Witness Tampering"]
-                      :bad-pub 3}})
-    (play-from-hand state :corp "Witness Tampering")
-    (is (= 1 (count-bad-pub state)) "Corp should lose 2 bad pub")))
-
-
 (deftest ^{:card-title "24-7-news-cycle"}
   twenty-four-seven-news-cycle
   ;; 24/7 News Cycle
@@ -1005,6 +120,33 @@
         (click-prompt state :corp "Hedge Fund")
         (is (= 9 (:credit (get-corp))) "Corp gained credits from Hedge Fund")))))
 
+(deftest ad-blitz
+  ;; Launch Campaign
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ad Blitz" "Launch Campaign"]
+                      :discard ["Pop-up Window"]}})
+    (play-from-hand state :corp "Ad Blitz")
+    (click-prompt state :corp "2")
+    (click-card state :corp "Launch Campaign")
+    (click-prompt state :corp "New remote")
+    (click-card state :corp "Pop-up Window")
+    (click-prompt state :corp "Server 1")
+    (is (zero? (count (:hand (get-corp)))) "Corp should have no cards in HQ")
+    (is (= ["Ad Blitz"] (->> (get-corp) :discard (map :title))) "Corp should have only Ad Blitz in Archives")))
+
+(deftest aggressive-negotiation
+  ;; Hostile Takeover
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Aggressive Negotiation" "Hostile Takeover"]}})
+    (play-from-hand state :corp "Aggressive Negotiation")
+    (is (empty? (:prompt (get-corp))) "Corp should have no prompt")
+    (play-and-score state "Hostile Takeover")
+    (play-from-hand state :corp "Aggressive Negotiation")
+    (click-prompt state :corp "Hedge Fund")
+    (is (= ["Hedge Fund"] (->> (get-corp) :hand (map :title))) "Hedge Fund is now in HQ")))
+
 (deftest an-offer-you-can-t-refuse
   ;; An Offer You Can't Refuse - exact card added to score area, not the last discarded one
   (do-game
@@ -1019,6 +161,40 @@
     (is (find-card "An Offer You Can't Refuse" (:scored (get-corp))))
     (is (= 1 (count (:discard (get-corp)))))
     (is (find-card "Celebrity Gift" (:discard (get-corp))))))
+
+(deftest anonymous-tip
+  ;; Anonymous Tip
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Anonymous Tip"]}})
+    (is (= 1 (count (:hand (get-corp)))) "Corp starts with 1 card in HQ")
+    (is (zero? (count (:discard (get-corp)))) "Corp starts with 0 cards in Archives")
+    (play-from-hand state :corp "Anonymous Tip")
+    (is (= 3 (count (:hand (get-corp)))) "Corp should draw 3 cards")
+    (is (= 1 (count (:discard (get-corp)))) "Corp has 1 card in Archives")))
+
+(deftest archived-memories
+  ;; Archived Memories
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Archived Memories"]
+                      :discard ["Hostile Takeover"]}})
+    (play-from-hand state :corp "Archived Memories")
+    (click-card state :corp "Hostile Takeover")
+    (is (= ["Hostile Takeover"] (->> (get-corp) :hand (map :title))) "Hostile Takeover should be in HQ")))
+
+(deftest ark-lockdown
+  ;; Ark Lockdown
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Ark Lockdown"]}
+               :runner {:hand ["Sure Gamble"]
+                        :discard [(qty "Sure Gamble" 2) "Corroder"]}})
+    (play-from-hand state :corp "Ark Lockdown")
+    (click-prompt state :corp "Sure Gamble")
+    (is (= ["Corroder"] (->> (get-runner) :discard (map :title))) "Both copies of Sure Gamble should be rfg")
+    (is (= ["Sure Gamble"] (->> (get-runner) :hand (map :title))) "Sure Gambles in hand should be around")
+    (is (= ["Sure Gamble" "Sure Gamble"] (->> (get-runner) :rfg (map :title))) "Two copies of Sure Gamble should be rfg'd")))
 
 (deftest attitude-adjustment
   ;; Attitude Adjustment
@@ -1041,6 +217,108 @@
       (is (= (dec hand) (-> (get-corp) :hand count)) "One card from HQ is shuffled into R&D")
       (is (= (+ -1 1 discard) (-> (get-corp) :discard count)) "One card from Archives should be shuffled into R&D, AA enters")
       (is (= (+ 2 deck) (-> (get-corp) :deck count)) "Corp should draw two cards and shuffle two cards into R&D"))))
+
+(deftest audacity
+  ;; Audacity
+  (testing "requires 3 cards in hand to play"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Audacity" 2) "Ice Wall"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Audacity")
+      (is (empty? (:prompt (get-corp))) "Can't play Audacity with too few cards in HQ")))
+  (testing "when placing counters on 1 card"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Audacity" 3) "Ice Wall" "Hostile Takeover"]}})
+      (play-from-hand state :corp "Audacity")
+      (is (empty? (:prompt (get-corp))) "Can't play Audacity without an advanceable card")
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Audacity")
+      (click-card state :corp "Ice Wall")
+      (click-card state :corp "Ice Wall")
+      (is (= 2 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should have 2 counters")))
+  (testing "when placing counters on two cards"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Audacity" 3) "Ice Wall" "Hostile Takeover"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Hostile Takeover" "New remote")
+      (play-from-hand state :corp "Audacity")
+      (click-card state :corp "Ice Wall")
+      (click-card state :corp "Hostile Takeover")
+      (is (= 1 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should have 1 counter")
+      (is (= 1 (get-counters (get-content state :remote1 0) :advancement)) "Hostile Takeover should have 1 counter"))))
+
+(deftest back-channels
+  ;; Back Channels
+  (testing "trashing a card with no advancements"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Back Channels" "NGO Front"]}})
+      (play-from-hand state :corp "NGO Front" "New remote")
+      (let [credits (:credit (get-corp))]
+        (play-from-hand state :corp "Back Channels")
+        (click-card state :corp "NGO Front")
+        (is (= credits (:credit (get-corp))) "Corp should gain 0 credits"))))
+  (testing "trashing a card with some advancements"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Back Channels" "NGO Front"]}})
+      (play-from-hand state :corp "NGO Front" "New remote")
+      (core/set-prop state :corp (get-content state :remote1 0) :advance-counter 3)
+      (let [credits (:credit (get-corp))]
+        (play-from-hand state :corp "Back Channels")
+        (click-card state :corp "NGO Front")
+        (is (= (+ credits 9) (:credit (get-corp))) "Corp should gain 3 * 3 credits")))))
+
+(deftest bad-times
+  ;; Bad Times
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Bad Times"]}})
+      (is (= 4 (core/available-mu state)) "Runner should start with 4 MU")
+      (play-from-hand state :corp "Bad Times")
+      (is (= 4 (core/available-mu state)) "Corp can't play without a tag")
+      (core/gain-tags state :runner 1)
+      (play-from-hand state :corp "Bad Times")
+      (is (= 2 (core/available-mu state)) "Runner should lose 2 available MU")
+      (take-credits state :corp)
+      (is (= 4 (core/available-mu state)) "Runner should regain 2 available MU")))
+
+(deftest beanstalk-royalties
+  ;; Beanstalk Royalties
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Beanstalk Royalties"]}})
+    (let [credits (:credit (get-corp))]
+      (play-from-hand state :corp "Beanstalk Royalties")
+      (is (= (+ credits 3) (:credit (get-corp))) "Corp should gain 3"))))
+
+(deftest best-defense
+  ;; Best Defense
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Best Defense" 2)]}
+               :runner {:hand ["Dorm Computer" "Mass-Driver"]
+                        :credits 10}})
+    (play-from-hand state :corp "Best Defense")
+    (is (empty? (:prompt (get-corp))) "Corp can't play Best Defense without installed runner cards")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Dorm Computer")
+    (play-from-hand state :runner "Mass-Driver")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Best Defense")
+    (is (= "Choose a Runner card with an install cost of 0 or less to trash" (-> (get-corp) :prompt first :msg)))
+    (click-card state :corp "Mass-Driver")
+    (is (get-program state 0) "Mass-Driver should still be installed")
+    (click-card state :corp "Dorm Computer")
+    (is (not (get-hardware state 0)) "Dorm Computer should be trashed")
+    (core/gain-tags state :runner 8)
+    (play-from-hand state :corp "Best Defense")
+    (click-card state :corp "Mass-Driver")
+    (is (not (get-program state 0)) "Mass-Driver should still be installed")
+    (is (= 2 (count (:discard (get-runner)))) "2 cards should be in heap")))
 
 (deftest biased-reporting
   ;; Biased Reporting
@@ -1072,6 +350,18 @@
     (play-from-hand state :corp "Big Brother")
     (is (= 3 (count-tags state)) "Runner gained 2 tags")))
 
+(deftest bioroid-efficiency-research
+  ;; Eli 1.0
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Bioroid Efficiency Research" "Eli 1.0"]}})
+    (play-from-hand state :corp "Eli 1.0" "HQ")
+    (play-from-hand state :corp "Bioroid Efficiency Research")
+    (let [credits (:credit (get-corp))]
+      (click-card state :corp "Eli 1.0")
+      (is (rezzed? (get-ice state :hq 0)) "Eli 1.0 should be rezzed")
+      (is (= credits (:credit (get-corp))) "Corp should spend no money to rez"))))
+
 (deftest biotic-labor
   ;; Biotic Labor - Gain 2 clicks
   (do-game
@@ -1090,6 +380,19 @@
     (is (= 8 (:credit (get-corp))) "Gained 5 credits")
     (is (= 1 (:click (get-corp))))
     (is (= 7 (count (:hand (get-corp)))) "Drew 2 cards")))
+
+(deftest boom
+  ;; BOOM!
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["BOOM!"]}
+               :runner {:hand [(qty "Sure Gamble" 10)]}})
+    (play-from-hand state :corp "BOOM!")
+    (is (= 1 (count (:hand (get-corp)))) "BOOM! should not be played as runner has no tags")
+    (core/gain-tags state :runner 2)
+    (is (zero? (count (:discard (get-runner)))) "Runner should have 0 cards in discard")
+    (play-from-hand state :corp "BOOM!")
+    (is (= 7 (count (:discard (get-runner)))) "Runner should take 7 damage")))
 
 (deftest building-blocks
   ;; Building Blocks - install and rez a barrier from HQ at no cost
@@ -1140,6 +443,20 @@
           (click-prompt state :runner "Steal")
           (is (= 2 (count-tags state)) "Runner took 2 tags from accessing agenda with Casting Call hosted on it"))))))
 
+(deftest celebrity-gift
+  ;; Ice Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Celebrity Gift" "NGO Front" "IPO" "PAD Campaign" "Hostile Takeover" "Ice Wall"]}})
+    (play-from-hand state :corp "Celebrity Gift")
+    (let [credits (:credit (get-corp))]
+      (click-card state :corp "NGO Front")
+      (click-card state :corp "IPO")
+      (click-card state :corp "PAD Campaign")
+      (click-card state :corp "Hostile Takeover")
+      (click-card state :corp "Ice Wall")
+      (is (= (+ credits 10 (:credit (get-corp)))) "Corp should gain 10 credits from 5 cards"))))
+
 (deftest cerebral-cast
   ;; Cerebral Cast
   (testing "Runner wins"
@@ -1186,6 +503,15 @@
       (is (= 4 (core/available-mu state)) "Cerebral Static causes CT to have 4 memory")
       (play-from-hand state :corp "Lag Time")
       (is (= 5 (core/available-mu state)) "CT 5 memory restored"))))
+
+(deftest clones-are-not-people
+  ;; Merger
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["\"Clones are not People\"" "Merger"]}})
+    (play-from-hand state :corp "\"Clones are not People\"")
+    (play-and-score state "Merger")
+    (is (= 2 (count (get-scored state :corp))) "Corp should have 2 cards in score area")))
 
 (deftest closed-accounts
   ;; Closed Accounts - Play if Runner is tagged to make Runner lose all credits
@@ -1355,6 +681,31 @@
         (is (= (list "Beanstalk Royalties" "Green Level Clearance" nil) (prompt-names)))
         (click-prompt state :corp (find-card "Green Level Clearance" (:deck (get-corp))))
         (is (= 5 (:credit (get-corp))))))))
+
+(deftest corporate-shuffle
+  ;; Ice Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Corporate Shuffle" (qty "Ice Wall" 2)]}})
+    (is (= 5 (count (:deck (get-corp)))) "Corp should start with 5 cards in deck")
+    (is (= 3 (count (:hand (get-corp)))) "Corp should have 3 cards in hand")
+    (play-from-hand state :corp "Corporate Shuffle")
+    (is (= 2 (count (:deck (get-corp)))) "Corp should have 3 cards in deck after draw")
+    (is (= 5 (count (:hand (get-corp)))) "Corp should draw up to 5 cards")
+    (is (= 1 (count (:discard (get-corp)))) "Corp should have 1 card in discard from playing")))
+
+(deftest cyberdex-trial
+  ;; Cyberdex Trial
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Cyberdex Trial"]}
+               :runner {:hand ["Datasucker"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Datasucker")
+    (core/add-counter state :runner (get-program state 0) :virus 2)
+    (take-credits state :runner)
+    (play-from-hand state :corp "Cyberdex Trial")
+    (is (zero? (get-counters (get-program state 0) :virus)) "Datasucker should have no virus countes left")))
 
 (deftest death-and-taxes
   ;; Death and Taxes gain credit on runner install, runner trash installed card
@@ -1609,6 +960,25 @@
     (is (= 1 (count-tags state)) "Runner should still have 1 tag")
     (is (= 2 (-> (get-runner) :hand count)) "Runner should take 1 meat damage from Door to Door")))
 
+(deftest eavesdrop
+  ;; Ice Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Eavesdrop" "Ice Wall"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Eavesdrop")
+    (click-card state :corp "Ice Wall")
+    (is (= "Eavesdrop" (:title (first (:hosted (get-ice state :hq 0))))) "Eavesdrop is successfully hosted on Ice Wall")
+    (take-credits state :corp)
+    (run-on state :hq)
+    (core/rez state :corp (get-ice state :hq 0))
+    (card-ability state :corp (first (:hosted (get-ice state :hq 0))) 0)
+    (is (= :trace (:prompt-type (prompt-map :corp))) "Corp should initiate a trace")
+    (is (zero? (count-tags state)) "Runner should have no tags")
+    (click-prompt state :corp "0")
+    (click-prompt state :runner "0")
+    (is (= 1 (count-tags state)) "Runner should gain 1 tag from Eavesdrop ability")))
+
 (deftest economic-warfare
   ;; Economic Warfare - If successful run last turn, make the runner lose 4 credits if able
   (do-game
@@ -1646,6 +1016,19 @@
     (is (= 2 (count (:hand (get-corp)))) "Corp has now 1 + 1 cards before Election Day")
     (play-from-hand state :corp "Election Day")
     (is (= 5 (count (:hand (get-corp)))) "Corp has now 5 cards due to Election Day")))
+
+(deftest enforced-curfew
+  ;; Hostile Takeover
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Enforced Curfew" "Hostile Takeover"]}})
+    (is (= 5 (core/hand-size state :runner)) "Runner should start with 5 max hand size")
+    (play-from-hand state :corp "Enforced Curfew")
+    (is (= 4 (core/hand-size state :runner)) "Runner should lose 1 hand size")
+    (take-credits state :corp)
+    (run-empty-server state :hq)
+    (click-prompt state :runner "Steal")
+    (is (= 5 (core/hand-size state :runner)) "Runner should go back to 5 hand size")))
 
 (deftest enforcing-loyalty
   ;; Enforcing Loyalty - Win trace to trash installed card not of Runner's faction
@@ -1948,6 +1331,65 @@
       (is (= (- credits 2) (:credit (get-corp))) "Corp should pay 2 credits to install third Ice Wall")
       (is (empty? (:prompt (get-corp))) "Corp should be able to stop installing early"))))
 
+(deftest fast-track
+  ;; Fast Track
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5) "Hostile Takeover"]
+                      :hand ["Fast Track"]}})
+    (play-from-hand state :corp "Fast Track")
+    (click-prompt state :corp "Hostile Takeover")
+    (is (= ["Hostile Takeover"] (->> (get-corp) :hand (map :title))) "Hostile Takeover should now be in hand")))
+
+(deftest financial-collapse
+  ;; Financial Collapse
+  (testing "runner has no credits"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Financial Collapse"]}
+                 :runner {:hand ["Kati Jones" "Net Mercur"]}})
+      (play-from-hand state :corp "Financial Collapse")
+      (is (= ["Financial Collapse"] (->> (get-corp) :hand (map :title)))
+          "Financial Collapse shouldn't be playable without credit req")))
+  (testing "Runner has no installed resources"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Financial Collapse"]}
+                 :runner {:credits 6}})
+      (let [credits (:credit (get-runner))]
+        (play-from-hand state :corp "Financial Collapse")
+        (is (= credits (:credit (get-runner))) "Runner should lose no credits from no resources in play"))))
+  (testing "Runner has 2 installed resources and doesn't trash a resource"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Financial Collapse"]}
+                 :runner {:hand ["Kati Jones" "Net Mercur"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Kati Jones")
+      (play-from-hand state :runner "Net Mercur")
+      (core/gain-credits state :runner 6)
+      (take-credits state :runner)
+      (let [credits (:credit (get-runner))]
+        (play-from-hand state :corp "Financial Collapse")
+        (click-prompt state :runner "No")
+        (is (= (+ credits -4) (:credit (get-runner))) "Runner should lose 4 credits from 2 resources in play"))))
+  (testing "Runner has 2 installed resources and does trash a resource"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Financial Collapse"]}
+                 :runner {:hand ["Kati Jones" "Net Mercur"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Kati Jones")
+      (play-from-hand state :runner "Net Mercur")
+      (core/gain-credits state :runner 6)
+      (take-credits state :runner)
+      (let [credits (:credit (get-runner))
+            kati (get-resource state 0)]
+        (play-from-hand state :corp "Financial Collapse")
+        (click-prompt state :runner "Yes")
+        (click-card state :runner "Kati Jones")
+        (is (not (refresh kati)) "Kati Jones should be trashed")
+        (is (= credits (:credit (get-runner))) "Runner should lose no credits")))))
+
 (deftest focus-group
   ;; Focus Group
   (testing "Regular scenario - can afford"
@@ -2016,6 +1458,38 @@
     (click-prompt state :runner "0")
     (click-card state :corp (get-resource state 0))
     (is (= 2 (-> (get-runner) :discard count)) "Corp should trash Ice Carver from winning Foxfire trace")))
+
+(deftest freelancer
+  ;; Freelancer
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Freelancer"]}
+               :runner {:hand ["Kati Jones" "Net Mercur"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Kati Jones")
+    (play-from-hand state :runner "Net Mercur")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Freelancer")
+    (is (= ["Freelancer" "Hedge Fund"] (->> (get-corp) :hand (map :title))) "Freelancer shouldn't be playable without a tag")
+    (core/gain-tags state :runner 1)
+    (play-from-hand state :corp "Freelancer")
+    (click-card state :corp "Kati Jones")
+    (click-card state :corp "Net Mercur")
+    (is (zero? (count (get-resource state))) "Runner should have no resources left in play")))
+
+(deftest friends-in-high-places
+  ;; Friends in High Places
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Friends in High Places"]
+                      :discard ["Ice Wall" "Hostile Takeover"]}})
+    (play-from-hand state :corp "Friends in High Places")
+    (click-card state :corp "Ice Wall")
+    (click-prompt state :corp "New remote")
+    (click-card state :corp "Hostile Takeover")
+    (click-prompt state :corp "Server 1")
+    (is (= "Ice Wall" (:title (get-ice state :remote1 0))) "Ice Wall should be installed")
+    (is (= "Hostile Takeover" (:title (get-content state :remote1 0))) "Hostile Takeover should be installed")))
 
 (deftest fully-operational
   ;; Fully Operational
@@ -2130,6 +1604,32 @@
       (is (some? (find-card "Nyashia" (:discard (get-runner)))) "Nyashia trashed")
       (is (some? (find-card "Takobi" (:discard (get-runner)))) "Takobi trashed")
       (is (= 1 (count-bad-pub state))))))
+
+(deftest genotyping
+  ;; Genotyping
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Genotyping"]
+                      :discard ["Ice Wall" "Fire Wall" "Hostile Takeover" "Prisec"]}})
+    (play-from-hand state :corp "Genotyping")
+    (is (= 6 (count (:discard (get-corp)))) "Corp should trash top two cards to Genotyping")
+    (click-card state :corp "Ice Wall")
+    (click-card state :corp "Fire Wall")
+    (click-card state :corp "Hostile Takeover")
+    (click-card state :corp "Prisec")
+    (is (= ["Fire Wall" "Hedge Fund" "Hedge Fund" "Hedge Fund" "Hostile Takeover" "Ice Wall" "Prisec"]
+           (->> (get-corp) :deck (map :title) sort))
+        "All four chosen cards should be shuffled back into R&D")
+    (is (= ["Genotyping"] (->> (get-corp) :rfg (map :title))) "Genotyping should be rfg'd")))
+
+(deftest green-level-clearance
+  ;; Green Level Clearance
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Green Level Clearance"]}})
+    (play-from-hand state :corp "Green Level Clearance")
+    (is (= (+ 5 -1 +3) (:credit (get-corp))) "Corp should gain net 2 credits")
+    (is (= 1 (count (:hand (get-corp)))) "Corp should draw 1 card")))
 
 (deftest hangeki
   ;; Hangeki
@@ -2282,6 +1782,16 @@
       (click-prompt state :runner "2")
       (is (= 1 (count-bad-pub state)) "Corp should gain 1 bad publicity from losing Hellion Beta Test trace"))))
 
+(deftest heritage-committee
+  ;; Hostile Takeover
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Heritage Committee" "Hostile Takeover"]}})
+    (play-from-hand state :corp "Heritage Committee")
+    (is (= 4 (count (:hand (get-corp)))) "Corp should draw 3 cards")
+    (click-card state :corp "Hostile Takeover")
+    (is (= "Hostile Takeover" (-> (get-corp) :deck first :title)) "Hostile Takeover should be moved to the top of R&D")))
+
 (deftest high-profile-target
   (testing "when the runner has no tags"
     (do-game
@@ -2329,6 +1839,37 @@
     (is (= 1 (count (:discard (get-runner)))) "Card trashed")
     (play-from-hand state :runner "Cache")
     (is (empty? (:prompt (get-runner))) "Housekeeping didn't trigger on 2nd install")))
+
+(deftest hunter-seeker
+  ;; Hostile Takeover
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hunter Seeker" "Hostile Takeover"]}
+               :runner {:hand ["Kati Jones"]}})
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Kati Jones")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Hunter Seeker")
+    (is (empty? (:prompt (get-corp))) "Corp should have no prompt without agenda stolen")
+    (take-credits state :corp)
+    (run-empty-server state :remote1)
+    (click-prompt state :runner "Steal")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Hunter Seeker")
+    (click-card state :corp "Kati Jones")
+    (is (not (get-resource state 0)) "Kati should be trashed")))
+
+(deftest interns
+  ;; Fire Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Interns" "Ice Wall" "Fire Wall"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Interns")
+    (click-card state :corp "Fire Wall")
+    (click-prompt state :corp "HQ")
+    (is (= 5 (:credit (get-corp))) "Installing second ice on HQ shouldn't cost anything")))
 
 (deftest invasion-of-privacy
   ;; Invasion of Privacy - Full test
@@ -2415,6 +1956,48 @@
     (is (= "Breaking News" (:title (get-content state :remote1 0)))
         "Breaking News installed by Lateral Growth")
     (is (= 7 (:credit (get-corp))))))
+
+(deftest liquidation
+  ;; Marilyn Campaign
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Liquidation" "PAD Campaign" "Launch Campaign" "Marilyn Campaign"]
+                      :credits 10}})
+    (core/gain state :corp :click 5)
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "Launch Campaign" "New remote")
+    (play-from-hand state :corp "Marilyn Campaign" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (core/rez state :corp (get-content state :remote2 0))
+    (play-from-hand state :corp "Liquidation")
+    (let [credits (:credit (get-corp))]
+      (click-card state :corp "Marilyn Campaign")
+      (click-card state :corp "PAD Campaign")
+      (click-card state :corp "Launch Campaign")
+      (is (installed? (get-content state :remote3 0)) "Marilyn Campaign should still be installed")
+      (is (= (+ credits 6) (:credit (get-corp))) "Corp should gain 6 for 2 assets trashed"))))
+
+(deftest load-testing
+  ;; Load Testing
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Load Testing"]}})
+    (play-from-hand state :corp "Load Testing")
+    (take-credits state :corp)
+    (is (= 3 (:click (get-runner))) "Runner should lose 1 click start of turn")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (is (= 4 (:click (get-runner))) "Runner should gain 4 clicks per turn again")))
+
+(deftest localized-product-line
+  ;; Localized Product Line
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5) (qty "Hostile Takeover" 2)]
+                      :hand ["Localized Product Line"]}})
+    (play-from-hand state :corp "Localized Product Line")
+    (click-prompt state :corp "Hedge Fund")
+    (click-prompt state :corp "5")
+    (is (= 5 (count (:hand (get-corp)))) "Corp should have all 5 Hedge Funds in hand")))
 
 (deftest manhunt
   ;; Manhunt - only fires once per turn. Unreported issue.
@@ -2508,6 +2091,27 @@
       (card-side-ability state :runner (-> (get-resource state 0) :hosted first) 0)
       (is (nil? (get-resource state 0)) "Beth should now be trashed")
       (is (= (- credits 2) (:credit (get-runner))) "Runner should pay 2 credits to trash MCA"))))
+
+(deftest media-blitz
+  ;; Hostile Takeover
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Media Blitz" "Government Takeover" "Hostile Takeover"]}})
+    (play-from-hand state :corp "Government Takeover" "New remote")
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state :remote1)
+    (click-prompt state :runner "Steal")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Media Blitz")
+    (click-card state :corp "Government Takeover")
+    (let [credits (:credit (get-corp))]
+      (card-ability state :corp (first (:current (get-corp))) 0)
+      (is (= (+ credits 3) (:credit (get-corp))) "Corp should gain 3 from Media Blitz' GT ability"))
+    (take-credits state :corp)
+    (run-empty-server state :remote2)
+    (click-prompt state :runner "Steal")
+    (is (last-log-contains? state "Media Blitz is trashed") "Media Blitz should be trashed")))
 
 (deftest medical-research-fundraiser
   ;; Medical Research Fundraiser - runner gains 8creds, runner gains 3creds
@@ -2622,6 +2226,37 @@
     (take-credits state :runner)
     (play-from-hand state :corp "Neural EMP")
     (is (= 1 (count (:discard (get-runner)))) "Runner took 1 net damage")))
+
+(deftest o-shortage
+  ;; O₂ Shortage
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "O₂ Shortage" 2)]
+                      :credits 10}
+               :runner {:hand [(qty "Sure Gamble" 2)]}})
+    (play-from-hand state :corp "O₂ Shortage")
+    (click-prompt state :runner "Yes")
+    (is (= 1 (count (:discard (get-runner)))) "Runner should discard a single card")
+    (play-from-hand state :corp "O₂ Shortage")
+    (let [clicks (:click (get-corp))]
+      (click-prompt state :runner "No")
+      (is (= (+ 2 clicks) (:click (get-corp))) "Corp should gain 2 clicks"))))
+
+(deftest observe-and-destroy
+  ;; Observe and Destroy
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Observe and Destroy"]}
+               :runner {:hand ["Kati Jones"]
+                        :credits 2
+                        :tags 1}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Kati Jones")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Observe and Destroy")
+    (click-card state :corp "Kati Jones")
+    (is (zero? (count-tags state)) "Runner should lose 1 tag")
+    (is (not (get-resource state 0)) "Kati should be trashed")))
 
 (deftest oversight-ai
   ;; Oversight AI - Rez a piece of ICE ignoring all costs
@@ -2749,6 +2384,19 @@
     (is (= "Jackson Howard" (:title (second (rest (rest (:deck (get-corp))))))))
     (is (= "Global Food Initiative" (:title (second (rest (rest (rest (:deck (get-corp)))))))))))
 
+(deftest predictive-algorithm
+  ;; Hostile Takeover
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Predictive Algorithm" "Hostile Takeover"]}})
+    (play-from-hand state :corp "Predictive Algorithm")
+    (take-credits state :corp)
+    (run-empty-server state :hq)
+    (let [credits (:credit (get-runner))]
+      (is (= ["Pay to steal" "No action"] (:choices (prompt-map :runner))) "Runner has option to pay to steal")
+      (click-prompt state :runner "Pay to steal")
+      (is (= (+ credits -2) (:credit (get-runner))) "Runner should pay 2 to steal"))))
+
 (deftest preemptive-action
   ;; Preemptive Action - Shuffles cards into R&D and removes itself from game
   (testing "Basic test"
@@ -2790,6 +2438,31 @@
       (click-card state :corp (last (:discard (get-corp))))
       (is (zero? (count (:discard (get-corp)))))
       (is (= 1 (count (:rfg (get-corp))))))))
+
+(deftest priority-construction
+  ;; Ice Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Priority Construction" "Fire Wall" "Ice Wall"]}})
+    (play-from-hand state :corp "Fire Wall" "New remote")
+    (play-from-hand state :corp "Priority Construction")
+    (click-card state :corp "Ice Wall")
+    (let [credits (:credit (get-corp))]
+      (click-prompt state :corp "Server 1")
+      (is (= credits (:credit (get-corp))) "Installing another ice in an iced server shouldn't cost credits")
+      (is (= 3 (get-counters (get-ice state :remote1 1) :advancement)) "Ice Wall should be installed with 3 counters on it"))))
+
+(deftest product-recall
+  ;; Crisium Grid
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Product Recall" "Crisium Grid"]}})
+    (play-from-hand state :corp "Crisium Grid" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (play-from-hand state :corp "Product Recall")
+    (let [credits (:credit (get-corp))]
+      (click-card state :corp "Crisium Grid")
+      (is (= (+ credits 5) (:credit (get-corp))) "Corp should gain 5 credits from trashing Crisium Grid"))))
 
 (deftest psychographics
   ;; Psychographics - Place advancements up to the number of Runner tags on a card
@@ -2855,6 +2528,33 @@
     (click-prompt state :runner "0")
     (is (empty? (:hand (get-runner))) "Runner took 3 meat damage")))
 
+(deftest reclamation-order
+  ;; Reclamation Order
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Reclamation Order"]
+                      :discard [(qty "Ice Wall" 5) (qty "IPO" 3)]}})
+    (play-from-hand state :corp "Reclamation Order")
+    (click-card state :corp (find-card "IPO" (:discard (get-corp))))
+    (click-prompt state :corp "3")
+    (is (= 3 (count (:hand (get-corp)))) "Corp should have all 3 IPO in hand")
+    (is (= 6 (count (:discard (get-corp)))) "Corp should have 5 Ice Wall and 1 Reclamation Order in discard")))
+
+(deftest recruiting-trip
+  ;; Mason Bellamy
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5) "Keegan Lane" "Midori"
+                             "The Twins" "Arella Salvatore" "Mason Bellamy"]
+                      :hand ["Recruiting Trip"]}})
+    (play-from-hand state :corp "Recruiting Trip")
+    (click-prompt state :corp "5")
+    (click-prompt state :corp "Midori")
+    (click-prompt state :corp "The Twins")
+    (click-prompt state :corp "Arella Salvatore")
+    (click-prompt state :corp "Mason Bellamy")
+    (click-prompt state :corp "Keegan Lane")
+    (is (= 5 (count (:hand (get-corp)))) "Corp should have 5 cards in hand")))
+
 (deftest red-level-clearance
   ;; Red Level Clearance
   (testing "Basic test"
@@ -2918,6 +2618,56 @@
       (is (zero? (get-counters (refresh iw2) :advancement)) "Advancements removed")
       (is (= 6 (get-counters (refresh gt) :advancement)) "Gained 6 advancements"))))
 
+(deftest replanting
+  ;; Prisec
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Replanting" "Ice Wall" "Prisec"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Replanting")
+    (click-card state :corp "Ice Wall")
+    (click-card state :corp "Ice Wall")
+    (click-prompt state :corp "New remote")
+    (click-card state :corp "Prisec")
+    (click-prompt state :corp "Server 1")
+    (is (= "Ice Wall" (:title (get-ice state :remote1 0))) "Ice Wall has been moved")
+    (is (= "Prisec" (:title (get-content state :remote1 0))) "Prisec has been installed")))
+
+(deftest restore
+  ;; Fire Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Restore" "Fire Wall"]
+                      :discard [(qty "Ice Wall" 10)]}})
+    (play-from-hand state :corp "Fire Wall" "HQ")
+    (play-from-hand state :corp "Restore")
+    (click-card state :corp (find-card "Ice Wall" (:discard (get-corp))))
+    (let [credits (:credit (get-corp))]
+      (click-prompt state :corp "HQ")
+      (is (= (+ credits -2) (:credit (get-corp))) "Corp should pay for both install and rez cost"))
+    (is (= ["Restore"] (->> (get-corp) :discard (map :title))) "All other copies of Ice Wall should be rfg'd")))
+
+(deftest restoring-face
+  ;; Midori
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Restoring Face" "Midori"]
+                      :bad-pub 3}})
+    (play-from-hand state :corp "Midori" "New remote")
+    (play-from-hand state :corp "Restoring Face")
+    (click-card state :corp "Midori")
+    (is (= 1 (count-bad-pub state)) "Corp should lose 2 bad pub")
+    (is (= "Midori" (-> (get-corp) :discard first :title)) "Midori should be in Archives")))
+
+(deftest restructure
+  ;; Restructure
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Restructure"]
+                      :credits 10}})
+    (play-from-hand state :corp "Restructure")
+    (is (= 15 (:credit (get-corp))) "Corp should gain 5 credits")))
+
 (deftest reuse
   ;; Reuse - Gain 2 credits for each card trashed from HQ
   (do-game
@@ -2960,6 +2710,16 @@
     (is (zero? (get-counters (get-resource state 0) :virus)) "Viruses purged from VBG")
     (is (zero? (get-counters (get-program state 0) :virus)) "Viruses purged from Datasucker")
     (is (= 3 (count (:discard (get-runner)))) "Three cards trashed from stack")))
+
+(deftest rework
+  ;; Ice Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Rework" "Ice Wall"]}})
+    (play-from-hand state :corp "Rework")
+    (click-card state :corp "Ice Wall")
+    (is (zero? (count (:hand (get-corp)))) "Corp should have no cards in hand")
+    (is (find-card "Ice Wall" (:deck (get-corp))) "Corp should shuffle Ice Wall into deck")))
 
 (deftest riot-suppression
   ;; Riot Suppression - lose 3 clicks or take 1 brain damage
@@ -3021,6 +2781,30 @@
     (play-from-hand state :runner "Easy Mark")
     (is (= 12 (:credit (get-runner))) "Easy Mark netted 3c after Brownout trashed")))
 
+(deftest rover-algorithm
+  ;; Enigma
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Rover Algorithm" "Enigma"]
+                      :credits 10}})
+    (play-from-hand state :corp "Enigma" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (play-from-hand state :corp "Rover Algorithm")
+    (click-card state :corp "Enigma")
+    (take-credits state :corp)
+    (let [enigma (get-ice state :hq 0)
+          strength (core/get-strength (refresh enigma))]
+      (run-on state :hq)
+      (run-continue state)
+      (run-jack-out state)
+      (run-on state :hq)
+      (run-continue state)
+      (run-jack-out state)
+      (run-on state :hq)
+      (run-continue state)
+      (run-jack-out state)
+      (is (= (+ strength 3) (core/get-strength (refresh enigma))) "Enigma should gain 3 str from Rover Algorithm"))))
+
 (deftest sacrifice
   ;; Sacrifice - Remove BP for each agenda point sacrificed and gain a credit
   (testing "Basic test"
@@ -3060,6 +2844,19 @@
     (play-from-hand state :corp "Salem's Hospitality")
     (click-prompt state :corp "Plascrete Carapace")
     (is (= 2 (count (:hand (get-runner)))))))
+
+(deftest scarcity-of-resources
+  ;; Scarcity of Resources
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Scarcity of Resources"]}
+               :runner {:hand ["Kati Jones"]}})
+    (play-from-hand state :corp "Scarcity of Resources")
+    (take-credits state :corp)
+    (let [credits (:credit (get-runner))
+          cost (:cost (find-card "Kati Jones" (:hand (get-runner))))]
+      (play-from-hand state :runner "Kati Jones")
+      (is (= (- credits (+ cost 2)) (:credit (get-runner))) "Runner should pay 2 extra for Kati Jones"))))
 
 (deftest scorched-earth
   ;; Scorched Earth
@@ -3302,6 +3099,35 @@
       (run-on state "R&D")
       (is (= 4 (:credit (get-runner))) "Second run fine"))))
 
+(deftest shipment-from-kaguya
+  ;; NGO Front
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Shipment from Kaguya" "Ice Wall" "NGO Front"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "NGO Front" "New remote")
+    (play-from-hand state :corp "Shipment from Kaguya")
+    (click-card state :corp "Ice Wall")
+    (click-card state :corp "NGO Front")
+    (is (= 1 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should be advanced")
+    (is (= 1 (get-counters (get-content state :remote1 0) :advancement)) "NGO should be advanced")))
+
+(deftest shipment-from-mirrormorph
+  ;; Prisec
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Shipment from MirrorMorph" "Ice Wall" "PAD Campaign" "Prisec"]}})
+    (play-from-hand state :corp "Shipment from MirrorMorph")
+    (click-card state :corp "Ice Wall")
+    (click-prompt state :corp "New remote")
+    (click-card state :corp "PAD Campaign")
+    (click-prompt state :corp "Server 1")
+    (click-card state :corp "Prisec")
+    (click-prompt state :corp "Server 1")
+    (is (= "Ice Wall" (:title (get-ice state :remote1 0))) "Ice Wall should be installed")
+    (is (= "PAD Campaign" (:title (get-content state :remote1 0))) "PAD Campaign should be installed")
+    (is (= "Prisec" (:title (get-content state :remote1 1))) "Prisec should be installed")))
+
 (deftest shipment-from-sansan
   ;; Shipment from SanSan - placing advancements
   (do-game
@@ -3313,6 +3139,32 @@
       (click-card state :corp iwall)
       (is (= 5 (:credit (get-corp))))
       (is (= 2 (get-counters (refresh iwall) :advancement))))))
+
+(deftest shipment-from-tennin
+  ;; Ice Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Shipment from Tennin" "Ice Wall"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp)
+    (take-credits state :runner)
+    (play-from-hand state :corp "Shipment from Tennin")
+    (click-card state :corp "Ice Wall")
+    (is (= 2 (get-counters (get-ice state :hq 0) :advancement)) "Ice Wall should be advanced")))
+
+(deftest shoot-the-moon
+  ;; Ice Wall
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Shoot the Moon" "Ice Wall"]}})
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (play-from-hand state :corp "Shoot the Moon")
+    (is (empty? (:prompt (get-corp))) "Shouldn't be able to play without runner being tagged")
+    (core/gain-tags state :runner 1)
+    (play-from-hand state :corp "Shoot the Moon")
+    (let [credits (:credit (get-corp))]
+      (click-card state :corp "Ice Wall")
+      (is (= credits (:credit (get-corp))) "Corp shouldn't pay anything to rez Ice Wall"))))
 
 (deftest snatch-and-grab
   ;; Snatch and Grab
@@ -3336,6 +3188,33 @@
     (click-card state :corp (get-resource state 0))
     (click-prompt state :runner "No")
     (is (= 1 (-> (get-runner) :discard count)) "Scrubber should be in Runner's heap after losing Snatch and Grab trace")))
+
+(deftest special-report
+  ;; NGO Front
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Special Report" "Ice Wall" "IPO" "NGO Front"]}})
+    (play-from-hand state :corp "Special Report")
+    (click-card state :corp "Ice Wall")
+    (click-card state :corp "IPO")
+    (click-card state :corp "NGO Front")
+    (is (= 3 (count (:hand (get-corp)))) "corp should draw 3 cards")))
+
+(deftest standard-procedure
+  ;; Standard Procedure
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Standard Procedure"]}
+               :runner {:hand ["Sure Gamble" "Account Siphon" "Kati Jones" "Corroder"]}})
+    (play-from-hand state :corp "Standard Procedure")
+    (is (find-card "Standard Procedure" (:hand (get-corp))) "Corp shouldn't play anything as runner can't run")
+    (take-credits state :corp)
+    (run-empty-server state :archives)
+    (take-credits state :runner)
+    (play-from-hand state :corp "Standard Procedure")
+    (let [credits (:credit (get-corp))]
+      (click-prompt state :corp "Event")
+      (is (= (+ credits 4) (:credit (get-corp))) "Corp should gain 4 from 2 events in the grip"))))
 
 (deftest stock-buy-back
   ;; Stock Buy-Back - Gain 3c for every agenda in Runner's area
@@ -3587,6 +3466,26 @@
     (play-from-hand state :corp "Successful Demonstration")
     (is (= 13 (:credit (get-corp))) "Paid 2 to play event; gained 7 credits")))
 
+(deftest sunset
+  ;; Hunter
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Sunset" "Ice Wall" "Enigma" "Hunter"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Enigma" "HQ")
+    (play-from-hand state :corp "Hunter" "HQ")
+    (core/gain state :corp :click 1)
+    (play-from-hand state :corp "Sunset")
+    (click-prompt state :corp "HQ")
+    (click-card state :corp "Ice Wall")
+    (click-card state :corp "Hunter")
+    (click-card state :corp "Ice Wall")
+    (click-card state :corp "Enigma")
+    (click-prompt state :corp "Done")
+    (is (= "Hunter" (:title (get-ice state :hq 0))) "Hunter should be in position 1")
+    (is (= "Ice Wall" (:title (get-ice state :hq 1))) "Ice Wall should be in position 2")
+    (is (= "Enigma" (:title (get-ice state :hq 2))) "Hunter should be in position 3")))
+
 (deftest surveillance-sweep
   ;; Surveillance Sweep
   (testing "Basic test"
@@ -3664,6 +3563,22 @@
       (click-card state :corp "Surveillance Sweep")
       (core/end-turn state :runner nil)
       (is (prompt-is-type? state :runner :waiting) "Runner is waiting on Corp"))))
+
+(deftest sweeps-week
+  ;; Sweeps Week
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Sweeps Week" 2)]}
+               :runner {:deck [(qty "Sure Gamble" 5)]
+                        :hand ["Sure Gamble"]}})
+    (play-from-hand state :corp "Sweeps Week")
+    (is (= 5 (:credit (get-corp))) "Corp should spend 1 and gain 1 for 1 card in grip")
+    (dotimes [_ 5]
+      (core/move state :runner (find-card "Sure Gamble" (:deck (get-runner))) :hand))
+    (let [credits (:credit (get-corp))]
+      (play-from-hand state :corp "Sweeps Week")
+      (is (= (+ credits -1 (count (:hand (get-runner)))) (:credit (get-corp)))
+          "Corp should gain 5 for 6 cards in the grip"))))
 
 (deftest targeted-marketing
   ;; Targeted Marketing
@@ -3815,6 +3730,33 @@
     (click-prompt state :runner "0")
     (is (= 6 (count-tags state)) "Runner took 3 tag because they had 3")))
 
+(deftest too-big-to-fail
+  ;; Too Big to Fail
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "Too Big to Fail" 2)]}})
+    (let [credits (:credit (get-corp))]
+      (play-from-hand state :corp "Too Big to Fail")
+      (is (= 1 (count-bad-pub state)) "Corp should gain 1 bad pub")
+      (is (= (+ credits 7) (:credit (get-corp))) "Corp should gain 7 credits"))
+    (let [credits (:credit (get-corp))
+          bp (count-bad-pub state)]
+      (play-from-hand state :corp "Too Big to Fail")
+      (is (= bp (count-bad-pub state)) "Corp shouldn't gain any more bad pub")
+      (is (= credits (:credit (get-corp))) "Corp shouldn't gain any more as over 10 credits"))))
+
+(deftest traffic-accident
+  ;; Traffic Accident
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Traffic Accident"]}
+               :runner {:hand [(qty "Sure Gamble" 5)]}})
+    (play-from-hand state :corp "Traffic Accident")
+    (is (= 5 (count (:hand (get-runner)))) "Runner shouldn't take damage as they're not tagged")
+    (core/gain-tags state :runner 2)
+    (play-from-hand state :corp "Traffic Accident")
+    (is (= 3 (count (:hand (get-runner)))) "Runner should take 2 damage")))
+
 (deftest transparency-initiative
   ;; Transparency Initiative - Full test
   (do-game
@@ -3849,6 +3791,26 @@
       (is (= 6 (:credit (get-corp))) "Transparency initiative didn't fire")
       (core/advance state :corp {:card (refresh atlas)})
       (is (= 5 (:credit (get-corp))) "Transparency initiative didn't fire"))))
+
+(deftest trick-of-light
+  ;; NGO Front
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Trick of Light" "Ice Wall" "NGO Front"]
+                      :credits 10}})
+    (core/gain state :corp :click 5)
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "NGO Front" "New remote")
+    (let [ngo (get-content state :remote1 0)
+          iw (get-ice state :hq 0)]
+      (advance state (refresh ngo) 2)
+      (is (= 2 (get-counters (refresh ngo) :advancement)) "NGO Front should have 2 counters")
+      (play-from-hand state :corp "Trick of Light")
+      (click-card state :corp ngo)
+      (click-prompt state :corp "2")
+      (click-card state :corp "Ice Wall")
+      (is (= 2 (get-counters (refresh iw) :advancement)) "Ice Wall is now advanced")
+      (is (zero? (get-counters (refresh ngo) :advancement)) "NGO Front should have 0 counters"))))
 
 (deftest trojan-horse
   ;; Trojan Horse
@@ -3919,6 +3881,34 @@
     (is (empty? (get-resource state)) "Runner has no resource installed")
     (is (= 2 (count (:discard (get-runner)))) "Runner has 2 trashed cards")
     (is (= 1 (count-bad-pub state)) "Corp takes 1 bad pub"))))
+
+(deftest violet-level-clearance
+  ;; Violet Level Clearance
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Violet Level Clearance"]}})
+    (play-from-hand state :corp "Violet Level Clearance")
+    (is (= 8 (:credit (get-corp))) "Corp should gain 8 credits")
+    (is (= 4 (count (:hand (get-corp)))) "Corp should draw 4 cards")
+    (is (= 1 (count (:deck (get-corp)))) "Corp should draw 4 cards")))
+
+(deftest voter-intimidation
+  ;; Hostile Takeover
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Voter Intimidation" "Hostile Takeover"]}
+               :runner {:hand ["Kati Jones"]}})
+    (play-from-hand state :corp "Hostile Takeover" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Kati Jones")
+    (run-empty-server state :remote1)
+    (click-prompt state :runner "Steal")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Voter Intimidation")
+    (click-prompt state :corp "1 [Credits]")
+    (click-prompt state :runner "0 [Credits]")
+    (click-card state :corp "Kati Jones")
+    (is (not (get-resource state 0)) "Kati Jones is trashed")))
 
 (deftest wake-up-call
   ;; Wake Up Call
@@ -4017,3 +4007,12 @@
       (click-card state :corp (refresh vanilla))
       (is (not= "Wetwork Refit" (:title (first (:hosted (refresh vanilla)))))
           "Wetwork Refit is not hosted on Vanilla"))))
+
+(deftest witness-tampering
+  ;; Witness Tampering
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Witness Tampering"]
+                      :bad-pub 3}})
+    (play-from-hand state :corp "Witness Tampering")
+    (is (= 1 (count-bad-pub state)) "Corp should lose 2 bad pub")))

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -2499,8 +2499,6 @@
       (click-prompt state :runner "Make the Runner lose 2 [Credits]")
       (click-prompt state :runner "End the run")
       (is (:broken (first (:subroutines (refresh afshar)))) "Broke a code gate subroutine"))))
-
-
 (deftest scheherazade
   ;; Scheherazade - Gain 1 credit when it hosts a program
   (do-game
@@ -2944,20 +2942,6 @@
       (is (zero? (get-counters (refresh upya) :power)) "3 counters spent")
       (is (= 5 (:click (get-runner))) "Gained 2 clicks"))))
 
-(deftest wari
-  (do-game
-    (new-game {:corp {:deck ["Ice Wall"]}
-               :runner {:deck ["Wari"]}})
-    (play-from-hand state :corp "Ice Wall" "R&D")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Wari")
-    (run-empty-server state "HQ")
-    (click-prompt state :runner "Yes")
-    (click-prompt state :runner "Barrier")
-    (click-card state :runner (get-ice state :rd 0))
-    (is (= 1 (count (:discard (get-runner)))) "Wari in heap")
-    (is (seq (get-in @state [:runner :prompt])) "Runner is currently accessing Ice Wall")))
-
 (deftest utae
   ;; Utae
   (do-game
@@ -2996,6 +2980,20 @@
         (click-prompt state :runner "Done")
         (is (= (dec credits) (:credit (get-runner)))))
       (is (= 3 (:credit (get-runner))) "Able to use ability now"))))
+
+(deftest wari
+  (do-game
+    (new-game {:corp {:deck ["Ice Wall"]}
+               :runner {:deck ["Wari"]}})
+    (play-from-hand state :corp "Ice Wall" "R&D")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Wari")
+    (run-empty-server state "HQ")
+    (click-prompt state :runner "Yes")
+    (click-prompt state :runner "Barrier")
+    (click-card state :runner (get-ice state :rd 0))
+    (is (= 1 (count (:discard (get-runner)))) "Wari in heap")
+    (is (seq (get-in @state [:runner :prompt])) "Runner is currently accessing Ice Wall")))
 
 (deftest wyrm
   ;; Wyrm reduces strength of ice

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -2594,17 +2594,17 @@
   ;; Paige Piper
   (testing "interaction with Frantic Coding. Issue #2190"
     (do-game
-      (new-game {:runner {:deck ["Paige Piper" (qty "Frantic Coding" 2) (qty "Sure Gamble" 3)
-                                 (qty "Gordian Blade" 2) "Ninja" (qty "Bank Job" 3) (qty "Indexing" 2)]}})
+      (new-game {:runner {:hand ["Paige Piper" "Frantic Coding" "Frantic Coding"]
+                          :deck [(qty "Sure Gamble" 3) (qty "Gordian Blade" 2)
+                                 "Ninja" (qty "Bank Job" 3) (qty "Indexing" 2)]}})
       (take-credits state :corp)
-      (starting-hand state :runner ["Paige Piper" "Frantic Coding" "Frantic Coding"])
       (play-from-hand state :runner "Paige Piper")
       (click-prompt state :runner "No")
       (take-credits state :runner) ; now 8 credits
       (take-credits state :corp)
       (play-from-hand state :runner "Frantic Coding")
       (click-prompt state :runner "OK")
-      (click-prompt state :runner (find-card "Gordian Blade" (:deck (get-runner))))
+      (click-prompt state :runner "Gordian Blade")
       (is (= 1 (count (get-program state))) "Installed Gordian Blade")
       (click-prompt state :runner "Yes")
       (click-prompt state :runner "0")
@@ -2613,7 +2613,7 @@
       ;; a second Frantic Coding will not trigger Paige (once per turn)
       (play-from-hand state :runner "Frantic Coding")
       (click-prompt state :runner "OK")
-      (click-prompt state :runner (find-card "Ninja" (:deck (get-runner))))
+      (click-prompt state :runner "Ninja")
       (is (= 2 (count (get-program state))) "Installed Ninja")
       (is (= 11 (count (:discard (get-runner)))) "11 cards in heap")
       (is (= 2 (:credit (get-runner))) "No charge to install Ninja"))))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -292,29 +292,6 @@
     (run-empty-server state :hq)
     (is (= 1 (count (:discard (get-corp)))) "Bhagat milled one card")))
 
-(deftest ^:skip-card-coverage companions
-  ;; Fencer Fueno, Mystic Maemi, Trickster Taka:
-  ;; Gain 1c on start of turn or agenda steal
-  (letfn [(companion-test [card]
-            (do-game
-              (new-game {:corp {:hand ["Hostile Takeover"]}
-                         :runner {:hand [card]}})
-              (play-from-hand state :corp "PAD Campaign" "New remote")
-              (take-credits state :corp)
-              (play-from-hand state :runner card)
-              (let [cc (get-resource state 0)
-                    counters (get-counters (refresh cc) :credit)] ;; cc for companion card
-                (is (zero? (get-counters (refresh cc) :credit)) "Companion starts with 0 credits")
-                (run-empty-server state "HQ")
-                (click-prompt state :runner "Steal")
-                (is (= (inc counters) (get-counters (refresh cc) :credit)) "Companion gains 1c for stealing agenda")
-                (run-empty-server state "Archives")
-                (is (= (inc counters) (get-counters (refresh cc) :credit)) "Companion doesn't gain 1c when no agenda stolen"))))]
-    (doall (map companion-test
-                ["Fencer Fueno"
-                 "Trickster Taka"
-                 "Mystic Maemi"]))))
-
 (deftest chrome-parlor
   ;; Chrome Parlor - Prevent all meat/brain dmg when installing cybernetics
   (do-game
@@ -3916,6 +3893,27 @@
                            (click-card state :runner rara))
         (is (= 0 (count (:hand (get-runner)))) "Installed Darwin")))))
 
+(deftest tri-maf-contact
+  ;; Tri-maf Contact - Click for 2c once per turn; take 3 meat dmg when trashed
+  (do-game
+    (new-game {:runner {:deck ["Tri-maf Contact" (qty "Cache" 3) "Shiv"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Tri-maf Contact")
+    (let [tmc (get-resource state 0)]
+      (card-ability state :runner tmc 0)
+      (is (= 5 (:credit (get-runner))) "Gained 2c")
+      (is (= 2 (:click (get-runner))) "Spent 1 click")
+      (card-ability state :runner tmc 0)
+      (is (= 5 (:credit (get-runner))) "No credits gained; already used this turn")
+      (core/move state :runner tmc :hand)
+      (is (= 5 (count (:hand (get-runner)))) "No meat damage")
+      (play-from-hand state :runner "Tri-maf Contact")
+      (core/gain-tags state :runner 1)
+      (take-credits state :runner)
+      (core/trash-resource state :corp nil)
+      (click-card state :corp (get-resource state 0))
+      (is (= 4 (count (:discard (get-runner)))) "Took 3 meat damage"))))
+
 (deftest trickster-taka
   ;; Trickster Taka - Companion, credits spendable on programs during runs (not during access)
   (testing "Basic test"
@@ -3988,27 +3986,6 @@
                            (run-on state :hq)
                            (card-ability state :runner refr 1)
                            (click-card state :runner refr))))))
-
-(deftest tri-maf-contact
-  ;; Tri-maf Contact - Click for 2c once per turn; take 3 meat dmg when trashed
-  (do-game
-    (new-game {:runner {:deck ["Tri-maf Contact" (qty "Cache" 3) "Shiv"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Tri-maf Contact")
-    (let [tmc (get-resource state 0)]
-      (card-ability state :runner tmc 0)
-      (is (= 5 (:credit (get-runner))) "Gained 2c")
-      (is (= 2 (:click (get-runner))) "Spent 1 click")
-      (card-ability state :runner tmc 0)
-      (is (= 5 (:credit (get-runner))) "No credits gained; already used this turn")
-      (core/move state :runner tmc :hand)
-      (is (= 5 (count (:hand (get-runner)))) "No meat damage")
-      (play-from-hand state :runner "Tri-maf Contact")
-      (core/gain-tags state :runner 1)
-      (take-credits state :runner)
-      (core/trash-resource state :corp nil)
-      (click-card state :corp (get-resource state 0))
-      (is (= 4 (count (:discard (get-runner)))) "Took 3 meat damage"))))
 
 (deftest virus-breeding-ground
   ;; Virus Breeding Ground - Gain counters

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1249,7 +1249,7 @@
   ;; Khondi Plaza
   (testing "Pay-credits prompt"
     (do-game
-      (new-game {:corp {:hand ["Khondi Plaza" "Enigma" (qty "PAD Campaign" 3)]}})
+      (new-game {:corp {:hand ["Khondi Plaza" "Ice Wall" "Enigma" (qty "PAD Campaign" 3)]}})
       (core/gain state :corp :click 10)
       (play-from-hand state :corp "Khondi Plaza" "New remote")
       (play-from-hand state :corp "Enigma" "Server 1")

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -678,7 +678,6 @@
      (core/gain state :corp :credit 10 :click 10)
      (play-from-hand state :corp "Cold Site Server" "HQ")
      (play-from-hand state :corp "Test Ground" "New remote")
-
      (let [css (get-content state :hq 0)
            tg (get-content state :remote1 0)]
        (core/rez state :corp (refresh css))
@@ -1264,7 +1263,6 @@
                            "Used 3 credits from Khondi Plaza"
                            (core/rez state :corp en)
                            (dotimes [c 3] (click-card state :corp kh)))))))
-
 
 (deftest la-costa-grid
   (testing "La Costa Grid cannot be installed in a central server"

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -250,15 +250,19 @@
      (when (string? x)
        (find-card x (get-in @state [side :scored]))))))
 
-(defn play-from-hand
+(defn get-rfg
+  ([state side] (get-in @state [side :rfg]))
+  ([state side pos]
+   (get-in @state [side :rfg pos])))
+
+(defmacro play-from-hand
   "Play a card from hand based on its title. If installing a Corp card, also indicate
   the server to install into with a string."
-  ([state side title] (play-from-hand state side title nil))
-  ([state side title server]
-   (let [card (find-card title (get-in @state [side :hand]))]
-     (is (some? card) (str title " is in the hand"))
-     (core/play state side {:card (find-card title (get-in @state [side :hand]))
-                            :server server}))))
+  [state side title & server]
+  `(let [card# (find-card ~title (get-in @~state [~side :hand]))]
+     (is (some? card#) (str ~title " is in the hand"))
+     (core/play ~state ~side {:card card#
+                              :server ~(first server)})))
 
 
 ;;; Run functions

--- a/test/clj/game_test/core.clj
+++ b/test/clj/game_test/core.clj
@@ -255,8 +255,10 @@
   the server to install into with a string."
   ([state side title] (play-from-hand state side title nil))
   ([state side title server]
-   (core/play state side {:card (find-card title (get-in @state [side :hand]))
-                          :server server})))
+   (let [card (find-card title (get-in @state [side :hand]))]
+     (is (some? card) (str title " is in the hand"))
+     (core/play state side {:card (find-card title (get-in @state [side :hand]))
+                            :server server}))))
 
 
 ;;; Run functions
@@ -310,6 +312,10 @@
   (run-on state server)
   (run-successful state))
 
+(defn get-run-event
+  ([state] (get-in @state [:runner :play-area]))
+  ([state pos]
+   (get-in @state [:runner :play-area pos])))
 
 ;;; Misc functions
 (defn score-agenda

--- a/test/clj/game_test/engine/scenarios.clj
+++ b/test/clj/game_test/engine/scenarios.clj
@@ -159,3 +159,27 @@
           (click-prompt state :corp "1 [Credits]")
           (click-prompt state :runner "2 [Credits]")
           (is (not (:run @state)) "Corp won Caprice psi game and ended the run"))))))
+
+(deftest companions
+  ;; Fencer Fueno, Mystic Maemi, Trickster Taka:
+  ;; Gain 1c on start of turn or agenda steal
+  (letfn [(companion-test [card]
+            (do-game
+              (new-game {:corp {:hand ["Hostile Takeover"]}
+                         :runner {:hand [card]}})
+              (play-from-hand state :corp "PAD Campaign" "New remote")
+              (take-credits state :corp)
+              (play-from-hand state :runner card)
+              (let [cc (get-resource state 0)
+                    counters (get-counters (refresh cc) :credit)] ;; cc for companion card
+                (is (zero? (get-counters (refresh cc) :credit)) "Companion starts with 0 credits")
+                (run-empty-server state "HQ")
+                (click-prompt state :runner "Steal")
+                (is (= (inc counters) (get-counters (refresh cc) :credit)) "Companion gains 1c for stealing agenda")
+                (run-empty-server state "Archives")
+                (is (= (inc counters) (get-counters (refresh cc) :credit)) "Companion doesn't gain 1c when no agenda stolen"))))]
+    (doall (map companion-test
+                ["Fencer Fueno"
+                 "Trickster Taka"
+                 "Mystic Maemi"]))))
+

--- a/test/clj/game_test/engine/scenarios.clj
+++ b/test/clj/game_test/engine/scenarios.clj
@@ -165,13 +165,13 @@
   ;; Gain 1c on start of turn or agenda steal
   (letfn [(companion-test [card]
             (do-game
-              (new-game {:corp {:hand ["Hostile Takeover"]}
+              (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                                :hand ["Hostile Takeover"]}
                          :runner {:hand [card]}})
-              (play-from-hand state :corp "PAD Campaign" "New remote")
               (take-credits state :corp)
               (play-from-hand state :runner card)
               (let [cc (get-resource state 0)
-                    counters (get-counters (refresh cc) :credit)] ;; cc for companion card
+                    counters (get-counters (refresh cc) :credit)]
                 (is (zero? (get-counters (refresh cc) :credit)) "Companion starts with 0 credits")
                 (run-empty-server state "HQ")
                 (click-prompt state :runner "Steal")


### PR DESCRIPTION
A redo of #4438.

Currently, we have to hack around the fact that an event/operation is "resolved" and the immediately put into the trash, even tho the card is supposed to stay in the play-area until it is fully resolved. Run events are the biggest offender here: we have to call register-events and then tag the card as in the discard, even tho when it's resolving it's not in the discard and we're not supposed to have access to it in the discard at all. This is a big issue with a lot of cards, so correcting this will go a long way to comprehensive and consistent handling of events/operations.