### PR TITLE
Added button for reloading lobby list

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -204,7 +204,7 @@
       (not-any? #(= username %) (blocked-users game))
       (some #(= username %) (map :username (superusers)))))
 
-(defn handle-ws-connect [{:keys [client-id] :as msg}]
+(defn handle-lobby-list [{:keys [client-id] :as msg}]
   (ws/send! client-id [:games/list (mapv game-public-view (vals @all-games))]))
 
 (defn handle-lobby-create
@@ -372,7 +372,8 @@
                     :date (java.util.Date.)})))))
 
 (ws/register-ws-handlers!
-  :chsk/uidport-open #'handle-ws-connect
+  :chsk/uidport-open #'handle-lobby-list
+  :lobby/list #'handle-lobby-list
   :lobby/create #'handle-lobby-create
   :lobby/leave #'handle-lobby-leave
   :lobby/join #'handle-lobby-join

--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -256,6 +256,10 @@
 (defn games-list-panel [s games gameid password-gameid user]
   [:div.games
    [:div.button-bar
+    [:div.rooms
+     [room-tab user s games "tournament" "Tournament"]
+     [room-tab user s games "competitive" "Competitive"]
+     [room-tab user s games "casual" "Casual"]]
     [cond-button "New game"
      (and (not (or @gameid
                    (:editing @s)
@@ -266,10 +270,8 @@
                empty?))
      #(do (new-game s)
           (resume-sound))]
-    [:div.rooms
-     [room-tab user s games "tournament" "Tournament"]
-     [room-tab user s games "competitive" "Competitive"]
-     [room-tab user s games "casual" "Casual"]]]
+    [:button {:type "button"
+              :on-click #(ws/ws-send! [:lobby/list])} "Reload list"]]
    (let [password-game (some #(when (= @password-gameid (:gameid %)) %) @games)]
      [game-list user {:password-game password-game
                       :editing (:editing @s)


### PR DESCRIPTION
There is a known bug (related to #5102), where the lobby appears empty. This could be happening, because the server only sends the full lobby list on `:chsk/uidport-open` which is triggered when a new websocket is opened (as far as I can see). If this for whatever reason fails, the client never receives a full lobby list and only sees changes to the lobby.

I added a button to manually initiate a lobby refresh, which should make these problems fixable manually.