### PR TITLE
Divide and Conquer fix

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -777,7 +777,8 @@
    :effect (effect (make-run eid :archives nil card))
    :events [{:event :end-access-phase
              :async true
-             :req (req (= :archives (:from-server target)))
+             :req (req (and (= :archives (:from-server target))
+                            (get-in @state [:run :successful])))
              :effect (req (wait-for (do-access state side [:hq] {:no-root true})
                                     (do-access state side eid [:rd] {:no-root true})))}]})
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -778,7 +778,7 @@
    :events [{:event :end-access-phase
              :async true
              :req (req (and (= :archives (:from-server target))
-                            (get-in @state [:run :successful])))
+                            (:successful run)))
              :effect (req (wait-for (do-access state side [:hq] {:no-root true})
                                     (do-access state side eid [:rd] {:no-root true})))}]})
 

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1589,7 +1589,18 @@
       (is (seq (:prompt (get-runner))) "Even with no cards in Archives, there's a prompt for accessing R&D")
       (click-prompt state :runner "Steal")
       (is (seq (:prompt (get-runner))) "Even with no cards in Archives, there's a prompt for accessing HQ")
-      (click-prompt state :runner "Steal"))))
+      (click-prompt state :runner "Steal")))
+  (testing "interaction with Crisium Grid on archives. Issue #5315"
+    (do-game
+     (new-game {:corp {:deck ["Hostile Takeover"]
+                       :hand ["Hostile Takeover" "Crisium Grid"]}
+                :runner {:hand ["Divide and Conquer"]}})
+     (play-from-hand state :corp "Crisium Grid" "Archives")
+     (rez state :corp (get-content state :archives 0))
+     (take-credits state :corp)
+     (play-run-event state "Divide and Conquer" :archives)
+     (click-prompt state :runner "No action")
+     (is (empty? (:prompt (get-runner))) "There's no prompt for accessing R&D"))))
 
 (deftest drive-by
   ;; Drive By - Expose card in remote server and trash if asset or upgrade


### PR DESCRIPTION
Closes #5315 

Fix and new test.

Divide and Conquer is only card that triggers in `end-access-phase` and requires `successful run`.