### PR TITLE
Fix Slot Machine's Log Message

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2719,7 +2719,7 @@
    (letfn [(top-3 [state] (take 3 (get-in @state [:runner :deck])))
            (effect-type [card] (keyword (str "slot-machine-top-3-" (:cid card))))
            (name-builder [card] (str (:title card) " (" (:type card) ")"))
-           (top-3-names [state card et] (map name-builder (get-effects state :corp card et)))
+           (top-3-names [cards] (map name-builder cards))
            (top-3-types [state card et]
                         (->> (get-effects state :corp card et)
                              first
@@ -2739,7 +2739,7 @@
                                     (system-msg state side
                                                 (str "uses Slot Machine to put the top card of the stack to the bottom,"
                                                      " then reveal the top 3 cards in the stack: "
-                                                     (join ", " (top-3-names state card effect-type))))))}
+                                                     (join ", " (top-3-names t3))))))}
       :subroutines [{:label "Runner loses 3 [Credits]"
                      :msg "force the Runner to lose 3 [Credits]"
                      :effect (effect (lose-credits :runner 3))}

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -3210,18 +3210,18 @@
         (is (zero? (get-counters (refresh iw) :advancement)))
         (click-card state :corp iw)
         (is (= 3 (get-counters (refresh iw) :advancement))))))
-  (testing "Basic test"
+  (testing "Slot Machine chat log test"
     (do-game
       (new-game {:corp {:hand ["Slot Machine" "Ice Wall"]}
-                  :runner {:deck [(qty "Sure Gamble" 10)]}})
+                 :runner {:deck [(qty "Sure Gamble" 10)]}})
       (play-from-hand state :corp "Slot Machine" "HQ")
       (take-credits state :corp)
       (run-on state :hq)     
       (run-next-phase state)
       (let [sm (get-ice state :hq 0)]
-      (core/rez state :corp sm))   
-      (run-continue state)    
-      (is (last-log-contains? state "Corp uses Slot Machine to put the top card of the stack to the bottom, then reveal the top 3 cards in the stack: Sure Gamble \\(Event\\), Sure Gamble \\(Event\\), Sure Gamble \\(Event\\).") "3 top cards revelaed"))))
+        (core/rez state :corp sm))   
+        (run-continue state)    
+        (is (last-log-contains? state "Corp uses Slot Machine to put the top card of the stack to the bottom, then reveal the top 3 cards in the stack: Sure Gamble \\(Event\\), Sure Gamble \\(Event\\), Sure Gamble \\(Event\\).") "3 top cards revelaed"))))
 
 (deftest snowflake
   ;; Snowflake - Win a psi game to end the run

--- a/test/clj/game_test/cards/ice.clj
+++ b/test/clj/game_test/cards/ice.clj
@@ -3184,31 +3184,44 @@
 
 (deftest slot-machine
   ;; Slot Machine
-  (do-game
-    (new-game {:corp {:hand ["Slot Machine" "Ice Wall"]}
-               :runner {:deck [(qty "Sure Gamble" 10)]}})
-    (play-from-hand state :corp "Ice Wall" "R&D")
-    (play-from-hand state :corp "Slot Machine" "HQ")
-    (take-credits state :corp)
-    (run-on state :hq)
-    (run-next-phase state)
-    (let [sm (get-ice state :hq 0)]
-      (core/rez state :corp sm))
-    (let [sm (get-ice state :hq 0)
-          iw (get-ice state :rd 0)
-          corp-credits (:credit (get-corp))
-          runner-credits (:credit (get-runner))
-          cid (:cid (first (:deck (get-runner))))]
-      (run-continue state)
-      (is (not= cid (:cid (first (:deck (get-runner))))))
-      (card-subroutine state :corp sm 0)
-      (is (= (- runner-credits 3) (:credit (get-runner))))
-      (card-subroutine state :corp sm 1)
-      (is (= (+ corp-credits 3) (:credit (get-corp))))
-      (card-subroutine state :corp sm 2)
-      (is (zero? (get-counters (refresh iw) :advancement)))
-      (click-card state :corp iw)
-      (is (= 3 (get-counters (refresh iw) :advancement))))))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:hand ["Slot Machine" "Ice Wall"]}
+                :runner {:deck [(qty "Sure Gamble" 10)]}})
+      (play-from-hand state :corp "Ice Wall" "R&D")
+      (play-from-hand state :corp "Slot Machine" "HQ")
+      (take-credits state :corp)
+      (run-on state :hq)
+      (run-next-phase state)
+      (let [sm (get-ice state :hq 0)]
+        (core/rez state :corp sm))
+      (let [sm (get-ice state :hq 0)
+            iw (get-ice state :rd 0)
+            corp-credits (:credit (get-corp))
+            runner-credits (:credit (get-runner))
+            cid (:cid (first (:deck (get-runner))))]
+        (run-continue state)
+        (is (not= cid (:cid (first (:deck (get-runner))))))
+        (card-subroutine state :corp sm 0)
+        (is (= (- runner-credits 3) (:credit (get-runner))))
+        (card-subroutine state :corp sm 1)
+        (is (= (+ corp-credits 3) (:credit (get-corp))))
+        (card-subroutine state :corp sm 2)
+        (is (zero? (get-counters (refresh iw) :advancement)))
+        (click-card state :corp iw)
+        (is (= 3 (get-counters (refresh iw) :advancement))))))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:hand ["Slot Machine" "Ice Wall"]}
+                  :runner {:deck [(qty "Sure Gamble" 10)]}})
+      (play-from-hand state :corp "Slot Machine" "HQ")
+      (take-credits state :corp)
+      (run-on state :hq)     
+      (run-next-phase state)
+      (let [sm (get-ice state :hq 0)]
+      (core/rez state :corp sm))   
+      (run-continue state)    
+      (is (last-log-contains? state "Corp uses Slot Machine to put the top card of the stack to the bottom, then reveal the top 3 cards in the stack: Sure Gamble \\(Event\\), Sure Gamble \\(Event\\), Sure Gamble \\(Event\\).") "3 top cards revelaed"))))
 
 (deftest snowflake
   ;; Snowflake - Win a psi game to end the run


### PR DESCRIPTION
Closes #4707 

It seems that encounter effect works fine (based on my testing on local and in production), but doesn't print top cards to chat. This fixes that issue.