### PR TITLE
Two tests for Eli 1.0

### DIFF
--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -5115,3 +5115,40 @@
       (play-from-hand state :runner "Corroder")
       (is (zero? (get-strength (refresh wrap)))
           "Wraparound 0 strength after Corroder installed"))))
+
+(deftest eli-1-0
+  ;; Eli 1.0
+  (testing "Runner with 1 click left, uses it to break first subroutine but run ends when second 'End the run' is triggered"
+    (do-game
+      (new-game
+        {:corp   {:hand ["Eli 1.0"]}})
+      (play-from-hand state :corp "Eli 1.0" "HQ")
+      (take-credits state :corp)
+      (let [eli (get-ice state :hq 0)]
+        (take-credits state :runner 2)
+        (run-on state :hq)
+        (rez state :corp eli)
+        (run-continue state)
+        (is (= 1 (:click (get-runner))) "Runner starts with 1 click")
+        (card-side-ability state :runner eli 0)
+        (click-prompt state :runner "End the run")
+        (is (= 0 (:click (get-runner))) "Runner has no clicks left")
+        (card-subroutine state :corp eli 0)
+        (is (not (:run @state)) "Run has ended"))))
+  (testing "Runner uses 2 clicks to break all subroutines so Runner passes the rezzed Eli 1.0 ice"
+    (do-game
+      (new-game
+        {:corp   {:hand ["Accelerated Beta Test", "Eli 1.0"]}})
+      (play-from-hand state :corp "Eli 1.0" "HQ")
+      (take-credits state :corp)
+      (let [eli (get-ice state :hq 0)]
+        (run-on state :hq)
+        (rez state :corp eli)
+        (run-continue state)
+        (is (= 3 (:click (get-runner))) "Runner starts with 3 clicks")
+        (card-side-ability state :runner eli 0)
+        (click-prompt state :runner "End the run")
+        (card-side-ability state :runner eli 0)
+        (click-prompt state :runner "End the run")
+        (is (= 1 (:click (get-runner))) "Runner has one click left")
+        (is (:run @state)) "Run has not ended"))))


### PR DESCRIPTION
I have added two tests for Eli 1.0 https://netrunnerdb.com/en/card/02110 This PR is mostly to ask if the direction is good and comment the code, I'm a clojure noob. No merging is *requested*.

![image](https://user-images.githubusercontent.com/4249331/108895992-9bc90c80-7614-11eb-9f4b-6a1bfe1a4605.png)

So, the two tests try to achieve the following:
1. Runner with 1 click left, uses it to break first subroutine but run ends when second 'End the run' is triggered. What I tried here was to write a test that passed the first subroutine but that the run stats is "ended" after the second. I'm not fully sure if I achieved it, but the test was passing.
2. Runner uses 2 clicks to break all subroutines so Runner passes the rezzed Eli 1.0 ice. In this case I wanted to check that after using clicks to break both subroutines of Eli 1.0, Runner's click was 1 and the run didn't ended. I have some doubts at the last part so I self commented my code with the question.

I can write more tests, like strengths comparison against a program. Because this PR mostly tests the `bioroid-break` ability that is already tested here https://github.com/mtgred/netrunner/blob/master/test/clj/game/core/ice_test.clj#L88 (and I have just realized that it's done with Eli 1.0 :sweat_smile: )

Just feel free to ask to rewrite everything is necessary, I won't assume malice. It's a bunch of copy pasting trying to understand how everything works and it's glue together.