### PR TITLE
Remove pay in favor of async pay

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -321,18 +321,19 @@
                                                                  (count (:hand runner))))}
                                      :async true
                                      :effect (req (when (pos? target)
-                                                    (pay state :corp card :credit target)
-                                                    (let [from (take target (shuffle (:hand runner)))]
-                                                      (doseq [c from]
-                                                        (move state :runner c :deck))
-                                                      (system-msg state side (str "uses Brain Rewiring to pay " target
-                                                                                  " [Credits] and add " target
-                                                                                  " cards from the Runner's Grip"
-                                                                                  " to the bottom of their Stack."
-                                                                                  " The Runner draws 1 card"))
-                                                      (wait-for (draw state :runner 1 nil)
-                                                                (clear-wait-prompt state :runner)
-                                                                (effect-completed state side eid)))))}
+                                                    (wait-for
+                                                      (pay-sync state :corp card :credit target)
+                                                      (let [from (take target (shuffle (:hand runner)))]
+                                                        (doseq [c from]
+                                                          (move state :runner c :deck))
+                                                        (system-msg state side (str "uses Brain Rewiring to pay " target
+                                                                                    " [Credits] and add " target
+                                                                                    " cards from the Runner's Grip"
+                                                                                    " to the bottom of their Stack."
+                                                                                    " The Runner draws 1 card"))
+                                                        (wait-for (draw state :runner 1 nil)
+                                                                  (clear-wait-prompt state :runner)
+                                                                  (effect-completed state side eid))))))}
                        :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
                      card nil))})
 

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -320,7 +320,7 @@
                                      :choices {:number (req (min (:credit corp)
                                                                  (count (:hand runner))))}
                                      :async true
-                                     :effect (req (when (pos? target)
+                                     :effect (req (if (pos? target)
                                                     (wait-for
                                                       (pay state :corp card :credit target)
                                                       (let [from (take target (shuffle (:hand runner)))]
@@ -333,7 +333,9 @@
                                                                                     " The Runner draws 1 card"))
                                                         (wait-for (draw state :runner 1 nil)
                                                                   (clear-wait-prompt state :runner)
-                                                                  (effect-completed state side eid))))))}
+                                                                  (effect-completed state side eid))))
+                                                    (do (clear-wait-prompt state :runner)
+                                                        (effect-completed state side eid))))}
                        :no-ability {:effect (effect (clear-wait-prompt :runner))}}}
                      card nil))})
 

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -322,7 +322,7 @@
                                      :async true
                                      :effect (req (when (pos? target)
                                                     (wait-for
-                                                      (pay-sync state :corp card :credit target)
+                                                      (pay state :corp card :credit target)
                                                       (let [from (take target (shuffle (:hand runner)))]
                                                         (doseq [c from]
                                                           (move state :runner c :deck))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -345,8 +345,7 @@
              :effect (req (case target
                             "Pay 1 [Credits]"
                             (do (system-msg state :runner "pays 1 [Credits]")
-                                (pay state :runner card :credit 1)
-                                (effect-completed state side eid))
+                                (pay-sync state :runner eid card :credit 1))
                             (do (system-msg state :runner "takes 1 tag")
                                 (gain-tags state :corp eid 1))))}]})
 

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -345,7 +345,7 @@
              :effect (req (case target
                             "Pay 1 [Credits]"
                             (do (system-msg state :runner "pays 1 [Credits]")
-                                (pay-sync state :runner eid card :credit 1))
+                                (pay state :runner eid card :credit 1))
                             (do (system-msg state :runner "takes 1 tag")
                                 (gain-tags state :corp eid 1))))}]})
 
@@ -385,7 +385,7 @@
                  :effect (req (case target
                                 "Pay 1 [Credits]"
                                 (do (system-msg state side "pays 1 [Credits]")
-                                    (pay-sync state side eid card :credit 1))
+                                    (pay state side eid card :credit 1))
                                 "Trash top card"
                                 (do (system-msg state side "trashes the top card of the Stack")
                                     (mill state :runner eid :runner 1))))}]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2862,7 +2862,7 @@
                        :choices (req (map str (range 0 (inc (:click runner)))))
                        :async true
                        :effect (req (let [n (str->int target)]
-                                      (wait-for (pay-sync state :runner card :click n)
+                                      (wait-for (pay state :runner card :click n)
                                                 (trash-cards state :corp eid (take n (shuffle (:hand corp)))))))}}
                      card))})
 

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -104,7 +104,7 @@
                   (do (system-msg state :corp
                                   (str "uses " (:title card) " to end the run"))
                       (end-run state :corp eid card))
