### PR TITLE
Make runner install use checkpoints

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -254,7 +254,7 @@
              {:player :corp
               :req (req (and (has-subtype? (:card context) "Run")
                              (first-event? state :runner :play-event #(has-subtype? (:card (first %)) "Run"))
-                             (no-event? state :runner :runner-install #(has-subtype? (first %) "Icebreaker"))))
+                             (no-event? state :runner :runner-install #(has-subtype? (:card (first %)) "Icebreaker"))))
               :waiting-prompt "Corp to use Better Citizen Program"
               :prompt "Give the runner 1 tag?"
               :yes-ability
@@ -265,9 +265,9 @@
              :silent (req true)
              :optional
              {:player :corp
-              :req (req (and (not (facedown? target))
-                             (has-subtype? target "Icebreaker")
-                             (first-event? state :runner :runner-install #(has-subtype? (first %) "Icebreaker"))
+              :req (req (and (not (:facedown context))
+                             (has-subtype? (:card context) "Icebreaker")
+                             (first-event? state :runner :runner-install #(has-subtype? (:card (first %)) "Icebreaker"))
                              (no-event? state :runner :play-event #(has-subtype? (:card (first %)) "Run"))))
               :waiting-prompt "Corp to use Better Citizen Program"
               :prompt "Give the runner 1 tag?"
@@ -1100,7 +1100,7 @@
     {:events [(assoc pp :event :searched-stack)
               (assoc pp
                      :event :runner-install
-                     :req (req (and (some #{:discard} (:previous-zone target))
+                     :req (req (and (some #{:discard} (:previous-zone (:card context)))
                                     (pos? (count (:hand runner))))))]}))
 
 (defcard "Philotic Entanglement"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -611,7 +611,8 @@
              :silent (req true)
              :req (req (and (pos? (get-counters card :power))
                             (not (get-in @state [:per-turn (:cid card)]))))
-             :msg (msg "increase the install cost of " (:title target) " by " (get-counters card :power) " [Credits]")
+             :msg (msg "increase the install cost of " (:title (:card context))
+                       " by " (get-counters card :power) " [Credits]")
              :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}]})
 
 (defcard "Drudge Work"
@@ -2069,8 +2070,8 @@
                                         (not (:facedown (second targets)))))
                          :value 1}]
      :events [{:event :runner-install
-               :req (req (and (is-techno-target target)
-                              (not (:facedown (second targets)))))
+               :req (req (and (is-techno-target (:card context))
+                              (not (:facedown context))))
                :msg "gain 1 [Credits]"
                :async true
                :effect (effect (gain-credits :corp eid 1))}]}))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -304,12 +304,14 @@
 (defcard "Career Fair"
   {:prompt "Select a resource to install from your Grip"
    :req (req (some #(and (resource? %)
-                         (can-pay? state side (assoc eid :source card :source-type :runner-install) % nil
+                         (can-pay? state side (assoc eid :source card :source-type :runner-install)
+                                   % nil
                                    [:credit (install-cost state side % {:cost-bonus -3})]))
                    (:hand runner)))
    :choices {:req (req (and (resource? target)
                             (in-hand? target)
-                            (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
+                            (can-pay? state side (assoc eid :source card :source-type :runner-install)
+                                      target nil
                                       [:credit (install-cost state side target {:cost-bonus -3})])))}
    :async true
    :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target {:cost-bonus -3}))})
@@ -465,8 +467,6 @@
 
 (defcard "Corporate \"Grant\""
   {:events [{:event :runner-install
-             ;; there are no current interactions where we'd want Grant to not be last, and this fixes a bug with Hayley
-             :silent (req true)
              :req (req (first-event? state side :runner-install))
              :msg "force the Corp to lose 1 [Credit]"
              :async true
@@ -1385,10 +1385,9 @@
 (defcard "In the Groove"
   {:events [{:event :runner-install
              :duration :end-of-turn
-             :req (req (<= 1 (:cost target)))
-             :interactive (req (or
-                                 (has-subtype? target "Cybernetic")
-                                 (first-event? state side :runner-install)))
+             :req (req (<= 1 (:cost (:card context))))
+             :interactive (req (or (has-subtype? (:card context) "Cybernetic")
+                                   (first-event? state side :runner-install)))
              :async true
              :prompt "What to get from In the Groove?"
              :choices ["Draw 1 card" "Gain 1 [Credits]"]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2034,7 +2034,7 @@
                     :effect (req (doseq [c (get-in card [:hosted])]
                                    (card-init state side c {:resolve-effect false})))}
      :events [{:event :runner-install
-               :req (req (same-card? card (:host target)))
+               :req (req (same-card? card (:host (:card context))))
                :effect (req (disable-hosted state side card)
                          (update-ice-strength state side card))}]
      :subroutines [end-the-run]}))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -990,7 +990,8 @@
              :choices {:card #(and (runner? %)
                                    (in-hand? %))}
              :async true
-             :msg (msg "force the Runner to trash" (:title target) " from their grip")
+             :msg (msg "force the Runner to trash"
+                       (:title target) " from their grip")
              :effect (effect (trash :runner eid target {:unpreventable true}))}]})
 
 (defcard "Hunter Seeker"
@@ -2162,20 +2163,17 @@
              :effect (effect (trash eid card nil))}]})
 
 (defcard "Targeted Marketing"
-  (let [gaincr {:async true
-                :effect (effect (gain-credits :corp eid 10))
-                :msg (msg "gain 10 [Credits] from " (:marketing-target card))}]
+  (let [gaincr {:req (req (= (:title (:card context)) (get-in card [:special :marketing-target])))
+                :async true
+                :msg (msg "gain 10 [Credits] from " (:marketing-target card))
+                :effect (effect (gain-credits :corp eid 10))}]
     {:prompt "Name a Runner card"
      :choices {:card-title (req (and (runner? target)
                                      (not (identity? target))))}
      :effect (effect (update! (assoc-in card [:special :marketing-target] target))
                      (system-msg (str "uses Targeted Marketing to name " target)))
-     :events [(assoc gaincr
-                     :event :runner-install
-                     :req (req (= (:title target) (get-in card [:special :marketing-target]))))
-              (assoc gaincr
-                     :event :play-event
-                     :req (req (= (:title (:card context)) (get-in card [:special :marketing-target]))))]}))
+     :events [(assoc gaincr :event :runner-install)
+              (assoc gaincr :event :play-event)]}))
 
 (defcard "The All-Seeing I"
   (let [trash-all-resources

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1263,7 +1263,8 @@
               :yes-ability {:prompt "Select a card to rez"
                             :choices {:req (req (and (not (rezzed? target))
                                                      (not (agenda? target))
-                                                     (can-pay? state side (assoc eid :source card :source-type :runner-install) target nil
+                                                     (can-pay? state side (assoc eid :source card :source-type :rez)
+                                                               target nil
                                                                [:credit (rez-cost state side target {:cost-bonus -2})])))}
                             :msg (msg "rez " (:title target) ", lowering the rez cost by 2 [Credits]")
                             :async true

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -184,7 +184,7 @@
 (defmacro defcard
   [title ability]
   `(defmethod ~'defcard-impl ~title [~'_]
-     (if-let [cached-ability# (get @card-defs-cache ~title)]
+     (if-let [cached-ability# (get card-defs-cache ~title)]
        cached-ability#
        (let [ability# (add-default-abilities ~title ~ability)]
          (swap! card-defs-cache assoc ~title ability#)

--- a/src/clj/game/core/finding.clj
+++ b/src/clj/game/core/finding.clj
@@ -17,8 +17,8 @@
   "Returns the newest version of a card where-ever it may be"
   [state card]
   (find-cid (:cid card) (concat (all-installed state (-> card :side to-keyword))
-                                (-> (map #(-> @state :corp %) [:hand :discard :deck :rfg :scored]) concat flatten)
-                                (-> (map #(-> @state :runner %) [:hand :discard :deck :rfg :scored]) concat flatten))))
+                                (-> (map #(get-in @state [:corp %]) [:hand :discard :deck :rfg :scored]) concat flatten)
+                                (-> (map #(get-in @state [:runner %]) [:hand :discard :deck :rfg :scored]) concat flatten))))
 
 (defn get-scoring-owner
   "Returns the owner of the scoring area the card is in"

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -2775,7 +2775,8 @@
                              (click-prompt state :runner "Gain 1 [Credits]")))))
   (testing "Hayley Kaplan interaction"
     (do-game
-      (new-game {:runner {:deck [(qty "In the Groove" 3) "Pelangi" "Imp" "Sure Gamble"]
+      (new-game {:runner {:deck [(qty "Sure Gamble" 5)]
+                          :hand ["In the Groove" "Pelangi" "Imp" "Sure Gamble"]
                           :id "Hayley Kaplan: Universal Scholar"}})
       (take-credits state :corp)
       (play-from-hand state :runner "In the Groove")

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3503,7 +3503,7 @@
       (play-from-hand state :runner "Rolodex")
       (is (= "Choose a trigger to resolve" (:msg (prompt-map :runner)))
           "Runner has simultaneous resolution prompt")
-      (is (= ["Rolodex" "Paige Piper"] (prompt-titles :runner))
+      (is (= #{"Rolodex" "Paige Piper"} (set (prompt-titles :runner)))
           "Both Rolodex and Paige Piper can be chosen")
       (click-prompt state :runner "Paige Piper")
       (click-prompt state :runner "Yes")


### PR DESCRIPTION
Same as #5641 but for runners. Bundled converting all "when installed" abilities to use `:on-install` to save ourselves some headaches.