### PR TITLE
Ugly fix for Dr. Lovegood and Lewi Guilherme interaction

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1432,9 +1432,7 @@
     {:flags {:drip-economy true ;; for Drug Dealer
              :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :drip-economy true)
                                                        (all-active-installed state :runner)))))}
-     ;; KNOWN ISSUE: :effect is not fired when Assimilator turns cards over or Dr. Lovegood re-enables it.
-     :effect (effect (lose :corp :hand-size 1))
-     :leave-play (effect (gain :corp :hand-size 1))
+     :in-play [:corp :hand-size -1]
      :abilities [(assoc ability :req (req (:runner-phase-12 @state)))]
      :events [(assoc ability :event :runner-turn-begins)]}))
 

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -42,7 +42,11 @@
               (or rezzed
                   installed))
      (when-let [in-play (:in-play (card-def card))]
-       (apply lose state side in-play)))
+        (if (some #(= :corp %) in-play)
+                (apply lose state :corp (remove #(= :corp %) in-play))
+        (if (some #(= :runner %) in-play)
+                (apply lose state :runner (remove #(= :runner %) in-play))
+        (apply lose state side in-play)))))
    (dissoc-card card keep-counter)))
 
 
@@ -101,5 +105,9 @@
        (resolve-ability state side eid (dissoc cdef :cost :additional-cost) c nil)
        (effect-completed state side eid))
      (when-let [in-play (:in-play cdef)]
-       (apply gain state side in-play))
+       (if (some #(= :corp %) in-play)
+            (apply gain state :corp (remove #(= :corp %) in-play))
+        (if (some #(= :runner %) in-play)
+            (apply gain state :runner (remove #(= :runner %) in-play))
+       (apply gain state side in-play))))
      (get-card state c))))


### PR DESCRIPTION
Closes #5229
Closes #5208 
Closes #3345

I don't think that this is optimal way to fix this interaction, but I couldn't think of more clean solution. Is there better way to specify which side is targeted by `:in-play` effect? 