-                  (wait-for (pay-sync state :runner card [:credit amount])
+                  (wait-for (pay state :runner card [:credit amount])
                             (when async-result
                               (let [cost-str (str async-result
                                                   " due to " (:title card)
@@ -121,7 +121,7 @@
              (str "Pay " amount " [Credits]")]
    :effect (req (if (= "End the run" target)
                   (end-run state :corp eid card)
-                  (pay-sync state :corp eid card [:credit amount])))})
+                  (pay state :corp eid card [:credit amount])))})
 
 (defn end-the-run-unless-runner
   [label prompt ability]
@@ -972,7 +972,7 @@
                   :async true
                   :effect (req (if (= target "Pay 3 [Credits]")
                                  (do (system-msg state :runner "pays 3 [Credits]")
-                                     (pay-sync state :runner eid card :credit 3))
+                                     (pay state :runner eid card :credit 3))
                                  (do (system-msg state :runner "takes 1 tag on encountering Data Ward")
                                      (gain-tags state :runner eid 1))))}
    :subroutines [end-the-run-if-tagged
@@ -983,7 +983,7 @@
 (define-card "Datapike"
   {:subroutines [{:msg "force the Runner to pay 2 [Credits] if able"
                   :async true
-                  :effect (effect (pay-sync :runner eid card :credit 2))}
+                  :effect (effect (pay :runner eid card :credit 2))}
                  end-the-run]})
 
 (define-card "DNA Tracker"
@@ -1047,7 +1047,7 @@
               {:asycn true
                :effect
                (req (if (seq unbroken-subs)
-                      (wait-for (pay-sync state :runner (make-eid state {:source-type :subroutine}) card [:credit 1])
+                      (wait-for (pay state :runner (make-eid state {:source-type :subroutine}) card [:credit 1])
                                 (system-msg state :runner async-result)
                                 (continue-ability
                                   state side
@@ -1187,7 +1187,7 @@
              :async true
              :effect (req (if (= target "Pay 1 [Credits]")
                             (do (system-msg state side "pays 1 [Credits]")
-                                (pay-sync state side eid card :credit 1))
+                                (pay state side eid card :credit 1))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
     {:subroutines [sub
                    sub]
@@ -1202,7 +1202,7 @@
              :async true
              :effect (req (if (= target "Pay 2 [Credits]")
                             (do (system-msg state side "pays 2 [Credits]")
-                                (pay-sync state side eid card :credit 2))
+                                (pay state side eid card :credit 2))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
     {:subroutines [sub
                    sub
@@ -1218,7 +1218,7 @@
              :async true
              :effect (req (if (= target "Pay 3 [Credits]")
                             (do (system-msg state side "pays 3 [Credits]")
-                                (pay-sync state side eid card :credit 3))
+                                (pay state side eid card :credit 3))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
     {:subroutines [sub
                    sub
@@ -1467,7 +1467,7 @@
                   :effect (req (let [c (str->int target)]
                                  (if (can-pay? state side (assoc eid :source card :source-type :subroutine) card (:title card) :credit c)
                                    (let [new-eid (make-eid state {:source card :source-type :subroutine})]
-                                     (wait-for (pay-sync state :corp new-eid card :credit c)
+                                     (wait-for (pay state :corp new-eid card :credit c)
                                                (continue-ability
                                                  state side
                                                  {:msg (msg "pay " c "[Credits] and place " (quantify c " advancement token")
@@ -2422,7 +2422,7 @@
                                     :effect (req (clear-wait-prompt state :corp)
                                                  (if (= target "Access card")
                                                    (access-card state :runner eid c)
-                                                   (pay-sync state :runner eid card :credit 3)))}
+                                                   (pay state :runner eid card :credit 3)))}
                                    card nil)))}]})
 
 (define-card "Owl"
@@ -2475,7 +2475,7 @@
                        "Pay 1 [Credits]"]
              :effect (req (if (= "Suffer 1 net damage" target)
                             (continue-ability state :corp (do-net-damage 1) card nil)
-                            (pay-sync state :runner eid card [:credit 1])))}]
+                            (pay state :runner eid card [:credit 1])))}]
     {:subroutines [sub
                    sub]}))
 
@@ -2897,7 +2897,7 @@
                        "Pay 3 [Credits]"]
              :effect (req (if (= "Corp trash" target)
                             (continue-ability state :corp trash-program card nil)
-                            (pay-sync state :runner eid card [:credit 3])))}
+                            (pay state :runner eid card [:credit 3])))}
         ability {:req (req (same-card? card target))
                  :effect (effect (reset-variable-subs card (get-counters card :advancement) sub))}]
     {:advanceable :always
@@ -3031,7 +3031,7 @@
 
 (define-card "Tollbooth"
   {:on-encounter {:async true
-                  :effect (req (wait-for (pay-sync state :runner card [:credit 3])
+                  :effect (req (wait-for (pay state :runner card [:credit 3])
                                          (if-let [cost-str async-result]
                                            (do (system-msg state :corp "uses Tollbooth to force the Runner to pay 3 [Credits]")
                                                (effect-completed state side eid))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -77,7 +77,7 @@
                                                             (expose state :runner eid itarget))}
                                               :yes-ability
                                               {:async true
-                                               :effect (req (wait-for (pay-sync state :corp card [:credit 1])
+                                               :effect (req (wait-for (pay state :corp card [:credit 1])
                                                                       (system-msg state :corp (str "spends 1 [Credits] to prevent "
                                                                                                    " card from being exposed"))
                                                                       (clear-wait-prompt state :runner)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -73,13 +73,15 @@
                                               :player :corp
                                               :no-ability
                                               {:async true
-                                               :effect (req (expose state :runner eid itarget)
-                                                            (clear-wait-prompt state :runner))}
+                                               :effect (req (clear-wait-prompt state :runner)
+                                                            (expose state :runner eid itarget))}
                                               :yes-ability
-                                              {:effect (req (pay state :corp card [:credit 1])
-                                                            (system-msg state :corp (str "spends 1 [Credits] to prevent "
-                                                                                         " card from being exposed"))
-                                                            (clear-wait-prompt state :runner))}}}
+                                              {:async true
+                                               :effect (req (wait-for (pay-sync state :corp card [:credit 1])
+                                                                      (system-msg state :corp (str "spends 1 [Credits] to prevent "
+                                                                                                   " card from being exposed"))
+                                                                      (clear-wait-prompt state :runner)
+                                                                      (effect-completed state side eid)))}}}
                                             card nil))))}}}
                       card nil)))}]
    :abilities [(set-autoresolve :auto-419 "419")]})

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -732,14 +732,15 @@
                        :choices {:number (req numtargets)}
                        :effect (req (let [c target]
                                       (if (can-pay? state side (assoc eid :source card :source-type :ability) card (:title card) :credit c)
-                                        (do (pay state :corp card :credit c)
-                                            (continue-ability
-                                              state :corp
-                                              {:msg (msg "place " (quantify c " advancement token") " on "
-                                                         (card-str state target))
-                                               :choices {:card installed?}
-                                               :effect (effect (add-prop target :advance-counter c {:placed true}))}
-                                              card nil))
+                                        (let [new-eid (make-eid state {:source card :source-type :ability})]
+                                          (wait-for (pay-sync state :corp new-eid card :credit c)
+                                                    (continue-ability
+                                                      state :corp
+                                                      {:msg (msg "place " (quantify c " advancement token") " on "
+                                                                 (card-str state target))
+                                                       :choices {:card installed?}
+                                                       :effect (effect (add-prop target :advance-counter c {:placed true}))}
+                                                      card nil)))
                                         (effect-completed state side eid))))}
                       card nil)
                     (effect-completed state side eid))))})
