### PR TITLE
Catch nil client-ids when broadcasting

### DIFF
--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -34,8 +34,9 @@
     ;; To fix, we would want to keep the order of loading correct perhaps by blocking successive go blocks until the previous ones have completed
     (go
       (doseq [client uids]
-        (>! websocket-buffer true) ;; Block if we have recently sent a lot of messages. The data supplied is arbitrary
-        (send! client [event msg])))))
+        (when (some? client)
+          (>! websocket-buffer true) ;; Block if we have recently sent a lot of messages. The data supplied is arbitrary
+          (send! client [event msg]))))))
 
 (defn broadcast!
   "Sends the given event and msg to all connected clients."

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -33,8 +33,8 @@
     ;; TODO in high stress situations, multiple go blocks could be competing. This could result in out of order messages and thus a stale client.
     ;; To fix, we would want to keep the order of loading correct perhaps by blocking successive go blocks until the previous ones have completed
     (go
-      (doseq [client uids]
-        :when (some? client)
+      (doseq [client uids
+              :when (some? client)]
         (>! websocket-buffer true) ;; Block if we have recently sent a lot of messages. The data supplied is arbitrary
         (send! client [event msg])))))
 

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -34,9 +34,9 @@
     ;; To fix, we would want to keep the order of loading correct perhaps by blocking successive go blocks until the previous ones have completed
     (go
       (doseq [client uids]
-        (when (some? client)
-          (>! websocket-buffer true) ;; Block if we have recently sent a lot of messages. The data supplied is arbitrary
-          (send! client [event msg]))))))
+        :when (some? client)
+        (>! websocket-buffer true) ;; Block if we have recently sent a lot of messages. The data supplied is arbitrary
+        (send! client [event msg])))))
 
 (defn broadcast!
   "Sends the given event and msg to all connected clients."


### PR DESCRIPTION
Server log is full of these warnings
```
Exception in thread "async-dispatch-15" java.lang.AssertionError: Assert failed: Support for sending to `nil` user-ids has been REMOVED. Please send to `:sente/all-users-without-uid` instead.
uid
	at taoensso.sente$make_channel_socket_server_BANG_$send_fn__63428.doInvoke(sente.cljc:406)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at web.ws$fn__65440$broadcast_to_BANG___65515$fn__65587$state_machine__56047__auto____65596$fn__65598.invoke(ws.clj:35)
	at web.ws$fn__65440$broadcast_to_BANG___65515$fn__65587$state_machine__56047__auto____65596.invoke(ws.clj:35)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:973)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:972)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:977)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:975)
	at web.ws$fn__65440$broadcast_to_BANG___65515$fn__65587.invoke(ws.clj:35)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Looking into how we are getting `nil` client ids separately.