### PR TITLE
Fix crash in Net Mercur when firing ability

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1668,8 +1668,8 @@
                 :async true
                 :req (req (pos? (get-counters (get-card state card) :credit)))
                 :effect (req (add-counter state side card :credit -1)
-                             (wait-for (gain-credits state side eid 1)
-                                       (trigger-event-sync state side (make-eid state eid) :spent-credits-from-card card)))}]
+                             (wait-for (gain-credits state side (make-eid state eid) 1)
+                                       (trigger-event-sync state side eid :spent-credits-from-card card)))}]
    :events [{:event :spent-credits-from-card
              :req (req (and (:run @state)
                             (has-subtype? target "Stealth")))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1666,9 +1666,10 @@
 (defcard "Net Mercur"
   {:abilities [{:msg "gain 1 [Credits]"
                 :async true
+                :req (req (pos? (get-counters (get-card state card) :credit)))
                 :effect (req (add-counter state side card :credit -1)
                              (wait-for (gain-credits state side eid 1)
-                                       (trigger-event-sync state side eid :spent-credits-from-card card)))}]
+                                       (trigger-event-sync state side (make-eid state eid) :spent-credits-from-card card)))}]
    :events [{:event :spent-credits-from-card
              :req (req (and (:run @state)
                             (has-subtype? target "Stealth")))

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2947,6 +2947,8 @@
       (let [sil (get-hardware state 0)
             nm (get-resource state 0)
             gr (get-resource state 1)]
+        (card-ability state :runner nm 0)
+        (is (empty? (:prompt (get-runner))) "Net Mercur doesn't stack overflow if you click on it")
         (card-ability state :runner gr 0)
         (is (empty? (:prompt (get-runner))) "No Net Mercur prompt from stealth spent outside of run")
         (run-on state :hq)


### PR DESCRIPTION
Was causing a stack overflow loop on `trigger-event-sync`