### PR TITLE
Fix private lobbies

### DIFF
--- a/src/clj/web/diffs.clj
+++ b/src/clj/web/diffs.clj
@@ -29,6 +29,7 @@
   [full-game game-update]
     (-> game-update
         (dissoc :state :last-update :on-close)
+        (update-if-contains :password (fn [_] true))
         (update-if-contains :players #(map (partial user-public-view full-game) %))
         (update-if-contains :original-players #(map (partial user-public-view full-game) %))
         (update-if-contains :spectators #(map (partial user-public-view full-game) %))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -49,7 +49,7 @@
       game-lobby-updates (atom {})
       send-ready (atom true)]
 
-  (def lobby-only-keys [:messages :spectators :mute-spectators :password :spectatorhands])
+  (def lobby-only-keys [:messages :spectators :mute-spectators :spectatorhands])
 
   (defn game-public-view
     "Strips private server information from a game map, preparing to send the game to clients."
@@ -92,7 +92,7 @@
 
   (defn refresh-lobby-assoc-in
     [gameid targets val]
-    (refresh-lobby-update-in gameid targets (fn [n] val)))
+    (refresh-lobby-update-in gameid targets (fn [_] val)))
 
   (defn refresh-lobby-dissoc
     [gameid]

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -43,7 +43,7 @@
                       (let [password (:password password-game password)
                             input-password (:password @s)]
                         (cond
-                          (empty? password)
+                          (not password)
                           (join-game (if password-game (:gameid password-game) gameid) s action nil)
                           input-password
                           (join-game (if password-game (:gameid password-game) gameid) s action input-password)
@@ -82,7 +82,7 @@
          :class (when (or (:isadmin user)
                           (:ismoderator user))
                   "clickable")}
-        (str (when-not (empty? (:password game))
+        (str (when (:password game)
                "[PRIVATE] ")
              (:title game)
              (when (pos? c)

--- a/src/cljs/nr/player_view.cljs
+++ b/src/cljs/nr/player_view.cljs
@@ -22,7 +22,7 @@
    [:span.player
     [avatar (:user player) {:opts {:size 22}}]
     [user-status-span player]
-    (when (empty? (:password game))
+    (when (not (:password game))
       (let [side (:side player)
             faction (:faction (:identity (:deck player)))
             identity (:title (:identity (:deck player)))


### PR DESCRIPTION
The password parameter was no longer shared and therefore the lobbies not able to be joined. Now the client wont know the hash, but will know it is a protected lobby.