### PR TITLE
Consistent rejoin, join and watch states

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -61,7 +61,7 @@
     (reset! last-state @game-state)
     (reset! lock false)))
 
-(defn launch-game [{:keys [state]}]
+(defn launch-game [state]
   (init-game state)
   (set! (.-onbeforeunload js/window) #(clj->js "Leaving this page will disconnect you from the game."))
   (-> "#gamelobby" js/$ .fadeOut)
@@ -87,8 +87,6 @@
                 (get-in @last-state aid))
       (reset! lock false))))
 
-(defn handle-state [{:keys [state]}] (init-game state))
-
 (defn handle-diff [{:keys [gameid diff]}]
   (when (= gameid (:gameid @game-state))
     (swap! game-state #(differ/patch @last-state diff))
@@ -102,7 +100,7 @@
 (defn parse-state [state]
   (js->clj (.parse js/JSON state) :keywordize-keys true))
 
-(ws/register-ws-handler! :netrunner/state #(handle-state (parse-state %)))
+(ws/register-ws-handler! :netrunner/state #(init-game (parse-state %)))
 (ws/register-ws-handler! :netrunner/start #(launch-game (parse-state %)))
 (ws/register-ws-handler! :netrunner/diff #(handle-diff (parse-state %)))
 (ws/register-ws-handler! :netrunner/timeout #(handle-timeout (parse-state %)))

--- a/test/clj/game/core/set_up_test.clj
+++ b/test/clj/game/core/set_up_test.clj
@@ -27,7 +27,9 @@
         (new-game setup)
         (let [corp-hand (:hand (get-corp))]
           (click-prompt state :corp "Mulligan")
+          (is (not (identical? corp-hand (:hand (get-corp)))))
           (is (last-log-contains? state "Corp takes a mulligan")))
         (let [runner-hand (:hand (get-runner))]
           (click-prompt state :runner "Mulligan")
+          (is (not (identical? runner-hand (:hand (get-runner)))))
           (is (last-log-contains? state "Runner takes a mulligan")))))))


### PR DESCRIPTION
In my websocket cleanup commit, I removed some duplicate information being sent in the rejoin, turns out the client wasnt parsing the lobby/select state updates at all so rejoins are now broken. I have fixed the lobby/select message to correctly update the state and cleaned up some unnecessary params that were being sent.

When a user was removed from the game, the state was updated without notifying clients (in remove-users), preventing rejoins until the client was refreshed. This is now fixed to properly notify clients.

I also went through and made sure that the client full state update is sent before any of the diffs for watch, rejoin and join. This prevents the client receiving a game diff before they have received any state to diff against.