### PR TITLE
Make a test for every missing upgrade

### DIFF
--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3551,3 +3551,28 @@
       (card-ability state :corp (refresh hg) 0)
       (is (= 2 (:click (get-runner))) "Runner spent 1 click on the run and 1 more to break 1st sub")
       (is (zero? (:credit (get-runner) "Heinlein Grid did the runner loose all credits"))))))
+
+(deftest mason-bellamy
+  (do-game
+    (new-game {:corp {:hand ["Mason Bellamy" "Cobra"]
+                      :deck [(qty "Hedge Fund" 5)]}
+               :runner {:credits 10 :hand [(qty "Garrote" 5)]}})
+    (play-from-hand state :corp "Mason Bellamy" "HQ")
+    (play-from-hand state :corp "Cobra" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Garrote")
+    (let [mb (get-content state :hq 0)
+          cobra (get-ice state :hq 0)
+          garrote (get-program state 0)]
+      (run-on state "HQ")
+      (rez state :corp mb)
+      (rez state :corp cobra)
+      (run-continue state)
+      (card-ability state :runner (refresh garrote) 0)
+      (click-prompt state :runner "Trash a program")
+      (click-prompt state :runner "Done")
+      (fire-subs state cobra)
+      (run-continue state)
+      (is (:run @state) "Run is not over")
+      ;; 1 click to play program, 1 for run, 1 of Mason
+      (is (= 1 (:click (get-runner)))))))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3408,3 +3408,28 @@
     (click-prompt state :runner "0")
     (is (= 1 (:credit (get-corp))) "After using all credits to boost trace, Corp gains 1c thanks to Traffic Analyzer")
     ))
+
+(deftest defense-construct
+  (do-game
+    (new-game {:corp {:hand ["Defense Construct" (qty "PAD Campaign" 3)]}})
+    ;; Play 3 PAD Campaigns on the same server so 2 of them are trashed facedown
+    (play-from-hand state :corp "Defense Construct" "Archives")
+    (play-from-hand state :corp "PAD Campaign" "HQ")
+    (play-from-hand state :corp "PAD Campaign" "HQ")
+    (click-prompt state :corp "OK")
+    (take-credits state :runner)
+    (play-from-hand state :corp "PAD Campaign" "HQ")
+    (click-prompt state :corp "OK")
+    ;; Advance Defense Construct twice to recover both PAD Campaigns from discard
+    (let [dc (get-content state :archives 0)
+          advance-tokens 2]
+      (rez state :corp dc)
+      (advance state dc advance-tokens)
+      (take-credits state :corp)
+      (run-on state :archives)
+      (card-ability state :corp dc 0)
+      (click-card state :corp (get (:discard (get-corp)) 0))
+      (click-card state :corp (get (:discard (get-corp)) 1))
+      (is (= advance-tokens (count (filter #(= (:title %) "PAD Campaign") (:hand (get-corp))))) "2 advance tokens of DC so 2 PAD Campaign back to corp")
+      (is (= "Defense Construct" (:title (first (:discard (get-corp)))))))) "Defense Construct is trashed after using it")
+

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3336,3 +3336,21 @@
        (click-card state :corp (refresh cor))
        (is (empty? (get-program state)) "Corroder uninstalled")
        (is (= "Corroder" (:title (last (:deck (get-runner))))) "GoCorroderrdian on bottom of Stack")))))
+
+(deftest oaktown-grid
+  (do-game
+    (new-game {:corp {:hand ["Oaktown Grid" "PAD Campaign"]}
+               :runner {:credits 15}})
+    (play-from-hand state :corp "Oaktown Grid" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "Remote 1")
+    (let [og (get-content state :remote1 0)
+          pad (get-content state :remote1 1)]
+      (rez state :corp og)
+      (rez state :corp pad)
+    (take-credits state :corp)
+    (run-on state "Server 1")
+    (run-continue state)
+    (click-card state :runner pad)
+    (click-prompt state :runner "Pay 7 [Credits] to trash")
+    (is (= "PAD Campaign" (:title (first (:discard (get-corp))))) "PAD Campaign trashed for 7c (3 more than normal cost thanks to Oaktown Grid")
+    )))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3462,4 +3462,19 @@
       (is (zero? (count (:deck (get-runner)))))
       (is (= 2 (count (:discard (get-runner)))))
       )))
