### PR TITLE
Close prompt when user drags card to heap/archives

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -156,7 +156,7 @@
                (or (= last-zone :play-area)
                    (same-side? side (:side card))))
       (let [move-card-to (partial move state s c)
-            card-prompts (filter #(= (get-in % [:card :title]) (:title c) ) (get-in @state [side :prompt]))
+            card-prompts (filter #(same-card? :title % c) (get-in @state [side :prompt]))
             log-move (fn [verb & text]
                        (system-msg state side (str verb " " label from-str
                                                    (when (seq text)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -156,6 +156,7 @@
                (or (= last-zone :play-area)
                    (same-side? side (:side card))))
       (let [move-card-to (partial move state s c)
+            card-prompts (filter #(= (get-in % [:card :title]) (:title c) ) (get-in @state [side :prompt]))
             log-move (fn [verb & text]
                        (system-msg state side (str verb " " label from-str
                                                    (when (seq text)
@@ -167,7 +168,9 @@
             (do (move-card-to :discard {:force true})
                 (log-move "discards"))
             (do (trash state s c {:unpreventable true})
-                (log-move "trashes")))
+                (log-move "trashes")
+                (println card-prompts)
+                ))
           ("Grip" "HQ")
           (do (move-card-to :hand {:force true})
               (log-move "moves" "to " server))

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -163,14 +163,16 @@
                                                      (apply str " " text)))))]
         (case server
           ("Heap" "Archives")
-          (if (= :hand (first (:zone c)))
-            ;; Discard from hand, do not trigger trash
-            (do (move-card-to :discard {:force true})
-                (log-move "discards"))
-            (do (trash state s c {:unpreventable true})
-                (log-move "trashes")
-                (println card-prompts)
-                ))
+          (do (if (not (zero? (count card-prompts)))
+                  ;remove all prompts associated with the trashed card
+                  (do (swap! state update-in [side :prompt] #(filter (fn [p] (not= (get-in p [:card :title]) (:title c))) %))
+                      (map #(effect-completed state side (:eid %)) card-prompts)))
+              (if (= :hand (first (:zone c)))
+                ;; Discard from hand, do not trigger trash
+                (do (move-card-to :discard {:force true})
+                    (log-move "discards"))
+                (do (trash state s c {:unpreventable true})
+                    (log-move "trashes"))))
           ("Grip" "HQ")
           (do (move-card-to :hand {:force true})
               (log-move "moves" "to " server))


### PR DESCRIPTION
Closes #587

Fix is taken from issue #2952 and modified to be used when user drags card to Heap/Archives. 