### PR TITLE
Refactor "When scored" agenda abilities

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -723,18 +723,26 @@
                 :effect (effect (gain-credits eid 3))}]})
 
 (defcard "Glenn Station"
-  {:implementation "Doesn't prohibit hosting multiple cards"
-   :abilities [{:label "Host a card from HQ on Glenn Station"
+  {:abilities [{:label "Host a card from HQ on Glenn Station"
+                :req (req (and (not-empty (:hand corp))
+                               (empty? (filter corp? (:hosted card)))))
                 :cost [:click 1]
                 :msg "host a card from HQ"
                 :prompt "Choose a card to host on Glenn Station"
-                :choices (req (:hand corp))
+                :choices {:card #(and (corp? %) (in-hand? %))}
                 :effect (effect (host card target {:facedown true}))}
                {:label "Add a card on Glenn Station to HQ"
+                :req (req (not-empty (filter corp? (:hosted card))))
                 :cost [:click 1]
                 :msg "add a hosted card to HQ"
                 :prompt "Choose a card on Glenn Station"
-                :choices (req (:hosted card))
+                :choices {:all true
+                          :req (req (let [hosted-corp-cards
+                                          (->> (:hosted card)
+                                               (filter corp?)
+                                               (map :cid)
+                                               (into #{}))]
+                                      (hosted-corp-cards (:cid target))))}
                 :effect (effect (move target :hand))}]})
 
 (defcard "Global Food Initiative"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -13,10 +13,10 @@
                                           (:ices server)))))
                     0
                     (flatten (seq (:servers corp)))))]
-    {:msg (msg "gain " (count-ice corp) " [Credits]")
-     :interactive (req true)
-     :async true
-     :effect (effect (gain-credits eid (count-ice corp)))
+    {:on-score {:msg (msg "gain " (count-ice corp) " [Credits]")
+                :interactive (req true)
+                :async true
+                :effect (effect (gain-credits eid (count-ice corp)))}
      :constant-effects [{:type :ice-strength
                          :req (req (has-subtype? target subtype))
                          :value 1}]}))
@@ -64,24 +64,25 @@
              :async true
              :effect (effect (system-msg (str "trashes " (quantify (count choices) "card")))
                              (trash-cards eid choices {:unpreventable true}))})]
