### PR TITLE
Turning Wheel bounce

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2644,20 +2644,8 @@
                 :silent (req true)}]
       :abilities [(ttw-ab "R&D" :rd)
                   (ttw-ab "HQ" :hq)
-                  {:label "Bounce HQ"
-                   :cost [:click 1]
-                   :req (req true)
-                   :effect (req (add-counter state side card :power 1)
-                                (swap! state update-in [:runner :register :unsuccessful-run] #(conj % :hq))
-                                (swap! state assoc-in [:run :unsuccessful] true)
-                                (system-msg state :runner (str "places a power counter on " (:title card))))}
-                  {:label "Bounce R&D"
-                   :cost [:click 1]
-                   :req (req true)
-                   :effect (req (add-counter state side card :power 1)
-                                (swap! state update-in [:runner :register :unsuccessful-run] #(conj % :rd))
-                                (swap! state assoc-in [:run :unsuccessful] true)
-                                (system-msg state :runner (str "places a power counter on " (:title card))))}]})
+                  (ttw-bounce "R&D" :rd)
+                  (ttw-bounce "HQ" :hq)]})
 
    "Theophilius Bagbiter"
    {:effect (req (lose-credits state :runner :all)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2625,7 +2625,13 @@
             :req (req run)
             :msg (msg "access 1 additional card from " name " for the remainder of the run")
             :effect (req (access-bonus state side server 1))})
-          ]
+                  (ttw-bounce [name server]
+                   :label (str "Bounce " name)
+                   :cost [:click 1]
+                   :effect (req (add-counter state side card :power 1)
+                                (swap! state update-in [:runner :register :unsuccessful-run] #(conj % server))
+                                (swap! state assoc-in [:run :unsuccessful] true)
+                                (system-msg state :runner (str "places a power counter on " (:title card))))}]
      {:events [{:event :agenda-stolen
                 :effect (effect (update! (assoc card :agenda-stolen true)))
                 :silent (req true)}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2625,13 +2625,11 @@
             :req (req run)
             :msg (msg "access 1 additional card from " name " for the remainder of the run")
             :effect (req (access-bonus state side server 1))})
-                  (ttw-bounce [name server]
-                   :label (str "Bounce " name)
-                   :cost [:click 1]
-                   :effect (req (add-counter state side card :power 1)
-                                (swap! state update-in [:runner :register :unsuccessful-run] #(conj % server))
-                                (swap! state assoc-in [:run :unsuccessful] true)
-                                (system-msg state :runner (str "places a power counter on " (:title card))))}]
+           (ttw-bounce [name server]
+            {:label (str "Bounce " name)
+            :cost [:click 1]
+            :effect (req (add-counter state side card :power 1)
+                        (system-msg state :runner (str "places a power counter on " (:title card))))})]
      {:events [{:event :agenda-stolen
                 :effect (effect (update! (assoc card :agenda-stolen true)))
                 :silent (req true)}

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -4376,7 +4376,7 @@
       (play-from-hand state :runner "The Turning Wheel")
       (let [ttw (get-resource state 0)]
         (card-ability state :runner ttw 2) ;; Bounce ability
-        (is (= 0 (get-counters (refresh ttw) :power)) "Bounce add 1 counter to The Turning Wheel")))))
+        (is (= 0 (get-counters (refresh ttw) :power)) "Bounce didn't add counter to The Turning Wheel")))))
 
 (deftest theophilius-bagbiter
   ;; Theophilius Bagbiter - hand size is equal to credit pool

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -4313,8 +4313,7 @@
         (card-ability state :runner ttw 2) ;; Bounce HQ ability
         (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 1 power counter")
         (card-ability state :runner ttw 3) ;; Bounce R&D ability
-        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 2 power counter")
-        (is (get-in @state [:runner :register :unsuccessful-run]) "Server is registered as unsuccessful")))))
+        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 2 power counter")))))
 
 (deftest theophilius-bagbiter
   ;; Theophilius Bagbiter - hand size is equal to credit pool

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -4300,83 +4300,21 @@
         (is (= "You accessed Fire Wall." (-> (get-runner) :prompt first :msg)))
         (click-prompt state :runner "No action")
         (is (empty? (:prompt (get-runner))) "Runner should have no more access prompts available"))))
