### PR TITLE
Clean up prompt handling

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -291,7 +291,6 @@
          {:async true
           :effect pay-rest}
          {:async true
-          :priority 12
           :prompt (str "Select a credit providing card ("
                        counter-count (when (and target-count (pos? target-count))
                                        (str " of " target-count))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1461,11 +1461,10 @@
                                        (clear-wait-prompt state :runner)
                                        (effect-completed state :corp eid))))
              :effect (req (wait-for (trash state side target {:unpreventable true})
-                                    (do
-                                      (system-msg state side (str "trashes " (card-str state target) " due to Standoff"))
-                                      (clear-wait-prompt state (other-side side))
-                                      (show-wait-prompt state side (str (side-str (other-side side)) " to trash a card for Standoff"))
-                                      (continue-ability state (other-side side) (stand (other-side side)) card nil))))})]
+                                    (system-msg state side (str "trashes " (card-str state target) " due to Standoff"))
+                                    (clear-wait-prompt state (other-side side))
+                                    (show-wait-prompt state side (str (side-str (other-side side)) " to trash a card for Standoff"))
+                                    (continue-ability state (other-side side) (stand (other-side side)) card nil)))})]
     {:interactive (req true)
      :async true
      :effect (effect (show-wait-prompt (str (side-str (other-side side)) " to trash a card for Standoff"))
@@ -1484,7 +1483,6 @@
 (define-card "Successful Field Test"
   (letfn [(sft [n max-ops]
             {:prompt "Select a card in HQ to install with Successful Field Test"
-             :priority -1
              :async true
              :choices {:card #(and (corp? %)
                                    (not (operation? %))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -104,7 +104,6 @@
                                   {:prompt "Prevent Alexa Belsky from shuffling back in 1 card for every 2 [Credits] spent. How many credits?"
                                    :choices :credit
                                    :player :runner
-                                   :priority 2
                                    :msg (msg "shuffle "
                                              (quantify (- (count (:hand corp)) (quot target 2)) "card")
                                              " in HQ into R&D")
@@ -281,7 +280,6 @@
                                   (continue-ability :corp
                                                     {:optional
                                                      {:prompt "Draw 2 cards?"
-                                                      :priority 1
                                                       :player :corp
                                                       :yes-ability {:msg "draw 2 cards"
                                                                     :effect (effect (draw eid 2 nil))}
@@ -1124,7 +1122,6 @@
                                       {:optional
                                        {:prompt "Shuffle Marilyn Campaign into R&D?"
                                         :autoresolve (get-autoresolve :auto-reshuffle)
-                                        :priority 1
                                         :player :corp
                                         :yes-ability {:msg "shuffle it back into R&D"
                                                       :effect (effect (move :corp card :deck)
@@ -1247,7 +1244,6 @@
                                                          (rezzed? %))
                                                    (all-installed state :corp))))}
                 :show-discard true
-                :priority 1
                 :once :per-turn
                 :once-key :museum-of-history
                 :msg (msg "shuffle "
@@ -1309,7 +1305,7 @@
                                    {:optional
                                     {:prompt "Draw from Net Analytics?"
                                      :yes-ability {:msg (msg "draw a card")
-                                                   :effect (effect (draw :corp 1))}
+                                                   :effect (effect (draw :corp eid 1 nil))}
                                      :end-effect (effect (clear-wait-prompt :runner))}}
                                    card nil))}]
     {:events [(assoc ability

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1950,7 +1950,6 @@
         ashes-flag [{:event :runner-phase-12
                      :location :discard
                      :condition :in-discard
-                     :priority -1
                      :once :per-turn
                      :once-key :out-of-ashes
                      :effect (effect (continue-ability

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -290,7 +290,6 @@
 
 (define-card "Clone Chip"
   {:abilities [{:prompt "Select a program to install from your Heap"
-                :priority true
                 :show-discard true
                 :req (req (and (not (seq (get-in @state [:runner :locked :discard])))
                                (not (install-locked? state side))
@@ -389,7 +388,7 @@
    :events [{:event :runner-install
              :optional
              {:req (req (has-subtype? target "Caïssa"))
-              :prompt "Use Deep Red?" :priority 1
+              :prompt "Use Deep Red?"
               :yes-ability {:async true
                             :effect (req (let [cid (:cid target)]
                                            (continue-ability
@@ -1299,7 +1298,6 @@
                                                    state side
                                                    {:prompt (str "Trash a card to lower the " cost-type
                                                                  " cost of " (:title targetcard) " by 2 [Credits].")
-                                                    :priority 2
                                                     :async true
                                                     :choices {:card #(and (in-hand? %)
                                                                           (runner? %)
@@ -1447,7 +1445,6 @@
                                  state side
                                  {:async true
                                   :prompt "Choose how much damage to prevent"
-                                  :priority 50
                                   :choices {:number (req (min n (count (:deck runner))))}
                                   :msg (msg "trash " (join ", " (map :title (take target (:deck runner))))
                                             " from their Stack and prevent " target " damage")
@@ -1469,7 +1466,6 @@
                                (:cid (first (:pre-access-card (eventmap @state))))))
                   :effect (effect (continue-ability
                                     {:prompt "Choose how much damage to prevent"
-                                     :priority 50
                                      :choices {:number (req (min (last (:pre-damage (eventmap @state)))
                                                                  (:credit runner)))}
                                      :msg (msg "prevent " target " damage")

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -468,7 +468,6 @@
                                            {:optional
                                             {:player :runner
                                              :prompt "You are encountering Archangel. Allow its subroutine to fire?"
-                                             :priority 1
                                              :yes-ability {:async true
                                                            :effect (effect (resolve-unbroken-subs! eid card))}
                                              :no-ability {:effect (effect (effect-completed eid))}}}
@@ -490,7 +489,6 @@
    :subroutines [{:label "Look at the top 5 cards of R&D"
                   :prompt "Choose a card to install"
                   :async true
-                  :priority true
                   :activatemsg "uses Architect to look at the top 5 cards of R&D"
                   :req (req (and (not (string? target))
                                  (not (operation? target))))
@@ -503,7 +501,6 @@
                  {:label "Install a card from HQ or Archives"
                   :prompt "Select a card to install from Archives or HQ"
                   :show-discard true
-                  :priority true
                   :choices {:card #(and (corp? %)
                                         (not (operation? %))
                                         (or (in-hand? %)
@@ -778,7 +775,6 @@
                               :runner {:optional
                                        {:player :runner
                                         :prompt "You are encountering Chrysalis. Allow its subroutine to fire?"
-                                        :priority 1
                                         :yes-ability {:effect (effect (clear-wait-prompt :corp)
                                                                       (resolve-unbroken-subs! :corp eid card))}
                                         :no-ability {:effect (effect (clear-wait-prompt :corp)
@@ -879,7 +875,6 @@
   {:subroutines [{:label "install a card from Archives"
                   :prompt "Select a card to install from Archives"
                   :show-discard true
-                  :priority true
                   :async true
                   :choices {:card #(and (not (operation? %))
                                         (in-discard? %)
@@ -1458,7 +1453,6 @@
                               :runner {:optional
                                        {:player :runner
                                         :prompt "You are encountering Herald. Allow its subroutines to fire?"
-                                        :priority 1
                                         :yes-ability {:effect (effect (clear-wait-prompt :corp)
                                                                       (resolve-unbroken-subs! :corp eid card))}
                                         :no-ability {:effect (effect (clear-wait-prompt :corp)
@@ -1742,7 +1736,6 @@
                                      (continue-ability
                                        state :runner
                                        {:player :runner
-                                        :priority 1
                                         :prompt "Select a card to move to the Stack"
                                         :choices {:card #(some (partial same-card? %) targets)}
                                         :effect (req (clear-wait-prompt state :corp)
@@ -2660,7 +2653,6 @@
                               {:optional
                                {:player :runner
                                 :prompt "Allow Sapper subroutine to fire?"
-                                :priority 1
                                 :yes-ability
                                 {:effect (effect (clear-wait-prompt :corp)
                                                  (show-wait-prompt :runner "Corp to trash a program with Sapper")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -54,7 +54,6 @@
                       state side
                       {:optional
                        {:prompt "Expose installed card unless Corp pays 1 [Credits]?"
-                        :priority 2
                         :player :runner
                         :autoresolve (get-autoresolve :auto-419)
                         :no-ability {:effect (req (clear-wait-prompt state :corp))}
@@ -1427,7 +1426,6 @@
                                    (in-discard? %))}
              :player :corp
              :show-discard true
-             :priority true
              :msg (msg "shuffle " (if (:seen target) (:title target) "a card")
                        " into R&D")
              :effect (effect (move :corp target :deck)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -771,7 +771,6 @@
 
 (define-card "Friends in High Places"
   (let [fhelper (fn fhp [n] {:prompt "Select a card in Archives to install with Friends in High Places"
-                             :priority -1
                              :async true
                              :show-discard true
                              :choices {:card #(and (corp? %)
@@ -1688,7 +1687,6 @@
   {:async true
    :effect (effect (continue-ability
                      {:prompt "Select a card in Archives to install & rez with Restore"
-                      :priority -1
                       :async true
                       :show-discard true
                       :choices {:card #(and (corp? %)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1340,7 +1340,6 @@
              :req (req (same-card? target card))
              :effect (effect (update-all-icebreakers))}]
    :abilities [{:req (req (pos? (get-counters card :virus)))
-                :priority true
                 :prompt "Move a virus counter to which card?"
                 :choices {:card #(has-subtype? % "Virus")}
                 :effect (req (let [abilities (:abilities (card-def target))
@@ -2213,7 +2212,7 @@
                                                    (runner-install (assoc eid :source card :source-type :runner-install) target {:host-card card}))}
                                   card nil))}
                {:label "Host an installed program"
-                :prompt "Choose a program to host on Scheherazade" :priority 2
+                :prompt "Choose a program to host on Scheherazade"
                 :choices {:card #(and (program? %)
                                       (installed? %))}
                 :msg (msg "host " (:title target) " and gain 1 [Credits]")
@@ -2229,10 +2228,9 @@
                                    :msg (req (if (not= target "No install")
                                                (str "install " (:title target))
                                                (str "shuffle their Stack")))
-                                   :priority true
                                    :choices (req (conj (filter #(can-pay? state side
                                                                   (assoc eid :source card :source-type :runner-install) 
-                                                                  % nil [:credit (install-cost state side % {:cost-bonus 2})])                                                                                      
+                                                                  % nil [:credit (install-cost state side % {:cost-bonus 2})])
                                                                (vec (sort-by :title (filter program? (:deck runner)))))
                                                         "No install"))
                                    :cost [:credit 2]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -234,6 +234,7 @@
                                                       (same-server? card %)))
                                         count
                                         pos?))
+                 :async true
                  :effect
                  (effect
                    (continue-ability
@@ -252,6 +253,7 @@
               {:event :approach-server
                :interactive (req true)
                :req (req this-server)
+               :async true
                :effect
                (effect
                  (show-wait-prompt :corp "Runner to choose for Cayambe Grid")
@@ -625,20 +627,19 @@
 (define-card "Increased Drop Rates"
   {:flags {:rd-reveal (req true)}
    :access {:interactive (req true)
+            :async true
             :effect (effect (show-wait-prompt :corp "Runner to decide if they will take 1 tag")
                             (continue-ability
                               {:optional
                                {:player :runner
                                 :prompt "Take 1 tag to prevent Corp from removing 1 bad publicity?"
                                 :yes-ability {:async true
-                                              :effect (req (gain-tags state :runner eid 1 {:unpreventable true})
-                                                           (system-msg
-                                                             state :runner
-                                                             "takes 1 tag to prevent Corp from removing 1 bad publicity"))}
+                                              :effect (effect (system-msg "takes 1 tag to prevent Corp from removing 1 bad publicity")
+                                                              (gain-tags eid 1 {:unpreventable true}))}
                                 :no-ability {:msg "remove 1 bad publicity"
-                                             :effect (effect (lose-bad-publicity :corp 1))}
-                                :end-effect (effect (clear-wait-prompt :corp)
-                                                    (effect-completed eid))}}
+                                             :effect (effect (lose-bad-publicity :corp 1)
+                                                             (effect-completed eid))}
+                                :end-effect (effect (clear-wait-prompt :corp))}}
                               card nil))}})
 
 (define-card "Intake"
@@ -658,9 +659,11 @@
                                                                   (and (resource? %)
                                                                        (has-subtype? % "Virtual"))))}
                                         :msg (msg "move " (:title target) " to the Grip")
-                                        :effect (effect (move :runner target :hand))
-                                        :end-effect (req (clear-wait-prompt state :runner)
-                                                         (effect-completed state side eid))}
+                                        :effect (req (move state :runner target :hand)
+                                                     (clear-wait-prompt state :runner)
+                                                     (effect-completed state side eid))
+                                        :cancel-effect (req (clear-wait-prompt state :runner)
+                                                            (effect-completed state side eid))}
                                        card nil))}}}})
 
 (define-card "Jinja City Grid"

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -65,10 +65,6 @@
         or 2) the keyword :req with a value of the req 5-fn returning true or false. Triggers a 'select' prompt
         with targeting cursor; only cards that cause the 1-argument function to return true will be allowed.
   :prompt -- a string or 4-argument function returning a string to display in the prompt menu.
-  :priority -- a numeric value, or true (equivalent to 1). Prompts are inserted into the prompt queue and sorted base
-               on priority, with higher priorities coming first. The sort is stable, so if two prompts have the same
-               priority, the prompt that was inserted first will remain first after the sort. You should rarely need
-               to use a priority larger than 1.
   :not-distinct -- true if the prompt should not collapse :choices entries of the same string to one button.
                    Defaults to false.
   :cancel-effect -- if the prompt uses a Cancel button, this 4-argument function will be called if the user
@@ -523,7 +519,6 @@
                                        :base base
                                        :bonus bonus
                                        :link link
-                                       :priority (or priority 2)
                                        :corp-credits corp-credits
                                        :runner-credits runner-credits})]
                (trace-start state side eid card trace)))))

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -173,9 +173,6 @@
                         (is-remote? z)
                         (empty? (get-in @state (conj z :content)))
                         (empty? (get-in @state (conj z :ices))))
-               (when-let [run (:run @state)]
-                 (when (= (last (:server run)) (last z))
-                   (handle-end-run state side)))
                (swap! state dissoc-in z)))
            (when-let [move-zone-fn (:move-zone (card-def moved-card))]
              (move-zone-fn state side (make-eid state) moved-card card))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -443,7 +443,6 @@
                                 :max amount
                                 :card select-fn}
                       :async true
-                      :priority 11
                       :effect (req (wait-for (trash-cards state side targets (merge args {:unpreventable true}))
                                              (complete-with-result
                                                state side eid
@@ -516,7 +515,6 @@
   (continue-ability
     state side
     {:prompt (str "Choose a " card-type " to trash from your grip")
-     :priority 11
      :async true
      :choices {:all true
                :max amount
@@ -563,7 +561,6 @@
                                   :max amount
                                   :card select-fn}
                         :async true
-                        :priority 11
                         :effect (req (doseq [c targets]
                                        (move state side target :deck (select-keys args [:front])))
                                      (complete-with-result

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -209,7 +209,6 @@
   ([state side eid ice subroutines msgs]
    (if (and (seq subroutines)
             (:run @state)
-            (not (get-in @state [:run :ending]))
             (not (get-in @state [:run :ended])))
      (let [sub (first subroutines)]
        (wait-for (resolve-subroutine! state side (make-eid state eid) ice sub)
@@ -510,8 +509,7 @@
    (req (let [abs (remove #(or (= (:dynamic %) :auto-pump)
                                (= (:dynamic %) :auto-pump-and-break))
                           (:abilities card))
-              current-ice (when-not (or (get-in @state [:run :ending])
-                                        (get-in @state [:run :ended]))
+              current-ice (when-not (get-in @state [:run :ended])
                             (get-card state current-ice))
               ;; match strength
               can-pump (fn [ability]

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -203,11 +203,10 @@
                           "meat" :meat)
             prevented (get-in @state [:damage :damage-prevent promptdtype] 0)
             newprompt (assoc oldprompt :msg (str "Prevent any of the " dnumber " " (name promptdtype) " damage? (" prevented "/" dnumber " prevented)"))
-            update-fn #(cons newprompt (rest %))
-            done-update-fn #(rest %)]
+            update-fn #(cons newprompt (rest %))]
         (if (>= prevented dnumber)
-          (do ((:effect oldprompt) nil)
-              (swap! state update-in [side :prompt] done-update-fn))
+          (do (swap! state update-in [side :prompt] next)
+              ((:effect oldprompt) nil))
           (swap! state update-in [side :prompt] update-fn))))))
 
 (defn damage-prevent

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -116,6 +116,15 @@
                        (effect-completed state side eid))))
        (effect-completed state side eid)))))
 
+(defn check-for-empty-server
+  [state]
+  (let [run (:run @state)
+        server (first (:server run))]
+    (and run
+         (is-remote? server)
+         (empty? (get-in @state [:corp :servers server :content]))
+         (empty? (get-in @state [:corp :servers server :ices])))))
+
 (defmethod start-next-phase :approach-ice
   [state side args]
   (set-phase state :approach-ice)
@@ -125,7 +134,8 @@
   (let [ice (get-current-ice state)]
     (system-msg state :runner (str "approaches " (card-str state ice)))
     (wait-for (trigger-event-simult state :runner :approach-ice
-                                    {:cancel-fn (fn [state] (:ended (:run @state)))}
+                                    {:cancel-fn (fn [state] (or (:ended (:run @state))
+                                                                (check-for-empty-server state)))}
                                     ice)
               (update-all-ice state side)
               (update-all-icebreakers state side)
@@ -176,7 +186,8 @@
                                      ;; * run is moved to another server
                                      :cancel-fn (fn [state] (or (:ended (:run @state))
                                                                 (can-bypass-ice state side (get-card state ice))
-                                                                (not= current-server (:server (:run @state)))))}
+                                                                (not= current-server (:server (:run @state)))
+                                                                (check-for-empty-server state)))}
                                     ice)
               (update-all-ice state side)
               (update-all-icebreakers state side)
@@ -227,7 +238,8 @@
                ;; * run ends
                ;; * run is moved to another server
                :cancel-fn (fn [state] (or (:ended (:run @state))
-                                          (not= current-server (:server (:run @state))))))]
+                                          (not= current-server (:server (:run @state)))
+                                          (check-for-empty-server state))))]
     (set-phase state :pass-ice)
     (update-all-ice state side)
     (update-all-icebreakers state side)
@@ -256,7 +268,8 @@
                (when (and no-ice
                           (= :initiation (get-in @state [:run :phase])))
                  {:card-abilities (gather-events state side :pass-all-ice nil)})
-               :cancel-fn (fn [state] (:ended (:run @state))))]
+               :cancel-fn (fn [state] (or (:ended (:run @state))
+                                          (check-for-empty-server state))))]
         (set-phase state :approach-server)
         (system-msg state :runner (str "approaches " (zone->name (:server (:run @state)))))
         (wait-for (trigger-event-simult state side :approach-server args (count (get-run-ices state)))
@@ -295,18 +308,22 @@
 (defn access-end
   "Trigger events involving the end of the access phase, including :no-trash and :post-access-card"
   [state side eid c]
-  (when-not (find-cid (:cid c) (get-in @state [:corp :discard]))
-    ;; Do not trigger :no-trash if card has already been trashed
-    (trigger-event state side :no-trash c))
-  (when (and (agenda? c)
-             (not (find-cid (:cid c) (get-in @state [:runner :scored]))))
-    (trigger-event state side :no-steal c))
-  (when (and (get-card state c)
-             ;; Don't increment :no-trash-or-steal if accessing a card in Archives
-             (not= (:zone c) [:discard]))
-    (no-trash-or-steal state))
-  (swap! state dissoc :access)
-  (trigger-event-sync state side eid :post-access-card c))
+  ;; Do not trigger :no-trash if card has already been trashed
+  (wait-for (trigger-event-sync state side
+                                (when-not (find-cid (:cid c) (get-in @state [:corp :discard]))
+                                  :no-trash)
+                                c)
+            (wait-for (trigger-event-sync state side
+                                          (when (and (agenda? c)
+                                                     (not (find-cid (:cid c) (get-in @state [:runner :scored]))))
+                                            :no-steal)
+                                          c)
+                      (when (and (get-card state c)
+                                 ;; Don't increment :no-trash-or-steal if accessing a card in Archives
+                                 (not= (:zone c) [:discard]))
+                        (no-trash-or-steal state))
+                      (swap! state dissoc :access)
+                      (trigger-event-sync state side eid :post-access-card c))))
 
 ;;; Stealing agendas
 (defn steal
@@ -1309,7 +1326,6 @@
   [state side]
   (let [server (-> @state :run :server first)
         event (when (= :encounter-ice (get-in @state [:run :phase])) :encounter-ice-ends)]
-    (swap! state assoc-in [:run :ending] true)
     (swap! state assoc-in [:run :ended] true)
     (wait-for (trigger-event-simult state side event nil (get-current-ice state))
               (unregister-floating-effects state side :end-of-encounter)

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2791,8 +2791,8 @@
       (run-empty-server state "Server 1")
       (click-prompt state :corp "Yes") ; Ghost Branch ability
       (card-ability state :runner nach 0)
-      (click-prompt state :runner "Done")
       (click-prompt state :corp "Yes") ; Draw from Net Analytics
+      (click-prompt state :runner "Done")
       (click-prompt state :runner "No action")
       (is (empty? (:prompt (get-runner))) "Runner waiting prompt is cleared")
       (is (zero? (count-tags state)) "Avoided 1 Ghost Branch tag")

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2600,9 +2600,8 @@
           (card-subroutine state :corp dm 0)
           (card-ability state :runner rr1 0)
           (click-prompt state :runner "1")
-          (is (last-log-contains? state "Sure Gamble")
+          (is (second-last-log-contains? state "Sure Gamble")
               "Ramujan did log trashed card names")
-          (click-prompt state :runner "Done")
           (is (= 2 (count (:hand (get-runner)))) "1 net damage prevented")
           (run-continue state)
           (run-continue state)
@@ -2616,7 +2615,7 @@
           (click-prompt state :corp "Yes")
           (card-ability state :runner rr2 0)
           (click-prompt state :runner "3")
-          (is (last-log-contains? state "Sure Gamble, Sure Gamble, Sure Gamble")
+          (is (second-last-log-contains? state "Sure Gamble, Sure Gamble, Sure Gamble")
               "Ramujan did log trashed card names")
           (is (= 1 (count (:hand (get-runner)))) "3 net damage prevented")))))
   (testing "Prevent up to X net or brain damage. Empty stack"
@@ -2671,7 +2670,6 @@
       (click-prompt state :corp "Yes")
       (card-ability state :runner rd1 0)
       (click-prompt state :runner "3")
-      (click-prompt state :runner "Done")
       (click-prompt state :runner "No action")
       (is (= 5 (count (:hand (get-runner)))) "Runner took no net damage")
       ; fire HOK while accessing Snare!
@@ -2704,7 +2702,6 @@
       (card-ability state :runner rd3 0)
       (is (= 1 (:number (:choices (prompt-map :runner)))) "Recon Drone choice limited to 1 meat")
       (click-prompt state :runner "1")
-      (click-prompt state :runner "Done")
       (click-prompt state :runner "Pay 3 [Credits] to trash")
       (is (= 2 (count (:hand (get-runner)))) "Runner took no meat damage")
       (run-empty-server state "Server 4")
@@ -2712,7 +2709,6 @@
       (click-prompt state :corp "Yes")
       (card-ability state :runner rd4 0)
       (click-prompt state :runner "1")
-      (click-prompt state :runner "Done")
       (is (= 2 (count (:hand (get-runner)))) "Runner took no brain damage"))))
 
 (deftest record-reconstructor

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -2321,7 +2321,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (is (= 1 (count-tags state)) "Runner took 1 unpreventable tag")
-      (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage from DRT")))
+      (is (= 2 (count (:discard (get-runner)))) "Runner took 0 meat damage from DRT cuz it's trashed")))
   (testing "Trace shouldn't fire on second trash after trash during Direct Access run. #4168"
     (do-game
       (new-game {:corp {:id "NBN: Controlling the Message"

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2423,8 +2423,8 @@
       (is (= 3 (count (:hosted (refresh lib)))) "Still 3 programs hosted")
       (is (= 2 (:click (get-runner))) "Failed Darwin didn't use a click")
       (is (= 1 (count (:hand (get-runner)))))
-      (card-ability state :runner lib 1) ; Add a program hosted on London Library to your Grip
       (click-prompt state :runner "Done")
+      (card-ability state :runner lib 1) ; Add a program hosted on London Library to your Grip
       (click-card state :runner (find-card "Study Guide" (:hosted (refresh lib))))
       (is (= 2 (count (:hand (get-runner)))) "Return Study Guide to hand")
       (is (= 2 (count (:hosted (refresh lib)))) "2 programs hosted")
@@ -2734,7 +2734,6 @@
       (card-ability state :runner noh 0)
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (click-prompt state :runner "Done")
       (is (= 3 (count (:hand (get-runner)))) "1 net damage prevented")
       (run-continue state)
       (run-continue state)
@@ -4568,7 +4567,6 @@
       (is (= 3 (:credit (get-runner))) "Runner is now at 3 credits")
       (core/gain-tags state :corp 1)
       (card-ability state :runner (get-resource state 1) 0)
-      (click-prompt state :runner "Done")
       (click-card state :runner "Corroder")
       (is (zero? (:credit (get-runner))) "Runner paid one less to install")
       (is (= "Corroder" (:title (get-program state 0))) "Corroder is installed")))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -653,7 +653,7 @@
           (core/rez state :corp cg2)
           (take-credits state :corp)
           (take-credits state :runner)
-          (click-prompt state :corp "Cayambe Grid")
+          (click-prompt state :corp cg1)
           (is (= (:msg (prompt-map :corp)) "Place 1 advancement token on an ice protecting HQ")
               "Correct server in prompt title (HQ)")
           (click-card state :corp iw1)
@@ -906,7 +906,6 @@
         (run-empty-server state "Archives")
         (click-prompt state :runner "Cyberdex Virus Suite")
         (click-prompt state :corp "Yes")
-        (println (:prompt (get-runner)))
         (is (pos? (count (:prompt (get-runner)))) "CVS purge did not interrupt archives access")
         ;; purged counters
         (is (zero? (get-counters (refresh cache) :virus))
@@ -1229,37 +1228,27 @@
     (click-card state :corp (get-program state 0))
     (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")
     (click-prompt state :runner "Pay 0 [Credits] to trash") ; trash
-    ;; TODO: Understand weird :waiting prompt on Runner side here:
-    ;; Corp:
-    ;; Type: nil
-    ;;
-    ;; Runner: Waiting for Corp to resolve runner-trash triggers
-    ;; Type: :waiting
-    ; (run-empty-server state "Archives")
-    ; (is (empty? (:prompt (get-corp))) "No prompt from Archives access")
-    ; (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")
-    ; (run-on state "Server 1")
-    ; (run-successful state)
-    ; (click-prompt state :corp "0") ; trace
-    ; (click-prompt state :runner "0")
-    ; (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")
-    ; (click-card state :corp (get-resource state 0))
-    ; (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
-    ; (click-prompt state :runner "No action") ; trash
-    ; (run-on state "HQ")
-    ; (run-successful state)
-    ; (click-prompt state :corp "0") ; trace
-    ; (click-prompt state :runner "0")
-    ; (click-prompt state :corp "Done")
-    ; (click-prompt state :runner "No action") ; trash
-    ; (is (empty? (:prompt (get-corp))) "Prompt closes after done")
-    ; (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
-    ; (run-on state "HQ")
-    ; (run-successful state)
-    ; (click-prompt state :corp "0") ; trace
-    ; (click-prompt state :runner "5")
-    ; (is (empty? (:prompt (get-corp))) "Prompt closes after lost trace")
-    ))
+    (run-empty-server state "Archives")
+    (is (empty? (:prompt (get-corp))) "No prompt from Archives access")
+    (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")
+    (run-empty-server state "Server 1")
+    (click-prompt state :corp "0") ; trace
+    (click-prompt state :runner "0")
+    (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")
+    (click-card state :corp (get-resource state 0))
+    (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
+    (click-prompt state :runner "No action") ; trash
+    (run-empty-server state "HQ")
+    (click-prompt state :corp "0") ; trace
+    (click-prompt state :runner "0")
+    (click-prompt state :corp "Done")
+    (click-prompt state :runner "No action") ; trash
+    (is (empty? (:prompt (get-corp))) "Prompt closes after done")
+    (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
+    (run-empty-server state "HQ")
+    (click-prompt state :corp "0") ; trace
+    (click-prompt state :runner "5")
+    (is (empty? (:prompt (get-corp))) "Prompt closes after lost trace")))
 
 (deftest jinja-city-grid
   ;; Jinja City Grid - install drawn ice, lowering install cost by 4
@@ -2850,7 +2839,6 @@
       (is (= 2 (-> (get-corp) :discard count)) "Corp has both cards in discard")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0") ; Corp wins trace
-      (is (= 1 (-> (get-runner) :discard count)) "Runner should start with only Singularity in heap")
       (dotimes [_ 4]
         (click-card state :runner (get-program state 0)))
       (is (empty? (:prompt (get-corp))) "Warroid Tracker can't trash anything else")


### PR DESCRIPTION
Our prompt system is wack and this is a step towards cleaning it up:

- Remove a prompt before the effect is resolved instead of either after it's
  resolved or after it's been awaited.
- Remove `:priority` from prompts
- Don't sort prompts, always place new prompts at the front
- Remove `handle-end-run` from `move`
- Add empty server guard to run timing `:cancel-fn` checks
- Add `handle-end-run` to `do-play-ability` after ability resolution
- Make `:no-trash` and `:no-steal` events awaitable
- Clean up broken card implementations
- Clean up broken tests