### PR TITLE
Don't display canceled decks

### DIFF
--- a/src/clj/web/decks.clj
+++ b/src/clj/web/decks.clj
@@ -101,7 +101,5 @@
         (response 403 {:message "Forbidden"}))
       (response 401 {:message "Unauthorized"}))
     (catch Exception ex
-      (.printStackTrace ex)
-      (println "Deck delete failure: User:" username ", Deck ID:", id)
-      (println "Known decks:" (map #(select-keys % [:_id :date :name]) (mc/find-maps db "decks" {:username username})))
+      ;; Deleting a deck that was never saved throws an exception
       (response 409 {:message "Unknown deck id"}))))

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -236,8 +236,12 @@
   (-> (:viewport @db-dom) js/$ (.removeClass "edit")))
 
 (defn cancel-edit [s]
-  (end-edit s)
-  (put! select-channel (:old-deck @s)))
+  (let [deck (:deck @s)
+        decks (remove #(= (:_id deck) (:_id %)) (:decks @app-state))
+        selected (or (:old-deck @s) (first decks))]
+    (end-edit s)
+    (load-decks decks)
+    (put! select-channel selected)))
 
 (defn delete-deck [s]
   (swap! s assoc :delete true)
@@ -796,15 +800,15 @@
      [:span.small "(Type or paste a decklist, it will be parsed)"]]]
    [edit-textbox s]])
 
-(defn collection-buttons [s user]
+(defn collection-buttons [s user decks-loaded]
   [:div.button-bar
-   [cond-button "New Corp deck" @user #(new-deck s "Corp")]
-   [cond-button "New Runner deck" @user #(new-deck s "Runner")]])
+   [cond-button  "New Corp deck" (and @user @decks-loaded) #(new-deck s "Corp")]
+   [cond-button  "New Runner deck" (and @user @decks-loaded) #(new-deck s "Runner")]])
 
 (defn list-panel
   [s user decks decks-loaded]
   [:div.decks
-   [collection-buttons s user]
+   [collection-buttons s user decks-loaded]
    [deck-collection s decks decks-loaded]
    [:div {:class (when (:edit @s) "edit")}
     (when-let [line (:zoom @s)]

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -802,8 +802,8 @@
 
 (defn collection-buttons [s user decks-loaded]
   [:div.button-bar
-   [cond-button  "New Corp deck" (and @user @decks-loaded) #(new-deck s "Corp")]
-   [cond-button  "New Runner deck" (and @user @decks-loaded) #(new-deck s "Runner")]])
+   [cond-button "New Corp deck" (and @user @decks-loaded) #(new-deck s "Corp")]
+   [cond-button "New Runner deck" (and @user @decks-loaded) #(new-deck s "Runner")]])
 
 (defn list-panel
   [s user decks decks-loaded]


### PR DESCRIPTION
Creating a new deck, then canceling before saving, left the deck in your decklist display. Attempting to delete it would generate an exception on the server for an unknown deck id.

Also disabling the deck creation buttons until all decks are loaded; this path could also cause the above behavior.