### PR TITLE
Prevent jack out fix

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3203,11 +3203,9 @@
                {:msg "prevent the Runner from using a chosen program for the remainder of this run"})))
 
 (define-card "Whirlpool"
-  {:subroutines [{:msg "prevent the Runner from jacking out"
-                  :effect (req (when (and (is-remote? (second (:zone card)))
-                                          (> (count (concat (:ices (card->server state card))
-                                                            (:content (card->server state card)))) 1))
-                                 (prevent-jack-out state side))
+  {:subroutines [{:label "The Runner cannot jack out for the remainder of this run. Trash Whirlpool."
+                  :msg "prevent the Runner from jacking out"
+                  :effect (req (prevent-jack-out state side)
                                (when current-ice
                                  (no-action state side nil)
                                  (continue state side nil))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1646,7 +1646,7 @@
                                                [{:event :encounter-ice-ends
                                                  :duration :end-of-encounter
                                                  :unregister-once-resolved true
-                                                 :effect (req (swap! state update :run dissoc :prevent-jack-out))}]))}]))}]})
+                                                 :effect (req (swap! state update :run dissoc :cannot-jack-out))}]))}]))}]})
 
 (define-card "Information Overload"
   (let [ef (effect (reset-variable-subs card (count-tags state) runner-trash-installed-sub))
@@ -2866,6 +2866,20 @@
   {:subroutines [{:req (req (not= (:server run) [:discard]))
                   :msg "make the Runner continue the run on Archives"
                   :effect (req (let [n (count (get-in corp [:servers :archives :ices]))]
+                                  (register-events
+                                    state side card
+                                    [{:event :approach-ice
+                                      :duration :end-of-run
+                                      :unregister-once-resolved true
+                                      :msg "prevent the runner from jacking out"
+                                      :effect (req (prevent-jack-out state side)
+                                                  (register-events
+                                                    state side card
+                                                    [{:event :encounter-ice-ends
+                                                      :duration :end-of-encounter
+                                                      :unregister-once-resolved true
+                                                      :effect (req (swap! state update :run dissoc :cannot-jack-out))
+                                                      }]))}])
                                  (swap! state update :run assoc :position n :server [:archives])
                                  (set-next-phase state (if (pos? n) :approach-ice :approach-server))))}]})
 

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -95,7 +95,8 @@
                       :yes-ability {:msg (str "let the Runner make a run on " serv)
                                     :async true
                                     :effect (effect (clear-wait-prompt :corp)
-                                                    (make-run eid serv nil card))}
+                                                    (make-run eid serv nil card)
+                                                    (prevent-jack-out))}
                       :no-ability {:async true
                                    :msg "add it to their score area as an agenda worth 1 agenda point"
                                    :effect (req (clear-wait-prompt state :corp)

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1490,6 +1490,63 @@
       (core/lose-tags state :runner 2)
       (is (zero? (count (:subroutines (refresh io))))))))
 
+(deftest inazuma
+  ;;Inazuma
+  (testing "basic jack out test"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Inazuma" "Ice Wall" "Cortex Lock"]
+                        :credits 30}
+               :runner {:hand [(qty "Sure Gamble" 5)]
+                        :credits 20}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Cortex Lock" "HQ")
+      (play-from-hand state :corp "Inazuma" "HQ")
+      (take-credits state :corp)
+      (let [inazuma (get-ice state :hq 2)
+            cl (get-ice state :hq 1)]
+        (run-on state "HQ")
+        (core/rez state :corp inazuma)
+        (run-continue state)
+        (fire-subs state (refresh inazuma))
+        (run-continue state)
+        (core/rez state :corp cl)
+        (run-continue state)
+        (is (not (= nil (get-in @state [:run :cannot-jack-out]))) "Runner cannot jack out")
+        (fire-subs state cl)
+        (run-continue state)
+        (is (not (get-in @state [:run :cannot-jack-out])) "Runner can jack out")))))
+;TODO: prepared test for nonbreakable subs
+;  (testing "basic unbreakable subs test"
+;    (do-game
+;      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+;                        :hand ["Inazuma" "Ice Wall" "Cortex Lock"]
+;                        :credits 30}
+;               :runner {:hand [(qty "Sure Gamble" 5) "Bukhgalter"]
+;                        :credits 20}})
+;      (play-from-hand state :corp "Ice Wall" "HQ")
+;      (play-from-hand state :corp "Cortex Lock" "HQ")
+;      (play-from-hand state :corp "Inazuma" "HQ")
+;      (take-credits state :corp)
+;      (play-from-hand state :runner "Bukhgalter")
+;      (let [inazuma (get-ice state :hq 2)
+;            cl (get-ice state :hq 1)
+;            buk (get-program state 0)]
+;        (run-on state "HQ")
+;        (core/rez state :corp inazuma)
+;        (run-continue state)
+;        (fire-subs state (refresh inazuma))
+;        (run-continue state)
+;        (core/rez state :corp cl)
+;        (run-continue state)
+;        ;;should be blocked
+;        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh buk)})
+;        ;;Inazuma subs prevented break on next ice
+;        (is (second-last-log-contains? state "cannot break?") "Runner couldn't break sub")
+;        (changes-val-macro -3 (count (:hand (get-runner)))
+;                                  "3 net damage from Cortex Lock"
+;                                  (fire-subs state (refresh cl)))))))
+
 (deftest interrupt-0
   ;; Interrupt 0
   (do-game
@@ -3456,6 +3513,33 @@
       (core/move-card state :corp {:card (get-ice state :hq 1) :server "Archives"})
       (is (= 4 (:current-strength (refresh surv))) "Surveyor has 4 strength for 2 pieces of ICE"))))
 
