### PR TITLE
Fix for breaking ICE

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -352,7 +352,7 @@
 ;; Card definitions
 (def card-definitions
   {"Afshar"
-   (let [breakable-fn (fn [ice] (empty? (filter #(and (:broken %) (:printed %)) (:subroutines ice))))]
+   (let [breakable-fn (fn [ice] (empty? (filter #(and (= :hq (second (:zone ice))) (:broken %) (:printed %)) (:subroutines ice))))]
      {:subroutines [{:msg "make the Runner lose 2 [Credits]"
                      :breakable breakable-fn
                      :effect (effect (lose-credits :runner 2))}

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -113,7 +113,7 @@
 
 (defn reset-sub
   [ice sub]
-  (assoc ice :subroutines (assoc (:subroutines ice) (:index sub) (dissoc sub :broken :fired :resolve :breakable))))
+  (assoc ice :subroutines (assoc (:subroutines ice) (:index sub) (dissoc sub :broken :fired :resolve))))
 
 (defn reset-sub!
   [state ice sub]
@@ -477,7 +477,7 @@
               unbroken-subs (count (remove :broken (:subroutines current-ice)))
               no-unbreakable-subs (empty? (filter #(if (fn? (:breakable %))
                                                      true
-                                                     (not (:breakable %)))
+                                                     (not (:breakable % true)))
                                                   (:subroutines current-ice)))
               times-break (when (and (pos? unbroken-subs)
                                      subs-broken-at-once)

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -38,7 +38,23 @@
         (click-prompt state :runner "End the run")
         (is (empty? (:prompt (get-runner))) "No prompt for further breaking")
         (card-ability state :runner gord 0)
-        (is (empty? (:prompt (get-runner))) "Can't use break ability")))))
+        (is (empty? (:prompt (get-runner))) "Can't use break ability"))))
+  (testing "No breaking restriction on other servers"
+    (do-game
+      (new-game {:corp {:hand ["Afshar"]}
+                 :runner {:hand ["Gordian Blade"]
+                          :credits 10}})
+      (play-from-hand state :corp "Afshar" "R&D")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Gordian Blade")
+      (run-on state "R&D")
+      (let [afshar (get-ice state :rd 0)
+            gord (get-program state 0)]
+        (core/rez state :corp afshar)
+        (card-ability state :runner gord 0)
+        (click-prompt state :runner "End the run")
+        (is (not-empty (:prompt (get-runner))) "Can break more subs")
+        (click-prompt state :runner "Make the Runner lose 2 [Credits]")))))
 
 (deftest aimor
   ;; Aimor - trash the top 3 cards of the stack, trash Aimor

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -54,7 +54,32 @@
         (card-ability state :runner gord 0)
         (click-prompt state :runner "End the run")
         (is (not-empty (:prompt (get-runner))) "Can break more subs")
-        (click-prompt state :runner "Make the Runner lose 2 [Credits]")))))
+        (click-prompt state :runner "Make the Runner lose 2 [Credits]"))))
+  (testing "Breaking restriction also on the second encounter"
+    (do-game
+      (new-game {:corp {:hand ["Afshar"]}
+                 :runner {:hand ["Gordian Blade"]
+                          :credits 10}})
+      (play-from-hand state :corp "Afshar" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Gordian Blade")
+      (run-on state "HQ")
+      (let [afshar (get-ice state :hq 0)
+            gord (get-program state 0)]
+        (core/rez state :corp afshar)
+        (is (empty? (filter #(:dynamic %) (:abilities (refresh gord)))) "No auto break dynamic ability")
+        (card-ability state :runner gord 0)
+        (click-prompt state :runner "Make the Runner lose 2 [Credits]")
+        (core/resolve-unbroken-subs! state :corp (refresh afshar))
+        (is (not (:run @state)) "Run ended")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (run-on state "HQ")
+        (card-ability state :runner gord 0)
+        (click-prompt state :runner "Make the Runner lose 2 [Credits]")
+        (is (empty? (:prompt (get-runner))) "No prompt for further breaking")
+        (card-ability state :runner gord 0)
+        (is (empty? (:prompt (get-runner))) "Can't use break ability")))))
 
 (deftest aimor
   ;; Aimor - trash the top 3 cards of the stack, trash Aimor

--- a/test/clj/game_test/engine/ice.clj
+++ b/test/clj/game_test/engine/ice.clj
@@ -29,7 +29,28 @@
         (is (= "1 [Credits]: Fully break Tour Guide" (-> (refresh buk) :abilities first :label)))
         (core/rez state :corp p2)
         (is (= "2 [Credits]: Fully break Tour Guide" (-> (refresh buk) :abilities first :label)))
-        (is (= 2 (count (:subroutines (refresh tg)))))))))
+        (is (= 2 (count (:subroutines (refresh tg))))))))
+  (testing "Also works on second encounter"
+    (do-game
+      (new-game {:corp {:hand ["Tour Guide" (qty "PAD Campaign" 2)]
+                        :credits 10}
+                 :runner {:hand ["Bukhgalter"]}})
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (play-from-hand state :corp "Tour Guide" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Bukhgalter")
+      (let [p1 (get-content state :remote1 0)
+            tg (get-ice state :hq 0)
+            buk (get-program state 0)]
+        (core/rez state :corp p1)
+        (core/rez state :corp tg)
+        (run-on state :hq)
+        (is (= "1 [Credits]: Fully break Tour Guide" (-> (refresh buk) :abilities first :label)))
+        (core/resolve-unbroken-subs! state :corp (refresh tg))
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (run-on state :hq)
+        (is (= "1 [Credits]: Fully break Tour Guide" (-> (refresh buk) :abilities first :label)))))))
 
 (deftest bioroid-break-abilities
   ;; The click-to-break ablities on bioroids shouldn't create an undo-click


### PR DESCRIPTION
Auto-pump-and-break was only working on the first encounter. Afshar was restricting breaking subs outside of HQ as well.