### PR TITLE
Add option to continue displaying zoomed card after mouse out

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -168,7 +168,8 @@
     (if (acknowledged? (mc/update db "users"
                                   {:username username}
                                   {"$set" {:options (select-keys body [:background :pronouns :language :show-alt-art :blocked-users
-                                                                       :alt-arts :card-resolution :deckstats :gamestats :card-zoom :card-back])}}))
+                                                                       :alt-arts :card-resolution :deckstats :gamestats :card-zoom
+                                                                       :pin-zoom :card-back])}}))
       (response 200 {:message "Refresh your browser"})
       (response 404 {:message "Account not found"}))
     (response 401 {:message "Unauthorized"})))

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -37,6 +37,7 @@
   (swap! app-state assoc-in [:options :background] (:background @s))
   (swap! app-state assoc-in [:options :card-back] (:card-back @s))
   (swap! app-state assoc-in [:options :card-zoom] (:card-zoom @s))
+  (swap! app-state assoc-in [:options :pin-zoom] (:pin-zoom @s))
   (swap! app-state assoc-in [:options :show-alt-art] (:show-alt-art @s))
   (swap! app-state assoc-in [:options :card-resolution] (:card-resolution @s))
   (swap! app-state assoc-in [:options :stacked-servers] (:stacked-servers @s))
@@ -56,6 +57,7 @@
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
   (.setItem js/localStorage "card-back" (:card-back @s))
   (.setItem js/localStorage "card-zoom" (:card-zoom @s))
+  (.setItem js/localStorage "pin-zoom" (:pin-zoom @s))
   (post-options url (partial post-response s)))
 
 (defn add-user-to-block-list
@@ -341,7 +343,14 @@
                                       :value (:ref option)
                                       :on-change #(swap! s assoc :card-zoom (.. % -target -value))
                                       :checked (= (:card-zoom @s) (:ref option))}]
-                      (:name option)]]))]
+                      (:name option)]]))
+           [:br]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :name "pin-zoom"
+                             :checked (:pin-zoom @s)
+                             :on-change #(swap! s assoc-in [:pin-zoom] (.. % -target -checked))}]
+             (tr [:settings.pin-zoom "Keep zoomed cards on screen"])]]]
 
           [:section
            [:h3 (tr [:settings.game-stats " Game Win/Lose statistics "])]
@@ -449,6 +458,7 @@
                        :background (get-in @app-state [:options :background])
                        :card-back (get-in @app-state [:options :card-back])
                        :card-zoom (get-in @app-state [:options :card-zoom])
+                       :pin-zoom (get-in @app-state [:options :pin-zoom])
                        :pronouns (get-in @app-state [:options :pronouns])
                        :language (get-in @app-state [:options :language])
                        :sounds (get-in @app-state [:options :sounds])

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -14,6 +14,7 @@
            :options (merge {:background "lobby-bg"
                             :card-back (get-local-value "card-back" "nisei")
                             :card-zoom (get-local-value "card-zoom" "image")
+                            :pin-zoom (get-local-value "pin-zoom" false)
                             :pronouns "none"
                             :language "en"
                             :show-alt-art true


### PR DESCRIPTION
Added a new option in Settings to keep displaying a zoomed card after moving the mouse away from the card on the board.

![image](https://user-images.githubusercontent.com/47226/111700530-e868c780-880f-11eb-824e-dcdf8208681a.png)

![image](https://user-images.githubusercontent.com/47226/111700568-f4ed2000-880f-11eb-8697-8c3cf1959a64.png)

Click on the card toggles from the card image to the card text. Clicking the `x` button in the upper right closes the display.
Unless the `x` button is clicked, the image will remain until another card is moused over.