### PR TITLE
Add :location key for events to register in non-default zones

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1917,30 +1917,22 @@
       :effect (effect (continue-ability (sc 1 card) card nil))})
 
    "Subliminal Messaging"
-   (let [subliminal [{:event :corp-phase-12
-                      :async true
-                      :effect
-                      (effect
-                        (continue-ability
-                          (when (not-last-turn? state :runner :made-run)
-                            {:optional
-                             {:prompt "Add Subliminal Messaging to HQ?"
-                              :yes-ability
-                              {:msg "add Subliminal Messaging to HQ"
-                               :effect (effect (move card :hand)
-                                               (unregister-events card {:events [{:event :corp-phase-12}]}))}}})
-                          card nil))}]]
-     {:msg "gain 1 [Credits]"
-      :effect (effect (gain-credits 1)
-                      (continue-ability
-                        {:once :per-turn
-                         :once-key :subliminal-messaging
-                         :msg "gain [Click]"
-                         :effect (effect (gain :corp :click 1))}
-                        card nil))
-      :move-zone (req (if (in-discard? card)
-                        (register-events state side (assoc card :zone '(:discard)) subliminal)
-                        (unregister-events state side card {:events [{:event :corp-phase-12}]})))})
+   {:msg "gain 1 [Credits]"
+    :effect (effect (gain-credits 1)
+                    (continue-ability
+                      {:once :per-turn
+                       :once-key :subliminal-messaging
+                       :msg "gain [Click]"
+                       :effect (effect (gain :corp :click 1))}
+                      card nil))
+    :events [{:event :corp-phase-12
+              :location :discard
+              :optional
+              {:req (req (not-last-turn? state :runner :made-run))
+               :prompt "Add Subliminal Messaging to HQ?"
+               :yes-ability
+               {:msg "add Subliminal Messaging to HQ"
+                :effect (effect (move card :hand))}}}]}
 
    "Success"
    {:additional-cost [:forfeit]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -21,24 +21,25 @@
 
 (defn- shard-constructor
   "Function for constructing a Shard card"
-  ([target-server message effect-fn] (shard-constructor target-server message nil effect-fn))
-  ([target-server message ability-options effect-fn]
-   (letfn [(can-install-shard? [state run] (and run
-                                                (= (:server run) [target-server])
-                                                (zero? (:position run))
-                                                (not (:access @state))))]
-     {:implementation "Click Shard to install when last ICE is passed, but before hitting Successful Run button"
-      :abilities [(merge {:effect (effect (effect-fn eid card target))
-                          :cost [:trash]
-                          :msg message}
-                    ability-options)]
-      :install-cost-bonus (req (when (can-install-shard? state run)
-                                 (- INFINITY)))
-      :effect (req (when (can-install-shard? state run)
-                     (wait-for (register-successful-run state side (:server run))
-                               (do (clear-wait-prompt state :corp)
-                                   (swap! state update-in [:runner :prompt] rest)
-                                   (handle-end-run state side)))))})))
+  [title target-server message effect-fn]
+  {:events [{:event :successful-run
+             :location :hand
+             :req (req (and run (= (:server run) [target-server])))
+             :optional
+             {:prompt (str "Install " title "?")
+              :yes-ability
+              {:effect (effect
+                         (add-run-effect
+                           {:card card
+                            :replace-access
+                            {:mandatory true
+                             :async true
+                             :msg (str "install " title ", ignoring all costs")
+                             :effect (effect (runner-install eid card {:ignore-all-cost true}))}}))}}}]
+   :abilities [{:async true
+                :cost [:trash]
+                :msg message
+                :effect (effect (effect-fn eid card target))}]})
 
 (defn- trash-when-tagged-contructor
   "Constructor for a 'trash when tagged' card. Does not overwrite `:effect` key."
@@ -595,48 +596,43 @@
                  :effect (effect (damage-prevent :meat 3))}]}
 
    "Crowdfunding"
