### PR TITLE
Limit game logs query to 100 results

### DIFF
--- a/src/clj/tasks/db.clj
+++ b/src/clj/tasks/db.clj
@@ -83,6 +83,7 @@
      ["cards" (array-map :type 1)]
      ["decks" (array-map :username 1)]
      ["game-logs" (array-map :gameid 1)]
+     ["game-logs" (array-map :start-date -1)]
      ["game-logs" (array-map "corp.player.username" 1)]
      ["game-logs" (array-map "runner.player.username" 1)]
      ["messages" (array-map :channel 1 :date -1)]

--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -213,7 +213,8 @@
     (let [games (->> (mq/with-collection db "game-logs"
                        (mq/find {$or [{:corp.player.username username}
                                       {:runner.player.username username}]})
-                       (mq/sort (array-map :start-date 1)))
+                       (mq/sort (array-map :start-date -1))
+                       (mq/limit 100))
                      (map #(dissoc % :_id :log))
                      (into []))]
       (response 200 games))

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -196,8 +196,8 @@
      :component-will-unmount #(store-scroll-top % list-scroll-top)
      :reagent-render
      (fn [state list-scroll-top log-scroll-top]
-       (let [rev-games (reverse (:games @state))
-             games (if (:filter-replays @state) (filter #(:replay-shared %) rev-games) rev-games)
+       (let [all-games (:games @state)
+             games (if (:filter-replays @state) (filter #(:replay-shared %) all-games) all-games)
              cnt (count games)]
          [:div.game-list
            [:div.controls

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -52,7 +52,7 @@
   (let [game (:view-game @state)]
     [:div.games.panel
      [:p.return-button [:button {:on-click #(swap! state dissoc :view-game)} (tr [:stats.view-games "Return to stats screen"])]]
-     [:h4 (:title game) (when (:replay-shared game) " ⭐")]
+     [:h4 (:title game) (when (:has-replay game) (if (:replay-shared game) " ⭐" " 🟢"))]
      [:div
       [:div.game-details-table
        [:div (str (tr [:stats.lobby "Lobby"]) ": " (capitalize (tr-lobby (:room game))))]
@@ -64,10 +64,10 @@
       (when (:stats game)
         [build-game-stats (get-in game [:stats :corp]) (get-in game [:stats :runner])])
       [:p
-       (when (and (:replay game)
+       (when (and (:has-replay game)
                   (not (:replay-shared game)))
          [:button {:on-click #(share-replay state (:gameid game))} (tr [:stats.share "Share replay"])])
-       (if (:replay game)
+       (if (:has-replay game)
          [:span
           [:button {:on-click #(launch-replay game)} (tr [:stats.launch "Launch Replay"])]
           [:a.button {:href (str "/profile/history/full/" (:gameid game)) :download (str (:title game) ".json")} (tr [:stats.download "Download replay"])]]
@@ -159,9 +159,10 @@
           (swap! state assoc :view-game (assoc game :log json))))))
 
 (defn game-row
-  [state {:keys [title corp runner turn winner reason replay-shared start-date] :as game} log-scroll-top]
+  [state {:keys [title corp runner turn winner reason replay-shared has-replay start-date] :as game} log-scroll-top]
   (let [corp-id (first (filter #(= (:title %) (:identity corp)) @all-cards))
-        runner-id (first (filter #(= (:title %) (:identity runner)) @all-cards))]
+        runner-id (first (filter #(= (:title %) (:identity runner)) @all-cards))
+        turn-count (if turn turn 0)]
     [:div.gameline {:style {:min-height "auto"}}
      [:button.float-right
       {:on-click #(do
@@ -170,7 +171,7 @@
       (tr [:stats.view-log "View log"])]
      [:h4.log-title
       {:title (when replay-shared "Replay shared")}
-      title " (" (tr [:stats.turn-count] turn) ")" (when replay-shared " ⭐")]
+      title " (" (tr [:stats.turn-count] turn-count) ")" (when has-replay (if replay-shared " ⭐" " 🟢"))]
 
      [:div.log-date (-> start-date js/Date. js/moment (.format "dddd MMM Do - HH:mm"))]
 

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1335,6 +1335,7 @@ input.url
 
     .game-details-table
       margin-bottom: 10px
+      min-width: 500px
 
     .log-title
       margin-bottom: 0px


### PR DESCRIPTION
__IMPORTANT__: This update uses a new field in the database `has-replay`. To update the mongo instance appropriately, the following command should be run:
```
db["game-logs"].updateMany({replay: {$ne: null}}, {$set: {"has-replay": true}})
```