### PR TITLE
Fix Rebirth and DJ Fenris, and simplify prompt handling

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -195,12 +195,9 @@
 (defn resolve-prompt
   "Resolves a prompt by invoking its effect function with the selected target of the prompt.
   Triggered by a selection of a prompt choice button in the UI."
-  [state side {:keys [choice card] :as args}]
-  (let [servercard (get-card state card)
-        card (if (not= (:title card) (:title servercard))
-               (server-card (:title card))
-               servercard)
-        prompt (first (get-in @state [side :prompt]))
+  [state side {:keys [choice] :as args}]
+  (let [prompt (first (get-in @state [side :prompt]))
+        card (get-card state (:card prompt))
         choices (:choices prompt)]
     (cond
       ;; Shortcut
@@ -221,7 +218,7 @@
               (pay state side card :credit (min choice (get-in @state [side :credit]))))
             (when (:counter choices)
               ;; :Counter prompts deduct counters from the card
-              (add-counter state side (:card prompt) (:counter choices) (- choice)))
+              (add-counter state side card (:counter choices) (- choice)))
             ;; trigger the prompt's effect function
             (when-let [effect-prompt (:effect prompt)]
               (effect-prompt (or choice card)))
@@ -238,7 +235,7 @@
         (let [title-fn (:card-title choices)
               found (some #(when (= (lower-case choice) (lower-case (:title % ""))) %) (server-cards))]
           (if found
-            (if (title-fn state side (make-eid state) (:card prompt) [found])
+            (if (title-fn state side (make-eid state) card [found])
               (do (when-let [effect-prompt (:effect prompt)]
                     (effect-prompt (or choice card)))
                   (finish-prompt state side prompt card))
@@ -250,20 +247,14 @@
                               (Exception. "Error in a card-title prompt") 25)))
           (.println *err* (str "Current prompt: " prompt))))
 
-      ;; Default text prompt
+      ;; Otherwise, choices is a sequence of strings and/or cards
+      ;; choice is a string and should match one of the strings, or the title of one of the cards
       :else
-      (let [buttons (filter #(or (= choice %)
-                                 (same-card? card %)
-                                 (let [choice-str (if (string? choice)
-                                                    (lower-case choice)
-                                                    (lower-case (:title choice "do-not-match")))]
-                                   (or (= choice-str (lower-case %))
-                                       (= choice-str (lower-case (:title % ""))))))
-                            choices)
-            button (first buttons)]
-        (if button
-          (do (when-let [effect-prompt (:effect prompt)]
-                (effect-prompt button))
+      (let [match (first (filter #(or (= choice %)
+                                      (= choice (:title % "")))
+                                 choices))]
+        (if match
+          (do ((:effect prompt) match)
               (finish-prompt state side prompt card))
           (do
             (.println *err* (with-out-str

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -250,7 +250,7 @@
 
       ;; Otherwise, choices is a sequence of strings and/or cards
       ;; choice is a string and should match one of the strings, or the title of one of the cards
-      :else
+      (string? choice)
       (let [match (first (filter #(or (= choice %)
                                       (= choice (:title % "")))
                                  choices))]
@@ -262,7 +262,14 @@
                               (clojure.stacktrace/print-stack-trace
                                 (Exception. "Error in a text prompt") 25)))
             (.println *err* (str "Current prompt: " prompt))
-            (.println *err* (str "Current args: " args))))))))
+            (.println *err* (str "Current args: " args)))))
+      :else
+      (do
+        (.println *err* (with-out-str
+                          (clojure.stacktrace/print-stack-trace
+                            (Exception. "Error in an unknown prompt type") 25)))
+        (.println *err* (str "Current prompt: " prompt))
+        (.println *err* (str "Current args: " args))))))
 
 (defn select
   "Attempt to select the given card to satisfy the current select prompt. Calls resolve-select

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -197,6 +197,7 @@
   Triggered by a selection of a prompt choice button in the UI."
   [state side {:keys [choice] :as args}]
   (let [prompt (first (get-in @state [side :prompt]))
+        effect (:effect prompt)
         card (get-card state (:card prompt))
         choices (:choices prompt)]
     (cond
@@ -220,8 +221,8 @@
               ;; :Counter prompts deduct counters from the card
               (add-counter state side card (:counter choices) (- choice)))
             ;; trigger the prompt's effect function
-            (when-let [effect-prompt (:effect prompt)]
-              (effect-prompt (or choice card)))
+            (when effect
+              (effect (or choice card)))
             (finish-prompt state side prompt card))
         (do
           (.println *err* (with-out-str
@@ -236,8 +237,8 @@
               found (some #(when (= (lower-case choice) (lower-case (:title % ""))) %) (server-cards))]
           (if found
             (if (title-fn state side (make-eid state) card [found])
-              (do (when-let [effect-prompt (:effect prompt)]
-                    (effect-prompt (or choice card)))
+              (do (when effect
+                    (effect (or choice card)))
                   (finish-prompt state side prompt card))
               (toast state side (str "You cannot choose " choice " for this effect.") "warning"))
             (toast state side (str "Could not find a card named " choice ".") "warning")))
@@ -254,7 +255,7 @@
                                       (= choice (:title % "")))
                                  choices))]
         (if match
-          (do ((:effect prompt) match)
+          (do (effect match)
               (finish-prompt state side prompt card))
           (do
             (.println *err* (with-out-str

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1544,7 +1544,7 @@
                                   (render-message c)]
                                  [:button {:key (or (:cid c) i)
                                            :class (when (:rotated c) :rotated)
-                                           :on-click #(send-command "choice" {:card c})
+                                           :on-click #(send-command "choice" {:choice (:title c)})
                                            :id {:code c}}
                                   (render-message (:title c))])))
                            (:choices prompt))))]

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -4036,7 +4036,7 @@
         (is (zero? (get-counters (refresh sr) :power)) "No power counters initially")
         (is (empty? (:discard (get-runner))) "Nothing in trash")
         (run-empty-server state :hq)
