### PR TITLE
Akhet fix

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -381,15 +381,18 @@
                                 (system-msg state side (str "trashes Aimor")))}]}
 
    "Akhet"
-   {:implementation "Breaking both subs not restricted"
-    :subroutines [{:label "Gain 1[Credit]. Place 1 advancement token."
-                   :msg (msg "gain 1 [Credit] and place 1 advancement token on " (card-str state target))
-                   :prompt "Choose an installed card"
-                   :choices {:card installed?}
-                   :effect (effect (gain-credits 1)
-                                   (add-prop target :advance-counter 1 {:placed true}))}
-                  end-the-run]
-    :strength-bonus (req (if (<= 3 (get-advance-counters card)) 3 0))}
+   (let [breakable-fn (fn [ice] (if (<= 3 (get-advance-counters ice)) 
+                                  (empty? (filter #(and (:broken %) (:printed %)) (:subroutines ice)))
+                                  true))]
+     {:subroutines [{:label "Gain 1[Credit]. Place 1 advancement token."
+                     :breakable breakable-fn
+                     :msg (msg "gain 1 [Credit] and place 1 advancement token on " (card-str state target))
+                     :prompt "Choose an installed card"
+                     :choices {:card installed?}
+                     :effect (effect (gain-credits 1)
+                                     (add-prop target :advance-counter 1 {:placed true}))}
+                    (assoc end-the-run :breakable breakable-fn)]
+      :strength-bonus (req (if (<= 3 (get-advance-counters card)) 3 0))})
 
    "Anansi"
    (let [corp-draw {:optional {:prompt "Draw 1 card?"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -381,7 +381,7 @@
                                 (system-msg state side (str "trashes Aimor")))}]}
 
    "Akhet"
-   (let [breakable-fn (fn [ice] (if (<= 3 (get-advance-counters ice)) 
+   (let [breakable-fn (fn [ice] (if (<= 3 (get-counters ice :advancement))
                                   (empty? (filter #(and (:broken %) (:printed %)) (:subroutines ice)))
                                   true))]
      {:subroutines [{:label "Gain 1[Credit]. Place 1 advancement token."

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -385,11 +385,11 @@
     :subroutines [{:label "Gain 1[Credit]. Place 1 advancement token."
                    :msg (msg "gain 1 [Credit] and place 1 advancement token on " (card-str state target))
                    :prompt "Choose an installed card"
-                   :choices {:req installed?}
+                   :choices {:card installed?}
                    :effect (effect (gain-credits 1)
                                    (add-prop target :advance-counter 1 {:placed true}))}
                   end-the-run]
-    :strength-bonus (req (if (>= 3 (get-advance-counters card)) 3 0))}
+    :strength-bonus (req (if (<= 3 (get-advance-counters card)) 3 0))}
 
    "Anansi"
    (let [corp-draw {:optional {:prompt "Draw 1 card?"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -352,7 +352,9 @@
 ;; Card definitions
 (def card-definitions
   {"Afshar"
-   (let [breakable-fn (fn [ice] (empty? (filter #(and (= :hq (second (:zone ice))) (:broken %) (:printed %)) (:subroutines ice))))]
+   (let [breakable-fn (fn [ice] (if (= :hq (second (:zone ice)))
+                                  (empty? (filter #(and (:broken %) (:printed %)) (:subroutines ice)))
+                                  :unrestricted))]
      {:subroutines [{:msg "make the Runner lose 2 [Credits]"
                      :breakable breakable-fn
                      :effect (effect (lose-credits :runner 2))}
@@ -383,7 +385,7 @@
    "Akhet"
    (let [breakable-fn (fn [ice] (if (<= 3 (get-counters ice :advancement))
                                   (empty? (filter #(and (:broken %) (:printed %)) (:subroutines ice)))
-                                  true))]
+                                  :unrestricted))] ; returning :unrestricted allows auto-pump-and-break to break this ice
      {:subroutines [{:label "Gain 1[Credit]. Place 1 advancement token."
                      :breakable breakable-fn
                      :msg (msg "gain 1 [Credit] and place 1 advancement token on " (card-str state target))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -475,9 +475,9 @@
               subs-broken-at-once (when break-ability
                                     (:break break-ability 1))
               unbroken-subs (count (remove :broken (:subroutines current-ice)))
-              no-unbreakable-subs (empty? (filter #(if (fn? (:breakable %))
-                                                     true
-                                                     (not (:breakable % true)))
+              no-unbreakable-subs (empty? (filter #(if (fn? (:breakable %)) ; filter for possibly unbreakable subs
+                                                     (if (= :unrestricted ((:breakable %) current-ice)) false true) ; breakable is a 1-fn
+                                                     (not (:breakable % true))) ; breakable is a bool
                                                   (:subroutines current-ice)))
               times-break (when (and (pos? unbroken-subs)
                                      subs-broken-at-once)

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -162,8 +162,38 @@
         (is (= 0 (get-counters (refresh akhet) :advancement)) "Akhet has no adv tokens")
         (click-card state :corp (refresh akhet))
         (is (= 1 (get-counters (refresh akhet) :advancement)) "Akhet gained 1 adv tokens")
-        (is (not (:run @state)) "Run has ended")))))
-
+        (is (not (:run @state)) "Run has ended"))))
+  (testing "Breaking restriction"
+    (do-game
+      (new-game {:corp {:hand ["Akhet"]}
+                 :runner {:hand ["Corroder"]}})
+      (play-from-hand state :corp "Akhet" "HQ")
+      (let [akhet (get-ice state :hq 0)]
+        (dotimes [n 2] (core/advance state :corp {:card akhet}))
+        (is (= 2 (get-counters (refresh akhet) :advancement)) "Akhet has 2 adv tokens")
+        (take-credits state :corp)
+        (play-from-hand state :runner "Corroder")
+        (run-on state :hq)
+        (let [cor (get-program state 0)]
+          (core/rez state :corp (refresh akhet))
+          (card-ability state :runner cor 0)
+          (click-prompt state :runner "End the run")
+          (is (not-empty (:prompt (get-runner))) "Prompt to break second sub open")
+          (click-prompt state :runner "Gain 1[Credit]. Place 1 advancement token.")
+          (is (empty? (:prompt (get-runner))) "Prompt now closed")
+          (is (empty? (remove :broken (:subroutines (refresh akhet)))) "All subroutines broken")
+          (run-jack-out state)
+          (take-credits state :runner)
+          (core/gain state :corp :credit 1)
+          (core/advance state :corp {:card (refresh akhet)})
+          (is (= 3 (get-counters (refresh akhet) :advancement)) "Akhet now has 3 adv tokens")
+          (take-credits state :corp)
+          (core/gain state :runner :credit 5)
+          (run-on state :hq)
+          (core/play-dynamic-ability state :runner {:dynamic "auto-pump" :card (refresh cor)})
+          (card-ability state :runner (refresh cor) 0)
+          (click-prompt state :runner "End the run")
+          (is (empty? (:prompt (get-runner))) "No option to break second sub"))))))
 
 (deftest archangel
   ;; Archangel - accessing from R&D does not cause run to hang.

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -132,6 +132,39 @@
                            "3 net damage from passing Anansi"
                            (run-continue state))))))
 
+(deftest akhet
+  ;; Akhet
+  (testing "Akhet gains strength at 3 advancements"
+    (do-game
+      (new-game {:corp {:deck ["Akhet"]}})
+      (play-from-hand state :corp "Akhet" "HQ")
+      (core/gain state :corp :click 1 :credit 1)
+      (let [akhet (get-ice state :hq 0)]
+        (core/rez state :corp akhet)
+        (is (= 0 (get-counters (refresh akhet) :advancement)) "Akhet has no adv tokens")
+        (is (= 2 (:current-strength (refresh akhet))) "Akhet starts at 2 strength")
+        (dotimes [n 2]
+          (core/advance state :corp {:card akhet})
+          (is (= (inc n) (get-counters (refresh akhet) :advancement)) (str "Akhet has " (inc n) " adv tokens"))
+          (is (= 2 (:current-strength (refresh akhet))) "Akhet stays at 2 strength"))
+        (core/advance state :corp {:card akhet})
+        (is (= 3 (get-counters (refresh akhet) :advancement)) "Akhet has 3 adv tokens")
+        (is (= 5 (:current-strength (refresh akhet))) "Akhet is now at 5 strength"))))
+  (testing "Akhet subroutines"
+    (do-game
+      (new-game {:corp {:deck ["Akhet"]}})
+      (play-from-hand state :corp "Akhet" "HQ")
+      (take-credits state :corp)
+      (let [akhet (get-ice state :hq 0)]
+        (run-on state :hq)
+        (core/rez state :corp akhet)
+        (core/resolve-unbroken-subs! state :corp (refresh akhet))
+        (is (= 0 (get-counters (refresh akhet) :advancement)) "Akhet has no adv tokens")
+        (click-card state :corp (refresh akhet))
+        (is (= 1 (get-counters (refresh akhet) :advancement)) "Akhet gained 1 adv tokens")
+        (is (not (:run @state)) "Run has ended")))))
+
+
 (deftest archangel
   ;; Archangel - accessing from R&D does not cause run to hang.
   (testing "Basic test of subroutine"

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -67,7 +67,7 @@
       (let [afshar (get-ice state :hq 0)
             gord (get-program state 0)]
         (core/rez state :corp afshar)
-        (is (empty? (filter #(:dynamic %) (:abilities (refresh gord)))) "No auto break dynamic ability")
+        (is (empty? (filter #(= :auto-pump-and-break (:dynamic %)) (:abilities (refresh gord)))) "No auto break dynamic ability")
         (card-ability state :runner gord 0)
         (click-prompt state :runner "Make the Runner lose 2 [Credits]")
         (core/resolve-unbroken-subs! state :corp (refresh afshar))

--- a/test/clj/game_test/engine/ice.clj
+++ b/test/clj/game_test/engine/ice.clj
@@ -50,7 +50,35 @@
         (take-credits state :runner)
         (take-credits state :corp)
         (run-on state :hq)
-        (is (= "1 [Credits]: Fully break Tour Guide" (-> (refresh buk) :abilities first :label)))))))
+        (is (= "1 [Credits]: Fully break Tour Guide" (-> (refresh buk) :abilities first :label))))))
+  (testing "Breaking restrictions on auto-pump-and-break - No auto pumping if (:breakable sub) does not return :unrestricted"
+    (do-game
+      (new-game {:corp {:hand ["Afshar"]}
+                 :runner {:hand ["Gordian Blade"]
+                          :credits 10}})
+      (play-from-hand state :corp "Afshar" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Gordian Blade")
+      (run-on state :hq)
+      (let [afshar (get-ice state :hq 0)
+            gord (get-program state 0)]
+        (core/rez state :corp afshar)
+        (is (empty? (filter #(= :auto-pump-and-break (:dynamic %)) (:abilities (refresh gord)))) "No auto break dynamic ability"))))
+  (testing "Breaking restrictions on auto-pump-and-break - Auto pumping if (:breakable sub) returns :unrestricted"
+    (do-game
+      (new-game {:corp {:hand ["Afshar"]}
+                 :runner {:hand ["Gordian Blade"]
+                          :credits 10}})
+      (play-from-hand state :corp "Afshar" "R&D")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Gordian Blade")
+      (run-on state :rd)
+      (let [afshar (get-ice state :rd 0)
+            gord (get-program state 0)]
+        (core/rez state :corp afshar)
+        (is (not-empty (filter #(= :auto-pump-and-break (:dynamic %)) (:abilities (refresh gord)))) "Autobreak is active")
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh gord)})
+        (is (empty? (remove :broken (:subroutines (refresh afshar)))) "All subroutines broken")))))
 
 (deftest bioroid-break-abilities
   ;; The click-to-break ablities on bioroids shouldn't create an undo-click


### PR DESCRIPTION
Closes #4654 
Added `:unrestricted` option for the `:breakable` key on subroutines, which marks that a subroutine will not become unbreakable at any point during breaking the ice (e.g. Afshar not on HQ).