### PR TITLE
Prey double trigger fix

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2044,6 +2044,7 @@
    :effect (effect (make-run eid target nil card))
    :events [{:event :pass-ice
              :req (req (and (rezzed? target)
+                            (not-used-once? state {:once :per-run} card)
                             (<= (get-strength target) (count (all-installed state :runner)))))
              :async true
              :effect
@@ -2056,7 +2057,7 @@
                                     " to trash " (:title ice) "?")
                        :yes-ability
                        {:async true
-                        :once :per-turn
+                        :once :per-run
                         :cost [:installed (get-strength ice)]
                         :msg (msg "trash " (card-str state ice))
                         :effect (effect (trash eid ice nil))}}}
@@ -2064,7 +2065,7 @@
                       {:prompt (str "Use Prey to trash " (:title ice) "?")
                        :yes-ability
                        {:async true
-                        :once :per-turn
+                        :once :per-run
                         :msg (msg "trash " (card-str state ice))
                         :effect (effect (trash eid ice nil))}}}))
                  card nil))}]})

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -3948,7 +3948,35 @@
           "Runner has correct prompt")
       (click-prompt state :runner "Yes")
       (is (find-card "Burke Bugs" (:discard (get-corp))) "Burke Bugs is trashed")
-      (is (not (get-ice state :hq 0)) "Burke Bugs is trashed"))))
+      (is (not (get-ice state :hq 0)) "Burke Bugs is trashed")))
+  (testing "Prompt should be shown only until ICE is trashed."
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Burke Bugs" "Ice Wall"]}
+                 :runner {:hand ["Prey" (qty "Clone Chip" 3)]}})
+      (play-from-hand state :corp "Burke Bugs" "HQ")
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (dotimes [_ 3]
+        (play-from-hand state :runner "Clone Chip"))
+      (play-from-hand state :runner "Prey")
+      (click-prompt state :runner "HQ")
+      (core/rez state :corp (get-ice state :hq 1))
+      (run-continue state)
+      (run-continue state)
+      (is (get-ice state :hq 1) "Ice Wall should not be trashed yet")
+      (is (= "Use Prey to trash 1 card to trash Ice Wall?" (:msg (prompt-map :runner)))
+          "Runner has correct prompt")
+      (click-prompt state :runner "Yes")
+      (click-card state :runner (get-hardware state 0))
+      (is (find-card "Ice Wall" (:discard (get-corp))) "Ice Wall is trashed")
+      (is (not (get-ice state :hq 1)) "Ice Wall is trashed")
+      (core/rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (run-continue state)
+      (is (not (= "Use Prey to trash Burke Bugs?" (:msg (prompt-map :runner))))
+          "Runner has no prompt trash ice")
+      )))
 
 (deftest process-automation
   ;; Process Automation

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -3975,8 +3975,7 @@
       (run-continue state)
       (run-continue state)
       (is (not (= "Use Prey to trash Burke Bugs?" (:msg (prompt-map :runner))))
-          "Runner has no prompt trash ice")
-      )))
+          "Runner has no prompt trash ice"))))
 
 (deftest process-automation
   ;; Process Automation


### PR DESCRIPTION
Fix for Prey prompt shown twice when passing ICE with positive STR and then with zero STR. 

New test case.