### PR TITLE
Fix spectator chat

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -109,22 +109,22 @@
   (defn reset-send-lobby
     []
     (let [[old] (reset-vals! send-ready true)]
-      (if-not old (send-lobby)))))
+      (when-not old (send-lobby)))))
 
 (defn player?
   "True if the given client-id is a player in the given game"
   [client-id game]
-    (some #(when (= client-id (:ws-id %)) %) (:players game)))
+  (some #(when (= client-id (:ws-id %)) %) (:players game)))
 
 (defn first-player?
   "True if the given client-id is the first player in the given game"
   [client-id game]
-    (= client-id (-> game :players first :ws-id)))
+  (= client-id (-> game :players first :ws-id)))
 
 (defn spectator?
   "True if the given client-id is a spectator in the given game"
   [client-id game]
-    (some #(when (= client-id (:ws-id %)) %) (:spectators game)))
+  (some #(when (= client-id (:ws-id %)) %) (:spectators game)))
 
 (defn player-or-spectator
   "True if the given client-id is a player or spectator in the given game"

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -112,29 +112,26 @@
       (if-not old (send-lobby)))))
 
 (defn player?
-  "True if the given client-id is a player in the given gameid"
-  [client-id gameid]
-  (when-let [game (game-for-id gameid)]
-    (some #(when (= client-id (:ws-id %)) %) (:players game))))
+  "True if the given client-id is a player in the given game"
+  [client-id game]
+    (some #(when (= client-id (:ws-id %)) %) (:players game)))
 
 (defn first-player?
-  "True if the given client-id is the first player in the given gameid"
-  [client-id gameid]
-  (when-let [game (game-for-id gameid)]
-    (= client-id (-> game :players first :ws-id))))
+  "True if the given client-id is the first player in the given game"
+  [client-id game]
+    (= client-id (-> game :players first :ws-id)))
 
 (defn spectator?
-  "True if the given client-id is a spectator in the given gameid"
-  [client-id gameid]
-  (when-let [game (game-for-id gameid)]
-    (not (some #(when (= client-id (:ws-id %)) %) (:players game))))) ; Faster to check players than to check spectators
+  "True if the given client-id is a spectator in the given game"
+  [client-id game]
+    (some #(when (= client-id (:ws-id %)) %) (:spectators game)))
 
 (defn player-or-spectator
-  "True if the given client-id is a player or spectator in the given gameid"
+  "True if the given client-id is a player or spectator in the given game"
   [client-id gameid]
   (when-let [game (game-for-id gameid)]
-    (or (player? client-id gameid)
-        (spectator? client-id gameid))))
+    (or (player? client-id game)
+        (spectator? client-id game))))
 
 (defn close-lobby
   "Closes the given game lobby, booting all players and updating stats."
@@ -170,10 +167,9 @@
   Deletes the game from the lobby if all players have left."
   [client-id gameid]
   (when-let [{:keys [players started state] :as game} (game-for-id gameid)]
-    (cond (player? client-id gameid)
+    (cond (player? client-id game)
           (swap! all-games update-in [gameid :players] #(remove-once (fn [p] (= client-id (:ws-id p))) %))
-
-          (spectator? client-id gameid)
+          (spectator? client-id game)
           (do 
             (refresh-lobby-update-in gameid [:spectator-count] dec)
             (refresh-lobby-update-in gameid [:spectators] #(remove-once (fn [p] (= client-id (:ws-id p))) %))))
@@ -376,7 +372,7 @@
                    (update-in d [:identity] #(@all-cards (:title %)))
                    (assoc d :status (calculate-deck-status d)))]
     (when (and (:identity deck)
-               (player? client-id gameid))
+               (player? client-id game))
       (refresh-lobby-assoc-in gameid [:players first-player :deck] deck))))
 
 (defn handle-rename-game


### PR DESCRIPTION
In one of my other commits I mistakenly thought spectator? returned a boolean. Turns out, it is relied upon to return the actual user, so the spectator chat stopped working. I also cleaned up the functions to take a game object, since that is just as easy to pass as the game id and results in one less call in all those functions.