->>>>>>> 6937396a1 (Add tests to fractal-threat-matrix)
+
+(deftest shell-corporation
+  (do-game
+    (new-game {:corp {:hand ["Shell Corporation"]}})
+    (play-from-hand state :corp "Shell Corporation" "New remote")
+    (let [sc (get-content state :remote1 0)]
+      (rez state :corp sc)
+      (card-ability state :corp (refresh sc) 0)
+      (card-ability state :corp (refresh sc) 0)             ;;Retrigger ability, no extra credits are given
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (card-ability state :corp (refresh sc) 0)             ;;Store another 3c. Total 6c
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (card-ability state :corp (refresh sc) 1)             ;;Now take those 6c
+      (is (= 12 (:credit (get-corp)))))))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3352,5 +3352,20 @@
     (run-continue state)
     (click-card state :runner pad)
     (click-prompt state :runner "Pay 7 [Credits] to trash")
-    (is (= "PAD Campaign" (:title (first (:discard (get-corp))))) "PAD Campaign trashed for 7c (3 more than normal cost thanks to Oaktown Grid")
-    )))
+    (is (= "PAD Campaign" (:title (first (:discard (get-corp))))) "PAD Campaign trashed for 7c (3 more than normal cost thanks to Oaktown Grid"))))
+
+(deftest rutherfold-grid
+  (do-game
+    (new-game {:corp {:hand ["Rutherford Grid" "Caduceus"]}})
+    (play-from-hand state :corp "Rutherford Grid" "New remote")
+    (play-from-hand state :corp "Caduceus" "Remote 1")
+    (let [rg (get-content state :remote1 0)
+          caduceus (get-ice state :remote1 0)]
+      (rez state :corp rg)
+      (rez state :corp caduceus)
+      (take-credits state :corp)
+      (run-on state "Server 1")
+      (run-continue state)
+      (fire-subs state caduceus)
+      (println (get-prompt state :corp)))))
+

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3439,3 +3439,27 @@
     (play-from-hand state :corp "K. P. Lynn" "New remote")
     ))
 
+(deftest fractal-threat-matrix
+  (do-game
+    (new-game {:corp {:hand ["Fractal Threat Matrix" "Najja 1.0"]}
+               :runner {:deck [(qty "Acacia" 7)]}})
+    (play-from-hand state :corp "Fractal Threat Matrix" "New remote")
+    (play-from-hand state :corp "Najja 1.0" "Remote 1")
+    (take-credits state :corp)
+    (is (= 2 (count (:deck (get-runner)))))
+    (run-on state :remote1)
+    (let [najja (get-ice state :remote1 0)
+          ftm (get-content state :remote1 0)]
+      (rez state :corp najja)
+      (rez state :corp ftm)
+      (run-continue state)
+      (card-side-ability state :runner najja 0)
+      (click-prompt state :runner "End the run")
+      (card-side-ability state :runner najja 0)
+      (click-prompt state :runner "End the run")
+      ;; All subroutines broken. Manually trigger Fractal Thread Matrix
+      (card-ability state :corp ftm 0)
+      (is (zero? (count (:deck (get-runner)))))
+      (is (= 2 (count (:discard (get-runner)))))
+      )))
+>>>>>>> 6937396a1 (Add tests to fractal-threat-matrix)

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3433,3 +3433,9 @@
       (is (= advance-tokens (count (filter #(= (:title %) "PAD Campaign") (:hand (get-corp))))) "2 advance tokens of DC so 2 PAD Campaign back to corp")
       (is (= "Defense Construct" (:title (first (:discard (get-corp)))))))) "Defense Construct is trashed after using it")
 
+(deftest k-p-lynn
+  (do-game
+    (new-game {:corp {:hand ["K. P. Lynn"]}})
+    (play-from-hand state :corp "K. P. Lynn" "New remote")
+    ))
+

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3370,3 +3370,16 @@
       (click-prompt state :corp "3")                        ;;Boost trace by 3
       (is (= 8 (:strength (get-prompt state :runner))) "3 base, +2 of upgrade +3 boost"))))
 
