### PR TITLE
fix for Exile interaction with Harbinger

### DIFF
--- a/data/quotes-runner.edn
+++ b/data/quotes-runner.edn
@@ -158,9 +158,9 @@
   "NBN"
   ["Archiving user's personal data without their consent is illegal, but too profitable not to do. Let's hope they kept better tabs on her than I ever could. This could be her last trace."]
   "Weyland"
-  ["Whether they are building up or tearing down, they always leave choice peices of scrap."]
+  ["Whether they are building up or tearing down, they always leave choice pieces of scrap."]
   "Jinteki"
-  ["The real danger is losing a peice of yourself down in their servers... I just need to figure out a way to bring her back."]
+  ["The real danger is losing a piece of yourself down in their servers... I just need to figure out a way to bring her back."]
  }
 
  "Freedom Khumalo: Crypto-Anarchist"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -445,7 +445,8 @@
               :silent (req (not (and (program? target)
                                      (some #{:discard} (:previous-zone target)))))
               :async true
-              :req (req (and (program? target)
+              :req (req (and (and (program? target)
+                                  (not (facedown? target)))
                              (some #{:discard} (:previous-zone target))))
               :msg (msg "draw a card")
               :effect (req (draw state side eid 1 nil))}]}

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -772,7 +772,23 @@
       ;; Make sure the simultaneous-resolution prompt is showing with 2 choices
       (is (= 2 (-> (get-runner) :prompt first :choices count)) "Simultaneous-resolution prompt is showing")
       (click-prompt state :runner "Exile: Streethawk")
-      (is (= 1 (count (:hand (get-runner)))) "Exile drew a card"))))
+      (is (= 1 (count (:hand (get-runner)))) "Exile drew a card")))
+  (testing "Interaction with harbringer"
+    (do-game
+      (new-game {:corp {:deck ["Grim"]}
+                 :runner {:id "Exile: Streethawk"
+                          :deck ["Harbinger", (qty "Sure Gamble" 10)]}})
+      (play-from-hand state :corp "Grim" "HQ")
+      (take-credits state :corp)              
+      (starting-hand state :runner ["Harbinger"])      
+      (play-from-hand state :runner "Harbinger")
+      (let [harb (get-program state 0)
+            grim (get-ice state :hq 0)]
+        (run-on state :hq)
+        (core/rez state :corp grim)
+        (card-subroutine state :corp (refresh grim) 0)
+        (click-card state :corp harb)
+        (is (= 0 (count (:hand (get-runner)))) "Exile didn't drew a card")))))
 
 (deftest freedom-khumalo-crypto-anarchist
   ;; Freedom Khumalo - Can spend virus counters from other cards to trash accessed cards with play/rez costs


### PR DESCRIPTION
Closes #4598 

It seems that Harbinger enters discard briefly, before its ability triggers and reinstalls itself facedown. Proper fix would be to prevent Harbinger ever entering discard, right? Is there any way to do that?

Current fix prevents Exile's ability to trigger, if program is being installed facedown.