### PR TITLE
Embezzle double trash fix

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -842,7 +842,7 @@
                                         (when (or (same-card? card (first cards-to-trash))
                                                   (same-card? card (second cards-to-trash))) (update! state side (assoc card :seen true))))
                                       (wait-for (trash-cards state :runner (map #(assoc % :seen true) cards-to-trash)
-                                              (gain-credits state :runner eid credits nil)))
+                                              (gain-credits state :runner eid credits nil))))
                                   (effect-completed state side eid))))}}
                card))})
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -838,8 +838,11 @@
                                              (join " and " (map :title cards-to-trash))
                                              " from HQ and gain "
                                              credits " [Credits]"))
-                                      (wait-for (trash-cards state :runner (map #(assoc % :seen true) cards-to-trash))
-                                                (gain-credits state :runner eid credits nil)))
+                                      (doseq [card (get-in @state [:corp :hand])]
+                                        (when (or (same-card? card (first cards-to-trash))
+                                                  (same-card? card (second cards-to-trash))) (update! state side (assoc card :seen true))))
+                                      (wait-for (trash-cards state :runner (map #(assoc % :seen true) cards-to-trash)
+                                              (gain-credits state :runner eid credits nil)))
                                   (effect-completed state side eid))))}}
                card))})
 


### PR DESCRIPTION
Closes #4997 

The problem: Embezzle trashes cards facedown when trashing 2 cards.

The code: `trash-cards` in `trashing.clj` on `line 86` decides where to look for cards. If only 1 card was supplied as param, it takes supplied card. If 2 or more cards were supplied, it instead looks at global state and ignores params. 

The fix (temp): We mark cards trashed via Embezzle as `:seen true` in state.

The fix (permanent): `trash-cards` should look at state, but should also receive new param `facedown` or `seen` or something. That param will specify if trashing effects trashes facedown or faceup. This fix would require rewrite of all trash effect cards. And replacing all those `(trash eid (assoc target :seen true) nil)` with something like `(trash-cards eid target true)`    
