### PR TITLE
Clean up costs again

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -184,7 +184,7 @@
   n is the number of virus counters selected, msg is the msg string of all the cards and the virus counters taken from each.
   If called with no arguments, allows user to select as many counters as they like until 'Cancel' is pressed."
   ([] (pick-virus-counters-to-spend nil (hash-map) 0))
-  ([target-count] (pick-virus-counters-to-spend target-count (hash-map) 0 ))
+  ([target-count] (pick-virus-counters-to-spend target-count (hash-map) 0))
   ([target-count selected-cards counter-count]
    {:async true
     :prompt (str "Select a card with virus counters ("
@@ -203,20 +203,20 @@
                      (continue-ability state side
                                        (pick-virus-counters-to-spend target-count selected-cards counter-count)
                                        card nil)
-                     (let [msg (join ", " (map #(let [{:keys [card number]} %
-                                                      title (:title card)]
-                                                  (str (quantify number "virus counter") " from " title))
-                                               (vals selected-cards)))]
-                       (effect-completed state side (make-result eid {:number counter-count :msg msg}))))))
+                     (let [message (join ", " (map #(let [{:keys [card number]} %
+                                                          title (:title card)]
+                                                      (str (quantify number "virus counter") " from " title))
+                                                   (vals selected-cards)))]
+                       (effect-completed state side (make-result eid {:number counter-count :msg message}))))))
     :cancel-effect (if target-count
                      (req (doseq [{:keys [card number]} (vals selected-cards)]
                             (add-counter state :runner (get-card state card) :virus number))
                           (effect-completed state side (make-result eid :cancel)))
-                     (req (let [msg (join ", " (map #(let [{:keys [card number]} %
-                                                      title (:title card)]
-                                                  (str (quantify number "virus counter") " from " title))
-                                               (vals selected-cards)))]
-                           (effect-completed state side (make-result eid {:number counter-count :msg msg})))))}))
+                     (req (let [message (join ", " (map #(let [{:keys [card number]} %
+                                                               title (:title card)]
+                                                           (str (quantify number "virus counter") " from " title))
+                                                        (vals selected-cards)))]
+                           (effect-completed state side (make-result eid {:number counter-count :msg message})))))}))
 
 (defn pick-credit-triggers
   [state side eid selected-cards counter-count message]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1744,7 +1744,7 @@
                  :effect (effect (gain-credits target))}]}
 
    "Security Subcontract"
