### PR TITLE
Fixed cards disappearing from R&D in replays

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -14,6 +14,7 @@
     [game.core.costs]
     [game.core.damage]
     [game.core.def-helpers]
+    [game.core.diffs]
     [game.core.drawing]
     [game.core.effects]
     [game.core.eid]
@@ -264,6 +265,10 @@
    make-recurring-ability
    reorder-choice
    trash-on-empty]
+
+  [game.core.diffs
+   public-states
+   public-diffs]
 
   [game.core.drawing
    draw

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -1,19 +1,28 @@
-(ns game.diffs
-  (:require [game.core :refer [card-is-public?]]
+(ns game.core.diffs
+  (:require [game.core.flags :refer [card-is-public?]]
             [game.core.card :refer [private-card]]
-            [game.core.set-up :refer [strip-for-replay]]
             [game.utils :refer [dissoc-in]]
             [differ.core :as differ]))
 
 (defn- strip [state]
   (-> state
-    (dissoc :eid :events :turn-events :per-turn :prevent :damage :effect-completed :click-state :turn-state :history)
-    (update-in [:corp :register] select-keys [:spent-click])
-    (update-in [:runner :register] select-keys [:spent-click])
-    (dissoc-in [:corp :register-last-turn])
-    (dissoc-in [:runner :register-last-turn])
-    (dissoc-in [:run :current-ice])
-    (dissoc-in [:run :events])))
+      (dissoc :eid :events :turn-events :per-turn :prevent :damage :effect-completed :click-state :turn-state :history)
+      (update-in [:corp :register] select-keys [:spent-click])
+      (update-in [:runner :register] select-keys [:spent-click])
+      (dissoc-in [:corp :register-last-turn])
+      (dissoc-in [:runner :register-last-turn])
+      (dissoc-in [:run :current-ice])
+      (dissoc-in [:run :events])))
+
+(defn strip-for-replay [state]
+  (-> state
+      (strip)
+      (dissoc-in [:runner :user :isadmin])
+      (dissoc-in [:runner :user :options :blocked-users])
+      (dissoc-in [:runner :user :stats])
+      (dissoc-in [:corp :user :isadmin])
+      (dissoc-in [:corp :user :options :blocked-users])
+      (dissoc-in [:corp :user :stats])))
 
 (defn- private-card-vector [state side cards]
   (mapv (fn [card]
@@ -65,7 +74,7 @@
      (if (get-in @state [:options :spectatorhands])
        (assoc @state :corp corp-deck :runner runner-deck)
        (assoc @state :corp corp-private :runner runner-private))
-     (assoc @state :corp corp-deck :runner runner-deck)]))
+     @state]))
 
 (defn public-states [state]
   (let [[new-corp new-runner new-spect new-hist] (private-states state)]

--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -3,6 +3,7 @@
     [game.core.card :refer [corp? runner?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.checkpoint :refer [fake-checkpoint]]
+    [game.core.diffs :refer [public-states]]
     [game.core.drawing :refer [draw]]
     [game.core.eid :refer [make-eid]]
     [game.core.engine :refer [trigger-event trigger-event-sync]]
@@ -17,22 +18,6 @@
     [game.quotes :as quotes]
     [game.utils :refer [server-card dissoc-in]]
     [clj-time.core :as t]))
-
-(defn strip-for-replay [state]
-  (-> state
-    (dissoc :eid :events :turn-events :per-turn :prevent :damage :effect-completed :click-state :turn-state :history)
-    (update-in [:corp :register] select-keys [:spent-click])
-    (update-in [:runner :register] select-keys [:spent-click])
-    (dissoc-in [:corp :register-last-turn])
-    (dissoc-in [:runner :register-last-turn])
-    (dissoc-in [:run :current-ice])
-    (dissoc-in [:run :events])
-    (dissoc-in [:runner :user :isadmin])
-    (dissoc-in [:runner :user :options :blocked-users])
-    (dissoc-in [:runner :user :stats])
-    (dissoc-in [:corp :user :isadmin])
-    (dissoc-in [:corp :user :options :blocked-users])
-    (dissoc-in [:corp :user :stats])))
 
 (defn build-card
   [card]
@@ -142,5 +127,5 @@
                   (wait-for (trigger-event-sync state side :pre-start-game nil)
                             (init-hands state)
                             (fake-checkpoint state)))))
-    (swap! state assoc :history [(strip-for-replay @state)])
+    (swap! state assoc :history [(:hist-state (public-states state))])
     state))

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -4,7 +4,7 @@
             [web.utils :refer [response]]
             [web.stats :as stats]
             [game.main :as main]
-            [game.diffs :refer [public-diffs public-states]]
+            [game.core.diffs :refer [public-diffs public-states]]
             [game.core :as core]
             [web.db :refer [db object-id]]
             [monger.collection :as mc]


### PR DESCRIPTION
The initial state was prepared incorrectly, which lead to the diffs doing weird things to R&D (drawing from the bottom, duplicating cards, etc.)

Unfortunately old replays are not fixed by this bugfix and will continue showing R&D incorrectly.

Closes #5553 