### PR TITLE
Fix for prevent damage message in log

### DIFF
--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -300,7 +300,7 @@
              (fn [_] (let [prevent (get-in @state [:damage :damage-prevent type])]
                        (when prevent (trigger-event state side :prevented-damage type prevent))
                        (system-msg state :runner
-                                   (if prevent (str "prevents " (if (= prevent Integer/MAX_VALUE) "all" prevent)
+                                   (if prevent (str "prevents " (if (>= prevent Integer/MAX_VALUE) "all" prevent)
                                                     " " (name type) " damage") "will not prevent damage"))
                        (clear-wait-prompt state :corp)
                        (resolve-damage state side eid type (max 0 (- n (or prevent 0))) args)))


### PR DESCRIPTION
Closes #4642 

What happens: When paparazzi triggers, we add Integer/MAX_VALUE to state as :damage :damage-prevent using (fnil #(+ % n) 0). When second paparazzi triggers, we add another Integer/MAX_VALUE. Every paparazzi also prints msg. Everything good so far. 

But then runner has option to prevent dmg by trashing Citadel Sanctuary. After he decides, we trigger damage function and there is another log msg inside that function, which prints :damage :damage-prevent value. Which is now 2 * Integer/MAX_VALUE eg. 4294967294 from two paparazzis.

Fix: I have changed final log msg to print "all" when prevented dmg is >= Integer/MAX_VALUE.