### PR TITLE
Switch select prompts :req to :card and :five to :req

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -3,31 +3,31 @@
 (def trash-program {:prompt "Select a program to trash"
                     :label "Trash a program"
                     :msg (msg "trash " (:title target))
-                    :choices {:req #(and (installed? %)
-                                         (program? %))}
+                    :choices {:card #(and (installed? %)
+                                          (program? %))}
                     :effect (effect (trash target {:cause :subroutine})
                                     (clear-wait-prompt :runner))})
 
 (def trash-hardware {:prompt "Select a piece of hardware to trash"
                      :label "Trash a piece of hardware"
                      :msg (msg "trash " (:title target))
-                     :choices {:req #(and (installed? %)
-                                          (hardware? %))}
+                     :choices {:card #(and (installed? %)
+                                           (hardware? %))}
                      :effect (effect (trash target {:cause :subroutine}))})
 
 (def trash-resource-sub {:prompt "Select a resource to trash"
                          :label "Trash a resource"
                          :msg (msg "trash " (:title target))
-                         :choices {:req #(and (installed? %)
-                                              (resource? %))}
+                         :choices {:card #(and (installed? %)
+                                               (resource? %))}
                          :effect (effect (trash target {:cause :subroutine}))})
 
 (def trash-installed {:prompt "Select an installed card to trash"
                       :player :runner
                       :label "Force the Runner to trash an installed card"
                       :msg (msg "force the Runner to trash " (:title target))
-                      :choices {:req #(and (installed? %)
-                                           (runner? %))}
+                      :choices {:card #(and (installed? %)
+                                            (runner? %))}
                       :effect (effect (trash target {:cause :subroutine}))})
 
 (def corp-rez-toast
@@ -191,8 +191,8 @@
                  counter-count (when (and target-count (pos? target-count))
                                  (str " of " target-count))
                  " virus counters)")
