### PR TITLE
Fix keep hand always mulliganing

### DIFF
--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -68,7 +68,7 @@
     (when (-> @state side :identity :title)
       (show-prompt state side nil "Keep hand?"
                    ["Keep" "Mulligan"]
-                   #(if (= % "Keep")
+                   #(if (= (:value %) "Keep")
                       (keep-hand state side nil)
                       (mulligan state side nil))
                    {:prompt-type :mulligan})))


### PR DESCRIPTION
Caused by commit b5f84f4972dd0eab0e09dbd77f8401331ee235b7, missed a conversion of the prompt to use the full object instead