### PR TITLE
Make Marilyn Campaign not prompt until last usage

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1127,7 +1127,7 @@
 
 (defcard "Marilyn Campaign"
   (let [ability {:once :per-turn
-                 :interactive (req (>= 2 (get-counters (get-card state card) :credit)))
+                 :interactive (req (>= 2 (get-counters card :credit)))
                  :req (req (:corp-phase-12 @state))
                  :label (str "Gain 2 [Credits] (start of turn)")
                  :msg (msg "gain " (min 2 (get-counters card :credit)) " [Credits]")

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1127,7 +1127,7 @@
 
 (defcard "Marilyn Campaign"
   (let [ability {:once :per-turn
-                 :interactive (req true)
+                 :interactive (req (>= 2 (get-counters (get-card state card) :credit)))
                  :req (req (:corp-phase-12 @state))
                  :label (str "Gain 2 [Credits] (start of turn)")
                  :msg (msg "gain " (min 2 (get-counters card :credit)) " [Credits]")

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -684,14 +684,16 @@
                                (filter #(and (card-for-ability state %)
                                              (not (:disabled (card-for-ability state %))))
                                 handlers))
-                    non-silent (filter #(let [silent-fn (:silent (:ability %))]
+                    non-silent (filter #(let [silent-fn (:silent (:ability %))
+                                              card (card-for-ability state %)]
                                           (not (and silent-fn
-                                                    (silent-fn state side (make-eid state) (:card %) event-targets))))
+                                                    (silent-fn state side (make-eid state) card event-targets))))
                                        handlers)
                     titles (map :card non-silent)
-                    interactive (filter #(let [interactive-fn (:interactive (:ability %))]
+                    interactive (filter #(let [interactive-fn (:interactive (:ability %))
+                                               card (card-for-ability state %)]
                                            (and interactive-fn
-                                                (interactive-fn state side (make-eid state) (:card %) event-targets)))
+                                                (interactive-fn state side (make-eid state) card event-targets)))
                                         handlers)]
                 ;; If there is only 1 non-silent ability, resolve that then recurse on the rest
                 (if (or (= 1 (count handlers)) (empty? interactive) (= 1 (count non-silent)))

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2706,7 +2706,28 @@
         (is (= 8 (get-counters (refresh marilyn) :credit)) "Marilyn Campaign should start with 8 credits")
         (derez state :corp (refresh marilyn))
         (rez state :corp (refresh marilyn))
-        (is (= 16 (get-counters (refresh marilyn) :credit)) "Marilyn Campaign should now have 16 credits")))))
+        (is (= 16 (get-counters (refresh marilyn) :credit)) "Marilyn Campaign should now have 16 credits"))))
+  (testing "Interactive prompt only on last trigger"
+    (do-game
+      (new-game {:corp {:deck ["PAD Campaign" "Marilyn Campaign"]}})
+      (play-from-hand state :corp "Marilyn Campaign" "New remote")
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (let [marilyn (get-content state :remote1 0)
+            pad (get-content state :remote2 0)]
+        (core/rez state :corp marilyn)
+        (core/rez state :corp pad)
+        (take-credits state :corp)
+        (take-credits state :runner)
+        (is (empty? (:prompt (get-corp))) "No interactive prompt")
+        (take-credits state :corp)
+        (take-credits state :runner)
+        (is (empty? (:prompt (get-corp))) "No interactive prompt")
+        (take-credits state :corp)
+        (take-credits state :runner)
+        (is (empty? (:prompt (get-corp))) "No interactive prompt")
+        (take-credits state :corp)
+        (take-credits state :runner)
+        (is (not-empty (:prompt (get-corp))) "Interactive prompt")))))
 
 (deftest mark-yale
   ;; Mark Yale


### PR DESCRIPTION
Fixes #4998 (originally implemented by @lostgeek on a cocktail napkin at an embassy party, I just made a new PR for it)