### PR TITLE
Restore fix for unseen agenda. New tests.

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1683,7 +1683,7 @@
                                             (in-discard? %))}
                       :effect (req (wait-for
                                      (corp-install state side target nil {:install-state :rezzed})
-                                     (let [seen (assoc-in target [:seen] true)]
+                                     (let [seen (assoc target :seen true)]
                                         (system-msg state side (str "uses Restore to "
                                                                       (corp-install-msg seen)))
                                          (let [leftover (filter #(= (:title target) (:title %)) (-> @state :corp :discard))]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1683,8 +1683,9 @@
                                             (in-discard? %))}
                       :effect (req (wait-for
                                      (corp-install state side target nil {:install-state :rezzed})
-                                     (do (system-msg state side (str "uses Restore to "
-                                                                     (corp-install-msg target)))
+                                     (let [seen (assoc-in target [:seen] true)]
+                                        (system-msg state side (str "uses Restore to "
+                                                                      (corp-install-msg seen)))
                                          (let [leftover (filter #(= (:title target) (:title %)) (-> @state :corp :discard))]
                                            (when (seq leftover)
                                              (doseq [c leftover]

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2821,6 +2821,7 @@
       (play-from-hand state :corp "Restore")
       (click-card state :corp (find-card "Project Vitruvius" (:discard (get-corp))))
       (click-prompt state :corp "New remote")
+      (is (not(:seen (get-content state :remote1 0))) "Agenda is facedown")
       (is (last-log-contains? state "Corp uses Restore to install Project Vitruvius from Archives.") "Should write correct log")))
   (testing "Show removed count in log when installed"
     (do-game

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2812,6 +2812,35 @@
       (is (zero? (get-counters (refresh iw2) :advancement)) "Advancements removed")
       (is (= 6 (get-counters (refresh gt) :advancement)) "Gained 6 advancements"))))
 
+(deftest restore
+  ;;Restore
+  (testing "Show agenda name in log when installed"
+    (do-game
+      (new-game {:corp {:discard ["Project Vitruvius"]
+                        :hand ["Restore"]}})
+      (play-from-hand state :corp "Restore")
+      (click-card state :corp (find-card "Project Vitruvius" (:discard (get-corp))))
+      (click-prompt state :corp "New remote")
+      (is (last-log-contains? state "Corp uses Restore to install Project Vitruvius from Archives.") "Should write correct log")))
+  (testing "Show removed count in log when installed"
+    (do-game
+      (new-game {:corp {:discard [(qty "Marilyn Campaign" 3)]
+                        :hand ["Restore"]}})
+      (play-from-hand state :corp "Restore")
+      (click-card state :corp (find-card "Marilyn Campaign" (:discard (get-corp))))
+      (click-prompt state :corp "New remote")
+      (is (last-log-contains? state "Corp removes 2 copies of Marilyn Campaign from the game.") "Should write correct log")))
+  (testing "Card is installed and rezzed"
+    (do-game
+      (new-game {:corp {:discard ["Marilyn Campaign"]
+                        :hand ["Restore"]}})
+      (play-from-hand state :corp "Restore")
+      (click-card state :corp (find-card "Marilyn Campaign" (:discard (get-corp))))
+      (click-prompt state :corp "New remote")
+      (is (= "Marilyn Campaign" (:title (get-content state :remote1 0))) "Marilyn Campaign should be installed")
+      (is (rezzed? (get-content state :remote1 0)) "Marilyn Campaign was rezzed")
+      (is (= 2 (:credit (get-corp))) "Rezzed Marilyn Campaign 2 credit + 1 credit for Restore"))))
+
 (deftest reuse
   ;; Reuse - Gain 2 credits for each card trashed from HQ
   (do-game


### PR DESCRIPTION
Restore should show which card is installed. Asset/Upgrade/etc will be rezzed, so there is no problem. Agenda cannot be rezzed, so we should print card title in chat log.

Added tests for Restore.