### PR TITLE
Fairchild 3 etr async

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1183,9 +1183,11 @@
              :player :runner
              :prompt "Choose one"
              :choices ["Pay 1 [Credits]" "Trash an installed card"]
+             :async true
              :effect (req (if (= target "Pay 1 [Credits]")
                             (do (pay state side card :credit 1)
-                                (system-msg state side "pays 1 [Credits]"))
+                                (system-msg state side "pays 1 [Credits]")
+                                (effect-completed state side eid))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
     {:subroutines [sub
                    sub]
@@ -1197,9 +1199,11 @@
              :player :runner
              :prompt "Choose one"
              :choices ["Pay 2 [Credits]" "Trash an installed card"]
+             :async true
              :effect (req (if (= target "Pay 2 [Credits]")
                             (do (pay state side card :credit 2)
-                                (system-msg state side "pays 2 [Credits]"))
+                                (system-msg state side "pays 2 [Credits]")
+                                (effect-completed state side eid))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
     {:subroutines [sub
                    sub
@@ -1212,9 +1216,11 @@
              :player :runner
              :prompt "Choose one"
              :choices ["Pay 3 [Credits]" "Trash an installed card"]
+             :async true
              :effect (req (if (= target "Pay 3 [Credits]")
                             (do (pay state side card :credit 3)
-                                (system-msg state side "pays 3 [Credits]"))
+                                (system-msg state side "pays 3 [Credits]")
+                                (effect-completed state side eid))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
     {:subroutines [sub
                    sub

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1120,6 +1120,86 @@
         (card-subroutine state :corp (refresh f2p) 0)
         (is (empty? (:prompt (get-corp))) "F2P doesn't fire if no installed cards")))))
 
+(deftest fairchild-1-0
+  ;; Fairchild 1.0
+  (testing "Basic Test"
+    (do-game
+      (new-game {:corp {:deck ["Fairchild 1.0"]}
+                 :runner {:deck ["Sacrificial Construct", "Clone Chip"]}})
+      (play-from-hand state :corp "Fairchild 1.0" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Sacrificial Construct")
+      (play-from-hand state :runner "Clone Chip")
+      (let [fairchild (get-ice state :hq 0)]
+        (run-on state "HQ")
+        (core/rez state :corp fairchild)
+        (run-continue state)
+        (card-subroutine state :corp fairchild 0)
+        (click-prompt state :runner "Trash an installed card")
+        (is (= "Select an installed card to trash" (:msg (prompt-map :runner))))
+        (click-card state :runner "Sacrificial Construct")
+        (is (empty? (get-resource state)) "Sac Con trashed")
+        (card-subroutine state :corp fairchild 1)
+        (click-prompt state :runner "Trash an installed card")
+        (is (= "Select an installed card to trash" (:msg (prompt-map :runner))))
+        (click-card state :runner "Clone Chip")
+        (is (empty? (get-hardware state)) "Sac Con trashed")))))
+
+(deftest fairchild-2-0
+  ;; Fairchild 2.0
+  (testing "Basic Test"
+    (do-game
+      (new-game {:corp {:deck ["Fairchild 2.0"]}
+                 :runner {:deck ["Sacrificial Construct", "Clone Chip", "Sure Gamble"]}})
+      (play-from-hand state :corp "Fairchild 2.0" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Sacrificial Construct")
+      (play-from-hand state :runner "Clone Chip")
+      (let [fairchild (get-ice state :hq 0)]
+        (run-on state "HQ")
+        (core/rez state :corp fairchild)
+        (run-continue state)
+        (card-subroutine state :corp fairchild 0)
+        (click-prompt state :runner "Trash an installed card")
+        (is (= "Select an installed card to trash" (:msg (prompt-map :runner))))
+        (click-card state :runner "Sacrificial Construct")
+        (is (empty? (get-resource state)) "Sac Con trashed")
+        (card-subroutine state :corp fairchild 1)
+        (click-prompt state :runner "Trash an installed card")
+        (is (= "Select an installed card to trash" (:msg (prompt-map :runner))))
+        (click-card state :runner "Clone Chip")
+        (is (empty? (get-hardware state)) "Sac Con trashed")
+        (card-subroutine state :corp fairchild 2)
+        (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")))))
+
+(deftest fairchild-3-0
+  ;; Fairchild 3.0
+  (testing "Basic Test"
+    (do-game
+      (new-game {:corp {:deck ["Fairchild 3.0"]}
+                 :runner {:deck ["Sacrificial Construct", "Clone Chip", "Sure Gamble"]}})
+      (play-from-hand state :corp "Fairchild 3.0" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Sacrificial Construct")
+      (play-from-hand state :runner "Clone Chip")
+      (let [fairchild (get-ice state :hq 0)]
+        (run-on state "HQ")
+        (core/rez state :corp fairchild)
+        (run-continue state)
+        (card-subroutine state :corp fairchild 0)
+        (click-prompt state :runner "Trash an installed card")
+        (is (= "Select an installed card to trash" (:msg (prompt-map :runner))))
+        (click-card state :runner "Sacrificial Construct")
+        (is (empty? (get-resource state)) "Sac Con trashed")
+        (card-subroutine state :corp fairchild 1)
+        (click-prompt state :runner "Trash an installed card")
+        (is (= "Select an installed card to trash" (:msg (prompt-map :runner))))
+        (click-card state :runner "Clone Chip")
+        (is (empty? (get-hardware state)) "Sac Con trashed")
+        (card-subroutine state :corp fairchild 2)
+        (click-prompt state :corp "End the run")
+        (is (not (:run @state)) "Run is ended")))))
+
 (deftest fenris
   ;; Fenris - Illicit ICE give Corp 1 bad publicity when rezzed
   (do-game


### PR DESCRIPTION
Fixes #5184 

I've set the trash-or-pay subs on Fairchild 1.0, 2.0 and 3.0 to be async so the runner can fully resolve their trash effects before the corp gets prompted to either attempt to end the run or brain damage them if resolving all, and the runner can resolve the first trash before deciding what to do with the second sub.

I've also set up basic tests for each of the 3 pieces of ice which ensure that their main behaviour is working properly but I can't think of / see on another test for a piece of ice a simple way to replicate the exact "Resolve all unbroken subroutines" behaviour as it works in game which would be necessary here (to check, for example, that if you hit the button on F3 then selected brain damage that the brain damage itself doesn't land until the runner has chosen their second card to trash.