### PR TITLE
Add card name to prompts for clarity

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1416,7 +1416,8 @@ nav ul
     box-shadow(0 0 1px 2px limegreen)
 
   .card.hovered
-    box-shadow(0 0 1px 2px cyan)
+    box-shadow(0 0 1px 2px blue)
+    border-color: blue
 
   .counters
     position: absolute


### PR DESCRIPTION
A lot of prompt messages will now be awkward by naming the originating card, but that's okay. We can remove those over time.

Closes #3931