### PR TITLE
Fix UI inconsistencies

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -30,8 +30,7 @@
         left: 0
         z-index: 1
         padding: 1px 4px
-        font-size: 10px
-        line-height: 14px
+        font-size: 12px
 
     .darkbg
         background: rgba(0, 0, 0, 0.6)
@@ -42,7 +41,6 @@
         color: white
         text-align: center
         position: absolute
-        font-size: 105%
         width: 100%
         top: 100%
         transform: translate(0, -100%)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -245,9 +245,6 @@
         min-height: 84px
         min-width: 60px
 
-        &.central
-            margin-top: 12px
-
         &.shift
             margin-left: -36px
 


### PR DESCRIPTION
Addresses #4376 and one other inconsistency I've found: previously Grip and HQ did not have a label showing the amount of cards. Especially for HQ I think this makes a lot of sense.

The three commits are independent of one another, so feel free to just merge some of them! I actually was just too lazy to create multiple sets of screenshots and kind of hoping you'll like all of the changes, anyway ;-).

![jnet-ui-inconsistencies-pr](https://user-images.githubusercontent.com/3992739/110993869-2bdab600-8378-11eb-8f88-3611ab84924f.png)
(I was using two different browsers, hence the slightly different fonts...)