-    :choices {:req #(and (installed? %)
-                         (pos? (get-counters % :virus)))}
+    :choices {:card #(and (installed? %)
+                          (pos? (get-counters % :virus)))}
     :effect (req (add-counter state :runner target :virus -1)
                  (let [selected-cards (update selected-cards (:cid target)
                                               ;; Store card reference and number of counters picked
@@ -277,7 +277,7 @@
                        counter-count (when (and target-count (pos? target-count))
                                        (str " of " target-count))
                        " credits)")
-          :choices {:req #(in-coll? (map :cid provider-cards) (:cid %))}
+          :choices {:card #(in-coll? (map :cid provider-cards) (:cid %))}
           :effect (req (let [pay-credits-type (-> target card-def :interactions :pay-credits :type)
                              pay-credits-custom (when (= :custom pay-credits-type)
                                                   (-> target card-def :interactions :pay-credits :custom))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -46,9 +46,9 @@
              (if (pos? i)
                {:async true
                 :prompt "Select a piece of ICE from the Temporary Zone to install"
-                :choices {:req #(and (corp? %)
-                                     (ice? %)
-                                     (in-play-area? %))}
+                :choices {:card #(and (corp? %)
+                                      (ice? %)
+                                      (in-play-area? %))}
                 :effect (req (wait-for (corp-install state side target nil
                                                      {:ignore-all-cost true :install-state :rezzed-no-cost})
                                        (let [card (get-card state card)]
@@ -170,7 +170,7 @@
     :silent (req true)
     :abilities [{:cost [:agenda 1]
                  :msg (msg "place 1 advancement token on " (card-str state target))
-                 :choices {:req can-be-advanced?}
+                 :choices {:card can-be-advanced?}
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "Award Bait"
@@ -185,7 +185,7 @@
                                 :effect (req (let [c (str->int target)]
                                                (continue-ability
                                                  state side
-                                                 {:choices {:req can-be-advanced?}
+                                                 {:choices {:card can-be-advanced?}
                                                   :msg (msg "place " c " advancement tokens on " (card-str state target))
                                                   :cancel-effect (req (clear-wait-prompt state :runner)
                                                                       (effect-completed state side eid))
@@ -274,13 +274,13 @@
                                    (:scored corp)))))
     :optional {:prompt "Trigger the ability of a scored agenda?"
                :yes-ability {:prompt "Select an agenda to trigger the \"when scored\" ability of"
-                             :choices {:req #(and (agenda? %)
-                                                  (not= (:title %)
-                                                        "Bifrost Array")
-                                                  (= (first (:zone %))
-                                                     :scored)
-                                                  (when-scored? %)
-                                                  (:abilities %))}
+                             :choices {:card #(and (agenda? %)
+                                                   (not= (:title %)
+                                                         "Bifrost Array")
+                                                   (= (first (:zone %))
+                                                      :scored)
+                                                   (when-scored? %)
+                                                   (:abilities %))}
                              :msg (msg "trigger the \"when scored\" ability of " (:title target))
                              :effect (effect (continue-ability (card-def target) target nil))}
                :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
@@ -365,8 +365,8 @@
 
    "Character Assassination"
    {:prompt "Select a resource to trash"
-    :choices {:req #(and (installed? %)
-                         (resource? %))}
+    :choices {:card #(and (installed? %)
+                          (resource? %))}
     :msg (msg "trash " (:title target))
     :interactive (req true)
     :async true
@@ -435,9 +435,9 @@
    (letfn [(install-ability [server-name n]
              {:prompt "Select a card to install"
               :show-discard true
-              :choices {:req #(and (corp? %)
-                                   (not (operation? %))
-                                   (#{[:hand] [:discard]} (:zone %)))}
+              :choices {:card #(and (corp? %)
+                                    (not (operation? %))
+                                    (#{[:hand] [:discard]} (:zone %)))}
               :msg (msg (corp-install-msg target)
                         (when (zero? n)
                           ", creating a new remote server")
@@ -567,8 +567,8 @@
    {:silent (req true)
     :effect (effect (add-counter card :agenda 3))
     :abilities [{:cost [:agenda 1]
-                 :choices {:req #(and (ice? %)
-                                      (can-be-advanced? %))}
+                 :choices {:card #(and (ice? %)
+                                       (can-be-advanced? %))}
                  :req (req (pos? (get-counters card :agenda)))
                  :msg (msg "place 1 advancement token on " (card-str state target))
                  :once :per-turn
@@ -580,7 +580,7 @@
     :effect (req (gain-tags state :runner eid 1))}
 
    "Genetic Resequencing"
-   {:choices {:req #(= (last (:zone %)) :scored)}
+   {:choices {:card #(= (last (:zone %)) :scored)}
     :msg (msg "add 1 agenda counter on " (:title target))
     :effect (effect (add-counter target :agenda 1))
     :silent (req true)}
@@ -649,8 +649,8 @@
                                      (is-scored? state :corp card)))}
     :abilities [{:prompt "Select a card to add to the bottom of R&D"
                  :show-discard true
-                 :choices {:req #(and (corp? %)
-                                      (in-discard? %))}
+                 :choices {:card #(and (corp? %)
+                                       (in-discard? %))}
                  :effect (effect (move target :deck))
                  :msg (msg "add "
                            (if (:seen target)
@@ -666,7 +666,7 @@
     :effect (req (let [c (str->int target)]
                    (continue-ability
                      state side
-                     {:choices {:req #(pos? (get-counters % :power))}
+                     {:choices {:card #(pos? (get-counters % :power))}
                       :msg (msg "add " c " power counters on " (:title target))
                       :effect (effect (add-counter target :power c))}
                      card nil)))}
@@ -686,8 +686,8 @@
               :effect (req (let [n (if (>= (get-counters (get-card state card) :advancement) 6) 2 1)]
                              (continue-ability
                                state side
-                               {:choices {:req #(and (not (same-card? % card))
-                                                     (can-be-advanced? %))}
+                               {:choices {:card #(and (not (same-card? % card))
+                                                      (can-be-advanced? %))}
                                 :msg (msg "place " n
                                           " advancement tokens on "
                                           (card-str state target))
@@ -759,8 +759,8 @@
                       (all-installed state :corp)))
       :prompt "Select a card to place 2 advancement tokens on"
       :player :corp
-      :choices {:req #(and (= (last (:zone %)) :content)
-                           (is-remote? (second (:zone %))))}
+      :choices {:card #(and (= (last (:zone %)) :content)
+                            (is-remote? (second (:zone %))))}
       :msg (msg "place 2 advancement token on " (card-str state target))
       :effect (effect (add-prop :corp target :advance-counter 2 {:placed true}))}]}
 
@@ -778,17 +778,17 @@
    {:interactive (req true)
     :prompt "Select an asset or upgrade to install from Archives or HQ"
     :show-discard true
-    :choices {:req #(and (#{"Asset" "Upgrade"} (:type %))
-                         (#{[:hand] [:discard]} (:zone %))
-                         (corp? %))}
+    :choices {:card #(and (#{"Asset" "Upgrade"} (:type %))
+                          (#{[:hand] [:discard]} (:zone %))
+                          (corp? %))}
     :msg (msg "install and rez " (:title target) ", ignoring all costs")
     :async true
     :effect (effect (corp-install eid target nil {:install-state :rezzed-no-cost}))}
 
    "Mandatory Seed Replacement"
    (letfn [(msr [] {:prompt "Select two pieces of ICE to swap positions"
-                    :choices {:req #(and (installed? %)
-                                         (ice? %))
+                    :choices {:card #(and (installed? %)
+                                          (ice? %))
                               :max 2}
                     :async true
                     :effect (req (if (= (count targets) 2)
@@ -884,10 +884,10 @@
               {:req (req (same-card? card target))
                :prompt "Install a card from HQ in a new remote?"
                :yes-ability {:prompt "Select a card to install"
-                             :choices {:req #(and (not (operation? %))
-                                                  (not (ice? %))
-                                                  (corp? %)
-                                                  (in-hand? %))}
+                             :choices {:card #(and (not (operation? %))
+                                                   (not (ice? %))
+                                                   (corp? %)
+                                                   (in-hand? %))}
                              :msg (msg "install a card from HQ"
                                        (when (<= 5 (get-counters (get-card state card) :advancement))
                                          " and rez it, ignoring all costs"))
@@ -965,9 +965,9 @@
 
    "Priority Requisition"
    {:interactive (req true)
-    :choices {:req #(and (ice? %)
-                         (not (rezzed? %))
-                         (installed? %))}
+    :choices {:card #(and (ice? %)
+                          (not (rezzed? %))
+                          (installed? %))}
     :effect (effect (rez target {:ignore-cost :all-costs}))}
 
    "Private Security Force"
@@ -1000,8 +1000,8 @@
                         {:prompt (msg "Select " (trash-count-str card) " installed cards to trash")
                          :choices {:max (min (- (get-counters card :advancement) 4)
                                              (count (all-installed state :runner)))
-                                   :req #(and (runner? %)
-                                              (installed? %))}
+                                   :card #(and (runner? %)
+                                               (installed? %))}
                          :effect (effect (trash-cards targets)
                                          (system-msg (str "trashes " (join ", " (map :title targets))))
                                          (gain-bad-publicity :corp 1))}
@@ -1042,8 +1042,8 @@
                            (update! state side (dissoc-in card [:special :kusanagi])))}]
     :abilities [{:label "Give a piece of ICE \"[Subroutine] Do 1 net damage\""
                  :prompt "Choose a piece of ICE"
-                 :choices {:req #(and (ice? %)
-                                      (rezzed? %))}
+                 :choices {:card #(and (ice? %)
+                                       (rezzed? %))}
                  :cost [:agenda 1]
                  :msg (str "make a piece of ICE gain \"[Subroutine] Do 1 net damage\" "
                            "after all its other subroutines for the remainder of the run")
@@ -1059,8 +1059,8 @@
                  :label "Add 1 card from Archives to HQ"
                  :prompt "Choose a card in Archives to add to HQ"
                  :show-discard true
-                 :choices {:req #(and (in-discard? %)
-                                      (corp? %))}
+                 :choices {:card #(and (in-discard? %)
+                                       (corp? %))}
                  :req (req (pos? (get-counters card :agenda)))
                  :msg (msg "add "
                            (if (:seen target)
@@ -1101,13 +1101,13 @@
            (choose-swap [to-swap]
              {:prompt (str "Select a card in HQ to swap with " (:title to-swap))
               :choices {:not-self true
-                        :req #(and (corp? %)
-                                   (in-hand? %)
-                                   (if (ice? to-swap)
-                                     (ice? %)
-                                     (or (agenda? %)
-                                         (asset? %)
-                                         (upgrade? %))))}
+                        :card #(and (corp? %)
+                                    (in-hand? %)
+                                    (if (ice? to-swap)
+                                      (ice? %)
+                                      (or (agenda? %)
+                                          (asset? %)
+                                          (upgrade? %))))}
               :msg (msg "swap " (card-str state to-swap) " with a card from HQ")
               :effect (req (move state :corp to-swap (:zone target) {:keep-server-alive true})
                            (move state :corp target (:zone to-swap) {:keep-server-alive true})
@@ -1116,7 +1116,7 @@
                                      (clear-wait-prompt :runner))})
            (choose-card [run-server]
              {:prompt "Choose a card in or protecting the attacked server."
-              :choices {:req #(= (first run-server) (second (:zone %)))}
+              :choices {:card #(= (first run-server) (second (:zone %)))}
               :effect (effect (continue-ability (choose-swap target) card nil))
               :cancel-effect (effect (put-back-counter card)
                                      (clear-wait-prompt :runner))})]
@@ -1136,7 +1136,7 @@
                              state :corp
                              {:prompt "Select a card to place 1 advancement token on"
                               :player :corp
-                              :choices {:req can-be-advanced?}
+                              :choices {:card can-be-advanced?}
                               :cancel-effect (effect (clear-wait-prompt :runner)
                                                      (effect-completed eid))
                               :msg (msg "place 1 advancement token on " (card-str state target))
@@ -1223,7 +1223,7 @@
     :abilities [{:cost [:agenda 1]
                  :msg (msg "place 1 advancement token on " (card-str state target))
                  :label "Place 1 advancement token on an installed card"
-                 :choices {:req installed?}
+                 :choices {:card installed?}
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
 
    "Remote Data Farm"
@@ -1268,7 +1268,7 @@
     :async true
     :effect (effect (continue-ability
                       {:prompt "Select another installed copy of Research Grant to score"
-                       :choices {:req #(= (:title %) "Research Grant")}
+                       :choices {:card #(= (:title %) "Research Grant")}
                        :interactive (req true)
                        :async true
                        :req (req (not (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp)))))
@@ -1293,8 +1293,8 @@
                      {:prompt "Select a program to trash"
                       :label "Trash a program"
                       :msg (msg "trash " (:title target))
-                      :choices {:req #(and (installed? %)
-                                           (program? %))}
+                      :choices {:card #(and (installed? %)
+                                            (program? %))}
                       :effect (effect (trash target)
                                       (clear-wait-prompt :runner))
                       :end-effect (effect (clear-wait-prompt :runner))}
@@ -1315,7 +1315,8 @@
     :abilities [{:cost [:agenda 1]
                  :req (req (some #(and (has-subtype? % "Bioroid") (not (rezzed? %))) (all-installed state :corp)))
                  :prompt "Choose a bioroid to rez, ignoring all costs"
-                 :choices {:req #(and (has-subtype? % "Bioroid") (not (rezzed? %)))}
+                 :choices {:card #(and (has-subtype? % "Bioroid")
+                                       (not (rezzed? %)))}
                  :msg (msg "rez " (card-str state target) ", ignoring all costs")
                  :effect (req (let [c target]
                                 (rez state side c {:ignore-cost :all-costs})
@@ -1364,8 +1365,8 @@
    (letfn [(stand [side]
              {:async true
               :prompt "Choose one of your installed cards to trash due to Standoff"
-              :choices {:req #(and (installed? %)
-                                   (same-side? side (:side %)))}
+              :choices {:card #(and (installed? %)
+                                    (same-side? side (:side %)))}
               :cancel-effect (req (if (= side :runner)
                                     (do (draw state :corp)
                                         (gain-credits state :corp 5)
@@ -1402,9 +1403,9 @@
              {:prompt "Select a card in HQ to install with Successful Field Test"
               :priority -1
               :async true
-              :choices {:req #(and (corp? %)
-                                   (not (operation? %))
-                                   (in-hand? %))}
+              :choices {:card #(and (corp? %)
+                                    (not (operation? %))
+                                    (in-hand? %))}
               :effect (req (wait-for
                              (corp-install state side target nil {:ignore-all-cost true})
                              (continue-ability state side (when (< n max-ops) (sft (inc n) max-ops)) card nil)))})]
@@ -1455,9 +1456,9 @@
                  :label "Install a piece of ice in any position, ignoring all costs"
                  :prompt "Select a piece of ice to install"
                  :show-discard true
-                 :choices {:req #(and (ice? %)
-                                      (or (in-hand? %)
-                                          (in-discard? %)))}
+                 :choices {:card #(and (ice? %)
+                                       (or (in-hand? %)
+                                           (in-discard? %)))}
                  :msg (msg "install "
                            (if (and (in-discard? target)
                                     (or (faceup? target)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -84,10 +84,10 @@
                  :async true
                  :prompt "Select a non-agenda card to install from HQ"
                  :req (req (not (:run @state)))
-                 :choices {:req #(and (not (operation? %))
-                                      (not (agenda? %))
-                                      (in-hand? %)
-                                      (corp? %))}
+                 :choices {:card #(and (not (operation? %))
+                                       (not (agenda? %))
+                                       (in-hand? %)
+                                       (corp? %))}
                  :msg (msg (corp-install-msg target))
                  :cost [:trash]
                  :effect (effect (corp-install eid target nil nil))}]}
@@ -100,8 +100,8 @@
                                              :async true
                                              :cost [:credit 2]
                                              :choices {:max agg
-                                                       :req #(and (installed? %)
-                                                                  (program? %))}
+                                                       :card #(and (installed? %)
+                                                                   (program? %))}
                                              :effect (effect (trash-cards eid targets nil))
                                              :msg (msg "trash " (join ", " (map :title targets)))}]
                                      (continue-ability state side ab card nil)))}
@@ -160,8 +160,8 @@
                          :autoresolve (get-autoresolve :auto-fire)
                          :yes-ability {:trace {:base (effect (advancement-cost agenda))
                                                :successful
-                                               {:choices {:req #(and (installed? %)
-                                                                     (runner? %))}
+                                               {:choices {:card #(and (installed? %)
+                                                                      (runner? %))}
                                                 :label "add an installed card to the Grip"
                                                 :msg (msg "add " (:title target) " to the Runner's Grip")
                                                 :effect (effect (move :runner target :hand))}}}}})]
@@ -213,8 +213,8 @@
                    :once :per-turn
                    :label "Remove an advancement token (start of turn)"
                    :prompt "Select a card to remove an advancement token from"
-                   :choices {:req #(and (pos? (get-counters % :advancement))
-                                        (installed? %))}
+                   :choices {:card #(and (pos? (get-counters % :advancement))
+                                         (installed? %))}
                    :effect (req (let [cnt (get-counters target :advancement)]
                                   (set-prop state side target :advance-counter (dec cnt))
                                   (gain-credits state :corp 3)
@@ -243,9 +243,9 @@
     :abilities [{:label "Install 1 card, paying all costs"
                  :req (req (= (:active-player @state) :corp))
                  :prompt "Select a card in HQ to install"
-                 :choices {:req #(and (not (operation? %))
-                                      (in-hand? %)
-                                      (corp? %))}
+                 :choices {:card #(and (not (operation? %))
+                                       (in-hand? %)
+                                       (corp? %))}
                  :cost [:trash]
                  :async true
                  :effect (effect (corp-install eid target nil nil))
@@ -375,8 +375,8 @@
                                    {:prompt "Select an operation in Archives to add to HQ"
                                     :once :per-turn
                                     :show-discard true
-                                    :choices {:req #(and (operation? %)
-                                                         (in-discard? %))}
+                                    :choices {:card #(and (operation? %)
+                                                          (in-discard? %))}
                                     :msg (msg "add "
                                               (if (:seen target)
                                                 (:title target)
@@ -442,15 +442,15 @@
                  :effect (req (show-wait-prompt state :runner "Corp to use Constellation Protocol")
                               (continue-ability
                                 state side
-                                {:choices {:req #(and (ice? %)
-                                                      (get-counters % :advancement))}
+                                {:choices {:card #(and (ice? %)
+                                                       (get-counters % :advancement))}
                                  :effect (req (let [from-ice target]
                                                 (continue-ability
                                                   state side
                                                   {:prompt "Move to where?"
-                                                   :choices {:req #(and (ice? %)
-                                                                        (not (same-card? from-ice %))
-                                                                        (can-be-advanced? %))}
+                                                   :choices {:card #(and (ice? %)
+                                                                         (not (same-card? from-ice %))
+                                                                         (can-be-advanced? %))}
                                                    :msg (msg "move an advancement token from "
                                                              (card-str state from-ice)
                                                              " to "
@@ -467,7 +467,7 @@
                  :async true
                  :cost [:click 1 :trash]
                  :req (req (>= (get-counters card :advancement) 2))
-                 :choices {:req #(has-subtype? % "Connection")}
+                 :choices {:card #(has-subtype? % "Connection")}
                  :msg (msg "trash " (:title target))
                  :effect (effect (trash eid target nil))}
                 {:label "Do 2 meat damage"
@@ -489,7 +489,7 @@
                  :once :per-turn
                  :async true
                  :prompt "Select a resource to trash with Corporate Town"
-                 :choices {:req resource?}
+                 :choices {:card resource?}
                  :msg (msg "trash " (:title target))
                  :effect (effect (trash eid target {:unpreventable true}))}]}
 
@@ -546,7 +546,7 @@
                                          {:prompt (str "Select " (quantify dbs "card") " to add to the bottom of R&D")
                                           :msg (msg "add " (quantify dbs "card") " to the bottom of R&D")
                                           :choices {:max dbs
-                                                    :req #(some (fn [c] (same-card? c %)) drawn)}
+                                                    :card #(some (fn [c] (same-card? c %)) drawn)}
                                           :effect (req (doseq [c targets]
                                                          (move state side c :deck)))}
                                          card targets)
@@ -611,9 +611,9 @@
    {:effect (effect (add-counter card :power 3))
     :abilities [{:cost [:click 1 :power 1]
                  :async true
-                 :choices {:req #(and (agenda? %)
-                                      (or (in-hand? %)
-                                          (in-discard? %)))}
+                 :choices {:card #(and (agenda? %)
+                                       (or (in-hand? %)
+                                           (in-discard? %)))}
                  :label "Reveal an agenda from HQ or Archives"
                  :msg (msg "reveal " (:title target) " from " (zone->name (:zone target))
                            (let [target-agenda-points (get-agenda-points state :corp target)]
@@ -635,9 +635,9 @@
                                       (all-installed state :corp)))}
     :abilities [{:cost [:credit 1]
                  :label "Place 1 advancement token on a card that can be advanced in a server"
-                 :choices {:req #(and (can-be-advanced? %)
-                                      (installed? %)
-                                      (in-server? %))} ; should be *in* a server
+                 :choices {:card #(and (can-be-advanced? %)
+                                       (installed? %)
+                                       (in-server? %))} ; should be *in* a server
                  :once :per-turn
                  :msg (msg "place 1 advancement token on " (card-str state target))
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}
@@ -658,7 +658,8 @@
                                                           {:card card}))}))
 
    "Eliza's Toybox"
-   {:abilities [{:cost [:click 3] :choices {:req #(not (:rezzed %))}
+   {:abilities [{:cost [:click 3]
+                 :choices {:card #(not (:rezzed %))}
                  :label "Rez a card at no cost" :msg (msg "rez " (:title target) " at no cost")
                  :effect (effect (rez target {:ignore-cost :all-costs}))}]}
 
@@ -668,7 +669,7 @@
     :abilities [{:cost [:click 1 :trash]
                  :label "Trash a location"
                  :msg (msg "trash " (:title target) " and take 1 bad publicity")
-                 :choices {:req #(has-subtype? % "Location")}
+                 :choices {:card #(has-subtype? % "Location")}
                  :effect (effect (trash target)
                                  (gain-bad-publicity :corp 1))}]}
 
@@ -706,7 +707,7 @@
               :effect (effect (update! (dissoc card :ebc-rezzed)))}]
     :abilities [{:async true
                  :once :per-turn
-                 :choices {:req (complement rezzed?)}
+                 :choices {:card (complement rezzed?)}
                  :label "Rez a card, lowering the cost by 1 [Credits]"
                  :msg (msg "rez " (:title target))
                  :effect (req (wait-for (rez state side target {:no-warning true :cost-bonus -1})
@@ -773,18 +774,19 @@
                  :req (req (< (count (:hosted card)) 2))
                  :cost [:click 1]
                  :prompt "Select an asset or agenda to install"
-                 :choices {:req #(and (or (asset? %) (agenda? %))
-                                      (in-hand? %)
-                                      (corp? %))}
+                 :choices {:card #(and (or (asset? %)
+                                           (agenda? %))
+                                       (in-hand? %)
+                                       (corp? %))}
                  :msg "install and host an asset or agenda"
                  :async true
                  :effect (effect (corp-install eid target card nil))}
                 {:label "Install a previously-installed asset or agenda on Full Immersion RecStudio (fixes only)"
                  :req (req (< (count (:hosted card)) 2))
                  :prompt "Select an installed asset or agenda to host on Full Immersion RecStudio"
-                 :choices {:req #(and (or (asset? %) (agenda? %))
-                                      (installed? %)
-                                      (corp? %))}
+                 :choices {:card #(and (or (asset? %) (agenda? %))
+                                       (installed? %)
+                                       (corp? %))}
                  :msg "install and host an asset or agenda"
                  :effect (req (host state side card target))}]}
 
@@ -916,7 +918,7 @@
    "Isabel McGuire"
    {:abilities [{:label "Add an installed card to HQ"
                  :cost [:click 1]
-                 :choices {:req installed?}
+                 :choices {:card installed?}
                  :msg (msg "move " (card-str state target) " to HQ")
                  :effect (effect (move target :hand))}]}
 
@@ -926,7 +928,8 @@
                  :effect (effect (add-counter card :power 1))}
                 {:cost [:power 1]
                  :label "Add strength to a rezzed ICE"
-                 :choices {:req #(and (ice? %) (rezzed? %))}
+                 :choices {:card #(and (ice? %)
+                                       (rezzed? %))}
                  :req (req (pos? (get-counters card :power)))
                  :msg (msg "add strength to a rezzed ICE")
                  :effect (effect (register-floating-effect
@@ -1000,9 +1003,9 @@
                               (continue-ability
                                 state side
                                 {:prompt "Select an Agenda in HQ to move to score area"
-                                 :choices {:req #(and (agenda? %)
-                                                      (= (:agendapoints %) (get-counters (get-card state card) :power))
-                                                      (in-hand? %))}
+                                 :choices {:card #(and (agenda? %)
+                                                       (= (:agendapoints %) (get-counters (get-card state card) :power))
+                                                       (in-hand? %))}
                                  :msg (msg "add " (:title target) " to score area")
                                  :async true
                                  :effect (req (wait-for (as-agenda state :corp target (:agendapoints target)
@@ -1025,8 +1028,8 @@
                                 (resolve-ability
                                   state side
                                   {:prompt "Select an agenda in HQ to reveal"
-                                   :choices {:req #(and (agenda? %)
-                                                        (>= c (:agendapoints %)))}
+                                   :choices {:card #(and (agenda? %)
+                                                         (>= c (:agendapoints %)))}
                                    :msg (msg "reveal " (:title target) " from HQ")
                                    :effect (req (reveal state side target)
                                                 (let [title (:title target)
@@ -1096,10 +1099,10 @@
      {:effect (effect (update! (assoc card :malia-target target))
                       (disable-card :runner target))
       :msg (msg (str "blank the text box of " (card-str state target)))
-      :choices {:req #(and (runner? %)
-                           (installed? %)
-                           (resource? %)
-                           (not (has-subtype? % "Virtual")))}
+      :choices {:card #(and (runner? %)
+                            (installed? %)
+                            (resource? %)
+                            (not (has-subtype? % "Virtual")))}
       :leave-play re-enable-target
       :move-zone re-enable-target})
 
@@ -1229,7 +1232,7 @@
                                 (not-empty (all-active-installed state :corp))))
                  :label "Move an advancement token to a faceup card"
                  :prompt "Select a faceup card"
-                 :choices {:req rezzed?}
+                 :choices {:card rezzed?}
                  :msg (msg "move an advancement token to " (card-str state target))
                  :effect (effect (add-prop card :advance-counter -1 {:placed true})
                                  (add-prop target :advance-counter 1 {:placed true}))}]}
@@ -1244,8 +1247,8 @@
                                 (str "Select "
                                      (if (> mus 1) "a card " (str mus " cards "))
                                      "in Archives to shuffle into R&D")))
-                 :choices {:req #(and (corp? %)
-                                      (in-discard? %))
+                 :choices {:card #(and (corp? %)
+                                       (in-discard? %))
                            :max (req (count (filter #(and (= "10019" (:code %))
                                                           (rezzed? %))
                                                     (all-installed state :corp))))}
@@ -1337,8 +1340,8 @@
                                        {:prompt (msg "Choose " (quantify cnt "installed card") " to shuffle into the stack")
                                         :player :corp
                                         :cost [:credit 3]
-                                        :choices {:req #(and (installed? %)
-                                                             (runner? %))
+                                        :choices {:card #(and (installed? %)
+                                                              (runner? %))
                                                   :max cnt}
                                         :msg (msg "shuffle " (join ", " (map :title targets)) " into the stack")
                                         :effect (req (doseq [c targets]
@@ -1384,8 +1387,8 @@
                               (continue-ability
                                 {:prompt "Choose a card in HQ to put on top of R&D"
                                  :async true
-                                 :choices {:req #(and (in-hand? %)
-                                                      (corp? %))}
+                                 :choices {:card #(and (in-hand? %)
+                                                       (corp? %))}
                                  :msg "add 1 card from HQ to the top of R&D"
                                  :effect (effect (move target :deck {:front true})
                                                  (effect-completed eid))}
@@ -1403,7 +1406,7 @@
    "PAD Factory"
    {:abilities [{:cost [:click 1]
                  :label "Place 1 advancement token on a card"
-                 :choices {:req installed?}
+                 :choices {:card installed?}
                  :msg (msg "place 1 advancement token on " (card-str state target))
                  :effect (req (add-prop state :corp target :advance-counter 1 {:placed true})
                               (let [tgtcid (:cid target)]
@@ -1453,9 +1456,9 @@
                    (continue-ability
                      state side
                      {:prompt "Select an Agenda in HQ to score"
-                      :choices {:req #(and (agenda? %)
-                                           (<= (:current-cost %) (get-counters (get-card state card) :advancement))
-                                           (in-hand? %))}
+                      :choices {:card #(and (agenda? %)
+                                            (<= (:current-cost %) (get-counters (get-card state card) :advancement))
+                                            (in-hand? %))}
                       :msg (msg "score " (:title target))
                       :effect (effect (score (assoc target :advance-counter
                                                     (:current-cost target)))
@@ -1558,7 +1561,8 @@
    "Quarantine System"
    (letfn [(rez-ice [cnt] {:prompt "Select an ICE to rez"
                            :async true
-                           :choices {:req #(and (ice? %) (not (rezzed? %)))}
+                           :choices {:card #(and (ice? %)
+                                                 (not (rezzed? %)))}
                            :msg (msg "rez " (:title target))
                            :effect (req (let [agenda (last (:rfg corp))
                                               ap (:agendapoints agenda 0)]
@@ -1581,16 +1585,16 @@
                                 (resolve-ability
                                   state side
                                   {:prompt "Choose a card in HQ that you just drew to swap for a card of the same type in Archives"
-                                   :choices {:req #(some (fn [c] (same-card? c %)) drawn)}
+                                   :choices {:card #(some (fn [c] (same-card? c %)) drawn)}
                                    :effect (req (let [hqcard target
                                                       t (:type hqcard)]
                                                   (resolve-ability
                                                     state side
                                                     {:show-discard true
                                                      :prompt (msg "Choose an " t " in Archives to reveal and swap into HQ for " (:title hqcard))
-                                                     :choices {:req #(and (corp? %)
-                                                                          (= (:type %) t)
-                                                                          (in-discard? %))}
+                                                     :choices {:card #(and (corp? %)
+                                                                           (= (:type %) t)
+                                                                           (in-discard? %))}
                                                      :msg (msg "lose [Click], reveal " (:title hqcard) " from HQ, and swap it for " (:title target) " from Archives")
                                                      :effect (req (let [swappedcard (assoc hqcard :zone [:discard])
                                                                         archndx (ice-index state target)
@@ -1640,7 +1644,7 @@
                               (system-msg "adds 1 advancement token to Reconstruction Contract"))}]
     :abilities [{:label "Move advancement tokens to another card"
                  :prompt "Select a card that can be advanced"
-                 :choices {:req can-be-advanced?}
+                 :choices {:card can-be-advanced?}
                  :effect (req (let [move-to target]
                                 (resolve-ability
                                   state side
@@ -1758,8 +1762,8 @@
                  :effect (effect (draw 3)
                                  (resolve-ability
                                    {:prompt "Select a card in HQ to add to the bottom of R&D"
-                                    :choices {:req #(and (corp? %)
-                                                         (in-hand? %))}
+                                    :choices {:card #(and (corp? %)
+                                                          (in-hand? %))}
                                     :msg "add 1 card from HQ to the bottom of R&D"
                                     :effect (effect (move target :deck))}
                                    card nil))}]}
@@ -1809,8 +1813,8 @@
                                      :msg (msg "trash " (join ", " (map :title targets)))
                                      :cost [:credit 1]
                                      :choices {:max counters
-                                               :req #(and (installed? %)
-                                                          (hardware? %))}
+                                               :card #(and (installed? %)
+                                                           (hardware? %))}
                                      :effect (effect (trash-cards targets))})
                                   card nil))}
                    "Pay 1 [Credits] to use Shattered Remains ability?")
@@ -1892,7 +1896,7 @@
                                                      (effect-completed state side eid))
                                  :yes-ability {:msg (msg "place 1 advancement token on " (card-str state target))
                                                :prompt "Select a card to place an advancement token on with Space Camp"
-                                               :choices {:req can-be-advanced?}
+                                               :choices {:card can-be-advanced?}
                                                :effect (effect (add-prop target :advance-counter 1 {:placed true})
                                                                (clear-wait-prompt :runner))}
                                  :no-ability {:effect (req (clear-wait-prompt state :runner)
@@ -1952,9 +1956,9 @@
               :show-discard true
               :interactive (req true)
               :async true
-              :choices {:req #(and (not (operation? %))
-                                   (corp? %)
-                                   (#{[:hand] [:discard]} (:zone %)))}
+              :choices {:card #(and (not (operation? %))
+                                    (corp? %)
+                                    (#{[:hand] [:discard]} (:zone %)))}
               :msg (msg (corp-install-msg target))
               :effect (effect (corp-install eid target nil {:ignore-install-cost true}))}]}
 
@@ -1992,8 +1996,8 @@
    {:abilities [{:label "Swap 2 pieces of installed ICE"
                  :cost [:click 1]
                  :prompt "Select two pieces of ICE to swap positions"
-                 :choices {:req #(and (installed? %)
-                                      (ice? %))
+                 :choices {:card #(and (installed? %)
+                                       (ice? %))
                            :max 2
                            :all true}
                  :effect (req (when (= (count targets) 2)
@@ -2007,8 +2011,8 @@
    (letfn [(derez-card [advancements]
              {:async true
               :prompt "Derez a card"
-              :choices {:req #(and (installed? %)
-                                   (rezzed? %))}
+              :choices {:card #(and (installed? %)
+                                    (rezzed? %))}
               :effect (req (derez state side target)
                            (if (pos? (dec advancements))
                              (continue-ability state side (derez-card (dec advancements)) card nil)
@@ -2077,9 +2081,9 @@
      0
      {:effect (effect (continue-ability
                         {:prompt "Select an asset or agenda in HQ"
-                         :choices {:req #(and (or (agenda? %)
-                                                  (asset? %))
-                                              (in-hand? %))}
+                         :choices {:card #(and (or (agenda? %)
+                                                   (asset? %))
+                                               (in-hand? %))}
                          :msg "swap it for an asset or agenda from HQ"
                          :effect (req (let [tidx (ice-index state card)
                                             srvcont (get-in @state (cons :corp (:zone card)))
@@ -2185,8 +2189,8 @@
                                  (continue-ability
                                    {:prompt "Select a card in Archives to add to the bottom of R&D"
                                     :show-discard true
-                                    :choices {:req #(and (in-discard? %)
-                                                         (corp? %))}
+                                    :choices {:card #(and (in-discard? %)
+                                                          (corp? %))}
                                     :msg (msg "trash 1 card from HQ and add "
                                               (if (:seen target) (:title target) "a card") " from Archives to the bottom of R&D")
                                     :effect (effect (move target :deck)
@@ -2198,9 +2202,9 @@
                  :req (req (< (count (:hosted card)) 3))
                  :cost [:click 1]
                  :prompt "Select an asset to install on Worlds Plaza"
-                 :choices {:req #(and (asset? %)
-                                      (in-hand? %)
-                                      (corp? %))}
+                 :choices {:card #(and (asset? %)
+                                       (in-hand? %)
+                                       (corp? %))}
                  :msg (msg "host " (:title target))
                  :async true
                  :effect (req (wait-for (corp-install state side target card nil) ;; install target onto card

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -219,11 +219,11 @@
               :choices :credit
               :msg (msg "spends " target " [Credit] on Brute-Force-Hack")
               :effect (effect (continue-ability
-                                {:choices {:req #(and (rezzed? %)
-                                                      (some (fn [c] (and (= (first c)
-                                                                            (:cid %))
-                                                                         (<= (second c) target)))
-                                                            affordable-ice))}
+                                {:choices {:card #(and (rezzed? %)
+                                                       (some (fn [c] (and (= (first c)
+                                                                             (:cid %))
+                                                                          (<= (second c) target)))
+                                                             affordable-ice))}
                                  :msg (msg "derez " (card-str state target))
                                  :effect (effect (derez target))}
                                 card nil))}
@@ -258,16 +258,16 @@
                           (can-pay? state side eid card nil
                                     [:credit (install-cost state side % {:cost-bonus -3})]))
                     (:hand runner)))
-    :choices {:five (req (and (resource? target)
-                              (in-hand? target)
-                              (can-pay? state side eid card nil
-                                        [:credit (install-cost state side target {:cost-bonus -3})])))}
+    :choices {:req (req (and (resource? target)
+                             (in-hand? target)
+                             (can-pay? state side eid card nil
+                                       [:credit (install-cost state side target {:cost-bonus -3})])))}
     :async true
     :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3}))}
 
    "Careful Planning"
    {:prompt "Choose a card in or protecting a remote server"
-    :choices {:req #(is-remote? (second (:zone %)))}
+    :choices {:card #(is-remote? (second (:zone %)))}
     :effect (effect (add-icon card target "CP" "red")
                     (system-msg (str "prevents the rezzing of " (card-str state target)
                                      " for the rest of this turn via Careful Planning"))
@@ -356,7 +356,7 @@
     :events [{:event :run-ends
               :player :runner
               :prompt "Choose a program that was used during the run to trash "
-              :choices {:req program?}
+              :choices {:card program?}
               :msg (msg "trash " (:title target))
               :async true
               :effect (effect (trash eid target {:unpreventable true}))}]}
@@ -397,9 +397,9 @@
    {:effect (req (resolve-ability
                    state side
                    {:msg (msg "place 3 virus tokens on " (:title target))
-                    :choices {:req #(and (installed? %)
-                                         (runner? %)
-                                         (zero? (get-virus-counters state %)))}
+                    :choices {:card #(and (installed? %)
+                                          (runner? %)
+                                          (zero? (get-virus-counters state %)))}
                     :effect (req (add-counter state :runner target :virus 3))}
                    card nil))}
 
@@ -452,10 +452,10 @@
    "Credit Kiting"
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
     :prompt "Select a card to install from your Grip"
-    :choices {:five (req (and (not (event? target))
-                              (in-hand? target)
-                              (can-pay? state side eid card nil
-                                        [:credit (install-cost state side target {:cost-bonus -8})])))}
+    :choices {:req (req (and (not (event? target))
+                             (in-hand? target)
+                             (can-pay? state side eid card nil
+                                       [:credit (install-cost state side target {:cost-bonus -8})])))}
     :async true
     :effect (req (let [new-eid (make-eid state {:source card :source-type :runner-install})]
                    (wait-for (runner-install state :runner new-eid target {:cost-bonus -8})
@@ -480,11 +480,11 @@
                          :yes-ability {:async true
                                        :prompt (msg "Select a piece of ICE protecting " serv " to rez")
                                        :player :corp
-                                       :choices {:req #(and (installed? %)
-                                                            (not (rezzed? %))
-                                                            (ice? %)
-                                                            (can-pay? state side eid card nil
-                                                                      [:credit (rez-cost state side %)]))}
+                                       :choices {:card #(and (installed? %)
+                                                             (not (rezzed? %))
+                                                             (ice? %)
+                                                             (can-pay? state side eid card nil
+                                                                       [:credit (rez-cost state side %)]))}
                                        :effect (effect (rez :corp eid target nil))
                                        :cancel-effect
                                        (effect (register-run-flag!
@@ -585,8 +585,8 @@
                :msg "remove 1 tag"}
               {:prompt "Select 1 piece of ice to expose"
                :msg "expose 1 ice and make a run"
-               :choices {:req #(and (installed? %)
-                                    (ice? %))}
+               :choices {:card #(and (installed? %)
+                                     (ice? %))}
                :async true
                :effect (req (wait-for (expose state side target)
                                       (continue-ability
@@ -624,9 +624,9 @@
                  (effect
                    (continue-ability
                      {:prompt "Choose a program in your grip to install"
-                      :choices {:req #(and (in-hand? %)
-                                           (program? %)
-                                           (runner-can-install? state side % false))}
+                      :choices {:card #(and (in-hand? %)
+                                            (program? %)
+                                            (runner-can-install? state side % false))}
                       :msg (msg "install " (:title target) ", ignoring all costs")
                       :async true
                       :effect (req (let [diana-card (assoc-in target [:special :diana-installed] true)]
@@ -712,10 +712,10 @@
                                      (do-access state side eid [:rd] {:no-root true})))}]}
 
    "Drive By"
-   {:choices {:req #(let [topmost (get-nested-host %)]
-                      (and (is-remote? (second (:zone topmost)))
-                           (= (last (:zone topmost)) :content)
-                           (not (:rezzed %))))}
+   {:choices {:card #(let [topmost (get-nested-host %)]
+                       (and (is-remote? (second (:zone topmost)))
+                            (= (last (:zone topmost)) :content)
+                            (not (:rezzed %))))}
     :async true
     :effect (req (wait-for (expose state side target) ;; would be nice if this could return a value on completion
                            (if async-result ;; expose was successful
@@ -776,8 +776,8 @@
    "Emergency Shutdown"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
     :msg (msg "derez " (:title target))
-    :choices {:req #(and (ice? %)
-                         (rezzed? %))}
+    :choices {:card #(and (ice? %)
+                          (rezzed? %))}
     :effect (effect (derez target))}
 
    "Emergent Creativity"
@@ -798,9 +798,9 @@
                                      (runner-install state side (assoc eid :source card :source-type :runner-install)
                                                      target {:cost-bonus (- trash-cost)})))})]
      {:prompt "Choose Hardware and Programs to trash from your Grip"
-      :choices {:req #(and (or (hardware? %)
-                               (program? %))
-                        (in-hand? %))
+      :choices {:card #(and (or (hardware? %)
+                                (program? %))
+                            (in-hand? %))
                 :max (req (count (:hand runner)))}
       :cancel-effect (effect (continue-ability (ec 0 []) card nil))
       :async true
@@ -825,9 +825,9 @@
                   {:async true
                    :prompt (str "Choose an unrezzed piece of ICE protecting "
                                 (zone->name server) " that you passed on your last run")
-                   :choices {:req #(and (ice? %)
-                                        (not (rezzed? %))
-                                        (= server (second (:zone %))))}
+                   :choices {:card #(and (ice? %)
+                                         (not (rezzed? %))
+                                         (= server (second (:zone %))))}
                    :msg (msg "trash " (card-str state target))
                    :effect (req (swap! state assoc-in [:runner :register :trashed-card] true)
                                 (trash state side eid target nil))})
@@ -844,8 +844,8 @@
    "Escher"
    (letfn [(es [] {:async true
                    :prompt "Select two pieces of ICE to swap positions"
-                   :choices {:req #(and (installed? %)
-                                        (ice? %))
+                   :choices {:card #(and (installed? %)
+                                         (ice? %))
                              :max 2}
                    :effect (req (if (= (count targets) 2)
                                   (do (swap-ice state side (first targets) (second targets))
@@ -906,7 +906,9 @@
                    (some #{:rd} (:successful-run runner-reg))
                    (some #{:archives} (:successful-run runner-reg))))
     :prompt "Choose up to 3 pieces of ICE to derez"
-    :choices {:max 3 :req #(and (rezzed? %) (ice? %))}
+    :choices {:max 3
+              :card #(and (rezzed? %)
+                          (ice? %))}
     :msg (msg "derez " (join ", " (map :title targets)))
     :effect (req (doseq [c targets]
                    (derez state side c)))}
@@ -927,8 +929,8 @@
                                        (show-wait-prompt state :corp "Runner to remove advancements")
                                        (continue-ability
                                          state side
-                                         {:choices {:req #(and (contains? % :advance-counter)
-                                                               (= (first (:server run)) (second (:zone %))))}
+                                         {:choices {:card #(and (contains? % :advance-counter)
+                                                                (= (first (:server run)) (second (:zone %))))}
                                           :msg (msg "remove " (quantify c "advancement token")
                                                     " from " (card-str state target))
                                           :effect (req (let [to-remove (min c (get-counters target :advancement))]
@@ -951,10 +953,10 @@
     :effect (effect
               (continue-ability
                 (let [chosen-type target]
-                  {:choices {:req #(let [topmost (get-nested-host %)]
-                                     (and (is-remote? (second (:zone topmost)))
-                                          (= (last (:zone topmost)) :content)
-                                          (not (rezzed? %))))}
+                  {:choices {:card #(let [topmost (get-nested-host %)]
+                                      (and (is-remote? (second (:zone topmost)))
+                                           (= (last (:zone topmost)) :content)
+                                           (not (rezzed? %))))}
                    :async true
                    :effect (req             ;taken from Drive By - maybe refactor
                                 (wait-for (expose state side target)
@@ -984,8 +986,8 @@
                                   (continue-ability
                                     (let [n (count (filter #(same-card? :title card %) (:hand runner)))]
                                       {:prompt "Reveal how many copies of Fear the Masses?"
-                                       :choices {:req #(and (in-hand? %)
-                                                            (same-card? :title card %))
+                                       :choices {:card #(and (in-hand? %)
+                                                             (same-card? :title card %))
                                                  :max n}
                                        :msg (msg "reveal " (count targets) " copies of Fear the Masses,"
                                                  " forcing the Corp to trash " (count targets)
@@ -1011,8 +1013,8 @@
                            (draw state :corp eid 3 nil)))}
 
    "Forged Activation Orders"
-   {:choices {:req #(and (ice? %)
-                         (not (rezzed? %)))}
+   {:choices {:card #(and (ice? %)
+                          (not (rezzed? %)))}
     :effect (req (let [ice target
                        serv (zone->name (second (:zone ice)))
                        icepos (ice-index state ice)]
@@ -1086,8 +1088,8 @@
 
    "Freelance Coding Contract"
    {:choices {:max 5
-              :req #(and (program? %)
-                         (in-hand? %))}
+              :card #(and (program? %)
+                          (in-hand? %))}
     :msg (msg "trash " (join ", " (map :title targets)) " and gain "
               (* 2 (count targets)) " [Credits]")
     :effect (req (doseq [c targets]
@@ -1106,8 +1108,8 @@
                       :prompt "Select 5 cards from Archives to add to HQ"
                       :choices {:max 5
                                 :all true
-                                :req #(and (corp? %)
-                                           (in-discard? %))}
+                                :card #(and (corp? %)
+                                            (in-discard? %))}
                       :msg (msg "move "
                                 (let [seen (filter :seen targets)
                                       m (count  (remove :seen targets))]
@@ -1226,9 +1228,9 @@
                                 (let [ice target]
                                   {:async true
                                    :prompt (msg "Select a rezzed copy of " (:title ice) " to trash")
-                                   :choices {:req #(and (ice? %)
-                                                        (rezzed? %)
-                                                        (same-card? :title % ice))}
+                                   :choices {:card #(and (ice? %)
+                                                         (rezzed? %)
+                                                         (same-card? :title % ice))}
                                    :msg (msg "trash " (card-str state target))
                                    :effect (effect (trash eid target nil))})
                                 card nil))}]}
@@ -1254,8 +1256,8 @@
      {:async true
       :prompt "Choose up to 5 installed cards to trash with Independent Thinking"
       :choices {:max 5
-                :req #(and (installed? %)
-                        (runner? %))}
+                :card #(and (installed? %)
+                            (runner? %))}
       :effect (req (wait-for (trash-cards state side targets nil)
                              (draw state :runner eid (cards-to-draw targets) nil)))
       :msg (msg "trash " (join ", " (map :title targets)) " and draw " (quantify (cards-to-draw targets) "card"))})
@@ -1284,8 +1286,8 @@
     :choices ["Gain 2 [Credits]" "Expose a card"]
     :effect (effect (continue-ability
                       (if (= target "Expose a card")
-                        {:choices {:req #(and (installed? %)
-                                              (not (rezzed? %)))}
+                        {:choices {:card #(and (installed? %)
+                                               (not (rezzed? %)))}
                          :async true
                          :effect (effect (expose eid target))}
                         {:msg "gain 2 [Credits]"
@@ -1326,7 +1328,8 @@
                                  state :corp
                                  {:async true
                                   :prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
-                                  :choices {:req #(and (in-hand? %) (corp? %))
+                                  :choices {:card #(and (in-hand? %)
+                                                        (corp? %))
                                             :max (req (dec (count (:hand corp))))}
                                   :effect (effect (clear-wait-prompt :runner)
                                                   (show-wait-prompt :corp "Runner to select a pile")
@@ -1364,8 +1367,8 @@
                       (let [server target]
                         {:async true
                          :prompt "Select an icebreaker"
-                         :choices {:req #(and (installed? %)
-                                              (has-subtype? % "Icebreaker"))}
+                         :choices {:card #(and (installed? %)
+                                               (has-subtype? % "Icebreaker"))}
                          :effect (effect (pump target 2 :end-of-run)
                                          (make-run eid server nil card))})
                       card nil))}
@@ -1490,8 +1493,8 @@
                   {:player :corp
                    :async true
                    :prompt (msg "Select a piece of ICE in " target " to trash")
-                   :choices {:req #(and (ice? %)
-                                        (= serv (second (:zone %))))}
+                   :choices {:card #(and (ice? %)
+                                         (= serv (second (:zone %))))}
                    :effect (effect (system-msg (str "trashes " (card-str state target)))
                                    (trash :corp eid target nil))})
                 card nil))}
@@ -1512,8 +1515,8 @@
                         :choices {:max heap-count
                                   :all true
                                   :not-self true
-                                  :req #(and (runner? %)
-                                             (in-discard? %))}
+                                  :card #(and (runner? %)
+                                              (in-discard? %))}
                         :effect (req (doseq [c targets]
                                        (move state side c :deck))
                                      (system-msg state :runner (str "shuffles " (join ", " (map :title targets))
@@ -1678,10 +1681,10 @@
                                                 [:credit (install-cost state side %)]))
                                 (:hand runner)))
                 :prompt "Select a program to install"
-                :choices {:five (req (and (program? target)
-                                          (in-hand? target)
-                                          (can-pay? state side eid card nil
-                                                    [:credit (install-cost state side target)])))}
+                :choices {:req (req (and (program? target)
+                                         (in-hand? target)
+                                         (can-pay? state side eid card nil
+                                                   [:credit (install-cost state side target)])))}
                 :effect (req (wait-for (runner-install state side target nil)
                                        (continue-ability state side (mhelper (inc n)) card nil)))}))]
      {:async true
@@ -1737,11 +1740,11 @@
 
    "Modded"
    {:prompt "Select a program or piece of hardware to install from your Grip"
-    :choices {:five (req (and (or (hardware? target)
-                                  (program? target))
-                              (in-hand? target)
-                              (can-pay? state side eid card nil
-                                        [:credit (install-cost state side target {:cost-bonus -3})])))}
+    :choices {:req (req (and (or (hardware? target)
+                                 (program? target))
+                             (in-hand? target)
+                             (can-pay? state side eid card nil
+                                       [:credit (install-cost state side target {:cost-bonus -3})])))}
     :async true
     :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3}))}
 
@@ -1788,8 +1791,8 @@
    "On the Lam"
    {:req (req (some resource? (all-active-installed state :runner)))
     :prompt "Choose a resource to host On the Lam"
-    :choices {:req #(and (resource? %)
-                         (installed? %))}
+    :choices {:card #(and (resource? %)
+                          (installed? %))}
     :effect (effect (host target (assoc card :installed true))
                     (card-init (find-latest state card) {:resolve-effect false})
                     (system-msg (str "hosts On the Lam on " (:title target))))
@@ -1882,7 +1885,7 @@
                          :replace-access
                          {:mandatory true
                           :prompt "Select an agenda to host Political Graffiti"
-                          :choices {:req #(in-corp-scored? state side %)}
+                          :choices {:card #(in-corp-scored? state side %)}
                           :msg (msg "host Political Graffiti on " (:title target) " as a hosted condition counter")
                           :effect (req (host state :runner (get-card state target)
                                              ; keep host cid in :agenda-cid because `trash` will clear :host
@@ -2000,9 +2003,9 @@
     :effect (req (let [c (str->int target)]
                    (resolve-ability
                      state side
-                     {:choices {:req #(and (is-remote? (second (:zone %)))
-                                           (= (last (:zone %)) :content)
-                                           (not (:rezzed %)))}
+                     {:choices {:card #(and (is-remote? (second (:zone %)))
+                                            (= (last (:zone %)) :content)
+                                            (not (:rezzed %)))}
                       :msg (msg "add " c " advancement tokens on a card and gain " (* 2 c) " [Credits]")
                       :effect (effect (gain-credits (* 2 c))
                                       (add-prop :corp target :advance-counter c {:placed true})
@@ -2015,7 +2018,8 @@
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
                    (some #{:rd} (:successful-run runner-reg))
                    (some #{:archives} (:successful-run runner-reg))))
-    :choices {:req installed?} :msg (msg "access " (:title target))
+    :choices {:card installed?}
+    :msg (msg "access " (:title target))
     :effect (effect (access-card target))}
 
    "Rebirth"
@@ -2074,8 +2078,8 @@
                     :prompt "Choose up to five cards to install"
                     :show-discard true
                     :choices {:max 5
-                              :req #(and (in-discard? %)
-                                         (runner? %))}
+                              :card #(and (in-discard? %)
+                                          (runner? %))}
                     :effect (effect (install-cards eid card targets (map :title targets)))}}
                   card))})
 
@@ -2093,18 +2097,18 @@
                                            (hardware? card))))
          pick-up {:async true
                   :prompt "Select a program or piece of hardware to add to your Grip"
-                  :choices {:req #(and (valid-target? %)
-                                       (installed? %))}
+                  :choices {:card #(and (valid-target? %)
+                                        (installed? %))}
                   :effect (req (move state side target :hand)
                                (effect-completed state side (make-result eid (:cost target))))}
          put-down (fn [bonus]
                     {:async true
                      :prompt "Select a program or piece of hardware to install"
                      :choices
-                     {:five (req (and (valid-target? target)
-                                      (can-pay? state side eid card nil
-                                                [:credit (install-cost state side target
-                                                                       {:cost-bonus (- bonus)})])))}
+                     {:req (req (and (valid-target? target)
+                                     (can-pay? state side eid card nil
+                                               [:credit (install-cost state side target
+                                                                      {:cost-bonus (- bonus)})])))}
                      :effect (effect (runner-install (assoc eid :source card :source-type :runner-install)
                                                      target {:cost-bonus (- bonus)}))})]
      {:req (req (some valid-target? (all-installed state :runner)))
@@ -2115,7 +2119,10 @@
 
    "Reshape"
    {:prompt "Select two non-rezzed ICE to swap positions"
-    :choices {:req #(and (installed? %) (not (rezzed? %)) (ice? %)) :max 2}
+    :choices {:card #(and (installed? %)
+                          (not (rezzed? %))
+                          (ice? %))
+              :max 2}
     :msg (msg "swap the positions of " (card-str state (first targets)) " and " (card-str state (second targets)))
     :effect (req (when (= (count targets) 2)
                    (swap-ice state side (first targets) (second targets))))}
@@ -2159,7 +2166,7 @@
            (choose-ice []
              {:async true
               :prompt "Select a piece of ICE to bypass"
-              :choices {:req ice?}
+              :choices {:card ice?}
               :msg (msg "make a run and bypass " (card-str state target))
               :effect (effect (make-run eid (second (:zone target)) nil card))})]
      {:async true
@@ -2194,8 +2201,8 @@
                          :msg (msg "take " (join ", " (map :title targets)) " from their Heap to their Grip")
                          :choices {:max (min n heap)
                                    :all true
-                                   :req #(and (runner? %)
-                                              (in-discard? %))}
+                                   :card #(and (runner? %)
+                                               (in-discard? %))}
                          :effect (req (doseq [c targets]
                                         (move state side c :hand))
                                       (do-access state side eid (:server run) {:hq-root-only true}))}
