### PR TITLE
Heap-breakers now work on ice with multiple subtypes

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -65,14 +65,14 @@
                        (continue-ability
                          {:optional
                           {:req (req (and (not-any? #(= title (:title %)) (all-active-installed state :runner))
-                                          (not (get-in @state [:run :register :conspiracy (:cid current-ice)]))))
+                                          (not (get-in @state [:run :register (keyword (str "conspiracy-" title)) (:cid current-ice)]))))
                            :player :runner
                            :prompt (str "Install " title "?")
                            :yes-ability {:async true
                                          :effect (effect (runner-install :runner eid card nil))}
                            ;; Add a register to note that the player was already asked about installing,
                            ;; to prevent multiple copies from prompting multiple times.
-                           :no-ability {:effect (req (swap! state assoc-in [:run :register :conspiracy (:cid current-ice)] true))}}}
+                           :no-ability {:effect (req (swap! state assoc-in [:run :register (keyword (str "conspiracy-" title)) (:cid current-ice)] true))}}}
                          card targets))}]})
 
 (defn- pump-and-break

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3270,7 +3270,29 @@
         (let [pc (get-program state 0)]
           (run-on state :hq)
           (run-continue state)
-          (is (empty? (filter #(:dynamic %) (:abilities (refresh pc)))) "No auto-pumping option for Akhet"))))))
+          (is (empty? (filter #(:dynamic %) (:abilities (refresh pc)))) "No auto-pumping option for Akhet"))))
+    (testing "Orion triggers all heap breakers once"
+      (do-game
+        (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                          :hand ["Orion"]
+                          :credits 15}
+                   :runner {:hand [(qty "Paperclip" 2) (qty "MKUltra" 2) (qty "Black Orchestra" 2)]
+                            :credits 100}})
+        (play-from-hand state :corp "Orion" "HQ")
+        (take-credits state :corp)
+        (trash-from-hand state :runner "Paperclip")
+        (trash-from-hand state :runner "Paperclip")
+        (trash-from-hand state :runner "MKUltra")
+        (trash-from-hand state :runner "MKUltra")
+        (trash-from-hand state :runner "Black Orchestra")
+        (trash-from-hand state :runner "Black Orchestra")
+        (run-on state :hq)
+        (core/rez state :corp (get-ice state :hq 0))
+        (run-continue state)
+        (click-prompt state :runner "No")
+        (click-prompt state :runner "No")
+        (click-prompt state :runner "No")
+        (is (empty? (:prompt (get-runner))) "No further prompts to install heap breakers")))))
 
 (deftest parasite
   (testing "Basic functionality: Gain 1 counter every Runner turn"

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3276,16 +3276,10 @@
         (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                           :hand ["Orion"]
                           :credits 15}
-                   :runner {:hand [(qty "Paperclip" 2) (qty "MKUltra" 2) (qty "Black Orchestra" 2)]
+                   :runner {:discard [(qty "Paperclip" 2) (qty "MKUltra" 2) (qty "Black Orchestra" 2)]
                             :credits 100}})
         (play-from-hand state :corp "Orion" "HQ")
         (take-credits state :corp)
-        (trash-from-hand state :runner "Paperclip")
-        (trash-from-hand state :runner "Paperclip")
-        (trash-from-hand state :runner "MKUltra")
-        (trash-from-hand state :runner "MKUltra")
-        (trash-from-hand state :runner "Black Orchestra")
-        (trash-from-hand state :runner "Black Orchestra")
         (run-on state :hq)
         (core/rez state :corp (get-ice state :hq 0))
         (run-continue state)


### PR DESCRIPTION
Heap breakers were checking for a single `:conspiracy` key, instead of using their own. This lead to problems with install triggers on multi-type ice.

Closes #5099 