### PR TITLE
Make q loop run ability async to fix masterwork interaction

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1405,10 +1405,12 @@
                         :prompt "Look at top 2 cards of the stack?"
                         :player :runner
                         :autoresolve (get-autoresolve :auto-fire)
-                        :yes-ability {:msg "look at the top 2 cards of the stack"
+                        :yes-ability {:async true
+                                      :msg "look at the top 2 cards of the stack"
                                       :effect (effect (prompt! card (str "The top two cards of your Stack are "
                                                                          (join ", " (map :title (take 2 (:deck runner))))
-                                                                         ".") ["OK"] {}))}}}]
+                                                                         ".") ["OK"] {}
+                                                                         (effect-completed state side eid)))}}}]
    :abilities [(set-autoresolve :auto-fire "Prognostic Q-Loop")
                {:label "Reveal and install top card of stack"
                 :once :per-turn

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1402,15 +1402,15 @@
              :silent (get-autoresolve :auto-fire never?)
              :optional {:req (req (and (first-event? state side :run)
                                        (pos? (count (:deck runner)))))
-                        :prompt "Look at top 2 cards of the stack?"
-                        :player :runner
                         :autoresolve (get-autoresolve :auto-fire)
-                        :yes-ability {:async true
-                                      :msg "look at the top 2 cards of the stack"
-                                      :effect (effect (prompt! card (str "The top two cards of your Stack are "
-                                                                         (join ", " (map :title (take 2 (:deck runner))))
-                                                                         ".") ["OK"] {}
-                                                                         (effect-completed state side eid)))}}}]
+                        :player :runner
+                        :prompt "Look at top 2 cards of the stack?"
+                        :yes-ability {
+                          :msg "look at the top 2 cards of the stack"
+                          :choices ["OK"]
+                          :prompt (msg "The top two cards of your Stack are "
+                                  (join ", " (map :title (take 2 (:deck runner))))
+                                  ".")}}}]
    :abilities [(set-autoresolve :auto-fire "Prognostic Q-Loop")
                {:label "Reveal and install top card of stack"
                 :once :per-turn

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2776,7 +2776,6 @@
       (take-credits state :runner)
       (take-credits state :corp)
       ; Reset runner first-hardware-install
-      (core/move state :runner (find-card "Clone Chip" (:hand (get-runner))) :deck)
       (run-on state :hq)
       (is (= "Choose a trigger to resolve" (:msg (prompt-map :runner))))
       (click-prompt state :runner "Masterwork (v37)")

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2786,8 +2786,7 @@
       (is (= "Look at top 2 cards of the stack?" (:msg (prompt-map :runner))))
       (click-prompt state :runner "Yes")
       ; Au Revoir drawn by Masterwork off it's own install, Q Loop prompt shows accurate info
-      (is (= "The top two cards of your Stack are Bankroll, Clone Chip." (:msg (prompt-map :runner))))
-    )))
+      (is (= "The top two cards of your Stack are Bankroll, Clone Chip." (:msg (prompt-map :runner)))))))
 
 (deftest public-terminal
   ;; Public Terminal


### PR DESCRIPTION
Fixes #4973 

When running with a Masterwork (v37) and a Prognostic Q-Loop the two triggers were previously not ordering properly, selecting Q-Loop to fire first would then offer the Masterwork install, then show you the top two cards of the deck (which were now incorrect if the hardware installed with Masterwork had triggered it's other ability and drawn a card). Now both abilities are async and can be resolved correctly in either order.

Demo: https://www.youtube.com/watch?v=X5YwxTmqMf4