### PR TITLE
Add more indexes to speed up queries and reduce load on the database server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,8 @@
             "delete-duplicate-users" ["run" "-m" "tasks.db/delete-duplicate-users"]
             "update-all-decks" ["run" "-m" "tasks.db/update-all-decks"]
             "card-coverage" ["run" "-m" "tasks.cards/test-coverage"]
-            "create-indexes" ["run" "-m" "tasks.db/create-indexes"]}
+            "create-indexes" ["run" "-m" "tasks.db/create-indexes"]
+            "drop-indexes" ["run" "-m" "tasks.db/drop-indexes"]}
 
   ;; Compilation.
   :source-paths ["src/clj" "src/cljs/nr" "src/cljc"]

--- a/src/clj/tasks/db.clj
+++ b/src/clj/tasks/db.clj
@@ -4,6 +4,7 @@
             [web.decks :refer [update-deck prepare-deck-for-db]]
             [web.core :refer [load-data]]
             [monger.collection :as mc]
+            [monger.db]
             [monger.operators :refer :all]
             [jinteki.cards :refer [all-cards]]
             [jinteki.validator :refer [calculate-deck-status]]))
@@ -91,5 +92,21 @@
       (clojure.pprint/pprint (mc/indexes-on db "users")))
     (catch Exception e (do
                          (println "Create indexes failed" (.getMessage e))
+                         (.printStackTrace e)))
+    (finally (webdb/disconnect))))
+
+(defn drop-indexes
+  "Drop all indexes except the index on the `_id` field."
+  []
+  (webdb/connect)
+  (try
+    (do
+      (doseq [coll (monger.db/get-collection-names db)]
+        (do
+          (mc/drop-indexes db coll)
+          (println "Dropped indexes on" coll)))
+      (println "\nIndexes successfully dropped."))
+    (catch Exception e (do
+                         (println "Drop indexes failed" (.getMessage e))
                          (.printStackTrace e)))
     (finally (webdb/disconnect))))


