### PR TITLE
Make non-agenda counters use add-counter on init

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1276,10 +1276,7 @@
 
 (defcard "Project Yagi-Uda"
   (letfn [(put-back-counter [state side card]
-            (set-prop state side card :counter
-                      (merge
-                        (:counter card)
-                        {:agenda (+ 1 (get-counters card :agenda))})))
+            (update! state side (assoc-in card [:counter :agenda] (+ 1 (get-counters card :agenda)))))
           (choose-swap [to-swap]
             {:prompt (str "Select a card in HQ to swap with " (:title to-swap))
              :choices {:not-self true

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1356,8 +1356,7 @@
                   (assoc-in [:optional :req] (req (seq (filter #(some #{:tag} %) targets)))))]}))
 
 (defcard "Net Police"
-  {:recurring (effect (set-prop card :rec-counter (get-link state)))
-   :on-rez {:effect (effect (set-prop card :rec-counter (get-link state)))}
+  {:recurring (req (get-link state))
    :interactions {:pay-credits {:req (req (= :trace (:source-type eid)))
                                 :type :recurring}}})
 

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2686,10 +2686,16 @@
    :effect (effect (gain-credits eid 9))})
 
 (defcard "Surge"
-  {:msg (msg "place 2 virus tokens on " (:title target))
-   :choices {:card #(and (has-subtype? % "Virus")
-                         (:added-virus-counter %))}
-   :effect (req (add-counter state :runner target :virus 2))})
+  (letfn [(placed-virus-cards [state]
+            (->> (turn-events state :runner :counter-added)
+                 (filter #(= :virus (:counter-type (second %))))
+                 (map first)
+                 (keep #(get-card state %))
+                 (seq)))]
+    {:req (req (placed-virus-cards state))
+     :choices {:req (req (some #(same-card? % target) (placed-virus-cards state)))}
+     :msg (msg "place 2 virus tokens on " (:title target))
+     :effect (effect (add-counter :runner target :virus 2))}))
 
 (defcard "SYN Attack"
   {:player :corp

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1024,9 +1024,8 @@
 
 (defcard "Māui"
   {:constant-effects [(mu+ 2)]
-   :recurring (effect (set-prop card :rec-counter (count (:ices (get-in @state [:corp :servers :hq])))))
-   :effect (effect (set-prop card :rec-counter (count (:ices (get-in @state [:corp :servers :hq])))))
-   :interactions {:pay-credits {:req (req (= :hq (get-in @state [:run :server 0])))
+   :recurring (req (count (get-in corp [:servers :hq :ices])))
+   :interactions {:pay-credits {:req (req (= [:hq] (get-in @state [:run :server])))
                                 :type :recurring}}})
 
 (defcard "Maw"
@@ -1082,7 +1081,7 @@
                                {:prompt "Select a card and replace 1 spent [Recurring Credits] on it"
                                 :choices {:card #(< (get-counters % :recurring) (:recurring (card-def %) 0))}
                                 :msg (msg "replace 1 spent [Recurring Credits] on " (:title target))
-                                :effect (effect (add-prop target :rec-counter 1))}
+                                :effect (effect (add-counter target :recurring 1))}
                                card nil))}]})
 
 (defcard "Monolith"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1346,7 +1346,7 @@
        :type :custom}}}))
 
 (defcard "Plascrete Carapace"
-  {:data [:counter {:power 4}]
+  {:data {:counter {:power 4}}
    :interactions {:prevent [{:type #{:meat}
                              :req (req true)}]}
    :events [(trash-on-empty :power)]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1920,8 +1920,7 @@
                                      :value target})))}]})
 
 (defcard "Pheromones"
-  {:recurring (req (when (< (get-counters card :recurring) (get-counters card :virus))
-                     (set-prop state side card :rec-counter (get-counters card :virus))))
+  {:recurring (req (get-counters card :virus))
    :events [{:event :successful-run
              :silent (req true)
              :req (req (= :hq (target-server context)))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -801,8 +801,7 @@
                 :effect (effect (trash eid target nil))}]})
 
 (defcard "Khondi Plaza"
-  {:recurring (effect (set-prop card :rec-counter (count (get-remotes state))))
-   :on-rez {:effect (effect (set-prop card :rec-counter (count (get-remotes state))))}
+  {:recurring (req (count (get-remotes state)))
    :interactions {:pay-credits {:req (req (and (= :rez (:source-type eid))
                                                (ice? target)
                                                (= (card->server state card) (card->server state target))))
@@ -1210,7 +1209,7 @@
      :once :per-turn
      :label "Take all credits"
      :async true
-     :effect (effect (set-prop card :counter {:credit 0})
+     :effect (effect (add-counter card :credit (- (get-counters card :credit)))
                      (gain-credits eid (get-counters card :credit)))}]})
 
 (defcard "Signal Jamming"

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -24,6 +24,7 @@
     [game.core.to-string :refer [card-str]]
     [game.core.toasts :refer [show-error-toast toast]]
     [game.core.trace :refer [init-trace]]
+    [game.core.update :refer [update!]]
     [game.core.winning :refer [clear-win]]
     [game.macros :refer [continue-ability effect msg req wait-for]]
     [game.utils :refer [dissoc-in quantify safe-split same-card? same-side? server-card string->num]]
@@ -71,7 +72,7 @@
                                "error" {:time-out 0 :close-button true})
 
                         :else
-                        (do (set-prop state side target :counter (merge (:counter target) {counter-type value}))
+                        (do (update! state side (assoc-in target [:counter counter-type] value))
                             (system-msg state side (str "sets " (name counter-type) " counters to " value " on "
                                                         (card-str state target))))))))}
     (map->Card {:title "/counter command"}) nil))
