### PR TITLE
Remove tokens from agenda hosted on Film Critic

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -982,6 +982,7 @@
            (host-agenda? [agenda]
              {:optional {:prompt (str "You access " (:title agenda) ". Host it on Film Critic?")
                          :yes-ability {:effect (req (host state side card (move state side agenda :play-area))
+                                                    (update! state side (dissoc (get-card state agenda) :counter))
                                                     (access-end state side eid agenda)
                                                     (when-not (:run @state)
                                                       (swap! state dissoc :access)))

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1395,7 +1395,20 @@
         (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant hosted on FC")
         (take-credits state :corp)
         (card-ability state :runner fc 0)
-        (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant still hosted on FC")))))
+        (is (= 1 (count (:hosted (refresh fc)))) "MCA Informant still hosted on FC"))))
+  (testing "remove hosted advancement tokens"
+    (do-game
+      (new-game {:corp {:deck ["Priority Requisition"]}
+                 :runner {:deck ["Film Critic"]}})
+      (play-from-hand state :corp "Priority Requisition" "New remote")
+      (let [prireq (get-content state :remote1 0)]
+        (dotimes [_ 2] (core/advance state :corp {:card (refresh prireq)}))
+        (take-credits state :corp)
+        (play-from-hand state :runner "Film Critic")
+        (run-empty-server state :remote1)
+        (is (= 2 (get-counters (refresh prireq) :advancement)) "Two advancement tokens on Pri Req")
+        (click-prompt state :runner "Yes")
+        (is (= 0 (get-counters (refresh prireq) :advancement)) "No more counters on the Pri Req")))))
 
 (deftest find-the-truth
   ;; Find the Truth


### PR DESCRIPTION
Since the agenda is being uninstalled in the act of being hosted on Film Critic (see card text), it loses all its counters.