### PR DESCRIPTION
Based on the queries in our codebase and the official docs (https://docs.mongodb.com/manual/indexes/) I'd recommend the creation of the following indexes, in addition to the ones we've already created in ae6da4a7163cec06bd3e56779c1a94d40a4f4e90. These don't cover all the queries listed below, but I think we should create the obvious ones first and then do some benchmarking/profiling.

- `cards`:
  - `{ code: 1 }`
  - `{ previous-versions: 1 }`
  - `{ type: 1 }`

- `decks`:
  - `{ username: 1 }`

- `game-logs`:
  - `{ gameid: 1 }`
  - `{ "corp.player.username": 1 }`
  - `{ "runner.player.username": 1 }`

- `messages`:
  - `{ username: 1, date: -1 }`
  - `{ channel: 1, date: -1 }`

- `news`:
  - `{ date: -1 }`

- `users`:
  - `{ username: 1 }` (the case-insensitive index is not used for case-sensitive queries)
  - `{ email: 1 }` (the case-insensitive index is not used for case-sensitive queries)
  - `{ isadmin: 1 }`
  - `{ ismoderator: 1 }`
  - `{ special: 1 }`
  - `{ resetPasswordToken: 1 }`

## Queries in our codebase

I hope this table is complete, but I could not do much apart from grepping through the code for `(mc/` und `with-collection`.

This excludes:
- Queries using `:_id`, as these are using indexes created by MongoDB by default,
- Queries returning the whole collection (without sorting), as these don't benefit from indexes.

Collection | Query                                                                    | Sort          | Functions                                                                                                                                                                                                           
-----------|--------------------------------------------------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
cards      | code                                                                     |               | web.nrdb/lookup-card, tasks.altart/add-alt-art                                                                                                                                                                      
cards      | previous-versions                                                        |               | web.nrdb/lookup-card, tasks.altart/add-alt-art                                                                                                                                                                      
cards      | type                                                                     |               | tasks.cards/get-card-by-type                                                                                                                                                                                        
decks      | username                                                                 |               | web.decks/decks-handler                                                                                                                                                                                             
decks      | _id username                                                             |               | web.decks/deck-save-handler, web.decks/decks-delete-handler, web.lobby/handle-select-deck                                                                                                                           
game-logs  | gameid                                                                   |               | web.stats/fetch-log, web.stats/game-finished, web.stats/fetch-replay, web.stats/share-replay, web.stats/delete-old-replay                                                                                           
game-logs  | $or [corp.player.username runner.player.username]                        |               | web.stats/history                                                                                                                                                                                                   
game-logs  | {$or [corp.player.username runner.player.username]} replay replay-shared | start-date -1 | web.stats/delete-old-replay                                                                                                                                                                                         
game-logs  | gameid {or [corp.player.username runner.player.username]}                |               | web.stats/share-replay                                                                                                                                                                                              
messages   | username date                                                            |               | web.chat/within-rate-limit                                                                                                                                                                                          
messages   | channel                                                                  | date -1       | web.chat/messages-handler                                                                                                                                                                                           
messages   | username                                                                 |               | web.chat/delete-all-msg                                                                                                                                                                                             
news       |                                                                          | date -1       | web.data/news-handler                                                                                                                                                                                               
users      | username                                                                 |               | web.admin/mods-update-handler, web.admin/specials-update-handler, web.auth/register-handler, web.auth/login-handler, web.auth/update-profile-handler, web.auth/reset-password-handler, web.auth/change-email-handler
users      | _id emailhash                                                            |               | web.auth/wrap-user                                                                                                                                                                                                  
users      | $or [isadmin ismoderator tournament-organizer]                           |               | web.lobby/superusers                                                                                                                                                                                                
users      | ismoderator                                                              | username 1    | web.admin/mods-handler                                                                                                                                                                                              
users      | special                                                                  | username 1    | web.admin/specials-handler                                                                                                                                                                                          
users      | email                                                                    |               | web.auth/change-email-handler, web.auth/set-password-reset-code!, web.auth/forgot-password-handler                                                                                                                  
users      | resetPasswordToken resetPasswordExpires                                  |               | web.auth/reset-password-handler, web.pages/reset-password-page                                                                                                                                                      

## Deployment

The names of the case-insensitive indexes created before will unfortunately conflict with the default indexes on `username` und `email`. Therefore we have to drop and recreate them:

```
$ lein drop-indexes
[...]
Indexes successfully dropped.

$ time lein create-indexes
[...]
Indexes successfully created.

real    0m11.440s
user    0m8.441s
sys     0m0.488s
```

## Benchmarks

I've not done overly scientific benchmarks. Basically I've just created a bunch of sample documents (10k users, 50k decks, 100k games, 10k messages) and a small "stats" function in a Mongo shell to print the millisecs for a query and the number of documents Mongo needed to examine. This should at least give an idea of potential improvements.

```
> [ db.decks.count(), db["game-logs"].count(), db.messages.count(), db.users.count() ]
[ 500000, 1000000, 100000, 10000 ]

> stats = (query) => { s = query.explain("executionStats")["executionStats"]; return [ s["executionTimeMillis"], s["totalDocsExamined"] ]; }

> stats(db["game-logs"].find({"$or": [{"corp.player.username": "user-42"}, {"runner.player.username": "user-42"}]}))
[ 512, 1000000 ]
> stats(db["game-logs"].find({"$or": [{"corp.player.username": "user-42"}, {"runner.player.username": "user-42"}]}))
[ 507, 1000000 ]
> stats(db["game-logs"].find({"$or": [{"corp.player.username": "user-42"}, {"runner.player.username": "user-42"}]}))
[ 514, 1000000 ]

> stats(db.decks.find({ username: "user-9001" }))
[ 127, 500000 ]
> stats(db.decks.find({ username: "user-9001" }))
[ 131, 500000 ]
> stats(db.decks.find({ username: "user-9001" }))
[ 129, 500000 ]

> stats(db.messages.find({ username: "user-4711", date: { "$gt": "2021-01-26 00:00:00" }}))
[ 35, 100000 ]
> stats(db.messages.find({ username: "user-4711", date: { "$gt": "2021-01-26 00:00:00" }}))
[ 37, 100000 ]
> stats(db.messages.find({ username: "user-4711", date: { "$gt": "2021-01-26 00:00:00" }}))
[ 36, 100000 ]
```

And now the same with indexes. Both execution time and examined documents are greatly reduced! :tada:

```
> stats(db["game-logs"].find({"$or": [{"corp.player.username": "user-42"}, {"runner.player.username": "user-42"}]}))
[ 4, 100 ]
> stats(db["game-logs"].find({"$or": [{"corp.player.username": "user-42"}, {"runner.player.username": "user-42"}]}))
[ 0, 100 ]
> stats(db["game-logs"].find({"$or": [{"corp.player.username": "user-42"}, {"runner.player.username": "user-42"}]}))
[ 0, 100 ]

> stats(db.decks.find({ username: "user-9001" }))
[ 1, 50 ]
> stats(db.decks.find({ username: "user-9001" }))
[ 0, 50 ]
> stats(db.decks.find({ username: "user-9001" }))
[ 0, 50 ]

> stats(db.messages.find({ username: "user-4711", date: { "$gt": "2021-01-26 00:00:00" }}))
[ 2, 0 ]
> stats(db.messages.find({ username: "user-4711", date: { "$gt": "2021-01-26 00:00:00" }}))
[ 0, 0 ]
> stats(db.messages.find({ username: "user-4711", date: { "$gt": "2021-01-26 00:00:00" }}))
[ 0, 0 ]
```