-    {:interactive (req true)
-     :optional
-     {:prompt "Look at the top 3 cards of R&D?"
-      :yes-ability
-      {:async true
-       :msg "look at the top 3 cards of R&D"
-       :effect (req (register-events
-                      state side card
-                      [{:event :corp-shuffle-deck
-                        :effect (effect (update! (assoc-in card [:special :shuffle-occurred] true)))}])
-                 (let [choices (take 3 (:deck corp))
-                       titles (string/join ", " (map :title choices))]
-                   (continue-ability
-                     state side
-                     (if (seq (filter ice? choices))
-                       (abt titles choices)
-                       (suffer titles choices))
-                     card nil)))}}}))
+    {:on-score
+     {:interactive (req true)
+      :optional
+      {:prompt "Look at the top 3 cards of R&D?"
+       :yes-ability
+       {:async true
+        :msg "look at the top 3 cards of R&D"
+        :effect (req (register-events
+                       state side card
+                       [{:event :corp-shuffle-deck
+                         :effect (effect (update! (assoc-in card [:special :shuffle-occurred] true)))}])
+                  (let [choices (take 3 (:deck corp))
+                        titles (string/join ", " (map :title choices))]
+                    (continue-ability
+                      state side
+                      (if (seq (filter ice? choices))
+                        (abt titles choices)
+                        (suffer titles choices))
+                      card nil)))}}}}))
 
 (defcard "Advanced Concept Hopper"
   {:events
@@ -122,41 +123,43 @@
              :effect (effect (gain-tags eid 1))}]})
 
 (defcard "Architect Deployment Test"
-  {:interactive (req true)
-   :async true
-   :msg "look at the top 5 cards of R&D"
-   :prompt (msg "The top cards of R&D are (top->bottom) " (string/join ", " (map :title (take 5 (:deck corp)))))
-   :choices ["OK"]
-   :effect (effect (continue-ability
-                     {:prompt "Install a card?"
-                      :choices (cancellable (filter corp-installable-type? (take 5 (:deck corp))))
-                      :async true
-                      :effect (effect (corp-install eid target nil
-                                                    {:ignore-all-cost true
-                                                     :install-state :rezzed-no-rez-cost}))
-                      :cancel-effect (effect (system-msg "does not install any of the top 5 cards")
-                                             (effect-completed eid))}
-                     card nil))})
+  {:on-score
+   {:interactive (req true)
+    :async true
+    :msg "look at the top 5 cards of R&D"
+    :prompt (msg "The top cards of R&D are (top->bottom) " (string/join ", " (map :title (take 5 (:deck corp)))))
+    :choices ["OK"]
+    :effect (effect (continue-ability
+                      {:prompt "Install a card?"
+                       :choices (cancellable (filter corp-installable-type? (take 5 (:deck corp))))
+                       :async true
+                       :effect (effect (corp-install eid target nil
+                                                     {:ignore-all-cost true
+                                                      :install-state :rezzed-no-rez-cost}))
+                       :cancel-effect (effect (system-msg "does not install any of the top 5 cards")
+                                              (effect-completed eid))}
+                      card nil))}})
 
 (defcard "Armed Intimidation"
-  {:player :runner
-   :async true
-   :waiting-prompt "Runner to suffer 5 meat damage or take 2 tags"
-   :prompt "Choose Armed Intimidation score effect"
-   :choices ["Suffer 5 meat damage" "Take 2 tags"]
-   :effect (req (case target
-                  "Suffer 5 meat damage"
-                  (do (system-msg state :runner "chooses to suffer 5 meat damage from Armed Intimidation")
-                      (damage state :runner eid :meat 5 {:card card :unboostable true}))
-                  "Take 2 tags"
-                  (do (system-msg state :runner "chooses to take 2 tags from Armed Intimidation")
-                      (gain-tags state :runner eid 2 {:card card}))
-                  ; else
-                  (effect-completed state side eid)))})
+  {:on-score
+   {:player :runner
+    :async true
+    :waiting-prompt "Runner to suffer 5 meat damage or take 2 tags"
+    :prompt "Choose Armed Intimidation score effect"
+    :choices ["Suffer 5 meat damage" "Take 2 tags"]
+    :effect (req (case target
+                   "Suffer 5 meat damage"
+                   (do (system-msg state :runner "chooses to suffer 5 meat damage from Armed Intimidation")
+                       (damage state :runner eid :meat 5 {:card card :unboostable true}))
+                   "Take 2 tags"
+                   (do (system-msg state :runner "chooses to take 2 tags from Armed Intimidation")
+                       (gain-tags state :runner eid 2 {:card card}))
+                   ; else
+                   (effect-completed state side eid)))}})
 
 (defcard "Armored Servers"
-  {:effect (effect (add-counter card :agenda 1))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 1))
+              :silent (req true)}
    :abilities [{:cost [:agenda 1]
                 :req (req run)
                 :label "increase cost to break subroutines or jack out"
@@ -173,8 +176,8 @@
                                    :value [:trash-from-hand 1]}))}]})
 
 (defcard "AstroScript Pilot Program"
-  {:effect (effect (add-counter card :agenda 1))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 1))
+              :silent (req true)}
    :abilities [{:cost [:agenda 1]
                 :label "place 1 advancement counter"
                 :msg (msg "place 1 advancement token on " (card-str state target))
@@ -236,13 +239,14 @@
                             (when (:access @state)
                               (swap! state assoc-in [:run :shuffled-during-access :rd] true))
                             (continue-ability state :corp (trash-step c '()) card nil)))}}}]
-      (assoc arrange-rd :stolen arrange-rd))))
+      {:on-score arrange-rd
+       :stolen arrange-rd})))
 
 (defcard "Bellona"
   {:steal-cost-bonus (req [:credit 5])
-   :async true
-   :msg "gain 5 [Credits]"
-   :effect (effect (gain-credits :corp eid 5))})
+   :on-score {:async true
+              :msg "gain 5 [Credits]"
+              :effect (effect (gain-credits :corp eid 5))}})
 
 (defcard "Better Citizen Program"
   {:events [{:event :play-event
@@ -273,56 +277,56 @@
                :effect (effect (gain-tags :corp eid 1))}}}]})
 
 (defcard "Bifrost Array"
-  {:optional {:req (req (seq (filter #(not= (:title %)
-                                            "Bifrost Array")
-                                     (:scored corp))))
-              :prompt "Trigger the ability of a scored agenda?"
-              :yes-ability {:prompt "Select an agenda to trigger the \"when scored\" ability of"
-                            :choices {:card #(and (agenda? %)
-                                                  (not= (:title %)
-                                                        "Bifrost Array")
-                                                  (in-scored? %)
-                                                  (when-scored? %)
-                                                  (:abilities %))}
-                            :msg (msg "trigger the \"when scored\" ability of " (:title target))
-                            :effect (effect (continue-ability (card-def target) target nil))}
-              :no-ability {:effect (effect (clear-wait-prompt :runner))}}})
+  {:on-score
+   {:optional
+    {:req (req (seq (filter #(not= (:title %) "Bifrost Array") (:scored corp))))
+     :prompt "Trigger the ability of a scored agenda?"
+     :yes-ability
+     {:prompt "Select an agenda to trigger its \"when scored\" ability"
+      :choices {:card #(and (agenda? %)
+                            (not= (:title %) "Bifrost Array")
+                            (in-scored? %)
+                            (when-scored? %))}
+      :msg (msg "trigger the \"when scored\" ability of " (:title target))
+      :async true
+      :effect (effect (continue-ability (:on-score (card-def target)) target nil))}}}})
 
 (defcard "Brain Rewiring"
-  {:optional
-   {:waiting-prompt "Corp to use Brain Rewiring"
-    :prompt "Pay credits to add random cards from Runner's Grip to the bottom of their Stack?"
-    :yes-ability
-    {:prompt "How many credits?"
-     :choices {:number (req (min (:credit corp)
-                                 (count (:hand runner))))}
-     :async true
-     :effect (req (if (pos? target)
-                    (wait-for
-                      (pay state :corp card :credit target)
-                      (let [from (take target (shuffle (:hand runner)))]
-                        (doseq [c from]
-                          (move state :runner c :deck))
-                        (system-msg state side (str "uses Brain Rewiring to pay " target
-                                                    " [Credits] and add " target
-                                                    " cards from the Runner's Grip"
-                                                    " to the bottom of their Stack."
-                                                    " The Runner draws 1 card"))
-                        (draw state :runner eid 1 nil)))
-                    (effect-completed state side eid)))}}})
+  {:on-score
+   {:optional
+    {:waiting-prompt "Corp to use Brain Rewiring"
+     :prompt "Pay credits to add random cards from Runner's Grip to the bottom of their Stack?"
+     :yes-ability
+     {:prompt "How many credits?"
+      :choices {:number (req (min (:credit corp)
+                                  (count (:hand runner))))}
+      :async true
+      :effect (req (if (pos? target)
+                     (wait-for
+                       (pay state :corp card :credit target)
+                       (let [from (take target (shuffle (:hand runner)))]
+                         (doseq [c from]
+                           (move state :runner c :deck))
+                         (system-msg state side (str "uses Brain Rewiring to pay " target
+                                                     " [Credits] and add " target
+                                                     " cards from the Runner's Grip"
+                                                     " to the bottom of their Stack."
+                                                     " The Runner draws 1 card"))
+                         (draw state :runner eid 1 nil)))
+                     (effect-completed state side eid)))}}}})
 
 (defcard "Braintrust"
-  {:effect (effect (add-counter card :agenda (quot (- (get-counters card :advancement) 3) 2)))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda (quot (- (get-counters card :advancement) 3) 2)))
+              :silent (req true)}
    :constant-effects [{:type :rez-cost
                        :req (req (ice? target))
                        :value (req (- (get-counters card :agenda)))}]})
 
 (defcard "Breaking News"
-  {:async true
-   :silent (req true)
-   :msg "give the Runner 2 tags"
-   :effect (effect (gain-tags :corp eid 2))
+  {:on-score {:async true
+              :silent (req true)
+              :msg "give the Runner 2 tags"
+              :effect (effect (gain-tags :corp eid 2))}
    :events (let [event {:unregister-once-resolved true
                         :req (effect (first-event? :agenda-scored #(same-card? card (first %))))
                         :msg "make the Runner lose 2 tags"
@@ -334,13 +338,16 @@
   (letfn [(add-counters [state side card eid]
             (add-counter state :corp card :agenda (count-bad-pub state))
             (effect-completed state side eid))]
-    {:optional
-     {:prompt "Take 1 bad publicity?"
-      :async true
-      :yes-ability {:effect (req (wait-for (gain-bad-publicity state :corp 1)
-                                           (system-msg state :corp "used Broad Daylight to take 1 bad publicity")
-                                           (add-counters state side card eid)))}
-      :no-ability {:effect (effect (add-counters card eid))}}
+    {:on-score
+     {:optional
+      {:prompt "Take 1 bad publicity?"
+       :async true
+       :yes-ability {:async true
+                     :effect (req (wait-for (gain-bad-publicity state :corp 1)
+                                            (system-msg state :corp "used Broad Daylight to take 1 bad publicity")
+                                            (add-counters state side card eid)))}
+       :no-ability {:async true
+                    :effect (effect (add-counters card eid))}}}
      :abilities [{:cost [:click 1 :agenda 1]
                   :async true
                   :label "Do 2 meat damage"
@@ -349,28 +356,32 @@
                   :effect (effect (damage eid :meat 2 {:card card}))}]}))
 
 (defcard "CFC Excavation Contract"
-  {:async true
-   :effect (req (let [bucks (->> (all-active-installed state :corp)
-                                 (filter #(has-subtype? % "Bioroid"))
-                                 (count)
-                                 (* 2))]
-                  (system-msg state :corp (str "gains " bucks " [Credits] from CFC Excavation Contract"))
-                  (gain-credits state :corp eid bucks)))})
+  (letfn [(bucks [state]
+            (->> (all-active-installed state :corp)
+                 (filter #(has-subtype? % "Bioroid"))
+                 (count)
+                 (* 2)))]
+    {:on-score
+     {:async true
+      :msg (msg "gain " (bucks state) " [Credits]")
+      :effect (effect (gain-credits :corp eid (bucks state)))}}))
 
 (defcard "Character Assassination"
-  {:prompt "Select a resource to trash"
-   :choices {:card #(and (installed? %)
-                         (resource? %))}
-   :msg (msg "trash " (:title target))
-   :interactive (req true)
-   :async true
-   :effect (effect (trash eid target {:unpreventable true}))})
+  {:on-score
+   {:prompt "Select a resource to trash"
+    :choices {:card #(and (installed? %)
+                          (resource? %))}
+    :msg (msg "trash " (:title target))
+    :interactive (req true)
+    :async true
+    :effect (effect (trash eid target {:unpreventable true}))}})
 
 (defcard "Chronos Project"
-  {:req (req (not (zone-locked? state :runner :discard)))
-   :msg "remove all cards in the Runner's Heap from the game"
-   :interactive (req true)
-   :effect (effect (move-zone :runner :discard :rfg))})
+  {:on-score
+   {:req (req (not (zone-locked? state :runner :discard)))
+    :msg "remove all cards in the Runner's Heap from the game"
+    :interactive (req true)
+    :effect (effect (move-zone :runner :discard :rfg))}})
 
 (defcard "City Works Project"
   (letfn [(meat-damage [s c] (+ 2 (get-counters (get-card s c) :advancement)))]
@@ -381,69 +392,75 @@
               :effect (effect (damage eid :meat (meat-damage state card) {:card card}))}}))
 
 (defcard "Clone Retirement"
-  {:msg "remove 1 bad publicity"
-   :effect (effect (lose-bad-publicity 1))
-   :silent (req true)
+  {:on-score {:msg "remove 1 bad publicity"
+              :effect (effect (lose-bad-publicity 1))
+              :silent (req true)}
    :stolen {:msg "force the Corp to take 1 bad publicity"
             :effect (effect (gain-bad-publicity :corp 1))}})
 
 (defcard "Corporate Oversight A"
-  {:interactive (req true)
-   :optional {:prompt "Search R&D for a piece of ice to install protecting a remote server?"
-              :yes-ability
-              {:async true
-               :effect (effect
-                         (continue-ability
-                           (if (not-empty (filter ice? (:deck corp)))
-                             {:async true
-                              :prompt "Choose a piece of ice"
-                              :choices (req (filter ice? (:deck corp)))
-                              :effect (effect
-                                        (continue-ability
-                                          (let [chosen-ice target]
-                                            {:async true
-                                             :prompt (str "Select a server to install " (:title chosen-ice) " on")
-                                             :choices (filter #(not (#{"HQ" "Archives" "R&D"} %))
-                                                              (corp-install-list state chosen-ice))
-                                             :effect (effect (shuffle! :deck)
-                                                             (corp-install eid chosen-ice target
-                                                                           {:ignore-all-cost true
-                                                                            :install-state :rezzed-no-rez-cost}))})
-                                          card nil))}
-                             {:prompt "You have no ice in R&D"
-                              :choices ["Carry on!"]
-                              :prompt-type :bogus
-                              :effect (effect (shuffle! :deck))})
-                           card nil))}}})
+  {:on-score
+   {:interactive (req true)
+    :optional
+    {:prompt "Search R&D for a piece of ice to install protecting a remote server?"
+     :yes-ability
+     {:async true
+      :effect (effect
+                (continue-ability
+                  (if (not-empty (filter ice? (:deck corp)))
+                    {:async true
+                     :prompt "Choose a piece of ice"
+                     :choices (req (filter ice? (:deck corp)))
+                     :effect
+                     (effect
+                       (continue-ability
+                         (let [chosen-ice target]
+                           {:async true
+                            :prompt (str "Select a server to install " (:title chosen-ice) " on")
+                            :choices (filter #(not (#{"HQ" "Archives" "R&D"} %))
+                                             (corp-install-list state chosen-ice))
+                            :effect (effect (shuffle! :deck)
+                                            (corp-install eid chosen-ice target
+                                                          {:ignore-all-cost true
+                                                           :install-state :rezzed-no-rez-cost}))})
+                         card nil))}
+                    {:prompt "You have no ice in R&D"
+                     :choices ["Carry on!"]
+                     :prompt-type :bogus
+                     :effect (effect (shuffle! :deck))})
+                  card nil))}}}})
 
 (defcard "Corporate Oversight B"
-  {:interactive (req true)
-   :optional {:prompt "Search R&D for a piece of ice to install protecting a central server?"
-              :yes-ability
-              {:async true
-               :effect (effect
-                         (continue-ability
-                           (if (not-empty (filter ice? (:deck corp)))
-                             {:async true
-                              :prompt "Choose a piece of ice"
-                              :choices (req (filter ice? (:deck corp)))
-                              :effect (effect
-                                        (continue-ability
-                                          (let [chosen-ice target]
-                                            {:async true
-                                             :prompt (str "Select a server to install " (:title chosen-ice) " on")
-                                             :choices (filter #(#{"HQ" "Archives" "R&D"} %)
-                                                              (corp-install-list state chosen-ice))
-                                             :effect (effect (shuffle! :deck)
-                                                             (corp-install eid chosen-ice target
-                                                                           {:ignore-all-cost true
-                                                                            :install-state :rezzed-no-rez-cost}))})
-                                          card nil))}
-                             {:prompt "You have no ice in R&D"
-                              :choices ["Carry on!"]
-                              :prompt-type :bogus
-                              :effect (effect (shuffle! :deck))})
-                           card nil))}}})
+  {:on-score
+   {:interactive (req true)
+    :optional
+    {:prompt "Search R&D for a piece of ice to install protecting a central server?"
+     :yes-ability
+     {:async true
+      :effect (effect
+                (continue-ability
+                  (if (not-empty (filter ice? (:deck corp)))
+                    {:async true
+                     :prompt "Choose a piece of ice"
+                     :choices (req (filter ice? (:deck corp)))
+                     :effect
+                     (effect
+                       (continue-ability
+                         (let [chosen-ice target]
+                           {:async true
+                            :prompt (str "Select a server to install " (:title chosen-ice) " on")
+                            :choices (filter #(#{"HQ" "Archives" "R&D"} %)
+                                             (corp-install-list state chosen-ice))
+                            :effect (effect (shuffle! :deck)
+                                            (corp-install eid chosen-ice target
+                                                          {:ignore-all-cost true
+                                                           :install-state :rezzed-no-rez-cost}))})
+                         card nil))}
+                    {:prompt "You have no ice in R&D"
+                     :choices ["Carry on!"]
+                     :prompt-type :bogus
+                     :effect (effect (shuffle! :deck))})
+                  card nil))}}}})
 
 (defcard "Corporate Sales Team"
   (let [e {:req (req (pos? (get-counters card :credit)))
@@ -451,18 +468,19 @@
            :async true
            :effect (req (add-counter state side card :credit -1)
                         (gain-credits state :corp eid 1))}]
-    {:effect (effect (add-counter card :credit 10))
-     :silent (req true)
+    {:on-score {:effect (effect (add-counter card :credit 10))
+                :silent (req true)}
      :events [(assoc e :event :runner-turn-begins)
               (assoc e :event :corp-turn-begins)]}))
 
 (defcard "Corporate War"
-  {:msg (msg (if (> (:credit corp) 6) "gain 7 [Credits]" "lose all credits"))
-   :interactive (req true)
-   :async true
-   :effect (req (if (> (:credit corp) 6)
-                  (gain-credits state :corp eid 7)
-                  (lose-credits state :corp eid :all)))})
+  {:on-score
+   {:msg (msg (if (> (:credit corp) 6) "gain 7 [Credits]" "lose all credits"))
+    :interactive (req true)
+    :async true
+    :effect (req (if (> (:credit corp) 6)
+                   (gain-credits state :corp eid 7)
+                   (lose-credits state :corp eid :all)))}})
 
 (defcard "Crisis Management"
   (let [ability {:req (req tagged)
@@ -475,9 +493,10 @@
      :abilities [ability]}))
 
 (defcard "Cyberdex Sandbox"
-  {:optional {:prompt "Purge virus counters with Cyberdex Sandbox?"
-              :yes-ability {:msg (msg "purge virus counters")
-                            :effect (effect (purge))}}
+  {:on-score {:optional
+              {:prompt "Purge virus counters with Cyberdex Sandbox?"
+               :yes-ability {:msg (msg "purge virus counters")
+                             :effect (effect (purge))}}}
    :events [{:event :purge
              :req (req (first-event? state :corp :purge))
              :once :per-turn
@@ -518,8 +537,10 @@
                                                       (when (< n 2)
                                                         (install-ability (last (get-remote-names state)) (inc n)))
                                                       card nil)))})]
-    {:optional {:prompt "Install cards in a new remote server?"
-                :yes-ability (install-ability "New remote" 0)}}))
+    {:on-score
+     {:optional
+      {:prompt "Install cards in a new remote server?"
+       :yes-ability (install-ability "New remote" 0)}}}))
 
 (defcard "Divested Trust"
   {:events
@@ -575,8 +596,8 @@
              :msg (msg "ignore the install cost of the first ICE this turn")}]})
 
 (defcard "Efficiency Committee"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 3))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 3))}
    :abilities [{:cost [:click 1 :agenda 1]
                 :effect (effect (gain :click 2)
                                 (register-turn-flag!
@@ -587,8 +608,8 @@
                 :msg "gain [Click][Click]"}]})
 
 (defcard "Elective Upgrade"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 2))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 2))}
    :abilities [{:cost [:click 1 :agenda 1]
                 :once :per-turn
                 :effect (effect (gain :click 2))
@@ -606,9 +627,9 @@
                 :effect (effect (gain-credits eid (count-tags state)))}]})
 
 (defcard "Executive Retreat"
-  {:effect (effect (add-counter card :agenda 1)
-                   (shuffle-into-deck :hand))
-   :interactive (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 1)
+                              (shuffle-into-deck :hand))
+              :interactive (req true)}
    :abilities [{:cost [:click 1 :agenda 1]
                 :msg "draw 5 cards"
                 :effect (effect (draw 5))}]})
