### PR TITLE
Add version number to chat page

### DIFF
--- a/src/clj/web/pages.clj
+++ b/src/clj/web/pages.clj
@@ -58,6 +58,11 @@
               "ga('send', 'pageview');"]))]))
 
 
+(defn- version-string []
+  (if-let [config (mc/find-one-as-map db "config" nil)]
+      (:version config "0.0")
+      "0.0"))
+
 (defn index-page [req]
   (layout
     req
@@ -74,7 +79,8 @@
         [:div.container
          [:h1 "Play Android: Netrunner in your browser"]
          [:div#news]
-         [:div#chat]]]
+         [:div#chat]]
+        [:div#version [:span (str "Version " (version-string))]]]
        [:div.item
         [:div.cardbrowser-bg]
         [:div#cardbrowser]]

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -851,6 +851,15 @@ nav ul
   button
     margin-right: 0
 
+// Version string on main page
+#version
+  position: absolute
+  bottom: 1px
+  left: 1px
+  span
+    color: gainsboro
+    font-size: smaller
+
 // Card Browser
 .cardbrowser
   display-flex()


### PR DESCRIPTION
Add a discreet version number to the bottom left of the main page. Set from the `/admin/version` endpoint.

![image](https://user-images.githubusercontent.com/47226/100489974-c96dea80-30e5-11eb-87f9-f1b4c5af8e1b.png)

Fixes #5410 
