### PR TITLE
Prevent successful run fix

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1602,25 +1602,16 @@
                             card nil))}]})
 
 (define-card "Transport Monopoly"
-  (let [suppress-event {:req (req (and (get-in (get-card state card) [:special :transport-monopoly])
-                                       (not (same-card? target card))))}]
     {:silent (req true)
      :effect (effect (add-counter card :agenda 2))
      :abilities [{:cost [:agenda 1]
                   :req (req run)
                   :msg "prevent this run from becoming successful"
-                  :effect (effect (update! (assoc-in (get-card state card) [:special :transport-monopoly] true)))}]
-     :suppress [(assoc suppress-event :event :pre-successful-run)
-                (assoc suppress-event :event :successful-run)]
-     :events [{:event :pre-successful-run
-               :silent (req true)
-               :req (req (get-in (get-card state card) [:special :transport-monopoly]))
-               :effect (req (swap! state update-in [:run :run-effects] #(mapv (fn [x] (dissoc x :replace-access)) %))
-                            (swap! state update-in [:run] dissoc :successful)
-                            (swap! state update-in [:runner :register :successful-run] #(seq (rest %))))}
-              {:event :run-ends
-               :silent (req true)
-               :effect (req (update! state side (dissoc-in (get-card state card) [:special :transport-monopoly])))}]}))
+                  :effect (effect (register-floating-effect
+                                      card
+                                      {:type :block-successful-run
+                                       :duration :end-of-run
+                                       :value true}))}]})
 
 (define-card "Underway Renovation"
   (letfn [(adv4? [s c] (if (>= (get-counters (get-card s c) :advancement) 4) 2 1))]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -335,15 +335,10 @@
                             card nil))}]})
 
 (define-card "Crisium Grid"
-  (let [suppress-event {:req (req (and this-server (not (same-card? target card))))}]
-    {:suppress [(assoc suppress-event :event :pre-successful-run)
-                (assoc suppress-event :event :successful-run)]
-     :events [{:event :pre-successful-run
-               :silent (req true)
-               :req (req this-server)
-               :effect (req (swap! state update-in [:run :run-effects] #(mapv (fn [x] (dissoc x :replace-access)) %))
-                            (swap! state update-in [:run] dissoc :successful)
-                            (swap! state update-in [:runner :register :successful-run] #(seq (rest %))))}]}))
+  {:constant-effects [{
+    :type :block-successful-run
+    :req (req this-server)
+    :value true}]})
 
 (define-card "Cyberdex Virus Suite"
   {:flags {:rd-reveal (req true)}

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -884,7 +884,22 @@
       (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (get-program state 0)})
       (core/continue state :corp nil)
       (run-continue state)
-      (is (seq (:prompt (get-runner))) "The Gauntlet has a prompt"))))
+      (is (seq (:prompt (get-runner))) "The Gauntlet has a prompt")))
+  (testing "Crisium Grid prevents first successful run abilities. Issue #5092"
+    (do-game
+     (new-game {:corp {:hand ["Crisium Grid"]
+                       :deck [(qty "Hedge Fund" 3)]}
+                :runner {:hand ["Bhagat"]
+                         :credits 20}})
+     (play-from-hand state :corp "Crisium Grid" "HQ")
+     (core/rez state :corp (get-content state :hq 0))
+     (take-credits state :corp)
+     (play-from-hand state :runner "Bhagat")
+     (run-empty-server state "HQ")
+     (click-prompt state :runner "Pay 5 [Credits] to trash")
+     (is (= 1 (count (:discard (get-corp)))) "Archive has 1 card (Crisium)")
+     (run-empty-server state "HQ")
+     (is (= 2 (count (:discard (get-corp)))) "Archive has 2 cards (Crisium and Hedge Fund)"))))
 
 (deftest cyberdex-virus-suite
   ;; Cyberdex Virus Suite


### PR DESCRIPTION
Closes #5092 

Fixed both cards that prevent successful run (Crisium Grid, Transport Monopoly). 
`The first time you make a successful run` type abilities now works correctly.

Added new effect type `:block-successful-run`

New test for Crisium Grid.