@@ -639,8 +660,8 @@
    :steal-cost-bonus (req [:credit 2])})
 
 (defcard "Firmware Updates"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 3))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 3))}
    :abilities [{:cost [:agenda 1]
                 :label "place 1 advancement counter"
                 :choices {:card #(and (ice? %)
@@ -651,8 +672,8 @@
                 :effect (effect (add-prop target :advance-counter 1))}]})
 
 (defcard "Flower Sermon"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 5))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 5))}
    :abilities [{:cost [:agenda 1]
                 :label "reveal and draw"
                 :once :per-turn
@@ -675,20 +696,20 @@
                                    card nil))))}]})
 
 (defcard "Fly on the Wall"
-  {:msg "give the runner 1 tag"
-   :async true
-   :effect (req (gain-tags state :runner eid 1))})
+  {:on-score {:msg "give the runner 1 tag"
+              :async true
+              :effect (req (gain-tags state :runner eid 1))}})
 
 (defcard "Genetic Resequencing"
-  {:choices {:card in-scored?}
-   :msg (msg "add 1 agenda counter on " (:title target))
-   :effect (effect (add-counter target :agenda 1)
-                   (update-all-agenda-points))
-   :silent (req true)})
+  {:on-score {:choices {:card in-scored?}
+              :msg (msg "add 1 agenda counter on " (:title target))
+              :effect (effect (add-counter target :agenda 1)
+                              (update-all-agenda-points))
+              :silent (req true)}})
 
 (defcard "Geothermal Fracking"
-  {:effect (effect (add-counter card :agenda 2))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 2))
+              :silent (req true)}
    :abilities [{:cost [:click 1 :agenda 1]
                 :msg "gain 7 [Credits] and take 1 bad publicity"
                 :async true
@@ -745,9 +766,10 @@
                                      (do (shuffle! state side :deck)
                                          (system-msg state side (str "shuffles R&D"))
                                          (effect-completed state side eid))))})]