@@ -2244,7 +2251,7 @@
                                  (when (seq diff)
                                    {:async true
                                     :prompt "Select an ice to trash"
-                                    :choices {:req #(some (partial same-card? %) diff)
+                                    :choices {:card #(some (partial same-card? %) diff)
                                               :all true}
                                     :effect (effect (trash eid target nil))})
                                  card nil)))}]})
@@ -2266,9 +2273,9 @@
    {:async true
     :req (req (some #(not (rezzed? %)) (all-installed state :corp)))
     :choices {:max 2
-              :req #(and (corp? %)
-                         (installed? %)
-                         (not (rezzed? %)))}
+              :card #(and (corp? %)
+                          (installed? %)
+                          (not (rezzed? %)))}
     :effect (req (if (pos? (count targets))
                    (wait-for (expose state side target)
                              (if (= 2 (count targets))
@@ -2282,8 +2289,8 @@
                           (installed? %))
                     (all-active-installed state :runner)))
     :prompt "Select an installed program to trash"
-    :choices {:req #(and (program? %)
-                         (installed? %))}
+    :choices {:card #(and (program? %)
+                          (installed? %))}
     :effect (req (let [trashed target
                        tcost (:cost trashed)]
                    (wait-for
@@ -2294,12 +2301,12 @@
                         :prompt "Select a program to install from your Grip or Heap"
                         :show-discard true
                         :choices
-                        {:five (req (and (program? target)
-                                         (or (in-hand? target)
-                                             (in-discard? target))
-                                         (can-pay? state side eid card nil
-                                                   [:credit (install-cost state side target
-                                                                          {:cost-bonus (- tcost)})])))}
+                        {:req (req (and (program? target)
+                                        (or (in-hand? target)
+                                            (in-discard? target))
+                                        (can-pay? state side eid card nil
+                                                  [:credit (install-cost state side target
+                                                                         {:cost-bonus (- tcost)})])))}
                         :msg (msg "trash " (:title trashed)
                                   " and install " (:title target)
                                   ", lowering the cost by " tcost " [Credits]")
@@ -2353,8 +2360,8 @@
 
    "Social Engineering"
    {:prompt "Select an unrezzed piece of ICE"
-    :choices {:req #(and (not (rezzed? %))
-                         (ice? %))}
+    :choices {:card #(and (not (rezzed? %))
+                          (ice? %))}
     :effect (effect
               (continue-ability
                 (let [ice target]
@@ -2397,9 +2404,9 @@
    "Spot the Prey"
    {:prompt "Select 1 non-ICE card to expose"
     :msg "expose 1 card and make a run"
-    :choices {:req #(and (installed? %)
-                         (not (ice? %))
-                         (corp? %))}
+    :choices {:card #(and (installed? %)
+                          (not (ice? %))
+                          (corp? %))}
     :async true
     :makes-run true
     :effect (req (wait-for (expose state side target)
@@ -2429,7 +2436,8 @@
 
    "Surge"
    {:msg (msg "place 2 virus tokens on " (:title target))
-    :choices {:req #(and (has-subtype? % "Virus") (:added-virus-counter %))}
+    :choices {:card #(and (has-subtype? % "Virus")
+                          (:added-virus-counter %))}
     :effect (req (add-counter state :runner target :virus 2))}
 
    "SYN Attack"
@@ -2449,7 +2457,8 @@
                                         state :corp
                                         {:prompt "Choose 2 cards to discard"
                                          :choices {:max 2
-                                                   :req #(and (in-hand? %) (corp? %))}
+                                                   :card #(and (in-hand? %)
+                                                               (corp? %))}
                                          :effect (effect (trash-cards :corp targets)
                                                          (clear-wait-prompt :runner)
                                                          (system-msg :corp "discards 2 cards from SYN Attack"))}
@@ -2555,8 +2564,8 @@
                           (installed? %))
                     (all-installed state :corp)))
     :prompt "Select a piece of ICE"
-    :choices {:req #(and (installed? %)
-                         (ice? %))}
+    :choices {:card #(and (installed? %)
+                          (ice? %))}
     :msg (msg "make " (card-str state target) " gain Sentry, Code Gate, and Barrier until the end of the turn")
     :effect (effect (update! (assoc target :subtype (combine-subtypes true (:subtype target) "Sentry" "Code Gate" "Barrier")))
                     (update! (assoc-in (get-card state target) [:special :tinkering] true))
@@ -2603,10 +2612,10 @@
    {:req (req (some #(or (hardware? %)
                          (program? %))
                     (all-active-installed state :runner)))
-    :choices {:req #(and (installed? %)
-                         (not (facedown? %))
-                         (or (hardware? %)
-                             (program? %)))}
+    :choices {:card #(and (installed? %)
+                          (not (facedown? %))
+                          (or (hardware? %)
+                              (program? %)))}
     :msg (msg "move " (:title target) " to their Grip")
     :effect (effect (move target :hand))}
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -40,7 +40,9 @@
    {:implementation "Click Adjusted Matrix to use ability."
     :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
     :prompt "Choose Icebreaker on which to install Adjusted Matrix"
-    :choices {:req #(and (runner? %) (has-subtype? % "Icebreaker") (installed? %))}
+    :choices {:card #(and (runner? %)
+                          (has-subtype? % "Icebreaker")
+                          (installed? %))}
     :msg (msg "host it on " (card-str state target))
     :effect (effect (update! (assoc target :subtype (combine-subtypes false (-> target :subtype) "AI")))
                     (host (get-card state target) (get-card state card)))
@@ -128,8 +130,8 @@
                  :cost [:click 1]
                  :msg "host up to 3 cards from their Grip facedown"
                  :choices {:max 3
-                           :req #(and (runner? %)
-                                      (in-hand? %))}
+                           :card #(and (runner? %)
+                                       (in-hand? %))}
                  :effect (req (doseq [c targets]
                                 (host state side (get-card state card) c {:facedown true})))}
                 {:label "Add all hosted cards to Grip"
@@ -178,8 +180,8 @@
                                   state side
                                   {:prompt "Select any number of cards to trash from your Grip"
                                    :choices {:max handsize
-                                             :req #(and (runner? %)
-                                                        (in-hand? %))}
+                                             :card #(and (runner? %)
+                                                         (in-hand? %))}
                                    :effect (req (let [trashed (count targets)
                                                       remaining (- handsize trashed)]
                                                   (doseq [c targets]
@@ -197,8 +199,8 @@
    {:flags {:runner-phase-12 (req (>= 2 (count (all-installed state :runner))))}
     :abilities [{:req (req (:runner-phase-12 @state))
                  :msg (msg "trash " (:title target))
-                 :choices {:req #(and (runner? %)
-                                      (installed? %))
+                 :choices {:card #(and (runner? %)
+                                       (installed? %))
                            :not-self true}
                  :async true
                  :effect (req (wait-for (trash state :runner target nil)
@@ -227,10 +229,10 @@
                                             (can-pay? state side eid card nil
                                                       [:credit (install-cost state side %)]))
                                       (:discard runner))))
-                 :choices {:five (req (and (program? target)
-                                           (in-discard? target)
-                                           (can-pay? state side eid card nil
-                                                     [:credit (install-cost state side target)])))}
+                 :choices {:req (req (and (program? target)
+                                          (in-discard? target)
+                                          (can-pay? state side eid card nil
+                                                    [:credit (install-cost state side target)])))}
                  :cost [:trash]
                  :msg (msg "install " (:title target))
                  :effect (effect (runner-install eid target nil))}]}
@@ -244,16 +246,16 @@
                            (update! state side (assoc card :comet-event true)))}]
     :abilities [{:req (req (:comet-event card))
                  :prompt "Select an Event in your Grip to play"
-                 :choices {:req #(and (event? %)
-                                      (in-hand? %))}
+                 :choices {:card #(and (event? %)
+                                       (in-hand? %))}
                  :msg (msg "play " (:title target))
                  :effect (effect (play-instant target)
                                  (update! (dissoc (get-card state card) :comet-event)))}]}
 
    "Cortez Chip"
    {:abilities [{:prompt "Select a piece of ICE"
-                 :choices {:req #(and (ice? %)
-                                      (not (rezzed? %)))}
+                 :choices {:card #(and (ice? %)
+                                       (not (rezzed? %)))}
                  :msg (msg "increase the rez cost of " (card-str state target)
                            " by 2 [Credits] until the end of the turn")
                  :cost [:trash]
@@ -304,9 +306,9 @@
    "Dedicated Processor"
    {:implementation "Click Dedicated Processor to use ability"
     :req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
-    :hosting {:req #(and (has-subtype? % "Icebreaker")
-                         (not (has-subtype? % "AI"))
-                         (installed? %))}
+    :hosting {:card #(and (has-subtype? % "Icebreaker")
+                          (not (has-subtype? % "AI"))
+                          (installed? %))}
     :abilities [{:cost [:credit 2]
                  :req (req run)
                  :effect (effect (pump (get-card state (:host card)) 4))
@@ -325,7 +327,7 @@
                                               state side
                                               {:async true
                                                :prompt "Choose the just-installed Caïssa to have Deep Red trigger its [Click] ability"
-                                               :choices {:req #(= cid (:cid %))}
+                                               :choices {:card #(= cid (:cid %))}
                                                :msg (msg "trigger the [Click] ability of " (:title target)
                                                          " without spending [Click]")
                                                :effect (req (gain state :runner :click 1)
@@ -353,18 +355,18 @@
    {:abilities [{:label "Install a non-AI icebreaker on Dinosaurus"
                  :req (req (empty? (:hosted card))) :cost [:click 1]
                  :prompt "Select a non-AI icebreaker in your Grip to install on Dinosaurus"
-                 :choices {:req #(and (has-subtype? % "Icebreaker")
-                                      (not (has-subtype? % "AI"))
-                                      (in-hand? %))}
+                 :choices {:card #(and (has-subtype? % "Icebreaker")
+                                       (not (has-subtype? % "AI"))
+                                       (in-hand? %))}
                  :async true
                  :effect (effect (update! (assoc-in (get-card state card) [:special :dino-breaker] (:cid target)))
                                  (runner-install eid target {:host-card card :no-mu true}))}
                 {:label "Host an installed non-AI icebreaker on Dinosaurus"
                  :req (req (empty? (:hosted card)))
                  :prompt "Select an installed non-AI icebreaker to host on Dinosaurus"
-                 :choices {:req #(and (has-subtype? % "Icebreaker")
-                                      (not (has-subtype? % "AI"))
-                                      (installed? %))}
+                 :choices {:card #(and (has-subtype? % "Icebreaker")
+                                       (not (has-subtype? % "AI"))
+                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (req (free-mu state (:memoryunits target))
                               (->> target
@@ -508,16 +510,16 @@
                    :req (req (empty? (:hosted card)))
                    :cost [:click 1]
                    :prompt "Select a program in your Grip to install on Flame-out"
-                   :choices {:req #(and (program? %)
-                                        (in-hand? %))}
+                   :choices {:card #(and (program? %)
+                                         (in-hand? %))}
                    :async true
                    :effect (effect (update! (assoc-in (get-card state card) [:special :flame-out] (:cid target)))
                                    (runner-install eid target {:host-card card}))}
                   {:label "Host an installed program on Flame-out"
                    :req (req (empty? (:hosted card)))
                    :prompt "Select an installed program to host on Flame-out"
-                   :choices {:req #(and (program? %)
-                                        (installed? %))}
+                   :choices {:card #(and (program? %)
+                                         (installed? %))}
                    :msg (msg "host " (:title target))
                    :effect (req (->> target
                                      (get-card state)
@@ -585,7 +587,7 @@
    (let [ability {:msg (msg "move 1 virus counter to " (:title target))
                   :req (req (and (pos? (get-counters card :virus))
                                  (pos? (count-virus-programs state))))
-                  :choices {:req virus-program?}
+                  :choices {:card virus-program?}
                   :effect (req (add-counter state :runner card :virus -1)
                                (add-counter state :runner target :virus 1))}]
      {:abilities [(set-autoresolve :auto-accept "Friday Chip")]
@@ -616,9 +618,9 @@
    "Gebrselassie"
    {:abilities [{:msg (msg "host it on an installed non-AI icebreaker")
                  :cost [:click 1]
-                 :choices {:req #(and (installed? %)
-                                      (has-subtype? % "Icebreaker")
-                                      (not (has-subtype? % "AI")))}
+                 :choices {:card #(and (installed? %)
+                                       (has-subtype? % "Icebreaker")
+                                       (not (has-subtype? % "AI")))}
                  :effect (req (when-let [host (get-card state (:host card))]
                                 (swap! state assoc :effects
                                        (reduce
@@ -727,9 +729,9 @@
               :optional {:prompt "Place a virus counter?"
                          :autoresolve (get-autoresolve :auto-add)
                          :yes-ability {:prompt "Select an installed virus program for Knobkierie to add a virus counter to"
-                                       :choices {:req #(and (installed? %)
-                                                            (has-subtype? % "Virus")
-                                                            (program? %))}
+                                       :choices {:card #(and (installed? %)
+                                                             (has-subtype? % "Virus")
+                                                             (program? %))}
                                        :msg (msg "place 1 virus counter on " (:title target))
                                        :effect (effect (add-counter target :virus 1))}}}]
     :abilities [(set-autoresolve :auto-add "Knobkierie")]}
@@ -737,7 +739,7 @@
    "Lemuria Codecracker"
    {:abilities [{:cost [:click 1 :credit 1]
                  :req (req (some #{:hq} (:successful-run runner-reg)))
-                 :choices {:req installed?}
+                 :choices {:card installed?}
                  :effect (effect (expose eid target))
                  :msg "expose 1 card"}]}
 
@@ -803,10 +805,10 @@
                :yes-ability {:async true
                              :prompt "Select a piece of hardware"
                              :choices
-                             {:five (req (and (in-hand? target)
-                                              (hardware? target)
-                                              (can-pay? state side eid card nil
-                                                        [:credit (install-cost state side target {:cost-bonus 1})])))}
+                             {:req (req (and (in-hand? target)
+                                             (hardware? target)
+                                             (can-pay? state side eid card nil
+                                                       [:credit (install-cost state side target {:cost-bonus 1})])))}
                              :msg (msg "install " (:title target) " from the grip, paying 1 [Credit] more")
                              :effect (effect (runner-install eid target {:cost-bonus 1}))}}}
              {:event :runner-install
@@ -859,9 +861,9 @@
                  :effect (effect (resolve-ability
                                    {:async true
                                     ;; only allow targeting cards that were accessed this turn
-                                    :choices {:req #(some (fn [accessed-card]
-                                                            (same-card? % accessed-card))
-                                                          (map first (turn-events state side :access)))}
+                                    :choices {:card #(some (fn [accessed-card]
+                                                             (same-card? % accessed-card))
+                                                           (map first (turn-events state side :access)))}
                                     :msg (msg "move " (:title target) " to the bottom of R&D")
                                     :effect (req (move state :corp target :deck)
                                                  (gain-tags state :runner eid 1)
@@ -895,7 +897,7 @@
               :req (req (= target :rd))
               :effect (effect (continue-ability
                                 {:prompt "Select a card and replace 1 spent [Recurring Credits] on it"
-                                 :choices {:req #(< (get-counters % :recurring) (:recurring (card-def %) 0))}
+                                 :choices {:card #(< (get-counters % :recurring) (:recurring (card-def %) 0))}
                                  :msg (msg "replace 1 spent [Recurring Credits] on " (:title target))
                                  :effect (effect (add-prop target :rec-counter 1))}
                                 card nil))}]}
@@ -904,10 +906,10 @@
    (let [mhelper
          (fn mh [n]
            {:prompt "Select a program to install"
-            :choices {:five (req (and (program? target)
-                                      (in-hand? target)
-                                      (can-pay? state side eid card nil
-                                                [:credit (install-cost state side target {:cost-bonus -4})])))}
+            :choices {:req (req (and (program? target)
+                                     (in-hand? target)
+                                     (can-pay? state side eid card nil
+                                               [:credit (install-cost state side target {:cost-bonus -4})])))}
             :async true
             :effect (req (wait-for (runner-install state side target {:cost-bonus -4})
                                    (continue-ability state side (when (< n 3) (mh (inc n))) card nil)))})]
@@ -935,8 +937,8 @@
               :req (req (some #(and (program? %)
                                     (has-subtype? % "Icebreaker"))
                               (all-active-installed state :runner)))
-              :choices {:req #(and (installed? %)
-                                   (has-subtype? % "Icebreaker"))}
+              :choices {:card #(and (installed? %)
+                                    (has-subtype? % "Icebreaker"))}
               :msg (msg "give " (:title target) " +1 strength")
               :effect (effect (pump target 1 :end-of-run))}]}
 
@@ -950,10 +952,10 @@
                                {:async true
                                 :cost [:click 1]
                                 :prompt "Select a program in your Grip to install on NetChip"
-                                :choices {:req #(and (program? %)
-                                                     (runner-can-install? state side % false)
-                                                     (<= (:memoryunits %) n)
-                                                     (in-hand? %))}
+                                :choices {:card #(and (program? %)
+                                                      (runner-can-install? state side % false)
+                                                      (<= (:memoryunits %) n)
+                                                      (in-hand? %))}
                                 :msg (msg "host " (:title target))
                                 :effect (effect (update! (assoc (get-card state card)
                                                                 :hosted-programs
@@ -967,9 +969,9 @@
                            (continue-ability
                              (let [n (count (filter #(= (:title %) (:title card)) (all-active-installed state :runner)))]
                                {:prompt "Select an installed program to host on NetChip"
-                                :choices {:req #(and (program? %)
-                                                     (<= (:memoryunits %) n)
-                                                     (installed? %))}
+                                :choices {:card #(and (program? %)
+                                                      (<= (:memoryunits %) n)
+                                                      (installed? %))}
                                 :msg (msg "host " (:title target))
                                 :effect (effect (host card target)
                                                 (free-mu (:memoryunits target))
@@ -1011,17 +1013,17 @@
                  :req (req (empty? (:hosted card)))
                  :cost [:click 1]
                  :prompt "Select a program of 1[Memory Unit] or less to install on Omni-drive from your grip"
-                 :choices {:req #(and (program? %)
-                                      (<= (:memoryunits %) 1)
-                                      (in-hand? %))}
+                 :choices {:card #(and (program? %)
+                                       (<= (:memoryunits %) 1)
+                                       (in-hand? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (update! (assoc (get-card state card) :Omnidrive-prog (:cid target)))
                                  (runner-install eid target {:host-card card :no-mu true}))}
                 {:label "Host an installed program of 1[Memory Unit] or less on Omni-drive"
                  :prompt "Select an installed program of 1[Memory Unit] or less to host on Omni-drive"
-                 :choices {:req #(and (program? %)
-                                      (<= (:memoryunits %) 1)
-                                      (installed? %))}
+                 :choices {:card #(and (program? %)
+                                       (<= (:memoryunits %) 1)
+                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target)
                                  (free-mu (:memoryunits target))
@@ -1093,9 +1095,9 @@
                                                                  " cost of " (:title targetcard) " by 2 [Credits].")
                                                     :priority 2
                                                     :async true
-                                                    :choices {:req #(and (in-hand? %)
-                                                                         (runner? %)
-                                                                         (not (same-card? % targetcard)))}
+                                                    :choices {:card #(and (in-hand? %)
+                                                                          (runner? %)
+                                                                          (not (same-card? % targetcard)))}
                                                     :msg (msg "trash " (:title target) " to lower the " cost-type " cost of "
                                                               (:title targetcard) " by 2 [Credits]")
                                                     :effect (req (trash state side target {:unpreventable true})
@@ -1302,9 +1304,9 @@
                  :choices :credit
                  :effect (effect (system-msg (str "spends a [Click] and " target " [Credit] on Rubicon Switch"))
                                  (continue-ability
-                                   {:choices {:req #(and (ice? %)
-                                                         (= :this-turn (:rezzed %))
-                                                         (<= (:cost %) target))}
+                                   {:choices {:card #(and (ice? %)
+                                                          (= :this-turn (:rezzed %))
+                                                          (<= (:cost %) target))}
                                     :effect (effect (derez target))
                                     :msg (msg "derez " (:title target))}
                                    card nil))}]}
@@ -1314,9 +1316,9 @@
                  :msg (msg "add " (:link runner) " strength to " (:title target) " until the end of the run")
                  :req (req (:run @state))
                  :prompt "Select one non-Cloud icebreaker"
-                 :choices {:req #(and (has-subtype? % "Icebreaker")
-                                      (not (has-subtype? % "Cloud"))
-                                      (installed? %))}
+                 :choices {:card #(and (has-subtype? % "Icebreaker")
+                                       (not (has-subtype? % "Cloud"))
+                                       (installed? %))}
                  :cost [:trash]
                  :effect (effect (pump target (:link runner) :end-of-run))}
                 {:label "Add [Link] strength to any Cloud icebreakers until the end of the run"
@@ -1324,9 +1326,9 @@
                  :req (req (:run @state))
                  :prompt "Select any number of Cloud icebreakers"
                  :choices {:max 50
-                           :req #(and (has-subtype? % "Icebreaker")
-                                      (has-subtype? % "Cloud")
-                                      (installed? %))}
+                           :card #(and (has-subtype? % "Icebreaker")
+                                       (has-subtype? % "Cloud")
+                                       (installed? %))}
                  :cost [:trash]
                  :effect (req (doseq [t targets]
                                 (pump state side t (:link runner) :end-of-run)
@@ -1350,8 +1352,8 @@
    (letfn [(implant-fn [srv kw]
              {:prompt "Choose at least 2 cards in your Grip to trash with Severnius Stim Implant"
               :choices {:max (req (count (:hand runner)))
-                        :req #(and (runner? %)
-                                   (in-hand? %))}
+                        :card #(and (runner? %)
+                                    (in-hand? %))}
               :msg (msg "trash " (quantify (count targets) "card")
                         " and access " (quantify (quot (count targets) 2) "additional card"))
               :effect (req (let [bonus (quot (count targets) 2)]
@@ -1493,8 +1495,8 @@
                                 card nil))}]}
 
    "The Personal Touch"
