### PR TITLE
Fix for Gene Splicer ability, new test case

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -806,7 +806,7 @@
              :async true
              :effect (effect (damage eid :net (get-counters (get-card state card) :advancement)
                                      {:card card}))}
-    :abilities [{:cost [:click 1 :advancement 2]
+    :abilities [{:cost [:click 1 :advancement 3]
                  :label "Add Gene Splicing to your score area as an agenda worth 1 agenda point"
                  :msg "add it to their score area as an agenda worth 1 agenda point"
                  :async true

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -1696,7 +1696,7 @@
         (core/rez state :corp (refresh gs))
         (card-ability state :corp (refresh gs) 0)
         (is (refresh gs) "Gene Splicer is still in remote")
-        (is (zero? (count (get-scored state :corp))) "Score area is still empty")))))
+        (is (empty (get-scored state :corp)) "Score area is still empty")))))
 
 (deftest genetics-pavilion
   ;; Genetics Pavilion - Limit Runner to 2 draws per turn, but only during Runner's turn

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -1686,12 +1686,11 @@
         (is (= 1 (:agendapoints (get-scored state :corp 0))) "Gene Splicer added to Corp score area"))))
   (testing "Corp double-advances a Gene Splicer and fails to use its ability to add to their score area as a 1 point agenda"
     (do-game
-      (new-game {:corp {:deck [(qty "Gene Splicer" 2) (qty "Ice Wall" 3) (qty "Vanilla" 2)]}
+      (new-game {:corp {:hand "Gene Splicer"}
                  :runner {:deck [(qty "Sure Gamble" 3)]}})
       (play-from-hand state :corp "Gene Splicer" "New remote")
       (let [gs (get-content state :remote1 0)]
-        (core/advance state :corp {:card (refresh gs)})
-        (core/advance state :corp {:card (refresh gs)})
+        (dotimes [_ 2] (core/advance state :corp {:card (refresh gs)}))
         (take-credits state :runner)
         (core/rez state :corp (refresh gs))
         (card-ability state :corp (refresh gs) 0)

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -1690,12 +1690,13 @@
                  :runner {:deck [(qty "Sure Gamble" 3)]}})
       (play-from-hand state :corp "Gene Splicer" "New remote")
       (let [gs (get-content state :remote1 0)]
-        (core/add-counter state :corp gs :advancement 2)
+        (core/advance state :corp {:card (refresh gs)})
+        (core/advance state :corp {:card (refresh gs)})
         (take-credits state :runner)
         (core/rez state :corp (refresh gs))
         (card-ability state :corp (refresh gs) 0)
-        (is (= "Gene Splicer" (:title (get-content state :remote1 0))) "Gene Splicer is still in remote")
-        (is (= nil (:agendapoints (get-scored state :corp 0))) "Score area is still empty")))))
+        (is (refresh gs) "Gene Splicer is still in remote")
+        (is (zero? (count (get-scored state :corp))) "Score area is still empty")))))
 
 (deftest genetics-pavilion
   ;; Genetics Pavilion - Limit Runner to 2 draws per turn, but only during Runner's turn

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -1695,7 +1695,7 @@
         (core/rez state :corp (refresh gs))
         (card-ability state :corp (refresh gs) 0)
         (is (refresh gs) "Gene Splicer is still in remote")
-        (is (empty (get-scored state :corp)) "Score area is still empty")))))
+        (is (empty? (get-scored state :corp)) "Score area is still empty")))))
 
 (deftest genetics-pavilion
   ;; Genetics Pavilion - Limit Runner to 2 draws per turn, but only during Runner's turn

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -1683,7 +1683,19 @@
         (core/rez state :corp (refresh gs))
         (card-ability state :corp (refresh gs) 0)
         (is (nil? (get-content state :remote1 0)) "Gene Splicer is no longer in remote")
-        (is (= 1 (:agendapoints (get-scored state :corp 0))) "Gene Splicer added to Corp score area")))))
+        (is (= 1 (:agendapoints (get-scored state :corp 0))) "Gene Splicer added to Corp score area"))))
+  (testing "Corp double-advances a Gene Splicer and fails to use its ability to add to their score area as a 1 point agenda"
+    (do-game
+      (new-game {:corp {:deck [(qty "Gene Splicer" 2) (qty "Ice Wall" 3) (qty "Vanilla" 2)]}
+                 :runner {:deck [(qty "Sure Gamble" 3)]}})
+      (play-from-hand state :corp "Gene Splicer" "New remote")
+      (let [gs (get-content state :remote1 0)]
+        (core/add-counter state :corp gs :advancement 2)
+        (take-credits state :runner)
+        (core/rez state :corp (refresh gs))
+        (card-ability state :corp (refresh gs) 0)
+        (is (= "Gene Splicer" (:title (get-content state :remote1 0))) "Gene Splicer is still in remote")
+        (is (= nil (:agendapoints (get-scored state :corp 0))) "Score area is still empty")))))
 
 (deftest genetics-pavilion
   ;; Genetics Pavilion - Limit Runner to 2 draws per turn, but only during Runner's turn


### PR DESCRIPTION
I have been playing Gene Splicer yesterday and noticed, that ability have incorrect cost (2 adv tokens vs correct 3). I have fixed that and wrote new test for this situation.