### PR TITLE
Filter trash-icon-test to only look at implemented cards

### DIFF
--- a/test/clj/game/core/abilities_test.clj
+++ b/test/clj/game/core/abilities_test.clj
@@ -57,9 +57,9 @@
         (is (= (+ 6 cr) (:credit (get-corp))) "Corp gained 3 credits")))))
 
 (deftest trash-icon
-  (doseq [card (->> @all-cards
-                    vals
-                    (filter #(re-find #"(?i)\[trash\].*:" (:text % ""))))]
+  (doseq [card (->> (vals @all-cards)
+                    (filter #(re-find #"(?i)\[trash\].*:" (:text % ""))))
+          :when (not-empty (card-def card))]
     (is (core/has-trash-ability? card) (str (:title card) " needs either :cost [:trash] or :trash-icon true"))))
 
 (deftest label


### PR DESCRIPTION
Fixes the failing CI tests.