-   {:hosting {:req #(and (has-subtype? % "Icebreaker")
-                         (installed? %))}
+   {:hosting {:card #(and (has-subtype? % "Icebreaker")
+                          (installed? %))}
     :effect (effect (update-breaker-strength (:host card)))
     :constant-effects [{:type :breaker-strength
                         :req (req (same-card? target (:host card)))
@@ -1533,8 +1535,8 @@
                                  {:prompt (msg "Select " dmg " cards to trash for the " (name dtype) " damage")
                                   :choices {:max dmg
                                             :all true
-                                            :req #(and (in-hand? %)
-                                                       (runner? %))}
+                                            :card #(and (in-hand? %)
+                                                        (runner? %))}
                                   :msg (msg "trash " (join ", " (map :title targets)))
                                   :effect (req (clear-wait-prompt state :corp)
                                                (chosen-damage state :runner targets)
@@ -1585,7 +1587,7 @@
                                          (continue-ability
                                            state side
                                            {:prompt (str "Select a scored Corp agenda to swap with " (:title stolen))
-                                            :choices {:req #(in-corp-scored? state side %)}
+                                            :choices {:card #(in-corp-scored? state side %)}
                                             :effect (req (let [scored target]
                                                            (swap-agendas state side scored stolen)
                                                            (system-msg state side (str "uses Turntable to swap "
@@ -1615,13 +1617,13 @@
       :req (req (some #{:hq} (:successful-run runner-reg)))
       :label "trash a Bioroid, Clone, Executive or Sysop"
       :prompt "Select a Bioroid, Clone, Executive, or Sysop to trash"
-      :choices {:req #(and (rezzed? %)
-                           (or (has-subtype? % "Bioroid")
-                               (has-subtype? % "Clone")
-                               (has-subtype? % "Executive")
-                               (has-subtype? % "Sysop"))
-                           (or (and (= (last (:zone %)) :content) (is-remote? (second (:zone %))))
-                               (= (last (:zone %)) :onhost)))}
+      :choices {:card #(and (rezzed? %)
+                            (or (has-subtype? % "Bioroid")
+                                (has-subtype? % "Clone")
+                                (has-subtype? % "Executive")
+                                (has-subtype? % "Sysop"))
+                            (or (and (= (last (:zone %)) :content) (is-remote? (second (:zone %))))
+                                (= (last (:zone %)) :onhost)))}
       :msg (msg "trash " (:title target)) :effect (effect (trash target))}]}
 
    "Vigil"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -212,7 +212,7 @@
   "Ability for revealing Grail ICE from HQ."
   {:label "Reveal up to 2 Grail ICE from HQ"
    :choices {:max 2
-             :req grail-in-hand}
+             :card grail-in-hand}
    :effect (effect (reveal targets))
    :msg (let [sub-label #(:label (first (:subroutines (card-def %))))]
           (msg "reveal " (join ", " (map #(str (:title %) " (" (sub-label %) ")") targets))))})
@@ -220,7 +220,7 @@
 (def resolve-grail
   "Ability for resolving a subroutine on a Grail ICE in HQ."
   {:label "Resolve a Grail ICE subroutine from HQ"
-   :choices {:req grail-in-hand}
+   :choices {:card grail-in-hand}
    :effect (req (doseq [ice targets]
                   (let [subroutine (first (:subroutines (card-def ice)))]
                     (resolve-ability state side subroutine card nil))))})
@@ -305,7 +305,7 @@
           (when (< 1 (count (filter pred (all-active-installed state :corp))))
             {:async true
              :prompt "Select the ice"
-             :choices {:req pred
+             :choices {:card pred
                        :all true}
              :effect (effect
                        (continue-ability
@@ -430,8 +430,8 @@
                     {:async true
                      :effect (effect (show-wait-prompt :runner "Corp to select Archangel target")
                                      (continue-ability
-                                       {:choices {:req #(and (installed? %)
-                                                             (runner? %))}
+                                       {:choices {:card #(and (installed? %)
+                                                              (runner? %))}
                                         :label "Add 1 installed card to the Runner's Grip"
                                         :msg "add 1 installed card to the Runner's Grip"
                                         :effect (effect (clear-wait-prompt :runner)
@@ -468,10 +468,10 @@
                    :prompt "Select a card to install from Archives or HQ"
                    :show-discard true
                    :priority true
-                   :choices {:req #(and (corp? %)
-                                        (not (operation? %))
-                                        (or (in-hand? %)
-                                            (in-discard? %)))}
+                   :choices {:card #(and (corp? %)
+                                         (not (operation? %))
+                                         (or (in-hand? %)
+                                             (in-discard? %)))}
                    :async true
                    :effect (effect (corp-install eid target nil nil))
                    :msg (msg (corp-install-msg target))}]}
@@ -568,8 +568,8 @@
     [{:label "Install a piece of ice from HQ protecting another server, ignoring all costs"
       :prompt "Choose ICE to install from HQ in another server"
       :async true
-      :choices {:req #(and (ice? %)
-                           (in-hand? %))}
+      :choices {:card #(and (ice? %)
+                            (in-hand? %))}
       :effect (req (let [this (zone->name (second (:zone card)))
                          nice target]
                      (continue-ability state side
@@ -581,8 +581,8 @@
      {:label "Install a piece of ice from HQ in the next innermost position, protecting this server, ignoring all costs"
       :prompt "Choose ICE to install from HQ in this server"
       :async true
-      :choices {:req #(and (ice? %)
-                           (in-hand? %))}
+      :choices {:card #(and (ice? %)
+                            (in-hand? %))}
       :effect (req (corp-install state side eid
                                  target (zone->name (first (:server run)))
                                  {:ignore-all-cost true
@@ -613,8 +613,8 @@
    "Builder"
    (let [sub {:label "Place 1 advancement token on an ICE that can be advanced protecting this server"
                    :msg (msg "place 1 advancement token on " (card-str state target))
-                   :choices {:req #(and (ice? %)
-                                        (can-be-advanced? %))}
+                   :choices {:card #(and (ice? %)
+                                         (can-be-advanced? %))}
                    :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]
      {:abilities [{:label "Move Builder to the outermost position of any server"
                    :cost [:click 1]
@@ -769,7 +769,7 @@
                            :prompt "Select a target for Clairvoyant Monitor"
                            :msg (msg "place 1 advancement token on "
                                      (card-str state target) " and end the run")
-                           :choices {:req installed?}
+                           :choices {:card installed?}
                            :effect (effect (add-prop target :advance-counter 1 {:placed true})
                                            (end-run eid))})]}
 
@@ -791,8 +791,8 @@
                                               state side
                                               {:prompt "Choose a resource to trash"
                                                :msg (msg "trash " (:title target))
-                                               :choices {:req #(and (installed? %)
-                                                                    (resource? %))}
+                                               :choices {:card #(and (installed? %)
+                                                                     (resource? %))}
                                                :cancel-effect (req (effect-completed state side eid))
                                                :effect (effect (trash target {:cause :subroutine}))}
                                               card nil)
@@ -830,9 +830,9 @@
                    :show-discard true
                    :priority true
                    :async true
-                   :choices {:req #(and (not (operation? %))
-                                        (in-discard? %)
-                                        (corp? %))}
+                   :choices {:card #(and (not (operation? %))
+                                         (in-discard? %)
+                                         (corp? %))}
                    :msg (msg (corp-install-msg target))
                    :effect (effect (corp-install eid target nil nil))}]
     :strength-bonus (req (if (= (second (:zone card)) :archives) 3 0))}
@@ -888,7 +888,8 @@
                                  (resolve-ability state side
                                                   {:prompt (msg "Choose " n " cards in your Grip to add to the top of the Stack (first card targeted will be topmost)")
                                                    :choices {:max n :all true
-                                                             :req #(and (in-hand? %) (runner? %))}
+                                                             :card #(and (in-hand? %)
+                                                                         (runner? %))}
                                                    :effect (req (doseq [c targets]
                                                                   (move state :runner c :deck {:front true}))
                                                                 (system-msg state :runner (str "adds " n " cards from their Grip to the top of the Stack")))}
@@ -1016,7 +1017,7 @@
                   (do-brain-damage 1)
                   {:label "Trash a console"
                    :prompt "Select a console to trash"
-                   :choices {:req #(has-subtype? % "Console")}
+                   :choices {:card #(has-subtype? % "Console")}
                    :msg (msg "trash " (:title target))
                    :effect (effect (trash target))}
                   {:msg "trash all virtual resources"
@@ -1132,7 +1133,7 @@
                                     :effect (effect (continue-ability
                                                       {:prompt "Select a piece of hardware to trash"
                                                        :label "Trash a piece of hardware"
-                                                       :choices {:req hardware?}
+                                                       :choices {:card hardware?}
                                                        :msg (msg "trash " (:title target))
                                                        :effect (req (wait-for
                                                                       (trash state side target {:cause :subroutine})
@@ -1187,10 +1188,10 @@
                   :effect (effect (draw eid target nil))}
          reveal-and-shuffle {:prompt "Reveal and shuffle up to 3 agendas"
                              :show-discard true
-                             :choices {:req #(and (corp? %)
-                                                  (or (= [:discard] (:zone %))
-                                                      (= [:hand] (:zone %)))
-                                                  (agenda? %))
+                             :choices {:card #(and (corp? %)
+                                                   (or (= [:discard] (:zone %))
+                                                       (= [:hand] (:zone %)))
+                                                   (agenda? %))
                                        :max (req 3)}
                              :effect (req (reveal state side targets)
                                           (doseq [c targets]
@@ -1246,11 +1247,11 @@
    {:subroutines [{:label "Trash 1 program"
                    :prompt "Choose a program that is not a decoder, fracter or killer"
                    :msg (msg "trash " (:title target))
-                   :choices {:req #(and (installed? %)
-                                        (program? %)
-                                        (not (has-subtype? % "Decoder"))
-                                        (not (has-subtype? % "Fracter"))
-                                        (not (has-subtype? % "Killer")))}
+                   :choices {:card #(and (installed? %)
+                                         (program? %)
+                                         (not (has-subtype? % "Decoder"))
+                                         (not (has-subtype? % "Fracter"))
+                                         (not (has-subtype? % "Killer")))}
                    :effect (effect (trash target {:cause :subroutine})
                                    (clear-wait-prompt :runner))}
                   end-the-run]
@@ -1277,7 +1278,7 @@
                                            {:prompt (msg "Select " delta " cards to discard")
                                             :player :runner
                                             :choices {:max delta
-                                                      :req #(in-hand? %)}
+                                                      :card #(in-hand? %)}
                                             :effect (req (doseq [c targets]
                                                            (trash state :runner c))
                                                          (system-msg state :runner
@@ -1313,7 +1314,7 @@
                                           state side
                                           {:msg (msg "pay " c "[Credits] and place " (quantify c " advancement token")
                                                      " on " (card-str state target))
-                                           :choices {:req can-be-advanced?}
+                                           :choices {:card can-be-advanced?}
                                            :effect (effect (add-prop target :advance-counter c {:placed true}))}
                                           card nil))
                                     (effect-completed state side eid))))}]
@@ -1363,7 +1364,7 @@
                   {:label "Trash an icebreaker"
                    :prompt "Choose an icebreaker to trash"
                    :msg (msg "trash " (:title target))
-                   :choices {:req #(and (installed? %)
+                   :choices {:card #(and (installed? %)
                                         (has-subtype? % "Icebreaker"))}
                    :effect (effect (trash target {:cause :subroutine})
                                    (clear-wait-prompt :runner))}]}
@@ -1560,8 +1561,8 @@
                    :req (req (>= (count (all-installed state :runner)) 2))
                    :async true
                    :prompt "Select 2 installed Runner cards"
-                   :choices {:req #(and (runner? %)
-                                        (installed? %))
+                   :choices {:card #(and (runner? %)
+                                         (installed? %))
                              :max 2
                              :all true}
                    :msg (msg "add either " (card-str state (first targets)) " or " (card-str state (second targets)) " to the Stack")
@@ -1594,8 +1595,8 @@
               :label (str "Trash an installed " (better-name kind))
               :msg (msg "trash " (:title target))
               :async true
-              :choices {:req #(and (installed? %)
-                                   (is-type? % (capitalize kind)))}
+              :choices {:card #(and (installed? %)
+                                    (is-type? % (capitalize kind)))}
               :cancel-effect (effect (system-msg (str "fails to trash an installed " (better-name kind)))
                                      (effect-completed eid))
               :effect (effect (trash eid target {:cause :subroutine}))})
@@ -1622,7 +1623,7 @@
 
    "Kitsune"
    {:subroutines [{:prompt "Select a card in HQ to force access"
-                   :choices {:req in-hand?}
+                   :choices {:card in-hand?}
                    :label "Force the Runner to access a card in HQ"
                    :msg (msg "force the Runner to access " (:title target))
                    :effect (req (trash state side card)
@@ -1735,8 +1736,8 @@
                   (trace-ability 3 {:label "Trash a virus"
                                     :prompt "Choose a virus to trash"
                                     :msg (msg "trash " (:title target))
-                                    :choices {:req #(and (installed? %)
-                                                         (has-subtype? % "Virus"))}
+                                    :choices {:card #(and (installed? %)
+                                                          (has-subtype? % "Virus"))}
                                     :effect (effect (trash target {:cause :subroutine})
                                                     (clear-wait-prompt :runner))})
                   (trace-ability 2 {:label "Remove a virus in the Heap from the game"
@@ -1759,9 +1760,9 @@
                                                   (remove-once #(same-card? % magnet)
                                                                (filter ice? (all-installed state corp)))))
                                   :prompt "Select a Program to host on Magnet"
-                                  :choices {:req #(and (program? %)
-                                                       (ice? (:host %))
-                                                       (not (same-card? (:host %) magnet)))}
+                                  :choices {:card #(and (program? %)
+                                                        (ice? (:host %))
+                                                        (not (same-card? (:host %) magnet)))}
                                   :effect (effect (host card target))}
                                  card nil)
                                (disable-hosted state side card))))
@@ -1792,9 +1793,9 @@
                                  (remove-sub! state side ice #(= cid (:from-cid %))))))
                            (update! state side (dissoc-in card [:special :marker])))}]
     :abilities [{:label "Give an End the run subroutine"
-                 :choices {:req #(and (ice? %)
-                                      (installed? %)
-                                      (rezzed? %))}
+                 :choices {:card #(and (ice? %)
+                                       (installed? %)
+                                       (rezzed? %))}
                  :effect (effect (add-sub! target end-the-run (:cid card) {:back true})
                                  (update! (update-in card [:special :marker] #(conj % target))))}]
     :subroutines [{:label "Give the next ICE encountered \"End the run\""
@@ -1818,8 +1819,9 @@
    {:implementation "Encounter effect is manual"
     :abilities [{:label "Place 1 advancement token on a card that can be advanced"
                  :msg (msg "place 1 advancement token on " (card-str state target))
-                 :choices {:req can-be-advanced?}
-                 :cost [:credit 1] :effect (effect (add-prop target :advance-counter 1))}]
+                 :choices {:card can-be-advanced?}
+                 :cost [:credit 1]
+                 :effect (effect (add-prop target :advance-counter 1))}]
     :subroutines [(tag-trace 2)]}
 
    "Mausolus"
@@ -1882,7 +1884,10 @@
                                     state side
                                     {:prompt "Select the two ICE to swap"
                                      :async true
-                                     :choices {:req #(and (installed? %) (ice? %)) :max 2 :all true}
+                                     :choices {:card #(and (installed? %)
+                                                           (ice? %))
+                                               :max 2
+                                               :all true}
                                      :msg (msg "swap the positions of " (card-str state (first targets)) " and " (card-str state (second targets)))
                                      :effect (req (when (= (count targets) 2)
                                                     (swap-ice state side (first targets) (second targets))
@@ -1892,7 +1897,10 @@
                                     state side
                                     {:prompt "Select the two cards to swap"
                                      :async true
-                                     :choices {:req #(and (installed? %) (not (ice? %))) :max 2 :all true}
+                                     :choices {:card #(and (installed? %)
+                                                           (not (ice? %)))
+                                               :max 2
+                                               :all true}
                                      :msg (msg "swap the positions of " (card-str state (first targets)) " and " (card-str state (second targets)))
                                      :effect (req (when (= (count targets) 2)
                                                     (swap-installed state side (first targets) (second targets))
@@ -1923,16 +1931,16 @@
                                                            :server (rest dest)))))})]
     :runner-abilities [{:label "Add an installed card to the bottom of your Stack"
                         :prompt "Choose one of your installed cards"
-                        :choices {:req #(and (installed? %)
-                                             (runner? %))}
+                        :choices {:card #(and (installed? %)
+                                              (runner? %))}
                         :effect (effect (move target :deck)
                                         (system-msg :runner (str "adds " (:title target) " to the bottom of their Stack")))}]}
 
    "Minelayer"
    {:subroutines [{:msg "install an ICE from HQ"
                    :async true
-                   :choices {:req #(and (ice? %)
-                                        (in-hand? %))}
+                   :choices {:card #(and (ice? %)
+                                         (in-hand? %))}
                    :prompt "Choose an ICE to install from HQ"
                    :effect (effect (corp-install eid target (zone->name (first (:server run))) {:ignore-all-cost true}))}]}
 
@@ -1956,7 +1964,8 @@
                                           (continue-ability
                                             state side
                                             {:prompt "Choose 1 card in HQ to shuffle into R&D"
-                                             :choices {:req #(and (in-hand? %) (corp? %))}
+                                             :choices {:card #(and (in-hand? %)
+                                                                   (corp? %))}
                                              :msg "shuffle 1 card in HQ into R&D"
                                              :effect (effect (move target :deck)
                                                              (shuffle! :deck))}
@@ -2087,8 +2096,8 @@
                   {:prompt "Select a card to trash"
                    :label "Trash 1 installed Runner card"
                    :msg (msg "trash " (:title target))
-                   :choices {:req #(and (installed? %)
-                                        (runner? %))}
+                   :choices {:card #(and (installed? %)
+                                         (runner? %))}
                    :async true
                    :effect (req (trash state side eid target {:cause :subroutine}))}]}
 
@@ -2102,9 +2111,9 @@
    (let [sub {:label "Install a card from HQ, paying all costs"
               :prompt "Choose a card in HQ to install"
               :req (req (some #(not (operation? %)) (:hand corp)))
-              :choices {:req #(and (not (operation? %))
-                                   (in-hand? %)
-                                   (corp? %))}
+              :choices {:card #(and (not (operation? %))
+                                    (in-hand? %)
+                                    (corp? %))}
               :async true
               :effect (effect (corp-install eid target nil nil))
               :msg (msg (corp-install-msg target))}
@@ -2125,8 +2134,8 @@
                   {:label "Add up to X cards from Archives to HQ"
                    :prompt "Select cards to add to HQ"
                    :show-discard  true
-                   :choices {:req #(and (corp? %)
-                                        (in-discard? %))
+                   :choices {:card #(and (corp? %)
+                                         (in-discard? %))
                              :max (req (next-ice-count corp))}
                    :effect (req (doseq [c targets]
                                   (move state side c :hand)))
@@ -2140,8 +2149,8 @@
                              " to HQ")}
                   {:label "Shuffle up to X cards from HQ into R&D"
                    :prompt "Select cards to shuffle into R&D"
-                   :choices {:req #(and (corp? %)
-                                        (in-hand? %))
+                   :choices {:card #(and (corp? %)
+                                         (in-hand? %))
                              :max (req (next-ice-count corp))}
                    :effect (req (doseq [c targets]
                                   (move state :corp c :deck))
@@ -2172,7 +2181,7 @@
                  :effect (req (add-prop state side card :advance-counter 1 {:placed true}))}
                 {:label "Place X advancement token on another piece of ice"
                  :msg (msg "place " (get-counters card :advancement) " advancement token on " (card-str state target))
-                 :choices {:req ice?
+                 :choices {:card ice?
                            :not-self true}
                  :effect (req (add-prop state side target :advance-counter (get-counters card :advancement) {:placed true}))}]
     :subroutines [end-the-run end-the-run]}
@@ -2187,8 +2196,8 @@
                    :label "Place 3 advancement tokens on installed card"
                    :msg "place 3 advancement tokens on installed card"
                    :prompt "Choose an installed Corp card"
-                   :choices {:req #(and (corp? %)
-                                        (installed? %))}
+                   :choices {:card #(and (corp? %)
+                                         (installed? %))}
                    :effect (req (let [c target
                                       title (if (:rezzed c)
                                               (:title c)
@@ -2214,8 +2223,8 @@
                                     card nil)))}]}
 
    "Owl"
-   {:subroutines [{:choices {:req #(and (installed? %)
-                                        (program? %))}
+   {:subroutines [{:choices {:card #(and (installed? %)
+                                         (program? %))}
                    :label "Add installed program to the top of the Runner's Stack"
                    :msg "add an installed program to the top of the Runner's Stack"
                    :effect (effect (move :runner target :deck {:front true})
@@ -2465,8 +2474,8 @@
               :effect (effect (show-wait-prompt :runner "Corp to select Sandman target")
                               (continue-ability
                                 {:prompt "Select an installed Runner card"
-                                 :choices {:req #(and (installed? %)
-                                                      (runner? %))}
+                                 :choices {:card #(and (installed? %)
+                                                       (runner? %))}
                                  :msg (msg "to add " (:title target) " to the grip")
                                  :effect (effect (clear-wait-prompt :runner)
                                                  (move :runner target :hand true))
@@ -2528,9 +2537,9 @@
                                  (remove-sub! state side ice #(= cid (:from-cid %))))))
                            (update! state side (dissoc-in card [:special :sensei])))}]
     :abilities [{:label "Give an End the run subroutine"
-                 :choices {:req #(and (ice? %)
-                                      (installed? %)
-                                      (rezzed? %))}
+                 :choices {:card #(and (ice? %)
+                                       (installed? %)
+                                       (rezzed? %))}
                  :effect (effect (add-sub! target end-the-run (:cid card) {:back true})
                                  (update! (update-in card [:special :sensei] conj target)))}]
     :subroutines [{:label "Give each other ICE encountered \"End the run\""
@@ -2543,16 +2552,16 @@
     :strength-bonus advance-counters}
 
    "Sherlock 1.0"
-   {:subroutines [(trace-ability 4 {:choices {:req #(and (installed? %)
-                                                         (program? %))}
+   {:subroutines [(trace-ability 4 {:choices {:card #(and (installed? %)
+                                                          (program? %))}
                                     :label "Add an installed program to the top of the Runner's Stack"
                                     :msg (msg "add " (:title target) " to the top of the Runner's Stack")
                                     :effect (effect (move :runner target :deck {:front true}))})]
     :runner-abilities [(bioroid-break 1 1)]}
 
    "Sherlock 2.0"
-   (let [sub (trace-ability 4 {:choices {:req #(and (installed? %)
-                                                    (program? %))}
+   (let [sub (trace-ability 4 {:choices {:card #(and (installed? %)
+                                                     (program? %))}
                                :label "Add an installed program to the bottom of the Runner's Stack"
                                :msg (msg "add " (:title target) " to the bottom of the Runner's Stack")
                                :effect (effect (move :runner target :deck))})]
@@ -2616,7 +2625,7 @@
                                     (when (= 1 unique-types)
                                       (continue-ability
                                         state side
-                                        {:choices {:req installed?}
+                                        {:choices {:card installed?}
                                          :prompt "Choose an installed card"
                                          :msg (msg "place 3 advancement tokens on "
                                                    (card-str state target))
@@ -2717,9 +2726,9 @@
                    :prompt "Select an AI program to trash"
                    :msg (msg "trash " (:title target))
                    :label "Trash an AI program"
-                   :choices {:req #(and (installed? %)
-                                        (program? %)
-                                        (has-subtype? % "AI"))}
+                   :choices {:card #(and (installed? %)
+                                         (program? %)
+                                         (has-subtype? % "AI"))}
                    :effect (effect (trash eid target nil))}]}
 
    "SYNC BRE"
@@ -2738,7 +2747,8 @@
                    :effect (effect (draw eid 1 nil))}
                   {:req (req (pos? (count (:hand corp))))
                    :prompt "Choose a card in HQ to move to the top of R&D"
-                   :choices {:req #(and (in-hand? %) (corp? %))}
+                   :choices {:card #(and (in-hand? %)
+                                         (corp? %))}
                    :msg "add 1 card in HQ to the top of R&D"
                    :effect (effect (move target :deck {:front true}))}]}
 
@@ -2750,7 +2760,7 @@
     :implementation "Does not restrict usage of swap ability to start of turn or after pass"
     :abilities [{:label "Swap Thimblerig with a piece of ice"
                  :prompt "Choose a piece of ice to swap Thimblerig with"
-                 :choices {:req ice?
+                 :choices {:card ice?
                            :not-self true}
                  :effect (effect (swap-ice card target))
                  :msg (msg "swap " (card-str state card) " with " (card-str state target))}]
@@ -2786,8 +2796,8 @@
                                     {:req (req (pos? (count (filter resource? (all-installed state :runner)))))
                                      :async true
                                      :choices {:all true
-                                               :req #(and (installed? %)
-                                                          (resource? %))}
+                                               :card #(and (installed? %)
+                                                           (resource? %))}
                                      :effect (req (wait-for (trash state side target {:cause :subroutine})
                                                             (complete-with-result state side eid target)))}
                                     card nil)
@@ -2810,9 +2820,9 @@
                              (update! state :corp new-card)
                              (update! state :corp (assoc-in card [:special :tldr] card-list))))}]
     :abilities [{:label "Double subroutines on an ICE"
-                 :choices {:req #(and (ice? %)
-                                      (installed? %)
-                                      (rezzed? %))}
+                 :choices {:card #(and (ice? %)
+                                       (installed? %)
+                                       (rezzed? %))}
                  :effect (req (let [curr-subs (:subroutines target)
                                     new-subs (into [] (interleave curr-subs curr-subs))
                                     new-card (assoc target :subroutines new-subs)]
@@ -2849,8 +2859,8 @@
     :subroutines [{:prompt "Select a card to trash"
                    :label "Trash 1 installed Runner card"
                    :msg (msg "trash " (:title target))
-                   :choices {:req #(and (installed? %)
-                                        (runner? %))}
+                   :choices {:card #(and (installed? %)
+                                         (runner? %))}
                    :async true
                    :effect (req (trash state side eid target {:cause :subroutine}))}
                   (trace-ability 6 {:label "The Runner cannot steal or trash Corp cards for the remainder of this run"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -127,8 +127,8 @@
                                                {:prompt (str "Choose 3 starting directives")
                                                 :choices {:max 3
                                                           :all true
-                                                          :req #(and (runner? %)
-                                                                     (in-play-area? %))}
+                                                          :card #(and (runner? %)
+                                                                      (in-play-area? %))}
                                                 :effect (req (doseq [c targets]
                                                                (runner-install state side c {:ignore-all-cost true
                                                                                              :custom-message (str "starts with " (:title c) " in play")}))
@@ -186,8 +186,8 @@
                   :label "Install a card facedown (start of turn)"
                   :once :per-turn
                   :choices {:max 1
-                            :req #(and (runner? %)
-                                       (in-hand? %))}
+                            :card #(and (runner? %)
+                                        (in-hand? %))}
                   :req (req (and (pos? (count (:hand runner)))
                                  (:runner-phase-12 @state)))
                   :async true
@@ -230,12 +230,12 @@
                                                "non-agenda"
                                                "piece of ice")
                                              " in HQ to install with Asa Group: Security Through Vigilance (optional)")
-                                :choices {:req #(and (in-hand? %)
-                                                     (corp? %)
-                                                     (corp-installable-type? %)
-                                                     (not (agenda? %))
-                                                     (or (is-remote? z)
-                                                         (ice? %)))}
+                                :choices {:card #(and (in-hand? %)
+                                                      (corp? %)
+                                                      (corp-installable-type? %)
+                                                      (not (agenda? %))
+                                                      (or (is-remote? z)
+                                                          (ice? %)))}
                                 :async true
                                 :effect (effect (corp-install eid target (zone->name z) nil))}
                                card nil)))}]}
@@ -261,8 +261,8 @@
                               :async true
                               :choices {:max 4
                                         :all true
-                                        :req #(and (runner? %)
-                                                   (in-play-area? %))}
+                                        :card #(and (runner? %)
+                                                    (in-play-area? %))}
                               :effect (req (doseq [c targets]
                                              (host state side (get-card state card) c {:facedown true}))
                                            (doseq [c (get-in @state [:runner :play-area])]
@@ -312,7 +312,7 @@
    "Blue Sun: Powering the Future"
    {:flags {:corp-phase-12 (req (and (not (:disabled card))
                                      (some rezzed? (all-installed state :corp))))}
-    :abilities [{:choices {:req rezzed?}
+    :abilities [{:choices {:card rezzed?}
                  :label "Add 1 rezzed card to HQ and gain credits equal to its rez cost"
                  :msg (msg "add " (:title target) " to HQ and gain " (rez-cost state side target) " [Credits]")
                  :effect (effect (gain-credits (rez-cost state side target))
@@ -467,8 +467,8 @@
                              (has-most-faction? state :corp "Weyland Consortium")
                              (some ice? (all-installed state side))))
               :prompt "Select a piece of ICE to place 1 advancement token on"
-              :choices {:req #(and (installed? %)
-                                   (ice? %))}
+              :choices {:card #(and (installed? %)
+                                    (ice? %))}
               :msg (msg "place 1 advancement token on " (card-str state target))
               :effect (req (add-prop state :corp target :advance-counter 1 {:placed true}))}]}
 
@@ -518,10 +518,10 @@
                                 {:prompt "Select a Bioroid to rez"
                                  :player :corp
                                  :choices
-                                 {:five (req (and (has-subtype? target "Bioroid")
-                                                  (not (rezzed? target))
-                                                  (can-pay? state side eid card nil
-                                                            [:credit (rez-cost state side target {:cost-bonus -4})])))}
+                                 {:req (req (and (has-subtype? target "Bioroid")
+                                                 (not (rezzed? target))
+                                                 (can-pay? state side eid card nil
+                                                           [:credit (rez-cost state side target {:cost-bonus -4})])))}
                                  :msg (msg "rez " (:title target))
                                  :cancel-effect (effect (clear-wait-prompt :runner)
                                                         (effect-completed eid))
@@ -583,8 +583,8 @@
                           {:prompt (msg "Install another " card-type " from your Grip?")
                            :yes-ability
                            {:prompt (msg "Select another " card-type " to install from your Grip")
-                            :choices {:req #(and (is-type? % card-type)
-                                                 (in-hand? %))}
+                            :choices {:card #(and (is-type? % card-type)
+                                                  (in-hand? %))}
                             :msg (msg "install " (:title target))
                             :async true
                             :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}
@@ -668,7 +668,8 @@
                              (continue-ability
                                state side
                                {:prompt "Select a card to place advancement tokens on with Jemison Astronautics: Sacrifice. Audacity. Success."
-                                :choices {:req #(and (installed? %) (corp? %))}
+                                :choices {:card #(and (installed? %)
+                                                      (corp? %))}
                                 :msg (msg "place " p " advancement tokens on " (card-str state target))
                                 :cancel-effect (effect (clear-wait-prompt :runner))
                                 :effect (effect (add-prop :corp target :advance-counter p {:placed true})
@@ -718,7 +719,7 @@
                                       (resolve-ability
                                         state side
                                         {:prompt "Select a card that can be advanced"
-                                         :choices {:req can-be-advanced?}
+                                         :choices {:card can-be-advanced?}
                                          :effect (effect (add-prop target :advance-counter 4 {:placed true}))} card nil)))
                                 (update! state side (assoc (get-card state card) :biotech-used true))))}]}
 
@@ -818,10 +819,10 @@
                                       (:hand runner))
                             {:prompt "Select an icebreaker to install from your Grip"
                              :choices
-                             {:five (req (and (in-hand? target)
-                                              (has-subtype? target "Icebreaker")
-                                              (can-pay? state side eid card nil
-                                                        [:credit (install-cost state side target {:cost-bonus -1})])))}
+                             {:req (req (and (in-hand? target)
+                                             (has-subtype? target "Icebreaker")
+                                             (can-pay? state side eid card nil
+                                                       [:credit (install-cost state side target {:cost-bonus -1})])))}
                              :async true
                              :msg (msg "install " (:title target) ", lowering the cost by 1 [Credits]")
                              :effect (effect (runner-install eid target {:cost-bonus -1}))})
@@ -859,9 +860,9 @@
    "Leela Patel: Trained Pragmatist"
    (let [leela {:interactive (req true)
                 :prompt "Select an unrezzed card to return to HQ"
-                :choices {:req #(and (not (rezzed? %))
-                                     (installed? %)
-                                     (corp? %))}
+                :choices {:card #(and (not (rezzed? %))
+                                      (installed? %)
+                                      (corp? %))}
                 :msg (msg "add " (card-str state target) " to HQ")
                 :effect (effect (move :corp target :hand))}]
      {:events [(assoc leela :event :agenda-scored)
@@ -909,8 +910,8 @@
                                  (not (contains? run :successful))))
                   :prompt "Choose ICE to install from HQ"
                   :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