-    {:async true
-     :msg "add up to 3 cards from R&D to HQ"
-     :effect (effect (continue-ability (graft 1) card nil))}))
+    {:on-score
+     {:async true
+      :msg "add up to 3 cards from R&D to HQ"
+      :effect (effect (continue-ability (graft 1) card nil))}}))
 
 (defcard "Hades Fragment"
   {:flags {:corp-phase-12 (req (and (not-empty (get-in @state [:corp :discard]))
@@ -765,21 +787,22 @@
                           " to the bottom of R&D")}]})
 
 (defcard "Helium-3 Deposit"
-  {:async true
-   :interactive (req true)
-   :prompt "How many power counters?"
-   :choices ["0" "1" "2"]
-   :effect (req (let [c (str->int target)]
-                  (continue-ability
-                    state side
-                    {:choices {:card #(pos? (get-counters % :power))}
-                     :msg (msg "add " c " power counters on " (:title target))
-                     :effect (effect (add-counter target :power c))}
-                    card nil)))})
+  {:on-score
+   {:async true
+    :interactive (req true)
+    :prompt "How many power counters?"
+    :choices ["0" "1" "2"]
+    :effect (req (let [c (str->int target)]
+                   (continue-ability
+                     state side
+                     {:choices {:card #(pos? (get-counters % :power))}
+                      :msg (msg "add " c " power counters on " (:title target))
+                      :effect (effect (add-counter target :power c))}
+                     card nil)))}})
 
 (defcard "High-Risk Investment"
-  {:effect (effect (add-counter card :agenda 1))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 1))
+              :silent (req true)}
    :abilities [{:cost [:click 1 :agenda 1]
                 :label "gain credits"
                 :msg (msg "gain " (:credit runner) " [Credits]")
@@ -802,15 +825,15 @@
                               card nil)))}]})
 
 (defcard "Hostile Takeover"
-  {:msg "gain 7 [Credits] and take 1 bad publicity"
-   :async true
-   :effect (req (wait-for (gain-credits state side 7)
-                          (gain-bad-publicity state :corp eid 1)))
-   :interactive (req true)})
+  {:on-score {:msg "gain 7 [Credits] and take 1 bad publicity"
+              :async true
+              :effect (req (wait-for (gain-credits state side 7)
+                                     (gain-bad-publicity state :corp eid 1)))
+              :interactive (req true)}})
 
 (defcard "House of Knives"
-  {:effect (effect (add-counter card :agenda 3))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 3))
+              :silent (req true)}
    :abilities [{:cost [:agenda 1]
                 :msg "do 1 net damage"
                 :req (req (:run @state))
@@ -818,41 +841,40 @@
                 :effect (effect (damage eid :net 1 {:card card}))}]})
 
 (defcard "Hyperloop Extension"
-  (let [he (req (system-msg state side (str "uses Hyperloop Extension to gain 3 [Credits]"))
-                (gain-credits state :corp eid 3))]
-    {:effect he
-     :async true
-     :stolen {:async true
-              :effect he}}))
+  (let [he {:async true
+            :effect (req (system-msg state side (str "uses Hyperloop Extension to gain 3 [Credits]"))
+                         (gain-credits state :corp eid 3))}]
+    {:on-score he
+     :stolen he}))
 
 (defcard "Ikawah Project"
   {:steal-cost-bonus (req [:credit 2 :click 1])})
 
 (defcard "Illicit Sales"
-  {:async true
-   :effect (req (wait-for (resolve-ability
-                            state side
-                            {:optional
-                             {:prompt "Take 1 bad publicity from Illicit Sales?"
-                              :yes-ability {:msg "take 1 bad publicity"
-                                            :effect (effect (gain-bad-publicity :corp 1))}}}
-                            card nil)
-                          (let [n (* 3 (count-bad-pub state))]
-                            (system-msg state side (str "gains " n " [Credits] from Illicit Sales"))
-                            (gain-credits state side eid n))))})
+  {:on-score
+   {:async true
+    :effect (req (wait-for (resolve-ability
+                             state side
+                             {:optional
+                              {:prompt "Take 1 bad publicity from Illicit Sales?"
+                               :yes-ability {:msg "take 1 bad publicity"
+                                             :effect (effect (gain-bad-publicity :corp 1))}}}
+                             card nil)
+                           (let [n (* 3 (count-bad-pub state))]
+                             (system-msg state side (str "gains " n " [Credits] from Illicit Sales"))
+                             (gain-credits state side eid n))))}})
 
 (defcard "Improved Protein Source"
-  {:msg "make the Runner gain 4 [Credits]"
-   :async true
-   :effect (effect (gain-credits :runner eid 4))
-   :interactive (req true)
-   :stolen {:msg "make the Runner gain 4 [Credits]"
-            :async true
-            :effect (effect (gain-credits :runner eid 4))}})
+  (let [ability {:async true
+                 :interactive (req true)
+                 :msg "make the Runner gain 4 [Credits]"
+                 :effect (effect (gain-credits :runner eid 4))}]
+    {:on-score ability
+     :stolen ability}))
 
 (defcard "Improved Tracers"
-  {:silent (req true)
-   :effect (req (update-all-ice state side))
+  {:on-score {:silent (req true)
+              :effect (req (update-all-ice state side))}
    :swapped {:effect (req (update-all-ice state side))}
    :constant-effects [{:type :ice-strength
                        :req (req (has-subtype? target "Tracer"))
@@ -876,25 +898,25 @@
      :effect (effect (add-prop :corp target :advance-counter 2 {:placed true}))}]})
 
 (defcard "Labyrinthine Servers"
-  {:interactions {:prevent [{:type #{:jack-out}
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :power 2))}
+   :interactions {:prevent [{:type #{:jack-out}
                              :req (req (pos? (get-counters card :power)))}]}
-   :silent (req true)
-   :effect (effect (add-counter card :power 2))
    :abilities [{:req (req (:run @state))
                 :cost [:power 1]
                 :msg "prevent the Runner from jacking out"
                 :effect (effect (jack-out-prevent))}]})
 
 (defcard "License Acquisition"
-  {:interactive (req true)
-   :prompt "Select an asset or upgrade to install from Archives or HQ"
-   :show-discard true
-   :choices {:card #(and (corp? %)
-                         (or (asset? %) (upgrade? %))
-                         (or (in-hand? %) (in-discard? %)))}
-   :msg (msg "install and rez " (:title target) ", ignoring all costs")
-   :async true
-   :effect (effect (corp-install eid target nil {:install-state :rezzed-no-cost}))})
+  {:on-score {:interactive (req true)
+              :prompt "Select an asset or upgrade to install from Archives or HQ"
+              :show-discard true
+              :choices {:card #(and (corp? %)
+                                    (or (asset? %) (upgrade? %))
+                                    (or (in-hand? %) (in-discard? %)))}
+              :msg (msg "install and rez " (:title target) ", ignoring all costs")
+              :async true
+              :effect (effect (corp-install eid target nil {:install-state :rezzed-no-cost}))}})
 
 (defcard "Mandatory Seed Replacement"
   (letfn [(msr [] {:prompt "Select two pieces of ICE to swap positions"
@@ -912,15 +934,14 @@
                                       (continue-ability state side (msr) card nil))
                                   (do (system-msg state :corp (str "has finished rearranging ICE"))
                                       (effect-completed state side eid))))})]
