### PR TITLE
DBS and TCA now print the position of the bottomed card #4996

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -532,7 +532,7 @@
                                                    :all true}
                                          :effect (req (doseq [c (reverse targets)]
                                                         (system-msg state side (str "uses Daily Business Show to add the "
-                                                                                    (pprint/cl-format nil "~:R" (+ 1 (first (keep-indexed #(when (same-card? c %2) %1) drawn))))
+                                                                                    (pprint/cl-format nil "~:R" (inc (first (keep-indexed #(when (same-card? c %2) %1) drawn))))
                                                                                     " card drawn to the bottom of R&D"))
                                                         (move state side c :deck)))}
                                         card targets)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2,6 +2,7 @@
   (:require [game.core :refer :all]
             [game.utils :refer :all]
             [jinteki.utils :refer :all]
+            [clojure.pprint :as pprint]
             [clojure.string :as string]))
 
 ;;; Asset-specific helpers
@@ -530,9 +531,9 @@
                                                    :card #(some (fn [c] (same-card? c %)) drawn)
                                                    :all true}
                                          :effect (req (doseq [c (reverse targets)]
-                                                        (system-msg state side (str "uses Daily Business Show to add card "
-                                                                                    (+ (first (keep-indexed #(when (same-card? c %2) %1) drawn)) 1)
-                                                                                    " to the bottom of R&D"))
+                                                        (system-msg state side (str "uses Daily Business Show to add the "
+                                                                                    (pprint/cl-format nil "~:R" (+ 1 (first (keep-indexed #(when (same-card? c %2) %1) drawn))))
+                                                                                    " card drawn to the bottom of R&D"))
                                                         (move state side c :deck)))}
                                         card targets)
                                       (clear-wait-prompt state :runner)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -526,11 +526,13 @@
                             (wait-for (resolve-ability
                                         state side
                                         {:prompt (str "Select " (quantify dbs "card") " to add to the bottom of R&D")
-                                         :msg (msg "add " (quantify dbs "card") " to the bottom of R&D")
                                          :choices {:max dbs
                                                    :card #(some (fn [c] (same-card? c %)) drawn)
                                                    :all true}
                                          :effect (req (doseq [c (reverse targets)]
+                                                        (system-msg state side (str "uses Daily Business Show to add card "
+                                                                                    (+ (first (keep-indexed #(when (same-card? c %2) %1) drawn)) 1)
+                                                                                    " to the bottom of R&D"))
                                                         (move state side c :deck)))}
                                         card targets)
                                       (clear-wait-prompt state :runner)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2,6 +2,7 @@
   (:require [game.core :refer :all]
             [game.utils :refer :all]
             [jinteki.utils :refer :all]
+            [clojure.pprint :as pprint]
             [clojure.string :as string]))
 
 (defn- genetics-trigger?
@@ -2601,9 +2602,9 @@
                                    :prompt "Select 1 card to add to the bottom of the stack"
                                    :choices to-draw
                                    :effect (effect (move target :deck)
-                                                   (system-msg (str "uses The Class Act to add card "
-                                                                    (+ 1 (first (keep-indexed #(when (same-card? target %2) %1) to-draw)))
-                                                                    " to the bottom of the Stack"))
+                                                   (system-msg (str "uses The Class Act to add the "
+                                                                    (pprint/cl-format nil "~:R" (+ 1 (first (keep-indexed #(when (same-card? target %2) %1) to-draw))))
+                                                                    " card drawn to the bottom of the Stack"))
                                                    (clear-wait-prompt :corp)
                                                    (effect-completed eid))}
                                   card nil))))}]}))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2603,7 +2603,7 @@
                                    :choices to-draw
                                    :effect (effect (move target :deck)
                                                    (system-msg (str "uses The Class Act to add the "
-                                                                    (pprint/cl-format nil "~:R" (+ 1 (first (keep-indexed #(when (same-card? target %2) %1) to-draw))))
+                                                                    (pprint/cl-format nil "~:R" (inc (first (keep-indexed #(when (same-card? target %2) %1) to-draw))))
                                                                     " card drawn to the bottom of the Stack"))
                                                    (clear-wait-prompt :corp)
                                                    (effect-completed eid))}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2599,9 +2599,11 @@
                                   state :runner
                                   {:async true
                                    :prompt "Select 1 card to add to the bottom of the stack"
-                                   :msg "add 1 card to the bottom of the Stack"
                                    :choices to-draw
                                    :effect (effect (move target :deck)
+                                                   (system-msg (str "uses The Class Act to add card "
+                                                                    (+ 1 (first (keep-indexed #(when (same-card? target %2) %1) to-draw)))
+                                                                    " to the bottom of the Stack"))
                                                    (clear-wait-prompt :corp)
                                                    (effect-completed eid))}
                                   card nil))))}]}))


### PR DESCRIPTION
To address #4996 

Not sure if the text is OK or if the full text for the position might be preferred, e.g. instead of
"uses Daily Business Show to add card 2 to the bottom of R&D"
perhaps
"uses Daily Business Show to add the second card to the bottom of R&D"
would be better?

Also, does this need a test or is just a text change OK?