### PR TITLE
added revealed cards to message from white hat

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2904,7 +2904,7 @@
      :trace {:base 3
              :unsuccessful
              {:async true
-              :msg (msg "reveal all cards in HQ" (when-let [hand (seq (get-in @state [:corp :hand]))]
+              :msg (msg "reveal all cards in HQ" (when-let [hand (seq (:hand corp))]
                                                    (str ": " (join ", " (map :title hand)))))
               :effect (effect (reveal (:hand corp))
                         (continue-ability :runner (choose-cards (set (:hand corp)) #{}) card nil))}}}))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2904,7 +2904,8 @@
      :trace {:base 3
              :unsuccessful
              {:async true
-              :msg "reveal all cards in HQ"
+              :msg (msg "reveal all cards in HQ" (when-let [hand (seq (get-in @state [:corp :hand]))]
+                                                   (str ": " (join ", " (map :title hand)))))
               :effect (effect (reveal (:hand corp))
                         (continue-ability :runner (choose-cards (set (:hand corp)) #{}) card nil))}}}))
 


### PR DESCRIPTION
Resolves: https://github.com/mtgred/netrunner/issues/5097

Resulting message looks like: 
![WhiteHatSnippet](https://user-images.githubusercontent.com/1417657/82342884-2747aa00-99c0-11ea-9209-e3ce929eee1a.PNG)

If you prefer a different message format I'm happy to change it.

The `when-let` is just to handle edge case where the corp has no cards.