-   (let [ability {:once :per-turn
+   (let [ability {:async true
+                  :once :per-turn
                   :label "Take 1 [Credits] (start of turn)"
                   :msg "gain 1 [Credits]"
                   :req (req (:runner-phase-12 @state))
-                  :async true
                   :effect (req (add-counter state side card :credit -1)
                                (gain-credits state :runner 1)
                                (if (not (pos? (get-counters (get-card state card) :credit)))
-                                 (do (trash state :runner card {:unpreventable true})
-                                     (system-msg state :runner (str "trashes Crowdfunding"
-                                                                    (when (not (empty? (:deck runner)))
-                                                                      " and draws 1 card")))
-                                     (draw state :runner eid 1 nil))
-                                 (effect-completed state side eid)))}
-         install-prompt {:req (req (and (in-discard? card)
-                                        (not (install-locked? state :runner))))
-                         :async true
-                         :effect (req (continue-ability
-                                        state side
-                                        {:optional {:req (req (and (>= (count (get-in @state [:runner :register :successful-run])) 3)
-                                                                   (not (get-in @state [:runner :register :crowdfunding-prompt]))))
-                                                    :player :runner
-                                                    :prompt "Install Crowdfunding?"
-                                                    :yes-ability {:effect (effect (unregister-events card)
-                                                                                  (runner-install :runner (assoc eid :source card :source-type :runner-install) card {:ignore-all-cost true}))}
-                                                    ;; Add a register to note that the player was already asked about installing,
-                                                    ;; to prevent multiple copies from prompting multiple times.
-                                                    :no-ability {:effect (req (swap! state assoc-in [:runner :register :crowdfunding-prompt] true))}}}
-                                        card nil))}
-         heap-event (req (when (in-discard? card)
-                           (unregister-events state side card)
-                           (register-events
-                             state side (assoc card :zone [:discard])
-                             [(assoc install-prompt :event :runner-turn-ends)])))]
+                                 (wait-for (trash state :runner card {:unpreventable true})
+                                           (system-msg state :runner (str "trashes Crowdfunding"
+                                                                          (when (not (empty? (:deck runner)))
+                                                                            " and draws 1 card")))
+                                           (draw state :runner eid 1 nil))
+                                 (effect-completed state side eid)))}]
      {:data {:counter {:credit 3}}
       :flags {:drip-economy true
               :runner-turn-draw (req (= 1 (get-counters (get-card state card) :credit)))
               :runner-phase-12 (req (= 1 (get-counters (get-card state card) :credit)))}
       :abilities [ability]
-      :move-zone heap-event
       :events [(assoc ability :event :runner-turn-begins)
-               {:event :runner-turn-ends}]})
+               {:event :runner-turn-ends
+                :async true
+                :location :discard
+                :req (req (not (install-locked? state :runner)))
+                :effect (effect
+                          (continue-ability
+                            {:optional
+                             {:req (req (and (<= 3 (count (get-in @state [:runner :register :successful-run])))
+                                             (not (get-in @state [:runner :register :crowdfunding-prompt]))))
+                              :player :runner
+                              :prompt "Install Crowdfunding?"
+                              :yes-ability {:effect (effect (runner-install :runner (assoc eid :source card :source-type :runner-install)
+                                                                            card {:ignore-all-cost true}))}
+                              ;; Add a register to note that the player was already asked about installing,
+                              ;; to prevent multiple copies from prompting multiple times.
+                              :no-ability {:effect (req (swap! state assoc-in [:runner :register :crowdfunding-prompt] true))}}}
+                            card nil))}]})
 
    "Crypt"
    {:events [{:event :successful-run
@@ -910,7 +906,7 @@
       :abilities [ability]})
 
    "Eden Shard"
-   (shard-constructor :rd "force the Corp to draw 2 cards" (req (draw state :corp eid 2 nil)))
+   (shard-constructor "Eden Shard" :rd "force the Corp to draw 2 cards" (effect (draw :corp eid 2 nil)))
 
    "Emptied Mind"
    (let [ability {:req (req (zero? (count (:hand runner))))
@@ -1105,7 +1101,7 @@
                                card nil)))}]}
 
    "Hades Shard"
