### PR TITLE
Stop card-zoom from obscuring gameboard even when invisible

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2042,7 +2042,7 @@ input.url
     display-flex()
     flex-direction(column)
     min-width: 90px
-    overflow: auto
+    overflow: visible
 
     .card-wrapper
       margin: 3px 6px
@@ -2260,6 +2260,7 @@ input.url
     position: relative
     display-flex()
     flex-direction(column)
+    z-index:10
 
     .card-zoom
       width: 220px


### PR DESCRIPTION
Previous:
![image](https://user-images.githubusercontent.com/1409906/107825644-c2b95000-6d83-11eb-88a5-aa2a6cc6ffa9.png)

Now:
![image](https://user-images.githubusercontent.com/1409906/107825451-6ce4a800-6d83-11eb-84b9-b73817b90f2a.png)