@@ -1506,13 +1507,14 @@
    :choices {:number (req (count-tags state))}
    :effect (req (let [c target]
                   (if (can-pay? state side (assoc eid :source card :source-type :ability) card (:title card) :credit c)
-                    (do (pay state :corp card :credit c)
-                        (continue-ability
-                          state side
-                          {:msg (msg "place " (quantify c " advancement token") " on " (card-str state target))
-                           :choices {:card can-be-advanced?}
-                           :effect (effect (add-prop target :advance-counter c {:placed true}))}
-                          card nil))
+                    (let [new-eid (make-eid state {:source card :source-type :ability})]
+                      (wait-for (pay-sync state :corp new-eid card :credit c)
+                                (continue-ability
+                                  state side
+                                  {:msg (msg "place " (quantify c " advancement token") " on " (card-str state target))
+                                   :choices {:card can-be-advanced?}
+                                   :effect (effect (add-prop target :advance-counter c {:placed true}))}
+                                  card nil)))
                     (effect-completed state side eid))))})
 
 (define-card "Psychokinesis"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -733,7 +733,7 @@
                        :effect (req (let [c target]
                                       (if (can-pay? state side (assoc eid :source card :source-type :ability) card (:title card) :credit c)
                                         (let [new-eid (make-eid state {:source card :source-type :ability})]
-                                          (wait-for (pay-sync state :corp new-eid card :credit c)
+                                          (wait-for (pay state :corp new-eid card :credit c)
                                                     (continue-ability
                                                       state :corp
                                                       {:msg (msg "place " (quantify c " advancement token") " on "
@@ -833,7 +833,7 @@
                                          :card #(and (installed? %)
                                                      (is-type? % card-type)
                                                      (not (has-subtype? % "Icebreaker")))}
-                               :effect (req (wait-for (pay-sync state :runner card :credit (* 3 (count targets)))
+                               :effect (req (wait-for (pay state :runner card :credit (* 3 (count targets)))
                                                       (system-msg
                                                         state :runner
                                                         (str async-result " to prevent the trashing of "
@@ -1508,7 +1508,7 @@
    :effect (req (let [c target]
                   (if (can-pay? state side (assoc eid :source card :source-type :ability) card (:title card) :credit c)
                     (let [new-eid (make-eid state {:source card :source-type :ability})]
-                      (wait-for (pay-sync state :corp new-eid card :credit c)
+                      (wait-for (pay state :corp new-eid card :credit c)
                                 (continue-ability
                                   state side
                                   {:msg (msg "place " (quantify c " advancement token") " on " (card-str state target))
@@ -2111,7 +2111,7 @@
              :prompt "Pay 4 [Credits] or take 1 tag?"
              :choices ["Pay 4 [Credits]" "Take 1 tag"]
              :effect (req (if (= target "Pay 4 [Credits]")
-                            (pay-sync state :runner eid card :credit 4)
+                            (pay state :runner eid card :credit 4)
                             (gain-tags state :corp eid 1 nil)))}
             {:event :corp-turn-begins
              :async true

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -852,7 +852,7 @@
                                           "remove a virus token from Crypsis"
                                           "trash Crypsis"))
                               :async true
-                              :effect (req (wait-for (pay-sync state :runner card [:virus 1])
+                              :effect (req (wait-for (pay state :runner card [:virus 1])
                                                      (if async-result
                                                        (effect-completed state side eid)
                                                        (trash state side eid card nil))))}]}))
@@ -1739,7 +1739,7 @@
                 :async true
                 ;; TODO use :x-credits when it's built
                 :effect (req (let [new-eid (make-eid state (assoc eid :source card :source-type :ability))]
-                               (wait-for (pay-sync state :runner new-eid card [:credit target])
+                               (wait-for (pay state :runner new-eid card [:credit target])
                                          (if-let [cost-str async-result]
                                            (do (system-msg state :runner
                                                            (str (build-spend-msg cost-str "use")

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -438,7 +438,7 @@
                                                               [:credit (get-strength target)])))
                                      :yes-ability
                                      {:async true
-                                      :effect (req (wait-for (pay-sync :runner card [:credit (get-strength target)])
+                                      :effect (req (wait-for (pay :runner card [:credit (get-strength target)])
                                                              (if-let [cost-str async-result]
                                                                (do (system-msg state :runner
                                                                                (str (build-spend-msg cost-str "use")
@@ -1029,7 +1029,7 @@
                               (do (system-msg state :runner "trashes Fencer Fueno")
                                   (trash state :runner eid card nil))
                               (do (system-msg state :runner "pays 1 [Credits] to avoid trashing Fencer Fueno")
-                                  (pay-sync state :runner eid card :credit 1))))}
+                                  (pay state :runner eid card :credit 1))))}
               card nil))
     ;; companion-builder: ability
     {:req (req (and (pos? (get-counters (get-card state card) :credit))
@@ -1602,7 +1602,7 @@
                             (if (= target "Trash")
                               (do (system-msg state :runner "trashes Mystic Maemi")
                                   (trash state :runner eid card nil))
-                              (wait-for (pay-sync state :runner
+                              (wait-for (pay state :runner
                                                   (make-eid state {:source card :source-type :ability})
                                                   card [:randomly-trash-from-hand 1])
                                         (system-msg state :runner (build-spend-msg async-result "avoid" "trashing Mystic Maemi"))
@@ -1982,7 +1982,7 @@
                                  :choices {:number (req (min num-counters
                                                              (total-available-credits state :runner eid card)))}
                                  :effect (req (wait-for
-                                                (pay-sync state :runner card [:credit target])
+                                                (pay state :runner card [:credit target])
                                                 (if-let [cost-str async-result]
                                                   (do (system-msg state side
                                                                   (str (build-spend-msg cost-str "use") (:title card)
@@ -2208,7 +2208,7 @@
      :async true
      :trash? false
      :effect (req (let [trash-cost (trash-cost state side target)]
-                    (wait-for (pay-sync state side (make-eid state eid) card [:credit trash-cost])
+                    (wait-for (pay state side (make-eid state eid) card [:credit trash-cost])
                               (let [card (move state :corp target :rfg)]
                                 (system-msg state side
                                             (str "pay " trash-cost

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -562,11 +562,10 @@
                                                 ["End the run"])
                                :effect (req (clear-wait-prompt state :corp)
                                             (if (= c-pay-str target)
-                                              (do (pay state :runner card :credit cost)
-                                                  (system-msg state :runner (str "pays " cost " [Credits]")))
-                                              (do (end-run state side eid card)
-                                                  (system-msg state :corp "ends the run")))
-                                            (effect-completed state side eid))}
+                                              (do (system-msg state :runner (str "pays " cost " [Credits]"))
+                                                  (pay-sync state :runner eid card :credit cost))
+                                              (do (system-msg state :corp "ends the run")
+                                                  (end-run state :corp eid card))))}
                               card nil)))}]})
 
 (define-card "Heinlein Grid"
@@ -1387,15 +1386,13 @@
                                :msg "do 1 brain damage instead of net damage"
                                :effect (req (swap! state update-in [:damage] dissoc :damage-replace :defer-damage)
                                             (clear-wait-prompt state :runner)
-                                            (pay state :corp card :credit 2)
-                                            (wait-for (damage state side :brain 1 {:card card})
-                                                      (do (swap! state assoc-in [:damage :damage-replace] true)
-                                                          (effect-completed state side eid))))}
+                                            (wait-for (pay-sync state :corp card :credit 2)
+                                                      (wait-for (damage state side :brain 1 {:card card})
+                                                                (swap! state assoc-in [:damage :damage-replace] true)
+                                                                (effect-completed state side eid))))}
                               :no-ability
-                              {:async true
-                               :effect (req (swap! state update-in [:damage] dissoc :damage-replace)
-                                            (clear-wait-prompt state :runner)
-                                            (effect-completed state side eid))}}}
+                              {:effect (req (swap! state update-in [:damage] dissoc :damage-replace)
+                                            (clear-wait-prompt state :runner))}}}
                             card nil))}
             {:event :prevented-damage
              :req (req (and this-server

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -275,7 +275,7 @@
                       :effect (req (clear-wait-prompt state :corp)
                                    (if (= target "End the run")
                                      (end-run state side eid card)
-                                     (pay-sync state :runner eid card :credit cost)))})
+                                     (pay state :runner eid card :credit cost)))})
                    card nil))}]
      :abilities [ability]}))
 
@@ -563,7 +563,7 @@
                                :effect (req (clear-wait-prompt state :corp)
                                             (if (= c-pay-str target)
                                               (do (system-msg state :runner (str "pays " cost " [Credits]"))
-                                                  (pay-sync state :runner eid card :credit cost))
+                                                  (pay state :runner eid card :credit cost))
                                               (do (system-msg state :corp "ends the run")
                                                   (end-run state :corp eid card))))}
                               card nil)))}]})
@@ -1386,7 +1386,7 @@
                                :msg "do 1 brain damage instead of net damage"
                                :effect (req (swap! state update-in [:damage] dissoc :damage-replace :defer-damage)
                                             (clear-wait-prompt state :runner)
-                                            (wait-for (pay-sync state :corp card :credit 2)
+                                            (wait-for (pay state :corp card :credit 2)
                                                       (wait-for (damage state side :brain 1 {:card card})
                                                                 (swap! state assoc-in [:damage :damage-replace] true)
                                                                 (effect-completed state side eid))))}

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -278,7 +278,7 @@
   "Perform the ability, checking all costs can be paid etc."
   [state side {:keys [eid cost] :as ability} card targets]
   ;; Ensure that any costs can be paid
-  (wait-for (pay-sync state side (make-eid state eid) card cost {:action (:cid card)})
+  (wait-for (pay state side (make-eid state eid) card cost {:action (:cid card)})
             (when-let [cost-str async-result]
               ;; Print the message
               (print-msg state side ability card targets cost-str)
@@ -372,10 +372,10 @@
   (let [opponent (if (= side :corp) :runner :corp)]
     (if-let [opponent-bet (get-in @state [:psi opponent])]
       (wait-for
-        (pay-sync state opponent (make-eid state eid) card [:credit opponent-bet])
+        (pay state opponent (make-eid state eid) card [:credit opponent-bet])
         (system-msg state opponent async-result)
         (wait-for
-          (pay-sync state side (make-eid state eid) card [:credit bet])
+          (pay state side (make-eid state eid) card [:credit bet])
           (system-msg state side async-result)
           (clear-wait-prompt state opponent)
           (wait-for (trigger-event-simult state side (make-eid state eid) :reveal-spent-credits nil (get-in @state [:psi :corp]) (get-in @state [:psi :runner]))
@@ -415,7 +415,7 @@
                           ((fnil + 0 0) link boost)
                           strength)
         trigger-trace (select-keys trace [:player :other :base :bonus :link :priority :ability :strength])]
-    (wait-for (pay-sync state other (make-eid state eid) card [:credit boost])
+    (wait-for (pay state other (make-eid state eid) card [:credit boost])
               (system-msg state other (str async-result
                                            " to increase " (if (corp-start? trace) "link" "trace")
                                            " strength to " (if (corp-start? trace)
@@ -456,7 +456,7 @@
                    ((fnil + 0 0 0) base bonus boost)
                    ((fnil + 0 0) link boost))
         trace (assoc trace :strength strength)]
-    (wait-for (pay-sync state player (make-eid state eid) card [:credit boost])
+    (wait-for (pay state player (make-eid state eid) card [:credit boost])
               (system-msg state player (str async-result
                                             " to increase " (if (corp-start? trace) "trace" "link")
                                             " strength to " strength))

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -94,7 +94,7 @@
 
                         ; Pay credits (from pool or cards) to trash
                         (= target (first trash-cost-str))
-                        (wait-for (pay-sync state side (make-eid state trash-eid) card [:credit trash-cost])
+                        (wait-for (pay state side (make-eid state trash-eid) card [:credit trash-cost])
                                   (when (:run @state)
                                     (swap! state assoc-in [:run :did-trash] true)
                                     (when must-trash?
@@ -218,7 +218,7 @@
 
                       ;; Pay additiional costs to steal
                       (= target "Pay to steal")
-                      (wait-for (pay-sync state side nil cost {:action :steal-cost})
+                      (wait-for (pay state side nil cost {:action :steal-cost})
                                 (system-msg state side (str async-result " to steal "
                                                             (:title card) " from "
                                                             (name-zone :corp (get-zone card))))
@@ -346,7 +346,7 @@
            :effect (req (if (or (= "OK" target)
                                 (= "No action" target))
                           (access-end state side eid accessed-card)
-                          (wait-for (pay-sync state side accessed-card cost)
+                          (wait-for (pay state side accessed-card cost)
                                     (if async-result
                                       (access-trigger-events state side eid accessed-card title (assoc args :cost-msg async-result))
                                       (access-end state side eid accessed-card)))))})

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -205,7 +205,7 @@
 (defn maybe-pay
   [state side eid card choices choice]
   (if (= choices :credit)
-    (pay-sync state side eid card :credit (min choice (get-in @state [side :credit])))
+    (pay state side eid card :credit (min choice (get-in @state [side :credit])))
     (effect-completed state side eid)))
 
 (defn resolve-prompt
@@ -352,7 +352,7 @@
                                    times-pump)
                           (repeat times-pump (:cost pump-ability)))]
     (when (can-pay? state side eid card total-pump-cost)
-      (wait-for (pay-sync state side (make-eid state eid) card total-pump-cost)
+      (wait-for (pay state side (make-eid state eid) card total-pump-cost)
                 (dotimes [n times-pump]
                   (resolve-ability state side (dissoc pump-ability :cost :msg) (get-card state card) nil))
                 (system-msg state side (str (build-spend-msg async-result "increase")
@@ -428,7 +428,7 @@
                              (repeat times-break (:break-cost break-ability)))
           total-cost (merge-costs (conj total-pump-cost total-break-cost))]
       (when (can-pay? state side eid card (:title card) total-cost)
-        (wait-for (pay-sync state side (make-eid state eid) card total-cost)
+        (wait-for (pay state side (make-eid state eid) card total-cost)
                   (dotimes [n times-pump]
                     (resolve-ability state side (dissoc pump-ability :cost :msg) (get-card state card) nil))
                   (let [cost-str async-result
@@ -527,7 +527,7 @@
                        [:credit x-number]
                        (repeat ability-uses-needed (:cost breaker-ability))))]
     (when (can-pay? state side eid card (:title card) total-cost)
-      (wait-for (pay-sync state side (make-eid state eid) card total-cost)
+      (wait-for (pay state side (make-eid state eid) card total-cost)
                 (if x-breaker
                   (pump state side (get-card state card) x-number)
                   (pump state side (get-card state card) (* pump-strength-at-once ability-uses-needed)))
@@ -664,7 +664,7 @@
            card nil)
          (let [cdef (card-def card)
                costs (get-rez-cost state side card args)]
-           (wait-for (pay-sync state side (make-eid state eid) card costs)
+           (wait-for (pay state side (make-eid state eid) card costs)
                      (if-let [cost-str (and (string? async-result) async-result)]
                        (do (when (:derezzed-events cdef)
                              (unregister-events state side card))
@@ -727,7 +727,7 @@
    (let [card (get-card state card)
          eid (eid-set-defaults eid :source nil :source-type :advance)]
      (when (can-advance? state side card)
-       (wait-for (pay-sync state side (make-eid state eid) card :click (if-not no-cost 1 0) :credit (if-not no-cost 1 0) {:action :corp-advance})
+       (wait-for (pay state side (make-eid state eid) card :click (if-not no-cost 1 0) :credit (if-not no-cost 1 0) {:action :corp-advance})
                  (when-let [cost-str async-result]
                    (let [spent   (build-spend-msg cost-str "advance")
                          card    (card-str state card)

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -691,22 +691,6 @@
        (swap! state update-in [:stats side :spent cost-type] (fnil + 0) amount)
        (complete-with-result state side eid (deduct state side [cost-type amount]))))))
 
-(defn pay
-  "Deducts each cost from the player.
-  args format as follows with each being optional ([:click 1 :credit 0] [:forfeit] {:action :corp-click-credit})
-  The map with :action was added for Jeeves so we can log what each click was used on"
-  [state side card & args]
-  (let [args (flatten args)
-        raw-costs (remove map? args)
-        actions (filter map? args)
-        eid (make-eid state)]
-    (when-let [costs (can-pay? state side (:title card) raw-costs)]
-        (->> costs
-             (map (partial cost-handler state side eid card actions costs))
-             (filter some?)
-             (interpose " and ")
-             (apply str)))))
-
 (defn- pay-sync-next
   [state side eid costs card actions msgs]
   (if (empty? costs)

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -414,7 +414,7 @@
                                                                 card ice))
                            message (when (seq broken-subs)
                                      (break-subroutines-msg ice broken-subs breaker args))]
-                       (wait-for (pay-sync state side (make-eid state {:source-type :ability}) card total-cost)
+                       (wait-for (pay state side (make-eid state {:source-type :ability}) card total-cost)
                                  (if-let [cost-str async-result]
                                    (do (when (not (blank? message))
                                          (system-msg state :runner (str cost-str " to " message)))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -185,7 +185,7 @@
                 [base-cost [:credit cost]])]
     (if (and (corp-can-install? state side card slot)
              (not (install-locked? state :corp)))
-      (wait-for (pay-sync state side (make-eid state eid) card costs {:action action})
+      (wait-for (pay state side (make-eid state eid) card costs {:action action})
                 (if-let [cost-str async-result]
                   (if (= server "New remote")
                     (wait-for (trigger-event-simult state side :server-created nil card)
@@ -333,7 +333,7 @@
          (let [cost (runner-get-cost state side (assoc card :facedown facedown) params)]
            (if (not (runner-can-install? state side card facedown))
              (effect-completed state side eid)
-             (wait-for (pay-sync state side (make-eid state eid) card cost)
+             (wait-for (pay state side (make-eid state eid) card cost)
                        (if-let [cost-str async-result]
                          (let [c (if host-card
                                    (host state side host-card card)

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -102,13 +102,13 @@
               ;; if priority, have not spent a click
               (not (and (has-subtype? card "Priority")
                         (get-in @state [side :register :spent-click]))))
-       ;; Wait on pay-sync to finish before triggering instant-effect
+       ;; Wait on pay to finish before triggering instant-effect
        (let [original-zone (:zone card)
              moved-card (move state side (assoc card :seen true) :play-area)]
          ;; Only mark the register once costs have been paid and card has been moved
          (if (has-subtype? card "Run")
            (swap! state assoc-in [:runner :register :click-type] :run))
-         (wait-for (pay-sync state side (make-eid state eid) moved-card costs {:action :play-instant})
+         (wait-for (pay state side (make-eid state eid) moved-card costs {:action :play-instant})
                    (if-let [cost-str async-result]
                      (complete-play-instant state side eid moved-card cost-str ignore-cost)
                      ;; could not pay the card's price; put it back and mark the effect as being over.

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -92,7 +92,7 @@
              (swap! state assoc-in [:runner :register :click-type] :run)
              (swap! state assoc-in [:runner :register :made-click-run] true)
              (play-sfx state side "click-run"))
-           (wait-for (pay-sync state :runner (make-eid state {:source card :source-type :make-run}) nil costs)
+           (wait-for (pay state :runner (make-eid state {:source card :source-type :make-run}) nil costs)
                      (if-let [cost-str async-result]
                        (let [s [(if (keyword? server) server (last (server->zone state server)))]
                              ices (get-in @state (concat [:corp :servers] s [:ices]))
@@ -563,7 +563,7 @@
    (swap! state update-in [:jack-out] dissoc :jack-out-prevent)
    (let [cost (jack-out-cost state side)]
      (if (can-pay? state side eid nil "jack out" cost)
-       (wait-for (pay-sync state :runner nil cost)
+       (wait-for (pay state :runner nil cost)
                  (if-let [cost-str async-result]
                    (let [prevent (get-prevent-list state :corp :jack-out)]
                      (if (cards-can-prevent? state :corp prevent :jack-out)


### PR DESCRIPTION
Given the async nature of all costs, we shouldn't ever be using the sync version of `pay`. In this PR, I've removed all calls to `pay`, converting them to the improperly named `pay-sync`, and then renamed all uses of `pay-sync` to `pay`.