### PR TITLE
Stop breakers from revealing information

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -112,10 +112,11 @@
   (Greek/Philosopher suite: Adept, Sage, Savant)"
   [first-qty first-type second-qty second-type]
   {:cost [:credit 2]
-   :req (req (or (and (has-subtype? current-ice first-type)
-                      (<= first-qty (count (remove :broken (:subroutines current-ice)))))
-                 (and (has-subtype? current-ice second-type)
-                      (<= second-qty (count (remove :broken (:subroutines current-ice)))))))
+   :req (req (and (rezzed? current-ice)
+               (or (and (has-subtype? current-ice first-type)
+                        (<= first-qty (count (remove :broken (:subroutines current-ice)))))
+                   (and (has-subtype? current-ice second-type)
+                        (<= second-qty (count (remove :broken (:subroutines current-ice))))))))
    :label (str "break "
                (quantify first-qty (str first-type " subroutine")) " or "
                (quantify second-qty (str second-type " subroutine")))
@@ -1178,6 +1179,7 @@
    "Grappling Hook"
    {:abilities [{:label "break all but 1 subroutine"
                  :req (req (and current-ice
+                                (rezzed? current-ice)
                                 (< 1 (count (remove :broken (:subroutines current-ice))))))
                  :cost [:trash]
                  :prompt "Select the subroutine to NOT break"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -80,6 +80,7 @@
   (let [selector (resolve f)
         descriptor (str f)]
     {:abilities [{:req (req (and current-ice
+                                 (rezzed? current-ice)
                                  (not (:broken (selector (:subroutines current-ice))))))
                   :cost [:trash]
                   :label (str "Break the " descriptor " subroutine")


### PR DESCRIPTION
Some breakers didn't check whether ice is rezzed and leaked information about the subroutines. Closes #4545 