-    {:async true
-     :msg "rearrange any number of ICE"
-     :effect (effect (continue-ability (msr) card nil))}))
+    {:on-score {:async true
+                :msg "rearrange any number of ICE"
+                :effect (effect (continue-ability (msr) card nil))}}))
 
 (defcard "Mandatory Upgrades"
-  {:msg "gain an additional [Click] per turn"
-   :silent (req true)
-   :effect (req (gain state :corp
-                      :click-per-turn 1))
+  {:on-score {:msg "gain an additional [Click] per turn"
+              :silent (req true)
+              :effect (req (gain state :corp :click-per-turn 1))}
    :swapped {:msg "gain an additional [Click] per turn"
              :effect (req (when (= (:active-player @state) :corp)
                             (gain state :corp :click 1))
@@ -930,11 +951,11 @@
                           :click-per-turn 1))})
 
 (defcard "Market Research"
-  {:interactive (req true)
-   :req (req tagged)
-   :effect (effect (add-counter card :agenda 1)
-                   (update-all-agenda-points)
-                   (check-winner))
+  {:on-score {:interactive (req true)
+              :req (req tagged)
+              :effect (effect (add-counter card :agenda 1)
+                              (update-all-agenda-points)
+                              (check-winner))}
    :agendapoints-corp (req (if (zero? (get-counters card :agenda)) 2 3))})
 
 (defcard "Medical Breakthrough"
@@ -944,32 +965,32 @@
                        :value -1}]})
 
 (defcard "Megaprix Qualifier"
-  {:silent (req true)
-   :req (req (< 1 (count (filter #(= (:title %) "Megaprix Qualifier")
-                                 (concat (:scored corp) (:scored runner))))))
-   :effect (effect (add-counter card :agenda 1))
+  {:on-score {:silent (req true)
+              :req (req (< 1 (count (filter #(= (:title %) "Megaprix Qualifier")
+                                            (concat (:scored corp) (:scored runner))))))
+              :effect (effect (add-counter card :agenda 1))}
    :agendapoints-corp (req (if (zero? (get-counters card :agenda)) 1 2))})
 
 (defcard "Merger"
   {:agendapoints-runner (req 3)})
 
 (defcard "Meteor Mining"
-  {:interactive (req true)
-   :async true
-   :prompt "Use Meteor Mining?"
-   :choices (req (if (< (count-tags state) 2)
-                   ["Gain 7 [Credits]" "No action"]
-                   ["Gain 7 [Credits]" "Do 7 meat damage" "No action"]))
-   :effect (req (case target
-                  "Gain 7 [Credits]"
-                  (do (system-msg state side "uses Meteor Mining to gain 7 [Credits]")
-                      (gain-credits state side eid 7))
-                  "Do 7 meat damage"
-                  (do (system-msg state side "uses Meteor Mining do 7 meat damage")
-                      (damage state side eid :meat 7 {:card card}))
-                  "No action"
-                  (do (system-msg state side "does not use Meteor Mining")
-                      (effect-completed state side eid))))})
+  {:on-score {:interactive (req true)
+              :async true
+              :prompt "Use Meteor Mining?"
+              :choices (req (if (< (count-tags state) 2)
+                              ["Gain 7 [Credits]" "No action"]
+                              ["Gain 7 [Credits]" "Do 7 meat damage" "No action"]))
+              :effect (req (case target
+                             "Gain 7 [Credits]"
+                             (do (system-msg state side "uses Meteor Mining to gain 7 [Credits]")
+                                 (gain-credits state side eid 7))
+                             "Do 7 meat damage"
+                             (do (system-msg state side "uses Meteor Mining do 7 meat damage")
+                                 (damage state side eid :meat 7 {:card card}))
+                             "No action"
+                             (do (system-msg state side "does not use Meteor Mining")
+                                 (effect-completed state side eid))))}})
 
 (defcard "NAPD Contract"
   {:steal-cost-bonus (req [:credit 4])
@@ -1011,18 +1032,25 @@
                                                 {:install-state :rezzed-no-cost})))}}}]})
 
 (defcard "NEXT Wave 2"
-  {:not-when-scored true
-   :optional {:prompt "Do 1 brain damage with NEXT Wave 2?"
-              :req (req (some #(and (rezzed? %)
-                                    (ice? %)
-                                    (has-subtype? % "NEXT"))
-                              (all-installed state :corp)))
-              :yes-ability {:msg "do 1 brain damage"
-                            :effect (effect (damage eid :brain 1 {:card card}))}}})
+  {:on-score
+   {:async true
+    :effect
+    (effect
+      (continue-ability
+        (when (some #(and (rezzed? %)
+                          (ice? %)
+                          (has-subtype? % "NEXT"))
+                    (all-installed state :corp))
+          {:optional
+           {:prompt "Do 1 brain damage with NEXT Wave 2?"
+            :yes-ability {:msg "do 1 brain damage"
+                          :async true
+                          :effect (effect (damage eid :brain 1 {:card card}))}}})
+        card nil))}})
 
 (defcard "Nisei MK II"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 1))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 1))}
    :abilities [{:req (req (:run @state))
                 :cost [:agenda 1]
                 :msg "end the run"
@@ -1041,13 +1069,16 @@
   {:steal-cost-bonus (req [:net 4])})
 
 (defcard "Paper Trail"
-  {:trace {:base 6
-           :successful {:msg "trash all connection and job resources"
-                        :async true
-                        :effect (req (let [resources (filter #(or (has-subtype? % "Job")
-                                                                  (has-subtype? % "Connection"))
-                                                             (all-active-installed state :runner))]
-                                       (trash-cards state side eid resources)))}}})
+  {:on-score
+   {:trace
+    {:base 6
+     :successful
+     {:msg "trash all connection and job resources"
+      :async true
+      :effect (req (let [resources (filter #(or (has-subtype? % "Job")
+                                                (has-subtype? % "Connection"))
+                                           (all-active-installed state :runner))]
+                     (trash-cards state side eid resources)))}}}})
 
 (defcard "Personality Profiles"
   (let [pp {:req (req (pos? (count (:hand runner))))
@@ -1063,25 +1094,27 @@
                                     (pos? (count (:hand runner))))))]}))
 
 (defcard "Philotic Entanglement"
-  {:interactive (req true)
-   :req (req (pos? (count (:scored runner))))
-   :msg (msg "do " (count (:scored runner)) " net damage")
-   :effect (effect (damage eid :net (count (:scored runner)) {:card card}))})
+  {:on-score {:interactive (req true)
+              :req (req (pos? (count (:scored runner))))
+              :msg (msg "do " (count (:scored runner)) " net damage")
+              :effect (effect (damage eid :net (count (:scored runner)) {:card card}))}})
 
 (defcard "Posted Bounty"
-  {:optional {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
-              :yes-ability {:msg "give the Runner 1 tag and take 1 bad publicity"
-                            :async true
-                            :effect (effect (gain-bad-publicity :corp eid 1)
-                                            (gain-tags :corp eid 1)
-                                            (forfeit card))}}})
+  {:on-score {:optional
+              {:prompt "Forfeit Posted Bounty to give the Runner 1 tag and take 1 bad publicity?"
+               :yes-ability
+               {:msg "give the Runner 1 tag and take 1 bad publicity"
+                :async true
+                :effect (effect (gain-bad-publicity :corp eid 1)
+                                (gain-tags :corp eid 1)
+                                (forfeit card))}}}})
 
 (defcard "Priority Requisition"
-  {:interactive (req true)
-   :choices {:card #(and (ice? %)
-                         (not (rezzed? %))
-                         (installed? %))}
-   :effect (effect (rez target {:ignore-cost :all-costs}))})
+  {:on-score {:interactive (req true)
+              :choices {:card #(and (ice? %)
+                                    (not (rezzed? %))
+                                    (installed? %))}
+              :effect (effect (rez target {:ignore-cost :all-costs}))}})
 
 (defcard "Private Security Force"
   {:abilities [{:req (req tagged)
@@ -1090,39 +1123,39 @@
                 :msg "do 1 meat damage"}]})
 
 (defcard "Profiteering"
-  {:interactive (req true)
-   :choices ["0" "1" "2" "3"]
-   :prompt "How many bad publicity?"
-   :msg (msg "take " target " bad publicity and gain " (* 5 (str->int target)) " [Credits]")
-   :async true
-   :effect (req (let [bp (count-bad-pub state)]
-                  (wait-for (gain-bad-publicity state :corp (str->int target))
-                            (if (< bp (count-bad-pub state))
-                              (gain-credits state :corp eid (* 5 (str->int target)))
-                              (effect-completed state side eid)))))})
+  {:on-score {:interactive (req true)
+              :choices ["0" "1" "2" "3"]
+              :prompt "How many bad publicity?"
+              :msg (msg "take " target " bad publicity and gain " (* 5 (str->int target)) " [Credits]")
+              :async true
+              :effect (req (let [bp (count-bad-pub state)]
+                             (wait-for (gain-bad-publicity state :corp (str->int target))
+                                       (if (< bp (count-bad-pub state))
+                                         (gain-credits state :corp eid (* 5 (str->int target)))
+                                         (effect-completed state side eid)))))}})
 
 (defcard "Project Ares"
   (letfn [(trash-count-str [card]
             (quantify (- (get-counters card :advancement) 4) "installed card"))]
-    {:player :runner
-     :silent (req true)
-     :req (req (and (> (get-counters card :advancement) 4)
-                    (pos? (count (all-installed state :runner)))))
-     :waiting-prompt "Runner to trash installed cards"
-     :prompt (msg "Select " (trash-count-str card) " installed cards to trash")
-     :choices {:max (req (min (- (get-counters card :advancement) 4)
-                              (count (all-installed state :runner))))
-               :card #(and (runner? %)
-                        (installed? %))}
-     :msg (msg "force the Runner to trash " (trash-count-str card) " and take 1 bad publicity")
-     :async true
-     :effect (req (wait-for (trash-cards state side targets)
-                            (system-msg state side (str "trashes " (string/join ", " (map :title targets))))
-                            (gain-bad-publicity state :corp eid 1)))}))
+    {:on-score {:player :runner
+                :silent (req true)
+                :req (req (and (> (get-counters card :advancement) 4)
+                               (pos? (count (all-installed state :runner)))))
+                :waiting-prompt "Runner to trash installed cards"
+                :prompt (msg "Select " (trash-count-str card) " installed cards to trash")
+                :choices {:max (req (min (- (get-counters card :advancement) 4)
+                                         (count (all-installed state :runner))))
+                          :card #(and (runner? %)
+                                   (installed? %))}
+                :msg (msg "force the Runner to trash " (trash-count-str card) " and take 1 bad publicity")
+                :async true
+                :effect (req (wait-for (trash-cards state side targets)
+                                       (system-msg state side (str "trashes " (string/join ", " (map :title targets))))
+                                       (gain-bad-publicity state :corp eid 1)))}}))
 
 (defcard "Project Atlas"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda (max 0 (- (get-counters card :advancement) 3))))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda (max 0 (- (get-counters card :advancement) 3))))}
    :abilities [{:cost [:agenda 1]
                 :prompt "Choose a card"
                 :label "Search R&D and add 1 card to HQ"
@@ -1135,17 +1168,17 @@
                                 (move target :hand))}]})
 
 (defcard "Project Beale"
-  {:interactive (req true)
-   :agendapoints-runner (req 2)
+  {:agendapoints-runner (req 2)
    :agendapoints-corp (req (+ 2 (get-counters card :agenda)))
-   :effect (req (let [n (quot (- (get-counters card :advancement) 3) 2)]
-                  (add-counter state side card :agenda n)
-                  (update-all-agenda-points state side)
-                  (check-winner state side)))})
+   :on-score {:interactive (req true)
+              :effect (req (let [n (quot (- (get-counters card :advancement) 3) 2)]
+                             (add-counter state side card :agenda n)
+                             (update-all-agenda-points state side)
+                             (check-winner state side)))}})
 
 (defcard "Project Kusanagi"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda (- (get-counters card :advancement) 2)))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda (- (get-counters card :advancement) 2)))}
    :events [{:event :run-ends
              :effect (req (let [cid (:cid card)
                                 ices (get-in card [:special :kusanagi])]
@@ -1193,8 +1226,8 @@
      :flags {:has-events-when-stolen true}}))
 
 (defcard "Project Vitruvius"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda (- (get-counters card :advancement) 3)))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda (- (get-counters card :advancement) 3)))}
    :abilities [{:cost [:agenda 1]
                 :label "Add 1 card from Archives to HQ"
                 :prompt "Choose a card in Archives to add to HQ"
@@ -1209,8 +1242,8 @@
                 :effect (effect (move target :hand))}]})
 
 (defcard "Project Wotan"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 3))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 3))}
    :events [{:event :run-ends
              :effect (req (let [cid (:cid card)
                                 ices (get-in card [:special :wotan])]
@@ -1258,8 +1291,8 @@
              :choices {:card #(= (first run-server) (second (get-zone %)))}
              :effect (effect (continue-ability (choose-swap target) card nil))
              :cancel-effect (effect (put-back-counter card))})]
-    {:silent (req true)
-     :effect (effect (add-counter card :agenda (- (get-counters card :advancement) 3)))
+    {:on-score {:silent (req true)
+                :effect (effect (add-counter card :agenda (- (get-counters card :advancement) 3)))}
      :abilities [{:cost [:agenda 1]
                   :label "swap card in HQ with installed card"
                   :req (req run)
@@ -1287,7 +1320,7 @@
             :effect (effect (as-agenda :corp eid card 1))}})
 
 (defcard "Rebranding Team"
-  {:msg "make all assets gain Advertisement"
+  {:on-score {:msg "make all assets gain Advertisement"}
    :swapped {:msg "make all assets gain Advertisement"}
    :constant-effects [{:type :gain-subtype
                        :req (req (asset? target))
@@ -1325,17 +1358,17 @@
                                 (continue-ability state side (corp-final (remove #(= % "Done") chosen) original) card nil)
                                 (do (system-msg state side "does not add any cards from HQ to bottom of R&D")
                                     (effect-completed state side eid))))))})]
-    {:async true
-     :waiting-prompt "Corp to add cards from HQ to bottom of R&D"
-     :effect (req (let [from (get-in @state [:corp :hand])]
-                    (if (pos? (count from))
-                      (continue-ability state :corp (corp-choice from '() from) card nil)
-                      (do (system-msg state side "does not add any cards from HQ to bottom of R&D")
-                          (effect-completed state side eid)))))}))
+    {:on-score {:async true
+                :waiting-prompt "Corp to add cards from HQ to bottom of R&D"
+                :effect (req (let [from (get-in @state [:corp :hand])]
+                               (if (pos? (count from))
+                                 (continue-ability state :corp (corp-choice from '() from) card nil)
+                                 (do (system-msg state side "does not add any cards from HQ to bottom of R&D")
+                                     (effect-completed state side eid)))))}}))
 
 (defcard "Remastered Edition"
-  {:effect (effect (add-counter card :agenda 1))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 1))
+              :silent (req true)}
    :abilities [{:cost [:agenda 1]
                 :msg (msg "place 1 advancement token on " (card-str state target))
                 :label "place 1 advancement token"
@@ -1343,52 +1376,54 @@
                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]})
 
 (defcard "Remote Data Farm"
-  {:silent (req true)
-   :msg "increase their maximum hand size by 2"
+  {:on-score {:silent (req true)
+              :msg "increase their maximum hand size by 2"}
    :constant-effects [(corp-hand-size+ 2)]})
 
 (defcard "Remote Enforcement"
-  {:interactive (req true)
-   :optional {:prompt "Search R&D for a piece of ice to install protecting a remote server?"
-              :yes-ability
-              {:async true
-               :effect (effect
-                         (continue-ability
-                           (if (not-empty (filter ice? (:deck corp)))
-                             {:async true
-                              :prompt "Choose a piece of ice"
-                              :choices (req (filter ice? (:deck corp)))
-                              :effect (effect
-                                        (continue-ability
-                                          (let [chosen-ice target]
-                                            {:async true
-                                             :prompt (str "Select a server to install " (:title chosen-ice) " on")
-                                             :choices (filter #(not (#{"HQ" "Archives" "R&D"} %))
-                                                              (corp-install-list state chosen-ice))
-                                             :effect (effect (shuffle! :deck)
-                                                             (corp-install eid chosen-ice target
-                                                                           {:install-state :rezzed-no-rez-cost}))})
-                                          card nil))}
-                             {:prompt "You have no ice in R&D"
-                              :choices ["Carry on!"]
-                              :prompt-type :bogus
-                              :effect (effect (shuffle! :deck))})
-                           card nil))}}})
+  {:on-score
+   {:interactive (req true)
+    :optional
+    {:prompt "Search R&D for a piece of ice to install protecting a remote server?"
+     :yes-ability
+     {:async true
+      :effect (effect
+                (continue-ability
+                  (if (not-empty (filter ice? (:deck corp)))
+                    {:async true
+                     :prompt "Choose a piece of ice"
+                     :choices (req (filter ice? (:deck corp)))
+                     :effect (effect
+                               (continue-ability
+                                 (let [chosen-ice target]
+                                   {:async true
+                                    :prompt (str "Select a server to install " (:title chosen-ice) " on")
+                                    :choices (filter #(not (#{"HQ" "Archives" "R&D"} %))
+                                                     (corp-install-list state chosen-ice))
+                                    :effect (effect (shuffle! :deck)
+                                                    (corp-install eid chosen-ice target
+                                                                  {:install-state :rezzed-no-rez-cost}))})
+                                 card nil))}
+                    {:prompt "You have no ice in R&D"
+                     :choices ["Carry on!"]
+                     :prompt-type :bogus
+                     :effect (effect (shuffle! :deck))})
+                  card nil))}}}})
 
 (defcard "Research Grant"
-  {:interactive (req true)
-   :silent (req (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp))))
-   :async true
-   :effect (effect (continue-ability
-                     {:prompt "Select another installed copy of Research Grant to score"
-                      :choices {:card #(= (:title %) "Research Grant")}
-                      :interactive (req true)
-                      :async true
-                      :req (req (seq (filter #(= (:title %) "Research Grant") (all-installed state :corp))))
-                      :effect (effect (set-prop target :advance-counter (:advancementcost target))
-                                      (score eid (get-card state target)))
-                      :msg "score another installed copy of Research Grant"}
-                     card nil))})
+  {:on-score {:interactive (req true)
+              :silent (req (empty? (filter #(= (:title %) "Research Grant") (all-installed state :corp))))
+              :async true
+              :effect (effect (continue-ability
+                                {:prompt "Select another installed copy of Research Grant to score"
+                                 :choices {:card #(= (:title %) "Research Grant")}
+                                 :interactive (req true)
+                                 :async true
+                                 :req (req (seq (filter #(= (:title %) "Research Grant") (all-installed state :corp))))
+                                 :effect (effect (set-prop target :advance-counter (:advancementcost target))
+                                                 (score eid (get-card state target)))
+                                 :msg "score another installed copy of Research Grant"}
+                                card nil))}})
 
 (defcard "Restructured Datapool"
   {:abilities [{:cost [:click 1]
@@ -1400,24 +1435,24 @@
 
 (defcard "SDS Drone Deployment"
   {:steal-cost-bonus (req [:program 1])
-   :req (req (seq (all-installed-runner-type state :program)))
-   :waiting-prompt "Corp to trash a card"
-   :prompt "Select a program to trash"
-   :choices {:card #(and (installed? %)
-                         (program? %))
-             :all true}
-   :msg (msg "trash " (:title target))
-   :async true
-   :effect (effect (trash eid target nil))})
+   :on-score {:req (req (seq (all-installed-runner-type state :program)))
+              :waiting-prompt "Corp to trash a card"
+              :prompt "Select a program to trash"
+              :choices {:card #(and (installed? %)
+                                    (program? %))
+                        :all true}
+              :msg (msg "trash " (:title target))
+              :async true
+              :effect (effect (trash eid target nil))}})
 
 (defcard "Self-Destruct Chips"
-  {:silent (req true)
-   :msg "decrease the Runner's maximum hand size by 1"
+  {:on-score {:silent (req true)
+              :msg "decrease the Runner's maximum hand size by 1"}
    :constant-effects [(runner-hand-size+ -1)]})
 
 (defcard "Sensor Net Activation"
-  {:effect (effect (add-counter card :agenda 1))
-   :silent (req true)
+  {:on-score {:effect (effect (add-counter card :agenda 1))
+              :silent (req true)}
    :abilities [{:cost [:agenda 1]
                 :req (req (some #(and (has-subtype? % "Bioroid")
                                       (not (rezzed? %)))
@@ -1444,29 +1479,30 @@
              :effect (effect (damage eid :net 1 {:card card}))}]})
 
 (defcard "Show of Force"
-  {:async true
-   :msg "do 2 meat damage"
-   :effect (effect (damage eid :meat 2 {:card card}))})
+  {:on-score {:async true
+              :msg "do 2 meat damage"
+              :effect (effect (damage eid :meat 2 {:card card}))}})
 
 (defcard "SSL Endorsement"
-  (let [add-credits (effect (add-counter card :credit 9))
-        remove-credits {:optional {:req (req (pos? (get-counters card :credit)))
-                                   :once :per-turn
-                                   :prompt "Gain 3 [Credits] from SSL Endorsement?"
-                                   :autoresolve (get-autoresolve :auto-fire)
-                                   :yes-ability
-                                   {:async true
-                                    :msg (msg "gain " (min 3 (get-counters card :credit)) " [Credits]")
-                                    :effect (req (if (pos? (get-counters card :credit))
-                                                   (do (add-counter state side card :credit -3)
-                                                       (gain-credits state :corp eid 3))
-                                                   (effect-completed state side eid)))}}}]
-    {:effect add-credits
+  (let [add-credits (effect (add-counter card :credit 9))]
+    {:flags {:has-events-when-stolen true}
+     :on-score {:effect add-credits
+                :interactive (req true)}
      :abilities [(set-autoresolve :auto-fire "whether to take credits off SSL")]
      :stolen {:effect add-credits}
-     :interactive (req true)
-     :events [(assoc remove-credits :event :corp-turn-begins)]
-     :flags {:has-events-when-stolen true}}))
+     :events [{:event :corp-turn-begins
+               :optional
+               {:req (req (pos? (get-counters card :credit)))
+                :once :per-turn
+                :prompt "Gain 3 [Credits] from SSL Endorsement?"
+                :autoresolve (get-autoresolve :auto-fire)
+                :yes-ability
+                {:async true
+                 :msg (msg "gain " (min 3 (get-counters card :credit)) " [Credits]")
+                 :effect (req (if (pos? (get-counters card :credit))
+                                (do (add-counter state side card :credit -3)
+                                    (gain-credits state :corp eid 3))
+                                (effect-completed state side eid)))}}}]}))
 
 (defcard "Standoff"
   (letfn [(stand [side]
@@ -1488,17 +1524,18 @@
                                     (clear-wait-prompt state (other-side side))
                                     (show-wait-prompt state side (str (side-str (other-side side)) " to trash a card for Standoff"))
                                     (continue-ability state (other-side side) (stand (other-side side)) card nil)))})]
-    {:interactive (req true)
-     :async true
-     :effect (effect (show-wait-prompt (str (side-str (other-side side)) " to trash a card for Standoff"))
-               (continue-ability :runner (stand :runner) card nil))}))
+    {:on-score
+     {:interactive (req true)
+      :async true
+      :effect (effect (show-wait-prompt (str (side-str (other-side side)) " to trash a card for Standoff"))
+                (continue-ability :runner (stand :runner) card nil))}}))
 
 (defcard "Sting!"
   (letfn [(count-opp-stings [state side]
             (count (filter #(= (:title %) "Sting!") (get-in @state [(other-side side) :scored]))))]
-    {:msg (msg "deal " (inc (count-opp-stings state :corp)) " net damage")
-     :async true
-     :effect (effect (damage eid :net (inc (count-opp-stings state :corp)) {:card card}))
+    {:on-score {:msg (msg "deal " (inc (count-opp-stings state :corp)) " net damage")
+                :async true
+                :effect (effect (damage eid :net (inc (count-opp-stings state :corp)) {:card card}))}
      :stolen {:msg (msg "deal " (inc (count-opp-stings state :runner)) " net damage")
               :async true
               :effect (effect (damage eid :net (inc (count-opp-stings state :runner)) {:card card}))}}))
@@ -1513,10 +1550,10 @@
              :effect (req (wait-for
                             (corp-install state side target nil {:ignore-all-cost true})
                             (continue-ability state side (when (< n max-ops) (sft (inc n) max-ops)) card nil)))})]
-    {:async true
-     :msg "install cards from HQ, ignoring all costs"
-     :effect (req (let [max-ops (count (filter (complement operation?) (:hand corp)))]
-                    (continue-ability state side (sft 1 max-ops) card nil)))}))
+    {:on-score {:async true
+                :msg "install cards from HQ, ignoring all costs"
+                :effect (req (let [max-ops (count (filter (complement operation?) (:hand corp)))]
+                               (continue-ability state side (sft 1 max-ops) card nil)))}}))
 
 (defcard "Superior Cyberwalls"
   (ice-boost-agenda "Barrier"))
@@ -1535,27 +1572,27 @@
              :effect (effect (damage-bonus :meat 1))}]})
 
 (defcard "The Future is Now"
-  {:interactive (req true)
-   :prompt "Choose a card to add to HQ"
-   :choices (req (:deck corp))
-   :msg (msg "add a card from R&D to HQ and shuffle R&D")
-   :req (req (pos? (count (:deck corp))))
-   :effect (effect (shuffle! :deck)
-                   (move target :hand))})
+  {:on-score {:interactive (req true)
+              :prompt "Choose a card to add to HQ"
+              :choices (req (:deck corp))
+              :msg (msg "add a card from R&D to HQ and shuffle R&D")
+              :req (req (pos? (count (:deck corp))))
+              :effect (effect (shuffle! :deck)
+                              (move target :hand))}})
 
 (defcard "The Future Perfect"
   {:flags {:rd-reveal (req true)}
-   :access
-   {:psi {:req (req (not installed))
-          :not-equal {:msg "prevent it from being stolen"
-                      :effect (effect (register-run-flag!
-                                        card :can-steal
-                                        (fn [_ _ c] (not (same-card? c card))))
-                                      (effect-completed eid))}}}})
+   :access {:psi {:req (req (not installed))
+                  :not-equal
+                  {:msg "prevent it from being stolen"
+                   :effect (effect (register-run-flag!
+                                     card :can-steal
+                                     (fn [_ _ c] (not (same-card? c card))))
+                                   (effect-completed eid))}}}})
 
 (defcard "Timely Public Release"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 1))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 1))}
    :abilities [{:cost [:agenda 1]
                 :label "Install a piece of ice in any position, ignoring all costs"
                 :prompt "Select a piece of ice to install"
@@ -1600,8 +1637,8 @@
                             card nil))}]})
 
 (defcard "Transport Monopoly"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 2))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 2))}
    :abilities [{:cost [:agenda 1]
                 :req (req run)
                 :msg "prevent this run from becoming successful"
@@ -1626,10 +1663,9 @@
 
 (defcard "Unorthodox Predictions"
   {:implementation "Prevention of subroutine breaking is not enforced"
-   :prompt "Choose an ICE type for Unorthodox Predictions"
-   :choices ["Barrier" "Code Gate" "Sentry"]
-   :msg (msg "prevent subroutines on " target " ICE from being broken until next turn.")
-   :effect (effect (effect-completed eid))})
+   :on-score {:prompt "Choose an ICE type for Unorthodox Predictions"
+              :choices ["Barrier" "Code Gate" "Sentry"]
+              :msg (msg "prevent subroutines on " target " ICE from being broken until next turn.")}})
 
 (defcard "Utopia Fragment"
   {:events [{:event :pre-steal-cost
@@ -1642,23 +1678,26 @@
   {})
 
 (defcard "Veterans Program"
-  {:interactive (req true)
-   :msg "lose 2 bad publicity"
-   :effect (effect (lose-bad-publicity 2))})
+  {:on-score {:interactive (req true)
+              :msg "lose 2 bad publicity"
+              :effect (effect (lose-bad-publicity 2))}})
 
 (defcard "Viral Weaponization"
-  {:effect (effect (register-events
-                     card
-                     [{:event (if (= :corp (:active-player @state)) :corp-turn-ends :runner-turn-ends)
-                       :unregister-once-resolved true
-                       :duration :end-of-turn
-                       :msg (msg "do " (count (:hand runner)) " net damage")
-                       :async true
-                       :effect (effect (damage eid :net (count (:hand runner)) {:card card}))}]))})
+  {:on-score
+   {:effect
+    (effect
+      (register-events
+        card
+        [{:event (if (= :corp (:active-player @state)) :corp-turn-ends :runner-turn-ends)
+          :unregister-once-resolved true
+          :duration :end-of-turn
+          :msg (msg "do " (count (:hand runner)) " net damage")
+          :async true
+          :effect (effect (damage eid :net (count (:hand runner)) {:card card}))}]))}})
 
 (defcard "Voting Machine Initiative"
-  {:silent (req true)
-   :effect (effect (add-counter card :agenda 3))
+  {:on-score {:silent (req true)
+              :effect (effect (add-counter card :agenda 3))}
    :events [{:event :runner-turn-begins
              :optional
              {:player :corp
@@ -1684,11 +1723,13 @@
                            true))))}]})
 
 (defcard "Vulcan Coverup"
-  {:interactive (req true)
-   :msg "do 2 meat damage"
-   :effect (effect (damage eid :meat 2 {:card card}))
+  {:on-score {:interactive (req true)
+              :msg "do 2 meat damage"
+              :async true
+              :effect (effect (damage eid :meat 2 {:card card}))}
    :stolen {:msg "force the Corp to take 1 bad publicity"
-            :effect (effect (gain-bad-publicity :corp 1))}})
+            :async true
+            :effect (effect (gain-bad-publicity :corp eid 1))}})
 
 (defcard "Water Monopoly"
   {:constant-effects [{:type :install-cost

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -10,18 +10,16 @@
   {:req (req (pos? (count (:scored corp))))
    :async true
    :additional-cost [:forfeit]
-   :effect (req (continue-ability
-                  state side
-                  {:prompt "Select an agenda in your score area to trigger its \"when scored\" ability"
-                   :choices {:card #(and (agenda? %)
-                                         (when-scored? %)
-                                         (is-scored? state :corp %))}
-                   :msg (msg "trigger the \"when scored\" ability of " (:title target))
-                   :async true
-                   :effect (effect (continue-ability (card-def target) target nil)
-                                   (unregister-events target {:events [{:event :corp-turn-ends}
-                                                                       {:event :runner-turn-ends}]}))}
-                  card nil))})
+   :effect (effect
+             (continue-ability
+               {:prompt "Select an agenda in your score area to trigger its \"when scored\" ability"
+                :choices {:card #(and (agenda? %)
+                                      (when-scored? %)
+                                      (is-scored? state :corp %))}
+                :msg (msg "trigger the \"when scored\" ability of " (:title target))
+                :async true
+                :effect (effect (continue-ability (:on-score (card-def target)) target nil))}
+               card nil))})
 
 (defcard "Accelerated Diagnostics"
   (letfn [(ad [st si e c cards]

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -584,7 +584,9 @@
                        _ (update-all-advancement-requirements state)
                        _ (update-all-agenda-points state)
                        c (get-card state c)
-                       points (get-agenda-points c)]
+                       points (get-agenda-points c)
+                       card-ability (when-let [ability (:on-score (card-def card))]
+                                      (ability-as-handler c ability))]
                    (system-msg state :corp (str "scores " (:title c)
                                                 " and gains " (quantify points "agenda point")))
                    (trigger-event-simult
@@ -595,7 +597,7 @@
                                                      (when (:disable-id (card-def current))
                                                        (swap! state assoc-in [:corp :disable-id] true)))
                                                    (remove-old-current state side eid :runner))}