-   (shard-constructor :archives "access all cards in Archives" {:async true}
+   (shard-constructor "Hades Shard" :archives "access all cards in Archives"
                       (req (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                            (wait-for (trigger-event-sync state side :pre-access :archives)
                                      (resolve-ability state :runner
@@ -2535,8 +2531,8 @@
       :events [(assoc ability :event :runner-turn-begins)]})
 
    "Utopia Shard"
-   (shard-constructor :hq "force the Corp to discard 2 cards from HQ at random"
-                      (effect (trash-cards :corp (take 2 (shuffle (:hand corp))))))
+   (shard-constructor "Utopia Shard" :hq "force the Corp to discard 2 cards from HQ at random"
+                      (effect (trash-cards :corp eid (take 2 (shuffle (:hand corp))) nil)))
 
    "Virus Breeding Ground"
    {:events [{:event :runner-turn-begins

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -1673,14 +1673,12 @@
   (testing "Basic test"
     (do-game
       (new-game {:corp {:deck ["Genetics Pavilion"]}
-                 :runner {:deck ["Diesel" (qty "Sure Gamble" 3) "Sports Hopper"]}})
+                 :runner {:deck [(qty "Sure Gamble" 3)]
+                          :hand ["Diesel" "Sports Hopper"]}})
       (play-from-hand state :corp "Genetics Pavilion" "New remote")
       (let [gp (get-content state :remote1 0)]
         (take-credits state :corp)
         (core/rez state :corp gp)
-        (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
-        (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
-        (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
         (play-from-hand state :runner "Sports Hopper")
         (play-from-hand state :runner "Diesel")
         (is (= 2 (count (:hand (get-runner)))) "Drew only 2 cards because of Genetics Pavilion")
@@ -1691,18 +1689,22 @@
           (card-ability state :runner hopper 0)
           (is (= 3 (count (:hand (get-runner)))) "Able to draw 3 cards during Corp's turn")
           (core/derez state :corp (refresh gp))
-          (take-credits state :corp)
-          (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
-          (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
-          (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
-          (core/move state :runner (find-card "Diesel" (:discard (get-runner))) :hand)
-          (is (= 1 (count (:hand (get-runner)))))
-          (play-from-hand state :runner "Diesel")
-          (is (= 3 (count (:hand (get-runner)))) "Drew 3 cards with Diesel")
-          (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
-          (core/rez state :corp (refresh gp))
-          (core/draw state :runner)
-          (is (= 2 (count (:hand (get-runner)))) "No card drawn; GP counts cards drawn prior to rez")))))
+          (take-credits state :corp)))))
+  (testing "Disables further draws after drawing"
+    (do-game
+      (new-game {:corp {:deck ["Genetics Pavilion"]}
+                 :runner {:deck [(qty "Sure Gamble" 3)]
+                          :hand ["Diesel"]}})
+      (play-from-hand state :corp "Genetics Pavilion" "New remote")
+      (let [gp (get-content state :remote1 0)]
+        (take-credits state :corp)
+        (is (= 1 (count (:hand (get-runner)))))
+        (play-from-hand state :runner "Diesel")
+        (is (= 3 (count (:hand (get-runner)))) "Drew 3 cards with Diesel")
+        (core/move state :runner (find-card "Sure Gamble" (:hand (get-runner))) :deck)
+        (core/rez state :corp (refresh gp))
+        (core/draw state :runner)
+        (is (= 2 (count (:hand (get-runner)))) "No card drawn; GP counts cards drawn prior to rez"))))
   (testing "vs Fisk Investment Seminar"
     (do-game
       (new-game {:corp {:deck ["Genetics Pavilion" (qty "Hedge Fund" 3)]}

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1483,19 +1483,18 @@
   ;; Laramy Fisk
   (testing "installing a Shard should still give option to force Corp draw"
     (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 3) (qty "Eli 1.0" 3)]}
+      (new-game {:corp {:deck ["Hedge Fund"]
+                        :hand [(qty "Hedge Fund" 2) (qty "Eli 1.0" 3)]}
                  :runner {:id "Laramy Fisk: Savvy Investor"
                           :deck ["Eden Shard"]}})
-      (starting-hand state :corp ["Hedge Fund" "Hedge Fund" "Hedge Fund" "Eli 1.0" "Eli 1.0"])
       (take-credits state :corp)
-      (run-on state "R&D")
-      (core/no-action state :corp nil)
-      ;; at Successful Run stage -- click Eden Shard to install
-      (play-from-hand state :runner "Eden Shard")
-      (is (= 5 (:credit (get-runner))) "Eden Shard install was free")
-      (is (= "Eden Shard" (:title (get-resource state 0))) "Eden Shard installed")
+      (run-empty-server state :rd)
+      (click-prompt state :runner "Eden Shard")
+      (click-prompt state :runner "Yes") ; Eden Shard optional, is a replacement effect
       (is (= "Identity" (-> (get-runner) :prompt first :card :type)) "Fisk prompt showing")
-      (click-prompt state :runner "Yes")
+      (click-prompt state :runner "Yes") ; Fisk optional
+      (is (= "Eden Shard" (:title (get-resource state 0))) "Eden Shard installed")
+      (is (= 5 (:credit (get-runner))) "Eden Shard install was free")
       (is (not (:run @state)) "Run ended")
       (is (= 6 (count (:hand (get-corp)))) "Corp forced to draw"))))
 

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1110,6 +1110,22 @@
         (run-successful state)
         (is (empty? (:prompt (get-runner))) "No prompt for accessing cards")))))
 
+(deftest egret
+  ;; Egret
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Mother Goddess"]}
+               :runner {:hand [(qty "Egret" 2)]}})
+    (play-from-hand state :corp "Mother Goddess" "HQ")
+    (core/rez state :corp (get-ice state :hq 0))
+    (let [mg (get-ice state :hq 0)]
+      (take-credits state :corp)
+      (play-from-hand state :runner "Egret")
+      (click-card state :runner mg)
+      (is (has-subtype? (refresh mg) "Barrier"))
+      (is (has-subtype? (refresh mg) "Code Gate"))
+      (is (has-subtype? (refresh mg) "Sentry")))))
+
 (deftest engolo
   ;; Engolo
   (testing "Subtype is removed when Engolo is trashed mid-encounter. Issue #4039"

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1154,13 +1154,14 @@
   ;; Eden Shard - Install from Grip in lieu of accessing R&D; trash to make Corp draw 2
   (testing "Basic test"
     (do-game
-      (new-game {:runner {:deck ["Eden Shard"]}})
-      (starting-hand state :corp ["Hedge Fund"])
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Hedge Fund"]}
+                 :runner {:deck ["Eden Shard"]}})
       (take-credits state :corp)
       (is (= 1 (count (:hand (get-corp)))))
       (run-on state :rd)
-      (core/no-action state :corp nil)
-      (play-from-hand state :runner "Eden Shard")
+      (run-successful state)
+      (click-prompt state :runner "Yes")
       (is (= 5 (:credit (get-runner))) "Eden Shard installed for 0c")
       (is (not (:run @state)) "Run is over")
       (card-ability state :runner (get-resource state 0) 0)
@@ -1168,12 +1169,14 @@
       (is (= 1 (count (:discard (get-runner)))) "Eden Shard trashed")))
   (testing "Do not install when accessing cards"
     (do-game
-      (new-game {:runner {:deck ["Eden Shard"]}})
-      (starting-hand state :corp ["Hedge Fund"])
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Hedge Fund"]}
+                 :runner {:deck ["Eden Shard"]}})
       (take-credits state :corp)
       (is (= 1 (count (:hand (get-corp)))))
       (run-empty-server state :rd)
