### PR TITLE
Fix NRDB 'imported from' link

### DIFF
--- a/src/clj/web/nrdb.clj
+++ b/src/clj/web/nrdb.clj
@@ -7,6 +7,7 @@
             [web.db :refer [db]]))
 
 (def nrdb-decklist-url "https://netrunnerdb.com/api/2.0/public/decklist/")
+(def nrdb-readable-url "https://netrunnerdb.com/en/decklist/")
 
 (defn- take-numbers [coll v]
   (if (re-matches #"^\d+$" v)
@@ -40,7 +41,7 @@
 
 (defn- parse-nrdb-deck [deck]
   (merge {:name (:name deck)
-          :notes (str "Imported from " nrdb-decklist-url (:id deck))}
+          :notes (str "Imported from " nrdb-readable-url (:id deck))}
          (parse-cards (:cards deck))))
 
 (defn- parse-response [body]


### PR DESCRIPTION
Was pointing to the API endpoint.  Now pointing to the human readable page.