### PR TITLE
Boomerang shuffle fix (multiple boomerangs used in single run)

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -183,7 +183,7 @@
                   {:effect (effect
                              (register-events
                                ;; Boomerang is trashed at this point
-                               (reverse-find-card "Boomerang" (:discard (:runner @state)))
+                               (find-card "Boomerang" (reverse (:discard (:runner @state))))
                                (let [server (:server run)]
                                  [{:event :run-ends
                                    :once :per-run

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -183,7 +183,7 @@
                   {:effect (effect
                              (register-events
                                ;; Boomerang is trashed at this point
-                               (find-card "Boomerang" (:discard (:runner @state)))
+                               (reverse-find-card "Boomerang" (:discard (:runner @state)))
                                (let [server (:server run)]
                                  [{:event :run-ends
                                    :once :per-run

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -13,11 +13,6 @@
   [title from]
   (some #(when (= (:title %) title) %) from))
 
-(defn reverse-find-card
-  "Return a card with given title from given sequence in reverse order (latest addition is first)"
-  [title from]
-  (some #(when (= (:title %) title) %) (reverse from)))
-
 (defn find-cid
   "Return a card with specific :cid from given sequence"
   [cid from]

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -13,6 +13,11 @@
   [title from]
   (some #(when (= (:title %) title) %) from))
 
+(defn reverse-find-card
+  "Return a card with given title from given sequence in reverse order (latest addition is first)"
+  [title from]
+  (some #(when (= (:title %) title) %) (reverse from)))
+
 (defn find-cid
   "Return a card with specific :cid from given sequence"
   [cid from]

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -489,7 +489,6 @@
         (click-card state :runner spiderweb)
         (card-ability state :runner pau 0)
         (click-card state :runner (find-card "Boomerang" (:hand (get-runner))))
-        (click-card state :runner spiderweb)
         (run-on state :hq)
         (core/rez state :corp spiderweb)
         (run-continue state)


### PR DESCRIPTION
Closes #5112 

Fix and new test.

I was thinking for few days. My "hack" solution is to `find-card` in reverse order. This way, we will always find latest trashed boomerang and register event on correct card. Should be good enough until we find a way to track cards entering discard?

Also my test seems to work, but I'm getting complaint about `click-card should only be used with prompts requiring the user to click on cards on table`. Is there any obvious mistake? Thanks for review.