-      (play-from-hand state :runner "Eden Shard")
+      (click-prompt state :runner "No")
+      (click-prompt state :runner "No action")
       (is (not (get-resource state 0)) "Eden Shard not installed")
       (is (= 1 (count (:hand (get-runner)))) "Eden Shard not installed"))))
 

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1212,18 +1212,19 @@
       (is (= 6 (count (get-in @state [:corp :servers :remote1 :ices]))) "6 ICE protecting Remote1")))
   (testing "Drawing non-ice on runner's turn"
     (do-game
-      (new-game {:corp {:deck ["Jinja City Grid" (qty "Hedge Fund" 3)]}
+      (new-game {:corp {:deck [(qty "Hedge Fund" 3)]
+                        :hand ["Jinja City Grid"]}
                  :runner {:id "Laramy Fisk: Savvy Investor"
                           :deck ["Eden Shard"]}})
-      (starting-hand state :corp ["Jinja City Grid"])
       (play-from-hand state :corp "Jinja City Grid" "HQ")
       (core/rez state :corp (get-content state :hq 0))
       (take-credits state :corp)
       (run-empty-server state :rd)
+      (click-prompt state :runner "Eden Shard")
+      (click-prompt state :runner "Yes")
       (click-prompt state :runner "Yes")
       (is (= :bogus (-> (get-corp) :prompt first :prompt-type)) "Corp has a bogus prompt to fake out the runner")
-      (click-prompt state :corp "Carry on!")
-      (click-prompt state :runner "No action"))))
+      (click-prompt state :corp "Carry on!"))))
 
 (deftest keegan-lane
   ;; Keegan Lane - Trash self and remove 1 Runner tag to trash a program


### PR DESCRIPTION
A redo of #4507. This has the same basic idea but is fully fleshed out and is based on the event/operations work.

In this PR, I've changed how `register-events` and `unregister-events` handle their optional final parameter. Instead of defaulting to the `card-def` contents, it now either uses the provided param or it filters the `card-def` to not include any events with `:location` entries. This allows us to write multiple events into a card def and only have some of them trigger from a given location. `default-locations` is so that in the future we can watch for/modify/inspect events for any location, not just the special cases.

This should greatly simplify card definitions in the future that have trigger conditions from non-active zones. (Technically, this should be how we handle "on access" effects, but those systems are already robust and tested. Too little gain to switch them and the various others over.)