@@ -106,7 +107,7 @@
       (if advance
         (command-adv-counter state side value)
         (resolve-ability state side
-                         {:effect (effect (set-prop target :counter (merge (:counter target) {counter-type value}))
+                         {:effect (effect (update! (assoc-in target [:counter counter-type] value))
                                           (system-msg (str "sets " (name counter-type) " counters to " value " on "
                                                            (card-str state target))))
                           :choices {:card (fn [t] (same-side? (:side t) side))}}

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -8,7 +8,7 @@
     [game.core.moving :refer [trash]]
     [game.core.play-instants :refer [async-rfg]]
     [game.core.prompts :refer [clear-wait-prompt]]
-    [game.core.props :refer [add-prop]]
+    [game.core.props :refer [add-counter]]
     [game.core.say :refer [system-msg system-say]]
     [game.core.toasts :refer [toast]]
     [game.macros :refer [continue-ability effect req wait-for]]
@@ -138,9 +138,9 @@
           {:msg "take 1 [Recurring Credits]"
            :req (req (pos? (get-counters card :recurring)))
            :async true
-           :effect (req (add-prop state side card :rec-counter -1)
+           :effect (req (add-counter state side card :recurring -1)
                         (wait-for (gain-credits state side 1)
-                                  (trigger-event-sync state side eid :spent-credits-from-card card)))}]
+                                  (trigger-event-sync state side eid :spent-credits-from-card (get-card state card))))}]
       (update ability :abilities #(conj (into [] %) recurring-ability)))
     ability))
 

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -1,7 +1,7 @@
 (ns game.core.initializing
   (:require
     [game.core.board :refer [all-active all-active-installed]]
-    [game.core.card :refer [get-card has-subtype? program? runner? map->Card]]
+    [game.core.card :refer [get-card get-counters has-subtype? program? runner? map->Card]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [card-ability-cost]]
     [game.core.effects :refer [register-constant-effects register-floating-effect unregister-constant-effects]]
@@ -12,7 +12,7 @@
     [game.core.ice :refer [add-sub]]
     [game.core.memory :refer [update-mu]]
     [game.core.payment :refer [add-cost-label-to-ability]]
-    [game.core.props :refer [add-counter set-prop]]
+    [game.core.props :refer [add-counter]]
     [game.core.update :refer [update!]]
     [game.macros :refer [effect req]]
     [game.utils :refer [make-cid server-card to-keyword]]
@@ -43,7 +43,7 @@
                   :runner-abilities :corp-abilities :rezzed :new
                   :subtype-target :server-target :extra-advance-counter)
         c (assoc c :subroutines (subroutines-init c cdef) :abilities (ability-init cdef) :special nil)
-        c (if keep-counter c (dissoc c :counter :rec-counter :advance-counter))]
+        c (if keep-counter c (dissoc c :counter :advance-counter))]
     c))
 
 (defn- trigger-leave-effect
@@ -101,14 +101,23 @@
          c (update! state side
                     (merge card {:runner-abilities run-abs
                                  :corp-abilities corp-abs}))
-         c (update! state side (if (number? recurring) (assoc c :rec-counter recurring) c))
-         _ (doseq [[c-type c-num] (when init-data (:counter (:data cdef)))]
+         data (merge
+                (when init-data (:counter (:data cdef)))
+                (when recurring
+                  {:recurring
+                   (cond
+                     (fn? recurring) (recurring state side eid c nil)
+                     (number? recurring) recurring
+                     :else (throw (Exception. (str (:title card) " - Recurring isn't number or fn"))))}))
+         _ (doseq [[c-type c-num] data]
              (add-counter state side (get-card state c) c-type c-num {:placed true}))
          c (get-card state c)]
      (when recurring
-       (let [r (if (number? recurring)
-                 (effect (set-prop card :rec-counter recurring))
-                 recurring)]
+       (let [recurring-fn (req (if (number? recurring) recurring (recurring state side eid card targets)))
+             r (req (let [card (update! state side (assoc-in card [:counter :recurring] 0))]
+                      (add-counter state side card
+                                   :recurring (recurring-fn state side eid card targets)
+                                   {:placed true})))]
          (register-events
            state side c
            [{:event (if (= side :corp) :corp-phase-12 :runner-phase-12)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -14,6 +14,7 @@
     [game.core.initializing :refer [card-init]]
     [game.core.moving :refer [move trash trash-cards]]
     [game.core.payment :refer [build-spend-msg merge-costs]]
+    [game.core.props :refer [add-counter]]
     [game.core.rezzing :refer [rez]]
     [game.core.say :refer [play-sfx system-msg]]
     [game.core.servers :refer [name-zone remote-num->name]]
@@ -341,13 +342,6 @@
                        (when host-card (str " on " (card-str state host-card)))
                        (when no-cost " at no cost"))))))
 
-(defn- handle-virus-counter-flag
-  "Deal with setting the added-virus-counter flag"
-  [state side installed-card]
-  (when (and (has-subtype? installed-card "Virus")
-           (pos? (get-counters installed-card :virus)))
-    (update! state side (assoc installed-card :added-virus-counter true))))
-
 (defn runner-install
   "Installs specified runner card if able"
   ([state side card] (runner-install state side (make-eid state) card nil))
@@ -388,7 +382,6 @@
                            (when-not no-msg
                              (runner-install-message state side (:title installed-card) payment-str params))
                            (play-sfx state side "install-runner")
-                           (handle-virus-counter-flag state side (get-card state installed-card))
                            (when (and (not facedown)
                                       (resource? card))
                              (swap! state assoc-in [:runner :register :installed-resource] true))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -14,7 +14,6 @@
     [game.core.initializing :refer [card-init]]
     [game.core.moving :refer [move trash trash-cards]]
     [game.core.payment :refer [build-spend-msg merge-costs]]
-    [game.core.props :refer [add-counter]]
     [game.core.rezzing :refer [rez]]
     [game.core.say :refer [play-sfx system-msg]]
     [game.core.servers :refer [name-zone remote-num->name]]

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -5,7 +5,7 @@
     [game.core.eid :refer [effect-completed make-eid complete-with-result]]
     [game.core.engine :refer [resolve-ability trigger-event-sync]]
     [game.core.gaining :refer [lose]]
-    [game.core.props :refer [add-counter set-prop]]
+    [game.core.props :refer [add-counter]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
     [game.utils :refer [in-coll? quantify same-card?]]
@@ -123,12 +123,11 @@
                                             {:async true :effect pay-credits-custom})
                            current-counters (get-counters target pay-credits-type)
                            ; In this next bit, we don't want to trigger any events yet
-                           ; so we use `set-prop` to directly change the number of credits
+                           ; so we use `update!` to directly change the number of credits
                            gained-credits (case pay-credits-type
-                                            :recurring
-                                            (do (set-prop state side target :rec-counter (dec current-counters)) 1)
-                                            :credit
-                                            (do (set-prop state side target :counter {:credit (dec current-counters)}) 1)
+                                            (:recurring :credit)
+                                            (do (update! state side (assoc-in target [:counter pay-credits-type] (dec current-counters)))
+                                                1)
                                             ; Custom credits will be handled separately later
                                             0)
                            target (get-card state target)

--- a/src/clj/game/core/props.clj
+++ b/src/clj/game/core/props.clj
@@ -24,12 +24,6 @@
              (trigger-event-sync state side eid :advancement-placed (get-card state updated-card) args)))
        (trigger-event-sync state side eid :counter-added (get-card state updated-card) args)))))
 
