### PR TITLE
Buffer drive fix

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -237,7 +237,7 @@
                      (= 1 (+ (event-count state side :runner-trash grip-or-stack-trash?)
                              (event-count state side :corp-trash grip-or-stack-trash?)))))
          :prompt "Add a trashed card to the bottom of the Stack"
-         :choices (req (conj (vec (sort-by :title (filter :cid targets))) "No action"))
+         :choices (req (conj (mapv #(assoc % :zone [:discard]) (sort-by :title (filter :cid targets))) "No action"))
          :effect (req (when-not (= "No action" target)
                         (move state side (get-card state (assoc target :zone [:discard])) :deck)))}]
     {:events [(assoc triggered-ability :event :runner-trash)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -253,7 +253,7 @@
       ;; Default text prompt
       :else
       (let [buttons (filter #(or (= choice %)
-                                 (= card %)
+                                 (same-card? card %)
                                  (let [choice-str (if (string? choice)
                                                     (lower-case choice)
                                                     (lower-case (:title choice "do-not-match")))]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -150,7 +150,11 @@
   "Checks if the two cards are the same by :cid. Alternatively specify 1-function to use to check the card"
   ([card1 card2] (same-card? :cid card1 card2))
   ([func card1 card2]
-    (= (func card1) (func card2))))
+   (let [id1 (func card1)
+         id2 (func card2)]
+     (and (some? id1)
+          (some? id2)
+          (= id1 id2)))))
 
 ;;; Functions for working with zones.
 (defn remote-num->name [num]

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -464,7 +464,7 @@
             {target-cid :cid} target
             non-target-cids (set (map :cid non-targets))]
         (core/trash-cards state :runner (:hand (get-runner)))
-        (click-prompt state :runner target)
+        (click-prompt state :runner (assoc target :zone [:discard]))
         (is (= 2 (count (:deck (get-runner)))))
         (is (= 2 (count (:discard (get-runner)))))
         (is (= target-cid (:cid (last (:deck (get-runner))))))
@@ -479,7 +479,7 @@
             {target-cid :cid} target
             non-target-cids (set (map :cid non-targets))]
         (core/trash-cards state :runner (:hand (get-runner)))
-        (click-prompt state :runner target)
+        (click-prompt state :runner (assoc target :zone [:discard]))
         (is (= 2 (count (:deck (get-runner)))))
         (is (= 2 (count (:discard (get-runner)))))
         (is (= target-cid (:cid (last (:deck (get-runner))))))
@@ -494,7 +494,7 @@
             {target-cid :cid} target
             non-target-cids (set (map :cid non-targets))]
         (core/trash-cards state :runner (take 3 (:deck (get-runner))))
-        (click-prompt state :runner target)
+        (click-prompt state :runner (assoc target :zone [:discard]))
         (is (= 2 (count (:deck (get-runner)))))
         (is (= 2 (count (:discard (get-runner)))))
         (is (= target-cid (:cid (last (:deck (get-runner))))))
@@ -2242,7 +2242,7 @@
   (testing "program trashed from hand shouldn't trash chip"
     (do-game
       (new-game {:corp {:deck [(qty "Breached Dome" 10)]}
-                 :runner {:deck ["Self-modifying Code", "Q-Coherence Chip"]}})               
+                 :runner {:deck ["Self-modifying Code", "Q-Coherence Chip"]}})
       (starting-hand state :runner ["Self-modifying Code" "Q-Coherence Chip"])
       (starting-hand state :corp ["Breached Dome"])
       (play-from-hand state :corp "Breached Dome" "New remote")
@@ -2255,7 +2255,7 @@
   (testing "program milled from stack shouldn't trash chip"
     (do-game
       (new-game {:corp {:deck [(qty "Breached Dome" 10)]}
-                 :runner {:deck ["Self-modifying Code", (qty "Q-Coherence Chip" 2)]}})               
+                 :runner {:deck ["Self-modifying Code", (qty "Q-Coherence Chip" 2)]}})
       (starting-hand state :runner ["Q-Coherence Chip", "Q-Coherence Chip"])
       (starting-hand state :corp ["Breached Dome"])
       (play-from-hand state :corp "Breached Dome" "New remote")

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -461,10 +461,10 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Buffer Drive")
       (let [[target & non-targets] (:hand (get-runner))
-            {target-name :title, target-cid :cid} target
+            {target-cid :cid} target
             non-target-cids (set (map :cid non-targets))]
         (core/trash-cards state :runner (:hand (get-runner)))
-        (click-prompt state :runner target-name)
+        (click-prompt state :runner target)
         (is (= 2 (count (:deck (get-runner)))))
         (is (= 2 (count (:discard (get-runner)))))
         (is (= target-cid (:cid (last (:deck (get-runner))))))
@@ -476,10 +476,10 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Buffer Drive")
       (let [[target & non-targets] (:hand (get-runner))
-            {target-name :title, target-cid :cid} target
+            {target-cid :cid} target
             non-target-cids (set (map :cid non-targets))]
         (core/trash-cards state :runner (:hand (get-runner)))
-        (click-prompt state :runner target-name)
+        (click-prompt state :runner target)
         (is (= 2 (count (:deck (get-runner)))))
         (is (= 2 (count (:discard (get-runner)))))
         (is (= target-cid (:cid (last (:deck (get-runner))))))
@@ -491,10 +491,10 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Buffer Drive")
       (let [[target & non-targets] (take 3 (:deck (get-runner)))
-            {target-name :title, target-cid :cid} target
+            {target-cid :cid} target
             non-target-cids (set (map :cid non-targets))]
         (core/trash-cards state :runner (take 3 (:deck (get-runner))))
-        (click-prompt state :runner target-name)
+        (click-prompt state :runner target)
         (is (= 2 (count (:deck (get-runner)))))
         (is (= 2 (count (:discard (get-runner)))))
         (is (= target-cid (:cid (last (:deck (get-runner))))))


### PR DESCRIPTION
This PR fixes an issue with Buffer Drive's triggered ability prompt causing an exception (appearing to the user to be unresponsive).

Some of the Buffer Drive tests have been adjusted to pass the full card definition to `click-prompt`, which more closely mimics the real behaviour of prompts in-game.