### PR TITLE
Change end of turn discard from trash to move

### DIFF
--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -228,7 +228,7 @@
                                         " from " (if (= :runner side) "their Grip" "HQ")
                                         " at end of turn"))
                        (doseq [t targets]
-                         (trash state side t {:unpreventable true}))
+                         (move state side t :discard))
                        (effect-completed state side eid))}
          nil nil)
        (effect-completed state side eid)))))


### PR DESCRIPTION
Cards discarded at the end of turn aren't trashed, they're moved.