+(deftest akitaro-watanabe
+  (do-game
+    (new-game {:corp {:hand ["Akitaro Watanabe" "Ice Wall" "Enigma"]}})
+    (play-from-hand state :corp "Akitaro Watanabe" "HQ")
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (play-from-hand state :corp "Enigma" "HQ")              ;;-1c
+    (let [akitaro (get-content state :hq 0)
+          iw (get-ice state :hq 0)
+          enigma (get-ice state :hq 1)]
+      (rez state :corp akitaro)
+      (rez state :corp iw)
+      (rez state :corp enigma)
+      (is (= 2 (:credit (get-corp))) "2c left after installing and rezzing with AW bonus"))))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3478,3 +3478,15 @@
       (take-credits state :runner)
       (card-ability state :corp (refresh sc) 1)             ;;Now take those 6c
       (is (= 12 (:credit (get-corp)))))))
+
+(deftest panic-button
+  (do-game
+    (new-game {:corp {:hand ["Panic Button"] :deck ["Enigma"]}})
+    (play-from-hand state :corp "Panic Button" "HQ")
+    (let [panic-btn (get-content state :hq 0)]
+      (rez state :corp panic-btn)
+      (take-credits state :corp)
+      (run-on state :hq)
+      (card-ability state :corp (refresh panic-btn) 0)
+      (is (= 1 (count (:hand (get-corp)))))
+      (is (zero? (:deck (get-corp)))))))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3531,3 +3531,23 @@
       (trash state :corp ed)
       (is (= 1 (core/ice-strength state :corp iw)) "Strength of Ice Wall after trashing Experiential Data is back to 1")
       (is (= 2 (core/ice-strength state :corp enigma)) "Strength of Enigma after trashing Experiential Data is back to 2"))))
+
+(deftest heinlein-grid
+  (do-game
+    (new-game {:corp {:credits 10 :hand ["Heinlein Grid" "Najja 1.0"]}})
+    (play-from-hand state :corp "Heinlein Grid" "New remote")
+    (play-from-hand state :corp "Najja 1.0" "Remote 1")
+    (let [hg (get-content state :remote1 0)
+          najja (get-ice state :remote1 0)]
+      (rez state :corp hg)
+      (take-credits state :corp)
+      (println "Runner credits 1: " (:credit (get-runner)))
+      (run-on state "Remote 1")
+      (rez state :corp najja)
+      (run-continue state)
+      (card-side-ability state :runner najja 0)
+      (click-prompt state :runner "End the run")
+      (click-prompt state :runner "Done")
+      (card-ability state :corp (refresh hg) 0)
+      (is (= 2 (:click (get-runner))) "Runner spent 1 click on the run and 1 more to break 1st sub")
+      (is (zero? (:credit (get-runner) "Heinlein Grid did the runner loose all credits"))))))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3395,3 +3395,16 @@
     (is (= nil (get-prompt state :corp)) "No prompt asking to discard cards from hand")
     (take-credits state :runner)
     (is (= 9 (count (:hand (get-corp)))) "Double check that you start next turn with 8 cards")))