-        (click-prompt state :runner "No Action")
+        (click-prompt state :runner "No action")
         (is (= 1 (get-counters (refresh sr) :power)) "Gained power counter when trashing Mimic")
         (is (= 2 (count (:discard (get-runner)))) "Mimic was trashed")
         (take-credits state :runner)

--- a/test/clj/game_test/cards/hardware.clj
+++ b/test/clj/game_test/cards/hardware.clj
@@ -2967,7 +2967,7 @@
       (click-prompt state :runner "Yes") ; Top Hat activation
       (is (= 0 (count (:discard (get-runner)))) "No damage yet")
       (click-prompt state :runner "2") ; Top Hat - accessing Brainstorm
-      (click-prompt state :runner "No Action")
+      (click-prompt state :runner "No action")
       (is (= 2 (count (:discard (get-runner)))) "Now the meat damage fires")
       ;; Stealing agenda
       (play-from-hand state :runner "Mad Dash")

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -883,7 +883,7 @@
                         :deck [(qty "Project Beale" 2) (qty "Hedge Fund" 3)]}})
       (take-credits state :corp)
       (run-empty-server state "HQ")
-      (click-prompt state :runner "No Action")
+      (click-prompt state :runner "No action")
       (take-credits state :runner)
       (play-from-hand state :corp "Digital Rights Management")
       (is (empty? (:prompt (get-corp))) "No prompt displayed"))))

--- a/test/clj/game_test/utils.clj
+++ b/test/clj/game_test/utils.clj
@@ -89,7 +89,7 @@
 
       ;; Default text prompt
       :else
-      (when-not (core/resolve-prompt state side {:choice choice})
+      (when-not (core/resolve-prompt state side {:choice (if (string? choice) choice (:title choice))})
         (is (= choice (first choices))
             (str (side-str side) " expected to click [ "
                  (if (string? choice) choice (:title choice ""))

--- a/test/clj/game_test/utils.clj
+++ b/test/clj/game_test/utils.clj
@@ -89,7 +89,7 @@
 
       ;; Default text prompt
       :else
-      (when-not (core/resolve-prompt state side {(if (string? choice) :choice :card) choice})
+      (when-not (core/resolve-prompt state side {:choice choice})
         (is (= choice (first choices))
             (str (side-str side) " expected to click [ "
                  (if (string? choice) choice (:title choice ""))


### PR DESCRIPTION
The front-end now only passes card titles to the backend when a prompt
with a choice of cards is clicked. The backend then compares this title
against the titles of the cards in the prompt hash-map.

Resolves #4672