### PR TITLE
Fix Trick of Light

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -2076,10 +2076,10 @@
 
    "Trick of Light"
    {:async true
-    :req (req (let [advanced (some #(when (pos? (get-counters % :advancement)) %)
-                                   (all-installed state :corp))]
-                (some #(and (not (same-card? advanced %))
-                            (can-be-advanced? %))
+    :req (req (let [can-be-advanced (some #(when (can-be-advanced? %) %)
+                                          (all-installed state :corp))]
+                (some #(and (not (same-card? can-be-advanced %))
+                            (pos? (get-counters % :advancement)))
                       (all-installed state :corp))))
     :choices {:req #(pos? (get-counters % :advancement))}
     :effect (effect


### PR DESCRIPTION
Closes #4565. For real, lol

I was performing the card very literally: find a card that has advancement counters, check the other cards to see if any exist that aren't the same card and can be advanced. This falls apart if the first card I find is the only card that can be advanced and already has advancement counters. The fix, of course, is the reverse: first find a card that can be advanced, and then check the rest of the cards to see if any exist that aren't the same card and have advancement counters.