### PR TITLE
Replace regex queries with case insensitive queries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [org.clojure/core.async "0.3.443"]
                  [cheshire "5.6.3"]
                  [stylefruits/gniazdo "1.1.4"]
-                 [danhut/monger "3.1.0"]
+                 [com.novemberain/monger "3.5.0"]
                  [differ "0.3.3"]
                  [com.taoensso/sente "1.16.0"]
                  [ring "1.7.1"]
@@ -59,7 +59,8 @@
             "load-test" ["run" "-m" "tasks.load-test/command"]
             "delete-duplicate-users" ["run" "-m" "tasks.db/delete-duplicate-users"]
             "update-all-decks" ["run" "-m" "tasks.db/update-all-decks"]
-            "card-coverage" ["run" "-m" "tasks.cards/test-coverage"]}
+            "card-coverage" ["run" "-m" "tasks.cards/test-coverage"]
+            "create-indexes" ["run" "-m" "tasks.db/create-indexes"]}
 
   ;; Compilation.
   :source-paths ["src/clj" "src/cljs/nr" "src/cljc"]

--- a/src/clj/tasks/db.clj
+++ b/src/clj/tasks/db.clj
@@ -74,3 +74,22 @@
                          (println "Delete duplicate users failed" (.getMessage e))
                          (.printStackTrace e)))
     (finally (webdb/disconnect))))
+
+(defn create-indexes
+  "Create case insensitive indexes on `username` and `email` in the \"users\" collection.
+
+  `create-indexes` can safely be executed multiple times, as long as the
+  existing indexes don't conflict with the ones created here."
+  []
+  (webdb/connect)
+  (try
+    (let [case-insensitive-index-opts {:collation {:locale "en" :strength (int 2)}}]
+      (mc/create-index db "users" (array-map :username 1) case-insensitive-index-opts)
+      (mc/create-index db "users" (array-map :email 1) case-insensitive-index-opts)
+      (println "Indexes successfully created.\n")
+      (println "All current indexes on \"users\":")
+      (clojure.pprint/pprint (mc/indexes-on db "users")))
+    (catch Exception e (do
+                         (println "Create indexes failed" (.getMessage e))
+                         (.printStackTrace e)))
+    (finally (webdb/disconnect))))

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -1,6 +1,6 @@
 (ns web.auth
   (:require [web.config :refer [server-config]]
-            [web.db :refer [db object-id]]
+            [web.db :refer [db find-one-as-map-case-insensitive object-id]]
             [web.utils :refer [response md5]]
             [aero.core :refer [read-config]]
             [clj-time.core :refer [days from-now]]
@@ -73,10 +73,10 @@
     (not= password confirm-password)
     (response 401 {:message "Passwords must match"})
 
-    (mc/find-one-as-map db "users" {:username {$regex (str "^" username "$") $options "i"}})
+    (find-one-as-map-case-insensitive db "users" {:username username})
     (response 422 {:message "Username taken"})
 
-    (mc/find-one-as-map db "users" {:email {$regex (str "^" email "$") $options "i"}})
+    (find-one-as-map-case-insensitive db "users" {:email email})
     (response 424 {:message "Email taken"})
 
     :else
@@ -122,22 +122,19 @@
                          :max-age -1}}))
 
 (defn check-username-handler [{{:keys [username]} :params}]
-  (if (mc/find-one-as-map db "users" {:username {$regex (str "^" username "$")
-                                                 $options "i"}})
+  (if (find-one-as-map-case-insensitive db "users" {:username username})
     (response 422 {:message "Username taken"})
     (response 200 {:message "OK"})))
 
 (defn check-email-handler [{{:keys [email]} :params}]
-  (if (mc/find-one-as-map db "users" {:email {$regex (str "^" email "$")
-                                              $options "i"}})
+  (if (find-one-as-map-case-insensitive db "users" {:email email})
     (response 422 {:message "Username taken"})
     (response 200 {:message "OK"})))
 
 (defn email-handler [{{username :username} :user
                       body                 :body}]
   (if username
-    (let [{:keys [email]} (mc/find-one-as-map db "users" {:username {$regex (str "^" username "$")
-                                                                     $options "i"}})]
+    (let [{:keys [email]} (find-one-as-map-case-insensitive db "users" {:username username})]
       (response 200 {:email email}))
     (response 401 {:message "Unauthorized"})))
 

--- a/src/clj/web/db.clj
+++ b/src/clj/web/db.clj
@@ -1,5 +1,7 @@
 (ns web.db
-  (:require [monger.core :as mg]
+  (:require [monger.collection]
+            [monger.core :as mg]
+            [monger.cursor]
             [web.config :refer [server-config]])
 
   (:import org.bson.types.ObjectId))
@@ -18,3 +20,32 @@
   (if (string? id)
     (org.bson.types.ObjectId. id)
     id))
+
+(defn- create-collation
+  [locale strength]
+  ;; This feels clumsy but there seems to be no support yet in Monger for doing
+  ;; this without falling back to the Java API.
+  (-> (com.mongodb.client.model.Collation/builder)
+      (.locale locale)
+      (.collationStrength (com.mongodb.client.model.CollationStrength/fromInt strength))
+      (.build)))
+
+(defn find-one-as-map-case-insensitive
+  "Returns a single object converted to Map from this collection matching the query.
+
+  Like `monger.collection/find-one-as-map`, but case-insensitive."
+  [db coll query]
+  (-> (monger.collection/find db coll query)
+      (.setCollation (create-collation "en" 2))
+      (.limit 1)
+      (monger.cursor/format-as :map)
+      (first)))
+
+(defn find-maps-case-insensitive
+  "Queries for objects in this collection, returning clojure Seq of Maps.
+
+  Like `monger.collection/find-maps`, but case-insensitive."
+  [db coll query]
+  (-> (monger.collection/find db coll query)
+      (.setCollation (create-collation "en" 2))
+      (monger.cursor/format-as :map)))


### PR DESCRIPTION
Currently, we're using `{$regex "^...$" $options "i"}` queries to find users by
username and email. They "cannot use indexes effectively" [0] and in our
particular case fail to escape the user input, enabling some nasty edge cases.

Since version 3.4, MongoDB supports case insensitive indexes [1], which can
replace all of these queries for better performance.

This commit consists of these changes:
1. Upgrade Monger to support the "collation" option
2. Replace all `$regex` queries
3. Add task `create-indexes`

The new queries also work on a database without the indexes created by
`create-indexes`, but adding them improves performance.

[0] https://docs.mongodb.com/manual/reference/operator/query/regex/
[1] https://docs.mongodb.com/manual/core/index-case-insensitive/