### PR TITLE
Yagura: fix subroutine order

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3276,12 +3276,12 @@
               (assoc wr :event :card-moved)])})
 
 (define-card "Yagura"
-  {:subroutines [(do-net-damage 1)
-                 {:msg "look at the top card of R&D"
+  {:subroutines [{:msg "look at the top card of R&D"
                   :optional {:prompt (msg "Move " (:title (first (:deck corp))) " to the bottom of R&D?")
                              :yes-ability {:msg "move the top card of R&D to the bottom"
                                            :effect (effect (move (first (:deck corp)) :deck))}
-                             :no-ability {:effect (effect (system-msg :corp (str "does not use Yagura to move the top card of R&D to the bottom")))}}}]})
+                             :no-ability {:effect (effect (system-msg :corp (str "does not use Yagura to move the top card of R&D to the bottom")))}}}
+                 (do-net-damage 1)]})
 
 (define-card "Zed 1.0"
   {:implementation "Restriction on having spent [click] is not implemented"


### PR DESCRIPTION
This fixes the subroutine order of [`Yagura`](http://www.netrunnerdb.com/en/card/04093). It should be:
1. Look at the top card of R&D. You may add that card to the bottom of R&D.
2. Do 1 net damage.

However, 1 and 2 were switched.

Closes https://github.com/mtgred/netrunner/issues/5063