### PR TITLE
fixed issue with personal workshop not installing at zero counters

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1928,13 +1928,12 @@
   (let [remove-counter
         {:async true
          :req (req (not (empty? (:hosted card))))
-         :once :per-turn
          :msg (msg "remove 1 counter from " (:title target))
          :choices {:card #(:host %)}
-         :effect (req (if (not (pos? (get-counters (get-card state target) :power)))
-                        (runner-install state side eid (dissoc target :counter) {:ignore-all-cost true})
-                        (do (add-counter state side target :power -1)
-                            (effect-completed state side eid))))}]
+         :effect (req (do (add-counter state side target :power -1)
+                          (if (not (pos? (get-counters (get-card state target) :power)))
+                            (runner-install state side eid (dissoc target :counter) {:ignore-all-cost true}))
+                          (effect-completed state side eid)))}]
     {:flags {:drip-economy true}
      :abilities [{:async true
                   :label "Host a program or piece of hardware"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1950,7 +1950,7 @@
                                      (effect-completed state side eid))))
                   :msg (msg "host " (:title target) "")}
                  (assoc remove-counter
-                        :label "Remove 1 counter from a hosted card (start of turn)"
+                        :label "Remove 1 counter from a hosted card"
                         :cost [:credit 1])
                  {:async true
                   :label "X[Credit]: Remove counters from a hosted card"

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3367,6 +3367,65 @@
                            (click-card state :runner (refresh pt)))
         (is (not-empty (:discard (get-runner))) "Empty Ghost Runner trashed")))))
 
+(deftest personal-workshop
+  ;; Personal Workshop
+  ;; Issue #5167
+  (testing "Removes token on start of turn and installs"
+    (do-game
+     (new-game {:runner {:deck ["Personal Workshop" "Medium"]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Personal Workshop")
+     (let [pw (get-resource state 0)]
+       ;; host medium and remove 2 of 3 counters
+       (card-ability state :runner pw 0)
+       (click-card state :runner (find-card "Medium" (:hand (get-runner))))
+       (card-ability state :runner pw 2)
+       (click-card state :runner (first (:hosted (refresh pw))))
+       (click-prompt state :runner "2")
+       ;; come back around to runner start of turn, remove last token
+       (take-credits state :runner)
+       (take-credits state :corp)
+       (click-card state :runner (first (:hosted (refresh pw))))
+       (is (= 1 (count (get-program state))))
+       (is (= "Medium" (:title (get-program state 0)))))))
+  (testing "Manually spending credits removes tokens and installs"
+    (do-game
+     (new-game {:runner {:deck ["Personal Workshop" "Medium"]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Personal Workshop")
+     (let [pw (get-resource state 0)]
+       ;; host medium and remove all 3 counters
+       (card-ability state :runner pw 0)
+       (click-card state :runner (find-card "Medium" (:hand (get-runner))))
+       (card-ability state :runner pw 2)
+       (click-card state :runner (first (:hosted (refresh pw))))
+       (click-prompt state :runner "3")
+       (is (= 1 (count (get-program state))))
+       (is (= "Medium" (:title (get-program state 0)))))))
+  (testing "Can host and install more than once per turn"
+    (do-game
+     (new-game {:runner {:deck ["Personal Workshop" "Medium" "Corroder"]}})
+     (take-credits state :corp)
+     (core/gain state :runner :credit 5)
+     (play-from-hand state :runner "Personal Workshop")
+     (let [pw (get-resource state 0)]
+       ;; host medium and remove all 3 counters
+       (card-ability state :runner pw 0)
+       (click-card state :runner (find-card "Medium" (:hand (get-runner))))
+       (card-ability state :runner pw 2)
+       (click-card state :runner (first (:hosted (refresh pw))))
+       (click-prompt state :runner "3")
+       (is (= 1 (count (get-program state))))
+       (is (= "Medium" (:title (get-program state 0))))
+       ;; do the same with corroder
+       (card-ability state :runner pw 0)
+       (click-card state :runner (find-card "Corroder" (:hand (get-runner))))
+       (card-ability state :runner pw 2)
+       (click-card state :runner (first (:hosted (refresh pw))))
+       (click-prompt state :runner "2")
+       (is (= 2 (count (get-program state))))
+       (is (= "Corroder" (:title (get-program state 1))))))))
+
 (deftest power-tap
   ;; Power Tap
   (do-game


### PR DESCRIPTION
Resolves https://github.com/mtgred/netrunner/issues/5167 and also adds tests for personal workshop. 

I believe the issue was the code is first checking if counters == 0 to install, then afterwards removing the counter. I simply flipped this logic, since we always want to remove the counter (the abilities actual effect) then conditionally install the hosted card. 

Separately I think the `:once :per-turn` is also a bug, though one that probably doesn't come up much. It won't let you click the spend 1 credit prompt more than once, and also won't let you use personal workshop on two different cards (if you wanted to for some reason). I removed it, but if there's some reason I'm not thinking of to have once per turn on there let me know!
