### PR TITLE
Null ability fix

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1051,12 +1051,14 @@
 
    "Nero Severn: Information Broker"
    {:events [{:event :encounter-ice
-              :req (req (has-subtype? target "Sentry"))
-              :interactive (req true)
-              :once :per-turn
-              :msg "jack out"
-              :async true
-              :effect (effect (jack-out eid))}]}
+              :optional {
+                 :req (req (and (not-used-once? state {:once :per-turn} card)
+                                (has-subtype? target "Sentry")))
+                 :prompt "Do you want to jack out?"
+                 :yes-ability {
+                      :once :per-turn
+                      :msg "jack out"
+                      :effect (effect (jack-out eid))}}}]}
 
    "New Angeles Sol: Your News"
    (let [nasol {:optional

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1051,14 +1051,12 @@
 
    "Nero Severn: Information Broker"
    {:events [{:event :encounter-ice
-              :optional {
-                 :req (req (and (not-used-once? state {:once :per-turn} card)
-                                (has-subtype? target "Sentry")))
-                 :prompt "Do you want to jack out?"
-                 :yes-ability {
-                      :once :per-turn
-                      :msg "jack out"
-                      :effect (effect (jack-out eid))}}}]}
+              :req (req (has-subtype? target "Sentry"))
+              :interactive (req true)
+              :once :per-turn
+              :msg "jack out"
+              :async true
+              :effect (effect (jack-out eid))}]}
 
    "New Angeles Sol: Your News"
    (let [nasol {:optional

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1111,27 +1111,27 @@
 
    "Null: Whistleblower"
    {:events [{:event :encounter-ice
-              :once :per-turn
-              :optional
-              {:req (req (pos? (count (:hand runner))))
-               :once :per-turn
-               :prompt "Trash a card in grip to lower ice strength by 2?"
-               :yes-ability
-               {:prompt "Select a card in your Grip to trash"
-                :choices {:card in-hand?}
-                :msg (msg "trash " (:title target)
-                          " and reduce the strength of " (:title current-ice)
-                          " by 2 for the remainder of the run")
-                :async true
-                :effect (effect (register-floating-effect
-                                  card
-                                  (let [ice current-ice]
-                                    {:type :ice-strength
-                                     :duration :end-of-run
-                                     :req (req (same-card? target ice))
-                                     :value -2}))
-                                (update-all-ice)
-                                (trash eid target {:unpreventable true}))}}}]}
+              :optional {
+                 :req (req (and (not-used-once? state {:once :per-turn} card)
+                                (pos? (count (:hand runner)))))
+                 :prompt "Trash a card in grip to lower ice strength by 2?"
+                 :yes-ability
+                   {:prompt "Select a card in your Grip to trash"
+                    :once :per-turn
+                    :choices {:card in-hand?}
+                    :msg (msg "trash " (:title target)
+                              " and reduce the strength of " (:title current-ice)
+                              " by 2 for the remainder of the run")
+                    :async true
+                    :effect (effect (register-floating-effect
+                                      card
+                                      (let [ice current-ice]
+                                        {:type :ice-strength
+                                        :duration :end-of-run
+                                        :req (req (same-card? target ice))
+                                        :value -2}))
+                                    (update-all-ice)
+                                    (trash eid target {:unpreventable true}))}}}]}
 
    "Omar Keung: Conspiracy Theorist"
    {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1111,27 +1111,27 @@
 
    "Null: Whistleblower"
    {:events [{:event :encounter-ice
-              :optional {
-                 :req (req (and (not-used-once? state {:once :per-turn} card)
+              :optional 
+              {:req (req (and (not-used-once? state {:once :per-turn} card)
                                 (pos? (count (:hand runner)))))
-                 :prompt "Trash a card in grip to lower ice strength by 2?"
-                 :yes-ability
-                   {:prompt "Select a card in your Grip to trash"
-                    :once :per-turn
-                    :choices {:card in-hand?}
-                    :msg (msg "trash " (:title target)
+               :prompt "Trash a card in grip to lower ice strength by 2?"
+               :yes-ability
+               {:prompt "Select a card in your Grip to trash"
+                :once :per-turn
+                :choices {:card in-hand?}
+                :msg (msg "trash " (:title target)
                               " and reduce the strength of " (:title current-ice)
                               " by 2 for the remainder of the run")
-                    :async true
-                    :effect (effect (register-floating-effect
-                                      card
-                                      (let [ice current-ice]
-                                        {:type :ice-strength
-                                        :duration :end-of-run
-                                        :req (req (same-card? target ice))
-                                        :value -2}))
-                                    (update-all-ice)
-                                    (trash eid target {:unpreventable true}))}}}]}
+                :async true
+                :effect (effect (register-floating-effect
+                                  card
+                                  (let [ice current-ice]
+                                    {:type :ice-strength
+                                    :duration :end-of-run
+                                    :req (req (same-card? target ice))
+                                    :value -2}))
+                                (update-all-ice)
+                                (trash eid target {:unpreventable true}))}}}]}
 
    "Omar Keung: Conspiracy Theorist"
    {:abilities [{:cost [:click 1]

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -2286,6 +2286,48 @@
         (take-credits state :runner)
         (is (= 2 (get-counters (refresh nbn-mn) :recurring)) "Recurring credits refill once MN isn't disabled anymore")))))
 
