### PR TITLE
Always call get-card on trashed cards

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2388,7 +2388,7 @@
                 :msg (msg "install " (:title target) ", lowering its install cost by 1 [Credits]. "
                           (join ", " (map :title (remove-once #(same-card? % target) (:hosted card))))
                           " are trashed as a result")
-                :effect (req (let [card (update-in card [:hosted] (fn [coll] (remove-once #(same-card? % target) coll)))]
+                :effect (req (let [card (update! state side (update card :hosted (fn [coll] (remove-once #(same-card? % target) coll))))]
                                (wait-for (trash state side card {:cause :ability-cost})
                                          (runner-install state side (assoc eid :source card :source-type :runner-install)
                                                          (dissoc target :facedown) {:cost-bonus -1}))))}]})

--- a/src/clj/game/core/cards.clj
+++ b/src/clj/game/core/cards.clj
@@ -45,7 +45,8 @@
       card)
 
     host
-    (update-hosted! state side card)
+    (do (update-hosted! state side card)
+        (get-card state card))
 
     :else
     (let [z (cons (to-keyword (or (get-scoring-owner state card) (:side card))) zone)

--- a/src/clj/game/core/trashing.clj
+++ b/src/clj/game/core/trashing.clj
@@ -81,9 +81,8 @@
   ([state side eid cards {:keys [cause keep-server-alive host-trashed game-trash] :as args}]
    (let [num-cards (< 1 (count cards))]
      (letfn [(get-card? [s c]
-               ;; Holdover from old code. Should be `get-card` in all cases, but that
-               ;; requires fixing a bunch of cards and there's not been time yet.
-               (if num-cards (get-card s c) c))
+               (when-let [card (get-card s c)]
+                 (assoc card :seen (:seen c))))
              (preventrec [cs]
                (if (seq cs)
                  (wait-for (prevent-trash state side (get-card? state (first cs)) eid args)


### PR DESCRIPTION
Instead of #5242, here's a more general fix for the underlying problem: We should be getting the latest version of the card when trashing. This wrecks our ability to set `:seen` on a card when trashing it, so carrying that forward onto the `get-card` version is best. Also, turns out `update!` wasn't returning the updated card if it was hosted, because of how `update-hosted` works. And Street Peddler needed to be `update!`d before finishing the ability.

Closes #4997 