### PR TITLE
Decklist checksums

### DIFF
--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -649,7 +649,8 @@
             [:span.invalid " (minimum " min-point ")"])
           (when (> points (inc min-point))
             [:span.invalid " (maximum " (inc min-point) ")"])]))
-     [:div [deck-status-span deck true true false]]]))
+     [:div [deck-status-span deck true true false]]
+     (when (:hash deck) [:div "Tournament hash: " (:hash deck)])]))
 
 (defn decklist-contents
   [s deck cards]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1409906/86837650-798f7800-c09f-11ea-861d-b96445f67aa7.png)
This is part of the #5188 PR and adds checksums to decklists.
The checksum is generated by concatenating the title of the identity and the quantities + codes of the cards in the deck to a long string and applying a SHA1 hash with the decklist name as salt.

This checksum can then be used by players (and TOs) to check whether the used decklist matches the one send in during registration.