-                      :card-abilities (card-as-handler c)
+                      :card-abilities card-ability
                       :after-active-player
                       {:effect (req (let [c (get-card state c)]
                                       (set-prop state :corp (get-card state moved-card) :advance-counter 0)

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -363,7 +363,7 @@
 (defn when-scored?
   "Checks if the specified card is able to be used for a when-scored text ability"
   [card]
-  (not (:not-when-scored (card-def card))))
+  (:on-score (card-def card)))
 
 (defn ab-can-prevent?
   "Checks if the specified ability definition should prevent.

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -1330,16 +1330,74 @@
 
 (deftest glenn-station
   ;; Glenn Station
-  (do-game
-    (new-game {:corp {:deck ["Glenn Station" "Ice Wall"]}})
-    (play-and-score state "Glenn Station")
-    (let [gs-scored (get-scored state :corp 0)]
-      (card-ability state :corp gs-scored 0)
-      (click-prompt state :corp (find-card "Ice Wall" (:hand (get-corp))))
-      (is (= 1 (count (:hosted (refresh gs-scored)))))
-      (card-ability state :corp gs-scored 1)
-      (click-prompt state :corp (find-card "Ice Wall" (:hosted (refresh gs-scored))))
-      (is (zero? (count (:hosted (refresh gs-scored))))))))
+  (before-each [state (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                                        :hand ["Glenn Station" "Ice Wall" "Enigma"]}
+                                 :runner {:hand ["Political Graffiti"]}})
+                _ (play-and-score state "Glenn Station")
+                gs-scored (get-scored state :corp 0)]
+    (testing "Can host a card"
+      (do-game state
+        (card-ability state :corp gs-scored 0)
+        (click-card state :corp "Ice Wall")
+        (is (find-card "Ice Wall" (:hosted (refresh gs-scored))))
+        (is (= 1 (count (:hosted (refresh gs-scored)))))))
+    (testing "Can't host more than 1 card"
+      (do-game state
+        (card-ability state :corp gs-scored 0)
+        (click-card state :corp "Ice Wall")
+        (card-ability state :corp gs-scored 0)
+        (is (empty? (:prompt (get-corp))))))
+    (testing "Requires at least 1 card in hand to host"
+      (do-game state
+        (starting-hand state :corp [])
+        (card-ability state :corp gs-scored 0)
+        (is (empty? (:prompt (get-corp))))))
+    (testing "Can take a hosted card"
+      (do-game state
+        (card-ability state :corp gs-scored 0)
+        (click-card state :corp "Ice Wall")
+        (card-ability state :corp gs-scored 1)
+        (click-card state :corp "Ice Wall")
+        (is (find-card "Ice Wall" (:hand (get-corp))))
+        (is (zero? (count (:hosted (refresh gs-scored)))))))
+    (testing "Can't take a hosted card if none exist"
+      (do-game state
+        (card-ability state :corp gs-scored 1)
+        (is (empty? (:prompt (get-corp))))))
+    (testing "Can host a single corp card even if a runner card is hosted"
+      (do-game state
+        (take-credits state :corp)
+        (play-from-hand state :runner "Political Graffiti")
+        (run-continue state)
+        (click-card state :runner "Glenn Station")
+        (is (= 1 (count (:hosted (refresh gs-scored)))))
+        (take-credits state :runner)
+        (card-ability state :corp (refresh gs-scored) 0)
+        (is (not-empty (:prompt (get-corp))))
+        (click-card state :corp "Enigma")
+        (is (find-card "Enigma" (:hosted (refresh gs-scored))))))
+    (testing "Can't take a card if only a runner card is hosted"
+      (do-game state
+        (take-credits state :corp)
+        (play-from-hand state :runner "Political Graffiti")
+        (run-continue state)
+        (click-card state :runner "Glenn Station")
+        (take-credits state :runner)
+        (card-ability state :corp (refresh gs-scored) 1)
+        (is (empty? (:prompt (get-corp))))))
+    (testing "Can take a hosted card even if a runner card is hosted"
+      (do-game state
+        (take-credits state :corp)
+        (play-from-hand state :runner "Political Graffiti")
+        (run-continue state)
+        (click-card state :runner "Glenn Station")
+        (take-credits state :runner)
+        (card-ability state :corp (refresh gs-scored) 0)
+        (click-card state :corp "Enigma")
+        (card-ability state :corp (refresh gs-scored) 1)
+        (is (not-empty (:prompt (get-corp))))
+        (click-card state :corp "Enigma")
+        (is (find-card "Enigma" (:hand (get-corp))))))))
 
 (deftest global-food-initiative
   ;; Global Food Initiative

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -55,9 +55,9 @@
     (is (empty? (:prompt (get-runner))))
     (is (some? (get-ice state :hq 0)))
     (is (= 2 (count (:discard (get-corp)))))
-    (core/move state :corp (find-card "Accelerated Beta Test" (:scored (get-corp))) :hand)
-    (core/move state :corp (find-card "Hedge Fund" (:discard (get-corp))) :deck)
-    (core/move state :corp (find-card "Hedge Fund" (:discard (get-corp))) :deck)
+    (move state :corp (find-card "Accelerated Beta Test" (:scored (get-corp))) :hand)
+    (move state :corp (find-card "Hedge Fund" (:discard (get-corp))) :deck)
+    (move state :corp (find-card "Hedge Fund" (:discard (get-corp))) :deck)
     (play-and-score state "Accelerated Beta Test")
     (is (= "Look at the top 3 cards of R&D?" (:msg (prompt-map :corp))))
     (click-prompt state :corp "Yes")
@@ -861,10 +861,16 @@
                              "Adonis Campaign"]
                       :discard ["Eli 1.0"]}})
     (play-and-score state "Director Haas' Pet Project")