-  (testing "Successful bounce test"
+  (testing "Bounce test"
     (do-game
       (new-game {:corp {:deck [(qty "Ice Wall" 5)]
-                        :hand [(qty "Ice Wall" 2) (qty "Fire Wall" 2)]
-                        :credits 20}
-                 :runner {:hand ["The Turning Wheel"]
-                          :credits 10}})
-      (play-from-hand state :corp "Ice Wall" "HQ")
-      (play-from-hand state :corp "Fire Wall" "HQ")
-      (play-from-hand state :corp "Ice Wall" "R&D")  
-      (core/rez state :corp (get-ice state :hq 0))
-      (core/rez state :corp (get-ice state :hq 1))
-      (core/rez state :corp (get-ice state :rd 0))
-      (take-credits state :corp)
-      (play-from-hand state :runner "The Turning Wheel")
-      (let [ttw (get-resource state 0)]
-        (card-ability state :runner ttw 2) ;; Bounce ability
-        (is (= 1 (get-counters (refresh ttw) :power)) "Bounce should add 1 counter to The Turning Wheel")
-        (is (last-log-contains? state "places a power counter on")))))
-  (testing "Bounce needs rezzed ICE"
-    (do-game
-      (new-game {:corp {:deck [(qty "Ice Wall" 5)]
-                        :hand [(qty "Ice Wall" 2) (qty "Fire Wall" 2)]
-                        :credits 20}
-                 :runner {:hand ["The Turning Wheel"]
-                          :credits 10}})
-      (play-from-hand state :corp "Fire Wall" "HQ")
-      (play-from-hand state :corp "Ice Wall" "R&D")  
-      (take-credits state :corp)
-      (play-from-hand state :runner "The Turning Wheel")
-      (let [ttw (get-resource state 0)]
-        (card-ability state :runner ttw 2) ;; Bounce ability
-        (is (= 0 (get-counters (refresh ttw) :power)) "Bounce didn't add counter to The Turning Wheel"))))   
-  (testing "No suitable ICE for bounce test"
-    (do-game
-      (new-game {:corp {:deck [(qty "Ice Wall" 5)]
-                        :hand [(qty "Rototurret" 2) (qty "Fire Wall" 2)]
-                        :credits 20}
-                 :runner {:hand ["The Turning Wheel"]
-                          :credits 10}})
-      (play-from-hand state :corp "Rototurret" "HQ")
-      (play-from-hand state :corp "Rototurret" "R&D")  
-      (core/rez state :corp (get-ice state :hq 0))
-      (core/rez state :corp (get-ice state :rd 0))
-      (take-credits state :corp)
-      (play-from-hand state :runner "The Turning Wheel")
-      (let [ttw (get-resource state 0)]
-        (card-ability state :runner ttw 2) ;; Bounce ability
-        (is (= 0 (get-counters (refresh ttw) :power)) "Bounce didn't add counter to The Turning Wheel"))))
-  (testing "No suitable ICE on HQ, suitable on R&D"
-    (do-game
-      (new-game {:corp {:deck [(qty "Ice Wall" 5)]
-                        :hand [(qty "Rototurret" 2) (qty "Eli 1.0" 2)]
-                        :credits 20}
-                 :runner {:hand ["The Turning Wheel"]
-                          :credits 10}})
-      (play-from-hand state :corp "Rototurret" "HQ")
-      (play-from-hand state :corp "Eli 1.0" "R&D")  
-      (core/rez state :corp (get-ice state :hq 0))
-      (core/rez state :corp (get-ice state :rd 0))
-      (take-credits state :corp)
-      (play-from-hand state :runner "The Turning Wheel")
-      (let [ttw (get-resource state 0)]
-        (card-ability state :runner ttw 2) ;; Bounce ability
-        (is (= 1 (get-counters (refresh ttw) :power)) "Bounce add 1 counter to The Turning Wheel"))))
-  (testing "No ICE bounce shouldn't be possible, enjoy your access"
-    (do-game
-      (new-game {:corp {:deck [(qty "Ice Wall" 5)]
-                        :hand [(qty "Rototurret" 2) (qty "Eli 1.0" 2)]
-                        :credits 20}
+                        :hand [(qty "Fire Wall" 5)]}
                  :runner {:hand ["The Turning Wheel"]
                           :credits 10}})
       (take-credits state :corp)
+      (core/gain state :runner :click 10)
       (play-from-hand state :runner "The Turning Wheel")
       (let [ttw (get-resource state 0)]
-        (card-ability state :runner ttw 2) ;; Bounce ability
-        (is (= 0 (get-counters (refresh ttw) :power)) "Bounce didn't add counter to The Turning Wheel")))))
+        (card-ability state :runner ttw 2) ;; Bounce HQ ability
+        (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 1 power counter")
+        (card-ability state :runner ttw 3) ;; Bounce R&D ability
+        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 2 power counter")
+        (is (get-in @state [:runner :register :unsuccessful-run]) "Server is registered as unsuccessful")))))
 
 (deftest theophilius-bagbiter
   ;; Theophilius Bagbiter - hand size is equal to credit pool


### PR DESCRIPTION
Will close #4775 sometimes in the future :)

Added new ability on Turning Wheel which will allow runner to bounce HQ/R&D and add power token. As @lostgeek suggested, it's not done as a run, so we have to set some run flags manually? I kind of need help with this, could you please check my changes? Thanks. :)

EDIT: Second question: Is there any way to show Toast or print chat message, if :req evaluates as false? I would like to add some message like "There is no suitable ICE for automatic bounce" for better UX.