### PR TITLE
Rewrite Trashing, Trash Effects

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -118,7 +118,7 @@
               :once :per-turn
               :async true
               :req (req (some corp? targets))
-              :msg "give the Runner a tag for trashing a Corp card"
+              :msg "give the Runner a tag"
               :effect (effect (gain-tags eid 1))}]}
 
    "Architect Deployment Test"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -117,6 +117,7 @@
    {:events [{:event :runner-trash
               :once :per-turn
               :async true
+              :interactive (req true)
               :req (req (some corp? targets))
               :msg "give the Runner a tag"
               :effect (effect (gain-tags eid 1))}]}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -843,31 +843,23 @@
              :effect (effect (lose-credits :runner 1))}}
 
    "Hostile Infrastructure"
-   {:trash-effect {:async true
-                   :req (req (and (= side :runner)
-                                  (some corp? targets)))
-                   :msg (msg (str "do " (count (filter corp? targets))
-                                  " net damage"))
-                   :effect (req (letfn [(do-damage [t]
-                                          (if (seq t)
-                                            (wait-for (damage state :corp :net 1 {:card card})
-                                                      (do-damage (rest t)))
-                                            (effect-completed state side eid)))]
-                                  (do-damage (filter corp? targets))))}
-    :events [{:event :runner-trash
-              :async true
-              :req (req (some corp? targets))
-              :msg (msg (str "do " (count (filter corp? targets))
-                             " net damage"))
-              :effect (req (letfn [(do-damage [t]
-                                     (if (seq t)
-                                       (wait-for (damage state :corp :net 1 {:card card})
-                                                 (do-damage (rest t)))
-                                       (effect-completed state side eid)))]
-                             (do-damage (filter corp? targets))))}]
-    :abilities [{:msg "do 1 net damage"
-                 :async true
-                 :effect (effect (damage eid :net 1 {:card card}))}]}
+   (let [ability
+         {:async true
+          :req (req (and (= side :runner)
+                         (some corp? targets)))
+          :msg (msg (str "do " (count (filter corp? targets))
+                         " net damage"))
+          :effect (req (letfn [(do-damage [t]
+                                 (if (seq t)
+                                   (wait-for (damage state :corp :net 1 {:card card})
+                                             (do-damage (rest t)))
+                                   (effect-completed state side eid)))]
+                         (do-damage (filter corp? targets))))}]
+     {:trash-effect ability
+      :events [(assoc ability :event :runner-trash)]
+      :abilities [{:msg "do 1 net damage"
+                   :async true
+                   :effect (effect (damage eid :net 1 {:card card}))}]})
 
    "Hyoubu Research Facility"
    {:events [{:event :reveal-spent-credits
@@ -1270,21 +1262,20 @@
     :implementation "Errata from FAQ 3.1: should be unique"}
 
    "Nanoetching Matrix"
-   {:events [{:event :runner-trash
-              :req (req (same-card? card target))
-              :effect (effect (show-wait-prompt :runner "Corp to use Nanoetching Matrix")
-                              (continue-ability
-                                :corp
-                                {:optional
-                                 {:prompt "Gain 2 [credits]?"
-                                  :yes-ability {:msg (msg "gain 2 [Credits]")
-                                                :effect (effect (gain-credits :corp 2))}
-                                  :end-effect (effect (clear-wait-prompt :runner))}}
-                                card nil))}]
-    :abilities [{:cost [:click 1]
+   {:abilities [{:cost [:click 1]
                  :once :per-turn
                  :msg "gain 2 [Credits]"
-                 :effect (effect (gain-credits 2))}]}
+                 :effect (effect (gain-credits 2))}]
+    :trash-effect {:req (req (= :runner side))
+                   :effect (effect (show-wait-prompt :runner "Corp to use Nanoetching Matrix")
+                                   (continue-ability
+                                     :corp
+                                     {:optional
+                                      {:prompt "Gain 2 [credits]?"
+                                       :yes-ability {:msg (msg "gain 2 [Credits]")
+                                                     :effect (effect (gain-credits :corp 2))}
+                                       :end-effect (effect (clear-wait-prompt :runner))}}
+                                     card nil))}}
 
    "NASX"
    (let [ability {:msg "gain 1 [Credits]"
@@ -1673,26 +1664,24 @@
      {:effect (effect (add-counter card :power 3))
       :derezzed-events [corp-rez-toast]
       :events [(trash-on-empty :power)
-               (assoc ability :event :corp-turn-begins)
-               {:event :corp-trash
-                :req (req (and (same-card? card target)
-                               (installed? target)
-                               (zero? (get-counters card :power))))
-                :prompt "Remove 1 bad publicity or gain 5 [Credits]?"
-                :choices ["Remove 1 bad publicity" "Gain 5 [Credits]"]
-                :msg (msg (if (= target "Remove 1 bad publicity")
-                            "remove 1 bad publicity" "gain 5 [Credits]"))
-                :effect (req (if (= target "Remove 1 bad publicity")
-                               (lose-bad-publicity state side 1)
-                               (gain-credits state side 5)))}]
-      :ability [ability]})
+               (assoc ability :event :corp-turn-begins)]
+      :ability [ability]
+      :trash-effect {:req (req (zero? (get-counters card :power)))
+                     :prompt "Remove 1 bad publicity or gain 5 [Credits]?"
+                     :choices ["Remove 1 bad publicity" "Gain 5 [Credits]"]
+                     :msg (msg (if (= target "Remove 1 bad publicity")
+                                 "remove 1 bad publicity" "gain 5 [Credits]"))
+                     :effect (req (if (= target "Remove 1 bad publicity")
+                                    (lose-bad-publicity state side 1)
+                                    (gain-credits state side 5)))}})
 
    "Ronald Five"
-   {:events [{:event :runner-trash
-              :req (req (and (= (:side target) "Corp")
-                             (pos? (:click runner))))
-              :msg "force the runner to lose 1 [Click]"
-              :effect (effect (lose :runner :click 1))}]}
+   (let [ability {:req (req (and (some corp? targets)
+                                 (pos? (:click runner))))
+                  :msg "force the runner to lose 1 [Click]"
+                  :effect (effect (lose :runner :click 1))}]
+     {:events [(assoc ability :event :runner-trash)]
+      :trash-effect ability})
 
    "Ronin"
    {:advanceable :always

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -283,6 +283,7 @@
                  :async true
                  :effect (effect (draw eid 2 nil))}]
     :trash-effect {:async true
+                   :interactive (req true)
                    :req (req (= :servers (first (:previous-zone card))))
                    :effect (effect (show-wait-prompt :runner "Corp to use Calvin B4L3Y")
                                    (continue-ability :corp
@@ -1119,6 +1120,7 @@
       :abilities [(set-autoresolve :auto-reshuffle "Marilyn reshuffle")]
       :trash-effect {:req (req (= :servers (first (:previous-zone card))))
                      :async true
+                     :interactive (req true)
                      :effect (effect (show-wait-prompt :runner "Corp to use Marilyn Campaign")
                                      (continue-ability
                                        :corp

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1203,8 +1203,9 @@
     :effect (effect (draw eid 3 nil))
     :trash-effect {:when-inactive true
                    :async true
-                   :req (req (#{:meat :net} target))
-                   :effect (effect (draw :runner eid 3 nil)) :msg "draw 3 cards"}}
+                   :req (req (some #{:meat :net} targets))
+                   :msg "draw 3 cards"
+                   :effect (effect (draw :runner eid 3 nil))}}
 
    "Immolation Script"
    {:async true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -779,8 +779,8 @@
               :req (req (and (some corp? targets)
                              (:access @state)
                              (:trash target)))
-              :effect (effect (system-msg (str "places " (:trash target) " power counters on Mâché"))
-                              (add-counter card :power (:trash target)))}]}
+              :effect (effect (system-msg (str "places " (trash-cost state side target) " power counters on Mâché"))
+                              (add-counter card :power (trash-cost state side target)))}]}
 
    "Masterwork (v37)"
    {:in-play [:memory 1]
@@ -1142,6 +1142,7 @@
    "Q-Coherence Chip"
    {:in-play [:memory 1]
     :events (let [e {:async true
+                     :interactive (req true)
                      :req (req (some program? targets))
                      :effect (effect (system-msg (str "trashes Q-Coherence Chip"))
                                      (trash eid card nil))}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -337,7 +337,7 @@
                         :value -1}]
     :events [{:event :runner-trash
               :once :per-turn
-              :req (req (corp? target))
+              :req (req (some corp? targets))
               :msg "gain 1 [Credits]"
               :effect (effect (gain-credits 1))}]}
 
@@ -776,7 +776,7 @@
                  :effect (effect (draw :runner eid 1 nil))}]
     :events [{:event :runner-trash
               :once :per-turn
-              :req (req (and (corp? target)
+              :req (req (and (some corp? targets)
                              (:access @state)
                              (:trash target)))
               :effect (effect (system-msg (str "places " (:trash target) " power counters on Mâché"))
@@ -1141,9 +1141,10 @@
 
    "Q-Coherence Chip"
    {:in-play [:memory 1]
-    :events (let [e {:req (req (= (last (:zone target)) :program))
-                     :effect (effect (trash card)
-                                     (system-msg (str "trashes Q-Coherence Chip")))}]
+    :events (let [e {:async true
+                     :req (req (some program? targets))
+                     :effect (effect (system-msg (str "trashes Q-Coherence Chip"))
+                                     (trash eid card nil))}]
               [(assoc e :event :runner-trash)
                (assoc e :event :corp-trash)])}
 
@@ -1183,9 +1184,10 @@
    "Ramujan-reliant 550 BMI"
    {:interactions {:prevent [{:type #{:net :brain}
                               :req (req true)}]}
-    :abilities [{:req (req (not-empty (:deck runner)))
+    :abilities [{:async true
+                 :req (req (not-empty (:deck runner)))
                  :effect (req (let [n (count (filter #(= (:title %) (:title card)) (all-active-installed state :runner)))]
-                                (resolve-ability
+                                (continue-ability
                                   state side
                                   {:prompt "Choose how much damage to prevent"
                                    :priority 50

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -209,9 +209,9 @@
 
    "Armand \"Geist\" Walker: Tech Lord"
    {:events [{:event :runner-trash
+              :async true
               :req (req (and (= side :runner) (= (second targets) :ability-cost)))
               :msg "draw a card"
-              :async true
               :effect (effect (draw eid 1 nil))}]}
 
    "Asa Group: Security Through Vigilance"
@@ -1421,21 +1421,18 @@
                                  :type :recurring}}}
 
    "Weyland Consortium: Builder of Nations"
-   {:implementation "Damage triggered manually"
-    :abilities [{:label "Do 1 meat damage"
+   {:implementation "Encounter effect is manual"
+    :abilities [{:async true
+                 :label "Do 1 meat damage"
                  :once :per-turn
-                 :prompt "Do a meat damage from identity ability?"
-                 :choices (cancellable ["Yes"])
-                 :async true
-                 :effect (req (when (= target "Yes")
-                                (damage state side eid :meat 1 {:card card})
-                                (system-msg state side "uses Weyland Consortium: Builder of Nations to do 1 meat damage")))}]}
+                 :msg "do 1 meat damage"
+                 :effect (effect (damage eid :meat 1 {:card card}))}]}
 
    "Weyland Consortium: Building a Better World"
    {:events [{:event :play-operation
+              :req (req (has-subtype? target "Transaction"))
               :msg "gain 1 [Credits]"
-              :effect (effect (gain-credits 1))
-              :req (req (has-subtype? target "Transaction"))}]}
+              :effect (effect (gain-credits 1))}]}
 
    "Whizzard: Master Gamer"
    {:recurring 3
@@ -1448,8 +1445,9 @@
               :effect draft-points-target}
              {:event :runner-trash
               :req (req (and (has-most-faction? state :runner "Anarch")
-                             (corp? target)
+                             (some corp? targets)
                              (pos? (count (:discard runner)))))
               :msg (msg "shuffle " (:title (last (:discard runner))) " into their Stack")
               :effect (effect (move :runner (last (:discard runner)) :deck)
-                              (shuffle! :runner :deck))}]}})
+                              (shuffle! :runner :deck)
+                              (trigger-event :searched-stack nil))}]}})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -210,6 +210,7 @@
    "Armand \"Geist\" Walker: Tech Lord"
    {:events [{:event :runner-trash
               :async true
+              :interactive (req true)
               :req (req (and (= side :runner) (= (second targets) :ability-cost)))
               :msg "draw a card"
               :effect (effect (draw eid 1 nil))}]}
@@ -938,6 +939,7 @@
    "NBN: Controlling the Message"
    {:events [{:event :runner-trash
               :async true
+              :interactive (req true)
               :req (req (and (= 1 (count (filter #(and (installed? (first %)) (corp? (first %)))
                                                  (turn-events state side :runner-trash))))
                              (corp? target)
@@ -1444,6 +1446,7 @@
    {:events [{:event :pre-start-game
               :effect draft-points-target}
              {:event :runner-trash
+              :interactive (req true)
               :req (req (and (has-most-faction? state :runner "Anarch")
                              (some corp? targets)
                              (pos? (count (:discard runner)))))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -421,7 +421,7 @@
               :msg "gain 1 [Credits]"
               :effect (effect (gain-credits :corp 1))}
              {:event :runner-trash
-              :req (req (installed? target))
+              :req (req (some installed? targets))
               :msg "gain 1 [Credits]"
               :effect (effect (gain-credits :corp 1))}]}
 

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1957,6 +1957,7 @@
    "Reaver"
    {:events [{:event :runner-trash
               :async true
+              :interactive (req true)
               :req (req (and (first-installed-trash? state side)
                              (installed? target)))
               :msg "draw 1 card"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1243,10 +1243,11 @@
                                   (break-subroutine! state (get-card state current-ice) sub))))}]}
 
    "Gravedigger"
-   (let [e {:req (req (and (installed? target)
-                           (corp? target)))
+   (let [e {:req (req (some #(and (installed? %)
+                                  (corp? %))
+                            targets))
             :msg (msg "place 1 virus counter on " (:title card))
-            :effect (effect (add-counter :runner card :virus 1 nil))}]
+            :effect (effect (add-counter :runner card :virus 1))}]
      {:events [(assoc e :event :runner-trash)
                (assoc e :event :corp-trash)]
       :abilities [{:cost [:click 1 :virus 1]
@@ -1955,11 +1956,11 @@
 
    "Reaver"
    {:events [{:event :runner-trash
+              :async true
               :req (req (and (first-installed-trash? state side)
                              (installed? target)))
-              :async true
-              :effect (effect (draw :runner eid 1 nil))
-              :msg "draw 1 card"}]}
+              :msg "draw 1 card"
+              :effect (effect (draw :runner eid 1 nil))}]}
 
    "Refractor"
    (auto-icebreaker {:implementation "Stealth credit restriction not enforced"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1264,7 +1264,8 @@
 
    "Harbinger"
    {:trash-effect
-    {:req (req (not-any? #{:facedown :hand} (:previous-zone card)))
+    {:async true
+     :req (req (not-any? #{:facedown :hand} (:previous-zone card)))
      :effect (req (let [lock (get-in @state [:runner :locked :discard])]
                     (swap! state assoc-in [:runner :locked] nil)
                     (runner-install state :runner (assoc eid :source card :source-type :runner-install) card {:facedown true})
@@ -1287,40 +1288,34 @@
                                 card nil))}]}
 
    "Hivemind"
-   (let [update-programs (req (let [virus-programs (->> (all-installed state :runner)
-                                                        (filter #(and (program? %)
-                                                                      (has-subtype? % "Virus")
-                                                                      (not (facedown? %)))))]
-                                (doseq [p virus-programs]
-                                  (update-breaker-strength state side p))))]
-     {:data {:counter {:virus 1}}
-      :effect update-programs
-      :trash-effect {:effect update-programs}
-      :events [{:event :counter-added
-                :req (req (same-card? target card))
-                :effect update-programs}]
-      :abilities [{:req (req (pos? (get-counters card :virus)))
-                   :priority true
-                   :prompt "Move a virus counter to which card?"
-                   :choices {:req #(has-subtype? % "Virus")}
-                   :effect (req (let [abilities (:abilities (card-def target))
-                                      virus target]
-                                  (add-counter state :runner virus :virus 1)
-                                  (add-counter state :runner card :virus -1)
-                                  (if (= (count abilities) 1)
-                                    (do (swap! state update-in [side :prompt] rest) ; remove the Hivemind prompt so Imp works
-                                        (resolve-ability state side (first abilities) (get-card state virus) nil))
-                                    (resolve-ability
-                                      state side
-                                      {:prompt "Choose an ability to trigger"
-                                       :choices (vec (map :msg abilities))
-                                       :effect (req (swap! state update-in [side :prompt] rest)
-                                                    (resolve-ability
-                                                      state side
-                                                      (first (filter #(= (:msg %) target) abilities))
-                                                      card nil))}
-                                      (get-card state virus) nil))))
-                   :msg (msg "trigger an ability on " (:title target))}]})
+   {:data {:counter {:virus 1}}
+    :effect (effect (update-all-icebreakers))
+    :trash-effect {:effect (effect (update-all-icebreakers))}
+    :events [{:event :counter-added
+              :req (req (same-card? target card))
+              :effect (effect (update-all-icebreakers))}]
+    :abilities [{:req (req (pos? (get-counters card :virus)))
+                 :priority true
+                 :prompt "Move a virus counter to which card?"
+                 :choices {:req #(has-subtype? % "Virus")}
+                 :effect (req (let [abilities (:abilities (card-def target))
+                                    virus target]
+                                (add-counter state :runner virus :virus 1)
+                                (add-counter state :runner card :virus -1)
+                                (if (= (count abilities) 1)
+                                  (do (swap! state update-in [side :prompt] rest) ; remove the Hivemind prompt so Imp works
+                                      (resolve-ability state side (first abilities) (get-card state virus) nil))
+                                  (resolve-ability
+                                    state side
+                                    {:prompt "Choose an ability to trigger"
+                                     :choices (vec (map :msg abilities))
+                                     :effect (req (swap! state update-in [side :prompt] rest)
+                                                  (resolve-ability
+                                                    state side
+                                                    (first (filter #(= (:msg %) target) abilities))
+                                                    card nil))}
+                                    (get-card state virus) nil))))
+                 :msg (msg "trigger an ability on " (:title target))}]}
 
    "Houdini"
    {:abilities [(break-sub 1 1 "Code Gate")

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2185,7 +2185,8 @@
 
    "Tech Trader"
    {:events [{:event :runner-trash
-              :req (req (and (= side :runner) (= (second targets) :ability-cost)))
+              :req (req (and (= side :runner)
+                             (= (second targets) :ability-cost)))
               :msg "gain 1 [Credits]"
               :effect (effect (gain-credits 1))}]}
 
@@ -2556,9 +2557,9 @@
    {:events [{:event :runner-trash
               :req (req (and (first-installed-trash-own? state :runner)
                              (installed? target)
-                             (= (:side target) "Runner")))
-              :effect (effect (gain-credits 1))
-              :msg "gain 1 [Credits]"}]}
+                             (runner? target)))
+              :msg "gain 1 [Credits]"
+              :effect (effect (gain-credits 1))}]}
 
    "Whistleblower"
    (letfn [(steal-events [named-agenda]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2275,14 +2275,14 @@
     :effect (req (swap! state assoc-in [:corp :cannot-win-on-points] true))
     :events [{:event :runner-turn-begins
               :effect (req (if (>= (get-counters card :power) 2)
-                             (do (move state side (dissoc card :counter) :rfg)
-                                 (swap! state update-in [:corp] dissoc :cannot-win-on-points)
+                             (do (move state side card :rfg)
+                                 (swap! state update :corp dissoc :cannot-win-on-points)
                                  (system-msg state side "removes The Black File from the game")
                                  (gain-agenda-point state :corp 0))
                              (add-counter state side card :power 1)))}]
-    :trash-effect {:effect (req (swap! state update-in [:corp] dissoc :cannot-win-on-points)
+    :trash-effect {:effect (req (swap! state update :corp dissoc :cannot-win-on-points)
                                 (gain-agenda-point state :corp 0))}
-    :leave-play (req (swap! state update-in [:corp] dissoc :cannot-win-on-points)
+    :leave-play (req (swap! state update :corp dissoc :cannot-win-on-points)
                      (gain-agenda-point state :corp 0))}
 
    "The Class Act"
@@ -2509,9 +2509,12 @@
                                   :type :credit}})
 
    "Tri-maf Contact"
-   {:abilities [{:cost [:click 1] :msg "gain 2 [Credits]" :once :per-turn
+   {:abilities [{:cost [:click 1]
+                 :msg "gain 2 [Credits]"
+                 :once :per-turn
                  :effect (effect (gain-credits 2))}]
-    :trash-effect {:effect (effect (damage eid :meat 3 {:unboostable true :card card}))}}
+    :trash-effect {:async true
+                   :effect (effect (damage eid :meat 3 {:unboostable true :card card}))}}
 
    "Tyson Observatory"
    {:abilities [{:prompt "Choose a piece of Hardware" :msg (msg "add " (:title target) " to their Grip")

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1084,7 +1084,8 @@
               :msg "prevent the Runner from jacking out unless they trash an installed program"
               :effect (effect (prevent-jack-out))}
              {:event :runner-trash
-              :req (req (and this-server (program? target)))
+              :req (req (and this-server
+                             (some program? targets)))
               :effect (req (swap! state update-in [:run] dissoc :cannot-jack-out))}]}
 
    "Prisec"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -127,22 +127,21 @@
                                 (continue-ability state side (dome card) card nil))}]})
 
    "Ben Musashi"
-   (let [bm {:req (req (or (in-same-server? card target)
-                           (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:net 2]))}]
-     {:trash-effect
-      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
-       :effect (effect (register-events
-                         (assoc card :zone '(:discard))
-                         [(assoc bm
-                                 :event :pre-steal-cost
-                                 :req (req (or (= (:zone target) (:previous-zone card))
-                                               (= (central->zone (:zone target))
-                                                  (butlast (:previous-zone card))))))
-                          {:event :run-ends
-                           :effect (effect (unregister-events card))}]))}
-      :events [(assoc bm :event :pre-steal-cost)
-               {:event :run-ends}]})
+   {:trash-effect
+    {:req (req (and (= :servers (first (:previous-zone card)))
+                    (:run @state)))
+     :effect (effect (register-events
+                       card
+                       [{:event :pre-steal-cost
+                         :duration :end-of-run
+                         :req (req (or (= (:zone target) (:previous-zone card))
+                                       (= (central->zone (:zone target))
+                                          (butlast (:previous-zone card)))))
+                         :effect (effect (steal-cost-bonus [:net 2]))}]))}
+    :events [{:event :pre-steal-cost
+              :req (req (or (in-same-server? card target)
+                            (from-same-server? card target)))
+              :effect (effect (steal-cost-bonus [:net 2]))}]}
 
    "Bernice Mai"
    {:events [{:event :successful-run
@@ -915,17 +914,15 @@
       :trash-effect                     ; if there is a run, mark mwanza effects to remain active until the end of the run
       {:req (req (:run @state))
        :effect (effect (register-events
-                         (assoc card :zone '(:discard))
+                         card
                          [(assoc boost-access-by-3
                                  :event :pre-access
+                                 :duration :end-of-run
                                  :req (req (= target (second (:previous-zone card)))))
                           (assoc gain-creds-and-clear
                                  :event :end-access-phase
-                                 :req (req (= (:from-server target) (second (:previous-zone card)))))
-                          {:event :unsuccessful-run-ends
-                           :effect (effect (unregister-events card))}
-                          {:event :successful-run-ends
-                           :effect (effect (unregister-events card))}]))}})
+                                 :duration :end-of-run
+                                 :req (req (= (:from-server target) (second (:previous-zone card)))))]))}})
 
    "NeoTokyo Grid"
    (let [ng {:req (req (in-same-server? card target))
@@ -1009,70 +1006,74 @@
     :leave-play (req (enable-run-on-server state card (second (:zone card))))}
 
    "Old Hollywood Grid"
-   (let [ohg {:req (req (or (in-same-server? card target)
-                            (from-same-server? card target)))
-              :effect (req (register-persistent-flag!
-                             state side
-                             card :can-steal
-                             (fn [state _ card]
-                               (if-not (some #(= (:title %) (:title card)) (:scored runner))
-                                 ((constantly false)
-                                  (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
-                                 true))))}]
-     {:trash-effect
-      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
-       :effect (req (register-events
-                      state side (assoc card :zone '(:discard))
-                      [(assoc ohg
-                              :event :pre-steal-cost
-                              :req (req (or (= (:zone (get-nested-host target))
-                                               (:previous-zone card))
-                                            (= (central->zone (:zone target))
-                                               (butlast (:previous-zone card))))))
-                       {:event :run-ends
-                        :effect (req (unregister-events state side (find-latest state card))
-                                     (clear-persistent-flag! state side card :can-steal))}]))}
-      :events [(assoc ohg :event :pre-steal-cost)
-               {:event :access
-                :effect (req (clear-persistent-flag! state side card :can-steal))}
-               {:event :run-ends}]})
-
-   "Overseer Matrix"
-   (let [om {:req (req (in-same-server? card target))
-             :async true
-             :effect (effect (show-wait-prompt :runner "Corp to use Overseer Matrix")
-                             (continue-ability
-                               {:optional
-                                {:prompt "Pay 1 [Credits] to use Overseer Matrix ability?"
-                                 :player :corp
-                                 :end-effect (effect (clear-wait-prompt :runner)
-                                                     (effect-completed eid))
-                                 :yes-ability {:cost [:credit 1]
-                                               :msg "give the Runner 1 tag"
-                                               :async true
-                                               :effect (req (gain-tags state :corp eid 1))}}}
-                               card nil))}]
+   (let [ohg {:effect (effect
+                        (register-persistent-flag!
+                          card :can-steal
+                          (fn [state _ card]
+                            (if-not (some #(= (:title %) (:title card)) (:scored runner))
+                              ((constantly false)
+                               (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
+                              true))))}]
      {:trash-effect
       {:req (req (and (= :servers (first (:previous-zone card)))
                       (:run @state)))
        :effect (effect (register-events
-                         (assoc card :zone '(:discard))
-                         [(assoc om
-                                 :event :runner-trash
+                         card
+                         [(assoc ohg
+                                 :event :pre-steal-cost
+                                 :duration :end-of-run
                                  :req (req (or (= (:zone (get-nested-host target))
                                                   (:previous-zone card))
                                                (= (central->zone (:zone target))
                                                   (butlast (:previous-zone card))))))
                           {:event :run-ends
-                           :effect (effect (unregister-events card))}]))}
-      :events [{:event :run-ends}
-               (assoc om :event :runner-trash)]})
+                           :duration :end-of-run
+                           :effect (req (clear-persistent-flag! state side card :can-steal))}]))}
+      :events [(assoc ohg
+                      :event :pre-steal-cost
+                      :req (req (or (in-same-server? card target)
+                                    (from-same-server? card target))))
+               {:event :access
+                :effect (req (clear-persistent-flag! state side card :can-steal))}]})
+
+   "Overseer Matrix"
+   (let [om {:async true
+             :effect (effect (show-wait-prompt :runner "Corp to use Overseer Matrix")
+                             (continue-ability
+                               {:optional
+                                {:prompt "Pay 1 [Credits] to use Overseer Matrix ability?"
+                                 :player :corp
+                                 :yes-ability {:cost [:credit 1]
+                                               :msg "give the Runner 1 tag"
+                                               :async true
+                                               :effect (req (gain-tags state :corp eid 1))}
+                                 :end-effect (effect (clear-wait-prompt :runner))}}
+                               card nil))}]
+     {:trash-effect
+      {:async true
+       :req (req (and (= :servers (first (:previous-zone card)))
+                      (:run @state)))
+       :effect (effect (register-events
+                         card
+                         [(assoc om
+                                 :event :runner-trash
+                                 :duration :end-of-run
+                                 :req (req (or (= (:zone (get-nested-host target))
+                                                  (:previous-zone card))
+                                               (= (central->zone (:zone target))
+                                                  (butlast (:previous-zone card))))))])
+                       (continue-ability om card nil))}
+      :events [(assoc om
+                      :event :runner-trash
+                      :req (req (in-same-server? card target)))]})
 
    "Panic Button"
    {:init {:root "HQ"}
     :install-req (req (filter #{"HQ"} targets))
-    :abilities [{:cost [:credit 1] :label "Draw 1 card" :effect (effect (draw))
-                 :req (req (and run (= (first (:server run)) :hq)))}]}
+    :abilities [{:cost [:credit 1]
+                 :msg "draw 1 card"
+                 :req (req (and run (= (first (:server run)) :hq)))
+                 :effect (effect (draw))}]}
 
    "Port Anson Grid"
    {:msg "prevent the Runner from jacking out unless they trash an installed program"
@@ -1103,26 +1104,26 @@
 
    "Product Placement"
    {:flags {:rd-reveal (req true)}
-    :access {:req (req (not= (first (:zone card)) :discard))
-             :msg "gain 2 [Credits]" :effect (effect (gain-credits :corp 2))}}
+    :access {:req (req (not (in-discard? card)))
+             :msg "gain 2 [Credits]"
+             :effect (effect (gain-credits :corp 2))}}
 
    "Red Herrings"
-   (let [ab {:req (req (or (in-same-server? card target)
-                           (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:credit 5]))}]
-     {:trash-effect
-      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
-       :effect (effect (register-events
-                         (assoc card :zone '(:discard))
-                         [(assoc ab
-                                 :event :pre-steal-cost
-                                 :req (req (or (= (:zone target) (:previous-zone card))
-                                               (= (central->zone (:zone target))
-                                                  (butlast (:previous-zone card))))))
-                          {:event :run-ends
-                           :effect (effect (unregister-events card))}]))}
-      :events [(assoc ab :event :pre-steal-cost)
-               {:event :run-ends}]})
+   {:trash-effect
+    {:req (req (and (= :servers (first (:previous-zone card)))
+                    (:run @state)))
+     :effect (effect (register-events
+                       card
+                       [{:event :pre-steal-cost
+                         :duration :end-of-run
+                         :req (req (or (= (:zone target) (:previous-zone card))
+                                       (= (central->zone (:zone target))
+                                          (butlast (:previous-zone card)))))
+                         :effect (effect (steal-cost-bonus [:credit 5]))}]))}
+    :events [{:event :pre-steal-cost
+              :req (req (or (in-same-server? card target)
+                            (from-same-server? card target)))
+              :effect (effect (steal-cost-bonus [:credit 5]))}]}
 
    "Reduced Service"
    {:constant-effects [{:type :run-additional-cost
@@ -1223,12 +1224,11 @@
    {:abilities [{:label "Cards cannot be installed until the end of the run"
                  :msg (msg "prevent cards being installed until the end of the run")
                  :req (req this-server)
-                 :cost [:trash]}]
-    :trash-effect {:effect (effect (register-run-flag! card :corp-lock-install (constantly true))
-                                   (register-run-flag! card :runner-lock-install (constantly true))
-                                   (toast :runner "Cannot install until the end of the run")
-                                   (toast :corp "Cannot install until the end of the run"))}
-    :events [{:event :run-ends}]}
+                 :cost [:trash]
+                 :effect (effect (register-run-flag! card :corp-lock-install (constantly true))
+                                 (register-run-flag! card :runner-lock-install (constantly true))
+                                 (toast :runner "Cannot install until the end of the run")
+                                 (toast :corp "Cannot install until the end of the run"))}]}
 
    "Simone Diego"
    {:recurring 2
@@ -1237,22 +1237,20 @@
                                  :type :recurring}}}
 
    "Strongbox"
-   (let [ab {:req (req (or (in-same-server? card target)
-                           (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:click 1]))}]
-     {:trash-effect
-      {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
-       :effect (effect (register-events
-                         (assoc card :zone '(:discard))
-                         [(assoc ab
-                                 :event :pre-steal-cost
-                                 :req (req (or (= (:zone target) (:previous-zone card))
-                                               (= (central->zone (:zone target))
-                                                  (butlast (:previous-zone card))))))
-                          {:event :run-ends
-                           :effect (effect (unregister-events card))}]))}
-      :events [(assoc ab :event :pre-steal-cost)
-               {:event :run-ends}]})
+   {:trash-effect
+    {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
+     :effect (effect (register-events
+                       card
+                       [{:event :pre-steal-cost
+                         :duration :end-of-run
+                         :req (req (or (= (:zone target) (:previous-zone card))
+                                       (= (central->zone (:zone target))
+                                          (butlast (:previous-zone card)))))
+                         :effect (effect (steal-cost-bonus [:click 1]))}]))}
+    :events [{:event :pre-steal-cost
+              :req (req (or (in-same-server? card target)
+                            (from-same-server? card target)))
+              :effect (effect (steal-cost-bonus [:click 1]))}]}
 
    "Surat City Grid"
    {:events [{:event :rez
@@ -1395,40 +1393,53 @@
     :abilities [{:req (req this-server)
                  :label "Reduce Runner's maximum hand size by 1 until start of next Corp turn"
                  :msg "reduce the Runner's maximum hand size by 1 until the start of the next Corp turn"
-                 :effect (req (update! state side (assoc card :times-used (inc (get card :times-used 0))))
-                              (change-hand-size state :runner -1))}]
-    :trash-effect {:req (req (and (= :servers (first (:previous-zone card))) (:run @state)))
-                   :effect (req (when-let [n (:times-used card)]
-                                  (register-events
-                                    state side (assoc card :zone '(:discard))
-                                    [{:event :corp-turn-begins
-                                      :msg (msg "increase the Runner's maximum hand size by " n)
-                                      :effect (effect (change-hand-size :runner n)
-                                                      (unregister-events card)
-                                                      (update! (dissoc card :times-used)))}])))}
-    :events [{:event :corp-turn-begins
-              :req (req (:times-used card))
-              :msg (msg "increase the Runner's maximum hand size by "
-                        (:times-used card))
-              :effect (effect (change-hand-size :runner (:times-used card))
-                              (update! (dissoc card :times-used)))}]}
+                 :effect (req (change-hand-size state :runner -1)
+                              (register-events
+                                state side card
+                                [{:event :corp-turn-begins
+                                  :duration :until-corp-turn-begins
+                                  :msg "increase the Runner's maximum hand size by 1"
+                                  :effect (effect (change-hand-size :runner 1))}]))}]}
 
    "Warroid Tracker"
    (letfn [(wt [n]
              {:prompt "Choose an installed card to trash due to Warroid Tracker"
               :async true
               :player :runner
-              :choices {:req #(and (installed? %) (runner? %))}
-              :effect (req (system-msg state :corp (str "uses Warriod Tracker to force the Runner to trash " (card-str state target)))
-                           (trash state side target {:unpreventable true})
-                           (if (pos? (dec n))
-                             (continue-ability state side (wt (dec n)) card nil)
-                             (do (clear-wait-prompt state :corp)
-                                 (effect-completed state side eid)))
-                           ;; this ends-the-run if WT is the only card and is trashed, and trashes at least one runner card
-                           (when (zero? (count (cards-to-access state side (get-in @state [:run :server]))))
-                             (handle-end-run state side)))})]
-     {:implementation "Does not handle UFAQ interaction with Singularity"
+              :choices {:req #(and (runner? %)
+                                   (installed? %))}
+              :msg (msg "force the Runner to trash " (card-str state target))
+              :effect (req (wait-for (trash state :runner target {:unpreventable true})
+                                     (if (pos? (dec n))
+                                       (continue-ability state side (wt (dec n)) card nil)
+                                       (do (clear-wait-prompt state :corp)
+                                           (effect-completed state side eid)))
+                                     ;; this ends-the-run if WT is the only card and is trashed, and trashes at least one runner card
+                                     (when (zero? (count (cards-to-access state side (get-in @state [:run :server]))))
+                                       (handle-end-run state side))))})
+           (ability [x]
+             {:trace {:base 4
+                      :successful
+                      {:async true
+                       :msg (msg (let [n (min (* x 2) (count (all-installed state :runner)))]
+                                   (str "to force the runner to trash "
+                                        (quantify n "installed card")
+                                        (when (not (pos? n))
+                                          "but there are no installed cards to trash"))))
+                       :effect (req (let [n (min (* x 2) (count (all-installed state :runner)))]
+                                      (if (pos? n)
+                                        (do (show-wait-prompt state :corp "Runner to choose cards to trash")
+                                            (continue-ability state side (wt n) card nil))
+                                        (effect-completed state side eid))))}}})]
+     {:trash-effect
+      {:async true
+       :req (req (and (corp? target)
+                      (let [target-zone (:zone target)
+                            target-zone (or (central->zone target-zone) target-zone)
+                            warroid-zone (:previous-zone card)]
+                        (= (second warroid-zone)
+                           (second target-zone)))))
+       :effect (effect (continue-ability (ability (count (filter :cid targets))) card nil))}
       :events [{:event :runner-trash
                 :async true
                 :req (req (and (corp? target)
@@ -1437,22 +1448,7 @@
                                      warroid-zone (:zone card)]
                                  (= (second warroid-zone)
                                     (second target-zone)))))
-                :trace {:base 4
-                        :successful
-                        {:async true
-                         :effect
-                         (req (let [n (min 2 (count (all-installed state :runner)))]
-                                (system-msg
-                                  state side
-                                  (str "uses Warroid Tracker "
-                                       (if (pos? n)
-                                         (str "to force the runner to trash "
-                                              (quantify n "installed card"))
-                                         "but there are no installed cards to trash")))
-                                (if (pos? n)
-                                  (do (show-wait-prompt state :corp "Runner to choose cards to trash")
-                                      (continue-ability state side (wt n) card nil))
-                                  (effect-completed state side eid))))}}}]})
+                :effect (effect (continue-ability (ability (count (filter :cid targets))) card nil))}]})
 
    "Will-o'-the-Wisp"
    {:events [{:event :successful-run

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1038,6 +1038,7 @@
 
    "Overseer Matrix"
    (let [om {:async true
+             :interactive (req true)
              :effect (effect (show-wait-prompt :runner "Corp to use Overseer Matrix")
                              (continue-ability
                                {:optional
@@ -1406,6 +1407,7 @@
    (letfn [(wt [n]
              {:prompt "Choose an installed card to trash due to Warroid Tracker"
               :async true
+              :interactive (req true)
               :player :runner
               :choices {:req #(and (runner? %)
                                    (installed? %))}

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -637,7 +637,7 @@
                                                                          (when (:disable-id (card-def current))
                                                                            (swap! state assoc-in [:corp :disable-id] true)))
                                                                        (remove-old-current state side :runner))}
-                                          :card-ability (card-as-handler c)
+                                          :card-abilities (card-as-handler c)
                                           :after-active-player {:effect (req (let [c (get-card state c)
                                                                                    points (or (get-agenda-points state :corp c) points)]
                                                                                (set-prop state :corp (get-card state moved-card) :advance-counter 0)

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -234,15 +234,16 @@
                              ;; then filter to remove suppressed handlers and those whose req is false.
                              ;; This is essentially Phase 9.3 and 9.6.7a of CR 1.1:
                              ;; http://nisei.net/files/Comprehensive_Rules_1.1.pdf
-                             (let [abis (->> (:events @state)
-                                             (filter #(= event (:event %)))
-                                             (concat (flatten [card-abilities]))
-                                             (filter (partial is-player player-side))) ]
-                               (filterv (fn [ability]
-                                          (let [card (card-for-ability state ability)]
-                                            (and (not (apply trigger-suppress state side event card targets))
-                                                 (can-trigger? state side (:ability ability) card targets))))
-                                        abis)))
+                             (->> (:events @state)
+                                  (filter #(= event (:event %)))
+                                  (concat (flatten [card-abilities]))
+                                  (filter identity)
+                                  (filter (partial is-player player-side))
+                                  (filter (fn [ability]
+                                            (let [card (card-for-ability state ability)]
+                                              (and (not (apply trigger-suppress state side event card targets))
+                                                   (can-trigger? state side (:ability ability) card targets)))))
+                                  (into [])))
               active-player-events (get-handlers active-player)
               opponent-events (get-handlers opponent)]
           (wait-for (resolve-ability state side (make-eid state eid) first-ability nil nil)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -442,7 +442,7 @@
                              (update-breaker-strength state side installed-card))
                            (trigger-event-simult state side eid :runner-install
                                                  (when-not facedown
-                                                   {:card-ability (card-as-handler (get-card state installed-card))})
+                                                   {:card-abilities (card-as-handler (get-card state installed-card))})
                                                  (get-card state installed-card)))
                          (effect-completed state side eid))))))
        (effect-completed state side eid)))))

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -511,7 +511,7 @@
    (let [num-cards (< 1 (count cards))]
      (letfn [(get-card? [s c] (if num-cards (get-card s c) c))
              (preventrec [cs]
-               (if (not-empty cs)
+               (if (seq cs)
                  (wait-for (prevent-trash state side (get-card? state (first cs)) eid args)
                            (preventrec (rest cs)))
                  (let [trashlist (get-in @state [:trash :trash-list eid])
@@ -531,8 +531,7 @@
                                         (filter identity)
                                         (map (juxt #(move state (to-keyword (:side %)) % :discard {:keep-server-alive keep-server-alive})
                                                    get-trash-effect))
-                                        (into []))
-                       ]
+                                        (into []))]
                    (swap! state update-in [:trash :trash-list] dissoc eid)
                    (when (seq (remove #{side} (map #(to-keyword (:side %)) trashlist)))
                      (swap! state assoc-in [side :register :trashed-card] true))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -125,7 +125,7 @@
                                        (when (card-flag? c :has-events-when-stolen true)
                                          (register-events state side c))
                                        (remove-old-current state side :corp))}
-          :card-ability (ability-as-handler c (:stolen (card-def c)))}
+          :card-abilities (ability-as-handler c (:stolen (card-def c)))}
          c)
        (access-end state side eid card)))))
 
@@ -368,7 +368,7 @@
     (swap! state assoc-in [:runner :register :accessed-cards] true)
     (msg-handle-access state side c title cost-msg)
     (wait-for (trigger-event-simult state side :access
-                                    {:card-ability access-effect
+                                    {:card-abilities access-effect
                                      ;; Cancel other access handlers if the card moves zones because of a handler
                                      :cancel-fn (fn [state] (not (get-card state c)))}
                                     c)

--- a/test/clj/game_test/cards/events.clj
+++ b/test/clj/game_test/cards/events.clj
@@ -2265,7 +2265,8 @@
   ;; I've Had Worse - Draw 3 cards when lost to net/meat damage; don't trigger if flatlined
   (testing "Basic test"
     (do-game
-      (new-game {:corp {:deck [(qty "Scorched Earth" 3) (qty "Pup" 3)]}
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand [(qty "Scorched Earth" 3) (qty "Pup" 3)]}
                  :runner {:deck [(qty "I've Had Worse" 2) (qty "Sure Gamble" 3) (qty "Imp" 2)]}})
       (core/gain state :runner :tag 1)
       (core/gain state :corp :credit 5)

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -2540,10 +2540,6 @@
                         :deck [(qty "Hedge Fund" 3)]}})
       (let [bon (get-in @state [:corp :identity])]
         (card-ability state :corp bon 0)
-        (click-prompt state :corp "Cancel")
-        (is (zero? (count (:discard (get-runner)))) "Runner took no meat damage from BoN")
-        (card-ability state :corp bon 0)
-        (click-prompt state :corp "Yes")
         (is (= 1 (count (:discard (get-runner)))) "Runner took 1 meat damage from BoN")
         (card-ability state :corp bon 0)
         (is (= 1 (count (:discard (get-runner)))) "Runner took only 1 meat damage from BoN total")
@@ -2558,7 +2554,6 @@
         (score-agenda state :corp clean)
         (let [bon (get-in @state [:corp :identity])]
           (card-ability state :corp bon 0)
-          (click-prompt state :corp "Yes")
           (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage from BoN/Cleaners combo"))))))
 
 (deftest whizzard-master-gamer

--- a/test/clj/game_test/engine/actions.clj
+++ b/test/clj/game_test/engine/actions.clj
@@ -1,7 +1,6 @@
 (ns game-test.engine.actions
   (:require [game.core :as core]
             [game.utils :as utils]
-            [jinteki.utils :as jutils]
             [game-test.core :refer :all]
             [game-test.utils :refer :all]
             [game-test.macros :refer :all]
@@ -12,23 +11,23 @@
     (do-game
       (new-game)
       (testing "Bad Publicity"
-        (is (zero? (jutils/count-bad-pub state)) "Corp starts with 0 bad pub")
+        (is (zero? (count-bad-pub state)) "Corp starts with 0 bad pub")
         (core/change state :corp {:key :bad-publicity :delta 1})
-        (is (= 1 (jutils/count-bad-pub state)) "Corp has gained 1 bad pub")
+        (is (= 1 (count-bad-pub state)) "Corp has gained 1 bad pub")
         (is (= 1 (get-in @state [:corp :bad-publicity :base])) "Only gained in the base")
         (is (zero? (get-in @state [:corp :bad-publicity :additional])) "Only gained in the base")
         (core/change state :corp {:key :bad-publicity :delta -1})
-        (is (zero? (jutils/count-bad-pub state)) "Corp has lost 1 bad pub")
+        (is (zero? (count-bad-pub state)) "Corp has lost 1 bad pub")
         (is (zero? (get-in @state [:corp :bad-publicity :base])) "Only lost in the base")
         (is (zero? (get-in @state [:corp :bad-publicity :additional])) "No change on loss either"))
       (testing "Tags"
-        (is (zero? (jutils/count-tags state)) "Runner starts with 0 tags")
+        (is (zero? (count-tags state)) "Runner starts with 0 tags")
         (core/change state :runner {:key :tag :delta 1})
-        (is (= 1 (jutils/count-tags state)) "Runner has gained 1 tag")
+        (is (= 1 (count-tags state)) "Runner has gained 1 tag")
         (is (= 1 (get-in @state [:runner :tag :base])) "Only gained in the base")
         (is (zero? (get-in @state [:runner :tag :additional])) "Only gained in the base")
         (core/change state :runner {:key :tag :delta -1})
-        (is (zero? (jutils/count-tags state)) "Runner has lost 1 tag")
+        (is (zero? (count-tags state)) "Runner has lost 1 tag")
         (is (zero? (get-in @state [:runner :tag :base])) "Only gained in the base")
         (is (zero? (get-in @state [:runner :tag :additional])) "No change on loss either"))))
   (testing "Generic changes"
@@ -42,3 +41,146 @@
         (is (zero? (get-in @state [:corp :agenda-point])) "Corp has lost 1 agenda point")
         (core/change state :corp {:key :agenda-point :delta -1})
         (is (= -1 (get-in @state [:corp :agenda-point])) "Corp can go below zero agenda points")))))
+
+(deftest undo-turn
+  (do-game
+    (new-game)
+    (play-from-hand state :corp "Hedge Fund")
+    (play-from-hand state :corp "Hedge Fund")
+    (is (= 1 (:click (get-corp))) "Corp spent 2 clicks")
+    (is (= 13 (:credit (get-corp))) "Corp has 13 credits")
+    (is (= 1 (count (:hand (get-corp)))) "Corp has 1 card in HQ")
+    (core/command-undo-turn state :runner)
+    (core/command-undo-turn state :corp)
+    (is (= 3 (count (:hand (get-corp)))) "Corp has 3 cards in HQ")
+    (is (zero? (:click (get-corp))) "Corp has no clicks - turn not yet started")
+    (is (= 5 (:credit (get-corp))) "Corp has 5 credits")))
+
+(deftest undo-click
+  (do-game
+    (new-game {:corp {:deck ["Ikawah Project"]}
+               :runner {:deck ["Day Job"]}})
+    (play-from-hand state :corp "Ikawah Project" "New remote")
+    (take-credits state :corp)
+    (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
+    (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
+    (run-empty-server state :remote1)
+    (click-prompt state :runner "Pay to steal")
+    (is (= 2 (:click (get-runner))) "Runner should lose 1 click to steal")
+    (is (= 3 (:credit (get-runner))) "Runner should lose 2 credits to steal")
+    (is (= 1 (count (:scored (get-runner)))) "Runner should steal Ikawah Project")
+    (core/command-undo-click state :corp)
+    (is (= 1 (count (:scored (get-runner)))) "Corp attempt to undo click does nothing")
+    (core/command-undo-click state :runner)
+    (is (zero? (count (:scored (get-runner)))) "Runner attempt to undo click works ok")
+    (is (= 4 (:click (get-runner))) "Runner back to 4 clicks")
+    (is (= 5 (:credit (get-runner))) "Runner back to 5 credits")
+    (play-from-hand state :runner "Day Job")
+    (is (zero? (:click (get-runner))) "Runner spent 4 clicks")
+    (core/command-undo-click state :runner)
+    (is (= 4 (:click (get-runner))) "Runner back to 4 clicks")
+    (is (= 5 (:credit (get-runner))) "Runner back to 5 credits")))
+
+(deftest counter-manipulation-commands
+  ;; Test interactions of various cards with /counter and /adv-counter commands
+  (do-game
+    (new-game {:corp {:deck ["Adonis Campaign"
+                             (qty "Public Support" 2)
+                             "Oaktown Renovation"]}})
+    ;; Turn 1 Corp, install oaktown and assets
+    (core/gain state :corp :click 4)
+    (play-from-hand state :corp "Adonis Campaign" "New remote")
+    (play-from-hand state :corp "Public Support" "New remote")
+    (play-from-hand state :corp "Public Support" "New remote")
+    (play-from-hand state :corp "Oaktown Renovation" "New remote")
+    (let [adonis (get-content state :remote1 0)
+          publics1 (get-content state :remote2 0)
+          publics2 (get-content state :remote3 0)
+          oaktown (get-content state :remote4 0)]
+      (core/advance state :corp {:card (refresh oaktown)})
+      (core/advance state :corp {:card (refresh oaktown)})
+      (core/advance state :corp {:card (refresh oaktown)})
+      (is (= 8 (:credit (get-corp))) "Corp 5+3 creds from Oaktown")
+      (core/end-turn state :corp nil)
+      (testing "Turn 1 Runner"
+        (core/start-turn state :runner nil)
+        (take-credits state :runner 3)
+        (core/click-credit state :runner nil)
+        (core/end-turn state :runner nil)
+        (core/rez state :corp (refresh adonis))
+        (core/rez state :corp (refresh publics1)))
+      (testing "Turn 2 Corp"
+        (core/start-turn state :corp nil)
+        (core/rez state :corp (refresh publics2))
+        (is (= 3 (:click (get-corp))))
+        (is (= 3 (:credit (get-corp))) "only Adonis money")
+        (is (= 9 (get-counters (refresh adonis) :credit)))
+        (is (= 2 (get-counters (refresh publics1) :power)))
+        (is (= 3 (get-counters (refresh publics2) :power))))
+      ;; oops, forgot to rez 2nd public support before start of turn,
+      ;; let me fix it with a /command
+      (testing "Advancement and Scoring checks"
+        (core/command-counter state :corp ["power" 2])
+        (click-card state :corp (refresh publics2))
+        (is (= 2 (get-counters (refresh publics2) :power)))
+        ;; Oaktown checks and manipulation
+        (is (= 3 (get-counters (refresh oaktown) :advancement)))
+        (core/command-adv-counter state :corp 2)
+        (click-card state :corp (refresh oaktown))
+        ;; score should fail, shouldn't be able to score with 2 advancement tokens
+        (core/score state :corp (refresh oaktown))
+        (is (zero? (:agenda-point (get-corp))))
+        (core/command-adv-counter state :corp 4)
+        (click-card state :corp (refresh oaktown))
+        (is (= 4 (get-counters (refresh oaktown) :advancement)))
+        (is (= 3 (:credit (get-corp))))
+        (is (= 3 (:click (get-corp))))
+        (core/score state :corp (refresh oaktown)) ; now the score should go through
+        (is (= 2 (:agenda-point (get-corp))))
+        (take-credits state :corp))
+      (testing "Modifying publics1 and adonis for brevity"
+        (is (= 2 (get-counters (refresh publics1) :power)))
+        (core/command-counter state :corp ["power" 1])
+        (click-card state :corp (refresh publics1))
+        (is (= 1 (get-counters (refresh publics1) :power)))
+        ;; let's adjust Adonis while at it
+        (is (= 9 (get-counters (refresh adonis) :credit)))
+        (core/command-counter state :corp ["credit" 3])
+        (click-card state :corp (refresh adonis))
+        (is (= 3 (get-counters (refresh adonis) :credit))))
+      (testing "Turn 2 Runner"
+        (take-credits state :runner))
+      (testing "Turn 3 Corp"
+        (is (= 3 (:agenda-point (get-corp)))) ; cheated PS1 should get scored
+        (is (= 9 (:credit (get-corp))))
+        ; (is (= :scored (:zone (refresh publics1))))
+        (is (= [:servers :remote3 :content] (:zone (refresh publics2))))
+        ; (is (= :discard (:zone (refresh adonis))))
+        (take-credits state :corp))
+      (testing "Turn 3 Runner"
+        (take-credits state :runner))
+      (testing "Turn 4 Corp"
+        (is (= 4 (:agenda-point (get-corp)))) ; PS2 should get scored
+        (is (= 12 (:credit (get-corp))))))))
+
+(deftest counter-manipulation-commands-smart
+  ;; Test interactions of smart counter advancement command
+  (do-game
+    (new-game {:corp {:deck ["House of Knives"]}})
+    (play-from-hand state :corp "House of Knives" "New remote")
+    (let [hok (get-content state :remote1 0)]
+      (core/command-counter state :corp [3])
+      (click-card state :corp (refresh hok))
+      (is (= 3 (get-counters (refresh hok) :advancement)))
+      (core/score state :corp (refresh hok)))
+    (let [hok-scored (get-scored state :corp 0)]
+      (is (= 3 (get-counters (refresh hok-scored) :agenda)) "House of Knives should start with 3 counters")
+      (core/command-counter state :corp ["virus" 2])
+      (click-card state :corp (refresh hok-scored))
+      (is (= 3 (get-counters (refresh hok-scored) :agenda)) "House of Knives should stay at 3 counters")
+      (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters")
+      (core/command-counter state :corp [4])
+      (click-card state :corp (refresh hok-scored)) ;; doesn't crash with unknown counter type
+      (is (empty? (:prompt (get-corp))) "Counter prompt closed")
+      (is (= 4 (get-counters (refresh hok-scored) :agenda)) "House of Knives should have 4 agenda counters")
+      (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters"))))

--- a/test/clj/game_test/engine/rules.clj
+++ b/test/clj/game_test/engine/rules.clj
@@ -5,45 +5,6 @@
             [game-test.macros :refer :all]
             [clojure.test :refer :all]))
 
-(deftest undo-turn
-  (do-game
-    (new-game)
-    (play-from-hand state :corp "Hedge Fund")
-    (play-from-hand state :corp "Hedge Fund")
-    (is (= 1 (:click (get-corp))) "Corp spent 2 clicks")
-    (is (= 13 (:credit (get-corp))) "Corp has 13 credits")
-    (is (= 1 (count (:hand (get-corp)))) "Corp has 1 card in HQ")
-    (core/command-undo-turn state :runner)
-    (core/command-undo-turn state :corp)
-    (is (= 3 (count (:hand (get-corp)))) "Corp has 3 cards in HQ")
-    (is (zero? (:click (get-corp))) "Corp has no clicks - turn not yet started")
-    (is (= 5 (:credit (get-corp))) "Corp has 5 credits")))
-
-(deftest undo-click
-  (do-game
-    (new-game {:corp {:deck ["Ikawah Project"]}
-               :runner {:deck ["Day Job"]}})
-    (play-from-hand state :corp "Ikawah Project" "New remote")
-    (take-credits state :corp)
-    (is (= 5 (:credit (get-runner))) "Runner has 5 credits")
-    (is (= 4 (:click (get-runner))) "Runner has 4 clicks")
-    (run-empty-server state :remote1)
-    (click-prompt state :runner "Pay to steal")
-    (is (= 2 (:click (get-runner))) "Runner should lose 1 click to steal")
-    (is (= 3 (:credit (get-runner))) "Runner should lose 2 credits to steal")
-    (is (= 1 (count (:scored (get-runner)))) "Runner should steal Ikawah Project")
-    (core/command-undo-click state :corp)
-    (is (= 1 (count (:scored (get-runner)))) "Corp attempt to undo click does nothing")
-    (core/command-undo-click state :runner)
-    (is (zero? (count (:scored (get-runner)))) "Runner attempt to undo click works ok")
-    (is (= 4 (:click (get-runner))) "Runner back to 4 clicks")
-    (is (= 5 (:credit (get-runner))) "Runner back to 5 credits")
-    (play-from-hand state :runner "Day Job")
-    (is (zero? (:click (get-runner))) "Runner spent 4 clicks")
-    (core/command-undo-click state :runner)
-    (is (= 4 (:click (get-runner))) "Runner back to 4 clicks")
-    (is (= 5 (:credit (get-runner))) "Runner back to 5 credits")))
-
 (deftest corp-rez-unique
   ;; Rezzing a second copy of a unique Corp card
   (do-game
@@ -352,110 +313,6 @@
     (run-empty-server state :remote1)
     (click-prompt state :runner "No action") ; Dismiss trash prompt
     (is (last-log-contains? state "PAD Campaign") "Accessed card name was logged")))
-
-(deftest counter-manipulation-commands
-  ;; Test interactions of various cards with /counter and /adv-counter commands
-  (do-game
-    (new-game {:corp {:deck ["Adonis Campaign"
-                             (qty "Public Support" 2)
-                             "Oaktown Renovation"]}})
-    ;; Turn 1 Corp, install oaktown and assets
-    (core/gain state :corp :click 4)
-    (play-from-hand state :corp "Adonis Campaign" "New remote")
-    (play-from-hand state :corp "Public Support" "New remote")
-    (play-from-hand state :corp "Public Support" "New remote")
-    (play-from-hand state :corp "Oaktown Renovation" "New remote")
-    (let [adonis (get-content state :remote1 0)
-          publics1 (get-content state :remote2 0)
-          publics2 (get-content state :remote3 0)
-          oaktown (get-content state :remote4 0)]
-      (core/advance state :corp {:card (refresh oaktown)})
-      (core/advance state :corp {:card (refresh oaktown)})
-      (core/advance state :corp {:card (refresh oaktown)})
-      (is (= 8 (:credit (get-corp))) "Corp 5+3 creds from Oaktown")
-      (core/end-turn state :corp nil)
-      (testing "Turn 1 Runner"
-        (core/start-turn state :runner nil)
-        (take-credits state :runner 3)
-        (core/click-credit state :runner nil)
-        (core/end-turn state :runner nil)
-        (core/rez state :corp (refresh adonis))
-        (core/rez state :corp (refresh publics1)))
-      (testing "Turn 2 Corp"
-        (core/start-turn state :corp nil)
-        (core/rez state :corp (refresh publics2))
-        (is (= 3 (:click (get-corp))))
-        (is (= 3 (:credit (get-corp))) "only Adonis money")
-        (is (= 9 (get-counters (refresh adonis) :credit)))
-        (is (= 2 (get-counters (refresh publics1) :power)))
-        (is (= 3 (get-counters (refresh publics2) :power))))
-      ;; oops, forgot to rez 2nd public support before start of turn,
-      ;; let me fix it with a /command
-      (testing "Advancement and Scoring checks"
-        (core/command-counter state :corp ["power" 2])
-        (click-card state :corp (refresh publics2))
-        (is (= 2 (get-counters (refresh publics2) :power)))
-        ;; Oaktown checks and manipulation
-        (is (= 3 (get-counters (refresh oaktown) :advancement)))
-        (core/command-adv-counter state :corp 2)
-        (click-card state :corp (refresh oaktown))
-        ;; score should fail, shouldn't be able to score with 2 advancement tokens
-        (core/score state :corp (refresh oaktown))
-        (is (zero? (:agenda-point (get-corp))))
-        (core/command-adv-counter state :corp 4)
-        (click-card state :corp (refresh oaktown))
-        (is (= 4 (get-counters (refresh oaktown) :advancement)))
-        (is (= 3 (:credit (get-corp))))
-        (is (= 3 (:click (get-corp))))
-        (core/score state :corp (refresh oaktown)) ; now the score should go through
-        (is (= 2 (:agenda-point (get-corp))))
-        (take-credits state :corp))
-      (testing "Modifying publics1 and adonis for brevity"
-        (is (= 2 (get-counters (refresh publics1) :power)))
-        (core/command-counter state :corp ["power" 1])
-        (click-card state :corp (refresh publics1))
-        (is (= 1 (get-counters (refresh publics1) :power)))
-        ;; let's adjust Adonis while at it
-        (is (= 9 (get-counters (refresh adonis) :credit)))
-        (core/command-counter state :corp ["credit" 3])
-        (click-card state :corp (refresh adonis))
-        (is (= 3 (get-counters (refresh adonis) :credit))))
-      (testing "Turn 2 Runner"
-        (take-credits state :runner))
-      (testing "Turn 3 Corp"
-        (is (= 3 (:agenda-point (get-corp)))) ; cheated PS1 should get scored
-        (is (= 9 (:credit (get-corp))))
-        ; (is (= :scored (:zone (refresh publics1))))
-        (is (= [:servers :remote3 :content] (:zone (refresh publics2))))
-        ; (is (= :discard (:zone (refresh adonis))))
-        (take-credits state :corp))
-      (testing "Turn 3 Runner"
-        (take-credits state :runner))
-      (testing "Turn 4 Corp"
-        (is (= 4 (:agenda-point (get-corp)))) ; PS2 should get scored
-        (is (= 12 (:credit (get-corp))))))))
-
-(deftest counter-manipulation-commands-smart
-  ;; Test interactions of smart counter advancement command
-  (do-game
-    (new-game {:corp {:deck ["House of Knives"]}})
-    (play-from-hand state :corp "House of Knives" "New remote")
-    (let [hok (get-content state :remote1 0)]
-      (core/command-counter state :corp [3])
-      (click-card state :corp (refresh hok))
-      (is (= 3 (get-counters (refresh hok) :advancement)))
-      (core/score state :corp (refresh hok)))
-    (let [hok-scored (get-scored state :corp 0)]
-      (is (= 3 (get-counters (refresh hok-scored) :agenda)) "House of Knives should start with 3 counters")
-      (core/command-counter state :corp ["virus" 2])
-      (click-card state :corp (refresh hok-scored))
-      (is (= 3 (get-counters (refresh hok-scored) :agenda)) "House of Knives should stay at 3 counters")
-      (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters")
-      (core/command-counter state :corp [4])
-      (click-card state :corp (refresh hok-scored)) ;; doesn't crash with unknown counter type
-      (is (empty? (:prompt (get-corp))) "Counter prompt closed")
-      (is (= 4 (get-counters (refresh hok-scored) :agenda)) "House of Knives should have 4 agenda counters")
-      (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters"))))
 
 (deftest run-bad-publicity-credits
   ;; Should not lose BP credits until a run is completely over. Issue #1721.
@@ -866,3 +723,28 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Corporate \"Grant\"")
     (is (= 2 (count (:hand (get-runner)))) "Runner doesn't take damage from clearing current")))
+
+(deftest ^:test-refresh/focus simultaneous-trash-effects
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Hostile Infrastructure" "Marilyn Campaign" "Calvin B4L3Y"]
+                      :credits 20}
+               :runner {:hand ["Apocalypse"]}})
+    (play-from-hand state :corp "Hostile Infrastructure" "New remote")
+    (play-from-hand state :corp "Marilyn Campaign" "New remote")
+    (play-from-hand state :corp "Calvin B4L3Y" "New remote")
+    (core/rez state :corp (get-content state :remote1 0))
+    (core/rez state :corp (get-content state :remote2 0))
+    (core/rez state :corp (get-content state :remote3 0))
+    (take-credits state :corp)
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (click-prompt state :runner "No action")
+    (run-empty-server state "HQ")
+    (play-from-hand state :runner "Apocalypse")
+    (is (= #{"Hostile Infrastructure" "Marilyn Campaign" "Calvin B4L3Y"}
+           (->> (get-corp) :prompt first :choices (into #{}))) "Corp has the simultaneous prompt")
+    (click-prompt state :corp "Marilyn Campaign")
+    (click-prompt state :corp "Yes")
+    (click-prompt state :corp "Calvin B4L3Y")
+    (click-prompt state :corp "Yes")))


### PR DESCRIPTION
Right now, we are not rules accurate with regards to trashing. There aren't formal rules in the CR just yet, but the process very much follows the other systems, and we currently don't adhere to it.

The way we have it now is:
1) Take in a list of cards (or 1 card for `trash` and make it a list)
2) Async step over every single card and check for prevention
3) Call `trigger-event-sync :X-trash` on all of the cards
4) Whatever hasn't been prevented we now step over one-by-one, move it to the discard, and then where appropriate call `:trash-effect` on.

The way it _should_ work is:
1) Take in the list of cards or single cards and make a list
2) Async step over every single card and check for prevention (will change to be simultaneous in the future, when I redo prevention)
3) Move all cards to the trash
4) Gather all `:trash-effects` that apply
5) Call `trigger-event-simult :X-trash` and pass all of the `:trash-effects` in as `:card-abilities`, so that they can be properly ordered

This requires rewriting the `core/rules` logic to adhere to the new steps and rewriting/cleaning up all of the card implementations that rely on the previous incorrect ideas.