-    (click-prompt state :corp "Yes")
-    (click-card state :corp "Adonis Campaign")
-    (click-card state :corp "Strongbox")
-    (click-card state :corp "Eli 1.0")))
+    (changes-val-macro
+      0 (:credit (get-corp))
+      "Corp spends no credits to install"
+      (click-prompt state :corp "Yes")
+      (click-card state :corp "Adonis Campaign")
+      (click-card state :corp "Strongbox")
+      (click-card state :corp "Eli 1.0")
+      (is (= "Adonis Campaign" (:title (get-content state :remote2 0))))
+      (is (= "Strongbox" (:title (get-content state :remote2 1))))
+      (is (= "Eli 1.0" (:title (get-ice state :remote2 0)))))))
 
 (deftest divested-trust
   ;; Divested Trust


### PR DESCRIPTION
3-ish years ago, the devs discussed [migrating](https://github.com/mtgred/netrunner/wiki/Card-definition-migration-proposal) the card definition to something cleaner, but no one ever put any effort in so it didn't happen. I got annoyed trying to refactor a separate part of agendas and running into the issue of the two parts being smooshed together, so I've taken it upon myself to make the change directly.

Changes:
* Expanded Glenn Station impl to probably handle various edge cases
* Changed `when-scored?` to look for the `:on-score` key instead of `:not-scored-when`
* Rewrote Bifrost Array and 24/7 News Cycle to use the `:on-score` key
* Rewrote NEXT Wave 2 to not proc if no NEXT ice exist