### PR TITLE
Increase the size of the card zoom

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -63,6 +63,8 @@
   (swap! app-state assoc-in [:options :show-alt-art] (:show-alt-art @s))
   (swap! app-state assoc-in [:options :stacked-servers] (:stacked-servers @s))
   (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
+  (swap! app-state assoc-in [:options :log-width] (:log-width @s))
+  (swap! app-state assoc-in [:options :log-top] (:log-top @s))
   (swap! app-state assoc-in [:options :blocked-users] (:blocked-users @s))
   (swap! app-state assoc-in [:options :alt-arts] (:alt-arts @s))
   (swap! app-state assoc-in [:options :gamestats] (:gamestats @s))
@@ -70,6 +72,8 @@
   (.setItem js/localStorage "sounds" (:sounds @s))
   (.setItem js/localStorage "lobby_sounds" (:lobby-sounds @s))
   (.setItem js/localStorage "sounds_volume" (:volume @s))
+  (.setItem js/localStorage "log-width" (:log-width @s))
+  (.setItem js/localStorage "log-top" (:log-top @s))
   (.setItem js/localStorage "stacked-servers" (:stacked-servers @s))
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
   (post-options url (partial post-response s)))
@@ -127,6 +131,33 @@
    (doseq [card (vals (:alt-arts @app-state))]
      (update-card-art card art s))))
 
+(defn log-width-option [s]
+  (let [log-width (r/atom (:log-width @s))]
+    (println @log-width)
+    (fn []
+      [:div
+       [:input {:type "number"
+                :min 100 :max 2000
+                :on-change #(do (swap! s assoc-in [:log-width] (.. % -target -value))
+                                (reset! log-width (.. % -target -value)))
+                :value @log-width}]
+       [:button.update-log-width {:type "button"
+                                  :on-click #(do (swap! s assoc-in [:log-width] (get-in @app-state [:options :log-width]))
+                                                 (reset! log-width (get-in @app-state [:options :log-width])))} "Get current log width" ]])))
+(defn log-top-option [s]
+  (let [log-top (r/atom (:log-top @s))]
+    (println @log-top)
+    (fn []
+      [:div
+       [:input {:type "number"
+                :min 100 :max 2000
+                :on-change #(do (swap! s assoc-in [:log-top] (.. % -target -value))
+                                (reset! log-top (.. % -target -value)))
+                :value @log-top}]
+       [:button.update-log-width {:type "button"
+                                  :on-click #(do (swap! s assoc-in [:log-top] (get-in @app-state [:options :log-top]))
+                                                 (reset! log-top (get-in @app-state [:options :log-top])))} "Get current log top" ]])))
+
 (defn account-view [user]
   (let [s (r/atom {:flash-message ""
                    :background (get-in @app-state [:options :background])
@@ -137,6 +168,8 @@
                    :all-art-select ""
                    :stacked-servers (get-in @app-state [:options :stacked-servers])
                    :runner-board-order (get-in @app-state [:options :runner-board-order])
+                   :log-width (get-in @app-state [:options :log-width])
+                   :log-top (get-in @app-state [:options :log-top])
                    :gamestats (get-in @app-state [:options :gamestats])
                    :deckstats (get-in @app-state [:options :deckstats])
                    :blocked-users (sort (get-in @app-state [:options :blocked-users]))})]
@@ -194,6 +227,9 @@
                             :checked (:runner-board-order @s)
                             :on-change #(swap! s assoc-in [:runner-board-order] (.. % -target -checked))}]
             "Runner rig layout is jnet-classic (Top to bottom: Programs, Hardware, Resources)"]]]
+
+         [log-width-option s]
+         [log-top-option s]
 
          [:section
           [:h3  "Game board background"]

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -17,6 +17,8 @@
                             :runner-board-order (= (get-local-value "runner-board-order" "true") "true")
                             :deckstats "always"
                             :gamestats "always"
+                            :log-width (str->int (get-local-value "log-width" "300"))
+                            :log-top (str->int (get-local-value "log-top" "419"))
                             :sounds (= (get-local-value "sounds" "true") "true")
                             :lobby-sounds (= (get-local-value "lobby_sounds" "true") "true")
                             :sounds-volume (str->int (get-local-value "sounds_volume" "100"))}

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -535,7 +535,7 @@
            [:span.impl-msg implemented])]))))
 
 (defn card-zoom [zoom-card]
-  (when-let [card @zoom-card]
+  (if-let [card @zoom-card]
     [:div.card-preview.blue-shade
      [:h4 (:title card)]
      (when-let [memory (:memoryunits card)]
@@ -569,7 +569,9 @@
                       (some #(when (= (:title %) title) %) @all-cards))]
              (render-icons (:text (card-by-title (:title card)))))]]
      (when-let [url (image-url card)]
-       [:img {:src url :alt (:title card) :onLoad #(-> % .-target js/$ .show)}])]))
+       [:img {:src url :alt (:title card) :onLoad #(-> % .-target js/$ .show)}])
+     (do (-> ".card-zoom" js/$ (.addClass "fade")) nil)]
+    (do (-> ".card-zoom" js/$ (.removeClass "fade")) nil)))
 
 (defn server-menu [card c-state remotes type zone]
   (let [centrals ["Archives" "R&D" "HQ"]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2078,15 +2078,18 @@ nav ul
       margin-top: 5px
       margin-right: 5px
       position: relative
-      transition(all 0.2s ease-in-out)
+      transition(opacity 0.2s ease-in-out)
+      opacity: 0
 
       .card-preview
         width: 100%
         height: 100%
-        transition(all 0.2s ease-in-out)
 
         .text
           height: 195px
+
+    .card-zoom.fade
+      opacity: 1
 
     // Card implementation div
     .implementation
@@ -2097,7 +2100,6 @@ nav ul
       text-align: right
       font-size: 12px
       line-height: 12px
-      transition(all 0.2s ease-in-out)
 
       .unimplemented
         color: red


### PR DESCRIPTION
The majority of card images are 300x418, so display them at that
resolution to prevent downscaling and blurring the text. This means the
image will be larger and crisper. The resulting image is significantly
easier to read in my opinion.

Current zoom:
![old-zoom](https://user-images.githubusercontent.com/6372/69924275-85b3b700-1478-11ea-9e87-b289e7cfa008.png)

New zoom:
![new-zoom](https://user-images.githubusercontent.com/6372/69924274-85b3b700-1478-11ea-895e-1eae2f7bab76.png)


