### PR TITLE
Gachapon install ability fix

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -771,7 +771,7 @@
                                                    (continue-ability state side (shuffle-next set-aside nil nil) card nil)
                                                    (let [to-install target
                                                          set-aside (remove-once #(= % target) set-aside)]
-                                                     (wait-for (runner-install state side (assoc eid :source card :source-type :ability) target {:cost-bonus -2})
+                                                     (wait-for (runner-install state side (assoc eid :source card :source-type :runner-install) target {:cost-bonus -2})
                                                                (continue-ability state side (shuffle-next set-aside nil nil) card nil)))))}
                                    card nil)))}]}))
 

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2930,6 +2930,7 @@
       (is (= 2 (:credit (get-runner))) "No charge to install Ninja"))))
 
 (deftest paladin-poemu
+  ;; Paladin Poemu
   (testing "Basic test"
     (do-game
       (new-game {:corp {:deck ["Project Vitruvius"]}


### PR DESCRIPTION
Closes #4888 

Paladin Poemu cradits checks eid for source-type `runner-install`. Gachapon install ability had source-type `ability`, so `all-active-pay-credit-cards` ignored Paladin. I have changed source-type for Gachapon install ability from `ability` to `runner-install` and it seems to work. Did I break anything else with this change?

Fix and  new test case.