### PR TITLE
Fix Grappling Hook crash

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1321,18 +1321,14 @@
                                                    (remove #(= (:index %) (:index target))))]
                               (break-subroutines-msg current-ice broken-subs card)))
                   :async true
-                  :effect (req (let [subroutines (:subroutines current-ice)
-                                     available (filter #(and (not (:broken %))
-                                                            (= target (make-label (:sub-effect %))))
-                                                      subroutines)
-                                     selected (nth available (:idx (first targets)))]
-                                 (let [subs-to-break (remove #(= (:index %) (:index selected)) subroutines)]
-                                   (break-subs state current-ice subs-to-break)
-                                   (let [ice (get-card state current-ice)
-                                         on-break-subs (when ice (:on-break-subs (card-def ice)))
-                                         event-args (when on-break-subs {:card-abilities (ability-as-handler ice on-break-subs)})]
-                                     (wait-for (trigger-event-simult state side :subroutines-broken event-args ice subs-to-break)
-                                               (effect-completed state side eid))))))}]}))
+                  :effect (req (let [selected (:idx (first targets))
+                                     subs-to-break (remove #(= (:index %) selected) (:subroutines current-ice))]
+                                 (break-subs state current-ice subs-to-break)
+                                 (let [ice (get-card state current-ice)
+                                       on-break-subs (when ice (:on-break-subs (card-def ice)))
+                                       event-args (when on-break-subs {:card-abilities (ability-as-handler ice on-break-subs)})]
+                                   (wait-for (trigger-event-simult state side :subroutines-broken event-args ice subs-to-break)
+                                             (effect-completed state side eid)))))}]}))
 
 (defcard "Gravedigger"
   (let [e {:req (req (and (installed? (:card target))

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2210,6 +2210,23 @@
         (card-ability state :runner gh2 0)
         (is (empty? (:prompt (get-runner))) "No break prompt as Little Engine has more than 1 broken sub")
         (is (refresh gh2) "Grappling Hook isn't trashed"))))
+  (testing "Interaction with Fairchild 3.0"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Fairchild 3.0"]
+                        :credits 6}
+                 :runner {:hand ["Grappling Hook"] }})
+      (play-from-hand state :corp "Fairchild 3.0" "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Grappling Hook")
+      (run-on state "HQ")
+      (run-continue state)
+      (card-ability state :runner (get-program state 0) 0)
+      (click-prompt state :runner "Do 1 brain damage or end the run")
+      (is (= 1 (count (remove :broken (:subroutines (get-ice state :hq 0))))) "Broke all but one subroutine")
+      (is (= "Do 1 brain damage or end the run" (:label (first (remove :broken (:subroutines (get-ice state :hq 0)))))) "Broke all but selected sub")
+      (is (nil? (refresh (get-program state 0))) "Grappling Hook is now trashed")))
   (testing "interaction with News Hound #4988"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]


### PR DESCRIPTION
Our tests for Grappling Hook were only checking cards that had enough duplicated subs for the `nth` call to succeed. Fairchild 3.0 doesn't fit that model and was causing a crash.