### PR TITLE
Deck lists support all unicode titles

### DIFF
--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -36,7 +36,8 @@
 
 (defn make-salt
   [deck-name]
-  (byte-array (map byte (slugify deck-name))))
+  (let [salt (byte-array (map byte (slugify deck-name)))]
+    (if (empty? salt) (byte-array (map byte "default-salt")) salt)))
 
 (defn hash-deck
   [deck]

--- a/test/clj/game/web/deck_test.clj
+++ b/test/clj/game/web/deck_test.clj
@@ -5,7 +5,9 @@
 (deftest hash-salt
   (testing "Generate salt for hash from unicode string"
     (let [unicode-string "Hüsker Dü Аквариум"
+          all-unicode-string "😀😀😀"
           ascii-string "Test Deck"]
       (is (java.util.Arrays/equals (make-salt unicode-string) (make-salt unicode-string)) "Unicode string salts match")
+      (is (java.util.Arrays/equals (make-salt all-unicode-string) (make-salt all-unicode-string)) "Unicode string salts match")
       (is (java.util.Arrays/equals (make-salt ascii-string) (make-salt ascii-string)) "Ascii string salts match")
       (is (not (java.util.Arrays/equals (make-salt ascii-string) (make-salt unicode-string))) "Ascii and unicode salts don't match"))))


### PR DESCRIPTION
Deck lists consisting solely of unicode characters was generating an empty string, which isn't a valid salt for the hash.