-                  :choices {:req #(and (ice? %)
-                                       (in-hand? %))}
+                  :choices {:card #(and (ice? %)
+                                        (in-hand? %))}
                   :async true
                   :effect (req (corp-install state side eid target (zone->name (first (:server run)))
                                              {:ignore-all-cost true
@@ -996,9 +997,9 @@
                  :yes-ability {:prompt "Select a Current to play from HQ or Archives"
                                :show-discard true
                                :async true
-                               :choices {:req #(and (has-subtype? % "Current")
-                                                    (corp? %)
-                                                    (#{[:hand] [:discard]} (:zone %)))}
+                               :choices {:card #(and (has-subtype? % "Current")
+                                                     (corp? %)
+                                                     (#{[:hand] [:discard]} (:zone %)))}
                                :msg (msg "play a current from " (name-zone "Corp" (:zone target)))
                                :effect (effect (play-instant eid target))}}}]
      {:events [(assoc nasol :event :agenda-scored)
@@ -1007,9 +1008,9 @@
    "NEXT Design: Guarding the Net"
    (let [ndhelper (fn nd [n] {:prompt (str "When finished, click NEXT Design: Guarding the Net to draw back up to 5 cards in HQ. "
                                            "Select a piece of ICE in HQ to install:")
-                              :choices {:req #(and (corp? %)
-                                                   (ice? %)
-                                                   (in-hand? %))}
+                              :choices {:card #(and (corp? %)
+                                                    (ice? %)
+                                                    (in-hand? %))}
                               :effect (req (wait-for (corp-install state side target nil nil)
                                                      (continue-ability state side (when (< n 3) (nd (inc n))) card nil)))})]
      {:events [{:event :pre-first-turn
@@ -1044,7 +1045,7 @@
                                 (rezzed? current-ice)
                                 (pos? (count (:hand runner)))))
                  :prompt "Select a card in your Grip to trash"
-                 :choices {:req in-hand?}
+                 :choices {:card in-hand?}
                  :msg (msg "trash " (:title target) " and reduce the strength of " (:title current-ice)
                            " by 2 for the remainder of the run")
                  :effect (effect (update! (assoc-in card [:special :null-target] current-ice))
@@ -1152,9 +1153,9 @@
                    :label "Install a card from HQ"
                    :cost [:click 1 :credit 1]
                    :prompt "Select a card to install from HQ"
-                   :choices {:req #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))
-                                     (corp? %)
-                                     (in-hand? %))}
+                   :choices {:card #(and (#{"Asset" "Agenda" "Upgrade"} (:type %))
+                                      (corp? %)
+                                      (in-hand? %))}
                    :msg (msg "install a card in a remote server and place 1 advancement token on it")
                    :effect (effect (continue-ability (install-card target) card nil))}]})
 
@@ -1164,7 +1165,8 @@
                  :once :per-turn
                  :prompt "Select a card to add to the top of R&D"
                  :show-discard true
-                 :choices {:req #(and (corp? %) (in-discard? %))}
+                 :choices {:card #(and (corp? %)
+                                       (in-discard? %))}
                  :effect (effect (move target :deck {:front true}))
                  :msg (msg "add " (if (:seen target) (:title target) "a card") " to the top of R&D")}]}
 
@@ -1174,8 +1176,8 @@
               :async true
               :req (req (and (= target :hq)
                              (first-successful-run-on-server? state :hq)))
-              :effect (effect (continue-ability {:choices {:req #(and (installed? %)
-                                                                      (not (rezzed? %)))}
+              :effect (effect (continue-ability {:choices {:card #(and (installed? %)
+                                                                       (not (rezzed? %)))}
                                                  :effect (effect (expose eid target))
                                                  :msg "expose 1 card"
                                                  :async true}
@@ -1258,7 +1260,7 @@
                                 state side
                                 {:prompt (str "Select ICE with no advancement tokens to place "
                                               (quantify agenda-points "advancement token") " on")
-                                 :choices {:req #(selectable-ice? %)}
+                                 :choices {:card #(selectable-ice? %)}
                                  :msg (msg "places " (quantify agenda-points "advancement token")
                                            " on ICE with no advancement tokens")
                                  :effect (req (add-prop state :corp target :advance-counter agenda-points {:placed true})
@@ -1277,8 +1279,8 @@
               :prompt "Select 2 cards in your Heap"
               :show-discard true
               :choices {:max 2
-                        :req #(and (in-discard? %)
-                                   (runner? %))}
+                        :card #(and (in-discard? %)
+                                    (runner? %))}
               :effect (req (let [c1 (first targets)
                                  c2 (second targets)]
                              (show-wait-prompt state :runner "Corp to choose which card to remove from the game")
@@ -1307,8 +1309,8 @@
                              (has-most-faction? state :corp "Haas-Bioroid")
                              (pos? (count (:discard corp)))))
               :prompt "Select a card in Archives to shuffle into R&D"
-              :choices {:req #(and (corp? %)
-                                   (in-discard? %))}
+              :choices {:card #(and (corp? %)
+                                    (in-discard? %))}
               :player :corp
               :show-discard true
               :priority true
@@ -1353,8 +1355,8 @@
                                      (has-most-faction? state :corp "Jinteki")
                                      (> (count (filter ice? (all-installed state :corp))) 1)))}
     :abilities [{:prompt "Select two pieces of ICE to swap positions"
-                 :choices {:req #(and (installed? %)
-                                      (ice? %))
+                 :choices {:card #(and (installed? %)
+                                       (ice? %))
                            :max 2}
                  :once :per-turn
                  :effect (req (when (= (count targets) 2)
@@ -1367,7 +1369,7 @@
                                      (not-last-turn? state :runner :successful-run)))}
     :abilities [{:msg (msg "place 1 advancement token on " (card-str state target))
                  :label "Place 1 advancement token on a card if the Runner did not make a successful run last turn"
-                 :choices {:req installed?}
+                 :choices {:card installed?}
                  :req (req (and (:corp-phase-12 @state) (not-last-turn? state :runner :successful-run)))
                  :once :per-turn
                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]}

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -20,9 +20,9 @@
     :effect (req (continue-ability
                    state side
                    {:prompt "Select an agenda in your score area to trigger its \"when scored\" ability"
-                    :choices {:req #(and (agenda? %)
-                                         (when-scored? %)
-                                         (is-scored? state :corp %))}
+                    :choices {:card #(and (agenda? %)
+                                          (when-scored? %)
+                                          (is-scored? state :corp %))}
                     :msg (msg "trigger the \"when scored\" ability of " (:title target))
                     :async true
                     :effect (effect (continue-ability (card-def target) target nil)
@@ -58,10 +58,10 @@
                {:async true
                 :show-discard true
                 :prompt "Select an Advertisement to install and rez"
-                :choices {:req #(and (corp? %)
-                                     (has-subtype? % "Advertisement")
-                                     (or (in-hand? %)
-                                         (in-discard? %)))}
+                :choices {:card #(and (corp? %)
+                                      (has-subtype? % "Advertisement")
+                                      (or (in-hand? %)
+                                          (in-discard? %)))}
                 :effect (req (wait-for (corp-install state side target nil {:install-state :rezzed})
                                        (continue-ability state side (ab (inc n) total) card nil)))}))]
      {:async true
@@ -113,9 +113,9 @@
                      state side
                      {:prompt "Select a card from Archives to add to HQ"
                       :show-discard true
-                      :choices {:req #(and (not= (:cid %) cid)
-                                           (corp? %)
-                                           (in-discard? %))}
+                      :choices {:card #(and (not= (:cid %) cid)
+                                            (corp? %)
+                                            (in-discard? %))}
                       :effect (effect (move target :hand)
                                       (system-msg (str "adds " (if (:seen target) (:title target) "an unseen card") " to HQ")))}
                      card nil)))}
@@ -137,10 +137,10 @@
                              state side
                              {:prompt "Choose up to 2 agendas in HQ or Archives"
                               :choices {:max 2
-                                        :req #(and (corp? %)
-                                                   (agenda? %)
-                                                   (or (in-hand? %)
-                                                       (in-discard? %)))}
+                                        :card #(and (corp? %)
+                                                    (agenda? %)
+                                                    (or (in-hand? %)
+                                                        (in-discard? %)))}
                               :effect (req (gain-credits state side (* 2 (count targets)))
                                            (doseq [c targets]
                                              (move state :corp c :deck))
@@ -166,7 +166,7 @@
              (if (< n 2)
                {:prompt "Choose a card on which to place an advancement"
                 :async true
-                :choices {:req can-be-advanced?
+                :choices {:card can-be-advanced?
                           :all true}
                 :msg (msg "place an advancement token on " (card-str state target))
                 :effect (req (add-prop state :corp target :advance-counter 1 {:placed true})
@@ -181,8 +181,8 @@
    "Back Channels"
    {:async true
     :prompt "Select an installed card in a server to trash"
-    :choices {:req #(and (= (last (:zone %)) :content)
-                         (is-remote? (second (:zone %))))}
+    :choices {:card #(and (= (last (:zone %)) :content)
+                          (is-remote? (second (:zone %))))}
     :effect (effect (gain-credits (* 3 (get-counters target :advancement)))
                     (trash eid target nil))
     :msg (msg "trash " (card-str state target) " and gain "
@@ -216,9 +216,9 @@
                 (let [t (count-tags state)]
                   {:async true
                    :prompt (msg "Choose a Runner card with an install cost of " t " or less to trash")
-                   :choices {:req #(and (runner? %)
-                                        (installed? %)
-                                        (<= (:cost %) t))}
+                   :choices {:card #(and (runner? %)
+                                         (installed? %)
+                                         (<= (:cost %) t))}
                    :msg (msg "trash " (:title target))
                    :effect (effect (trash eid target nil))})
                 card nil))}
@@ -238,7 +238,8 @@
                          state :runner
                          {:prompt (msg "Choose any number of cards of type " t " to trash")
                           :choices {:max n
-                                    :req #(and (installed? %) (is-type? % t))}
+                                    :card #(and (installed? %)
+                                                (is-type? % t))}
                           :effect (req (doseq [c targets]
                                          (trash state :runner c {:unpreventable true}))
                                        (gain-credits state :runner (count targets))
@@ -268,10 +269,10 @@
                           (has-subtype? % "Bioroid")
                           (not (rezzed? %)))
                     (all-installed state :corp)))
-    :choices {:req #(and (ice? %)
-                         (has-subtype? % "Bioroid")
-                         (installed? %)
-                         (not (rezzed? %)))}
+    :choices {:card #(and (ice? %)
+                          (has-subtype? % "Bioroid")
+                          (installed? %)
+                          (not (rezzed? %)))}
     :msg (msg "rez " (card-str state target {:visible true}) " at no cost")
     :effect (req (wait-for (rez state side target {:ignore-cost :all-costs})
                            (host state side (get-card state target) (assoc card :seen true :condition true))
@@ -296,9 +297,9 @@
    "Building Blocks"
    {:req (req (pos? (count (filter #(has-subtype? % "Barrier") (:hand corp)))))
     :prompt "Select a Barrier to install and rez"
-    :choices {:req #(and (corp? %)
-                         (has-subtype? % "Barrier")
-                         (in-hand? %))}
+    :choices {:card #(and (corp? %)
+                          (has-subtype? % "Barrier")
+                          (in-hand? %))}
     :async true
     :msg (msg "reveal " (:title target))
     :effect (effect (reveal target)
@@ -306,8 +307,8 @@
                                                   :install-state :rezzed-no-cost}))}
 
    "Casting Call"
-   {:choices {:req #(and (agenda? %)
-                         (in-hand? %))}
+   {:choices {:card #(and (agenda? %)
+                          (in-hand? %))}
     :async true
     :effect (effect
               (continue-ability
@@ -332,8 +333,8 @@
 
    "Celebrity Gift"
    {:choices {:max 5
-              :req #(and (corp? %)
-                         (in-hand? %))}
+              :card #(and (corp? %)
+                          (in-hand? %))}
     :msg (msg "reveal " (join ", " (map :title (sort-by :title targets))) " and gain " (* 2 (count targets)) " [Credits]")
     :effect (effect (reveal targets) (gain-credits (* 2 (count targets))))}
 
@@ -365,7 +366,7 @@
 
    "Commercialization"
    {:msg (msg "gain " (get-counters target :advancement) " [Credits]")
-    :choices {:req ice?}
+    :choices {:card ice?}
     :effect (effect (gain-credits (get-counters target :advancement)))}
 
    "Complete Image"
@@ -427,12 +428,12 @@
 
    "Dedication Ceremony"
    {:prompt "Select a faceup card"
-    :choices {:req #(or (and (corp? %)
-                             (rezzed? %))
-                        (and (runner? %)
-                             (or (installed? %)
-                                 (:host %))
-                             (not (facedown? %))))}
+    :choices {:card #(or (and (corp? %)
+                              (rezzed? %))
+                         (and (runner? %)
+                              (or (installed? %)
+                                  (:host %))
+                              (not (facedown? %))))}
     :msg (msg "place 3 advancement tokens on " (card-str state target))
     :effect (effect (add-prop target :advance-counter 3 {:placed true})
                     (register-turn-flag!
@@ -470,7 +471,9 @@
                    (shuffle! state side :deck)
                    (continue-ability state side
                                      {:prompt "You may install a card in HQ"
-                                      :choices {:req #(and (in-hand? %) (corp? %) (not (operation? %)))}
+                                      :choices {:card #(and (in-hand? %)
+                                                            (corp? %)
+                                                            (not (operation? %)))}
                                       :effect (req (wait-for (resolve-ability
                                                                state side
                                                                (let [card-to-install target]
@@ -490,8 +493,8 @@
          trash-from-hq {:async true
                         :prompt "Select up to 2 cards in HQ to trash"
                         :choices {:max 2
-                                  :req #(and (corp? %)
-                                             (in-hand? %))}
+                                  :card #(and (corp? %)
+                                              (in-hand? %))}
                         :msg (msg "trash " (quantify (count targets) "card") " from HQ")
                         :effect (req (wait-for
                                        (trash-cards state side targets nil)
@@ -515,8 +518,8 @@
    "Divert Power"
    {:async true
     :prompt "Select any number of cards to derez"
-    :choices {:req #(and (installed? %)
-                         (rezzed? %))
+    :choices {:card #(and (installed? %)
+                          (rezzed? %))
               :max (req (count (filter rezzed? (all-installed state :corp))))}
     :effect (req (doseq [c targets]
                    (derez state side c))
@@ -525,10 +528,10 @@
                      state side
                      {:async true
                       :prompt "Select a card to rez"
-                      :choices {:req #(and (installed? %)
-                                           (corp? %)
-                                           (not (rezzed? %))
-                                           (not (agenda? %)))}
+                      :choices {:card #(and (installed? %)
+                                            (corp? %)
+                                            (not (rezzed? %))
+                                            (not (agenda? %)))}
                       :effect (effect (rez eid target {:cost-bonus discount}))}
                      card nil)))}
 
@@ -546,8 +549,8 @@
 
    "Eavesdrop"
    {:implementation "On encounter effect is manual"
-    :choices {:req #(and (ice? %)
-                         (installed? %))}
+    :choices {:card #(and (ice? %)
+                          (installed? %))}
     :msg (msg "give " (card-str state target {:visible false}) " additional text")
     :effect (effect (host target (assoc card :seen true :condition true)))
     :leave-play (req (remove-extra-subs! state :corp (:cid card) (:host card)))
@@ -587,9 +590,9 @@
                             (continue-ability
                               state side
                               {:prompt "Select an installed card not matching the faction of the Runner's identity"
-                               :choices {:req #(and (installed? %)
-                                                    (not= f (:faction %))
-                                                    (runner? %))}
+                               :choices {:card #(and (installed? %)
+                                                     (not= f (:faction %))
+                                                     (runner? %))}
                                :msg (msg "trash " (:title target))
                                :effect (effect (trash target))}
                               card nil)))}}}
@@ -610,14 +613,14 @@
               (continue-ability
                 state side
                 {:prompt "Select a stolen agenda in the Runner's score area to swap"
-                 :choices {:req #(in-runner-scored? state side %)}
+                 :choices {:card #(in-runner-scored? state side %)}
                  :async true
                  :effect (req
                            (let [stolen target]
                              (continue-ability
                                state side
                                {:prompt (msg "Select a scored agenda to swap for " (:title stolen))
-                                :choices {:req #(in-corp-scored? state side %)}
+                                :choices {:card #(in-corp-scored? state side %)}
                                 :effect (req (let [scored target]
                                                (swap-agendas state side scored stolen)
                                                (system-msg state side (str "uses Exchange of Information to swap "
@@ -641,10 +644,10 @@
                install-cards (fn install-cards
                                [server n]
                                {:prompt "Select a card to install"
-                                :choices {:req #(and (corp? %)
-                                                     (not (operation? %))
-                                                     (in-hand? %)
-                                                     (seq (filter (fn [c] (= server c)) (corp-install-list state %))))}
+                                :choices {:card #(and (corp? %)
+                                                      (not (operation? %))
+                                                      (in-hand? %)
+                                                      (seq (filter (fn [c] (= server c)) (corp-install-list state %))))}
                                 :effect (req (wait-for
                                                (corp-install state side target server nil)
                                                (let [server (if (= "New remote" server)
@@ -686,7 +689,8 @@
                                               (if (= target "Yes")
                                                 {:player :runner
                                                  :prompt "Select a resource to trash"
-                                                 :choices {:req #(and (resource? %) (installed? %))}
+                                                 :choices {:card #(and (resource? %)
+                                                                       (installed? %))}
                                                  :effect (req (trash state side target {:unpreventable true})
                                                               (system-msg state :runner
                                                                           (str "trashes " (:title target)
@@ -726,7 +730,7 @@
                                                state :corp
                                                {:msg (msg "place " (quantify c " advancement token") " on "
                                                           (card-str state target))
-                                                :choices {:req installed?}
+                                                :choices {:card installed?}
                                                 :effect (effect (add-prop target :advance-counter c {:placed true}))}
                                                card nil))
                                          (effect-completed state side eid))))}
@@ -737,9 +741,9 @@
    {:trace {:base 7
             :successful {:prompt "Select 1 card to trash"
                          :not-distinct true
-                         :choices {:req #(and (installed? %)
-                                              (or (has-subtype? % "Virtual")
-                                                  (has-subtype? % "Link")))}
+                         :choices {:card #(and (installed? %)
+                                               (or (has-subtype? % "Virtual")
+                                                   (has-subtype? % "Link")))}
                          :msg "trash 1 virtual resource or link"
                          :effect (effect (trash target)
                                          (system-msg (str "trashes " (:title target))))}}}
@@ -748,8 +752,8 @@
    {:req (req tagged)
     :msg (msg "trash " (join ", " (map :title (sort-by :title targets))))
     :choices {:max 2
-              :req #(and (installed? %)
-                         (resource? %))}
+              :card #(and (installed? %)
+                          (resource? %))}
     :effect (effect (trash-cards :runner targets))}
 
    "Friends in High Places"
@@ -757,9 +761,9 @@
                               :priority -1
                               :async true
                               :show-discard true
-                              :choices {:req #(and (corp? %)
-                                                   (not (operation? %))
-                                                   (in-discard? %))}
+                              :choices {:card #(and (corp? %)
+                                                    (not (operation? %))
+                                                    (in-discard? %))}
                               :effect (req (wait-for
                                              (corp-install state side target nil nil)
                                              (do (system-msg state side (str "uses Friends in High Places to "
@@ -819,9 +823,9 @@
                         :req (req (<= 3 (:credit runner)))
                         :prompt (msg "Prevent any " typemsg " from being trashed? Pay 3 [Credits] per card.")
                         :choices {:max (req (min numtargets (quot (:credit runner) 3)))
-                                  :req #(and (installed? %)
-                                             (is-type? % type)
-                                             (not (has-subtype? % "Icebreaker")))}
+                                  :card #(and (installed? %)
+                                              (is-type? % type)
+                                              (not (has-subtype? % "Icebreaker")))}
                         :effect (req (pay state :runner card :credit (* 3 (count targets)))
                                      (system-msg
                                        state :runner
@@ -853,8 +857,8 @@
    {:req (req (last-turn? state :runner :trashed-card))
     :async true
     :prompt "Choose an installed Corp card"
-    :choices {:req #(and (corp? %)
-                         (installed? %))}
+    :choices {:card #(and (corp? %)
+                          (installed? %))}
     :effect (effect (show-wait-prompt :corp "Runner to resolve Hangeki")
                     (continue-ability
                       {:optional
@@ -912,9 +916,9 @@
 
    "Hatchet Job"
    {:trace {:base 5
-            :successful {:choices {:req #(and (installed? %)
-                                              (runner? %)
-                                              (not (has-subtype? % "Virtual")))}
+            :successful {:choices {:card #(and (installed? %)
+                                               (runner? %)
+                                               (not (has-subtype? % "Virtual")))}
                          :msg "add an installed non-virtual card to the Runner's grip"
                          :effect (effect (move :runner target :hand true))}}}
 
@@ -925,8 +929,8 @@
    {:req (req (last-turn? state :runner :installed-resource))
     :trace {:base 2
             :successful {:msg "add a Resource to the top of the Stack"
-                         :choices {:req #(and (installed? %)
-                                              (resource? %))}
+                         :choices {:card #(and (installed? %)
+                                               (resource? %))}
                          :effect (effect (move :runner target :deck {:front true})
                                          (system-msg (str "adds " (:title target) " to the top of the Stack")))}
             :unsuccessful {:msg "take 1 bad publicity"
@@ -941,8 +945,8 @@
                                                                    (concat (all-installed state :corp)
                                                                            (all-installed state :runner))))))
                                    :all true
-                                   :req #(and (installed? %)
-                                              (not (program? %)))}
+                                   :card #(and (installed? %)
+                                               (not (program? %)))}
                          :msg (msg "trash " (join ", " (map :title (sort-by :title targets))))
                          :effect (req (doseq [c targets]
                                         (trash state side c)))}
@@ -954,8 +958,8 @@
     :effect (req (wait-for (draw state side 3 nil)
                            (continue-ability state side
                                              {:prompt "Select a card in HQ to put on top of R&D"
-                                              :choices {:req #(and (corp? %)
-                                                                   (in-hand? %))}
+                                              :choices {:card #(and (corp? %)
+                                                                    (in-hand? %))}
                                               :msg "draw 3 cards and add 1 card from HQ to the top of R&D"
                                               :effect (effect (move target :deck {:front true}))}
                                              card nil)))}
@@ -972,8 +976,8 @@
               :player :runner
               :once :per-turn
               :prompt "Select a card from your Grip to trash for Housekeeping"
-              :choices {:req #(and (runner? %)
-                                   (in-hand? %))}
+              :choices {:card #(and (runner? %)
+                                    (in-hand? %))}
               :msg (msg "force the Runner to trash " (:title target) " from their Grip")
               :effect (effect (trash target {:unpreventable true}))}]}
 
@@ -981,7 +985,7 @@
    {:req (req (last-turn? state :runner :stole-agenda))
     :async true
     :prompt "Choose a card to trash"
-    :choices {:req installed?}
+    :choices {:card installed?}
     :msg (msg "trash " (card-str state target))
     :effect (effect (trash target))}
 
@@ -990,9 +994,9 @@
     :prompt "Select a card to install from Archives or HQ"
     :show-discard true
     :not-distinct true
-    :choices {:req #(and (not (operation? %))
-                         (corp? %)
-                         (#{[:hand] [:discard]} (:zone %)))}
+    :choices {:card #(and (not (operation? %))
+                          (corp? %)
+                          (#{[:hand] [:discard]} (:zone %)))}
     :effect (effect (corp-install eid target nil {:ignore-install-cost true}))
     :msg (msg (corp-install-msg target))}
 
@@ -1055,9 +1059,9 @@
     :effect (effect (gain-credits 4)
                     (continue-ability {:player :corp
                                        :prompt "Select a card to install"
-                                       :choices {:req #(and (corp? %)
-                                                            (not (operation? %))
-                                                            (in-hand? %))}
+                                       :choices {:card #(and (corp? %)
+                                                             (not (operation? %))
+                                                             (in-hand? %))}
                                        :async true
                                        :msg (msg (corp-install-msg target))
                                        :effect (effect (corp-install eid target nil nil))}
@@ -1074,8 +1078,8 @@
                      {:async true
                       :prompt "Select any number of rezzed cards to trash"
                       :choices {:max n
-                                :req #(and (rezzed? %)
-                                           (not (agenda? %)))}
+                                :card #(and (rezzed? %)
+                                            (not (agenda? %)))}
                       :msg (msg "trash " (join ", " (map :title targets))
                                 " and gain " (* (count targets) 3) " [Credits]")
                       :effect (req (wait-for (trash-cards state side targets nil)
@@ -1136,9 +1140,9 @@
    {:req (req (not-empty (filter #(has-subtype? % "Connection")
                                  (all-active-installed state :runner))))
     :prompt "Choose a connection to host MCA Informant on"
-    :choices {:req #(and (runner? %)
-                         (has-subtype? % "Connection")
-                         (installed? %))}
+    :choices {:card #(and (runner? %)
+                          (has-subtype? % "Connection")
+                          (installed? %))}
     :msg (msg "host it on " (card-str state target) ". The Runner has an additional tag")
     :effect (req (host state side (get-card state target) (assoc card :seen true))
                  (swap! state update-in [:runner :tag :additional] inc)
@@ -1161,8 +1165,8 @@
     (effect
       (continue-ability
         {:prompt "Select an agenda in the runner's score area"
-         :choices {:req #(and (agenda? %)
-                              (is-scored? state :runner %))}
+         :choices {:card #(and (agenda? %)
+                               (is-scored? state :runner %))}
          :effect (req (update! state side (assoc card :title (:title target)))
                       ;; TODO: Move reverting the name back to here when we move
                       ;; abilities into the card object and stop relying on `card-def`.
@@ -1189,9 +1193,9 @@
 
    "Mushin No Shin"
    {:prompt "Select a card to install from HQ"
-    :choices {:req #(and (not (operation? %))
-                         (corp? %)
-                         (in-hand? %))}
+    :choices {:card #(and (not (operation? %))
+                          (corp? %)
+                          (in-hand? %))}
     :async true
     :effect (req (wait-for (corp-install state side target "New remote" nil)
                            (let [target (find-latest state target)]
@@ -1217,8 +1221,8 @@
                           (rezzed? %))
                     (all-installed state :corp)))
     :prompt "Select a rezzed piece of ice to trash"
-    :choices {:req #(and (ice? %)
-                         (rezzed? %))}
+    :choices {:card #(and (ice? %)
+                          (rezzed? %))}
     :async true
     :effect (req (let [i (ice-index state target)
                        [revealed-cards r] (split-with (complement ice?) (get-in @state [:corp :deck]))
@@ -1277,21 +1281,23 @@
     :req (req (and (pos? (count-tags state))
                    (< (:credit runner) 6)))
     :prompt "Select an installed card to trash"
-    :choices {:req #(and (runner? %)
-                         (installed? %))}
+    :choices {:card #(and (runner? %)
+                          (installed? %))}
     :msg (msg "remove 1 Runner tag and trash " (card-str state target))
     :effect (effect (trash eid target nil))}
 
    "Oversight AI"
    {:implementation "Trashing ICE is manual"
-    :choices {:req #(and (ice? %) (not (rezzed? %)) (= (last (:zone %)) :ices))}
+    :choices {:card #(and (ice? %)
+                          (not (rezzed? %))
+                          (= (last (:zone %)) :ices))}
     :msg (msg "rez " (:title target) " at no cost")
     :effect (effect (rez target {:ignore-cost :all-costs})
                     (host (get-card state target) (assoc card :seen true :condition true)))}
 
    "Patch"
-   {:choices {:req #(and (ice? %)
-                         (rezzed? %))}
+   {:choices {:card #(and (ice? %)
+                          (rezzed? %))}
     :msg (msg "give +2 strength to " (card-str state target))
     :effect (req (let [card (host state side target (assoc card :seen true :condition true))]
                    (update-ice-strength state side (get-card state target))))
@@ -1322,8 +1328,8 @@
                          :effect (req (let [max-cost (- target (second targets))]
                                         (continue-ability
                                           state side
-                                          {:choices {:req #(and (hardware? %)
-                                                                (<= (:cost %) max-cost))}
+                                          {:choices {:card #(and (hardware? %)
+                                                                 (<= (:cost %) max-cost))}
                                            :msg (msg "trash " (:title target))
                                            :effect (effect (trash target))}
                                           card nil))
@@ -1344,8 +1350,8 @@
                  (let [n target]
                    (continue-ability state :runner
                                      {:prompt "Select a Program or piece of Hardware to trash"
-                                      :choices {:req #(and (#{"Hardware" "Program"} (:type %))
-                                                           (<= (:cost %) n))}
+                                      :choices {:card #(and (#{"Hardware" "Program"} (:type %))
+                                                            (<= (:cost %) n))}
                                       :msg (msg "trash " (:title target))
                                       :effect (effect (trash target))}
                                      card nil)))}
@@ -1378,7 +1384,9 @@
               :effect (effect (corp-install eid (assoc chosen :advance-counter 3) target {:ignore-all-cost true}))})]
      {:async true
       :prompt "Choose a piece of ICE in HQ to install"
-      :choices {:req #(and (in-hand? %) (corp? %) (ice? %))}
+      :choices {:card #(and (in-hand? %)
+                         (corp? %)
+                         (ice? %))}
       :msg "install an ICE from HQ and place 3 advancements on it"
       :cancel-effect (req (effect-completed state side eid))
       :effect (effect (continue-ability (install-card target) card nil))})
