### PR TITLE
Clean up :zone messiness

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -319,7 +319,7 @@
 
 (define-card "Careful Planning"
   {:prompt "Choose a card in or protecting a remote server"
-   :choices {:card #(is-remote? (second (:zone %)))}
+   :choices {:card #(is-remote? (second (get-zone %)))}
    :effect (effect (add-icon card target "CP" "red")
                    (system-msg (str "prevents the rezzing of " (card-str state target)
                                     " for the rest of this turn via Careful Planning"))
@@ -781,8 +781,8 @@
 
 (define-card "Drive By"
   {:choices {:card #(let [topmost (get-nested-host %)]
-                      (and (is-remote? (second (:zone topmost)))
-                           (= (last (:zone topmost)) :content)
+                      (and (is-remote? (second (get-zone topmost)))
+                           (= (last (get-zone topmost)) :content)
                            (not (:rezzed %))))}
    :async true
    :effect (req (wait-for (expose state side target)
@@ -999,7 +999,7 @@
                                       (continue-ability
                                         state side
                                         {:choices {:card #(and (contains? % :advance-counter)
-                                                               (= (first (:server run)) (second (:zone %))))}
+                                                               (= (first (:server run)) (second (get-zone %))))}
                                          :msg (msg "remove " (quantify c "advancement token")
                                                    " from " (card-str state target))
                                          :effect (req (let [to-remove (min c (get-counters target :advancement))]
@@ -1023,8 +1023,8 @@
              (continue-ability
                (let [chosen-type target]
                  {:choices {:card #(let [topmost (get-nested-host %)]
-                                     (and (is-remote? (second (:zone topmost)))
-                                          (= (last (:zone topmost)) :content)
+                                     (and (is-remote? (second (get-zone topmost)))
+                                          (= (last (get-zone topmost)) :content)
                                           (not (rezzed? %))))}
                   :async true
                   :effect (req             ;taken from Drive By - maybe refactor
@@ -1092,7 +1092,7 @@
                          (not (rezzed? %)))}
    :async true
    :effect (req (let [ice target
-                      serv (zone->name (second (:zone ice)))
+                      serv (zone->name (second (get-zone ice)))
                       icepos (ice-index state ice)]
                   (continue-ability
                     state :corp
@@ -1639,7 +1639,7 @@
                   :async true
                   :prompt (msg "Select a piece of ICE in " target " to trash")
                   :choices {:card #(and (ice? %)
-                                        (= serv (second (:zone %))))}
+                                        (= serv (second (get-zone %))))}
                   :effect (effect (system-msg (str "trashes " (card-str state target)))
                                   (trash :corp eid target nil))})
                card nil))})
@@ -2165,8 +2165,8 @@
    :effect (effect
              (continue-ability
                (let [c (str->int target)]
-                 {:choices {:card #(and (is-remote? (second (:zone %)))
-                                        (= (last (:zone %)) :content)
+                 {:choices {:card #(and (is-remote? (second (get-zone %)))
+                                        (= (last (get-zone %)) :content)
                                         (not (:rezzed %)))}
                   :msg (msg "add " c " advancement tokens on a card and gain " (* 2 c) " [Credits]")
                   :effect (effect (gain-credits (* 2 c))
@@ -2345,7 +2345,7 @@
                                    :req (req (same-card? target-ice target))
                                    :msg (msg "bypass " (:title target))
                                    :effect (req (bypass-ice state))}]))
-                             (make-run eid (second (:zone target)) nil card))})]
+                             (make-run eid (second (get-zone target)) nil card))})]
     {:async true
      :effect (req (show-wait-prompt state :corp "Runner to spend credits")
                (let [all-amounts (range (min 3 (inc (get-in @state [:runner :credit]))))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1042,7 +1042,7 @@
              :async true
              :req (req (and (= 1 (get-in @state [:runner :register :no-trash-or-steal]))
                             (pos? (count (:hand corp)))
-                            (not= (first (:zone target)) :discard)))
+                            (not (in-discard? target))))
              :once :per-turn
              :msg "force the Corp to trash a random card from HQ"
              :effect (req (let [card-to-trash (first (shuffle (:hand corp)))
@@ -1060,7 +1060,7 @@
                (continue-ability
                  (let [accessed-card target]
                    {:optional
-                    {:req (req (or (= [:deck] (:zone accessed-card))
+                    {:req (req (or (in-deck? accessed-card)
                                    (= [:deck] (:previous-zone accessed-card))))
                      :once :per-turn
                      :async true
@@ -1836,7 +1836,7 @@
              :effect (req (let [broken-ice
                                 (->> (run-events state side :subroutines-broken)
                                      (filter (fn [[ice broken-subs]]
-                                               (and (= :hq (second (:zone ice)))
+                                               (and (= :hq (second (get-zone ice)))
                                                     (all-subs-broken? ice)
                                                     (get-card state ice))))
                                      (keep #(:cid (first %)))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -123,7 +123,8 @@
                           (let [directives (->> (server-cards)
                                                 (filter #(has-subtype? % "Directive"))
                                                 (map make-card)
-                                                (zone :play-area))]
+                                                (map #(assoc % :zone [:play-area]))
+                                                (into []))]
                             ;; Add directives to :play-area - assumed to be empty
                             (swap! state assoc-in [:runner :play-area] directives)
                             (continue-ability state side

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -235,7 +235,7 @@
              :async true
              :req (req (first-event? state :corp :corp-install))
              :effect (req (let [installed-card target
-                                z (butlast (:zone installed-card))]
+                                z (butlast (get-zone installed-card))]
                             (continue-ability
                               state side
                               {:prompt (str "Select a "
@@ -420,7 +420,7 @@
                   :prompt "Select a server to be saved from the rules apocalypse"
                   :choices (req (get-remote-names state))
                   :async true
-                  :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target] (zone->name (second (:zone %))))
+                  :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target] (zone->name (second (get-zone %))))
                                                            (all-installed state :corp))]
                                  (system-msg state side (str "chooses " target
                                                              " to be saved from the rules apocalypse and trashes "
@@ -525,7 +525,7 @@
 
 (define-card "Gagarin Deep Space: Expanding the Horizon"
   {:events [{:event :pre-access-card
-             :req (req (is-remote? (second (:zone target))))
+             :req (req (is-remote? (second (get-zone target))))
              :effect (effect (access-cost-bonus [:credit 1]))
              :msg "make the Runner spend 1 [Credits] to access"}]})
 
@@ -1129,8 +1129,9 @@
                               :async true
                               :choices {:card #(and (has-subtype? % "Current")
                                                     (corp? %)
-                                                    (#{[:hand] [:discard]} (:zone %)))}
-                              :msg (msg "play a current from " (name-zone "Corp" (:zone target)))
+                                                    (or (in-hand? %)
+                                                        (in-discard? %)))}
+                              :msg (msg "play a current from " (name-zone "Corp" (get-zone target)))
                               :effect (effect (play-instant eid target nil))}}}]
     {:events [(assoc nasol :event :agenda-scored)
               (assoc nasol :event :agenda-stolen)]}))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -132,7 +132,7 @@
 (define-card "Aeneas Informant"
   {:events [{:event :no-trash
              :req (req (and (:trash target)
-                            (not= (first (:zone target)) :discard)))
+                            (not (in-discard? target))))
              :optional {:autoresolve (get-autoresolve :auto-reveal-and-gain)
                         :prompt "Use Aeneas Informant?"
                         :yes-ability {:msg (msg (str "gain 1 [Credits]"
@@ -513,8 +513,8 @@
           (trash-or-bonus [chosen-server]
             {:player :corp
              :prompt "Choose a piece of ice to trash or cancel"
-             :choices {:card #(and (= (last (:zone %)) :ices)
-                                   (= chosen-server (rest (butlast (:zone %)))))}
+             :choices {:card #(and (= (last (get-zone %)) :ices)
+                                   (= chosen-server (rest (butlast (get-zone %)))))}
              :async true
              :effect (effect (system-msg (str "trashes " (card-str state target)))
                              (trash :corp eid target {:unpreventable true}))
@@ -1504,7 +1504,7 @@
                 :prompt "Choose a piece of ICE protecting a remote server"
                 :choices {:card #(and (ice? %)
                                       (rezzed? %)
-                                      (is-remote? (second (:zone %))))}
+                                      (is-remote? (second (get-zone %))))}
                 :msg "derez a piece of ICE protecting a remote server"
                 :cost [:trash]
                 :effect (effect (derez target))}]})
@@ -2264,7 +2264,7 @@
                             (some #(and (ice? %)
                                         (not (protecting-same-server? target %))
                                         (= run-position (ice-index state %))
-                                        (is-central? (second (:zone %))))
+                                        (is-central? (second (get-zone %))))
                                   (all-installed state :corp))))
              :optional
              {:prompt "Trash Slipstream to change servers?"
@@ -2280,10 +2280,10 @@
                                                (not (protecting-same-server? passed-ice target))
                                                (= run-position (ice-index state target))
                                                (not (same-card? target passed-ice))
-                                               (is-central? (second (:zone target)))))}
+                                               (is-central? (second (get-zone target)))))}
                       :msg (msg "approach " (card-str state target))
                       :effect (req (wait-for (trash state side card {:unpreventable true})
-                                             (let [dest (second (:zone target))]
+                                             (let [dest (second (get-zone target))]
                                                (swap! state update-in [:run]
                                                       #(assoc % :position (inc run-position) :server [dest]))
                                                (set-next-phase state :approach-ice)

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -350,7 +350,7 @@
   is the innermost ice."
   [state ice]
   (or (:index ice)
-      (first (keep-indexed #(when (same-card? %2 ice) %1) (get-in @state (cons :corp (get-nested-zone ice)))))))
+      (first (keep-indexed #(when (same-card? %2 ice) %1) (get-in @state (cons :corp (get-zone ice)))))))
 
 ;; Break abilities
 (defn- break-subroutines-impl

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -350,7 +350,7 @@
   is the innermost ice."
   [state ice]
   (or (:index ice)
-      (first (keep-indexed #(when (same-card? %2 ice) %1) (get-in @state (cons :corp (:zone ice)))))))
+      (first (keep-indexed #(when (same-card? %2 ice) %1) (get-in @state (cons :corp (get-nested-zone ice)))))))
 
 ;; Break abilities
 (defn- break-subroutines-impl

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -222,7 +222,7 @@
        ;; A server was selected
        :else
        (let [slot (if host-card
-                    (get-nested-zone host-card)
+                    (get-zone host-card)
                     (conj (server->zone state server) (if (ice? card) :ices :content)))]
          (swap! state dissoc-in [:corp :install-list])
          (corp-install-pay state side eid card server args slot))))))
@@ -319,7 +319,7 @@
   ([state side card params] (runner-install state side (make-eid state) card params))
   ([state side eid card {:keys [host-card facedown no-mu no-msg cost-bonus] :as params}]
    (let [eid (eid-set-defaults eid :source nil :source-type :runner-install)]
-     (if (and (empty? (get-in @state [side :locked (first (get-nested-zone card))]))
+     (if (and (empty? (get-in @state [side :locked (first (get-zone card))]))
               (not (install-locked? state :runner)))
        (if-let [hosting (and (not host-card)
                              (not facedown)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -222,7 +222,7 @@
        ;; A server was selected
        :else
        (let [slot (if host-card
-                    (:zone host-card)
+                    (get-nested-zone host-card)
                     (conj (server->zone state server) (if (ice? card) :ices :content)))]
          (swap! state dissoc-in [:corp :install-list])
          (corp-install-pay state side eid card server args slot))))))
@@ -319,7 +319,7 @@
   ([state side card params] (runner-install state side (make-eid state) card params))
   ([state side eid card {:keys [host-card facedown no-mu no-msg cost-bonus] :as params}]
    (let [eid (eid-set-defaults eid :source nil :source-type :runner-install)]
-     (if (and (empty? (get-in @state [side :locked (-> card :zone first)]))
+     (if (and (empty? (get-in @state [side :locked (first (get-nested-zone card))]))
               (not (install-locked? state :runner)))
        (if-let [hosting (and (not host-card)
                              (not facedown)

--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -274,7 +274,7 @@
         card (when (and s-card (same-side? (:side s-card) side))
                (build-card s-card))]
     (when card
-      (swap! state update-in [side :hand] #(concat % (zone :hand [card]))))))
+      (swap! state update-in [side :hand] #(concat % [(assoc card :zone [:hand])])))))
 
 (defn command-replace-id
   [state side args]

--- a/src/clj/game/core/misc.clj
+++ b/src/clj/game/core/misc.clj
@@ -81,8 +81,8 @@
   [card1 card2]
   (and card1
        card2
-       (let [zone1 (get-nested-zone card1)
-             zone2 (get-nested-zone card2)]
+       (let [zone1 (get-zone card1)
+             zone2 (get-zone card2)]
          (= (second zone1) (second zone2)))))
 
 (defn protecting-same-server?
@@ -90,16 +90,16 @@
   [card ice]
   (and card
        ice
-       (let [zone1 (get-nested-zone card)
-             zone2 (get-nested-zone ice)]
+       (let [zone1 (get-zone card)
+             zone2 (get-zone ice)]
          (and (= (second zone1) (second zone2))
               (= :ices (last zone2))))))
 
 (defn in-same-server?
   "True if the two cards are installed IN the same server, or hosted on cards IN the same server."
   [card1 card2]
-  (let [zone1 (get-nested-zone card1)
-        zone2 (get-nested-zone card2)]
+  (let [zone1 (get-zone card1)
+        zone2 (get-zone card2)]
     (and card1
          card2
          (= zone1 zone2)
@@ -112,7 +112,7 @@
   (and (:cid upgrade)
        (:cid target)
        (= (central->zone (:zone target))
-          (butlast (get-nested-zone upgrade)))))
+          (butlast (get-zone upgrade)))))
 
 (defn all-installed
   "Returns a vector of all installed cards for the given side, including those hosted on other cards,

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -63,8 +63,8 @@
         room
         (t/now)
         spectatorhands
-        (new-corp (:user corp) corp-identity corp-options (zone :deck corp-deck) corp-deck-id corp-quote)
-        (new-runner (:user runner) runner-identity runner-options (zone :deck runner-deck) runner-deck-id runner-quote)))))
+        (new-corp (:user corp) corp-identity corp-options (map #(assoc % :zone [:deck]) corp-deck) corp-deck-id corp-quote)
+        (new-runner (:user runner) runner-identity runner-options (map #(assoc % :zone [:deck]) runner-deck) runner-deck-id runner-quote)))))
 
 (defn init-game
   "Initializes a new game with the given players vector."

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -16,21 +16,19 @@
       runner-reg (get-in @state [:runner :register])
       runner-reg-last (get-in @state [:runner :register-last-turn])
       target (first targets)
-      installed (#{:rig :servers} (first (:zone (get-nested-host card))))
+      installed (#{:rig :servers} (first (get-nested-zone card)))
       remotes (get-remote-names state)
       servers (zones->sorted-names (get-zones state))
-      unprotected (let [server (second (:zone (if (:host card)
-                                                (get-card state (:host card)) card)))]
+      unprotected (let [server (second (get-nested-zone card))]
                     (empty? (get-in @state [:corp :servers server :ices])))
       runnable-servers (zones->sorted-names (get-runnable-zones state side eid card nil))
       hq-runnable (not (:hq (get-in (:runner @state) [:register :cannot-run-on-server])))
       rd-runnable (not (:rd (get-in (:runner @state) [:register :cannot-run-on-server])))
       archives-runnable (not (:archives (get-in (:runner @state) [:register :cannot-run-on-server])))
       tagged (is-tagged? state)
-      this-server (let [s (-> card :zone rest butlast)
+      this-server (let [s (get-nested-zone card)
                         r (:server (:run @state))]
-                    (and (= (first r) (first s))
-                         (= (last r) (last s))))]
+                    (= (second s) (first r)))]
     (partition 2)
     (map (juxt first identity))
     (into {})))

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -16,17 +16,17 @@
       runner-reg (get-in @state [:runner :register])
       runner-reg-last (get-in @state [:runner :register-last-turn])
       target (first targets)
-      installed (#{:rig :servers} (first (get-nested-zone card)))
+      installed (#{:rig :servers} (first (get-zone card)))
       remotes (get-remote-names state)
       servers (zones->sorted-names (get-zones state))
-      unprotected (let [server (second (get-nested-zone card))]
+      unprotected (let [server (second (get-zone card))]
                     (empty? (get-in @state [:corp :servers server :ices])))
       runnable-servers (zones->sorted-names (get-runnable-zones state side eid card nil))
       hq-runnable (not (:hq (get-in (:runner @state) [:register :cannot-run-on-server])))
       rd-runnable (not (:rd (get-in (:runner @state) [:register :cannot-run-on-server])))
       archives-runnable (not (:archives (get-in (:runner @state) [:register :cannot-run-on-server])))
       tagged (is-tagged? state)
-      this-server (let [s (get-nested-zone card)
+      this-server (let [s (get-zone card)
                         r (:server (:run @state))]
                     (= (second s) (first r)))]
     (partition 2)

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -60,13 +60,6 @@
       :else
       (= value cv))))
 
-(defn zone
-  "Associate the specified zone to each item in the collection.
-  Zone can be a singleton or a sequential collection"
-  [zone coll]
-  (let [dest (if (sequential? zone) (vec zone) [zone])]
-    (map #(assoc % :zone dest) coll)))
-
 (defn to-keyword [string]
   (cond
 

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -41,37 +41,47 @@
   [card]
   (get-in card [:card :cid]))
 
+(defn get-nested-host
+  "Recursively searches upward to find the 'root' card of a hosting chain."
+  [card]
+  (if (:host card) (recur (:host card)) card))
+
+(defn get-zone
+  "Returns the zone of the 'root' card of a hosting chain"
+  [card]
+  (:zone (get-nested-host card)))
+
 (defn in-server?
   "Checks if the specified card is installed in -- and not PROTECTING -- a server"
   [card]
-  (= (last (:zone card)) :content))
+  (= (last (get-zone card)) :content))
 
 (defn in-hand?
   "Checks if the specified card is in the hand."
   [card]
-  (= (:zone card) [:hand]))
+  (= (get-zone card) [:hand]))
 
 (defn in-discard?
   "Checks if the specified card is in the discard pile."
   [card]
-  (= (:zone card) [:discard]))
+  (= (get-zone card) [:discard]))
 
 (defn in-deck?
   "Checks if the specified card is in the draw deck."
   [card]
-  (= (:zone card) [:deck]))
+  (= (get-zone card) [:deck]))
 
 (defn in-archives-root?
   [card]
-  (= (:zone card) [:servers :archives :content]))
+  (= (get-zone card) [:servers :archives :content]))
 
 (defn in-hq-root?
   [card]
-  (= (:zone card) [:servers :hq :content]))
+  (= (get-zone card) [:servers :hq :content]))
 
 (defn in-rd-root?
   [card]
-  (= (:zone card) [:servers :rd :content]))
+  (= (get-zone card) [:servers :rd :content]))
 
 (defn in-root?
   [card]
@@ -82,17 +92,17 @@
 (defn in-play-area?
   "Checks if the specified card is in the play area."
   [card]
-  (= (:zone card) [:play-area]))
+  (= (get-zone card) [:play-area]))
 
 (defn in-current?
   "Checks if the specified card is in the 'current' zone."
   [card]
-  (= (:zone card) [:current]))
+  (= (get-zone card) [:current]))
 
 (defn in-scored?
   "Checks if the specified card is in _a_ score area (don't know which one)."
   [card]
-  (= (:zone card) [:scored]))
+  (= (get-zone card) [:scored]))
 
 (defn- card-is?
   "Checks the property of the card to see if it is equal to the given value,
@@ -216,12 +226,12 @@
 (defn installed?
   [card]
   (or (:installed card)
-      (= :servers (first (:zone card)))))
+      (= :servers (first (get-zone card)))))
 
 (defn facedown?
   "Checks if the specified card is facedown."
   [card]
-  (or (= (:zone card) [:rig :facedown])
+  (or (= (get-zone card) [:rig :facedown])
       (:facedown card)))
 
 (defn active?
@@ -261,16 +271,6 @@
     (:rec-counter card 0)
     :else
     (get-in card [:counter counter] 0)))
-
-(defn get-nested-host
-  "Recursively searches upward to find the 'root' card of a hosting chain."
-  [card]
-  (if (:host card) (recur (:host card)) card))
-
-(defn get-nested-zone
-  "Returns the zone of the 'root' card of a hosting chain"
-  [card]
-  (:zone (get-nested-host card)))
 
 (defn assoc-host-zones
   "Associates a new zone onto a card and its host(s)."

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1282,7 +1282,7 @@
        (for [zone (runner-f [:program :hardware :resource :facedown])]
          ^{:key zone}
          [:div
-          (doall (for [c (zone @rig)]
+          (doall (for [c (get @rig zone)]
                    ^{:key (:cid c)}
                    [:div.card-wrapper {:class (when (playable? c) "playable")}
                     [card-view c]]))]))

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -1131,7 +1131,22 @@
       (take-credits state :corp)
       (is (= 6 (:credit (get-corp))))
       (take-credits state :runner)
-      (is (= 9 (:credit (get-corp))) "Corp gained credits due to no successful runs on Daily Quest server"))))
+      (is (= 9 (:credit (get-corp))) "Corp gained credits due to no successful runs on Daily Quest server")))
+  (testing "Works when hosted #4571"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Daily Quest" "Full Immersion RecStudio"]
+                        :credits 10}})
+      (play-from-hand state :corp "Full Immersion RecStudio" "New remote")
+      (core/rez state :corp (get-content state :remote1 0))
+      (card-ability state :corp (get-content state :remote1 0) 0)
+      (click-card state :corp "Daily Quest")
+      (core/rez state :corp (first (:hosted (get-content state :remote1 0))))
+      (take-credits state :corp)
+      (run-empty-server state :remote1)
+      (click-card state :runner "Daily Quest")
+      (click-prompt state :runner "No action")
+      (is (= 7 (:credit (get-runner)))))))
 
 (deftest dedicated-response-team
   ;; Dedicated Response Team - Do 2 meat damage when successful run ends if Runner is tagged


### PR DESCRIPTION
In trying to tackle #4571, I realized that we're not doing a good job of consistently checking for hosting. This is an effort to fix that: Reduce the use of `:zone` to the bare minimum, instead routing all checks through the renamed `get-zone` (`get-nested-zone` previously). There are still a lot of places we could be doing better (all of the `(is-remote? (second (get-zone %)))` and similar lines should be a single function call), but I think this is a good first step.

Closes #4571 