+(deftest susanoo-no-mikoto
+  ;;Susanoo-no-Mikoto
+  (testing "basic deflection test"
+    (do-game
+      (new-game {:corp {:deck ["Susanoo-no-Mikoto" "Cortex Lock" "Anansi"]
+                        :credits 20}
+                 :runner {:deck [(qty "Sure Gamble" 5)]}})
+      (play-from-hand state :corp "Anansi" "Archives")
+      (play-from-hand state :corp "Cortex Lock" "Archives")
+      (play-from-hand state :corp "Susanoo-no-Mikoto" "HQ")
+      (take-credits state :corp)
+      (let [susanoo (get-ice state :hq 0)
+            cl (get-ice state :archives 1)]
+        (run-on state "HQ")
+        (core/rez state :corp susanoo)
+        (run-continue state)
+        (fire-subs state susanoo)
+        (is (= :archives (get-in @state [:run :server 0])) "Deflected to archives")
+        (run-next-phase state)
+        (is (not (= nil (get-in @state [:run :cannot-jack-out]))) "Runner cannot jack out")
+        (core/rez state :corp cl)
+        (run-continue state)
+        (fire-subs state cl)
+        (run-continue state)
+        (run-continue state)
+        (is (not (get-in @state [:run :cannot-jack-out]))"Runner can jack out again")))))
+
 (deftest swarm
   ;; Swarm
   (do-game
@@ -3866,7 +3950,7 @@
         (run-continue state)
         (fire-subs state wp)
         (is (get-in @state [:run :cannot-jack-out]))
-        (is (nil? (refresh wp)) "Whirlpool is trashed")))))
+        (is (nil? (refresh wp)) "Whirlpool is trashed"))))
   (testing "Basic test - whirlpool on hq"
     (do-game
       (new-game {:corp {:hand ["Whirlpool" "Ice Wall" "Border Control"]}

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -149,18 +149,29 @@
 
 (deftest an-offer-you-can-t-refuse
   ;; An Offer You Can't Refuse - exact card added to score area, not the last discarded one
-  (do-game
-    (new-game {:corp {:hand ["An Offer You Can't Refuse"]
-                      :discard ["Celebrity Gift"]}})
-    (play-from-hand state :corp "An Offer You Can't Refuse")
-    (click-prompt state :corp "R&D")
-    (is (= 1 (count (:discard (get-corp)))))
-    (click-prompt state :runner "No")
-    (is (= 1 (:agenda-point (get-corp))) "An Offer the Runner refused")
-    (is (= 1 (count (:scored (get-corp)))))
-    (is (find-card "An Offer You Can't Refuse" (:scored (get-corp))))
-    (is (= 1 (count (:discard (get-corp)))))
-    (is (find-card "Celebrity Gift" (:discard (get-corp))))))
+  (testing "add card to score area"
+    (do-game
+      (new-game {:corp {:hand ["An Offer You Can't Refuse"]
+                        :discard ["Celebrity Gift"]}})
+      (play-from-hand state :corp "An Offer You Can't Refuse")
+      (click-prompt state :corp "R&D")
+      (is (= 1 (count (:discard (get-corp)))))
+      (click-prompt state :runner "No")
+      (is (= 1 (:agenda-point (get-corp))) "An Offer the Runner refused")
+      (is (= 1 (count (:scored (get-corp)))))
+      (is (find-card "An Offer You Can't Refuse" (:scored (get-corp))))
+      (is (= 1 (count (:discard (get-corp)))))
+      (is (find-card "Celebrity Gift" (:discard (get-corp))))))
+  (testing "prevent jack out during run"
+    (do-game
+      (new-game {:corp {:hand ["An Offer You Can't Refuse" "Ice Wall"]}})
+      (play-from-hand state :corp "Ice Wall" "R&D")
+      (play-from-hand state :corp "An Offer You Can't Refuse")
+      (click-prompt state :corp "R&D")
+      (click-prompt state :runner "Yes")
+      (is (:run @state) "Run started")
+      (is (get-in @state [:run :cannot-jack-out]) "Runner cannot jack out")
+      (is (not (find-card "An Offer You Can't Refuse" (:scored (get-corp)))) "Offer isn't in score area"))))
 
 (deftest anonymous-tip
   ;; Anonymous Tip


### PR DESCRIPTION
I have discovered that Whirlpool subs to prevent jack out has wrong implementation. And that An Offer You Can't Refuse doesn't prevent jack out at all. So, there are fixes and tests for that.