-(defn set-prop
-  "Like add-prop, but sets multiple keys to corresponding values without triggering events.
-  Example: (set-prop ... card :counter 4 :current-strength 0)"
-  [state side card & args]
-  (update! state side (apply assoc (cons card args))))
-
 (defn add-counter
   "Adds n counters of the specified type to a card"
   ([state side card prop-type n] (add-counter state side (make-eid state) card prop-type n nil))
@@ -40,6 +34,12 @@
      (add-prop state side eid card :advance-counter n args)
      (let [updated-card (update! state side (update-in card [:counter prop-type] #(+ (or % 0) n)))]
        (trigger-event-sync state side eid :counter-added updated-card {:counter-type prop-type :amount n :placed placed})))))
+
+(defn set-prop
+  "Like add-prop, but sets multiple keys to corresponding values without triggering events.
+  Example: (set-prop ... card :counter 4 :current-strength 0)"
+  [state side card & args]
+  (update! state side (apply assoc (cons card args))))
 
 (defn add-icon
   "Adds an icon to a card. E.g. a Femme Fatale token.

--- a/src/clj/game/core/props.clj
+++ b/src/clj/game/core/props.clj
@@ -10,21 +10,19 @@
 (defn add-prop
   "Adds the given value n to the existing value associated with the key in the card.
   Example: (add-prop ... card :counter 1) adds one power/virus counter. Triggers events."
-  ([state side card key n] (add-prop state side (make-eid state) card key n nil))
-  ([state side card key n args] (add-prop state side (make-eid state) card key n args))
-  ([state side eid card key n {:keys [placed]}]
-   (let [updated-card (if (has-subtype? card "Virus")
-                        (assoc card :added-virus-counter true)
-                        card)]
-     (update! state side (update-in updated-card [key] #(+ (or % 0) n)))
-     (if (= key :advance-counter)
+  ([state side card prop-type n] (add-prop state side (make-eid state) card prop-type n nil))
+  ([state side card prop-type n args] (add-prop state side (make-eid state) card prop-type n args))
+  ([state side eid card prop-type n {:keys [placed]}]
+   (let [updated-card (update! state side (update card prop-type #(+ (or % 0) n)))
+         args {:counter-type prop-type :amount n :placed placed}]
+     (if (= prop-type :advance-counter)
        (do (when (and (ice? updated-card)
                       (rezzed? updated-card))
              (update-ice-strength state side updated-card))
            (if-not placed
-             (trigger-event-sync state side eid :advance (get-card state updated-card) {:counter-type key :amount n :placed placed})
-             (trigger-event-sync state side eid :advancement-placed (get-card state updated-card) {:counter-type key :amount n :placed placed})))
-       (trigger-event-sync state side eid :counter-added (get-card state updated-card) {:counter-type key :amount n :placed placed})))))
+             (trigger-event-sync state side eid :advance (get-card state updated-card) args)
+             (trigger-event-sync state side eid :advancement-placed (get-card state updated-card) args)))
+       (trigger-event-sync state side eid :counter-added (get-card state updated-card) args)))))
 
 (defn set-prop
   "Like add-prop, but sets multiple keys to corresponding values without triggering events.
@@ -34,17 +32,14 @@
 
 (defn add-counter
   "Adds n counters of the specified type to a card"
-  ([state side card type n] (add-counter state side (make-eid state) card type n nil))
-  ([state side card type n args] (add-counter state side (make-eid state) card type n args))
-  ([state side eid card type n {:keys [placed] :as args}]
-   (let [updated-card (if (= type :virus)
-                        (assoc card :added-virus-counter true)
-                        card)]
-     (update! state side (update-in updated-card [:counter type] #(+ (or % 0) n)))
-     (if (= type :advancement)
-       ;; if advancement counter use existing system
-       (add-prop state side eid card :advance-counter n args)
-       (trigger-event-sync state side eid :counter-added (get-card state updated-card) {:counter-type key :amount n :placed placed})))))
+  ([state side card prop-type n] (add-counter state side (make-eid state) card prop-type n nil))
+  ([state side card prop-type n args] (add-counter state side (make-eid state) card prop-type n args))
+  ([state side eid card prop-type n {:keys [placed] :as args}]
+   (if (= prop-type :advancement)
+     ;; if advancement counter use existing system
+     (add-prop state side eid card :advance-counter n args)
+     (let [updated-card (update! state side (update-in card [:counter prop-type] #(+ (or % 0) n)))]
+       (trigger-event-sync state side eid :counter-added updated-card {:counter-type prop-type :amount n :placed placed})))))
 
 (defn add-icon
   "Adds an icon to a card. E.g. a Femme Fatale token.

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -137,10 +137,6 @@
                  ;; Clear :installed :this-turn as turn has ended
                  (when (= :this-turn (installed? card))
                    (update! state side (assoc (get-card state card) :installed true)))
-                 ;; Clear the added-virus-counter flag for each virus in play.
-                 ;; We do this even on the corp's turn to prevent shenanigans with something like Gorman Drip and Surge
-                 (when (has-subtype? card "Virus")
-                   (set-prop state :runner (get-card state card) :added-virus-counter false))
                  ;; Remove all :turn strength from icebreakers.
                  ;; We do this even on the corp's turn in case the breaker is boosted due to Offer You Can't Refuse
                  (when (has-subtype? card "Icebreaker")

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -12,7 +12,6 @@
     [game.core.hand-size :refer [hand-size]]
     [game.core.ice :refer [update-all-ice update-breaker-strength]]
     [game.core.moving :refer [move]]
-    [game.core.props :refer [set-prop]]
     [game.core.say :refer [system-msg]]
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -285,12 +285,8 @@
 (defn get-counters
   "Get number of counters of specified type."
   [card counter]
-  (cond
-    (= counter :advancement)
+  (if (= counter :advancement)
     (+ (:advance-counter card 0) (:extra-advance-counter card 0))
-    (= counter :recurring)
-    (:rec-counter card 0)
-    :else
     (get-in card [:counter counter] 0)))
 
 (defn assoc-host-zones

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -5151,8 +5151,7 @@
       (play-from-hand state :runner "Security Testing")
       (let [st (get-resource state 0)]
         (play-from-hand state :runner "Surge")
-        (click-card state :runner st)
-        (is (not (contains? st :counter)) "Surge does not fire on Security Testing"))))
+        (is (empty? (:prompt (get-runner))) "Surge does not fire on Security Testing"))))
   (testing "Don't fire surge if target does not have virus counter flag set"
     (do-game
       (new-game {:runner {:deck ["Imp" "Surge"]}})
@@ -5160,11 +5159,10 @@
       (play-from-hand state :runner "Imp")
       (let [imp (get-program state 0)]
         (is (= 2 (get-counters imp :virus)) "Imp has 2 counters after install")
-        (take-credits state :runner 3)
+        (take-credits state :runner)
         (take-credits state :corp)
         (play-from-hand state :runner "Surge")
-        (click-card state :runner imp)
-        (is (= 2 (get-counters (refresh imp) :virus)) "Surge does not fire on Imp turn after install"))))
+        (is (empty? (:prompt (get-runner))) "Surge does not fire on Imp turn after install"))))
   (testing "Don't allow surging Gorman Drip, since it happens on the corp turn"
     (do-game
       (new-game {:runner {:deck ["Gorman Drip v1" "Surge"]}})
@@ -5172,13 +5170,12 @@
       (play-from-hand state :runner "Gorman Drip v1")
       (let [gd (get-program state 0)]
         (is (zero? (get-counters gd :virus)) "Gorman Drip starts without counters")
-        (take-credits state :runner 3)
+        (take-credits state :runner)
         (take-credits state :corp)
         (is (= 3 (get-counters (refresh gd) :virus))
             "Gorman Drip gains 3 counters after Corp clicks 3 times for credits")
         (play-from-hand state :runner "Surge")
-        (click-card state :runner gd)
-        (is (= 3 (get-counters (refresh gd) :virus)) "Surge does not trigger on Gorman Drip")))))
+        (is (empty? (:prompt (get-runner))) "Surge does not trigger on Gorman Drip")))))
 
 (deftest syn-attack
   ;; SYN Attack

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -4213,12 +4213,13 @@
       (let [phero (get-program state 0)
             inti (get-program state 1)]
         (is (changes-credits (get-runner) -2 (card-ability state :runner inti 1)))
-        (changes-val-macro 0 (:credit (get-runner))
-                           "Used 2 credits from Pheromones"
-                           (run-on state "HQ")
-                           (card-ability state :runner inti 1)
-                           (click-card state :runner phero)
-                           (click-card state :runner phero))))))
+        (changes-val-macro
+          0 (:credit (get-runner))
+          "Used 2 credits from Pheromones"
+          (run-on state "HQ")
+          (card-ability state :runner inti 1)
+          (click-card state :runner phero)
+          (click-card state :runner phero))))))
 
 (deftest plague
   ;; Plague

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -1538,10 +1538,11 @@
             en (get-ice state :remote1 0)]
         (rez state :corp kh)
         (is (= 4 (get-counters (refresh kh) :recurring)) "4 recurring credits on Khondi")
