### PR TITLE
Changed can-pay? calls with certain :source-types

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -426,9 +426,14 @@
     :events [{:event :pre-access-card
               :once :per-run
               :async true
-              :req (req (not= (:type target) "Agenda"))
+              :req (req (not (agenda? target)))
               :effect (req (let [c target
-                                 cost (:cost c)
+                                 cost (or (and (or (asset? c)
+                                                   (upgrade? c)
+                                                   (ice? c))
+                                               (rez-cost state side c))
+                                          (and (operation? c)
+                                               (play-cost state side c)))
                                  title (:title c)]
                              (if (can-pay? state :corp eid card nil [:credit cost])
                                (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent the trash")

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1173,7 +1173,8 @@
     :effect (effect (trigger-event :searched-stack nil)
                     (continue-ability
                      (let [connection target]
-                       (if (can-pay? state side (assoc eid :source card :source-type :runner-install) connection nil :credit (:cost connection))
+                       (if (can-pay? state side (assoc eid :source card :source-type :runner-install) connection nil
+                                     [:credit (install-cost state side connection)])
                          {:optional {:prompt (str "Install " (:title connection) "?")
                                      :yes-ability {:async true
                                                    :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) connection nil)

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -255,12 +255,12 @@
    "Career Fair"
    {:prompt "Select a resource to install from your Grip"
     :req (req (some #(and (resource? %)
-                          (can-pay? state side eid card nil
+                          (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                     [:credit (install-cost state side % {:cost-bonus -3})]))
                     (:hand runner)))
     :choices {:req (req (and (resource? target)
                              (in-hand? target)
-                             (can-pay? state side eid card nil
+                             (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                        [:credit (install-cost state side target {:cost-bonus -3})])))}
     :async true
     :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3}))}
@@ -335,7 +335,7 @@
                     :msg (msg "install " (:title target) " and take 1 tag")
                     :choices (req (filter #(and (program? %)
                                                 (runner-can-install? state side % false)
-                                                (can-pay? state side eid card nil
+                                                (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                           [:credit (install-cost state side % {:cost-bonus (rd-ice state)})]))
                                           (:deck runner)))
                     :effect (req (trigger-event state side :searched-stack nil)
@@ -454,7 +454,7 @@
     :prompt "Select a card to install from your Grip"
     :choices {:req (req (and (not (event? target))
                              (in-hand? target)
-                             (can-pay? state side eid card nil
+                             (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                        [:credit (install-cost state side target {:cost-bonus -8})])))}
     :async true
     :effect (req (let [new-eid (make-eid state {:source card :source-type :runner-install})]
@@ -789,7 +789,7 @@
                         " lowering the cost by " trash-cost)
               :choices (req (cancellable (filter #(or (program? %)
                                                       (hardware? %)
-                                                      (can-pay? state side eid card nil
+                                                      (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                                 [:credit (install-cost state side % {:cost-bonus (- trash-cost)})]))
                                                  (:deck runner)) :sorted))
               :effect (req (trigger-event state side :searched-stack nil)
@@ -869,7 +869,7 @@
                        caninst (and (or (hardware? topcard)
                                         (program? topcard)
                                         (resource? topcard))
-                                    (can-pay? state side eid card nil
+                                    (can-pay? state side (assoc eid :source card :source-type :runner-install) topcard nil
                                               [:credit (install-cost state side topcard {:cost-bonus -10})]))]
                    (if caninst
                      (continue-ability
@@ -1059,7 +1059,7 @@
                 :choices (concat
                            (->> top-ten
                                 (filter #(and (program? %)
-                                              (can-pay? state side eid card nil
+                                              (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                         [:credit (install-cost state side % {:cost-bonus -5})])))
                                 (sort-by :title)
                                 (into []))
@@ -1173,7 +1173,7 @@
     :effect (effect (trigger-event :searched-stack nil)
                     (continue-ability
                      (let [connection target]
-                       (if (can-pay? state side eid card nil :credit (:cost connection))
+                       (if (can-pay? state side (assoc eid :source card :source-type :runner-install) connection nil :credit (:cost connection))
                          {:optional {:prompt (str "Install " (:title connection) "?")
                                      :yes-ability {:async true
                                                    :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) connection nil)
@@ -1677,19 +1677,19 @@
              (when (< n 3)
                {:async true
                 :req (req (some #(and (program? %)
-                                      (can-pay? state side eid card nil
+                                      (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                 [:credit (install-cost state side %)]))
                                 (:hand runner)))
                 :prompt "Select a program to install"
                 :choices {:req (req (and (program? target)
                                          (in-hand? target)
-                                         (can-pay? state side eid card nil
+                                         (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                    [:credit (install-cost state side target)])))}
                 :effect (req (wait-for (runner-install state side target nil)
                                        (continue-ability state side (mhelper (inc n)) card nil)))}))]
      {:async true
       :req (req (some #(and (program? %)
-                            (can-pay? state side eid card nil
+                            (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                       [:credit (install-cost state side %)]))
                       (:hand runner)))
       :effect (effect (continue-ability (mhelper 0) card nil))})
@@ -1743,7 +1743,7 @@
     :choices {:req (req (and (or (hardware? target)
                                  (program? target))
                              (in-hand? target)
-                             (can-pay? state side eid card nil
+                             (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                        [:credit (install-cost state side target {:cost-bonus -3})])))}
     :async true
     :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3}))}
@@ -1864,7 +1864,7 @@
     :prompt "Choose a Run event"
     :choices (req (sort-by :title
                            (filter #(and (has-subtype? % "Run")
-                                         (can-pay? state side eid card nil
+                                         (can-pay? state side (assoc eid :source card :source-type :play) % nil
                                                    [:credit (play-cost state side %)]))
                                    (:deck runner))))
     :msg (msg "play " (:title target))
@@ -2106,7 +2106,7 @@
                      :prompt "Select a program or piece of hardware to install"
                      :choices
                      {:req (req (and (valid-target? target)
-                                     (can-pay? state side eid card nil
+                                     (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                [:credit (install-cost state side target
                                                                       {:cost-bonus (- bonus)})])))}
                      :effect (effect (runner-install (assoc eid :source card :source-type :runner-install)
@@ -2304,7 +2304,7 @@
                         {:req (req (and (program? target)
                                         (or (in-hand? target)
                                             (in-discard? target))
-                                        (can-pay? state side eid card nil
+                                        (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                   [:credit (install-cost state side target
                                                                          {:cost-bonus (- tcost)})])))}
                         :msg (msg "trash " (:title trashed)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -226,16 +226,16 @@
                  :req (req (and (not (seq (get-in @state [:runner :locked :discard])))
                                 (not (install-locked? state side))
                                 (some #(and (program? %)
-                                            (can-pay? state side eid card nil
+                                            (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                       [:credit (install-cost state side %)]))
                                       (:discard runner))))
                  :choices {:req (req (and (program? target)
                                           (in-discard? target)
-                                          (can-pay? state side eid card nil
+                                          (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                     [:credit (install-cost state side target)])))}
                  :cost [:trash]
                  :msg (msg "install " (:title target))
-                 :effect (effect (runner-install eid target nil))}]}
+                 :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}]}
 
    "Comet"
    {:in-play [:memory 1]
@@ -798,7 +798,7 @@
               {:async true
                :interactive (req true)
                :req (req (some #(and (hardware? %)
-                                     (can-pay? state side eid card nil
+                                     (can-pay? state side (assoc eid :source card :source-type :runner-install) card %
                                                [:credit (install-cost state side % {:cost-bonus 1})]))
                                (:hand runner)))
                :prompt "Pay 1 [Credit] to install a hardware?"
@@ -807,7 +807,7 @@
                              :choices
                              {:req (req (and (in-hand? target)
                                              (hardware? target)
-                                             (can-pay? state side eid card nil
+                                             (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                        [:credit (install-cost state side target {:cost-bonus 1})])))}
                              :msg (msg "install " (:title target) " from the grip, paying 1 [Credit] more")
                              :effect (effect (runner-install eid target {:cost-bonus 1}))}}}
@@ -908,7 +908,7 @@
            {:prompt "Select a program to install"
             :choices {:req (req (and (program? target)
                                      (in-hand? target)
-                                     (can-pay? state side eid card nil
+                                     (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                [:credit (install-cost state side target {:cost-bonus -4})])))}
             :async true
             :effect (req (wait-for (runner-install state side target {:cost-bonus -4})

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1308,7 +1308,7 @@
                    :prompt "How many advancement tokens?"
                    :choices (req (map str (range (inc (min 2 (:credit corp))))))
                    :effect (req (let [c (str->int target)]
-                                  (if (can-pay? state side eid card (:title card) :credit c)
+                                  (if (can-pay? state side (assoc eid :source card :source-type :subroutine) card (:title card) :credit c)
                                     (do (pay state :corp card :credit c)
                                         (continue-ability
                                           state side
@@ -2887,7 +2887,7 @@
                                   :prompt "Choose one"
                                   :choices ["Lose [Click]" "End the run"]
                                   :effect (req (if-not (and (= target "Lose [Click]")
-                                                            (can-pay? state :runner eid card nil [:click 1]))
+                                                            (can-pay? state :runner (assoc eid :source card :source-type :subroutine) card nil [:click 1]))
                                                  (do (end-run state side)
                                                      (system-msg state side "ends the run"))
                                                  (do (lose state side :click 1)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -58,7 +58,7 @@
                          :yes-ability
                          {:async true
                           :effect (req (clear-wait-prompt state :corp)
-                                       (if (not (can-pay? state :corp eid card nil :credit 1))
+                                       (if (not (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil :credit 1))
                                          (do
                                            (toast state :corp "Cannot afford to pay 1 credit to block card exposure" "info")
                                            (expose state :runner eid itarget))
@@ -520,7 +520,7 @@
                                  :choices
                                  {:req (req (and (has-subtype? target "Bioroid")
                                                  (not (rezzed? target))
-                                                 (can-pay? state side eid card nil
+                                                 (can-pay? state side (assoc eid :source card :source-type :rez) target nil
                                                            [:credit (rez-cost state side target {:cost-bonus -4})])))}
                                  :msg (msg "rez " (:title target))
                                  :cancel-effect (effect (clear-wait-prompt :runner)
@@ -762,7 +762,7 @@
                  :choices (req (cancellable
                                  (filter #(and (program? %)
                                                (not (has-subtype? % "Virus"))
-                                               (can-pay? state :runner eid card nil
+                                               (can-pay? state :runner (assoc eid :source card :source-type :runner-install) % nil
                                                          [:credit (install-cost state side % {:cost-bonus -1})]))
                                          (:deck runner))))
                  :msg (msg "install " (:title target) " from the stack, lowering the cost by 1 [Credit]")
@@ -814,14 +814,14 @@
               :effect (effect
                         (continue-ability
                           (when (some #(and (has-subtype? % "Icebreaker")
-                                            (can-pay? state side eid card nil
+                                            (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                       [:credit (install-cost state side % {:cost-bonus -1})]))
                                       (:hand runner))
                             {:prompt "Select an icebreaker to install from your Grip"
                              :choices
                              {:req (req (and (in-hand? target)
                                              (has-subtype? target "Icebreaker")
-                                             (can-pay? state side eid card nil
+                                             (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                                        [:credit (install-cost state side target {:cost-bonus -1})])))}
                              :async true
                              :msg (msg "install " (:title target) ", lowering the cost by 1 [Credits]")

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -33,7 +33,7 @@
    "Accelerated Diagnostics"
    (letfn [(ad [st si e c cards]
              (when-let [cards (filterv #(and (operation? %)
-                                             (can-pay? st si e c nil [:credit (play-cost st si %)]))
+                                             (can-pay? st si (assoc e :source c :source-type :play) c nil [:credit (play-cost st si %)]))
                                        cards)]
                {:async true
                 :prompt "Select an operation to play"
@@ -561,7 +561,7 @@
 
    "Economic Warfare"
    {:req (req (and (last-turn? state :runner :successful-run)
-                   (can-pay? state :runner eid card nil :credit 4)))
+                   (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil :credit 4)))
     :msg "make the runner lose 4 [Credits]"
     :effect (effect (lose-credits :runner 4))}
 
@@ -723,7 +723,7 @@
                         :prompt "Pay how many credits?"
                         :choices {:number (req numtargets)}
                         :effect (req (let [c target]
-                                       (if (can-pay? state side eid card (:title card) :credit c)
+                                       (if (can-pay? state side (assoc eid :source card :source-type :ability) card (:title card) :credit c)
                                          (do (pay state :corp card :credit c)
                                              (continue-ability
                                                state :corp
@@ -1408,7 +1408,7 @@
     :prompt "Pay how many credits?"
     :choices {:number (req (count-tags state))}
     :effect (req (let [c target]
-                   (if (can-pay? state side eid card (:title card) :credit c)
+                   (if (can-pay? state side (assoc eid :source card :source-type :ability) card (:title card) :credit c)
                      (do (pay state :corp card :credit c)
                          (continue-ability
                            state side

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -58,7 +58,7 @@
                                        (rezzed? current-ice)
                                        (has-subtype? current-ice ice-type)
                                        (not (install-locked? state :runner))
-                                       (can-pay? state :runner eid card nil [:credit (install-cost state side card)])))
+                                       (can-pay? state :runner (assoc eid :source card :source-type :runner-install) card nil [:credit (install-cost state side card)])))
                         :effect (effect
                                   (continue-ability
                                     {:optional
@@ -278,7 +278,7 @@
    "Algernon"
    {:events
     [{:event :runner-turn-begins
-      :req (req (can-pay? state :runner eid card nil [:credit 2]))
+      :req (req (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil [:credit 2]))
       :optional
       {:prompt (msg "Pay 2 [Credits] to gain [Click]")
        :player :runner
@@ -748,10 +748,10 @@
                      (continue-ability state side (custsec-host from) card nil)))
       :abilities [{:cost [:click 1]
                    :prompt "Choose a program hosted on Customized Secretary to install"
-                   :choices (req (cancellable (filter #(can-pay? state side eid card nil [:credit (install-cost state side %)])
+                   :choices (req (cancellable (filter #(can-pay? state side (assoc eid :source card :source-type :runner-install) % nil [:credit (install-cost state side %)])
                                                       (:hosted card))))
                    :msg (msg "install " (:title target))
-                   :effect (req (if (can-pay? state side eid card nil [:credit (install-cost state side target)])
+                   :effect (req (if (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil [:credit (install-cost state side target)])
                                   (runner-install state side (assoc eid :source card :source-type :runner-install) target nil)
                                   (effect-completed state side eid)))}]})
 
@@ -862,7 +862,7 @@
    {:abilities [{:req (req (and (not (get-in card [:special :dheg-prog]))
                                 (some #(and (program? %)
                                             (runner-can-install? state side % false)
-                                            (can-pay? state side eid card nil
+                                            (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                       [:credit (install-cost state side % {:cost-bonus -1})]))
                                       (:hand runner))))
                  :cost [:click 1]
@@ -872,7 +872,7 @@
                  {:req (req (and (program? target)
                                  (runner-can-install? state side target false)
                                  (in-hand? target)
-                                 (can-pay? state side eid card nil
+                                 (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
                                            [:credit (install-cost state side target {:cost-bonus -1})])))}
                  :msg (msg (str "host " (:title target)
                                 (when (-> target :cost pos?)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1892,7 +1892,8 @@
                                                         (hardware? %)
                                                         (and (resource? %)
                                                              (has-subtype? % "Virtual")))
-                                                    (can-pay? state :runner (assoc eid :source card :source-type :runner-install) % nil (:cost %)))
+                                                    (can-pay? state :runner (assoc eid :source card :source-type :runner-install) % nil
+                                                              [:credit (install-cost state side %)]))
                                               (:discard runner))))
                                "No install"))
            :msg (msg (if (= target "No install")

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -25,7 +25,7 @@
               :optional
               {:req (req (and (ice? target)
                               (protecting-same-server? card target)
-                              (can-pay? state side eid card nil
+                              (can-pay? state side (assoc eid :source card :source-type :rez) target nil
                                         [:credit (rez-cost state side target {:cost-bonus -3})])))
                :prompt "Rez ICE with rez cost lowered by 3?"
                :yes-ability {:msg (msg "lower the rez cost of " (:title target) " by 3 [Credits]")
@@ -78,7 +78,7 @@
                  :effect (req (corp-install state side eid target card {:ignore-all-cost true}))}
                 {:req (req (and this-server
                                 (zero? (get-in @state [:run :position]))
-                                (some #(can-pay? state side eid card nil
+                                (some #(can-pay? state side (assoc eid :source card :source-type :rez) % nil
                                                  [:credit (rez-cost state side % {:cost-bonus -7})])
                                       (:hosted card))))
                  :label "Rez a hosted piece of Bioroid ICE"
@@ -266,7 +266,7 @@
                        :player :runner
                        :prompt (str "Pay " cost " [Credits] or end the run?")
                        :choices (concat
-                                  (when (can-pay? state :runner eid card nil [:credit cost])
+                                  (when (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil [:credit cost])
                                     [(str "Pay " cost " [Credits]")])
                                   ["End the run"])
                        :msg (msg (if (= target "End the run")
@@ -1264,7 +1264,7 @@
                              (not (same-card? target card))
                              (some #(and (not (rezzed? %))
                                          (not (agenda? %))
-                                         (can-pay? state side eid card nil
+                                         (can-pay? state side (assoc eid :source card :source-type :rez) % nil
                                                    [:credit (install-cost state side % {:cost-bonus -2})]))
                                    (all-installed state :corp))))
               :effect (effect (continue-ability
@@ -1273,7 +1273,7 @@
                                   :yes-ability {:prompt "Select a card to rez"
                                                 :choices {:card #(and (not (rezzed? %))
                                                                       (not (agenda? %))
-                                                                      (can-pay? state side eid card nil
+                                                                      (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
                                                                                 [:credit (rez-cost state side % {:cost-bonus -2})]))}
                                                 :msg (msg "rez " (:title target) ", lowering the rez cost by 2 [Credits]")
                                                 :effect (effect (rez eid target {:cost-bonus -2}))}}}
@@ -1340,7 +1340,7 @@
               :req (req (and this-server
                              (= target :net)
                              (pos? (last targets))
-                             (can-pay? state :corp eid card nil [:credit 2])))
+                             (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil [:credit 2])))
               :effect (req (swap! state assoc-in [:damage :damage-replace] true)
                            (show-wait-prompt state :runner "Corp to use Tori Hanzō")
                            (continue-ability

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -1588,7 +1588,19 @@
       (is (empty? (:discard (get-runner))) "Easy Mark is not in heap yet")
       (click-card state :runner "Easy Mark")
       (is (not-empty (:discard (get-runner))) "Easy Mark is in heap")
-      (is (= 9 (:credit (get-runner))) "Runner has only paid 3 for Sure Gamble"))))
+      (is (= 9 (:credit (get-runner))) "Runner has only paid 3 for Sure Gamble")))
+  (testing "Career Fair + Patchwork don't properly allow playing of cards only playable with both discounts. Issue #4617"
+    (do-game
+      (new-game {:runner {:deck ["Patchwork" "Sure Gamble" "Career Fair" "Liberated Account"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Patchwork")
+      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
+      (play-from-hand state :runner "Career Fair")
+      (click-card state :runner (find-card "Liberated Account" (:hand (get-runner))))
+      (click-card state :runner (get-hardware state 0))
+      (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))
+      (is (= 0 (:credit (get-runner))) "Paid 1c for Liberated Account")
+      (is (get-resource state 0) "Installed Liberated Account"))))
 
 (deftest plascrete-carapace
   ;; Plascrete Carapace - Prevent meat damage


### PR DESCRIPTION
Closes #4617 

`:source-types` that were changed:
`:runner-install` - `card` is now the card to be installed
`:ability` - `card` is the card ability being executed
`:rez` - `card` is the card to be rezzed
`:subroutine` - `card` is the ice containing the sub being executed