### PR TITLE
Experimental Muertos uninstall fix

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1563,19 +1563,23 @@
                                          card nil)))}]})
 
 (define-card "Muertos Gang Member"
-  {:effect (effect (continue-ability
-                     :corp
+  {:effect (req (show-wait-prompt state :runner "Corp to select a card to derez")
+                   (continue-ability
+                     state :corp
                      {:prompt "Select a card to derez"
                       :choices {:card #(and (corp? %)
                                             (not (agenda? %))
                                             (:rezzed %))}
-                      :effect (effect (derez target))}
+                      :effect (effect (clear-wait-prompt :runner)
+                                      (derez target))}
                      card nil))
-   :leave-play (effect (continue-ability
-                         :corp
+   :uninstall (req (show-wait-prompt state :runner "Corp to select a card to rez")
+                      (continue-ability
+                         state :corp
                          {:prompt "Select a card to rez, ignoring the rez cost"
                           :choices {:card (complement rezzed?)}
-                          :effect (effect (rez target {:ignore-cost :rez-cost :no-msg true})
+                          :effect (effect (clear-wait-prompt :runner)
+                                          (rez target {:ignore-cost :rez-cost :no-msg true})
                                           (system-say (str (:title card) " allows the Corp to rez " (:title target) " at no cost")))}
                          card nil))
    :abilities [{:msg "draw 1 card"

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -129,7 +129,8 @@
                    (not (facedown? c)))
             (deactivate state side c to-facedown)
             c)
-        c (if from-installed
+        c (if (and from-installed
+                   (not (facedown? c))) 
             (uninstall state side c)
             c)
         c (if to-installed


### PR DESCRIPTION
Closes #4532

Introduces new thing `:uninstall`. 

Current `leave-play` is used to disable constant effects or to reverse gains/loses from cards. 
We trigger `leave-play` whenever card leaves play OR when is being disabled by some other effect (Dr. Lovegood).
We need to trigger `leave-play` ability on Muertos Gang Member only when uninstalled, not when disabled.  
I have added new keyword `:uninstall` which will trigger only when card is really leaving play. (at least I hope so)

I'm very open to other suggestions, because it seems like overkill to add whole new keyword just for one card. 