### PR TITLE
Run id tracking and various bug fixes

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -451,7 +451,7 @@
 (define-card "Dedicated Neural Net"
   {:events [{:event :successful-run
              :interactive (req true)
-             :psi {:req (req (= (first (:server target)) :hq))
+             :psi {:req (req (= (target-server target) :hq))
                    :once :per-turn
                    :not-equal {:effect (effect (register-floating-effect
                                                  card

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -451,7 +451,7 @@
 (define-card "Dedicated Neural Net"
   {:events [{:event :successful-run
              :interactive (req true)
-             :psi {:req (req (= target :hq))
+             :psi {:req (req (= (first (:server target)) :hq))
                    :once :per-turn
                    :not-equal {:effect (effect (register-floating-effect
                                                  card

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -613,6 +613,7 @@
    :effect (effect (make-run eid :rd nil card))
    :events [{:event :successful-run
              :silent (req true)
+             :unregister-once-resolved true
              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}]})
 
 (define-card "Déjà Vu"
@@ -750,7 +751,7 @@
    :effect (effect (make-run eid target nil card))
    :events [{:event :run-ends
              :req (req (:successful target))
-             :silent (req true)
+             :once :per-turn
              :msg "gain 5 [Credits]"
              :effect (effect (gain-credits :runner 5))}]})
 
@@ -1288,7 +1289,7 @@
    :effect (effect (make-run eid target nil card))
    :events [{:event :run-ends
              :req (req (:successful target))
-             :silent (req true)
+             :once :per-turn
              :msg "gain 12 [Credits]"
              :effect (effect (gain-credits :runner 12))}]})
 
@@ -1719,6 +1720,7 @@
    :effect (effect (make-run eid :hq nil card))
    :events [{:event :successful-run
              :silent (req true)
+             :unregister-once-resolved true
              :effect (effect (access-bonus :hq 2))}]})
 
 (define-card "Leverage"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -614,7 +614,7 @@
    :req (req rd-runnable)
    :effect (effect (make-run eid :rd nil card))
    :events [{:event :successful-run
-             :req (req (and (= target :rd)
+             :req (req (and (= (first (:server target)) :rd)
                             this-card-run))
              :silent (req true)
              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}]})
@@ -1727,7 +1727,7 @@
    :effect (effect (make-run eid :hq nil card))
    :events [{:event :successful-run
              :silent (req true)
-             :req (req (and (= target :hq)
+             :req (req (and (= (first (:server target)) :hq)
                             this-card-run))
              :effect (effect (access-bonus :hq 2))}]})
 
@@ -1814,7 +1814,7 @@
    :effect (effect (make-run eid target nil card))
    :events [{:event :run-ends
              :req (req this-card-run)
-             :effect (req (prevent-run-on-server state card (:server target))
+             :effect (req (prevent-run-on-server state card (first (:server target)))
                           (when (:successful target)
                             (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
                             (gain state :runner :click 1)
@@ -1885,7 +1885,7 @@
                               (effect-completed state side eid)))))
    :events [{:event :successful-run
              :req (req (and (get-in card [:special :run-again])
-                            (= target :rd)))
+                            (= (first (:server target)) :rd)))
              :msg "gain 4 [Credits]"
              :effect (effect (gain-credits 4))}
             {:event :run-ends
@@ -2737,7 +2737,7 @@
    :effect (effect (make-run eid :rd nil card))
    :events [{:event :successful-run
              :silent (req true)
-             :req (req (and (= target :rd)
+             :req (req (and (= (first (:server target)) :rd)
                             this-card-run))
              :effect (effect (access-bonus :rd 2))}]})
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -22,7 +22,8 @@
    :effect (effect (make-run eid target nil card))
    :events [{:event :subroutines-broken
              :async true
-             :req (req (and (has-subtype? target subtype)
+             :req (req (and this-card-run
+                            (has-subtype? target subtype)
                             (every? :broken (:subroutines target))
                             (let [pred #(and (has-subtype? (first %) subtype)
                                              (every? :broken (:subroutines (first %))))]
@@ -433,6 +434,7 @@
      :makes-run true
      :effect (effect (make-run eid target nil card))
      :events [{:event :encounter-ice
+               :req (req this-card-run)
                :once :per-run
                :optional
                {:prompt "Install a program?"
@@ -612,7 +614,8 @@
    :req (req rd-runnable)
    :effect (effect (make-run eid :rd nil card))
    :events [{:event :successful-run
-             :req (req this-card-run)
+             :req (req (and (= target :rd)
+                            this-card-run))
              :silent (req true)
              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}]})
 
@@ -638,6 +641,7 @@
    :interactions {:access-ability
                   {:label "Trash card"
                    :msg (msg "trash " (:title target) " at no cost")
+                   :req (req this-card-run) ; TODO: figure out if this works or if the card is the access ability
                    :async true
                    :effect (effect (trash eid (assoc target :seen true) nil))}}})
 
@@ -1288,8 +1292,8 @@
                    (zones->sorted-names (remove (set bad-zones) (get-runnable-zones state side eid card nil)))))
    :effect (effect (make-run eid target nil card))
    :events [{:event :run-ends
-             :req (req (:successful target))
-             :once :per-turn
+             :req (req (and (:successful target)
+                            this-card-run))
              :msg "gain 12 [Credits]"
              :effect (effect (gain-credits :runner 12))}]})
 
@@ -1321,6 +1325,7 @@
    :events [{:event :successful-run
              :async true
              :msg "gain 9 [Credits] and take 1 tag"
+             :req (req this-card-run)
              :effect (req (wait-for (gain-tags state :runner 1)
                                     (gain-credits state :runner 9)
                                     (effect-completed state side eid)))}]})
@@ -1347,6 +1352,7 @@
    :events [{:event :pre-access
              :async true
              :req (req (and (= target :archives)
+                            this-card-run
                             ;; don't prompt unless there's at least 1 rezzed ICE matching one in Archives
                             (not-empty (clojure.set/intersection
                                          (into #{} (map :title (filter ice? (:discard corp))))
@@ -1523,7 +1529,8 @@
    :choices (req runnable-servers)
    :effect (effect (make-run eid target nil card))
    :events [{:event :encounter-ice
-             :req (req (first-run-event? state side :encounter-ice))
+             :req (req (and this-card-run
+                            (first-run-event? state side :encounter-ice)))
              :once :per-run
              :msg (msg "bypass " (:title target))
              :effect (req (bypass-ice state))}]})
@@ -1720,7 +1727,8 @@
    :effect (effect (make-run eid :hq nil card))
    :events [{:event :successful-run
              :silent (req true)
-             :unregister-once-resolved true
+             :req (req (and (= target :hq)
+                            this-card-run))
              :effect (effect (access-bonus :hq 2))}]})
 
 (define-card "Leverage"
@@ -1764,6 +1772,7 @@
    :effect (effect (make-run eid target nil card))
    :events [{:event :run-ends
              :async true
+             :req (req this-card-run)
              :effect (req (if (:did-steal target)
                             (do (system-msg state :runner
                                             (str "adds Mad Dash to their score area as an agenda worth 1 agenda point"))
@@ -1804,6 +1813,7 @@
    :choices (req (filter #(can-run-server? state %) remotes))
    :effect (effect (make-run eid target nil card))
    :events [{:event :run-ends
+             :req (req this-card-run)
              :effect (req (prevent-run-on-server state card (:server target))
                           (when (:successful target)
                             (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
@@ -2080,7 +2090,8 @@
    :choices (req runnable-servers)
    :effect (effect (make-run eid target nil card))
    :events [{:event :pass-ice
-             :req (req (and (rezzed? target)
+             :req (req (and this-card-run
+                            (rezzed? target)
                             (not-used-once? state {:once :per-run} card)
                             (<= (get-strength target) (count (all-installed state :runner)))))
              :async true
@@ -2256,6 +2267,7 @@
    :choices (req runnable-servers)
    :effect (effect (make-run eid target nil card))
    :events [{:event :encounter-ice
+             :req (req this-card-run)
              :once :per-run
              :optional
              {:prompt "Jack out?"
@@ -2345,7 +2357,8 @@
                                card
                                (let [target-ice target]
                                  [{:event :encounter-ice
-                                   :req (req (same-card? target-ice target))
+                                   :req (req (and this-card-run
+                                                  (same-card? target-ice target)))
                                    :msg (msg "bypass " (:title target))
                                    :effect (req (bypass-ice state))}]))
                              (make-run eid (second (get-zone target)) nil card))})]
@@ -2424,6 +2437,7 @@
      :effect (effect (update! (assoc-in card [:special :run-amok] (get-rezzed-cids (all-installed state :corp))))
                (make-run eid target nil (get-card state card)))
      :events [{:event :run-ends
+               :req (req this-card-run)
                :async true
                :effect (req (let [new (set (get-rezzed-cids (all-installed state :corp)))
                                   old (set (get-in (get-card state card) [:special :run-amok]))
@@ -2567,7 +2581,8 @@
    :choices (req runnable-servers)
    :effect (effect (make-run eid target nil card))
    :events [{:event :encounter-ice
-             :req (req (= 1 run-position))
+             :req (req (= 1 run-position)
+                       this-card-run)
              :msg (msg "bypass " (:title target))
              :effect (req (bypass-ice state))}]})
 
@@ -2614,6 +2629,7 @@
    :effect (effect (gain-next-run-credits 9)
                    (make-run eid target nil card))
    :events [{:event :run-ends
+             :req (req this-card-run)
              :msg "take 1 brain damage"
              :effect (effect (damage eid :brain 1 {:unpreventable true
                                                    :card card}))}]})
@@ -2720,9 +2736,9 @@
    :async true
    :effect (effect (make-run eid :rd nil card))
    :events [{:event :successful-run
-             :unregister-once-resolved true
              :silent (req true)
-             :req (req (= target :rd))
+             :req (req (and (= target :rd)
+                            this-card-run))
              :effect (effect (access-bonus :rd 2))}]})
 
 (define-card "The Noble Path"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -612,8 +612,8 @@
    :req (req rd-runnable)
    :effect (effect (make-run eid :rd nil card))
    :events [{:event :successful-run
+             :req (req this-card-run)
              :silent (req true)
-             :unregister-once-resolved true
              :effect (effect (access-bonus :rd (max 0 (min 4 (available-mu state)))))}]})
 
 (define-card "Déjà Vu"
@@ -750,8 +750,8 @@
    :choices (req runnable-servers)
    :effect (effect (make-run eid target nil card))
    :events [{:event :run-ends
-             :req (req (:successful target))
-             :once :per-turn
+             :req (req (and (:successful target)
+                            this-card-run))
              :msg "gain 5 [Credits]"
              :effect (effect (gain-credits :runner 5))}]})
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -894,7 +894,7 @@
              :msg "force the Corp to lose 1 [Credits]"
              :effect (effect (lose-credits :corp 1))}
             {:event :successful-run
-             :req (req (= (first (:server target)) :archives))
+             :req (req (= (target-server target) :archives))
              :optional
              {:prompt "Trash Hijacked Router to force the Corp to lose 3 [Credits]?"
               :yes-ability
@@ -1089,7 +1089,7 @@
    :implementation "Power counters added automatically"
    :events [{:event :successful-run
              :silent (req true)
-             :req (req (= (first (:server target)) :rd))
+             :req (req (= (target-server target) :rd))
              :effect (effect (add-counter card :power 1))}]
    :abilities [{:async true
                 :cost [:click 1 :power 3]
@@ -1100,7 +1100,7 @@
   {:in-play [:memory 2]
    :events [{:event :successful-run
              :async true
-             :req (req (= (first (:server target)) :rd))
+             :req (req (= (target-server target) :rd))
              :effect (effect (continue-ability
                                {:prompt "Select a card and replace 1 spent [Recurring Credits] on it"
                                 :choices {:card #(< (get-counters % :recurring) (:recurring (card-def %) 0))}
@@ -1133,7 +1133,7 @@
   {:implementation "Stealth credit restriction not enforced"
    :events [{:event :successful-run
              :optional
-             {:req (req (and (= (first (:server target)) :hq)
+             {:req (req (and (= (target-server target) :hq)
                              (some #(has-subtype? % "Stealth")
                                    (all-active state :runner))))
               :prompt "Pay 1 [Credits] to access 1 additional card?"
@@ -1151,7 +1151,7 @@
                    card nil))}}}
             {:event :successful-run
              :optional
-             {:req (req (and (= (first (:server target)) :rd)
+             {:req (req (and (= (target-server target) :rd)
                              (some #(has-subtype? % "Stealth")
                                    (all-active state :runner))))
               :prompt "Pay 2 [Credits] to access 1 additional card?"
@@ -1238,10 +1238,10 @@
    :events [{:event :run-ends
              :once :per-turn
              :req (req (and (:successful target)
-                            (#{:rd :hq} (first (:server target)))
+                            (#{:rd :hq} (target-server target))
                             (first-event? state side :run-ends
                                           #(and (:successful (first %))
-                                                (#{:rd :hq} (first (:server (first %))))))))
+                                                (#{:rd :hq} (target-server (first %)))))))
              :msg (msg "draw " (total-cards-accessed target) " cards")
              :async true
              :effect (effect (draw eid (total-cards-accessed target) nil))}
@@ -1527,7 +1527,7 @@
 (define-card "Record Reconstructor"
   {:events
    [{:event :successful-run
-     :req (req (= (first (:server target)) :archives))
+     :req (req (= (target-server target) :archives))
      :effect (effect (add-run-effect
                        {:card card
                         :replace-access
@@ -1912,7 +1912,7 @@
 (define-card "Top Hat"
   {:events [{:event :successful-run
              :interactive (req true)
-             :req (req (and (= (first (:server target)) :rd)
+             :req (req (and (= (target-server target) :rd)
                             (not= (:max-access run) 0)))
              :async true
              :effect

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -278,7 +278,7 @@
                                                                  (set installed-card-names))]
                                (wait-for (trash-cards state side targets {:unpreventable true})
                                          (let [trashed-cards async-result]
-                                           (wait-for (draw state side (count overlap) nil)
+                                           (wait-for (draw state side (count (filter overlap trashed-card-names)) nil)
                                                      (system-msg state side
                                                                  (str "spends [Click] to use Capstone to trash "
                                                                       (join ", " (map :title trashed-cards))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -894,7 +894,7 @@
              :msg "force the Corp to lose 1 [Credits]"
              :effect (effect (lose-credits :corp 1))}
             {:event :successful-run
-             :req (req (= target :archives))
+             :req (req (= (first (:server target)) :archives))
              :optional
              {:prompt "Trash Hijacked Router to force the Corp to lose 3 [Credits]?"
               :yes-ability
@@ -1089,7 +1089,7 @@
    :implementation "Power counters added automatically"
    :events [{:event :successful-run
              :silent (req true)
-             :req (req (= target :rd))
+             :req (req (= (first (:server target)) :rd))
              :effect (effect (add-counter card :power 1))}]
    :abilities [{:async true
                 :cost [:click 1 :power 3]
@@ -1100,7 +1100,7 @@
   {:in-play [:memory 2]
    :events [{:event :successful-run
              :async true
-             :req (req (= target :rd))
+             :req (req (= (first (:server target)) :rd))
              :effect (effect (continue-ability
                                {:prompt "Select a card and replace 1 spent [Recurring Credits] on it"
                                 :choices {:card #(< (get-counters % :recurring) (:recurring (card-def %) 0))}
@@ -1133,7 +1133,7 @@
   {:implementation "Stealth credit restriction not enforced"
    :events [{:event :successful-run
              :optional
-             {:req (req (and (= target :hq)
+             {:req (req (and (= (first (:server target)) :hq)
                              (some #(has-subtype? % "Stealth")
                                    (all-active state :runner))))
               :prompt "Pay 1 [Credits] to access 1 additional card?"
@@ -1151,7 +1151,7 @@
                    card nil))}}}
             {:event :successful-run
              :optional
-             {:req (req (and (= target :rd)
+             {:req (req (and (= (first (:server target)) :rd)
                              (some #(has-subtype? % "Stealth")
                                    (all-active state :runner))))
               :prompt "Pay 2 [Credits] to access 1 additional card?"
@@ -1527,7 +1527,7 @@
 (define-card "Record Reconstructor"
   {:events
    [{:event :successful-run
-     :req (req (= target :archives))
+     :req (req (= (first (:server target)) :archives))
      :effect (effect (add-run-effect
                        {:card card
                         :replace-access
@@ -1912,7 +1912,7 @@
 (define-card "Top Hat"
   {:events [{:event :successful-run
              :interactive (req true)
-             :req (req (and (= target :rd)
+             :req (req (and (= (first (:server target)) :rd)
                             (not= (:max-access run) 0)))
              :async true
              :effect

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -628,7 +628,7 @@
      :choices {:card #(and (ice? %)
                            (in-hand? %))}
      :effect (req (corp-install state side eid
-                                target (zone->name (first (:server run)))
+                                target (zone->name (target-server run))
                                 {:ignore-all-cost true
                                  :index (max (dec run-position) 0)})
                   (swap! state update-in [:run :position] inc))}]})
@@ -705,7 +705,7 @@
 
 (define-card "Cell Portal"
   {:subroutines [{:msg "make the Runner approach the outermost ICE"
-                  :effect (req (let [server (central->name (first (:server run)))]
+                  :effect (req (let [server (central->name (target-server run))]
                                  (redirect-run state side server :approach-ice)
                                  (derez state side card)))}]})
 
@@ -1285,7 +1285,7 @@
        :async true
        :effect (req (wait-for (rez state side card nil)
                               (move state side (get-card state card)
-                                    [:servers (first (:server run)) :ices]
+                                    [:servers (target-server run) :ices]
                                     {:front true})
                               (swap! state assoc-in [:run :position] 1)
                               (set-next-phase state :encounter-ice)
@@ -2132,7 +2132,7 @@
                   :choices {:card #(and (ice? %)
                                         (in-hand? %))}
                   :prompt "Choose an ICE to install from HQ"
-                  :effect (effect (corp-install eid target (zone->name (first (:server run))) {:ignore-all-cost true}))}]})
+                  :effect (effect (corp-install eid target (zone->name (target-server run)) {:ignore-all-cost true}))}]})
 
 (define-card "Mirāju"
   {:events [{:event :encounter-ice-ends

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -174,7 +174,7 @@
   {:events [{:event :successful-run
              :async true
              :interactive (req true)
-             :req (req (and (= (first (:server target)) :archives)
+             :req (req (and (= (target-server target) :archives)
                             (first-successful-run-on-server? state :archives)
                             (not-empty (:hand corp))))
              :effect (effect (show-wait-prompt :runner "Corp to trash 1 card from HQ")
@@ -405,7 +405,7 @@
                :req (req (= side :corp))
                :effect (effect (update! (assoc card :flipped false)))}
               {:event :successful-run
-               :req (req (and (= (first (:server target)) :hq)
+               :req (req (and (= (target-server target) :hq)
                               (:flipped card)))
                :effect flip-effect}]
      :constant-effects [{:type :run-additional-cost
@@ -520,7 +520,7 @@
 (define-card "Gabriel Santiago: Consummate Professional"
   {:events [{:event :successful-run
              :silent (req true)
-             :req (req (and (= (first (:server target)) :hq)
+             :req (req (and (= (target-server target) :hq)
                             (first-successful-run-on-server? state :hq)))
              :msg "gain 2 [Credits]"
              :effect (effect (gain-credits 2))}]})
@@ -1036,7 +1036,7 @@
                                      (in-hand? %))}
                :async true
                :msg "install ice at the innermost position of this server. Runner is now approaching that ice"
-               :effect (req (wait-for (corp-install state side target (zone->name (first (:server run)))
+               :effect (req (wait-for (corp-install state side target (zone->name (target-server run))
                                                     {:ignore-all-cost true
                                                      :front true})
                                       (swap! state assoc-in [:run :position] 1)
@@ -1318,7 +1318,7 @@
   {:events [{:event :successful-run
              :interactive (req (some #(not (rezzed? %)) (all-installed state :corp)))
              :async true
-             :req (req (and (= (first (:server target)) :hq)
+             :req (req (and (= (target-server target) :hq)
                             (first-successful-run-on-server? state :hq)))
              :effect (effect (continue-ability {:choices {:card #(and (installed? %)
                                                                       (not (rezzed? %)))}
@@ -1415,7 +1415,7 @@
 
 (define-card "Steve Cambridge: Master Grifter"
   {:events [{:event :successful-run
-             :req (req (and (= (first (:server target)) :hq)
+             :req (req (and (= (target-server target) :hq)
                             (first-successful-run-on-server? state :hq)
                             (<= 2 (count (:discard runner)))))
              :interactive (req true)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -174,7 +174,7 @@
   {:events [{:event :successful-run
              :async true
              :interactive (req true)
-             :req (req (and (= target :archives)
+             :req (req (and (= (first (:server target)) :archives)
                             (first-successful-run-on-server? state :archives)
                             (not-empty (:hand corp))))
              :effect (effect (show-wait-prompt :runner "Corp to trash 1 card from HQ")
@@ -405,7 +405,7 @@
                :req (req (= side :corp))
                :effect (effect (update! (assoc card :flipped false)))}
               {:event :successful-run
-               :req (req (and (= target :hq)
+               :req (req (and (= (first (:server target)) :hq)
                               (:flipped card)))
                :effect flip-effect}]
      :constant-effects [{:type :run-additional-cost
@@ -520,7 +520,7 @@
 (define-card "Gabriel Santiago: Consummate Professional"
   {:events [{:event :successful-run
              :silent (req true)
-             :req (req (and (= target :hq)
+             :req (req (and (= (first (:server target)) :hq)
                             (first-successful-run-on-server? state :hq)))
              :msg "gain 2 [Credits]"
              :effect (effect (gain-credits 2))}]})
@@ -832,7 +832,7 @@
              :effect (req (apply enable-run-on-server
                                  state card (map first (get-remotes state))))}]
    :req (req (empty? (let [successes (turn-events state side :successful-run)]
-                       (filter #(is-central? %) successes))))
+                       (filter #(is-central? %) (:map :server successes)))))
    :effect (req (apply prevent-run-on-server state card (map first (get-remotes state))))
    :leave-play (req (apply enable-run-on-server state card (map first (get-remotes state))))})
 
@@ -1318,7 +1318,7 @@
   {:events [{:event :successful-run
              :interactive (req (some #(not (rezzed? %)) (all-installed state :corp)))
              :async true
-             :req (req (and (= target :hq)
+             :req (req (and (= (first (:server target)) :hq)
                             (first-successful-run-on-server? state :hq)))
              :effect (effect (continue-ability {:choices {:card #(and (installed? %)
                                                                       (not (rezzed? %)))}
@@ -1415,7 +1415,7 @@
 
 (define-card "Steve Cambridge: Master Grifter"
   {:events [{:event :successful-run
-             :req (req (and (= target :hq)
+             :req (req (and (= (first (:server target)) :hq)
                             (first-successful-run-on-server? state :hq)
                             (<= 2 (count (:discard runner)))))
              :interactive (req true)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -257,7 +257,7 @@
   [break pump]
   (auto-icebreaker
     {:abilities [(break-sub (:break-cost break) (:break break) (:breaks break)
-                            {:req (req (and (#{:hq :rd :archives} (first (:server run)))
+                            {:req (req (and (#{:hq :rd :archives} (target-server run))
                                             (<= (get-strength current-ice) (get-strength card))
                                             (has-subtype? current-ice (:breaks break))))})
                  pump]}))
@@ -654,7 +654,7 @@
   {:leave-play (effect (update-all-advancement-costs))
    :events [{:event :successful-run
              :silent (req true)
-             :req (req (= (first (:server target)) :rd))
+             :req (req (= (target-server target) :rd))
              :effect (effect (add-counter card :virus 1))}
             {:event :pre-advancement-cost
              :req (req (>= (get-virus-counters state card) 3))
@@ -777,9 +777,9 @@
    :events [{:event :successful-run
              :interactive (req true)
              :optional
-             {:req (req (and (is-central? (first (:server target)))
+             {:req (req (and (is-central? (target-server target))
                              (can-pay? state side eid card nil [:virus 1])
-                             (not-empty (get-in @state [:corp :servers (first (:server target)) :ices]))
+                             (not-empty (get-in @state [:corp :servers (target-server target) :ices]))
                              (<= 2 (count (filter ice? (all-installed state :corp))))))
               :once :per-turn
               :prompt "Use Cordyceps to swap ice?"
@@ -787,7 +787,7 @@
               {:prompt "Select ice protecting this server"
                :choices {:req (req (and (installed? target)
                                         (ice? target)
-                                        (= (first (:server (:run @state))) (second (get-zone target)))))}
+                                        (= (target-server (:run @state)) (second (get-zone target)))))}
                :async true
                :effect (effect
                          (continue-ability
@@ -896,10 +896,10 @@
                     :effect (effect (update! (assoc card :server-target target)))
                     :leave-play (effect (update! (dissoc card :server-target)))
                     :abilities [(break-sub 1 1 "Code Gate" {:req (req (if (:server-target card)
-                                                                        (#{(last (server->zone state (:server-target card)))} (first (:server run)))
+                                                                        (#{(last (server->zone state (:server-target card)))} (target-server run))
                                                                         true))})
                                 (strength-pump 1 1 :end-of-encounter {:req (req (if (:server-target card)
-                                                                                  (#{(last (server->zone state (:server-target card)))} (first (:server run)))
+                                                                                  (#{(last (server->zone state (:server-target card)))} (target-server run))
                                                                                   true))})]}))
 
 (define-card "D4v1d"
@@ -934,7 +934,7 @@
 (define-card "Datasucker"
   {:events [{:event :successful-run
              :silent (req true)
-             :req (req (is-central? (first (:server target))))
+             :req (req (is-central? (target-server target)))
              :effect (effect (add-counter card :virus 1))}]
    :abilities [{:cost [:virus 1]
                 :label "Give -1 strength to current ICE"
@@ -969,7 +969,7 @@
   {:events [{:event :successful-run
              :silent (req true)
              :effect (effect (add-counter card :virus 1))
-             :req (req (= (first (:server target)) :rd))}
+             :req (req (= (target-server target) :rd))}
             {:event :runner-turn-begins
              :req (req (>= (get-virus-counters state card) 3)) :msg "look at the top card of R&D"
              :effect (effect (prompt! card (str "The top card of R&D is "
@@ -1167,7 +1167,7 @@
                                                                                        " from the top of R&D"))
                                                         (continue-ability state side (force-draw topcard) card nil)))}}}]
     {:events [{:event :successful-run
-               :req (req (= (first (:server target)) :rd))
+               :req (req (= (target-server target) :rd))
                :async true
                :interactive (req true)
                :effect (effect (continue-ability reveal card nil))}]}))
@@ -1581,7 +1581,7 @@
 
 (define-card "Lamprey"
   {:events [{:event :successful-run
-             :req (req (= (first (:server target)) :hq))
+             :req (req (= (target-server target) :hq))
              :msg "force the Corp to lose 1 [Credits]"
              :effect (effect (lose-credits :corp 1))}
             {:event :purge
@@ -1713,7 +1713,7 @@
 
 (define-card "Medium"
   {:events [{:event :successful-run
-             :req (req (= (first (:server target)) :rd))
+             :req (req (= (target-server target) :rd))
              :effect (effect (add-counter card :virus 1))}
             {:event :pre-access
              :async true
@@ -1787,7 +1787,7 @@
 
 (define-card "Nerve Agent"
   {:events [{:event :successful-run
-             :req (req (= (first (:server target)) :hq))
+             :req (req (= (target-server target) :hq))
              :effect (effect (add-counter card :virus 1))}
             {:event :pre-access
              :async true
@@ -2091,7 +2091,7 @@
                      (set-prop state side card :rec-counter (get-counters card :virus))))
    :events [{:event :successful-run
              :silent (req true)
-             :req (req (= (first (:server target)) :hq))
+             :req (req (= (target-server target) :hq))
              :effect (effect (add-counter card :virus 1))}]
    :interactions {:pay-credits {:req (req (= :hq (get-in @state [:run :server 0])))
                                 :type :recurring}}})
@@ -2223,12 +2223,9 @@
                           (update! state :runner (assoc-in card [:special :rng-highest] cost))
                           cost)))]
               {:event :successful-run
-               :req (req (and (#{:hq :rd} (first (:server target)))
+               :req (req (and (#{:hq :rd} (target-server target))
                               (first-event? state :runner :successful-run
-                                            ;; #(#{:hq :rd} (first (:server (first %))))
-                                            (fn [targets] #{:hq :rd} (first (:server (first targets))))
-                                            ;; #(#{:hq :rd} (first (:server (first %))))
-                                            )))
+                                            (fn [targets] #{:hq :rd} (first (:server (first targets)))))))
                :optional
                {:prompt "Fire RNG Key?"
                 :autoresolve (get-autoresolve :auto-fire)
@@ -2602,7 +2599,7 @@
   {:implementation "Power counters added automatically"
    :events [{:event :successful-run
              :silent (req true)
-             :req (req (= (first (:server target)) :rd))
+             :req (req (= (target-server target) :rd))
              :effect (effect (add-counter card :power 1))}]
    :abilities [{:cost [:click 1 :power 3]
                 :once :per-turn
@@ -2656,7 +2653,7 @@
     {:events [{:event :successful-run
                :interactive (req true)
                :async true
-               :req (req (and (= (first (:server target)) :hq)
+               :req (req (and (= (target-server target) :hq)
                               (first-successful-run-on-server? state :hq)
                               (some #(and (ice? %) (not (rezzed? %)))
                                     (all-installed state :corp))))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -340,7 +340,7 @@
 (define-card "Bhagat"
   {:events [{:event :successful-run
              :async true
-             :req (req (and (= (first (:server target)) :hq)
+             :req (req (and (= (target-server target) :hq)
                             (first-successful-run-on-server? state :hq)))
              :msg "force the Corp to trash the top card of R&D"
              :effect (req (mill state :corp eid :corp 1))}]})
@@ -624,7 +624,7 @@
                                                     {:cost [:credit tags]
                                                      :msg (str "access up to " tags " cards")
                                                      :effect
-                                                     (effect (access-bonus (first (:server target)) (dec tags)))}
+                                                     (effect (access-bonus (target-server target) (dec tags)))}
                                                     card targets)
                                                   ;; Can't pay, don't access cards
                                                   (do (system-msg state side "could not afford to use Counter Surveillance")
@@ -686,7 +686,7 @@
 (define-card "Crypt"
   {:events [{:event :successful-run
              :silent (req true)
-             :req (req (= :archives (first (:server target))))
+             :req (req (= :archives (target-server target)))
              :optional {:prompt "Place a virus counter on Crypt?"
                         :autoresolve (get-autoresolve :auto-add)
                         :yes-ability {:effect (effect (add-counter card :virus 1)
@@ -2033,7 +2033,7 @@
 (define-card "Psych Mike"
   {:events [{:event :run-ends
              :req (req (and (:successful target)
-                            (first-event? state side :run-ends #(and (= :rd (first (:server (first %))))
+                            (first-event? state side :run-ends #(and (= :rd (target-server (first %)))
                                                                      (:successful (first %))))))
              :msg (msg "gain " (total-cards-accessed target :deck) " [Credits]")
              :effect (effect (gain-credits :runner (total-cards-accessed target :deck)))}]})
@@ -2717,7 +2717,7 @@
                :silent (req true)}
               {:event :run-ends
                :effect (req (when (and (not (:agenda-stolen card))
-                                       (#{:hq :rd} (first (:server target))))
+                                       (#{:hq :rd} (target-server target)))
                               (add-counter state side card :power 1)
                               (system-msg state :runner (str "places a power counter on " (:title card))))
                          (update! state side (dissoc (get-card state card) :agenda-stolen)))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -340,7 +340,7 @@
 (define-card "Bhagat"
   {:events [{:event :successful-run
              :async true
-             :req (req (and (= target :hq)
+             :req (req (and (= (first (:server target)) :hq)
                             (first-successful-run-on-server? state :hq)))
              :msg "force the Corp to trash the top card of R&D"
              :effect (req (mill state :corp eid :corp 1))}]})
@@ -624,7 +624,7 @@
                                                     {:cost [:credit tags]
                                                      :msg (str "access up to " tags " cards")
                                                      :effect
-                                                     (effect (access-bonus target (dec tags)))}
+                                                     (effect (access-bonus (first (:server target)) (dec tags)))}
                                                     card targets)
                                                   ;; Can't pay, don't access cards
                                                   (do (system-msg state side "could not afford to use Counter Surveillance")
@@ -686,7 +686,7 @@
 (define-card "Crypt"
   {:events [{:event :successful-run
              :silent (req true)
-             :req (req (= :archives target))
+             :req (req (= :archives (first (:server target))))
              :optional {:prompt "Place a virus counter on Crypt?"
                         :autoresolve (get-autoresolve :auto-add)
                         :yes-ability {:effect (effect (add-counter card :virus 1)

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1018,7 +1018,7 @@
    :events [{:event :runner-turn-begins
              :effect (req (prevent-run-on-server state card (second (get-zone card))))}
             {:event :successful-run
-             :req (req (= target :hq))
+             :req (req (= (first (:server target)) :hq))
              :async true
              :effect (req (enable-run-on-server state card (second (get-zone card)))
                           (system-msg state :corp (str "trashes Off the Grid"))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -523,7 +523,7 @@
 
 (define-card "Georgia Emelyov"
   {:events [{:event :unsuccessful-run
-             :req (req (= (first (:server target))
+             :req (req (= (target-server target)
                           (second (get-zone card))))
              :async true
              :msg "do 1 net damage"
@@ -815,7 +815,7 @@
   {:events [{:event :run-ends
              :msg "gain a [Click] next turn"
              :req (req (and (:successful target)
-                            (= (first (:server target)) (second (get-zone card)))
+                            (= (target-server target) (second (get-zone card)))
                             (or (< (:credit runner) 6) (zero? (:click runner)))))
              :effect (req (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}]})
 
@@ -953,7 +953,7 @@
                        :req (req (let [target-card (first targets)]
                                    (and run
                                         (= (:side target-card) "Runner")
-                                        (= (first (:server run)) (second (get-zone card)))
+                                        (= (target-server run) (second (get-zone card)))
                                         (not (has-subtype? target-card "Icebreaker")))))
                        :value true}]})
 
@@ -1018,7 +1018,7 @@
    :events [{:event :runner-turn-begins
              :effect (req (prevent-run-on-server state card (second (get-zone card))))}
             {:event :successful-run
-             :req (req (= (first (:server target)) :hq))
+             :req (req (= (target-server target) :hq))
              :async true
              :effect (req (enable-run-on-server state card (second (get-zone card)))
                           (system-msg state :corp (str "trashes Off the Grid"))
@@ -1104,7 +1104,7 @@
   {:install-req (req (filter #{"HQ"} targets))
    :abilities [{:cost [:credit 1]
                 :msg "draw 1 card"
-                :req (req (and run (= (first (:server run)) :hq)))
+                :req (req (and run (= (target-server run) :hq)))
                 :effect (effect (draw))}]})
 
 (define-card "Port Anson Grid"

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -415,7 +415,7 @@
 (defn first-successful-run-on-server?
   "Returns true if the active run is the first succesful run on the given server"
   [state server]
-  (first-event? state :runner :successful-run #(= [server] %)))
+  (first-event? state :runner :successful-run #(= [server] (:server (first %)))))
 
 (defn first-trash?
   "Returns true if cards have been trashed by either player only once this turn.

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -366,7 +366,9 @@
 (defmethod start-next-phase :access-server
   [state side args]
   (set-phase state :access-server)
-  (successful-run state :runner nil))
+  (if (check-for-empty-server state)
+    (handle-end-run state side)
+    (successful-run state :runner nil)))
 
 (defmethod continue :default
   [state side args]

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -416,9 +416,9 @@
   ([state side eid server]
    (swap! state update-in [:runner :register :successful-run] #(conj % (first server)))
    (swap! state assoc-in [:run :successful] true)
-   (wait-for (trigger-event-simult state side :pre-successful-run nil (first server))
-             (wait-for (trigger-event-simult state side :successful-run nil (first (get-in @state [:run :server])))
-                       (wait-for (trigger-event-simult state side :post-successful-run nil (first (get-in @state [:run :server])))
+   (wait-for (trigger-event-simult state side :pre-successful-run nil (:run @state))
+             (wait-for (trigger-event-simult state side :successful-run nil (:run @state))
+                       (wait-for (trigger-event-simult state side :post-successful-run nil (:run @state))
                                  (effect-completed state side eid))))))
 
 (defn replace-access

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -102,20 +102,24 @@
                                                           (zone->name (unknown->kw server))
                                                           (when ignore-costs ", ignoring all costs"))))
                          ;; s is a keyword for the server, like :hq or :remote1
-                         (swap! state assoc
-                                :per-run nil
-                                :run {:server s
-                                      :position n
-                                      :corp-auto-no-action false
-                                      :jack-out false
-                                      :jack-out-after-pass false
-                                      :phase :initiation
-                                      :next-phase :initiation
-                                      :eid eid
-                                      :current-ice nil
-                                      :events nil})
+                         (let [run-id (make-eid state)]
+                           (swap! state assoc
+                                  :per-run nil
+                                  :run {:run-id run-id
+                                        :server s
+                                        :position n
+                                        :corp-auto-no-action false
+                                        :jack-out false
+                                        :jack-out-after-pass false
+                                        :phase :initiation
+                                        :next-phase :initiation
+                                        :eid eid
+                                        :current-ice nil
+                                        :events nil})
+                           (when card
+                             (update! state side (assoc-in card [:special :run-id] run-id))))
                          (when (or run-effect card)
-                           (add-run-effect state side (assoc run-effect :card card)))
+                           (add-run-effect state side (assoc run-effect :card (get-card state card))))
                          (trigger-event state side :begin-run :server s)
                          (gain-run-credits state side (get-in @state [:runner :next-run-credit]))
                          (swap! state assoc-in [:runner :next-run-credit] 0)

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -26,12 +26,11 @@
       rd-runnable (not (:rd (get-in (:runner @state) [:register :cannot-run-on-server])))
       archives-runnable (not (:archives (get-in (:runner @state) [:register :cannot-run-on-server])))
       tagged (is-tagged? state)
-      ;; true if the current run (or the previous run if no current run) was initiated by this card
+      ;; only intended for use in event listeners on (pre-/post-, un-)successful-run or run-ends
+      ;; true if the run was initiated by this card
       this-card-run (and (get-in card [:special :run-id])
                          (= (get-in card [:special :run-id])
-                            (if (:run @state)
-                              (:run-id (:run @state))
-                              (:run-id (get-in (:runner @state) [:register :last-run])))))
+                            (:run-id (first targets))))
       this-server (let [s (get-zone card)
                         r (:server (:run @state))]
                     (= (second s) (first r)))]

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -26,6 +26,12 @@
       rd-runnable (not (:rd (get-in (:runner @state) [:register :cannot-run-on-server])))
       archives-runnable (not (:archives (get-in (:runner @state) [:register :cannot-run-on-server])))
       tagged (is-tagged? state)
+      ;; true if the current run (or the previous run if no current run) was initiated by this card
+      this-card-run (and (get-in card [:special :run-id])
+                         (= (get-in card [:special :run-id])
+                            (if (:run @state)
+                              (:run-id (:run @state))
+                              (:run-id (get-in (:runner @state) [:register :last-run])))))
       this-server (let [s (get-zone card)
                         r (:server (:run @state))]
                     (= (second s) (first r)))]

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -289,3 +289,8 @@
                   (when (pred x)
                     idx))
                 coll))
+
+(defn target-server
+  [run]
+  "Returns the server keyword corresponding to the target of a run."
+  (first (:server run)))

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -3746,7 +3746,17 @@
         (is (zero? (get-counters (refresh rex) :power)))
         (click-prompt state :corp "Remove 1 bad publicity")
         (is (zero? (count-bad-pub state)) "Should not have the same amount of bad publicity")
-        (is (= "Rex Campaign" (-> (get-corp) :discard first :title)))))))
+        (is (= "Rex Campaign" (-> (get-corp) :discard first :title))))))
+  (testing "No trigger when trashed by Runner"
+    (do-game
+      (new-game {:corp {:deck ["Rex Campaign"]}})
+      (play-from-hand state :corp "Rex Campaign" "New remote")
+      (let [rex (get-content state :remote1 0)]
+        (core/rez state :corp rex)
+        (take-credits state :corp)
+        (run-empty-server state :remote1)
+        (click-prompt state :runner "Pay 3 [Credits] to trash")
+        (is (empty? (:prompt (get-corp))) "No prompt to trigger Rex Campaign when trashed by the Runner")))))
 
 (deftest ronald-five
   ;; Ronald Five - Runner loses a click every time they trash a Corp card

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1439,7 +1439,6 @@
      (click-prompt state :runner "Archives")
      (run-jack-out state)
      (is (= 6 (:credit (get-runner))) "Run unsuccessful; gained no credits")))
-
   (testing "Doppelgänger interaction"
     (do-game
      (new-game {:runner {:hand ["Doppelgänger" "Dirty Laundry"]}})

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -3257,7 +3257,24 @@
     (run-jack-out state)
     (run-empty-server state :hq)
     (click-prompt state :runner "Steal")
-    (is (not (:run @state)) "Run has finished"))))
+    (is (not (:run @state)) "Run has finished")))
+  (testing "Doppelgänger interaction"
+    (do-game
+     (new-game {:runner {:hand ["Doppelgänger" "Legwork"]}
+                :corp {:hand [(qty "Hostile Takeover" 5)]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Doppelgänger")
+     (play-run-event state "Legwork" :hq)
+     (do (dotimes [_ 3]
+           (click-prompt state :runner "Steal"))
+         (is (not (:run @state)))
+         (click-prompt state :runner "Yes")
+         (click-prompt state :runner "HQ")
+         (is (:run @state) "New run started")
+         (run-continue state)
+         (click-prompt state :runner "Steal")
+         (is (not (:run @state))
+             "Legwork only gives bonus accesses on its own run when combined with Doppelgänger")))))
 
 (deftest leverage
   ;; Leverage

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1450,6 +1450,7 @@
                           (do (click-prompt state :runner "Archives")
                               (run-continue state)
                               (is (not (:run @state)))
+                              (click-prompt state :runner "Doppelgänger")
                               (click-prompt state :runner "Yes")
                               (click-prompt state :runner "Archives")
                               (is (:run @state) "New run started")
@@ -5055,19 +5056,38 @@
       (is (= "Morning Star" (:title (get-program state 0))) "Morning Star still installed"))))
 
 (deftest the-maker-s-eye
-  (do-game
-    (new-game {:corp {:deck [(qty "Quandary" 5)]
-                      :hand [(qty "Quandary" 5)]}
-               :runner {:deck ["The Maker's Eye"]}})
-    (take-credits state :corp)
-    (play-run-event state "The Maker's Eye" :rd)
-    (is (= "You accessed Quandary." (:msg (prompt-map :runner))) "1st quandary")
-    (click-prompt state :runner "No action")
-    (is (= "You accessed Quandary." (:msg (prompt-map :runner))) "2nd quandary")
-    (click-prompt state :runner "No action")
-    (is (= "You accessed Quandary." (:msg (prompt-map :runner))) "3rd quandary")
-    (click-prompt state :runner "No action")
-    (is (not (:run @state)))))
+  (testing "Basic test"
+    (do-game
+     (new-game {:corp {:deck [(qty "Quandary" 5)]
+                       :hand [(qty "Quandary" 5)]}
+                :runner {:deck ["The Maker's Eye"]}})
+     (take-credits state :corp)
+     (play-run-event state "The Maker's Eye" :rd)
+     (is (= "You accessed Quandary." (:msg (prompt-map :runner))) "1st quandary")
+     (click-prompt state :runner "No action")
+     (is (= "You accessed Quandary." (:msg (prompt-map :runner))) "2nd quandary")
+     (click-prompt state :runner "No action")
+     (is (= "You accessed Quandary." (:msg (prompt-map :runner))) "3rd quandary")
+     (click-prompt state :runner "No action")
+     (is (not (:run @state)))))
+  (testing "Doppelgänger interaction"
+    (do-game
+     (new-game {:runner {:hand ["Doppelgänger" "The Maker's Eye"]}
+                :corp {:deck [(qty "Hostile Takeover" 20)]
+                       :hand [(qty "Hostile Takeover" 3)]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Doppelgänger")
+     (play-run-event state "The Maker's Eye" :rd)
+     (do (dotimes [_ 3]
+           (click-prompt state :runner "Steal"))
+         (is (not (:run @state)))
+         (click-prompt state :runner "Yes")
+         (click-prompt state :runner "R&D")
+         (is (:run @state) "New run started")
+         (run-continue state)
+         (click-prompt state :runner "Steal")
+         (is (not (:run @state))
+             "The Maker's Eye only gives bonus accesses on its own run when combined with Doppelgänger")))))
 
 (deftest the-noble-path
   ;; The Noble Path - Prevents damage during run

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1427,17 +1427,34 @@
 
 (deftest dirty-laundry
   ;; Dirty Laundry - Gain 5 credits at the end of the run if it was successful
-  (do-game
-    (new-game {:runner {:deck [(qty "Dirty Laundry" 2)]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Dirty Laundry")
-    (click-prompt state :runner "Archives")
-    (run-continue state)
-    (is (= 8 (:credit (get-runner))) "Gained 5 credits")
-    (play-from-hand state :runner "Dirty Laundry")
-    (click-prompt state :runner "Archives")
-    (run-jack-out state)
-    (is (= 6 (:credit (get-runner))) "Run unsuccessful; gained no credits")))
+  (testing "Basic test"
+    (do-game
+     (new-game {:runner {:deck [(qty "Dirty Laundry" 2)]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Dirty Laundry")
+     (click-prompt state :runner "Archives")
+     (run-continue state)
+     (is (= 8 (:credit (get-runner))) "Gained 5 credits")
+     (play-from-hand state :runner "Dirty Laundry")
+     (click-prompt state :runner "Archives")
+     (run-jack-out state)
+     (is (= 6 (:credit (get-runner))) "Run unsuccessful; gained no credits")))
+
+  (testing "Doppelgänger interaction"
+    (do-game
+     (new-game {:runner {:hand ["Doppelgänger" "Dirty Laundry"]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Doppelgänger")
+     (play-from-hand state :runner "Dirty Laundry")
+     (is (changes-credits (get-runner) 5
+                          (do (click-prompt state :runner "Archives")
+                              (run-continue state)
+                              (is (not (:run @state)))
+                              (click-prompt state :runner "Yes")
+                              (click-prompt state :runner "Archives")
+                              (is (:run @state) "New run started")
+                              (run-continue state)))
+         "Dirty Laundry pays out 5 creds when comboed with Doppelganger"))))
 
 (deftest diversion-of-funds
   ;; Diversion of Funds

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -795,7 +795,7 @@
   ;; Capstone
   (do-game
     (new-game {:runner {:deck [(qty "Sure Gamble" 10)]
-                        :hand ["Capstone" (qty "Corroder" 2) (qty "Cache" 2) "Patchwork"]
+                        :hand ["Capstone" (qty "Corroder" 3) (qty "Cache" 2) "Patchwork"]
                         :credits 100}})
     (take-credits state :corp)
     (core/gain state :runner :click 10)
@@ -804,12 +804,13 @@
     (play-from-hand state :runner "Cache")
     (let [capstone (get-hardware state 0)]
       (card-ability state :runner capstone 0)
-      (click-card state :runner (find-card "Corroder" (:hand (get-runner))))
-      (click-card state :runner (find-card "Cache" (:hand (get-runner))))
-      (click-card state :runner (find-card "Patchwork" (:hand (get-runner)))))))
+      (is (= 4 (count (:hand (get-runner)))) "4 cards in hand before using Capstone")
+      (dotimes [n 4]
+        (click-card state :runner (nth (:hand (get-runner)) n))))
+    (is (= 3 (count (:hand (get-runner)))) "3 cards in hand after using Capstone")))
 
 (deftest chop-bot-3000
-  ;; Chop Bot 3000 - when your turn beings trash 1 card, then draw or remove tag
+  ;; Chop Bot 3000 - when your turn begins trash 1 card, then draw or remove tag
   (do-game
     (new-game {:runner {:deck ["Chop Bot 3000" "Spy Camera"]}})
     (take-credits state :corp)


### PR DESCRIPTION
Fixes #5234 , #5235 , #5236 , #5237 . I'm happy to split this up if needed, but I figured most changes were small enough that a big PR was ok. The only interesting changes here are the addition of a run-id for each run which is (if applicable) stored in the card which initiated it, and the addition of a helper name `this-card-run` in the `req` macro to make it easier to include a test that the run an event handler is seeing is actually the run its card started. This has caused some issues with Doppelganger which I couldn't see a good fix for otherwise. I considered using durations, but felt this was sort of making the same assumption causing trouble in the first place, so opted not to. 

A simpler fix which fixes all (?) Doppelganger interactions is just making all the events I've used `this-card-run` for be `:once :per-turn` instead, and I'll understand if that's a better solution. Otherwise, it should be noted that run ids are generated as eids for convenience. I don't think this causes any trouble with the event system, but I might be wrong there.

EDIT: This PR grew a bit in scope. It now makes `:successful-run`, and the pre-/post- versions take the run objects as targets, making `this-card-run` less fragile. This necessitated changing a bunch of old card definitions, and I took the opportunity to introduce a convenience function to make them more readable while I was at it and touch up one or two which I struggled to read. It is a bit of a big change just to make a rarely-played console work, so as before I'm okay with reverting it.