### PR TITLE
Reworked :req in breaker abilities

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1088,7 +1088,7 @@
               :effect (effect (gain-credits :corp 1))}]}
 
    "Quetzal: Free Spirit"
-   {:abilities [(assoc (break-sub nil 1 "Barrier" {:req (req true)}) :once :per-turn)]}
+   {:abilities [(assoc (break-sub nil 1 "Barrier" {:ignore-strength true}) :once :per-turn)]}
 
    "Reina Roja: Freedom Fighter"
    (letfn [(not-triggered? [state card] (not (get-in @state [:per-turn (:cid card)])))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1088,7 +1088,7 @@
               :effect (effect (gain-credits :corp 1))}]}
 
    "Quetzal: Free Spirit"
-   {:abilities [(assoc (break-sub nil 1 "Barrier" {:ignore-strength true}) :once :per-turn)]}
+   {:abilities [(assoc (break-sub nil 1 "Barrier") :once :per-turn)]}
 
    "Reina Roja: Freedom Fighter"
    (letfn [(not-triggered? [state card] (not (get-in @state [:per-turn (:cid card)])))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -825,7 +825,7 @@
    "D4v1d"
    (let [david-req (req (<= 5 (get-strength current-ice)))]
      {:data {:counter {:power 3}}
-      :abilities [(break-sub [:power 1] 1 "All" {:req david-req})]})
+      :abilities [(break-sub [:power 1] 1 "All" {:req david-req :ignore-strength true})]})
 
    "Dagger"
    (auto-icebreaker {:implementation "Stealth credit restriction not enforced"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2428,24 +2428,23 @@
                  :effect (effect (gain :click 2))}]}
 
    "Utae"
