### PR TITLE
Turn card bson ids into strings when creating all-cards

### DIFF
--- a/src/clj/web/core.clj
+++ b/src/clj/web/core.clj
@@ -42,7 +42,8 @@
 (defn load-data []
   (web.db/connect)
   (let [cards (mc/find-maps db "cards" nil)
-        all-cards (into {} (map (juxt :title identity) cards))
+        stripped-cards (map (fn [c] (update c :_id #(str %))) cards)
+        all-cards (into {} (map (juxt :title identity) stripped-cards))
         sets (mc/find-maps db "sets" nil)
         cycles (mc/find-maps db "cycles" nil)
         mwl (mc/find-maps db "mwls" nil)

--- a/src/clj/web/diffs.clj
+++ b/src/clj/web/diffs.clj
@@ -1,24 +1,33 @@
 (ns web.diffs)
 
-(defn user-public-view
+(defn- filter-lobby-user
+  "Only take keys that are useful in the lobby from a user map"
+  [user]
+  (let [options (select-keys (:options user) [:blocked-users])
+        stats (select-keys (:stats user) [:games-started :games-completed])
+        filtered-user (select-keys user [:_id :username :emailhash])]
+    (assoc filtered-user :options options :stats stats)))
+
+(defn- user-public-view
   "Strips private server information from a player map."
   [{:keys [started format]} player]
   (as-> player p
-        (dissoc p :ws-id)
-        (if-let [{:keys [_id] :as deck} (:deck p)]
-          (let [legal (get-in deck [:status (keyword format) :legal])
-                status {:format format
-                        (keyword format) {:legal legal}}
-                deck (-> deck
-                         (select-keys
-                           (if started
-                             [:name :date :identity]
-                             [:name :date]))
-                         (assoc :_id (str _id) :status status))]
-            (assoc p :deck deck))
-          p)))
+    (dissoc p :ws-id)
+    (assoc p :user (filter-lobby-user (:user p)))
+    (if-let [{:keys [_id] :as deck} (:deck p)]
+      (let [legal (get-in deck [:status (keyword format) :legal])
+            status {:format format
+                    (keyword format) {:legal legal}}
+            deck (-> deck
+                     (select-keys
+                       (if started
+                         [:name :date :identity]
+                         [:name :date]))
+                     (assoc :_id (str _id) :status status))]
+        (assoc p :deck deck))
+      p)))
 
-(defn update-if-contains
+(defn- update-if-contains
   [m ks f & args]
   (if (get m ks)
     (apply (partial update m ks f) args)

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -73,7 +73,7 @@
 (defn handle-game-start
   [{{{:keys [username] :as user} :user} :ring-req
     client-id                           :client-id}]
-  (when-let [{:keys [players gameid started messages] :as game} (lobby/game-for-client client-id)]
+  (when-let [{:keys [players gameid started] :as game} (lobby/game-for-client client-id)]
     (when (and (lobby/first-player? client-id game)
                (not started))
       (let [strip-deck (fn [player] (-> player
@@ -147,7 +147,7 @@
           message (if mute-state "muted" "unmuted")]
       (when (lobby/player? client-id game)
         (lobby/refresh-lobby-assoc-in gameid [:mute-spectators] mute-state)
-        (main/handle-notification state (str username " " message " specatators."))
+        (main/handle-notification state (str username " " message " spectators."))
         (swap-and-send-diffs! game)))))
 
 (defn handle-game-action
@@ -179,7 +179,7 @@
   "Handles a watch command when a game has started."
   [{{{:keys [username] :as user} :user} :ring-req
     client-id                           :client-id
-    {:keys [gameid password options]}   :?data
+    {:keys [gameid password]}           :?data
     reply-fn                            :?reply-fn}]
   (if-let [{game-password :password state :state started :started :as game}
            (lobby/game-for-id gameid)]

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -18,8 +18,7 @@
                       "watch" :lobby/watch
                       "rejoin" :netrunner/rejoin)
                     {:gameid gameid
-                     :password password
-                     :options (:options @app-state)}]
+                     :password password}]
                    8000
                    #(if (sente/cb-success? %)
                       (case %

--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -130,10 +130,8 @@
         :else
         (do (swap! s assoc :editing false)
             (ws/ws-send! [:lobby/create
-                          (assoc
                           (select-keys @s [:title :password :allow-spectator
-                                           :spectatorhands :side :format :room])
-                          :options (:options @app-state))]))))))
+                                           :spectatorhands :side :format :room])]))))))
 
 (defn leave-lobby [s]
   (ws/ws-send! [:lobby/leave])


### PR DESCRIPTION
Sometimes the bson `_id` for a deck identity was making it through the websocket and causing an exception on the client.

Fixes #5454 