+
+(deftest traffic-analyzer
+  (do-game
+    (new-game {:corp   {:hand ["Traffic Analyzer" "Ice Wall"]}
+               :runner {:tag 2 :hand [(qty "Corroder" 2)]}})
+    (play-from-hand state :corp "Traffic Analyzer" "HQ")
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (rez state :corp (get-content state :hq 0))
+    (rez state :corp (get-ice state :hq 0))
+    (click-prompt state :corp "4")
+    (click-prompt state :runner "0")
+    (is (= 1 (:credit (get-corp))) "After using all credits to boost trace, Corp gains 1c thanks to Traffic Analyzer")
+    ))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3510,3 +3510,24 @@
         (take-credits state :corp)                          ;;+2c
         (take-credits state :runner)
         (is (= (+ 3 total-corp-credits) (:credit (get-corp))) "Corp does not gain any extra c with agenda")))))
+
+(deftest experiential-data
+  (do-game
+    (new-game {:corp {:credits 7 :hand ["Experiential Data" "Ice Wall" "Enigma"]}})
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (play-from-hand state :corp "Experiential Data" "Remote 1")
+    (play-from-hand state :corp "Enigma" "Remote 1")
+    (take-credits state :runner)
+    (let [iw (get-ice state :remote1 0)
+          ed (get-content state :remote1 0)
+          enigma (get-ice state :remote1 1)]
+      (rez state :corp iw)
+      (rez state :corp enigma)
+      (is (= 1 (core/ice-strength state :corp iw)) "Initial strength of Ice Wall is 1")
+      (is (= 2 (core/ice-strength state :corp enigma)) "Initial strength of Enigma is 2")
+      (rez state :corp ed)
+      (is (= 2 (core/ice-strength state :corp iw)) "Strength of Ice Wall after playing Experiential Data on the same server is now 2")
+      (is (= 3 (core/ice-strength state :corp enigma)) "Strength of Enigma after playing Experiential Data on the same server is now 3")
+      (trash state :corp ed)
+      (is (= 1 (core/ice-strength state :corp iw)) "Strength of Ice Wall after trashing Experiential Data is back to 1")
+      (is (= 2 (core/ice-strength state :corp enigma)) "Strength of Enigma after trashing Experiential Data is back to 2"))))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3383,3 +3383,15 @@
       (rez state :corp iw)
       (rez state :corp enigma)
       (is (= 2 (:credit (get-corp))) "2c left after installing and rezzing with AW bonus"))))
+
+(deftest research-station
+  (do-game
+    (new-game {:corp {:id "NBN: The World is Yours*"
+                      :hand [(qty "Research Station" 9)] :deck ["Research Station"]}})
+    (play-from-hand state :corp "Research Station" "HQ")
+    (rez state :corp (get-content state :hq 0))
+    (take-credits state :corp)
+    (is (= 8 (count (:hand (get-corp)))) "+3 cards, 2 of Research Station and +1 of ID")
+    (is (= nil (get-prompt state :corp)) "No prompt asking to discard cards from hand")
+    (take-credits state :runner)
+    (is (= 9 (count (:hand (get-corp)))) "Double check that you start next turn with 8 cards")))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3354,7 +3354,7 @@
     (click-prompt state :runner "Pay 7 [Credits] to trash")
     (is (= "PAD Campaign" (:title (first (:discard (get-corp))))) "PAD Campaign trashed for 7c (3 more than normal cost thanks to Oaktown Grid"))))
 
-(deftest rutherfold-grid
+(deftest rutherford-grid
   (do-game
     (new-game {:corp {:hand ["Rutherford Grid" "Caduceus"]}})
     (play-from-hand state :corp "Rutherford Grid" "New remote")
@@ -3367,5 +3367,6 @@
       (run-on state "Server 1")
       (run-continue state)
       (fire-subs state caduceus)
-      (println (get-prompt state :corp)))))
+      (click-prompt state :corp "3")                        ;;Boost trace by 3
+      (is (= 8 (:strength (get-prompt state :runner))) "3 base, +2 of upgrade +3 boost"))))
 

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3490,3 +3490,23 @@
       (card-ability state :corp (refresh panic-btn) 0)
       (is (= 1 (count (:hand (get-corp)))))
       (is (zero? (:deck (get-corp)))))))
