### PR TITLE
Fix Architect Earth Station interaction according to errata

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -405,8 +405,8 @@
                                  (system-msg state side (str "chooses " target
                                                              " to be saved from the rules apocalypse and trashes "
                                                              (quantify (count to-be-trashed) "card")))
-                                 ; even :unpreventable does not trash Architect
-                                 (trash-cards state side eid to-be-trashed {:unpreventable true})))}
+                                 ; these cards get trashed by the game and not by players
+                                 (trash-cards state side eid to-be-trashed {:unpreventable true :game-trash true})))}
                  card nil))
      :abilities [{:label "Flip identity to Earth Station: Ascending to Orbit"
                   :req (req (not (:flipped card)))

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -226,10 +226,11 @@
   (swap! state update-in [:trash :trash-prevent type] (fnil #(+ % n) 0)))
 
 (defn- prevent-trash-impl
-  [state side eid {:keys [zone type] :as card} oid {:keys [unpreventable cause] :as args}]
+  [state side eid {:keys [zone type] :as card} oid {:keys [unpreventable cause game-trash] :as args}]
   (if (and card (not-any? #{:discard} zone))
     (cond
-      (untrashable-while-rezzed? card)
+      (and (not game-trash)
+           (untrashable-while-rezzed? card))
       (do (enforce-msg state card "cannot be trashed while installed")
           (effect-completed state side eid))
       (and (= side :runner)

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -928,7 +928,7 @@
       (rez state :corp (get-ice state :remote2 0))
       (play-and-score state "Project Atlas")
       (click-prompt state :corp "Server 2")
-      (is (= 0 (count (:discard (get-corp)))) "None of the Architects were trashed")))
+      (is (= 1 (count (:discard (get-corp)))) "One of the Architects was trashed, since it gets trashed by the game and not by players")))
   (testing "Worlds Plaza interaction. Issue #4723"
     (do-game
       (new-game {:corp {:id "Earth Station: SEA Headquarters"


### PR DESCRIPTION
Earth Station now uses `:game-trash`. Closes #4797 