### PR TITLE
Better chat log for sub break

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1275,7 +1275,7 @@
                                             first)
                                 broken-subs (->> (:subroutines current-ice)
                                                  (remove #(= (:index %) (:index target))))]
-                            (break-subroutines-msg current-ice broken-subs)))
+                            (break-subroutines-msg current-ice broken-subs card)))
                 :effect (req (let [subroutines (:subroutines current-ice)
                                    target (->> subroutines
                                                (filter #(and (not (:broken %))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -372,9 +372,10 @@
                                                              :early-exit (zero? (count (breakable-subroutines-choice ice)))})))))}))
 
 (defn break-subroutines-msg
-  ([ice broken-subs] (break-subroutines-msg ice broken-subs nil))
-  ([ice broken-subs args]
-   (str "break " (quantify (count broken-subs)
+  ([ice broken-subs breaker] (break-subroutines-msg ice broken-subs breaker nil))
+  ([ice broken-subs breaker args]
+   (str "use " (:title breaker)
+        " to break " (quantify (count broken-subs)
                            (str (when-let [subtype (:subtype args)]
                                   (when (not= "All" subtype)
                                     (str subtype " ")))
@@ -403,7 +404,7 @@
                                                                        :broken-subs broken-subs)
                                                                 card ice))
                            message (when (seq broken-subs)
-                                     (break-subroutines-msg ice broken-subs args))]
+                                     (break-subroutines-msg ice broken-subs breaker args))]
                        (wait-for (pay-sync state side (make-eid state {:source-type :ability}) card total-cost)
                                  (if-let [cost-str async-result]
                                    (do (system-msg state :runner (str cost-str " to " message))

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2494,6 +2494,33 @@
         (click-prompt state :runner "Pay 1 [Credits]")
         (is (empty? (:prompt (get-runner))) "No more prompts open")))))
 
+(deftest maven
+  ;; Maven
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck ["Border Control"]
+                        :credits 20}
+                 :runner {:hand ["Maven" "Datasucker"]
+                          :credits 20}})
+      (play-from-hand state :corp "Border Control" "HQ") 
+      (core/rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)      
+      (play-from-hand state :runner "Maven")  
+      (let [maven (get-program state 0)]
+        (is (= 1 (:current-strength (refresh maven))) "Maven boosts itself")
+        (play-from-hand state :runner "Datasucker") 
+        (is (= 2 (:current-strength (refresh maven))) "+1 str from Datasucker")
+        (run-on state "HQ")
+        (run-continue state)
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh maven)})
+        (is (second-last-log-contains? state "Runner pays 4 \\[Credits\\] to use Maven to break all 2 subroutines on Border Control.") "Correct log with autopump ability")
+        (run-jack-out state)
+        (run-on state "HQ")
+        (run-continue state)
+        (card-ability state :runner (refresh maven) 0)
+        (click-prompt state :runner "End the run")
+        (is (last-log-contains? state "Runner pays 2 \\[Credits\\] to use Maven to break 1 subroutine on Border Control.") "Correct log with single sub break")))))
+
 (deftest multithreader
   ;; Multithreader
   (testing "Pay-credits prompt"


### PR DESCRIPTION
Closes #4860 

Breaker ability chat log message modified to also print breaker name. Previously was printed only when using pump-and-break abilities.