-        (changes-val-macro 0 (:credit (get-corp))
-                           "Used 3 credits from Khondi Plaza"
-                           (rez state :corp en)
-                           (dotimes [c 3] (click-card state :corp kh)))))))
+        (changes-val-macro
+          0 (:credit (get-corp))
+          "Used 3 credits from Khondi Plaza"
+          (rez state :corp en)
+          (dotimes [c 3] (click-card state :corp kh)))))))
 
 (deftest la-costa-grid
   (testing "La Costa Grid cannot be installed in a central server"

--- a/test/clj/game/core/rules_test.clj
+++ b/test/clj/game/core/rules_test.clj
@@ -392,36 +392,6 @@
       (take-credits state :corp)
       (is (= 0 (get-counters (refresh iw) :virus)) "Purging removed Ice Wall counters"))))
 
-(deftest virus-counter-flags
-  (testing "Set counter flag when virus card enters play with counters"
-    (do-game
-      (new-game {:runner {:deck ["Surge" "Imp" "Crypsis"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Imp")
-      (let [imp (get-program state 0)]
-        (is (get-in imp [:added-virus-counter]) "Counter flag was set on Imp"))))
-  (testing "Set counter flag when add-prop is called on a virus"
-    (do-game
-      (new-game {:runner {:deck ["Crypsis"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Crypsis")
-      (let [crypsis (get-program state 0)]
-        (card-ability state :runner crypsis 2) ;click to add a virus counter
-        (is (= 1 (get-counters (refresh crypsis) :virus)) "Crypsis added a virus token")
-        (is (get-in (refresh crypsis) [:added-virus-counter])
-            "Counter flag was set on Crypsis"))))
-  (testing "Clear the virus counter flag at the end of each turn"
-    (do-game
-      (new-game {:runner {:deck ["Crypsis"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Crypsis")
-      (let [crypsis (get-program state 0)]
-        (card-ability state :runner crypsis 2) ; click to add a virus counter
-        (take-credits state :runner 2)
-        (take-credits state :corp 1)
-        (is (not (get-in (refresh crypsis) [:added-virus-counter]))
-            "Counter flag was cleared on Crypsis")))))
-
 (deftest end-the-run-test
   ;; Since all ETR ice share a common ability, we only need one test
   (do-game

--- a/test/clj/game/core/rules_test.clj
+++ b/test/clj/game/core/rules_test.clj
@@ -103,11 +103,10 @@
     (play-from-hand state :corp "Ice Wall" "HQ")
     (take-credits state :corp 2)
     (play-from-hand state :runner "Off-Campus Apartment")
-    (play-from-hand state :runner "Compromised Employee")
     (let [iwall (get-ice state :hq 0)
           apt (get-resource state 0)]
-      (card-ability state :runner apt 1) ; use Off-Campus option to host an installed card
-      (click-card state :runner (find-card "Compromised Employee" (get-resource state)))
+      (card-ability state :runner apt 0) ; use Off-Campus option to host a card
+      (click-card state :runner "Compromised Employee")
       (let [cehosted (first (:hosted (refresh apt)))]
         (card-ability state :runner cehosted 0) ; take Comp Empl credit
         (is (= 4 (:credit (get-runner))))

--- a/test/clj/game/utils_test.clj
+++ b/test/clj/game/utils_test.clj
@@ -6,7 +6,7 @@
 
 (defmacro error-wrapper [form]
   `(try ~form
-        (catch Exception ex#
+        (catch clojure.lang.ExceptionInfo ex#
           (let [msg# (.getMessage ^Throwable ex#)
                 form# (:cause (ex-data ex#))
                 result# (:result (ex-data ex#))]

--- a/test/clj/game/utils_test.clj
+++ b/test/clj/game/utils_test.clj
@@ -21,7 +21,7 @@
       (if result#
         (do-report {:type :pass, :message ~msg,
                     :expected '~form, :actual (list result#)})
-        (throw (ex-info ~msg {:cause '~form :result result#}))))))
+        (throw (ex-info ~msg {:cause '~form :result '~form}))))))
 
 ;;; helper functions for prompt interaction
 (defn get-prompt
@@ -72,9 +72,7 @@
       ;; Prompt is a select, but card isn't correct type
       (not (or (map? card)
                (string? card)))
-      (is' (or (map? card)
-               (string? card))
-           (expect-type "card string or map" card)))))
+      (is' (true? (or (map? card) (string? card))) (expect-type "card string or map" card)))))
 
 (defmacro click-card
   "Resolves a 'select prompt' by clicking a card. Takes a card map or a card name."
@@ -113,7 +111,7 @@
       ;; List of card titles for auto-completion
       (:card-title choices)
       (when-not (core/process-action "choice" state side {:choice choice})
-        (is' (or (map? choice) (string? choice)) (expect-type "card string or map" choice)))
+        (is' (true? (or (map? choice) (string? choice))) (expect-type "card string or map" choice)))
 
       ;; Default text prompt
       :else


### PR DESCRIPTION
There is no need for us to be adding and keeping track of "flags" like `:added-virus-counter`.