### PR TITLE
Make corp-install use checkpoints

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -585,15 +585,17 @@
   {:constant-effects [{:type :ignore-install-cost
                        :req (req (and (ice? target)
                                       (->> (turn-events state side :corp-install)
-                                           (map first)
+                                           (map #(:card (first %)))
                                            (filter ice?)
                                            empty?)))
                        :value true}]
    :events [{:event :corp-install
              :req (req (and (ice? target)
-                            (empty? (let [cards (map first (turn-events state side :corp-install))]
-                                      (filter ice? cards)))))
-             :msg (msg "ignore the install cost of the first ICE this turn")}]})
+                            (->> (turn-events state side :corp-install)
+                                 (map #(:card (first %)))
+                                 (filter ice?)
+                                 empty?)))
+             :msg "ignore the install cost of the first ICE this turn"}]})
 
 (defcard "Efficiency Committee"
   {:on-score {:silent (req true)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -689,10 +689,12 @@
 
 (defcard "Estelle Moon"
   {:events [{:event :corp-install
-             :req (req (and (or (asset? target) (agenda? target) (upgrade? target))
-                            (is-remote? (second (get-zone target)))))
+             :req (req (and (or (asset? (:card context))
+                                (agenda? (:card context))
+                                (upgrade? (:card context)))
+                            (is-remote? (second (get-zone (:card context))))))
              :effect (effect (add-counter card :power 1)
-                             (system-msg (str "places 1 power counter on Estelle Moon")))}]
+                             (system-msg "places 1 power counter on Estelle Moon"))}]
    :abilities [{:label "Draw 1 card and gain 2 [Credits] for each power counter"
                 :cost [:trash]
                 :async true
@@ -1863,10 +1865,10 @@
      :abilities [ability]
      :events [(assoc ability :event :corp-turn-begins)
               {:event :corp-install
-               :req (req (ice? target))
+               :req (req (ice? (:card context)))
                :async true
-               :effect (req (system-msg state :runner "trashes Server Diagnostics")
-                            (trash state side eid card nil))}]}))
+               :effect (effect (system-msg :runner "trashes Server Diagnostics")
+                               (trash eid card))}]}))
 
 (defcard "Shannon Claire"
   {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2465,8 +2465,8 @@
      :effect (req (doseq [c (rumor state)]
                     (disable-card state :corp c)))
      :events [{:event :corp-install
-               :req (req (eligible? target))
-               :effect (effect (disable-card :corp target))}]}))
+               :req (req (eligible? (:card context)))
+               :effect (effect (disable-card :corp (:card context)))}]}))
 
 (defcard "Run Amok"
   (letfn [(get-rezzed-cids [ice]
@@ -2880,7 +2880,7 @@
 
 (defcard "Unscheduled Maintenance"
   {:events [{:event :corp-install
-             :req (req (ice? target))
+             :req (req (ice? (:card context)))
              :effect (effect (register-turn-flag!
                                card :can-install-ice
                                (fn [state side card]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -657,17 +657,10 @@
                                                      (seq (filter (fn [c] (= server c)) (corp-install-list state %))))}
                                :effect (req (wait-for
                                               (corp-install state side target server nil)
-                                              (let [server (if (= "New remote" server)
-                                                             (-> (turn-events state side :corp-install)
-                                                                 ffirst
-                                                                 get-zone
-                                                                 second
-                                                                 zone->name)
-                                                             server)]
+                                              (let [server (remote->name (second (:zone async-result)))]
                                                 (if (< n X)
                                                   (continue-ability state side (install-cards server (inc n)) card nil)
-                                                  (effect-completed state side eid)))))
-                               :cancel-effect (effect (effect-completed eid))})
+                                                  (effect-completed state side eid)))))})
               select-server {:async true
                              :prompt "Install cards in which server?"
                              :choices (req (conj (vec (get-remote-names state)) "New remote"))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -639,16 +639,17 @@
                                 :type :recurring}}})
 
 (defcard "Clot"
-  {:effect (req (let [agendas (map first (filter #(agenda? (first %))
-                                                 (turn-events state :corp :corp-install)))]
+  {:effect (req (let [agendas (->> (turn-events state :corp :corp-install)
+                                   (filter #(agenda? (:card (first %))))
+                                   (map first))]
                   (swap! state assoc-in [:corp :register :cannot-score] agendas)))
    :events [{:event :purge
              :async true
              :effect (req (swap! state update-in [:corp :register] dissoc :cannot-score)
                           (trash state side eid card {:cause :purge}))}
             {:event :corp-install
-             :req (req (agenda? target))
-             :effect (req (swap! state update-in [:corp :register :cannot-score] #(cons target %)))}]
+             :req (req (agenda? (:card context)))
+             :effect (req (swap! state update-in [:corp :register :cannot-score] #(cons (:card context) %)))}]
    :leave-play (req (swap! state update-in [:corp :register] dissoc :cannot-score))})
 
 (defcard "Collective Consciousness"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -15,14 +15,14 @@
 (defcard "Amazon Industrial Zone"
   {:events [{:event :corp-install
              :optional
-             {:req (req (and (ice? target)
-                             (protecting-same-server? card target)
-                             (can-pay? state side (assoc eid :source card :source-type :rez) target nil
-                                       [:credit (rez-cost state side target {:cost-bonus -3})])))
+             {:req (req (and (ice? (:card context))
+                             (protecting-same-server? card (:card context))
+                             (can-pay? state side (assoc eid :source card :source-type :rez) (:card context) nil
+                                       [:credit (rez-cost state side (:card context) {:cost-bonus -3})])))
               :prompt "Rez ICE with rez cost lowered by 3?"
-              :yes-ability {:msg (msg "lower the rez cost of " (:title target) " by 3 [Credits]")
+              :yes-ability {:msg (msg "lower the rez cost of " (:title (:card context)) " by 3 [Credits]")
                             :async true
-                            :effect (effect (rez eid target {:cost-bonus -3}))}}}]})
+                            :effect (effect (rez eid (:card context) {:cost-bonus -3}))}}}]})
 
 (defcard "Anoetic Void"
   {:events [{:event :successful-run
@@ -1173,9 +1173,9 @@
                            (set-prop state side c :extra-advance-counter 1))
                          (update-all-ice state side))}
    :events [{:event :corp-install
-             :req (req (and (ice? target)
-                            (protecting-same-server? card target)))
-             :effect (effect (set-prop target :extra-advance-counter 1))}]
+             :req (req (and (ice? (:card context))
+                            (protecting-same-server? card (:card context))))
+             :effect (effect (set-prop (:card context) :extra-advance-counter 1))}]
    :leave-play (req (doseq [c (:ices (card->server state card))]
                       (update! state side (dissoc c :extra-advance-counter)))
                     (update-all-ice state side))})
@@ -1365,11 +1365,11 @@
 (defcard "Tranquility Home Grid"
   {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
    :events [{:event :corp-install
-             :req (req (and (or (asset? target)
-                                (agenda? target)
-                                (upgrade? target))
-                            (in-same-server? card target)
-                            (first-event? state :corp :corp-install #(in-same-server? card (first %)))))
+             :req (req (and (or (asset? (:card context))
+                                (agenda? (:card context))
+                                (upgrade? (:card context)))
+                            (in-same-server? card (:card context))
+                            (first-event? state :corp :corp-install #(in-same-server? card (:card (first %))))))
              :prompt (msg "Use " (:title card) " to gain 2 [Credits] or draw 1 card?")
              :choices ["Gain 2 [Credits]" "Draw 1 card"]
              :msg (msg (decapitalize target))

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -89,7 +89,7 @@
                     (wait-for
                       (trash-hosted-cards state side (make-eid state eid) (get-card state card))
                       (wait-for
-                        (checkpoint state nil (make-eid state eid))
+                        (checkpoint state nil (make-eid state eid) {:duration :rez})
                         (when press-continue
                           (continue state side nil))
                         (complete-with-result state side eid {:card (get-card state card)})))))))))

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1927,6 +1927,42 @@
       (click-prompt state :runner "OK")
       (is (not (accessing state "Hostile Takeover"))))))
 
+(deftest howler
+  ;; Howler
+  (before-each [state (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                                        :hand ["Howler" "Eli 1.0" "Hedge Fund"]
+                                        :discard ["Ichi 1.0"]}})
+                _ (do (play-from-hand state :corp "Howler" "HQ")
+                      (take-credits state :corp))]
+    (testing "Choosing from HQ"
+      (do-game state
+        (run-on state :hq)
+        (let [howler (get-ice state :hq 0)]
+          (rez state :corp howler)
+          (run-continue state)
+          (fire-subs state (refresh howler))
+          (click-card state :corp "Eli 1.0")
+          (is (find-card "Eli 1.0" (get-ice state :hq))))
+        (run-continue state)
+        (run-continue state)
+        (click-prompt state :runner "No action")
+        (is (not (rezzed? (get-ice state :hq 0))))
+        (is (find-card "Howler" (:discard (get-corp))))))
+    (testing "Choosing from Archives"
+      (do-game state
+        (run-on state :hq)
+        (let [howler (get-ice state :hq 0)]
+          (rez state :corp howler)
+          (run-continue state)
+          (fire-subs state (refresh howler))
+          (click-card state :corp "Ichi 1.0")
+          (is (find-card "Ichi 1.0" (get-ice state :hq))))
+        (run-continue state)
+        (run-continue state)
+        (click-prompt state :runner "No action")
+        (is (not (rezzed? (get-ice state :hq 0))))
+        (is (find-card "Howler" (:discard (get-corp))))))))
+
 (deftest hydra
   ;; Hydra - do an effect Runner is tagged, otherwise give Runner 1 tag
   (do-game

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -1354,11 +1354,10 @@
 (deftest fast-break
   ;; Fast Break
   (do-game
-    (new-game {:corp {:deck ["Fast Break" "Hostile Takeover" "Keegan Lane" "Haas Arcology AI"
-                             "Research Station" (qty "Ice Wall" 10)]}
+    (new-game {:corp {:deck ["Ice Wall" "Enigma" "Rime" "Hedge Fund"]
+                      :hand ["Fast Break" "Hostile Takeover" "Keegan Lane"
+                             "Haas Arcology AI" "Research Station"]}
                :runner {:deck [(qty "Fan Site" 3)]}})
-    (starting-hand state :corp ["Fast Break" "Hostile Takeover" "Keegan Lane"
-                                "Haas Arcology AI" "Research Station"])
     (take-credits state :corp)
     (dotimes [_ 3]
       (play-from-hand state :runner "Fan Site"))
@@ -1373,7 +1372,7 @@
       (click-prompt state :corp "New remote")
       (click-card state :corp (find-card "Keegan Lane" (:hand (get-corp))))
       (click-card state :corp (find-card "Ice Wall" (:hand (get-corp))))
-      (click-card state :corp (find-card "Ice Wall" (:hand (get-corp))))
+      (click-card state :corp (find-card "Enigma" (:hand (get-corp))))
       (is (= (dec credits) (:credit (get-corp))) "Corp should pay 1 credit to install second Ice Wall"))
     (core/move state :corp (find-card "Fast Break" (:discard (get-corp))) :hand)
     (play-from-hand state :corp "Fast Break")
@@ -1386,7 +1385,7 @@
       (click-card state :corp (find-card "Haas Arcology AI" (:hand (get-corp))))
       (click-card state :corp (find-card "Research Station" (:hand (get-corp))))
       (is (= 2 (count (get-content state :remote2))) "Corp can't choose Research Station to install in a remote")
-      (click-card state :corp (find-card "Ice Wall" (:hand (get-corp))))
+      (click-card state :corp (find-card "Rime" (:hand (get-corp))))
       (click-prompt state :corp "Done")
       (is (= (- credits 2) (:credit (get-corp))) "Corp should pay 2 credits to install third Ice Wall")
       (is (empty? (:prompt (get-corp))) "Corp should be able to stop installing early"))))


### PR DESCRIPTION
This change is a doozy, and worries me a bit, lol. `eftest` goes from ~16 seconds to ~17.5 seconds, which is a lot. Last year we were sitting at 12 seconds. I know we're adding a lot of tests and checks, but mostly internal changes raising test time that much is worrisome.

AH WELL. Perfection above all else.