### PR TITLE
Fix trash-icon handling

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -663,22 +663,24 @@
                 (set-autoresolve :auto-accept "adding virus counters")]}
 
    "Copycat"
-   {:abilities [{:req (req (and (:run @state)
+   {:abilities [{:async true
+                 :req (req (and (:run @state)
                                 (:rezzed current-ice)))
-                 :effect (req (let [icename (:title current-ice)]
-                                (resolve-ability
-                                  state side
-                                  {:prompt (msg "Choose a rezzed copy of " icename)
-                                   :choices {:card #(and (rezzed? %)
-                                                         (ice? %)
-                                                         (= (:title %) icename))}
-                                   :msg "redirect the run"
-                                   :cost [:trash]
-                                   :effect (req (let [dest (second (:zone target))
-                                                      tgtndx (ice-index state target)]
-                                                  (swap! state update-in [:run]
-                                                         #(assoc % :position tgtndx :server [dest]))))}
-                                  card nil)))}]}
+                 :effect (effect
+                           (continue-ability
+                             (let [icename (:title current-ice)]
+                               {:async true
+                                :prompt (msg "Choose a rezzed copy of " icename)
+                                :choices {:card #(and (rezzed? %)
+                                                      (ice? %)
+                                                      (= (:title %) icename))}
+                                :msg "redirect the run"
+                                :effect (req (let [dest (second (:zone target))
+                                                   tgtndx (ice-index state target)]
+                                               (swap! state update-in [:run]
+                                                      #(assoc % :position tgtndx :server [dest]))
+                                               (trash state side eid card {:unpreventable true})))})
+                             card nil))}]}
 
    "Cordyceps"
    {:data {:counter {:virus 2}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1181,7 +1181,8 @@
 
    "Investigative Journalism"
    {:req (req (has-bad-pub? state))
-    :abilities [{:cost [:click 4 :trash] :msg "give the Corp 1 bad publicity"
+    :abilities [{:cost [:click 4 :trash]
+                 :msg "give the Corp 1 bad publicity"
                  :effect (effect (gain-bad-publicity :corp 1))}]}
 
    "Jackpot!"
@@ -1901,7 +1902,9 @@
 
    "Political Operative"
    {:req (req (some #{:hq} (:successful-run runner-reg)))
-    :abilities [{:effect
+    :abilities [{:async true
+                 :trash-icon true
+                 :effect
                  (effect
                    (continue-ability
                      ;; TODO: Convert this to a cost

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -213,6 +213,7 @@
    {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
     :abilities [{:label "Place 1 advancement token on a card in this server"
                  :async true
+                 :trash-icon true
                  :effect (effect (continue-ability
                                    {:prompt "Select a card in this server"
                                     :choices {:card #(in-same-server? % card)}
@@ -310,9 +311,11 @@
                  :effect (effect (add-counter card :power 1))}]}
 
    "Corporate Troubleshooter"
-   {:abilities [{:label "Add strength to a rezzed ICE protecting this server"
-                 :choices {:number (req (total-available-credits state :corp eid card))}
+   {:abilities [{:async true
+                 :trash-icon true
+                 :label "Add strength to a rezzed ICE protecting this server"
                  :prompt "How many credits?"
+                 :choices {:number (req (total-available-credits state :corp eid card))}
                  :effect (effect
                            (continue-ability
                              (let [boost target]
@@ -778,8 +781,8 @@
                                :autoresolve (get-autoresolve :auto-fire)
                                :yes-ability
                                {:msg "force the Runner to approach outermost piece of ice"
-                                :cost [:trash]
-                                :effect (req (swap! state assoc-in [:run :position] (count run-ices)))}
+                                :effect (req (swap! state assoc-in [:run :position] (count run-ices))
+                                             (trash state side eid card {:unpreventable true}))}
                                :end-effect (effect (clear-wait-prompt :runner))}}
                              card nil))}}}]
      {:events [(assoc ability :event :approach-server)]

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -788,4 +788,6 @@
 
 (defn has-trash-ability?
   [card]
-  (some #(= :trash (first %)) (merge-costs (map :cost (:abilities (card-def card))))))
+  (let [abilities (:abilities (card-def card))]
+    (or (some :trash-icon abilities)
+        (some #(= :trash (first %)) (merge-costs (map :cost abilities))))))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -397,23 +397,26 @@
          strength-req (req (if (has-subtype? card "Icebreaker")
                              (<= (get-strength current-ice) (get-strength card))
                              true))]
-     {:req (req (and (break-req state side eid card targets)
-                     (strength-req state side eid card targets)))
-      :break-req break-req
-      :break n
-      :breaks subtype
-      :break-cost cost
-      :additional-ability (:additional-ability args)
-      :label (str (when cost (str (build-cost-label cost) ": "))
-                  (or (:label args)
-                      (str "break "
-                           (when (< 1 n) "up to ")
-                           (if (pos? n) n "any number of")
-                           (when (not= "All" subtype) (str " " subtype))
-                           (pluralize " subroutine" n))))
-      :effect (effect (continue-ability
-                        (break-subroutines current-ice card cost n args)
-                        card nil))})))
+     (merge
+       (when (some #(= :trash (first %)) (merge-costs cost))
+         {:trash-icon true})
+       {:req (req (and (break-req state side eid card targets)
+                       (strength-req state side eid card targets)))
+        :break-req break-req
+        :break n
+        :breaks subtype
+        :break-cost cost
+        :additional-ability (:additional-ability args)
+        :label (str (when cost (str (build-cost-label cost) ": "))
+                    (or (:label args)
+                        (str "break "
+                             (when (< 1 n) "up to ")
+                             (if (pos? n) n "any number of")
+                             (when (not= "All" subtype) (str " " subtype))
+                             (pluralize " subroutine" n))))
+        :effect (effect (continue-ability
+                          (break-subroutines current-ice card cost n args)
+                          card nil))}))))
 
 (defn strength-pump
   "Creates a strength pump ability.

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -1,5 +1,6 @@
 (ns game.utils
   (:require [clojure.string :refer [split-lines split join]]
+            [clojure.stacktrace :refer [print-stack-trace]]
             [jinteki.cards :refer [all-cards]]))
 
 (defn server-card
@@ -7,7 +8,10 @@
   (let [card (get @all-cards title)]
     (if (and title card)
       card
-      (.println *err* (str "Tried to select server-card for " title)))))
+      (.println *err* (with-out-str
+                        (print-stack-trace
+                          (Exception. (str "Tried to select server-card for " title))
+                          2500))))))
 
 (defn server-cards
   []

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -3672,9 +3672,27 @@
       (is (= 2 (count (get-program state))) "2 Programs installed")
       (is (= 6 (:credit (get-runner))) "Artist discount applied new turn"))))
 
-; TODO: Enable this once card is fully implemented
-(deftest-pending the-back
-  ; The Back
+(deftest the-back
+  ;; The Back
+  (do-game
+      (new-game {:runner {:hand ["The Back"]
+                          :discard ["Spy Camera" "Recon Drone" "All-nighter" "Deus X"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Back")
+      (let [the-back (get-resource state 0)]
+        (core/add-counter state :runner (refresh the-back) :power 2)
+        (card-ability state :runner (refresh the-back) 1)
+        (is (= "Select up to 4 targets for The Back" (:msg (prompt-map :runner))) "Runner gets up to 4 cards")
+        (click-card state :runner "Spy Camera") ; Hardware
+        (click-card state :runner "Recon Drone") ; Hardware with :trash-icon
+        (click-card state :runner "Deus X") ; Program
+        (click-card state :runner "All-nighter") ; Resource
+        (is (find-card "Spy Camera" (:deck (get-runner))) "Spy Camera is shuffled back into the stack")
+        (is (find-card "Recon Drone" (:deck (get-runner))) "Program is shuffled back into the stack")
+        (is (find-card "Deus X" (:deck (get-runner))) "Deus X is shuffled back into the stack")
+        (is (find-card "All-nighter" (:deck (get-runner))) "All-nighter is shuffled back into the stack"))))
+(deftest-pending the-back-automated
+  ;; TODO: Enable this once card is fully implemented
   (testing "Basic test"
     (do-game
       (new-game {:runner {:hand ["The Back" (qty "Spy Camera" 2) "Lockpick" "Refractor"]


### PR DESCRIPTION
Added `:trash-icon` to abilities to handle when a `:trash` cost is nested instead of top-level (Political Operative, etc).

Closes #4694 