+
+(deftest expo-grid
+  (do-game
+    (new-game {:corp {:hand ["Expo Grid" "Dedicated Response Team" "Breaking News"]}})
+    (play-from-hand state :corp "Dedicated Response Team" "New remote") ;;-2c
+    (play-from-hand state :corp "Expo Grid" "Remote 1")
+    (let [drt (get-content state :remote1 0)
+          expo (get-content state :remote1 1)]
+      (rez state :corp drt)
+      (rez state :corp expo)
+      (take-credits state :corp)                            ;;+1c
+      (let [total-corp-credits (:credit (get-corp))]
+        (take-credits state :runner)
+        (is (= (+ 1 total-corp-credits) (:credit (get-corp))) "Corp gains 1c") ;;+1c
+        ;;Replace asset with agenda
+        (play-from-hand state :corp "Breaking News" "Remote 1")
+        (click-prompt state :corp "OK")
+        (take-credits state :corp)                          ;;+2c
+        (take-credits state :runner)
+        (is (= (+ 3 total-corp-credits) (:credit (get-corp))) "Corp does not gain any extra c with agenda")))))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3340,7 +3340,7 @@
 (deftest oaktown-grid
   (do-game
     (new-game {:corp {:hand ["Oaktown Grid" "PAD Campaign"]}
-               :runner {:credits 15}})
+               :runner {:credits 7}})
     (play-from-hand state :corp "Oaktown Grid" "New remote")
     (play-from-hand state :corp "PAD Campaign" "Remote 1")
     (let [og (get-content state :remote1 0)
@@ -3352,7 +3352,8 @@
     (run-continue state)
     (click-card state :runner pad)
     (click-prompt state :runner "Pay 7 [Credits] to trash")
-    (is (= "PAD Campaign" (:title (first (:discard (get-corp))))) "PAD Campaign trashed for 7c (3 more than normal cost thanks to Oaktown Grid"))))
+    (is (= "PAD Campaign" (:title (first (:discard (get-corp))))) "PAD Campaign trashed for 7c (3 more than normal cost thanks to Oaktown Grid")
+    (is (= 0 (:credit (get-runner)))))))
 
 (deftest rutherford-grid
   (do-game

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3489,7 +3489,7 @@
       (run-on state :hq)
       (card-ability state :corp (refresh panic-btn) 0)
       (is (= 1 (count (:hand (get-corp)))))
-      (is (zero? (:deck (get-corp)))))))
+      (is (zero? (count(:deck (get-corp))))))))
 
 (deftest expo-grid
   (do-game

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3542,7 +3542,6 @@
           najja (get-ice state :remote1 0)]
       (rez state :corp hg)
       (take-credits state :corp)
-      (println "Runner credits 1: " (:credit (get-runner)))
       (run-on state "Remote 1")
       (rez state :corp najja)
       (run-continue state)


### PR DESCRIPTION
This PR adds a test for every single Upgrade card that didn't have one except for [Tyr's Hand](https://netrunnerdb.com/en/card/03022) because its implementation looked fully manual and it didn't seem like it was testing anything useful.

The approach I have followed to develop them was to read the description of the card in NRDB, write a test without looking at the implementation and then run it. Yeah, I have to repeat the process many times to understand the workflow and when there was a prompt or a click card, of course. :sweat_smile: 

```shell
$ lein test game.cards.upgrades-test

lein test game.cards.upgrades-test

Ran 90 tests containing 2886 assertions.
0 failures, 0 errors.
```

```shell
Upgrade
	Unique cards in db: 91
	Tests: 90
	Cards with tests: 90
	Cards without tests: 1
		 tyr-s-hand
	Tests without cards: 0
```

No hurries with the review. I know it's maybe not the best month to open the PR with all the NISEI stuff ongoing