@@ -1386,9 +1394,9 @@
    "Product Recall"
    {:async true
     :prompt "Select a rezzed asset or upgrade to trash"
-    :choices {:req #(and (rezzed? %)
-                         (or (asset? %)
-                             (upgrade? %)))}
+    :choices {:card #(and (rezzed? %)
+                          (or (asset? %)
+                              (upgrade? %)))}
     :msg (msg "trash " (card-str state target)
               " and gain " (trash-cost state side target) " [Credits]")
     :effect (req (wait-for (trash state side target {:unpreventable true})
@@ -1406,7 +1414,7 @@
                          (continue-ability
                            state side
                            {:msg (msg "place " (quantify c " advancement token") " on " (card-str state target))
-                            :choices {:req can-be-advanced?}
+                            :choices {:card can-be-advanced?}
                             :effect (effect (add-prop target :advance-counter c {:placed true}))}
                            card nil))
                      (effect-completed state side eid))))}
@@ -1446,9 +1454,9 @@
    "Reclamation Order"
    {:prompt "Select a card from Archives"
     :show-discard true
-    :choices {:req #(and (corp? %)
-                         (not= (:title %) "Reclamation Order")
-                         (in-discard? %))}
+    :choices {:card #(and (corp? %)
+                          (not= (:title %) "Reclamation Order")
+                          (in-discard? %))}
     :msg (msg "name " (:title target))
     :effect (req (let [title (:title target)
                        cards (filter #(= title (:title %)) (:discard corp))
@@ -1503,9 +1511,9 @@
                :effect (effect (gain :click 1))}
               {:prompt "Choose a non-agenda to install"
                :msg "install a non-agenda from hand"
-               :choices {:req #(and (not (agenda? %))
-                                    (not (operation? %))
-                                    (in-hand? %))}
+               :choices {:card #(and (not (agenda? %))
+                                     (not (operation? %))
+                                     (in-hand? %))}
                :async true
                :effect (effect (corp-install eid target nil nil))}]
          can-install? (fn [hand]
@@ -1538,7 +1546,7 @@
    {:async true
     :req (req (some #(can-be-advanced? %) (all-installed state :corp)))
     :prompt "Select an installed card that can be advanced"
-    :choices {:req can-be-advanced?}
+    :choices {:card can-be-advanced?}
     :effect (req (let [installed (get-all-installed state)
                        total-adv (reduce + (map #(get-counters % :advancement) installed))]
                    (doseq [c installed]
@@ -1553,17 +1561,17 @@
    (letfn [(replant [n]
              {:prompt "Select a card to install with Replanting"
               :async true
-              :choices {:req #(and (corp? %)
-                                   (not (operation? %))
-                                   (in-hand? %))}
+              :choices {:card #(and (corp? %)
+                                    (not (operation? %))
+                                    (in-hand? %))}
               :effect (req (wait-for (corp-install state side target nil {:ignore-all-cost true})
                                      (if (< n 2)
                                        (continue-ability state side (replant (inc n)) card nil)
                                        (effect-completed state side eid))))})]
      {:async true
       :prompt "Select an installed card to add to HQ"
-      :choices {:req #(and (corp? %)
-                           (installed? %))}
+      :choices {:card #(and (corp? %)
+                            (installed? %))}
       :msg (msg "add " (card-str state target) " to HQ, then install 2 cards ignoring all costs")
       :effect (req (move state side target :hand)
                    (resolve-ability state side (replant 1) card nil))})
@@ -1575,9 +1583,9 @@
                        :priority -1
                        :async true
                        :show-discard true
-                       :choices {:req #(and (corp? %)
-                                            (not (operation? %))
-                                            (in-discard? %))}
+                       :choices {:card #(and (corp? %)
+                                             (not (operation? %))
+                                             (in-discard? %))}
                        :effect (req (wait-for
                                       (corp-install state side target nil {:install-state :rezzed})
                                       (do (system-msg state side (str "uses Restore to "
@@ -1594,9 +1602,9 @@
    {:async true
     :prompt "Select a Sysop, Executive or Clone to trash"
     :msg (msg "trash " (:title target) " to remove 2 bad publicity")
-    :choices {:req #(or (has-subtype? % "Clone")
-                        (has-subtype? % "Executive")
-                        (has-subtype? % "Sysop"))}
+    :choices {:card #(or (has-subtype? % "Clone")
+                         (has-subtype? % "Executive")
+                         (has-subtype? % "Sysop"))}
     :effect (req (lose-bad-publicity state side 2)
                  (when (facedown? target)
                    (reveal state side target))
@@ -1613,8 +1621,8 @@
                      state side
                      {:prompt (msg "Select up to " n " cards in HQ to trash with Reuse")
                       :choices {:max n
-                                :req #(and (corp? %)
-                                           (in-hand? %))}
+                                :card #(and (corp? %)
+                                            (in-hand? %))}
                       :msg (msg (let [m (count targets)]
                                   (str "trash " (quantify m "card")
                                        " and gain " (* 2 m) " [Credits]")))
@@ -1642,8 +1650,8 @@
 
    "Rework"
    {:prompt "Select a card from HQ to shuffle into R&D"
-    :choices {:req #(and (corp? %)
-                         (in-hand? %))}
+    :choices {:card #(and (corp? %)
+                          (in-hand? %))}
     :msg "shuffle a card from HQ into R&D"
     :effect (effect (move target :deck)
                     (shuffle! :deck))}
@@ -1680,8 +1688,8 @@
               :effect (effect (gain-credits :corp 1))}]}
 
    "Rover Algorithm"
-   {:choices {:req #(and (ice? %)
-                         (rezzed? %))}
+   {:choices {:card #(and (ice? %)
+                          (rezzed? %))}
     :msg (msg "host it as a condition counter on " (card-str state target))
     :effect (effect (host target (assoc card :installed true :seen true :condition true))
                     (update-ice-strength (get-card state target)))
@@ -1765,8 +1773,8 @@
    "Self-Growth Program"
    {:req (req tagged)
     :prompt "Select two installed Runner cards"
-    :choices {:req #(and (installed? %)
-                         (runner? %))
+    :choices {:card #(and (installed? %)
+                          (runner? %))
               :max 2}
     :msg (msg (str "move " (join ", " (map :title targets)) " to the Runner's grip"))
     :effect (req (doseq [c targets]
@@ -1780,9 +1788,9 @@
 
    "Shipment from Kaguya"
    {:choices {:max 2
-              :req #(and (corp? %)
-                         (installed? %)
-                         (can-be-advanced? %))}
+              :card #(and (corp? %)
+                          (installed? %)
+                          (can-be-advanced? %))}
     :msg (msg "place 1 advancement token on " (count targets) " cards")
     :effect (req (doseq [t targets]
                    (add-prop state :corp t :advance-counter 1 {:placed true})))}
@@ -1792,9 +1800,9 @@
              (when (< n 3)
                {:async true
                 :prompt "Select a card to install with Shipment from MirrorMorph"
-                :choices {:req #(and (corp? %)
-                                     (not (operation? %))
-                                     (in-hand? %))}
+                :choices {:card #(and (corp? %)
+                                      (not (operation? %))
+                                      (in-hand? %))}
                 :effect (req (wait-for (corp-install state side target nil nil)
                                        (continue-ability state side (shelper (inc n)) card nil)))}))]
      {:async true
@@ -1807,15 +1815,15 @@
     :effect (req (let [c (str->int target)]
                    (continue-ability
                      state side
-                     {:choices {:req can-be-advanced?}
+                     {:choices {:card can-be-advanced?}
                       :msg (msg "place " c " advancement tokens on " (card-str state target))
                       :effect (effect (add-prop :corp target :advance-counter c {:placed true}))}
                      card nil)))}
 
    "Shipment from Tennin"
    {:req (req (not-last-turn? state :runner :successful-run))
-    :choices {:req #(and (corp? %)
-                         (installed? %))}
+    :choices {:card #(and (corp? %)
+                          (installed? %))}
     :msg (msg "place 2 advancement tokens on " (card-str state target))
     :effect (effect (add-prop target :advance-counter 2 {:placed true}))}
 