-   {:abilities [{:cost [:click 1 :ice]
+   {:abilities [{:cost [:click 1 :ice 1]
                  :msg "gain 4 [Credits]"
                  :label "Gain 4 [Credits]"
                  :effect (effect (gain-credits 4))}]}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -158,47 +158,13 @@
   "Spends virus counters from any card to pump/break, gains virus counters for successful runs
   (Khumalo suite: Musaazi, Yusuf)"
   [ice-type]
-  (let [type-subroutine (str ice-type " subroutine")
-        add-strength (fn [state card message n]
-                       (dotimes [_ n]
-                         (pump state :runner (get-card state card) 1))
-                       (system-msg state :runner
-                                   (str "spends " message
-                                        " to add " n
-                                        " strength")))]
+  (auto-icebreaker
     {:events [{:event :successful-run
                :silent (req true)
                :effect (effect (system-msg (str "adds 1 virus counter to " (:title card)))
                                (add-counter card :virus 1))}]
-     :abilities [{:label (str "Break one or more " type-subroutine "s")
-                  :effect (req (wait-for (resolve-ability
-                                           state side (pick-virus-counters-to-spend) card nil)
-                                         (when-let* [message (:msg async-result)
-                                                     n (:number async-result)]
-                                           (break-subroutines current-ice nil n {:repeatable false})
-                                           (system-msg state :runner
-                                                       (str "spends " message
-                                                            " to break "
-                                                            (quantify n type-subroutine))))))}
-                 {:label "Match strength of currently encountered ice"
-                  :req (req (and current-ice
-                                 (> (ice-strength state side current-ice)
-                                    (get-strength card))))
-                  :effect (req (wait-for (resolve-ability
-                                           state side
-                                           (pick-virus-counters-to-spend
-                                             (- (ice-strength state side current-ice)
-                                                (get-strength card)))
-                                           card nil)
-                                         (when-let* [message (:msg async-result)
-                                                     n (:number async-result)]
-                                           (add-strength state card message n))))}
-                 {:label "Add strength"
-                  :effect (req (wait-for (resolve-ability
-                                           state side (pick-virus-counters-to-spend) card nil)
-                                         (when-let* [message (:msg async-result)
-                                                     n (:number async-result)]
-                                           (add-strength state card message n))))}]}))
+     :abilities [(break-sub [:any-virus-counter 1] 1 ice-type)
+                 (strength-pump [:any-virus-counter 1] 1)]}))
 
 (defn- central-only
   "Break ability cannot be used on remote servers

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -873,19 +873,16 @@
    {:abilities [{:cost [:click 4] :async true :effect (effect (draw eid 10 nil)) :msg "draw 10 cards"}]}
 
    "Dummy Box"
-   (letfn [(dummy-prevent [type] {:msg (str "prevent a " type " from being trashed")
-                                  :async true
-                                  :priority 15
-                                  :prompt (str "Choose a " type " in your Grip")
-                                  :choices {:req #(and (is-type? % (capitalize type))
-                                                       (in-hand? %))}
-                                  :effect (effect (move target :discard)
-                                                  (trash-prevent (keyword type) 1))})]
+   (letfn [(dummy-prevent [card-type]
+             {:msg (str "prevent a " card-type " from being trashed")
+              :async true
+              :cost [(keyword (str "trash-" card-type "-from-hand")) 1]
+              :effect (effect (trash-prevent (keyword card-type) 1))})]
      {:interactions {:prevent [{:type #{:trash-hardware :trash-resource :trash-program}
                                 :req (req (not= :purge (:cause target)))}]}
       :abilities [(dummy-prevent "hardware")
-                  (dummy-prevent "resource")
-                  (dummy-prevent "program")]})
+                  (dummy-prevent "program")
+                  (dummy-prevent "resource")]})
 
    "Earthrise Hotel"
    (let [ability {:msg "draw 2 cards"
@@ -1822,6 +1819,7 @@
     :abilities [{:effect
                  (effect
                    (continue-ability
+                     ;; TODO: Convert this to a cost
                      {:prompt "Select a rezzed card with a trash cost"
                       :choices {:req #(and (:trash %)
                                            (rezzed? %)

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1831,11 +1831,12 @@
       (is (= 2 (:current-strength (refresh musaazi))) "Musaazi strength 2")
       (is (empty? (:prompt (get-runner))) "No prompt open")
       (card-ability state :runner musaazi 0)
+      (click-prompt state :runner "Trash a program")
       (click-card state :runner musaazi)
+      (click-prompt state :runner "Resolve a Grail ICE subroutine from HQ")
       (click-card state :runner imp)
-      (click-prompt state :runner "Done")
-      (is (zero?(get-counters (refresh imp) :virus)) "Imp lost its final virus counter")
-      (is (zero?(get-counters (refresh imp) :virus)) "Musaazi lost its virus counter"))))
+      (is (zero? (get-counters (refresh imp) :virus)) "Imp lost its final virus counter")
+      (is (zero? (get-counters (refresh imp) :virus)) "Musaazi lost its virus counter"))))
 
 (deftest na-not-k
   ;; Na'Not'K - Strength adjusts accordingly when ice installed during run
@@ -3047,37 +3048,15 @@
         (is (= 3 (get-counters (refresh cache) :virus)) "Initial Cache virus counters")
         (run-on state "HQ")
         (core/rez state :corp fire-wall)
-        (card-ability state :runner yusuf 1) ; match strength
+        (card-ability state :runner yusuf 1)
         (click-card state :runner cache)
+        (card-ability state :runner yusuf 1)
         (click-card state :runner yusuf)
         (is (= 2 (get-counters (refresh cache) :virus)) "Cache lost 1 virus counter to pump")
         (is (= 5 (:current-strength (refresh yusuf))) "Yusuf strength 5")
-        (is (zero?(get-counters (refresh yusuf) :virus)) "Yusuf lost 1 virus counter to pump")
+        (is (zero? (get-counters (refresh yusuf) :virus)) "Yusuf lost 1 virus counter to pump")
         (is (empty? (:prompt (get-runner))) "No prompt open")
         (card-ability state :runner yusuf 0)
+        (click-prompt state :runner "End the run")
         (click-card state :runner cache)
-        (click-prompt state :runner "Done")
-        (is (= 1 (get-counters (refresh cache) :virus)) "Cache lost its final virus counter"))))
-  (testing "Yusuf add strength test"
-    (do-game
-      (new-game {:corp {:deck ["Fire Wall"]}
-                 :runner {:deck ["Yusuf" "Cache"]}})
-      (play-from-hand state :corp "Fire Wall" "HQ")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Yusuf")
-      (play-from-hand state :runner "Cache")
-      (let [fire-wall (get-ice state :hq 0)
-            yusuf (get-program state 0)
-            cache (get-program state 1)]
-        (run-empty-server state "Archives")
-        (is (= 1 (get-counters (refresh yusuf) :virus)) "Yusuf has 1 virus counter")
-        (is (= 3 (:current-strength (refresh yusuf))) "Initial Yusuf strength")
-        (is (= 3 (get-counters (refresh cache) :virus)) "Initial Cache virus counters")
-        (run-on state "HQ")
-        (core/rez state :corp fire-wall)
-        (card-ability state :runner yusuf 2) ; add strength
-        (click-card state :runner cache)
-        (click-prompt state :runner "Done")
-        (is (= 2 (get-counters (refresh cache) :virus)) "Cache lost 1 virus counter to pump")
-        (is (= 4 (:current-strength (refresh yusuf))) "Yusuf strength 4")
-        (is (empty? (:prompt (get-runner))) "No prompt open")))))
+        (is (= 1 (get-counters (refresh cache) :virus)) "Cache lost its final virus counter")))))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1096,7 +1096,7 @@
       (take-credits state :runner)
       (core/trash state :runner (get-program state 0))
       (is (not-empty (:prompt (get-runner))) "Dummy Box prompting to prevent program trash")
-      (card-ability state :runner (get-resource state 0) 2)
+      (card-ability state :runner (get-resource state 0) 1)
       (click-card state :runner (find-card "Clot" (:hand (get-runner))))
       (click-prompt state :runner "Done")
       (is (= 1 (count (:discard (get-runner)))) "Clot trashed")


### PR DESCRIPTION
Implements `:any-virus-counter` (for Yusuf and Musaazi) and `:trash-X-from-hand` (for Dummy Box) ~and `:pay-trash-cost` (for Political Operative)~. Can't do PolOp, as we don't have a way to pass the target of a cost back to the effect. For now this will have to be done manually.