### PR TITLE
Settings for the log width

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -63,6 +63,7 @@
   (swap! app-state assoc-in [:options :show-alt-art] (:show-alt-art @s))
   (swap! app-state assoc-in [:options :stacked-servers] (:stacked-servers @s))
   (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
+  (swap! app-state assoc-in [:options :log-width] (:log-width @s))
   (swap! app-state assoc-in [:options :blocked-users] (:blocked-users @s))
   (swap! app-state assoc-in [:options :alt-arts] (:alt-arts @s))
   (swap! app-state assoc-in [:options :gamestats] (:gamestats @s))
@@ -70,6 +71,7 @@
   (.setItem js/localStorage "sounds" (:sounds @s))
   (.setItem js/localStorage "lobby_sounds" (:lobby-sounds @s))
   (.setItem js/localStorage "sounds_volume" (:volume @s))
+  (.setItem js/localStorage "log-width" (:log-width @s))
   (.setItem js/localStorage "stacked-servers" (:stacked-servers @s))
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
   (post-options url (partial post-response s)))
@@ -127,6 +129,20 @@
    (doseq [card (vals (:alt-arts @app-state))]
      (update-card-art card art s))))
 
+(defn log-width-option [s]
+  (let [log-width (r/atom (:log-width @s))]
+    (println @log-width)
+    (fn []
+      [:div
+       [:input {:type "number"
+                :min 100 :max 2000
+                :on-change #(do (swap! s assoc-in [:log-width] (.. % -target -value))
+                                (reset! log-width (.. % -target -value)))
+                :value @log-width}]
+       [:button.update-log-width {:type "button"
+                                  :on-click #(do (swap! s assoc-in [:log-width] (get-in @app-state [:options :log-width]))
+                                                 (reset! log-width (get-in @app-state [:options :log-width])))} "Get current log width" ]])))
+
 (defn account-view [user]
   (let [s (r/atom {:flash-message ""
                    :background (get-in @app-state [:options :background])
@@ -137,6 +153,7 @@
                    :all-art-select ""
                    :stacked-servers (get-in @app-state [:options :stacked-servers])
                    :runner-board-order (get-in @app-state [:options :runner-board-order])
+                   :log-width (get-in @app-state [:options :log-width])
                    :gamestats (get-in @app-state [:options :gamestats])
                    :deckstats (get-in @app-state [:options :deckstats])
                    :blocked-users (sort (get-in @app-state [:options :blocked-users]))})]
@@ -194,6 +211,8 @@
                             :checked (:runner-board-order @s)
                             :on-change #(swap! s assoc-in [:runner-board-order] (.. % -target -checked))}]
             "Runner rig layout is jnet-classic (Top to bottom: Programs, Hardware, Resources)"]]]
+
+         [log-width-option s]
 
          [:section
           [:h3  "Game board background"]

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -17,6 +17,7 @@
                             :runner-board-order (= (get-local-value "runner-board-order" "true") "true")
                             :deckstats "always"
                             :gamestats "always"
+                            :log-width (str->int (get-local-value "log-width" "300"))
                             :sounds (= (get-local-value "sounds" "true") "true")
                             :lobby-sounds (= (get-local-value "lobby_sounds" "true") "true")
                             :sounds-volume (str->int (get-local-value "sounds_volume" "100"))}

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -316,7 +316,8 @@
         (.css "height" card-height))
     (set! (.. ui -size -width) width)
     (set! (.. ui -position -left) 0)
-    (set! (.. ui -position -top) (+ card-height 10))))
+    (set! (.. ui -position -top) (+ card-height 10))
+    (swap! app-state assoc-in [:options :log-width] width)))
 
 (defn log-pane []
   (r/create-class

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -306,6 +306,18 @@
 
 (def should-scroll (r/atom {:update true :send-msg false}))
 
+(defn log-resize [event ui]
+  (let [width (.. ui -size -width)
+        card-width (- width 5)
+        card-ratio (/ 418 300)
+        card-height (* card-width card-ratio)]
+    (-> ".card-zoom" js/$
+        (.css "width" card-width)
+        (.css "height" card-height))
+    (set! (.. ui -size -width) width)
+    (set! (.. ui -position -left) 0)
+    (set! (.. ui -position -top) (+ card-height 10))))
+
 (defn log-pane []
   (r/create-class
     (let [log (r/cursor game-state [:log])]
@@ -313,7 +325,8 @@
 
        :component-did-mount
        (fn [this]
-         (-> ".log" js/$ (.resizable #js {:handles "w"})))
+         (-> ".log" js/$ (.resizable #js {:handles "w"
+                                          :resize log-resize})))
 
        :component-will-update
        (fn [this]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2078,12 +2078,10 @@ nav ul
       margin-top: 5px
       margin-right: 5px
       position: relative
-      transition(all 0.2s ease-in-out)
 
       .card-preview
         width: 100%
         height: 100%
-        transition(all 0.2s ease-in-out)
 
         .text
           height: 195px
@@ -2097,7 +2095,6 @@ nav ul
       text-align: right
       font-size: 12px
       line-height: 12px
-      transition(all 0.2s ease-in-out)
 
       .unimplemented
         color: red


### PR DESCRIPTION
I've added a settings option called `:log-width` that lives in the `app-state`. You can get the current width with `(get-in @app-state [:options :log-width])`.

What is still missing is setting the initial width of the log panel... There's probably an easy way of doing that but I can't see it right now.