### PR TITLE
Fix small breaker bugs, undo click functionality

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -60,7 +60,7 @@
 
 (defn bioroid-break
   [cost qty]
-  (break-sub [:click cost] qty))
+  (break-sub [:click cost {:action :bioroid-cost}] qty))
 
 ;;; General subroutines
 (def end-the-run

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -553,7 +553,6 @@
                           (installed? %))}
     :msg (msg "give " (card-str state target {:visible false}) " additional text")
     :effect (effect (host target (assoc card :seen true :condition true)))
-    :leave-play (req (remove-extra-subs! state :corp (:cid card) (:host card)))
     :abilities [{:label "Give the Runner 1 tag"
                  :trace {:base 3
                          :successful {:msg "give the Runner 1 tag"
@@ -1908,7 +1907,7 @@
                    (add-extra-sub! state :corp (get-card state target) new-sub (:cid card))
                    (update-ice-strength state side target)
                    (host state side (get-card state target) (assoc card :seen true :condition true)))
-      :leave-play (req (remove-extra-subs! state :corp (:cid card) (:host card)))
+      :leave-play (req (remove-extra-subs! state :corp (:host card) (:cid card)))
       :events [{:event :rez
                 :req (req (same-card? target (:host card)))
                 :effect (req (add-extra-sub! state :corp (get-card state target) new-sub (:cid card)))}]})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -303,7 +303,7 @@
                  (strength-pump 2 3))
 
    "Alpha"
-   (auto-icebreaker {:abilities [(break-sub 1 1 {:req (req (= (:position run) (count run-ices)))})
+   (auto-icebreaker {:abilities [(break-sub 1 1 "All" {:req (req (= (:position run) (count run-ices)))})
                                  (strength-pump 1 1 :end-of-encounter {:req (req (= (:position run) (count run-ices)))})]})
 
    "Amina"
@@ -572,13 +572,9 @@
               :msg "add itself to Grip"
               :interactive (req true)
               :effect (effect (move card :hand))}]
-    :abilities [(merge
-                  (break-sub 1 1 "All" {:req (req (and (<= (get-strength current-ice) (get-strength card))
-                                                       (has-subtype? current-ice (:subtype-target card))))})
-                  {:effect (effect
-                             (continue-ability
-                               (break-sub 1 1 (:subtype-target card))
-                               card nil))})]}
+    :abilities [(break-sub 1 1 "All" {:req (req (if-let [subtype (:subtype-target card)]
+                                                  (has-subtype? current-ice subtype)
+                                                  true))})]}
 
    "Chisel"
    {:implementation "Encounter effect is manual."
@@ -1649,7 +1645,7 @@
     :abilities [(set-autoresolve :auto-nyashia "Nyashia")]}
 
    "Omega"
-   (auto-icebreaker {:abilities [(break-sub 1 1 {:req (req (= 1 (:position run)))})
+   (auto-icebreaker {:abilities [(break-sub 1 1 "All" {:req (req (= 1 (:position run)))})
                                  (strength-pump 1 1 :end-of-encounter {:req (req (= 1 (:position run)))})]})
 
    "Origami"


### PR DESCRIPTION
* Add subtype to Alpha and Omega
* Fix arguments to `remove-extra-subs!` in Eavesdrop
* Fix Chameleon crashing when `:subtype-target` not set
* Add `:bioroid-break` as potential action for not saving `:click-state` for undo-click functionality

Closes #4584 