### PR TITLE
Buffering of continue button during runs

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -260,7 +260,7 @@
   "The corp indicates they have no more actions for the encounter."
   [state side args]
   (if (get-in @state [:run :no-action])
-    (continue state side args)
+    (continue state :runner args)
     (do (swap! state assoc-in [:run :no-action] :corp)
         (system-msg state side "has no further action"))))
 

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -200,7 +200,8 @@
 
 (defmethod continue :encounter-ice
   [state side args]
-  (if (get-in @state [:run :no-action])
+  (if (or (get-in @state [:run :no-action])
+          (get-in @state [:run :bypass]))
     (encounter-ends state side args)
     (do (swap! state assoc-in [:run :no-action] :runner)
         (system-msg state side "has no further action"))))

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1507,7 +1507,7 @@
         (str "Continue to " (phase->next-phase-title run))))
     (and (not= "initiation" (:phase @run))
          (not= "pass-ice" (:phase @run))
-         (not (:no-action @run)))
+         (not= "corp" (:no-action @run)))
     #(send-command "no-action")]
 
    [:button {:on-click #(send-command "indicate-action")
@@ -1532,7 +1532,7 @@
             (not (zero? (:position @run))))
        [cond-button
         (str "Continue to " (phase->next-phase-title run))
-        (:no-action @run)
+        (not= "runner" (:no-action @run))
         #(send-command "continue")]
 
        (zero? (:position @run))

--- a/test/clj/game_test/engine/runs.clj
+++ b/test/clj/game_test/engine/runs.clj
@@ -151,3 +151,72 @@
         (card-ability state :corp (get-ice state :remote1 1) 0)
         (is (nil? (:run @state)) "Pressing Done properly handles the ended run")
         (is (= credits (:credit (get-runner))) "Runner shouldn't lose any credits to Tollbooth")))))
+
+(deftest buffered-continue
+  (testing "Buffered continue on approaching ice"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (let [iw (get-ice state :remote1 0)]
+        (take-credits state :corp)
+        (run-on state :remote1)
+        (is (= :approach-ice (:phase (:run @state))) "Runner in approach on ice")
+        (is (not (:no-action (:run @state))) "no-action is not set yet")
+        (core/continue state :runner nil)
+        (is (= :approach-ice (:phase (:run @state))) "Still in approach on ice")
+        (is (= :runner (:no-action (:run @state))) "Runner pressed Continue button")
+        (core/no-action state :corp nil)
+        (is (= :approach-server (:phase (:run @state))) "Corp pressed Continue button, now approaching server")
+        (is (not (:no-action (:run @state))) "no-action is reset")))
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (let [iw (get-ice state :remote1 0)]
+        (take-credits state :corp)
+        (run-on state :remote1)
+        (is (= :approach-ice (:phase (:run @state))) "Runner in approach on ice")
+        (is (not (:no-action (:run @state))) "no-action is not set yet")
+        (core/no-action state :corp nil)
+        (is (= :approach-ice (:phase (:run @state))) "Still in approach on ice")
+        (is (= :corp (:no-action (:run @state))) "Corp pressed Continue button")
+        (core/continue state :runner nil)
+        (is (= :approach-server (:phase (:run @state))) "Runner pressed Continue button, now approaching server")
+        (is (not (:no-action (:run @state))) "no-action is reset"))))
+  (testing "Buffered continue on encountering ice"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (let [iw (get-ice state :remote1 0)]
+        (take-credits state :corp)
+        (run-on state :remote1)
+        (core/rez state :corp iw)
+        (run-continue state)
+        (is (= :encounter-ice (:phase (:run @state))) "Runner in encounter with ice")
+        (is (not (:no-action (:run @state))) "no-action is not set yet")
+        (core/continue state :runner nil)
+        (is (= :encounter-ice (:phase (:run @state))) "Still in encounter with ice")
+        (is (= :runner (:no-action (:run @state))) "Runner pressed Continue button")
+        (core/no-action state :corp nil)
+        (is (= :approach-server (:phase (:run @state))) "Corp pressed Continue button, now approaching server")
+        (is (not (:no-action (:run @state))) "no-action is reset"))))
+  (testing "Buffered continue on encountering ice"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}})
+      (play-from-hand state :corp "Ice Wall" "New remote")
+      (let [iw (get-ice state :remote1 0)]
+        (take-credits state :corp)
+        (run-on state :remote1)
+        (core/rez state :corp iw)
+        (run-continue state)
+        (is (= :encounter-ice (:phase (:run @state))) "Runner in encounter with ice")
+        (is (not (:no-action (:run @state))) "no-action is not set yet")
+        (core/no-action state :corp nil)
+        (is (= :encounter-ice (:phase (:run @state))) "Still in encounter with ice")
+        (is (= :corp (:no-action (:run @state))) "Corp pressed Continue button")
+        (core/continue state :runner nil)
+        (is (= :approach-server (:phase (:run @state))) "Runner pressed Continue button, now approaching server")
+        (is (not (:no-action (:run @state))) "no-action is reset")))))


### PR DESCRIPTION
Closes #4773 
Both Runner and Corp can now press the continue button to automatically continue with the next phase once the other side has pressed it as well.