### PR TITLE
Allow non-ascii chars in deck names

### DIFF
--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -34,6 +34,10 @@
              :status status
              :hash deck-hash)))
 
+(defn make-salt
+  [deck-name]
+  (byte-array (map byte (slugify deck-name))))
+
 (defn hash-deck
   [deck]
   (let [check-deck (-> deck
@@ -44,7 +48,7 @@
         decklist (s/join (for [entry sorted-cards]
                            (str (:qty entry) (:code (:card entry)))))
         deckstr (str id decklist)
-        salt (byte-array (map byte (slugify (:name deck))))]
+        salt (make-salt (:name deck))]
     (last (s/split (pbkdf2/encrypt deckstr 100000 "HMAC-SHA1" salt) #"\$"))))
 
 (defn decks-create-handler [{{username :username} :user

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -7,6 +7,7 @@
             [web.config :refer [server-config]]
             [crypto.password.pbkdf2 :as pbkdf2]
             [jinteki.cards :refer [all-cards]]
+            [jinteki.utils :refer [slugify]]
             [jinteki.validator :refer [calculate-deck-status]]))
 
 
@@ -43,7 +44,7 @@
         decklist (s/join (for [entry sorted-cards]
                            (str (:qty entry) (:code (:card entry)))))
         deckstr (str id decklist)
-        salt (byte-array (map byte (:name deck)))]
+        salt (byte-array (map byte (slugify (:name deck))))]
     (last (s/split (pbkdf2/encrypt deckstr 100000 "HMAC-SHA1" salt) #"\$"))))
 
 (defn decks-create-handler [{{username :username} :user

--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -94,8 +94,14 @@
 
 (defn decks-delete-handler [{{username :username} :user
                              {id :id}             :params}]
-  (if (and username id)
-    (if (acknowledged? (mc/remove db "decks" {:_id (object-id id) :username username}))
-      (response 200 {:message "Deleted"})
-      (response 403 {:message "Forbidden"}))
-    (response 401 {:message "Unauthorized"})))
+  (try
+    (if (and username id)
+      (if (acknowledged? (mc/remove db "decks" {:_id (object-id id) :username username}))
+        (response 200 {:message "Deleted"})
+        (response 403 {:message "Forbidden"}))
+      (response 401 {:message "Unauthorized"}))
+    (catch Exception ex
+      (.printStackTrace ex)
+      (println "Deck delete failure: User:" username ", Deck ID:", id)
+      (println "Known decks:" (map #(select-keys % [:_id :date :name]) (mc/find-maps db "decks" {:username username})))
+      (response 409 {:message "Unknown deck id"}))))

--- a/test/clj/game/web/deck_test.clj
+++ b/test/clj/game/web/deck_test.clj
@@ -1,0 +1,11 @@
+(ns game.web.deck-test
+  (:require [web.decks :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest hash-salt
+  (testing "Generate salt for hash from unicode string"
+    (let [unicode-string "Hüsker Dü Аквариум"
+          ascii-string "Test Deck"]
+      (is (java.util.Arrays/equals (make-salt unicode-string) (make-salt unicode-string)) "Unicode string salts match")
+      (is (java.util.Arrays/equals (make-salt ascii-string) (make-salt ascii-string)) "Ascii string salts match")
+      (is (not (java.util.Arrays/equals (make-salt ascii-string) (make-salt unicode-string))) "Ascii and unicode salts don't match"))))


### PR DESCRIPTION
When computing the salt for a deck hash, non-ascii characters in the deck name will make `byte` throw a `java.lang.IllegalArgumentException`.

Using `slugify` to make the deckname all printable ascii.

No idea how to test this.