### PR TITLE
/unique command to toggle uniqueness of a card

### DIFF
--- a/src/clj/game/core/io.clj
+++ b/src/clj/game/core/io.clj
@@ -220,6 +220,17 @@
       (doseq [s [:runner :corp]]
         (toast state s "Game reset to start of turn")))))
 
+(defn command-unique
+  "Toggles :uniqueness of the selected card"
+  [state side]
+  (resolve-ability state side
+                   {:effect (effect (set-prop target :uniqueness (not (:uniqueness target))))
+                    :msg (msg "makes " (card-str state target)
+                              (when (not (:uniqueness (get-card state target))) " not")
+                              " unique")
+                    :choices {:card (fn [t] (same-side? (:side t) side))}}
+                   (map->Card {:title "/unique command"}) nil))
+
 (defn command-close-prompt [state side]
   (when-let [fprompt (-> @state side :prompt first)]
     (swap! state update-in [side :prompt] rest)
@@ -436,6 +447,7 @@
         "/trash"      command-trash
         "/undo-click" #(command-undo-click %1 %2)
         "/undo-turn"  #(command-undo-turn %1 %2)
+        "/unique"     command-unique
         nil))))
 
 (defn corp-install-msg

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -85,7 +85,8 @@
                           [:li [:code "/take-net n"] " - Take n net damage (Runner only)"]
                           [:li [:code "/trace n"] " - Start a trace with base strength n (Corp only)"]
                           [:li [:code "/undo-click"] " - Resets the game back to start of the click.  One click only retained. Only allowed for active player"]
-                          [:li [:code "/undo-turn"] " - Resets the game back to end of the last turn. Requires both players to request it"]]]]}
+                          [:li [:code "/undo-turn"] " - Resets the game back to end of the last turn. Requires both players to request it"]
+                          [:li [:code "/unique"] " - Toggles uniqueness of selected card (can be used to e.g. play with non-errata version of Wireless Net Pavillion)"]]]]}
             {:id "documentation"
              :title "Is there more documentation on how to use Jinteki.net?"
              :content [:ul


### PR DESCRIPTION
This PR adds a `/unique` command, that toggles the uniqueness of a card. It can be used to play games with non-errata'd versions of cards like Wireless Net Pavillion.