-   (auto-icebreaker {:abilities [{:label "X [Credits]: Break X Code Gate subroutines"
-                                  :once :per-run
-                                  :req (req (pos? (total-available-credits state :runner eid card)))
-                                  :prompt "How many credits?"
-                                  :choices {:number (req (total-available-credits state :runner eid card))}
-                                  :effect (effect
-                                            (continue-ability
-                                              (when (pos? target)
-                                                (break-sub target target "Code Gate"))
-                                              card nil))}
-                                 {:label "Break 1 Code Gate subroutine (Virtual restriction)"
-                                  :req (req (<= 3 (count (filter #(has-subtype? % "Virtual")
-                                                                 (all-active-installed state :runner)))))
-                                  :effect (effect
-                                            (continue-ability
-                                              (break-sub 1 1 "Code Gate")
-                                              card nil))}
-                                 (strength-pump 1 1)]})
+   (let [break-req (:break-req (break-sub 1 1 "Code Gate"))]
+     (auto-icebreaker {:abilities [{:label "X [Credits]: Break X Code Gate subroutines"
+                                    :once :per-run
+                                    :req (req (and (break-req state side eid card targets)
+                                                   (<= (get-strength current-ice) (get-strength card))))
+                                    ; no break-req to not enable auto-pumping
+                                    :prompt "How many credits?"
+                                    :choices {:number (req (total-available-credits state :runner eid card))}
+                                    :effect (effect
+                                              (continue-ability
+                                                (when (pos? target)
+                                                  (break-sub target target "Code Gate"))
+                                                card nil))}
+                                   (break-sub 1 1 "Code Gate" {:label "Break 1 Code Gate subroutine (Virtual restriction)"
+                                                               :req (req (<= 3 (count (filter #(has-subtype? % "Virtual")
+                                                                                              (all-active-installed state :runner)))))})
+                                   (strength-pump 1 1)]}))
 
    "Vamadeva"
    (swap-with-in-hand "Vamadeva"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -803,24 +803,12 @@
                      :choices (req servers)
                      :effect (effect (update! (assoc card :server-target target)))
                      :leave-play (effect (update! (dissoc card :server-target)))
-                     :abilities [(merge
-                                   (break-sub 1 1 "Code Gate")
-                                   {:req (req (if (:server-target card)
-                                                (#{(last (server->zone state (:server-target card)))} (first (:server run)))
-                                                true))
-                                    :effect (effect
-                                              (continue-ability
-                                                (break-sub nil 1 "Code Gate")
-                                                card nil))})
-                                 (merge
-                                   (strength-pump 1 1)
-                                   {:req (req (if (:server-target card)
-                                                (#{(last (server->zone state (:server-target card)))} (first (:server run)))
-                                                true))
-                                    :effect (effect
-                                              (continue-ability
-                                                (strength-pump nil 1)
-                                                card nil))})]})
+                     :abilities [(break-sub 1 1 "Code Gate" {:req (req (if (:server-target card)
+                                                                         (#{(last (server->zone state (:server-target card)))} (first (:server run)))
+                                                                         true))})
+                                 (strength-pump 1 1 :encounter {:req (req (if (:server-target card)
+                                                                            (#{(last (server->zone state (:server-target card)))} (first (:server run)))
+                                                                            true))})]})
 
    "D4v1d"
    (let [david-req (req (<= 5 (get-strength current-ice)))]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -807,7 +807,7 @@
    "D4v1d"
    (let [david-req (req (<= 5 (get-strength current-ice)))]
      {:data {:counter {:power 3}}
-      :abilities [(break-sub [:power 1] 1 "All" {:req david-req :ignore-strength true})]})
+      :abilities [(break-sub [:power 1] 1 "All" {:req david-req})]})
 
    "Dagger"
    (auto-icebreaker {:implementation "Stealth credit restriction not enforced"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -822,13 +822,7 @@
 
    "Dai V"
    (auto-icebreaker {:implementation "Stealth credit restriction not enforced"
-                     :abilities [(merge
-                                   (dissoc (break-sub 2 0) :req)
-                                   {:effect
-                                    (effect
-                                      (continue-ability
-                                        (break-sub 2 (count (:subroutines current-ice)) "All" {:all true})
-                                        card nil))})
+                     :abilities [(break-sub 2 0 "All" {:all true})
                                  (strength-pump 1 1)]})
 
    "Darwin"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -335,14 +335,8 @@
                  (strength-pump 2 3))
 
    "Alpha"
-   (auto-icebreaker {:abilities [(merge
-                                   (break-sub 1 1)
-                                   {:req (req (= (:position run) (count run-ices)))
-                                    :effect (effect (continue-ability (break-sub 1 1) card nil))})
-                                 (merge
-                                   (strength-pump 1 1)
-                                   {:req (req (= (:position run) (count run-ices)))
-                                    :effect (effect (continue-ability (strength-pump 1 1) card nil))})]})
+   (auto-icebreaker {:abilities [(break-sub 1 1 {:req (req (= (:position run) (count run-ices)))})
+                                 (strength-pump 1 1 :encounter {:req (req (= (:position run) (count run-ices)))})]})
 
    "Amina"
    (auto-icebreaker {:abilities [(break-sub 2 3 "Code Gate")
@@ -1681,14 +1675,8 @@
     :abilities [(set-autoresolve :auto-nyashia "Nyashia")]}
 
    "Omega"
-   (auto-icebreaker {:abilities [(merge
-                                   (break-sub 1 1)
-                                   {:req (req (= 1 (:position run)))
-                                    :effect (effect (continue-ability (break-sub 1 1) card nil))})
-                                 (merge
-                                   (strength-pump 1 1)
-                                   {:req (req (= 1 (:position run)))
-                                    :effect (effect (continue-ability (strength-pump 1 1) card nil))})]})
+   (auto-icebreaker {:abilities [(break-sub 1 1 {:req (req (= 1 (:position run)))})
+                                 (strength-pump 1 1 :encounter {:req (req (= 1 (:position run)))})]})
 
    "Origami"
    {:effect (effect (gain :hand-size

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -336,7 +336,7 @@
 
    "Alpha"
    (auto-icebreaker {:abilities [(break-sub 1 1 {:req (req (= (:position run) (count run-ices)))})
-                                 (strength-pump 1 1 :encounter {:req (req (= (:position run) (count run-ices)))})]})
+                                 (strength-pump 1 1 :end-of-encounter {:req (req (= (:position run) (count run-ices)))})]})
 
    "Amina"
    (auto-icebreaker {:abilities [(break-sub 2 3 "Code Gate")
@@ -800,9 +800,9 @@
                      :abilities [(break-sub 1 1 "Code Gate" {:req (req (if (:server-target card)
                                                                          (#{(last (server->zone state (:server-target card)))} (first (:server run)))
                                                                          true))})
-                                 (strength-pump 1 1 :encounter {:req (req (if (:server-target card)
-                                                                            (#{(last (server->zone state (:server-target card)))} (first (:server run)))
-                                                                            true))})]})
+                                 (strength-pump 1 1 :end-of-encounter {:req (req (if (:server-target card)
+                                                                                   (#{(last (server->zone state (:server-target card)))} (first (:server run)))
+                                                                                   true))})]})
 
    "D4v1d"
    (let [david-req (req (<= 5 (get-strength current-ice)))]
@@ -1676,7 +1676,7 @@
 
    "Omega"
    (auto-icebreaker {:abilities [(break-sub 1 1 {:req (req (= 1 (:position run)))})
-                                 (strength-pump 1 1 :encounter {:req (req (= 1 (:position run)))})]})
+                                 (strength-pump 1 1 :end-of-encounter {:req (req (= 1 (:position run)))})]})
 
    "Origami"
    {:effect (effect (gain :hand-size

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -371,7 +371,10 @@
         in-range (and (pos? ice-cnt) (< -1 ice-idx ice-cnt))
         current-ice (when (and run in-range) (get-card state (run-ice ice-idx)))
         ;; match strength
-        pump-ability (some #(when (:pump %) %) (:abilities (card-def card)))
+        can-pump (fn [ability]
+                   (when (:pump ability)
+                     ((:req ability) state side eid card nil)))
+        pump-ability (some #(when (can-pump %) %) (:abilities (card-def card)))
         strength-diff (when (and current-ice
                                  (get-strength current-ice)
                                  (get-strength card))
@@ -384,10 +387,8 @@
                           (repeat times-pump (:cost pump-ability)))
         ;; break all subs
         can-break (fn [ability]
-                    (if-let [subtype (:breaks ability)]
-                      (or (= subtype "All")
-                          (has-subtype? current-ice subtype))
-                      false))
+                    (when (:break-req ability)
+                      ((:break-req ability) state side eid card nil)))
         break-ability (some #(when (can-break %) %) (:abilities (card-def card)))
         subs-broken-at-once (when break-ability
                               (:break break-ability 1))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -321,7 +321,8 @@
   ([ice broken-subs args]
    (str "break " (quantify (count broken-subs)
                            (str (when-let [subtype (:subtype args)]
-                                  (str subtype " "))
+                                  (when (not= "All" subtype)
+                                    (str subtype " ")))
                                 "subroutine"))
         " on " (:title ice)
         " (\"[subroutine] "

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -368,8 +368,7 @@
   If n = 0 then any number of subs are broken.
   :label can be used to add a non-standard label to the ability
   :additional-ability is a non-async ability that is called after using the break ability.
-  :req will be added to the standard checks for encountering a piece of ice and strengths of the ice and breaker.
-  :ignore-strength can be used to skip the strength check."
+  :req will be added to the standard checks for encountering a piece of ice and strengths of the ice and breaker."
   ([cost n] (break-sub cost n nil nil))
   ([cost n subtype] (break-sub cost n subtype nil))
   ([cost n subtype args]
@@ -385,11 +384,11 @@
                              (if (:req args)
                                ((:req args) state side eid card targets)
                                true)))
-         ignore-strength (or (:ignore-strength args) false)]
+         strength-req (req (if (has-subtype? card "Icebreaker")
+                             (<= (get-strength current-ice) (get-strength card))
+                             true))]
      {:req (req (and (break-req state side eid card targets)
-                     (if ignore-strength
-                       true
-                       (<= (get-strength current-ice) (get-strength card)))))
+                     (strength-req state side eid card targets)))
       :break-req break-req
       :break n
       :breaks subtype

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -366,6 +366,7 @@
 (defn break-sub
   "Creates a break subroutine ability.
   If n = 0 then any number of subs are broken.
+  :label can be used to add a non-standard label to the ability
   :additional-ability is a non-async ability that is called after using the break ability.
   :req will be added to the standard checks for encountering a piece of ice and strengths of the ice and breaker.
   :ignore-strength can be used to skip the strength check."

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -343,7 +343,7 @@
                       :all false}
                      args)]
      {:async true
-      :effect (req (wait-for (resolve-ability state side (break-subroutines-impl ice n '() args) card nil)
+      :effect (req (wait-for (resolve-ability state side (break-subroutines-impl ice (if (zero? n) (count (:subroutines current-ice)) n) '() args) card nil)
                              (let [broken-subs (:broken-subs async-result)
                                    early-exit (:early-exit async-result)]
                                (wait-for (resolve-ability state side (make-eid state {:source-type :ability})

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -378,6 +378,7 @@
          break-req (or (:req args) (req true))
          ignore-strength (or (:ignore-strength args) false)]
      {:req (req (and current-ice
+                     (rezzed? current-ice)
                      (if subtype
                        (or (= subtype "All")
                            (has-subtype? current-ice subtype)))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -375,18 +375,20 @@
    (let [cost (if (number? cost) [:credit cost] cost)
          subtype (or subtype "All")
          args (assoc args :subtype subtype)
-         break-req (or (:req args) (req true))
+         break-req (req (and current-ice
+                             (rezzed? current-ice)
+                             (if subtype
+                               (or (= subtype "All")
+                                   (has-subtype? current-ice subtype)))
+                             (seq (remove :broken (:subroutines current-ice)))
+                             (if (:req args)
+                               ((:req args) state side eid card targets)
+                               true)))
          ignore-strength (or (:ignore-strength args) false)]
-     {:req (req (and current-ice
-                     (rezzed? current-ice)
-                     (if subtype
-                       (or (= subtype "All")
-                           (has-subtype? current-ice subtype)))
-                     (seq (remove :broken (:subroutines current-ice)))
+     {:req (req (and (break-req state side eid card targets)
                      (if ignore-strength
                        true
-                       (<= (get-strength current-ice) (get-strength card)))
-                     (break-req state side eid card targets)))
+                       (<= (get-strength current-ice) (get-strength card)))))
       :break-req break-req
       :break n
       :breaks subtype

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -968,6 +968,34 @@
         (card-ability state :runner d4 0)
         (is (empty? (:prompt (get-runner))) "No prompt for breaking 1 strength Ice Wall")))))
 
+(deftest dai-v
+  ;; Dai V
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck ["Enigma"]}
+                 :runner {:deck [(qty "Cloak" 2) "Dai V"]}})
+      (play-from-hand state :corp "Enigma" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Cloak")
+      (play-from-hand state :runner "Cloak")
+      (play-from-hand state :runner "Dai V")
+      (run-on state :hq)
+      (let [enig (get-ice state :hq 0)
+            cl1 (get-program state 0)
+            cl2 (get-program state 1)
+            daiv (get-program state 2)]
+        (core/rez state :corp enig)
+        (changes-val-macro -1 (:credit (get-runner))
+                           "Used 1 credit to pump and 2 credits from Cloaks to break"
+                           (card-ability state :runner daiv 1)
+                           (click-prompt state :runner "Done")
+                           (card-ability state :runner daiv 0)
+                           (click-prompt state :runner "Force the Runner to lose 1 [Click] if able")
+                           (click-prompt state :runner "End the run")
+                           (click-card state :runner cl1)
+                           (click-card state :runner cl2))))))
+
 (deftest darwin
   ;; Darwin - starts at 0 strength
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -943,6 +943,31 @@
       (is (zero? (count (filter :broken (:subroutines (get-ice state :rd 0))))) "No subs are broken")
       (is (empty? (:prompt (get-runner))) "Can't break subs on a different server"))))
 
+(deftest d4v1d
+  ;; D4v1d
+  (testing "Can break 5+ strength ice"
+    (do-game
+      (new-game {:corp {:deck ["Ice Wall" "Hadrian's Wall"]}
+                 :runner {:deck ["D4v1d"]}})
+      (core/gain state :corp :credit 10)
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Hadrian's Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "D4v1d")
+      (let [had (get-ice state :hq 1)
+            iw (get-ice state :hq 0)
+            d4 (get-program state 0)]
+        (is (= 3 (get-counters d4 :power)) "D4v1d installed with 3 power tokens")
+        (run-on state :hq)
+        (core/rez state :corp had)
+        (card-ability state :runner d4 0)
+        (dotimes [_ 2] (click-prompt state :runner "End the run"))
+        (is (= 1 (get-counters (refresh d4) :power)) "Used 2 power tokens from D4v1d to break")
+        (run-continue state)
+        (core/rez state :corp iw)
+        (card-ability state :runner d4 0)
+        (is (empty? (:prompt (get-runner))) "No prompt for breaking 1 strength Ice Wall")))))
+
 (deftest darwin
   ;; Darwin - starts at 0 strength
   (do-game

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -2849,13 +2849,13 @@
       (play-from-hand state :corp "Spiderweb" "HQ")
       (take-credits state :corp)
       (core/gain state :runner :credit 10)
+      (core/gain state :corp :credit 1)
       (play-from-hand state :runner "Snowball")
       (let [sp (get-ice state :hq 1)
             fw (get-ice state :hq 0)
             snow (get-program state 0)]
         (run-on state "HQ")
         (core/rez state :corp sp)
-        (core/rez state :corp fw)
         (card-ability state :runner snow 1) ; match strength
         (is (= 2 (:current-strength (refresh snow))))
         (card-ability state :runner snow 0) ; strength matched, break a sub
@@ -2864,6 +2864,7 @@
         (click-prompt state :runner "End the run")
         (is (= 5 (:current-strength (refresh snow))) "Broke 3 subs, gained 3 more strength")
         (run-continue state)
+        (core/rez state :corp fw)
         (is (= 4 (:current-strength (refresh snow))) "Has +3 strength until end of run; lost 1 per-encounter boost")
         (card-ability state :runner snow 1) ; match strength
         (is (= 5 (:current-strength (refresh snow))) "Matched strength, gained 1")


### PR DESCRIPTION
Helper functions `break-sub` and `strength-pump` now deal differently with the `:req` key. The `:req` key is only to be used for additional checks that have do be done outside of the standard ones required by the rules (ice is rezzed and being encountered, subtype matches breaker, there are unbroken subroutines, breaker strength matches to ice).
The break ability contains two different req keys: `:req` for the manual execution of the ability and `:break-req` for the auto-pump-and-break functionality. Here the strength check is omitted to be able to check whether pumping and breaking will be successful before resolving any abilities.
