### PR TITLE
new SMC filter to show only programs which can be installed

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2231,8 +2231,11 @@
                                                (str "shuffle their Stack")))
                                    :priority true
                                    :choices (req (cancellable
-                                                   (conj (vec (sort-by :title (filter program?
-                                                                                      (:deck runner))))
+                                                   (conj (filter #(can-pay? state side
+                                                                      (assoc eid :source card :source-type :runner-install) 
+                                                                      % nil [:credit (install-cost state side % {:cost-bonus 2})])                                                                                      
+                                                               (vec (sort-by :title (filter program? (:deck runner))))
+                                                               )
                                                          "No install")))
                                    :cost [:credit 2]
                                    :async true

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2234,8 +2234,7 @@
                                                    (conj (filter #(can-pay? state side
                                                                       (assoc eid :source card :source-type :runner-install) 
                                                                       % nil [:credit (install-cost state side % {:cost-bonus 2})])                                                                                      
-                                                               (vec (sort-by :title (filter program? (:deck runner))))
-                                                               )
+                                                               (vec (sort-by :title (filter program? (:deck runner)))))
                                                          "No install")))
                                    :cost [:credit 2]
                                    :async true

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2230,12 +2230,11 @@
                                                (str "install " (:title target))
                                                (str "shuffle their Stack")))
                                    :priority true
-                                   :choices (req (cancellable
-                                                   (conj (filter #(can-pay? state side
-                                                                      (assoc eid :source card :source-type :runner-install) 
-                                                                      % nil [:credit (install-cost state side % {:cost-bonus 2})])                                                                                      
+                                   :choices (req (conj (filter #(can-pay? state side
+                                                                  (assoc eid :source card :source-type :runner-install) 
+                                                                  % nil [:credit (install-cost state side % {:cost-bonus 2})])                                                                                      
                                                                (vec (sort-by :title (filter program? (:deck runner)))))
-                                                         "No install")))
+                                                        "No install"))
                                    :cost [:credit 2]
                                    :async true
                                    :effect (req (trigger-event state side :searched-stack nil)


### PR DESCRIPTION
Closes #4863 

Couldn't reproduce original issue. Afterimage stays in stack when there is not enough credits to pay. 

I have added new filter for SMC to only show programs which can by installed. 
Also, SMC has both `cancel` and `No install` options in prompt. Is this correct? Shouldn't there be only one?