+(deftest nero-severn-information-broker
+  ;; Nero Severn: Information Broker
+  (testing "Basic test"
+    (do-game
+      (new-game {:runner {:id "Nero Severn: Information Broker"
+                          :deck [(qty "Sure Gamble" 10)]}
+                :corp { :deck ["Komainu"]}})
+      (play-from-hand state :corp "Komainu" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (run-next-phase state)
+      (run-continue state)
+      (is (prompt-is-type? state :corp :waiting) "Corp should now be waiting on Runner for Nero ability")
+      (is (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg)))
+      (click-prompt state :runner "Yes")
+      (run-on state "HQ")
+      (run-next-phase state)
+      (run-continue state)
+      (is (not (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg))) "No prompt for Nero ability because we used it on previous run")))
+  (testing "Receives prompt on second run, if ability not used"
+    (do-game
+      (new-game {:runner {:id "Nero Severn: Information Broker"
+                          :deck [(qty "Sure Gamble" 10)]}
+                :corp { :deck ["Guard"]}})
+      (play-from-hand state :corp "Guard" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (run-next-phase state)
+      (run-continue state)
+      (is (prompt-is-type? state :corp :waiting) "Corp should now be waiting on Runner for Nero ability")
+      (is (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg)))
+      (click-prompt state :runner "No")
+      (fire-subs state (get-ice state :hq 0))
+      (run-on state "HQ")
+      (run-next-phase state)
+      (run-continue state)
+      (is (prompt-is-type? state :corp :waiting) "Corp should now be again waiting on Runner for Nero ability")
+      (is (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg)))
+      (click-prompt state :runner "Yes"))))
+
 (deftest new-angeles-sol-your-news
   ;; New Angeles Sol - interaction with runner stealing agendas
   (do-game

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -2437,7 +2437,28 @@
         (click-prompt state :runner "Yes")
         (click-card state :runner (first (:hand (get-runner))))
         (is (find-card "Spiderweb" (:discard (get-corp))) "Spiderweb trashed by Parasite + Null")
-        (is (= 1 (:current-strength (refresh iw))) "Ice Wall not reduced by Null")))))
+        (is (= 1 (:current-strength (refresh iw))) "Ice Wall not reduced by Null"))))
+  (testing "Receives prompt on second run, if ability not used"
+    (do-game
+      (new-game {:runner {:id "Null: Whistleblower"
+                          :deck [(qty "Sure Gamble" 10)]}
+                :corp { :deck ["Guard"]}})
+      (play-from-hand state :corp "Guard" "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (run-next-phase state)
+      (run-continue state)
+      (is (prompt-is-type? state :corp :waiting) "Corp should now be waiting on Runner for Null ability")
+      (is (= "Trash a card in grip to lower ice strength by 2?" (->> (get-runner) :prompt first :msg)))
+      (click-prompt state :runner "No")
+      (fire-subs state (get-ice state :hq 0))
+      (run-on state "HQ")
+      (run-next-phase state)
+      (run-continue state)
+      (is (prompt-is-type? state :corp :waiting) "Corp should now be again waiting on Runner for Null ability")
+      (is (= "Trash a card in grip to lower ice strength by 2?" (->> (get-runner) :prompt first :msg)))
+      (click-prompt state :runner "Yes"))))
 
 (deftest omar-keung-conspiracy-theorist
   ;; Omar Keung

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -2286,48 +2286,6 @@
         (take-credits state :runner)
         (is (= 2 (get-counters (refresh nbn-mn) :recurring)) "Recurring credits refill once MN isn't disabled anymore")))))
 
-(deftest nero-severn-information-broker
-  ;; Nero Severn: Information Broker
-  (testing "Basic test"
-    (do-game
-      (new-game {:runner {:id "Nero Severn: Information Broker"
-                          :deck [(qty "Sure Gamble" 10)]}
-                :corp { :deck ["Komainu"]}})
-      (play-from-hand state :corp "Komainu" "HQ")
-      (core/rez state :corp (get-ice state :hq 0))
-      (take-credits state :corp)
-      (run-on state "HQ")
-      (run-next-phase state)
-      (run-continue state)
-      (is (prompt-is-type? state :corp :waiting) "Corp should now be waiting on Runner for Nero ability")
-      (is (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg)))
-      (click-prompt state :runner "Yes")
-      (run-on state "HQ")
-      (run-next-phase state)
-      (run-continue state)
-      (is (not (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg))) "No prompt for Nero ability because we used it on previous run")))
-  (testing "Receives prompt on second run, if ability not used"
-    (do-game
-      (new-game {:runner {:id "Nero Severn: Information Broker"
-                          :deck [(qty "Sure Gamble" 10)]}
-                :corp { :deck ["Guard"]}})
-      (play-from-hand state :corp "Guard" "HQ")
-      (core/rez state :corp (get-ice state :hq 0))
-      (take-credits state :corp)
-      (run-on state "HQ")
-      (run-next-phase state)
-      (run-continue state)
-      (is (prompt-is-type? state :corp :waiting) "Corp should now be waiting on Runner for Nero ability")
-      (is (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg)))
-      (click-prompt state :runner "No")
-      (fire-subs state (get-ice state :hq 0))
-      (run-on state "HQ")
-      (run-next-phase state)
-      (run-continue state)
-      (is (prompt-is-type? state :corp :waiting) "Corp should now be again waiting on Runner for Nero ability")
-      (is (= "Do you want to jack out?" (->> (get-runner) :prompt first :msg)))
-      (click-prompt state :runner "Yes"))))
-
 (deftest new-angeles-sol-your-news
   ;; New Angeles Sol - interaction with runner stealing agendas
   (do-game


### PR DESCRIPTION
While fixing Nero ability, I have discovered that Null ability is broken too. 

Previous implementation allowed to use ability only on first encounter each turn. It should allow to use ability on any encounter, once per turn.