### PR TITLE
Hippo double trigger fix

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -905,10 +905,15 @@
                                       (effect-completed state side eid)))}}}]})
 
 (define-card "Hippo"
+  (letfn [(build-hippo-pred [outermost-ices]
+    (fn [events]
+      (or (map #(and (same-card? % (first events))
+                     (every? :broken (:subroutines (first events)))) outermost-ices))))]
   {:events [{:event :subroutines-broken
              :optional
-             {:req (req (let [pred #(and (same-card? (last run-ices) (first %))
-                                         (every? :broken (:subroutines (first %))))]
+              {:req (req (let [servers (->> (:corp @state) :servers seq flatten)
+                               outermost-ices (filter #(some? %) (map #(last (:ices %)) servers))
+                               pred (build-hippo-pred outermost-ices)]
                           (and (same-card? (last run-ices) target)
                                (every? :broken (:subroutines target))
                                (first-event? state side :subroutines-broken pred))))
@@ -917,7 +922,7 @@
               {:async true
                :effect (effect (system-msg (str "removes Hippo from the game to trash " (card-str state target)))
                                (move card :rfg)
-                               (trash eid target nil))}}}]})
+                               (trash eid target nil))}}}]}))
 
 (define-card "HQ Interface"
   {:in-play [:hq-access 1]})

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -907,8 +907,8 @@
 (define-card "Hippo"
   (letfn [(build-hippo-pred [outermost-ices]
     (fn [events]
-      (or (map #(and (same-card? % (first events))
-                     (every? :broken (:subroutines (first events)))) outermost-ices))))]
+      (not (empty? (filter #(true? %) (map #(and (same-card? % (first events))
+                                                 (every? :broken (:subroutines (first events)))) outermost-ices))))))]
   {:events [{:event :subroutines-broken
              :optional
               {:req (req (let [servers (->> (:corp @state) :servers seq flatten)

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -1753,7 +1753,34 @@
       (click-prompt state :runner "End the run")
       (click-prompt state :runner "Yes")
       (run-continue state)
-      (is (= 1 (get-counters (get-program state 0) :power)) "Nfr gains 1 counter"))))
+      (is (= 1 (get-counters (get-program state 0) :power)) "Nfr gains 1 counter")))
+  (testing "Can't be used after first ice on another server. Issue #4970"
+    (do-game
+      (new-game {:corp {:hand ["Ice Wall" "Vanilla"]}
+                 :runner {:hand ["Corroder" "Hippo"]
+                          :credits 20}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (play-from-hand state :corp "Vanilla" "R&D")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Hippo")
+      (play-from-hand state :runner "Corroder")
+      (run-on state "HQ")
+      (core/rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (is (not-empty (get-hardware state)) "Hippo installed")
+      (is (get-ice state :hq 0) "Ice Wall installed")
+      (card-ability state :runner (get-program state 0) 0)
+      (click-prompt state :runner "End the run")
+      (click-prompt state :runner "No")
+      (is (get-ice state :hq 0) "Ice Wall is not removed")
+      (run-continue state)
+      (run-continue state)
+      (run-on state "R&D")
+      (core/rez state :corp (get-ice state :rd 0))
+      (run-continue state)
+      (card-ability state :runner (get-program state 0) 0)
+      (click-prompt state :runner "End the run")
+      (is (empty? (:prompt (get-runner))) "No Hippo prompt on later ice"))))
 
 (deftest keiko
   ;; Keiko


### PR DESCRIPTION
Closes #4970

Fix and new test.

This PR fixes problem described in original issue. However, there are still situations when hippo will/won't trigger as should according to rules. Only permanent fix (that I can think of) would be setting special flag when runner first breaks all subs on outermost ICE and Hippo strictly checking only this flag and nothing else. Otherwise we have situations like previously broken inner ice becoming outermost during runner turn, outermost ice being trashed, etc.