### PR TITLE
Update default decks to System Core 2019

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -73,7 +73,7 @@
                                                        :password         hash-pw
                                                        :isadmin          first_user
                                                        :options          {}})
-            demo-decks (mc/find-maps db "decks" {:username "__demo__"})]
+            demo-decks (mc/find-maps db "decks" {:username "__demo2019__"})]
         (when (not-empty demo-decks)
           (mc/insert-batch db "decks" (map #(-> %
                                                 (dissoc :_id)

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -11,7 +11,6 @@
 (defn decks-handler [req]
   (if-let [user (:user req)]
     (response 200 (mc/find-maps db "decks" {:username (:username user)}))
-    (response 200 (mc/find-maps db "decks" {:username "__demo2019__"}))))
 
 (defn decks-create-handler [{{username :username} :user
                              deck                 :body}]

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -11,7 +11,7 @@
 (defn decks-handler [req]
   (if-let [user (:user req)]
     (response 200 (mc/find-maps db "decks" {:username (:username user)}))
-    (response 200 (mc/find-maps db "decks" {:username "__demo__"}))))
+    (response 200 (mc/find-maps db "decks" {:username "__demo2019__"}))))
 
 (defn decks-create-handler [{{username :username} :user
                              deck                 :body}]

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -11,6 +11,7 @@
 (defn decks-handler [req]
   (if-let [user (:user req)]
     (response 200 (mc/find-maps db "decks" {:username (:username user)}))
+    (response 200 (mc/find-maps db "decks" {:username "__demo2019__"}))))
 
 (defn decks-create-handler [{{username :username} :user
                              deck                 :body}]


### PR DESCRIPTION
resolves #4037

As far as I can tell the default decks are copied from an account called `__demo__` which I don't have access to. So I have created an account called `__demo2019__`, populated it with the [updated default decks](https://netrunnerdb.com/en/decklists/find?author=BlackCherries) and updated references to the old account in the code. Please see screenshot of the proposed decks

![Proposed](https://user-images.githubusercontent.com/21013982/79517485-41e7d580-8046-11ea-93e5-2c153640bd41.png)