### PR TITLE
Fix Tollbooth encounter message

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3119,9 +3119,9 @@
   {:on-encounter {:async true
                   :effect (req (wait-for (pay state :runner card [:credit 3])
                                          (if (:cost-paid async-result)
-                                           (do (system-msg state :corp "uses Tollbooth to force the Runner to pay 3 [Credits]")
+                                           (do (system-msg state :runner (str (:msg async-result) " when encountering Tollbooth"))
                                                (effect-completed state side eid))
-                                           (do (system-msg state :corp "uses Tollbooth to end the run as the Runner can't pay 3 [Credits]")
+                                           (do (system-msg state :runner "ends the run, as the Runner can't pay 3 [Credits] when encountering Tollbooth")
                                                (end-run state :corp eid card)))))}
    :subroutines [end-the-run]})
 

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3118,8 +3118,8 @@
 (defcard "Tollbooth"
   {:on-encounter {:async true
                   :effect (req (wait-for (pay state :runner card [:credit 3])
-                                         (if-let [payment-str (:msg async-result)]
-                                           (do (system-msg state :corp "uses Tollbooth to force the Runner to " payment-str)
+                                         (if (:cost-paid async-result)
+                                           (do (system-msg state :corp "uses Tollbooth to force the Runner to pay 3 [Credits]")
                                                (effect-completed state side eid))
                                            (do (system-msg state :corp "uses Tollbooth to end the run as the Runner can't pay 3 [Credits]")
                                                (end-run state :corp eid card)))))}


### PR DESCRIPTION
Original bug was that the entire message needed to be wrapped in a `str`, but the pay message is `pays 3 [Credits]`, which doesn't make sense for the log message.

So now we check if the price was paid and generate a hardcoded message.

Closes #5377 