@@ -1826,8 +1834,8 @@
                 :effect (req (wait-for (rez state side (first ice) {:ignore-cost :all-costs})
                                        (continue-ability state side (rez-helper (rest ice)) card nil)))}))]
      {:req (req tagged)
-      :choices {:req #(and (ice? %)
-                        (not (rezzed? %)))
+      :choices {:card #(and (ice? %)
+                         (not (rezzed? %)))
                 :max (req (min (count-tags state)
                                (reduce (fn [c server]
                                          (+ c (count (filter #(not (:rezzed %)) (:ices server)))))
@@ -1838,7 +1846,7 @@
    {:trace {:base 3
             :successful
             {:msg "trash a connection"
-             :choices {:req #(has-subtype? % "Connection")}
+             :choices {:card #(has-subtype? % "Connection")}
              :async true
              :effect (req (let [c target]
                             (show-wait-prompt state :corp "Runner to decide if they will take 1 tag")
@@ -1864,8 +1872,8 @@
    "Special Report"
    {:prompt "Select any number of cards in HQ to shuffle into R&D"
     :choices {:max (req (count (:hand corp)))
-              :req #(and (corp? %)
-                         (in-hand? %))}
+              :card #(and (corp? %)
+                          (in-hand? %))}
     :msg (msg "shuffle " (count targets) " cards in HQ into R&D and draw " (count targets) " cards")
     :async true
     :effect (req (doseq [c targets]
@@ -1893,8 +1901,8 @@
      {:sub-effect {:label "End the run"
                    :msg "end the run"
                    :effect (effect (end-run eid card))}
-      :choices {:req #(and (ice? %)
-                           (rezzed? %))}
+      :choices {:card #(and (ice? %)
+                            (rezzed? %))}
       :msg (msg "make " (card-str state target) " gain Barrier and \"[Subroutine] End the run\"")
       :effect (req (update! state side (assoc target :subtype (combine-subtypes true (:subtype target) "Barrier")))
                    (add-extra-sub! state :corp (get-card state target) new-sub (:cid card))
@@ -1908,9 +1916,9 @@
    "Subcontract"
    (letfn [(sc [i sccard]
              {:prompt "Select an operation in HQ to play"
-              :choices {:req #(and (corp? %)
-                                   (operation? %)
-                                   (in-hand? %))}
+              :choices {:card #(and (corp? %)
+                                    (operation? %)
+                                    (in-hand? %))}
               :async true
               :msg (msg "play " (:title target))
               :effect (req (wait-for (play-instant state side target)
@@ -1942,7 +1950,7 @@
    "Success"
    {:additional-cost [:forfeit]
     :effect (req (resolve-ability state side
-                                  {:choices {:req can-be-advanced?}
+                                  {:choices {:card can-be-advanced?}
                                    :msg (msg "advance " (card-str state target) " "
                                              (advancement-cost state side (last (:rfg corp))) " times")
                                    :effect (req (dotimes [_ (advancement-cost state side (last (:rfg corp)))]
@@ -1956,7 +1964,8 @@
    "Sunset"
    (letfn [(sun [serv]
              {:prompt "Select two pieces of ICE to swap positions"
-              :choices {:req #(and (= serv (rest (butlast (:zone %)))) (ice? %))
+              :choices {:card #(and (= serv (rest (butlast (:zone %))))
+                                    (ice? %))
                         :max 2}
               :async true
               :effect (req (if (= (count targets) 2)
@@ -2013,8 +2022,8 @@
    "Threat Assessment"
    {:req (req (last-turn? state :runner :trashed-card))
     :prompt "Select an installed Runner card"
-    :choices {:req #(and (runner? %)
-                         (installed? %))}
+    :choices {:card #(and (runner? %)
+                          (installed? %))}
     :rfg-instead-of-trashing true
     :async true
     :effect (effect (show-wait-prompt "Runner to resolve Threat Assessment")
@@ -2058,9 +2067,9 @@
     :effect (effect (damage eid :meat 2 {:card card}))}
 
    "Transparency Initiative"
-   {:choices {:req #(and (agenda? %)
-                         (installed? %)
-                         (not (faceup? %)))}
+   {:choices {:card #(and (agenda? %)
+                          (installed? %)
+                          (not (faceup? %)))}
     :effect (effect (update! (assoc target
                                     :seen true
                                     :rezzed true
@@ -2081,8 +2090,8 @@
     :req (req (let [advanceable (some can-be-advanced? (get-all-installed state))
                     advanced (some #(get-counters % :advancement) (get-all-installed state))]
                 (and advanceable advanced)))
-    :choices {:req #(and (pos? (get-counters % :advancement))
-                         (installed? %))}
+    :choices {:card #(and (pos? (get-counters % :advancement))
+                          (installed? %))}
     :effect (effect
               (continue-ability
                 (let [fr target]
@@ -2093,8 +2102,8 @@
                              (continue-ability
                                (let [c (str->int target)]
                                  {:prompt "Move to where?"
-                                  :choices {:req #(and (not (same-card? fr %))
-                                                       (can-be-advanced? %))}
+                                  :choices {:card #(and (not (same-card? fr %))
+                                                        (can-be-advanced? %))}
                                   :msg (msg "move " c " advancement tokens from "
                                             (card-str state fr) " to " (card-str state target))
                                   :effect (effect (add-prop :corp target :advance-counter c {:placed true})
@@ -2113,9 +2122,9 @@
                                           {:async true
                                            :prompt (str "Select a program with an install cost of no more than "
                                                         exceed "[Credits]")
-                                           :choices {:req #(and (program? %)
-                                                                (installed? %)
-                                                                (>= exceed (:cost %)))}
+                                           :choices {:card #(and (program? %)
+                                                                 (installed? %)
+                                                                 (>= exceed (:cost %)))}
                                            :msg (msg "trash " (card-str state target))
                                            :effect (effect (trash eid target nil))}
                                           card nil)))}}}
@@ -2128,9 +2137,9 @@
                              state side
                              {:async true
                               :prompt "Choose a card in HQ to install"
-                              :choices {:req #(and (in-hand? %)
-                                                   (corp? %)
-                                                   (not (operation? %)))}
+                              :choices {:card #(and (in-hand? %)
+                                                    (corp? %)
+                                                    (not (operation? %)))}
                               :msg "gain 10 [Credits], draw 4 cards, and install 1 card from HQ"
                               :cancel-effect (req (effect-completed state side eid))
                               :effect (effect (corp-install eid target nil nil))}
@@ -2143,10 +2152,10 @@
                                       (has-subtype? % "Connection"))
                                 (all-active-installed state :runner)))))
     :prompt "Choose a connection to trash"
-    :choices {:req #(and (runner? %)
-                         (resource? %)
-                         (has-subtype? % "Connection")
-                         (installed? %))}
+    :choices {:card #(and (runner? %)
+                          (resource? %)
+                          (has-subtype? % "Connection")
+                          (installed? %))}
     :msg (msg "trash " (:title target) " and take 1 bad publicity")
     :async true
     :effect (req (wait-for (trash state side target nil)
@@ -2163,8 +2172,8 @@
     :psi {:not-equal {:player :corp
                       :async true
                       :prompt "Select a resource to trash"
-                      :choices {:req #(and (installed? %)
-                                           (resource? %))}
+                      :choices {:card #(and (installed? %)
+                                            (resource? %))}
                       :msg (msg "trash " (:title target))
                       :effect (effect (trash eid target nil))}}}
 
@@ -2173,9 +2182,9 @@
     :rfg-instead-of-trashing true
     :req (req (last-turn? state :runner :trashed-card))
     :prompt "Select a piece of hardware or non-virtual resource"
-    :choices {:req #(or (hardware? %)
-                        (and (resource? %)
-                             (not (has-subtype? % "Virtual"))))}
+    :choices {:card #(or (hardware? %)
+                         (and (resource? %)
+                              (not (has-subtype? % "Virtual"))))}
     :effect (effect (show-wait-prompt "Runner to resolve Wake Up Call")
                     (continue-ability
                       :runner
@@ -2196,9 +2205,9 @@
 
    "Wetwork Refit"
    (let [new-sub {:label "[Wetwork Refit] Do 1 brain damage"}]
-     {:choices {:req #(and (ice? %)
-                           (has-subtype? % "Bioroid")
-                           (rezzed? %))}
+     {:choices {:card #(and (ice? %)
+                            (has-subtype? % "Bioroid")
+                            (rezzed? %))}
       :msg (msg "give " (card-str state target) " \"[Subroutine] Do 1 brain damage\" before all its other subroutines")
       :sub-effect (do-brain-damage 1)
       :effect (req (add-extra-sub! state :corp target new-sub (:cid card) {:front true})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -30,7 +30,8 @@
                   :label "Swap with a deva program from your Grip"
                   :cost [:credit 2]
                   :prompt (str "Select a deva program in your Grip to swap with " card-name)
-                  :choices {:req #(and in-hand? (has-subtype? % "Deva"))}
+                  :choices {:card #(and (in-hand? %)
+                                        (has-subtype? % "Deva"))}
                   :msg (msg "swap in " (:title target) " from their Grip")
                   :effect (req (if-let [hostcard (:host card)]
                                  (let [hosted (host state side (get-card state hostcard) target)]
@@ -325,9 +326,9 @@
                                      {:req (req (= target :rd))
                                       :replace-access
                                       {:prompt "Choose a card to shuffle into R&D"
-                                       :choices {:req #(and (not (ice? %))
-                                                            (not (rezzed? %))
-                                                            (zero? (get-counters % :advancement)))}
+                                       :choices {:card #(and (not (ice? %))
+                                                             (not (rezzed? %))
+                                                             (zero? (get-counters % :advancement)))}
                                        :msg (msg "shuffle " (card-str state target) " into R&D")
                                        :effect (effect (move :corp target :deck)
                                                        (shuffle! :corp :deck))}}
@@ -388,16 +389,16 @@
    (let [host-click {:cost [:click 1]
                      :label "Install a non-AI icebreaker on Baba Yaga"
                      :prompt "Choose a non-AI icebreaker in your Grip to install on Baba Yaga"
-                     :choices {:req #(and (has-subtype? % "Icebreaker")
-                                          (not (has-subtype? % "AI"))
-                                          (in-hand? %))}
+                     :choices {:card #(and (has-subtype? % "Icebreaker")
+                                           (not (has-subtype? % "AI"))
+                                           (in-hand? %))}
                      :async true
                      :effect (effect (runner-install eid target {:host-card card}))}
          host-free {:label "Host an installed non-AI icebreaker on Baba Yaga"
                     :prompt "Choose an installed non-AI icebreaker to host on Baba Yaga"
-                    :choices {:req #(and (has-subtype? % "Icebreaker")
-                                         (not (has-subtype? % "AI"))
-                                         (installed? %))}
+                    :choices {:card #(and (has-subtype? % "Icebreaker")
+                                          (not (has-subtype? % "AI"))
+                                          (installed? %))}
                     :effect (req (when (host state side card target)
                                    (gain :memory (:memoryunits target))))}
          gain-abis (req (let [new-abis (mapcat (fn [c] (map-indexed #(assoc %2
@@ -449,20 +450,20 @@
                                   state side
                                   {:prompt (msg "Host Bishop on a piece of ICE protecting "
                                                 (if hosted? (if remote? "a central" "a remote") "any") " server")
-                                   :choices {:req #(if hosted?
-                                                     (and (if remote?
-                                                            (is-central? (second (:zone %)))
-                                                            (is-remote? (second (:zone %))))
-                                                          (ice? %)
-                                                          (can-host? %)
-                                                          (= (last (:zone %)) :ices)
-                                                          (not-any? (fn [c] (has-subtype? c "Caïssa"))
-                                                                    (:hosted %)))
-                                                     (and (ice? %)
-                                                          (can-host? %)
-                                                          (= (last (:zone %)) :ices)
-                                                          (not-any? (fn [c] (has-subtype? c "Caïssa"))
-                                                                    (:hosted %))))}
+                                   :choices {:card #(if hosted?
+                                                      (and (if remote?
+                                                             (is-central? (second (:zone %)))
+                                                             (is-remote? (second (:zone %))))
+                                                           (ice? %)
+                                                           (can-host? %)
+                                                           (= (last (:zone %)) :ices)
+                                                           (not-any? (fn [c] (has-subtype? c "Caïssa"))
+                                                                     (:hosted %)))
+                                                      (and (ice? %)
+                                                           (can-host? %)
+                                                           (= (last (:zone %)) :ices)
+                                                           (not-any? (fn [c] (has-subtype? c "Caïssa"))
+                                                                     (:hosted %))))}
                                    :msg (msg "host it on " (card-str state target))
                                    :effect (effect (host target card))}
                                   card nil)))}]
@@ -495,10 +496,10 @@
                      :events (let [put-back {:req (req (get-in card [:special :brahman-used]))
                                              :player :runner ; Needed for when the run is ended by the Corp
                                              :prompt "Choose a non-virus program to put on top of your stack."
-                                             :choices {:req #(and (installed? %)
-                                                                  (program? %)
-                                                                  (not (facedown? %))
-                                                                  (not (has-subtype? % "Virus")))}
+                                             :choices {:card #(and (installed? %)
+                                                                   (program? %)
+                                                                   (not (facedown? %))
+                                                                   (not (has-subtype? % "Virus")))}
                                              :msg (msg "add " (:title target) " to the top of the Stack")
                                              :effect (effect (update! (dissoc-in card [:special :brahman-used]))
                                                              (move target :deck {:front true}))}]
@@ -580,7 +581,7 @@
 
    "Chisel"
    {:implementation "Encounter effect is manual."
-    :hosting {:req (every-pred ice? can-host?)}
+    :hosting {:card (every-pred ice? can-host?)}
     :abilities [{:req (req (and (same-card? current-ice (:host card))
                                 (rezzed? current-ice)))
                  :effect (req (if (not (pos? (get-strength current-ice)))
@@ -660,9 +661,9 @@
                                 (resolve-ability
                                   state side
                                   {:prompt (msg "Choose a rezzed copy of " icename)
-                                   :choices {:req #(and (rezzed? %)
-                                                        (ice? %)
-                                                        (= (:title %) icename))}
+                                   :choices {:card #(and (rezzed? %)
+                                                         (ice? %)
+                                                         (= (:title %) icename))}
                                    :msg "redirect the run"
                                    :cost [:trash]
                                    :effect (req (let [dest (second (:zone target))
@@ -822,11 +823,11 @@
               :silent (req true)
               :effect (effect (add-counter card :power 1))}]
     :abilities [{:prompt "Choose a card to install from your Grip"
-                 :choices {:five (req (and (in-hand? target)
-                                           (or (hardware? target)
-                                               (program? target)
-                                               (resource? target))
-                                           (<= (install-cost state side target) (get-counters card :power))))}
+                 :choices {:req (req (and (in-hand? target)
+                                          (or (hardware? target)
+                                              (program? target)
+                                              (resource? target))
+                                          (<= (install-cost state side target) (get-counters card :power))))}
                  :req (req (and (not (install-locked? state side))
                                 (some #(and (or (hardware? %)
                                                 (program? %)
@@ -871,11 +872,11 @@
                  :label "Install a program on Dhegdheer"
                  :prompt "Choose a program in your Grip to install on Dhegdheer"
                  :choices
-                 {:five (req (and (program? target)
-                                  (runner-can-install? state side target false)
-                                  (in-hand? target)
-                                  (can-pay? state side eid card nil
-                                            [:credit (install-cost state side target {:cost-bonus -1})])))}
+                 {:req (req (and (program? target)
+                                 (runner-can-install? state side target false)
+                                 (in-hand? target)
+                                 (can-pay? state side eid card nil
+                                           [:credit (install-cost state side target {:cost-bonus -1})])))}
                  :msg (msg (str "host " (:title target)
                                 (when (-> target :cost pos?)
                                   ", lowering its cost by 1 [Credit]")))
@@ -888,8 +889,8 @@
                 {:label "Host an installed program on Dhegdheer with [Credit] discount"
                  :req (req (nil? (get-in card [:special :dheg-prog])))
                  :prompt "Choose an installed program to host on Dhegdheer with [Credit] discount"
-                 :choices {:req #(and (program? %)
-                                      (installed? %))}
+                 :choices {:card #(and (program? %)
+                                       (installed? %))}
                  :msg (msg (str "host " (:title target)
                                 (when (-> target :cost pos?)
                                   ", lowering its cost by 1 [Credit]")))
@@ -902,8 +903,8 @@
                 {:label "Host an installed program on Dhegdheer"
                  :req (req (nil? (get-in card [:special :dheg-prog])))
                  :prompt "Choose an installed program to host on Dhegdheer"
-                 :choices {:req #(and (program? %)
-                                      (installed? %))}
+                 :choices {:card #(and (program? %)
+                                       (installed? %))}
                  :msg (msg (str "host " (:title target)
                                 (when (-> target :cost pos?)
                                   ", lowering its cost by 1 [Credit]")))
@@ -960,10 +961,10 @@
                  :effect (effect (continue-ability
                                    {:cost [:click 1]
                                     :prompt "Choose a non-Icebreaker program in your Grip to install on Djinn"
-                                    :choices {:req #(and (program? %)
-                                                         (runner-can-install? state side % false)
-                                                         (not (has-subtype? % "Icebreaker"))
-                                                         (in-hand? %))}
+                                    :choices {:card #(and (program? %)
+                                                          (runner-can-install? state side % false)
+                                                          (not (has-subtype? % "Icebreaker"))
+                                                          (in-hand? %))}
                                     :msg (msg "install and host " (:title target))
                                     :async true
                                     :effect (req (wait-for (runner-install state side target {:host-card card :no-mu true})
@@ -974,9 +975,9 @@
                                    card nil))}
                 {:label "Host an installed non-Icebreaker program on Djinn"
                  :prompt "Choose an installed non-Icebreaker program to host on Djinn"
-                 :choices {:req #(and (program? %)
-                                      (not (has-subtype? % "Icebreaker"))
-                                      (installed? %))}
+                 :choices {:card #(and (program? %)
+                                       (not (has-subtype? % "Icebreaker"))
+                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target)
                                  (free-mu (:memoryunits target))
@@ -996,7 +997,9 @@
 
    "Egret"
    {:implementation "Added subtypes don't get removed when Egret is moved/trashed"
-    :hosting {:req #(and (ice? %) (can-host? %) (rezzed? %))}
+    :hosting {:card #(and (ice? %)
+                          (can-host? %)
+                          (rezzed? %))}
     :msg (msg "make " (card-str state (:host card)) " gain Barrier, Code Gate and Sentry subtypes")
     :effect (req (when-let [h (:host card)]
                    (update! state side (assoc-in card [:special :installing] true))
@@ -1106,7 +1109,7 @@
 
    "Femme Fatale"
    (auto-icebreaker {:prompt "Select a piece of ICE to target for bypassing"
-                     :choices {:req ice?}
+                     :choices {:card ice?}
                      :leave-play (req (remove-icon state side card))
                      :effect (req (let [ice target]
                                     (add-icon state side card ice "F" "blue")
@@ -1256,7 +1259,7 @@
     :abilities [{:req (req (pos? (get-counters card :virus)))
                  :priority true
                  :prompt "Move a virus counter to which card?"
-                 :choices {:req #(has-subtype? % "Virus")}
+                 :choices {:card #(has-subtype? % "Virus")}
                  :effect (req (let [abilities (:abilities (card-def target))
                                     virus target]
                                 (add-counter state :runner virus :virus 1)
@@ -1291,9 +1294,9 @@
    (auto-icebreaker {:abilities [{:label "Host Ika on a piece of ICE"
                                   :prompt (msg "Host Ika on a piece of ICE")
                                   :cost [:credit 2]
-                                  :choices {:req #(and (ice? %)
-                                                       (installed? %)
-                                                       (can-host? %))}
+                                  :choices {:card #(and (ice? %)
+                                                        (installed? %)
+                                                        (can-host? %))}
                                   :msg (msg "host it on " (card-str state target))
                                   :effect (effect (host target card))}
                                  (break-sub 1 2 "Sentry")
@@ -1315,8 +1318,8 @@
               :effect (effect (add-counter card :virus 1))}]
     :abilities [{:cost [:click 1 :trash]
                  :msg (msg "move " (get-counters card :virus) " virus counter to " (:title target))
-                 :choices {:req #(and (installed? %)
-                                      (has-subtype? % "Virus"))}
+                 :choices {:card #(and (installed? %)
+                                       (has-subtype? % "Virus"))}
                  :effect (effect (add-counter target :virus (get-counters card :virus)))}]}
 
    "Inti"
@@ -1329,7 +1332,9 @@
                                   :once :per-turn
                                   :req (req (:run @state))
                                   :prompt "Select the Code Gate you just passed and another piece of ICE to swap positions"
-                                  :choices {:req #(and (installed? %) (ice? %)) :max 2}
+                                  :choices {:card #(and (installed? %)
+                                                        (ice? %))
+                                            :max 2}
                                   :msg (msg "swap the positions of " (card-str state (first targets)) " and " (card-str state (second targets)))
                                   :effect (req (when (= (count targets) 2)
                                                  (swap-ice state side (first targets) (second targets))))}
@@ -1370,24 +1375,25 @@
                                     {:prompt (msg "Host Knight on a piece of ICE"
                                                   (when hosted " not before or after the current host ICE"))
                                      :cost [:click 1]
-                                     :choices {:req #(if hosted
-                                                       (and (or (when (= (:zone %) (:zone (:host k)))
-                                                                  (not= 1 (abs (- (ice-index state %) icepos))))
-                                                                (not= (:zone %) (:zone (:host k))))
-                                                            (ice? %)
-                                                            (can-host? %)
-                                                            (installed? %)
-                                                            (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
-                                                       (and (ice? %)
-                                                            (installed? %)
-                                                            (can-host? %)
-                                                            (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
+                                     :choices {:card #(if hosted
+                                                        (and (or (when (= (:zone %) (:zone (:host k)))
+                                                                   (not= 1 (abs (- (ice-index state %) icepos))))
+                                                                 (not= (:zone %) (:zone (:host k))))
+                                                             (ice? %)
+                                                             (can-host? %)
+                                                             (installed? %)
+                                                             (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
+                                                        (and (ice? %)
+                                                             (installed? %)
+                                                             (can-host? %)
+                                                             (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
                                      :msg (msg "host it on " (card-str state target))
                                      :effect (effect (host target card))} card nil)))}
                   (break-sub 2 1 "All" {:req knight-req})]})
 
    "Kyuban"
-   {:hosting {:req #(and (ice? %) (can-host? %))}
+   {:hosting {:card #(and (ice? %)
+                          (can-host? %))}
     :events [{:event :pass-ice
               :req (req (same-card? target (:host card)))
               :msg "gain 2 [Credits]"
@@ -1413,9 +1419,9 @@
                  :effect (effect (continue-ability
                                    {:cost [:click 1]
                                     :prompt "Choose a program in your Grip to install on Leprechaun"
-                                    :choices {:req #(and (program? %)
-                                                         (runner-can-install? state side % false)
-                                                         (in-hand? %))}
+                                    :choices {:card #(and (program? %)
+                                                          (runner-can-install? state side % false)
+                                                          (in-hand? %))}
                                     :msg (msg "host " (:title target))
                                     :async true
                                     :effect (req (wait-for (runner-install state side target {:host-card card :no-mu true})
@@ -1428,8 +1434,8 @@
                 {:label "Host an installed program on Leprechaun"
                  :req (req (< (count (get-in card [:special :hosted-programs])) 2))
                  :prompt "Choose an installed program to host on Leprechaun"
-                 :choices {:req #(and (program? %)
-                                      (installed? %))}
+                 :choices {:card #(and (program? %)
+                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (free-mu (:memoryunits target))
                                  (update-breaker-strength target)
@@ -1659,9 +1665,9 @@
 
    "Paintbrush"
    {:abilities [{:cost [:click 1]
-                 :choices {:req #(and (installed? %)
-                                      (ice? %)
-                                      (rezzed? %))}
+                 :choices {:card #(and (installed? %)
+                                       (ice? %)
+                                       (rezzed? %))}
                  :effect (req (let [ice target
                                     stypes (:subtype ice)]
                                 (continue-ability
@@ -1720,7 +1726,9 @@
                                           card nil))}])
 
    "Parasite"
-   {:hosting {:req #(and (ice? %) (can-host? %) (rezzed? %))}
+   {:hosting {:card #(and (ice? %)
+                          (can-host? %)
+                          (rezzed? %))}
     :effect (req (when-let [h (:host card)]
                    (update! state side (assoc-in card [:special :installing] true))
                    (update-ice-strength state side h)
@@ -1761,18 +1769,18 @@
     :abilities [{:label "Host Pawn on the outermost ICE of a central server"
                  :cost [:click 1]
                  :prompt "Host Pawn on the outermost ICE of a central server"
-                 :choices {:req #(and (ice? %)
-                                      (can-host? %)
-                                      (= (last (:zone %)) :ices)
-                                      (is-central? (second (:zone %))))}
+                 :choices {:card #(and (ice? %)
+                                       (can-host? %)
+                                       (= (last (:zone %)) :ices)
+                                       (is-central? (second (:zone %))))}
                  :msg (msg "host it on " (card-str state target))
                  :effect (effect (host target card))}
                 {:label "Advance to next ICE"
                  :prompt "Choose the next innermost ICE to host Pawn on it"
-                 :choices {:req #(and (ice? %)
-                                      (can-host? %)
-                                      (= (last (:zone %)) :ices)
-                                      (is-central? (second (:zone %))))}
+                 :choices {:card #(and (ice? %)
+                                       (can-host? %)
+                                       (= (last (:zone %)) :ices)
+                                       (is-central? (second (:zone %))))}
                  :msg (msg "host it on " (card-str state target))
                  :effect (effect (host target card))}
                 {:label "Trash Pawn and install a Caïssa from your Grip or Heap, ignoring all costs"
@@ -1783,9 +1791,9 @@
                                   state side
                                   {:prompt "Choose a Caïssa program to install from your Grip or Heap"
                                    :show-discard true
-                                   :choices {:req #(and (has-subtype? % "Caïssa")
-                                                        (not= (:cid %) this-pawn)
-                                                        (#{[:hand] [:discard]} (:zone %)))}
+                                   :choices {:card #(and (has-subtype? % "Caïssa")
+                                                         (not= (:cid %) this-pawn)
+                                                         (#{[:hand] [:discard]} (:zone %)))}
                                    :msg (msg "install " (:title target))
                                    :async true
                                    :effect (effect (runner-install eid target {:ignore-all-cost true}))}
@@ -1883,9 +1891,9 @@
                  :effect (effect (continue-ability
                                    {:cost [:click 1]
                                     :prompt "Choose a Virus program to install on Progenitor"
-                                    :choices {:req #(and (program? %)
-                                                         (has-subtype? % "Virus")
-                                                         (in-hand? %))}
+                                    :choices {:card #(and (program? %)
+                                                          (has-subtype? % "Virus")
+                                                          (in-hand? %))}
                                     :msg (msg "host " (:title target))
                                     :async true
                                     :effect (req (wait-for (runner-install state side target {:host-card card :no-mu true})
@@ -1897,9 +1905,9 @@
                 {:label "Host an installed virus on Progenitor"
                  :req (req (empty? (:hosted card)))
                  :prompt "Choose an installed virus program to host on Progenitor"
-                 :choices {:req #(and (program? %)
-                                      (has-subtype? % "Virus")
-                                      (installed? %))}
+                 :choices {:card #(and (program? %)
+                                       (has-subtype? % "Virus")
+                                       (installed? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (host card target)
                                  (free-mu (:memoryunits target))
@@ -2014,17 +2022,17 @@
                                              (msg "Host Rook on a piece of ICE protecting this server or at position "
                                                   icepos " of a different server")
                                              (msg "Host Rook on a piece of ICE protecting any server"))
-                                   :choices {:req #(if hosted?
-                                                     (and (or (= (:zone %) (:zone (:host r)))
-                                                              (= (ice-index state %) icepos))
-                                                          (= (last (:zone %)) :ices)
-                                                          (ice? %)
-                                                          (can-host? %)
-                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
-                                                     (and (ice? %)
-                                                          (can-host? %)
-                                                          (= (last (:zone %)) :ices)
-                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
+                                   :choices {:card #(if hosted?
+                                                      (and (or (= (:zone %) (:zone (:host r)))
+                                                               (= (ice-index state %) icepos))
+                                                           (= (last (:zone %)) :ices)
+                                                           (ice? %)
+                                                           (can-host? %)
+                                                           (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
+                                                      (and (ice? %)
+                                                           (can-host? %)
+                                                           (= (last (:zone %)) :ices)
+                                                           (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
                                    :msg (msg "host it on " (card-str state target))
                                    :effect (effect (host target card))} card nil)))}]
     :constant-effects [{:type :rez-cost
@@ -2065,8 +2073,8 @@
                  :req (req (not (install-locked? state side)))
                  :msg (msg "install " (:title target))
                  :prompt "Choose a program to install from your grip"
-                 :choices {:req #(and (program? %)
-                                      (in-hand? %))}
+                 :choices {:card #(and (program? %)
+                                       (in-hand? %))}
                  :async true
                  :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}]}
 
@@ -2076,9 +2084,9 @@
                  :effect (effect (resolve-ability
                                    {:cost [:click 1]
                                     :prompt "Choose a program to install on Scheherazade from your grip"
-                                    :choices {:req #(and (program? %)
-                                                         (runner-can-install? state side % false)
-                                                         (in-hand? %))}
+                                    :choices {:card #(and (program? %)
+                                                          (runner-can-install? state side % false)
+                                                          (in-hand? %))}
                                     :msg (msg "host " (:title target) " and gain 1 [Credits]")
                                     :async true
                                     :effect (effect (gain-credits 1)
@@ -2086,8 +2094,8 @@
                                    card nil))}
                 {:label "Host an installed program"
                  :prompt "Choose a program to host on Scheherazade" :priority 2
-                 :choices {:req #(and (program? %)
-                                      (installed? %))}
+                 :choices {:card #(and (program? %)
+                                       (installed? %))}
                  :msg (msg "host " (:title target) " and gain 1 [Credits]")
                  :effect (req (when (host state side card target)
                                 (gain-credits state side 1)))}]}
@@ -2211,10 +2219,10 @@
    "Surfer"
    (letfn [(surf [state cice]
              {:prompt (msg "Choose an ICE before or after " (:title cice))
-              :choices {:req #(and (ice? %)
-                                   (= (:zone %) (:zone cice))
-                                   (= 1 (abs (- (ice-index state %)
-                                                (ice-index state cice)))))}
+              :choices {:card #(and (ice? %)
+                                    (= (:zone %) (:zone cice))
+                                    (= 1 (abs (- (ice-index state %)
+                                                 (ice-index state cice)))))}
               :effect (req (let [tgtndx (ice-index state target)
                                  cidx (ice-index state cice)]
                              (system-msg state :runner (str "uses Surfer to swap "
@@ -2257,9 +2265,9 @@
                    :cost [:power 2]
                    :label "Increase non-AI icebreaker strength by +3 until end of encounter"
                    :prompt "Choose an installed non-AI icebreaker"
-                   :choices {:req #(and (has-subtype? % "Icebreaker")
-                                        (not (has-subtype? % "AI"))
-                                        (installed? %))}
+                   :choices {:card #(and (has-subtype? % "Icebreaker")
+                                         (not (has-subtype? % "AI"))
+                                         (installed? %))}
                    :msg (msg "add +3 strength to " (:title target) " for remainder of encounter")
                    :effect (effect (pump target 3))}]})
 
@@ -2305,8 +2313,8 @@
                       :show-discard true
                       :choices {:max (min (get-counters card :power) (count (:discard runner)))
                                 :all true
-                                :req #(and (runner? %)
-                                           (in-discard? %))}
+                                :card #(and (runner? %)
+                                            (in-discard? %))}
                       :msg (msg "shuffle " (join ", " (map :title targets))
                                 " into their Stack")
                       :effect (req (doseq [c targets] (move state side c :deck))
@@ -2322,7 +2330,8 @@
                                  (unregister-events state side card)
                                  (trash state :runner eid h nil))
                              (effect-completed state side eid))))]
-     {:hosting {:req #(and (ice? %) (can-host? %))}
+     {:hosting {:card #(and (ice? %)
+                            (can-host? %))}
       :effect trash-if-5
       :abilities [(set-autoresolve :auto-accept "add virus counter to Trypano")]
       :events [{:event :runner-turn-begins
@@ -2397,7 +2406,8 @@
                                                        (expose-and-maybe-bounce target)
                                                        card nil)))})
            (expose-and-maybe-bounce [chosen-subtype]
-             {:choices {:req #(and (ice? %) (not (rezzed? %)))}
+             {:choices {:card #(and (ice? %)
+                                    (not (rezzed? %)))}
               :async true
               :msg (str "name " chosen-subtype)
               :effect (req (wait-for (expose state side target)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -144,9 +144,9 @@
     :abilities [{:effect (req (resolve-ability
                                 state side
                                 {:msg (msg "trash " (:title target) " and gain 3 [Credits]")
-                                 :choices {:req #(and (runner? %)
-                                                      (installed? %)
-                                                      (not (same-card? % card)))}
+                                 :choices {:card #(and (runner? %)
+                                                       (installed? %)
+                                                       (not (same-card? % card)))}
                                  :effect (effect (gain-credits 3)
                                                  (trash target {:unpreventable true}))}
                                 card nil))}]}
@@ -222,9 +222,9 @@
    {:abilities [{:label "Turn a facedown card faceup"
                  :cost [:click 2]
                  :prompt "Select a facedown installed card"
-                 :choices {:req #(and (facedown? %)
-                                      (installed? %)
-                                      (runner? %))}
+                 :choices {:card #(and (facedown? %)
+                                       (installed? %)
+                                       (runner? %))}
                  :effect (req (if (or (event? target)
                                       (and (has-subtype? target "Console")
                                            (some #(has-subtype? % "Console") (all-active-installed state :runner))))
@@ -269,7 +269,8 @@
                                              (continue-ability
                                                state side
                                                {:prompt "Select a copy of Bank Job to use"
-                                                :choices {:req #(and (installed? %) (= (:title %) "Bank Job"))}
+                                                :choices {:card #(and (installed? %)
+                                                                      (= (:title %) "Bank Job"))}
                                                 :effect (effect (continue-ability (select-credits-ability target) target nil))}
                                                card nil)
                                              (continue-ability state side (select-credits-ability card) card nil))))}}))}]}
@@ -363,8 +364,8 @@
                  :effect (req (wait-for (draw state side 3 nil)
                                         (resolve-ability state side
                                                          {:prompt "Choose a card in your Grip to shuffle back into your Stack"
-                                                          :choices {:req #(and (in-hand? %)
-                                                                               (runner? %))}
+                                                          :choices {:card #(and (in-hand? %)
+                                                                                (runner? %))}
                                                           :effect (effect (move target :deck)
                                                                           (shuffle! :deck))}
                                                          card nil)))}]}
@@ -376,7 +377,8 @@
                  :once :per-turn
                  :prompt "Choose a card in the Heap to remove from the game and gain 2 [Credits]"
                  :show-discard true
-                 :choices {:req #(and (in-discard? %) (runner? %))}
+                 :choices {:card #(and (in-discard? %)
+                                       (runner? %))}
                  :msg (msg "remove " (:title target) " from the game and gain 2 [Credits]")
                  :effect (effect (gain-credits 2)
                                  (move target :rfg))}]}
@@ -429,11 +431,11 @@
                  :prompt "Select a program to install from your Grip"
                  :choices
                  {:async true
-                  :five (req (and (program? target)
-                                  (in-hand? target)
-                                  (can-pay? state :runner eid card nil
-                                            [:credit (install-cost state side target
-                                                                   {:cost-bonus (- (get-counters card :power))})])))}
+                  :req (req (and (program? target)
+                                 (in-hand? target)
+                                 (can-pay? state :runner eid card nil
+                                           [:credit (install-cost state side target
+                                                                  {:cost-bonus (- (get-counters card :power))})])))}
                  :msg (msg "install " (:title target))
                  :effect (req (wait-for (runner-install state side target {:cost-bonus (- (get-counters card :power))})
                                         (when (pos? (get-counters card :power))
@@ -478,8 +480,8 @@
            (trash-or-bonus [chosen-server]
              {:player :corp
               :prompt "Choose a piece of ice to trash or cancel"
-              :choices {:req #(and (= (last (:zone %)) :ices)
-                                   (= chosen-server (rest (butlast (:zone %)))))}
+              :choices {:card #(and (= (last (:zone %)) :ices)
+                                    (= chosen-server (rest (butlast (:zone %)))))}
               :effect (effect (system-msg (str "trashes " (card-str state target)))
                               (trash :corp eid target {:unpreventable true}))
               :cancel-effect (effect (system-msg (str "does not trash a piece of ice protecting " (zone->name chosen-server)))
@@ -532,9 +534,9 @@
                                                      " that was just rezzed") "info")
                            (toast state :corp (str "Runner has the opportunity to derez with Councilman.") "error"))}]
     :abilities [{:prompt "Select an asset or upgrade that was just rezzed"
-                 :choices {:req #(and (rezzed? %)
-                                      (or (asset? %)
-                                          (upgrade? %)))}
+                 :choices {:card #(and (rezzed? %)
+                                       (or (asset? %)
+                                           (upgrade? %)))}
                  :effect (effect
                            (continue-ability
                              :runner
@@ -734,8 +736,8 @@
    "Dean Lister"
    {:abilities [{:req (req run)
                  :msg (msg "add +1 strength for each card in their Grip to " (:title target) " until the end of the run")
-                 :choices {:req #(and (installed? %)
-                                      (has-subtype? % "Icebreaker"))}
+                 :choices {:card #(and (installed? %)
+                                       (has-subtype? % "Icebreaker"))}
                  :cost [:trash]
                  :effect (effect (register-floating-effect
                                    card
@@ -829,7 +831,7 @@
     :abilities [{:req (req (:runner-phase-12 @state))
                  :prompt "Select an installed card to make its text box blank for the remainder of the turn"
                  :once :per-turn
-                 :choices {:req installed?}
+                 :choices {:card installed?}
                  :msg (msg "make the text box of " (:title target) " blank for the remainder of the turn")
                  :effect (req (let [c target]
                                 (disable-card state side c)
@@ -1365,7 +1367,7 @@
                                                          (if (= target "Yes")
                                                            {:player :corp
                                                             :prompt "Select an agenda to forfeit"
-                                                            :choices {:req #(in-corp-scored? state side %)}
+                                                            :choices {:card #(in-corp-scored? state side %)}
                                                             :effect (effect (forfeit target)
                                                                             (move :runner card :rfg)
                                                                             (clear-wait-prompt :runner))}
@@ -1398,14 +1400,14 @@
                  :label "Install a non-virus program on London Library"
                  :cost [:click 1]
                  :prompt "Select a non-virus program to install on London Library from your grip"
-                 :choices {:req #(and (program? %)
-                                      (not (has-subtype? % "Virus"))
-                                      (in-hand? %))}
+                 :choices {:card #(and (program? %)
+                                       (not (has-subtype? % "Virus"))
+                                       (in-hand? %))}
                  :msg (msg "host " (:title target))
                  :effect (effect (runner-install eid target {:host-card card :ignore-install-cost true}))}
                 {:label "Add a program hosted on London Library to your Grip"
                  :cost [:click 1]
-                 :choices {:req #(:host %)} ;TODO: this seems to allow all hosted cards to be bounced
+                 :choices {:card #(:host %)} ;TODO: this seems to allow all hosted cards to be bounced
                  :msg (msg "add " (:title target) " to their Grip")
                  :effect (effect (move target :hand))}]
     :events [{:event :runner-turn-ends
@@ -1417,7 +1419,9 @@
    {:in-play [:link 1]
     :abilities [{:req (req (some #{:hq} (:successful-run runner-reg)))
                  :prompt "Choose a piece of ICE protecting a remote server"
-                 :choices {:req #(and (ice? %) (rezzed? %) (is-remote? (second (:zone %))))}
+                 :choices {:card #(and (ice? %)
+                                       (rezzed? %)
+                                       (is-remote? (second (:zone %))))}
                  :msg "derez a piece of ICE protecting a remote server"
                  :cost [:trash]
                  :effect (effect (derez target))}]}
@@ -1455,8 +1459,8 @@
                                           state side
                                           (if-let [drawn (get-in @state [:runner :register :most-recent-drawn])]
                                             {:prompt "Select 1 card to add to the bottom of the Stack"
-                                             :choices {:req #(and (in-hand? %)
-                                                                  (some (fn [c] (same-card? c %)) drawn))}
+                                             :choices {:card #(and (in-hand? %)
+                                                                   (some (fn [c] (same-card? c %)) drawn))}
                                              :msg (msg "add 1 card to the bottom of the Stack")
                                              :effect (req (move state side target :deck))})
                                           card nil)))}]}
@@ -1465,15 +1469,15 @@
    {:effect (effect (continue-ability
                       :corp
                       {:prompt "Select a card to derez"
-                       :choices {:req #(and (corp? %)
-                                            (not (agenda? %))
-                                            (:rezzed %))}
+                       :choices {:card #(and (corp? %)
+                                             (not (agenda? %))
+                                             (:rezzed %))}
                        :effect (effect (derez target))}
                       card nil))
     :leave-play (effect (continue-ability
                           :corp
                           {:prompt "Select a card to rez, ignoring the rez cost"
-                           :choices {:req (complement rezzed?)}
+                           :choices {:card (complement rezzed?)}
                            :effect (effect (rez target {:ignore-cost :rez-cost :no-msg true})
                                            (system-say (str (:title card) " allows the Corp to rez " (:title target) " at no cost")))}
                           card nil))
@@ -1612,15 +1616,15 @@
                  :label "Install and host a connection on Off-Campus Apartment"
                  :cost [:click 1]
                  :prompt "Select a connection in your Grip to install on Off-Campus Apartment"
-                 :choices {:five (req (and (has-subtype? target "Connection")
-                                           (can-pay? state side eid card nil [:credit (install-cost state side target)])
-                                           (in-hand? target)))}
+                 :choices {:req (req (and (has-subtype? target "Connection")
+                                          (can-pay? state side eid card nil [:credit (install-cost state side target)])
+                                          (in-hand? target)))}
                  :msg (msg "host " (:title target) " and draw 1 card")
                  :effect (effect (runner-install eid target {:host-card card}))}
                 {:label "Host an installed connection"
                  :prompt "Select a connection to host on Off-Campus Apartment"
-                 :choices {:req #(and (has-subtype? % "Connection")
-                                      (installed? %))}
+                 :choices {:card #(and (has-subtype? % "Connection")
+                                       (installed? %))}
                  :msg (msg "host " (:title target) " and draw 1 card")
                  :async true
                  :effect (effect (host card target)
@@ -1761,7 +1765,7 @@
           :req (req (not (empty? (:hosted card))))
           :once :per-turn
           :msg (msg "remove 1 counter from " (:title target))
-          :choices {:req #(:host %)}
+          :choices {:card #(:host %)}
           :effect (req (if (not (pos? (get-counters (get-card state target) :power)))
                          (runner-install state side eid (dissoc target :counter) {:ignore-all-cost true})
                          (do (add-counter state side target :power -1)
@@ -1771,10 +1775,10 @@
                    :label "Host a program or piece of hardware"
                    :cost [:click 1]
                    :prompt "Select a card to host on Personal Workshop"
-                   :choices {:req #(and (or (program? %)
-                                            (hardware? %))
-                                        (in-hand? %)
-                                        (runner? %))}
+                   :choices {:card #(and (or (program? %)
+                                             (hardware? %))
+                                         (in-hand? %)
+                                         (runner? %))}
                    :effect (req (if (not (pos? (:cost target)))
                                   (runner-install state side (assoc eid :source card :source-type :runner-install) target nil)
                                   (do (host state side card
@@ -1786,7 +1790,7 @@
                          :cost [:credit 1])
                   {:async true
                    :label "X[Credit]: Remove counters from a hosted card"
-                   :choices {:req #(:host %)}
+                   :choices {:card #(:host %)}
                    :req (req (not (empty? (:hosted card))))
                    :effect (effect
                              (continue-ability
@@ -1818,9 +1822,9 @@
                    (continue-ability
                      ;; TODO: Convert this to a cost
                      {:prompt "Select a rezzed card with a trash cost"
-                      :choices {:req #(and (:trash %)
-                                           (rezzed? %)
-                                           (can-pay? state side eid card nil [:credit (trash-cost state :runner %)]))}
+                      :choices {:card #(and (:trash %)
+                                            (rezzed? %)
+                                            (can-pay? state side eid card nil [:credit (trash-cost state :runner %)]))}
                       :effect (effect
                                 (continue-ability
                                   {:async true
@@ -1866,7 +1870,7 @@
                                (resolve-ability state side ability card nil)))) }]
     :abilities [{:msg "expose 1 card"
                  :label "Expose 1 installed card"
-                 :choices {:req installed?}
+                 :choices {:card installed?}
                  :async true
                  :cost [:trash]
                  :effect (effect (expose eid target))}]}
@@ -2038,8 +2042,8 @@
                  :prompt "Select an event to play"
                  :msg (msg "play " (:title target))
                  :show-discard true
-                 :choices {:req #(and (event? %)
-                                      (in-discard? %))}
+                 :choices {:card #(and (event? %)
+                                       (in-discard? %))}
                  :effect (effect (play-instant target))}]}
 
    "Scrubber"
@@ -2080,9 +2084,9 @@
                                 (resolve-ability
                                   state side
                                   {:prompt (msg "Choose a piece of ICE protecting a central server at the same position as " (:title current-ice))
-                                   :choices {:req #(and (is-central? (second (:zone %)))
-                                                        (ice? %)
-                                                        (= ice-pos (inc (ice-index state %))))}
+                                   :choices {:card #(and (is-central? (second (:zone %)))
+                                                         (ice? %)
+                                                         (= ice-pos (inc (ice-index state %))))}
                                    :msg (msg "approach " (card-str state target))
                                    :effect (req (let [dest (second (:zone target))]
                                                   (swap! state update-in [:run]
@@ -2276,11 +2280,11 @@
                                  (:hand runner)))
                  :prompt "Select a program or piece of hardware to install from your Grip"
                  :choices
-                 {:five (req (and (or (hardware? target)
-                                      (program? target))
-                                  (in-hand? target)
-                                  (can-pay? state side eid card nil
-                                            [:credit (install-cost state side target {:cost-bonus -1})])))}
+                 {:req (req (and (or (hardware? target)
+                                     (program? target))
+                                 (in-hand? target)
+                                 (can-pay? state side eid card nil
+                                           [:credit (install-cost state side target {:cost-bonus -1})])))}
                  :once :per-turn
                  :once-key :artist-install
                  :async true
@@ -2336,8 +2340,8 @@
    "The Helpful AI"
    {:in-play [:link 1]
     :abilities [{:msg (msg "give +2 strength to " (:title target))
-                 :choices {:req #(and (has-subtype? % "Icebreaker")
-                                      (installed? %))}
+                 :choices {:card #(and (has-subtype? % "Icebreaker")
+                                       (installed? %))}
                  :cost [:trash]
                  :effect (effect (pump target 2 :end-of-turn))}]}
 
@@ -2401,10 +2405,10 @@
                   :req (req (some #(can-pay? state side eid card nil [:credit (install-cost state side % {:cost-bonus -2})])
                                   (:hosted card)))
                   :choices
-                  {:five (req (and (= "The Supplier" (:title (:host target)))
-                                   (runner? target)
-                                   (can-pay? state side eid card nil
-                                             [:credit (install-cost state side target {:cost-bonus -2})])))}
+                  {:req (req (and (= "The Supplier" (:title (:host target)))
+                                  (runner? target)
+                                  (can-pay? state side eid card nil
+                                            [:credit (install-cost state side target {:cost-bonus -2})])))}
                   :once :per-turn
                   :msg (msg "install " (:title target)
                             ", lowering its install cost by 2 [Credits]")
@@ -2424,9 +2428,9 @@
       :abilities [{:label "Host a resource or piece of hardware"
                    :cost [:click 1]
                    :prompt "Select a card to host on The Supplier"
-                   :choices {:req #(and (or (hardware? %)
-                                            (resource? %))
-                                        (in-hand? %))}
+                   :choices {:card #(and (or (hardware? %)
+                                             (resource? %))
+                                         (in-hand? %))}
                    :effect (effect (host card target))
                    :msg (msg "host " (:title target))}
                   ability]
@@ -2474,11 +2478,11 @@
    (let [first-event-check (fn [state fn1 fn2] (and (fn1 state :runner :runner-lose-tag #(= :runner (second %)))
                                                     (fn2 state :runner :runner-prevent (fn [t] (seq (filter #(some #{:tag} %) t))))))
          ability {:choices
-                  {:five (req (and (runner? target)
-                                   (in-hand? target)
-                                   (not (event? target))
-                                   (can-pay? state side eid card nil
-                                             [:credit (install-cost state side target {:cost-bonus -1})])))}
+                  {:req (req (and (runner? target)
+                                  (in-hand? target)
+                                  (not (event? target))
+                                  (can-pay? state side eid card nil
+                                            [:credit (install-cost state side target {:cost-bonus -1})])))}
                   :async true
                   :prompt (msg "Select a card to install with Thunder Art Gallery")
                   :msg (msg "install " (:title target))
@@ -2566,7 +2570,7 @@
                  :effect (req (resolve-ability
                                 state side
                                 {:msg (msg "move 1 virus counter to " (:title target))
-                                 :choices {:req #(pos? (get-virus-counters state %))}
+                                 :choices {:card #(pos? (get-virus-counters state %))}
                                  :effect (req (add-counter state side card :virus -1)
                                               (add-counter state side target :virus 1))}
                                 card nil))}]}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -34,9 +34,9 @@
    "Arella Salvatore"
    (let [select-ability
          {:prompt "Select a card to install with Arella Salvatore"
-          :choices {:req #(and (corp-installable-type? %)
-                               (in-hand? %)
-                               (corp? %))}
+          :choices {:card #(and (corp-installable-type? %)
+                                (in-hand? %)
+                                (corp? %))}
           :async true
           :cancel-effect (req (effect-completed state side eid))
           :effect (req (wait-for (corp-install state :corp target nil {:ignore-all-cost true :display-message false})
@@ -70,9 +70,9 @@
     :abilities [{:label "Host a piece of Bioroid ICE"
                  :cost [:click 1]
                  :prompt "Select a piece of Bioroid ICE to host on Awakening Center"
-                 :choices {:req #(and (ice? %)
-                                      (has-subtype? % "Bioroid")
-                                      (in-hand? %))}
+                 :choices {:card #(and (ice? %)
+                                       (has-subtype? % "Bioroid")
+                                       (in-hand? %))}
                  :msg "host a piece of Bioroid ICE"
                  :async true
                  :effect (req (corp-install state side eid target card {:ignore-all-cost true}))}
@@ -99,16 +99,16 @@
    (letfn [(dome [dcard]
              {:prompt "Select a card to add to HQ"
               :async true
-              :choices {:req #(and (corp? %)
-                                   (in-play-area? %))}
+              :choices {:card #(and (corp? %)
+                                    (in-play-area? %))}
               :msg "move a card to HQ"
               :effect (effect (move target :hand)
                               (continue-ability (put dcard) dcard nil))})
            (put [dcard]
              {:prompt "Select first card to put back onto R&D"
               :async true
-              :choices {:req #(and (corp? %)
-                                   (in-play-area? %))}
+              :choices {:card #(and (corp? %)
+                                    (in-play-area? %))}
               :msg "move remaining cards back to R&D"
               :effect (effect (move target :deck {:front true})
                               (move (first (get-in @state [:corp :play-area])) :deck {:front true})
@@ -215,7 +215,7 @@
                  :async true
                  :effect (effect (continue-ability
                                    {:prompt "Select a card in this server"
-                                    :choices {:req #(in-same-server? % card)}
+                                    :choices {:card #(in-same-server? % card)}
                                     :async true
                                     :msg (msg "place an advancement token on " (card-str state target))
                                     :cost [:trash]
@@ -245,8 +245,8 @@
                                  count
                                  pos?)
                         {:prompt "Place 1 advancement token on an ice protecting this server"
-                         :choices {:req #(and (ice? %)
-                                              (same-server? % card))}
+                         :choices {:card #(and (ice? %)
+                                               (same-server? % card))}
                          :msg (msg "place an advancement token on " (card-str state target))
                          :effect (effect (add-prop target :advance-counter 1 {:placed true}))})
                       card nil))}]
@@ -318,9 +318,9 @@
                              (let [boost target]
                                {:cost [:credit boost :trash]
                                 :choices {:all true
-                                          :req #(and (ice? %)
-                                                     (rezzed? %)
-                                                     (protecting-same-server? card %))}
+                                          :card #(and (ice? %)
+                                                      (rezzed? %)
+                                                      (protecting-same-server? card %))}
                                 :msg (msg "add " boost " strength to " (:title target))
                                 :effect (effect (pump-ice target boost :end-of-turn))})
                              card nil))}]}
@@ -356,12 +356,12 @@
    (letfn [(choose-swap [to-swap]
              {:prompt (str "Select a card to swap with " (:title to-swap))
               :choices {:not-self true
-                        :req #(and (corp? %)
-                                   (#{"Asset" "Agenda" "Upgrade"} (:type %))
-                                   (or (in-hand? %) ; agenda, asset or upgrade from HQ
-                                       (and (installed? %) ; card installed in a server
-                                            ;; central upgrades are not in a server
-                                            (not (#{:hq :rd :archives} (first (:zone %)))))))}
+                        :card #(and (corp? %)
+                                    (#{"Asset" "Agenda" "Upgrade"} (:type %))
+                                    (or (in-hand? %) ; agenda, asset or upgrade from HQ
+                                        (and (installed? %) ; card installed in a server
+                                             ;; central upgrades are not in a server
+                                             (not (#{:hq :rd :archives} (first (:zone %)))))))}
               :effect (req (wait-for (trash state :corp card nil)
                                      (move state :corp to-swap (:zone target) {:keep-server-alive true})
                                      (move state :corp target (:zone to-swap) {:keep-server-alive true})
@@ -374,8 +374,8 @@
              {:optional {:prompt "Trash Daruma to swap a card in this server?"
                          :yes-ability {:async true
                                        :prompt "Select a card in this server to swap"
-                                       :choices {:req #(and (installed? %)
-                                                            (in-same-server? card %))
+                                       :choices {:card #(and (installed? %)
+                                                             (in-same-server? card %))
                                                  :not-self true}
                                        :effect (effect (continue-ability (choose-swap target) card nil))}
                          :no-ability {:effect (effect (clear-wait-prompt :runner))}}})]
@@ -400,9 +400,9 @@
                  :effect (effect (resolve-ability
                                    {:show-discard true
                                     :choices {:max (get-counters card :advancement)
-                                              :req #(and (corp? %)
-                                                         (not (:seen %))
-                                                         (in-discard? %))}
+                                              :card #(and (corp? %)
+                                                          (not (:seen %))
+                                                          (in-discard? %))}
                                     :msg (msg "add " (count targets) " facedown cards in Archives to HQ")
                                     :effect (req (doseq [c targets]
                                                    (move state side c :hand)))}
@@ -413,8 +413,8 @@
    (letfn [(dhq [n i]
              {:req (req (pos? i))
               :prompt "Select a card in HQ to add to the bottom of R&D"
-              :choices {:req #(and (corp? %)
-                                   (in-hand? %))}
+              :choices {:card #(and (corp? %)
+                                    (in-hand? %))}
               :async true
               :msg "add a card to the bottom of R&D"
               :effect (req (move state side target :deck)
@@ -600,7 +600,7 @@
                                              {:prompt "Choose an Agenda to trash"
                                               :async true
                                               :choices {:max 1
-                                                        :req #(is-scored? state side %)}
+                                                        :card #(is-scored? state side %)}
                                               :effect (req (wait-for (trash state side target {:unpreventable true})
                                                                      (system-msg state :runner (str "trashes " (:title target)
                                                                                                     " as an additional cost to initiate a run"))
@@ -651,10 +651,10 @@
                                       (continue-ability
                                         {:prompt "Select a program or virtual resource"
                                          :player :corp
-                                         :choices {:req #(and (installed? %)
-                                                              (or (program? %)
-                                                                  (and (resource? %)
-                                                                       (has-subtype? % "Virtual"))))}
+                                         :choices {:card #(and (installed? %)
+                                                               (or (program? %)
+                                                                   (and (resource? %)
+                                                                        (has-subtype? % "Virtual"))))}
                                          :msg (msg "move " (:title target) " to the Grip")
                                          :effect (effect (move :runner target :hand))
                                          :end-effect (req (clear-wait-prompt state :runner)
@@ -754,7 +754,7 @@
                       (let [server-name (zone->name (second (:zone card)))]
                         {:prompt (str "Advance a card in Server " server-name)
                          :msg (msg "place an advancement token on " (card-str state target))
-                         :choices {:req #(in-same-server? % card)}
+                         :choices {:card #(in-same-server? % card)}
                          :effect (effect (add-prop target :advance-counter 1 {:placed true}))})
                       card nil))}]
      {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
@@ -791,8 +791,8 @@
                  :prompt "Select a program to trash"
                  :label "Trash a program"
                  :msg (msg "trash " (:title target))
-                 :choices {:req #(and (installed? %)
-                                      (program? %))}
+                 :choices {:card #(and (installed? %)
+                                       (program? %))}
                  :cost [:tag 1 :trash]
                  :effect (effect (trash eid target nil))}]}
 
@@ -819,8 +819,8 @@
                  :cost [:trash]
                  :psi {:not-equal
                        {:prompt "Select the ice"
-                        :choices {:req #(and (ice? %)
-                                             (rezzed? %))
+                        :choices {:card #(and (ice? %)
+                                              (rezzed? %))
                                   :all true}
                         :effect (effect
                                   (continue-ability
@@ -845,8 +845,8 @@
     [{:req (req this-server)
       :label "Swap the ICE being approached with a piece of ICE from HQ"
       :prompt "Select a piece of ICE"
-      :choices {:req #(and (ice? %)
-                           (in-hand? %))}
+      :choices {:card #(and (ice? %)
+                            (in-hand? %))}
       :once :per-run
       :msg (msg "swap " (card-str state current-ice) " with a piece of ICE from HQ")
       :effect (req (let [hqice target
@@ -875,7 +875,8 @@
                                 (resolve-ability
                                   state :corp
                                   {:prompt (msg "Select a piece of ICE to swap with " (:title passed-ice))
-                                   :choices {:req #(and (= ice-zone (:zone %)) (ice? %))}
+                                   :choices {:card #(and (= ice-zone (:zone %))
+                                                         (ice? %))}
                                    :effect (req (let [fndx (ice-index state passed-ice)
                                                       sndx (ice-index state target)
                                                       fnew (assoc passed-ice :zone (:zone target))
@@ -958,7 +959,7 @@
                                         (let [rdc target]
                                           {:async true
                                            :prompt (msg "Choose a card in HQ to swap for " (:title rdc))
-                                           :choices {:req in-hand?}
+                                           :choices {:card in-hand?}
                                            :msg "swap a card from the top 5 of R&D with a card in HQ"
                                            :effect
                                            (req (let [hqc target
@@ -1270,10 +1271,10 @@
                                 {:optional
                                  {:prompt (msg "Rez another card with Surat City Grid?")
                                   :yes-ability {:prompt "Select a card to rez"
-                                                :choices {:req #(and (not (rezzed? %))
-                                                                     (not (agenda? %))
-                                                                     (can-pay? state side eid card nil
-                                                                               [:credit (rez-cost state side % {:cost-bonus -2})]))}
+                                                :choices {:card #(and (not (rezzed? %))
+                                                                      (not (agenda? %))
+                                                                      (can-pay? state side eid card nil
+                                                                                [:credit (rez-cost state side % {:cost-bonus -2})]))}
                                                 :msg (msg "rez " (:title target) ", lowering the rez cost by 2 [Credits]")
                                                 :effect (effect (rez eid target {:cost-bonus -2}))}}}
                                 card nil))}]}
@@ -1322,9 +1323,9 @@
                                 (resolve-ability
                                   state side
                                   {:prompt "Select a copy of the ICE just passed"
-                                   :choices {:req #(and (in-hand? %)
-                                                        (ice? %)
-                                                        (= (:title %) icename))}
+                                   :choices {:card #(and (in-hand? %)
+                                                         (ice? %)
+                                                         (= (:title %) icename))}
                                    :effect (req (reveal state side target)
                                                 (trash state side (assoc target :seen true))
                                                 (swap! state update-in [:run]
@@ -1410,8 +1411,8 @@
               :async true
               :interactive (req true)
               :player :runner
-              :choices {:req #(and (runner? %)
-                                   (installed? %))}
+              :choices {:card #(and (runner? %)
+                                    (installed? %))}
               :msg (msg "force the Runner to trash " (card-str state target))
               :effect (req (wait-for (trash state :runner target {:unpreventable true})
                                      (if (pos? (dec n))
@@ -1464,10 +1465,10 @@
                               (continue-ability
                                 {:optional
                                  {:prompt "Trash Will-o'-the-Wisp?"
-                                  :choices {:req #(has-subtype? % "Icebreaker")}
+                                  :choices {:card #(has-subtype? % "Icebreaker")}
                                   :yes-ability {:async true
                                                 :prompt "Choose an icebreaker used to break at least 1 subroutine during this run"
-                                                :choices {:req #(has-subtype? % "Icebreaker")}
+                                                :choices {:card #(has-subtype? % "Icebreaker")}
                                                 :msg (msg "add " (:title target) " to the bottom of the Runner's Stack")
                                                 :effect (effect (trash card)
                                                                 (move :runner target :deck)

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -58,9 +58,9 @@
       * the keyword :counter -- user chooses an integer up to the :counter value of the given card.
       * a map containing the keyword :number with a value of a 4-argument function returning an integer -- user
         chooses an integer up to the value of the map.
-      * a map containing the keyword :req with a value of a 1-argument function returning true or false. Triggers a
-        'select' prompt with targeting cursor; only cards that cause the 1-argument function to return true will
-        be allowed.
+      * a map containing either: 1) the keyword :card with a value of a 1-argument function returning true or false,
+        or 2) the keyword :req with a value of the req 5-fn returning true or false. Triggers a 'select' prompt
+        with targeting cursor; only cards that cause the 1-argument function to return true will be allowed.
   :prompt -- a string or 4-argument function returning a string to display in the prompt menu.
   :priority -- a numeric value, or true (equivalent to 1). Prompts are inserted into the prompt queue and sorted base
                on priority, with higher priorities coming first. The sort is stable, so if two prompts have the same
@@ -215,7 +215,7 @@
        (prompt! state s card prompt choices ab args)
        ;; a select prompt
        (or (:req choices)
-           (:five choices))
+           (:card choices))
        (show-select state s card ability update! resolve-ability args)
        ;; a :number prompt
        (:number choices)
@@ -527,8 +527,8 @@
    (continue-ability state side
                     {:show-discard  true
                      :choices {:max (min (-> @state :corp :discard count) n)
-                               :req #(and (corp? %)
-                                          (in-discard? %))
+                               :card #(and (corp? %)
+                                           (in-discard? %))
                                :all all?}
                      :msg (msg "shuffle "
                                (let [seen (filter :seen targets)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -279,13 +279,13 @@
   (let [card (get-card state card)
         prompt (first (get-in @state [side :selected]))
         ability (:ability prompt)
-        five (:five prompt)
-        r (:req prompt)
+        card-req (:req prompt)
+        card-condition (:card prompt)
         cid (:not-self prompt)]
     (when (and (not= (:cid card) cid)
                (cond
-                 r (r card)
-                 five (five state side (:eid ability) (:card ability) [card])
+                 card-condition (card-condition card)
+                 card-req (card-req state side (:eid ability) (:card ability) [card])
                  :else true))
       (let [c (update-in card [:selected] not)]
         (update! state side c)
@@ -487,11 +487,11 @@
     (when-let [cost-str (pay state side nil :click 1 :credit trash-cost {:action :corp-trash-resource})]
       (resolve-ability state side
                        {:prompt  "Choose a resource to trash"
-                        :choices {:req (fn [card]
-                                         (if (and (seq (filter (fn [c] (untrashable-while-resources? c)) (all-active-installed state :runner)))
-                                                  (> (count (filter resource? (all-active-installed state :runner))) 1))
-                                           (and (resource? card) (not (untrashable-while-resources? card)))
-                                           (resource? card)))}
+                        :choices {:card (fn [card]
+                                          (if (and (seq (filter (fn [c] (untrashable-while-resources? c)) (all-active-installed state :runner)))
+                                                   (> (count (filter resource? (all-active-installed state :runner))) 1))
+                                            (and (resource? card) (not (untrashable-while-resources? card)))
+                                            (resource? card)))}
                         :cancel-effect (effect (gain :credit trash-cost :click 1))
                         :effect  (effect (trash target)
                                          (system-msg (str (build-spend-msg cost-str "trash")

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -373,7 +373,7 @@
                     {:prompt "Choose an Agenda to forfeit"
                      :async true
                      :choices {:max amount
-                               :req #(is-scored? state side %)}
+                               :card #(is-scored? state side %)}
                      :effect (req (wait-for (forfeit state side target {:msg false})
                                             (complete-with-result
                                               state side eid
@@ -420,7 +420,7 @@
     {:prompt (str "Choose " (quantify amount card-type) " to remove from the game")
      :choices {:all true
                :max amount
-               :req select-fn}
+               :card select-fn}
      :async true
      :effect (req (doseq [t targets]
                     (move state side (assoc-in t [:persistent :from-cid] (:cid card)) :rfg))
@@ -439,7 +439,7 @@
                      {:prompt (str "Choose " (quantify amount card-type) " to trash")
                       :choices {:all true
                                 :max amount
-                                :req select-fn}
+                                :card select-fn}
                       :async true
                       :priority 11
                       :effect (req (wait-for (trash-cards state side targets (merge args {:unpreventable true}))
@@ -476,7 +476,7 @@
                       {:prompt (str "Choose " (quantify amount (str "card in " hand)) " to trash")
                        :choices {:all true
                                  :max amount
-                                 :req select-fn}
+                                 :card select-fn}
                        :async true
                        :effect (req (wait-for (trash-cards state side targets {:unpreventable true :seen false})
                                               (complete-with-result
@@ -517,8 +517,8 @@
      :async true
      :choices {:all true
                :max amount
-               :req #(and (is-type? % (capitalize card-type))
-                          (in-hand? %))}
+               :card #(and (is-type? % (capitalize card-type))
+                           (in-hand? %))}
      :effect (req (wait-for (trash-cards state side targets {:unpreventable true})
                             (complete-with-result
                               state side eid
@@ -534,8 +534,8 @@
                     {:prompt (str "Choose " (quantify amount "card") " to shuffle into the stack")
                      :choices {:max amount
                                :all true
-                               :req #(and (installed? %)
-                                          (runner? %))}
+                               :card #(and (installed? %)
+                                           (runner? %))}
                      :async true
                      :effect (req (doseq [c targets]
                                     (move state :runner c :deck))
@@ -552,9 +552,9 @@
   (continue-ability
     state side
     {:prompt "Select an agenda with a counter"
-     :choices {:req #(and (agenda? %)
-                          (is-scored? state side %)
-                          (pos? (get-counters % :agenda)))}
+     :choices {:card #(and (agenda? %)
+                           (is-scored? state side %)
+                           (pos? (get-counters % :agenda)))}
      :effect (effect (add-counter target :agenda -1)
                      (trigger-event :agenda-counter-spent (get-card state target))
                      (complete-with-result

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -110,7 +110,7 @@
 (defn command-adv-counter [state side value]
   (resolve-ability state side
                    {:effect (effect (set-adv-counter target value))
-                    :choices {:req (fn [t] (same-side? (:side t) side))}}
+                    :choices {:card (fn [t] (same-side? (:side t) side))}}
                    (map->Card {:title "/adv-counter command"}) nil))
 
 (defn command-counter-smart [state side args]
@@ -137,14 +137,14 @@
                       (do (set-prop state side target :counter (merge (:counter target) {counter-type value}))
                           (system-msg state side (str "sets " (name counter-type) " counters to " value " on "
                                                       (card-str state target)))))))
-     :choices {:req (fn [t] (same-side? (:side t) side))}}
+     :choices {:card (fn [t] (same-side? (:side t) side))}}
     (map->Card {:title "/counter command"}) nil))
 
 (defn command-facedown [state side]
   (resolve-ability state side
                    {:prompt "Select a card to install facedown"
-                    :choices {:req #(and (runner? %)
-                                         (in-hand? %))}
+                    :choices {:card #(and (runner? %)
+                                          (in-hand? %))}
                     :effect (effect (runner-install target {:facedown true}))}
                    (map->Card {:title "/faceup command"}) nil))
 
@@ -173,7 +173,7 @@
                        {:effect (effect (set-prop target :counter (merge (:counter target) {counter-type value}))
                                         (system-msg (str "sets " (name counter-type) " counters to " value " on "
                                                          (card-str state target))))
-                        :choices {:req (fn [t] (same-side? (:side t) side))}}
+                        :choices {:card (fn [t] (same-side? (:side t) side))}}
                        (map->Card {:title "/counter command"}) nil)))))
 
 (defn command-rezall [state side value]
@@ -220,8 +220,8 @@
     (resolve-ability
       state side
       {:prompt "Select a piece of ice to install"
-       :choices {:req #(and (ice? %)
-                            (#{[:hand]} (:zone %)))}
+       :choices {:card #(and (ice? %)
+                             (#{[:hand]} (:zone %)))}
        :effect (effect
                  (continue-ability
                    (let [chosen-ice target]
@@ -270,16 +270,16 @@
     (resolve-ability
       state side
       {:prompt "Select the card to be hosted"
-       :choices {:req #(and (f %)
-                            (installed? %))}
+       :choices {:card #(and (f %)
+                             (installed? %))}
        :async true
        :effect (effect
                  (continue-ability
                    (let [h1 target]
                      {:prompt "Select the card to host the first card"
-                      :choices {:req #(and (f %)
-                                           (installed? %)
-                                           (not (same-card? % h1)))}
+                      :choices {:card #(and (f %)
+                                            (installed? %)
+                                            (not (same-card? % h1)))}
                       :effect (effect (host target h1 nil))})
                    nil nil))}
       nil nil)))
@@ -290,7 +290,7 @@
     (resolve-ability
       state side
       {:prompt "Select a card to trash"
-       :choices {:req #(f %)}
+       :choices {:card #(f %)}
        :effect (effect (trash eid target {:unpreventable true}))}
       nil nil)))
 
@@ -311,7 +311,7 @@
                                           {:effect (effect (system-msg (str "shows card-info of "
                                                                             (card-str state target)
                                                                             ": " (get-card state target))))
-                                           :choices {:req (fn [t] (same-side? (:side t) %2))}}
+                                           :choices {:card (fn [t] (same-side? (:side t) %2))}}
                                           (map->Card {:title "/card-info command"}) nil)
           "/clear-win"  clear-win
           "/click"      #(swap! %1 assoc-in [%2 :click] (max 0 value))
@@ -336,20 +336,20 @@
           "/move-bottom"  #(resolve-ability %1 %2
                                             {:prompt "Select a card in hand to put on the bottom of your deck"
                                              :effect (effect (move target :deck))
-                                             :choices {:req (fn [t] (and (same-side? (:side t) %2)
-                                                                         (in-hand? t)))}}
+                                             :choices {:card (fn [t] (and (same-side? (:side t) %2)
+                                                                          (in-hand? t)))}}
                                             (map->Card {:title "/move-bottom command"}) nil)
           "/move-deck"   #(resolve-ability %1 %2
                                            {:prompt "Select a card to move to the top of your deck"
                                             :effect (req (let [c (deactivate %1 %2 target)]
                                                            (move %1 %2 c :deck {:front true})))
-                                            :choices {:req (fn [t] (same-side? (:side t) %2))}}
+                                            :choices {:card (fn [t] (same-side? (:side t) %2))}}
                                            (map->Card {:title "/move-deck command"}) nil)
           "/move-hand"  #(resolve-ability %1 %2
                                           {:prompt "Select a card to move to your hand"
                                            :effect (req (let [c (deactivate %1 %2 target)]
                                                           (move %1 %2 c :hand)))
-                                           :choices {:req (fn [t] (same-side? (:side t) %2))}}
+                                           :choices {:card (fn [t] (same-side? (:side t) %2))}}
                                           (map->Card {:title "/move-hand command"}) nil)
           "/peek"       #(command-peek %1 %2 value)
           "/psi"        #(when (= %2 :corp) (psi-game %1 %2
@@ -359,14 +359,14 @@
           "/rez"        #(when (= %2 :corp)
                            (resolve-ability %1 %2
                                             {:effect (effect (rez target {:ignore-cost :all-costs :force true}))
-                                             :choices {:req (fn [t] (same-side? (:side t) %2))}}
+                                             :choices {:card (fn [t] (same-side? (:side t) %2))}}
                                             (map->Card {:title "/rez command"}) nil))
           "/rez-all"    #(when (= %2 :corp) (command-rezall %1 %2 value))
           "/rfg"        #(resolve-ability %1 %2
                                           {:prompt "Select a card to remove from the game"
                                            :effect (req (let [c (deactivate %1 %2 target)]
                                                           (move %1 %2 c :rfg)))
-                                           :choices {:req (fn [t] (same-side? (:side t) %2))}}
+                                           :choices {:card (fn [t] (same-side? (:side t) %2))}}
                                           (map->Card {:title "/rfg command"}) nil)
           "/roll"       #(command-roll %1 %2 value)
           "/summon"     #(command-summon %1 %2 args)
@@ -376,8 +376,8 @@
                              {:prompt "Select two installed ice to swap"
                               :choices {:max 2
                                         :all true
-                                        :req (fn [c] (and (installed? c)
-                                                          (ice? c)))}
+                                        :card (fn [c] (and (installed? c)
+                                                           (ice? c)))}
                               :effect (effect (swap-ice (first targets) (second targets)))}
                              (map->Card {:title "/swap-ice command"}) nil))
           "/swap-installed" #(when (= %2 :corp)
@@ -386,9 +386,9 @@
                                  {:prompt "Select two installed non-ice to swap"
                                   :choices {:max 2
                                             :all true
-                                            :req (fn [c] (and (installed? c)
-                                                              (corp? c)
-                                                              (not (ice? c))))}
+                                            :card (fn [c] (and (installed? c)
+                                                               (corp? c)
+                                                               (not (ice? c))))}
                                   :effect (effect (swap-installed (first targets) (second targets)))}
                                  (map->Card {:title "/swap-installed command"}) nil))
           "/tag"        #(swap! %1 assoc-in [%2 :tag :base] (max 0 value))

--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -109,8 +109,8 @@
            m (get-in ability [:choices :max])]
        (swap! state update-in [side :selected]
               #(conj (vec %) {:ability (dissoc ability :choices)
+                              :card (get-in ability [:choices :card])
                               :req (get-in ability [:choices :req])
-                              :five (get-in ability [:choices :five])
                               :not-self (when (get-in ability [:choices :not-self]) (:cid card))
                               :max m
                               :all all}))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -496,7 +496,7 @@
 
 (defn access-helper-remote [cards]
   {:prompt "Click a card to access it. You must access all cards in this server."
-   :choices {:req #(some (fn [c] (same-card? % c)) cards)}
+   :choices {:card #(some (fn [c] (same-card? % c)) cards)}
    :async true
    :effect (req (wait-for (access-card state side target)
                           (if (< 1 (count cards))
@@ -558,8 +558,8 @@
                           state side
                           {:async true
                            :prompt (str "Choose an upgrade in " server-name " to access.")
-                           :choices {:req #(and (= (second (:zone %)) chosen-zone)
-                                                (complement already-accessed))}
+                           :choices {:card #(and (= (second (:zone %)) chosen-zone)
+                                                 (complement already-accessed))}
                            :effect (req (wait-for (access-card state side target)
                                                   (continue-ability
                                                     state side
@@ -650,7 +650,7 @@
                         (continue-ability
                           state :corp
                           {:prompt (msg "Select " (access-count state side :hq-access) " cards in HQ for the Runner to access")
-                           :choices {:req #(and (in-hand? %) (corp? %))
+                           :choices {:card #(and (in-hand? %) (corp? %))
                                      :all true
                                      :max (req (access-count state side :hq-access))}
                            :async true
@@ -757,8 +757,8 @@
                           state side
                           {:async true
                            :prompt "Choose an upgrade in Archives to access."
-                           :choices {:req #(and (= (second (:zone %)) :archives)
-                                                (not (already-accessed %)))}
+                           :choices {:card #(and (= (second (:zone %)) :archives)
+                                                 (not (already-accessed %)))}
                            :effect (req (let [already-accessed (conj already-accessed target)]
                                           (wait-for (access-card state side target)
                                                     (if (must-continue? already-accessed)

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -216,7 +216,7 @@
        (continue-ability
          state side
          {:prompt (str "Discard down to " (quantify max-hand-size "card"))
-          :choices {:req in-hand?
+          :choices {:card in-hand?
                     :max (- cur-hand-size max-hand-size)
                     :all true}
           :effect (req (system-msg state side


### PR DESCRIPTION
This is a follow-up to the constant abilities pr, where I introduced the :five key to :choices. Making this align with normal ability maps will help lower confusion and increase consistency and flat abilities.