### PR TITLE
The Turning Wheel bounce ability

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2637,12 +2637,17 @@
                :effect (effect (update! (dissoc card :supplier-installed)))}]}))
 
 (define-card "The Turning Wheel"
-  (let [ttw-ab (fn [m s]
-                 {:label (str "Access an additional card in " m)
-                  :cost [:power 2]
-                  :req (req run)
-                  :msg (msg "access 1 additional card from " m " for the remainder of the run")
-                  :effect (req (access-bonus state side s 1))})]
+  (letfn [(ttw-ab [name server]
+            {:label (str "Access an additional card in " name)
+             :cost [:power 2]
+             :req (req run)
+             :msg (msg "access 1 additional card from " name " for the remainder of the run")
+             :effect (req (access-bonus state side server 1))})
+          (ttw-bounce [name server]
+            {:label (str "Bounce " name)
+             :cost [:click 1]
+             :effect (req (add-counter state side card :power 1)
+                          (system-msg state :runner (str "places a power counter on " (:title card))))})]
     {:events [{:event :agenda-stolen
                :effect (effect (update! (assoc card :agenda-stolen true)))
                :silent (req true)}
@@ -2651,10 +2656,12 @@
                                        (#{:hq :rd} target))
                               (add-counter state side card :power 1)
                               (system-msg state :runner (str "places a power counter on " (:title card))))
-                            (update! state side (dissoc (get-card state card) :agenda-stolen)))
+                         (update! state side (dissoc (get-card state card) :agenda-stolen)))
                :silent (req true)}]
      :abilities [(ttw-ab "R&D" :rd)
-                 (ttw-ab "HQ" :hq)]}))
+                 (ttw-ab "HQ" :hq)
+                 (ttw-bounce "R&D" :rd)
+                 (ttw-bounce "HQ" :hq)]}))
 
 (define-card "Theophilius Bagbiter"
   {:effect (req (lose-credits state :runner :all)

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -4444,7 +4444,21 @@
         (run-successful state)
         (is (= "You accessed Fire Wall." (-> (get-runner) :prompt first :msg)))
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "Runner should have no more access prompts available")))))
+        (is (empty? (:prompt (get-runner))) "Runner should have no more access prompts available"))))
+  (testing "Bounce test"
+    (do-game
+      (new-game {:corp {:deck [(qty "Ice Wall" 5)]
+                        :hand [(qty "Fire Wall" 5)]}
+                 :runner {:hand ["The Turning Wheel"]
+                          :credits 10}})
+      (take-credits state :corp)
+      (core/gain state :runner :click 10)
+      (play-from-hand state :runner "The Turning Wheel")
+      (let [ttw (get-resource state 0)]
+        (card-ability state :runner ttw 2) ;; Bounce HQ ability
+        (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 1 power counter")
+        (card-ability state :runner ttw 3) ;; Bounce R&D ability
+        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 2 power counter")))))
 
 (deftest theophilius-bagbiter
   ;; Theophilius Bagbiter - hand size is equal to credit pool


### PR DESCRIPTION
A redo of #4786 to use the new `define-card` stuff and fix the history (merges got fucked up when I tried).