### PR TITLE
Moved req inside optional in Zahya: fixes #5652

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1676,11 +1676,10 @@
 
 (defcard "Zahya Sadeghi: Versatile Smuggler"
   {:events [{:event :run-ends
-             :req (req (and (or (= :hq (target-server context))
-                                (= :rd (target-server context)))
-                            (pos? (total-cards-accessed context))))
              :optional
-             {:prompt "Gain 1 [Credits] for each card you accessed?"
+             {:req (req (and (#{:hq :rd} (target-server context))
+                          (pos? (total-cards-accessed context))))
+              :prompt "Gain 1 [Credits] for each card you accessed?"
               :async true
               :once :per-turn
               :yes-ability


### PR DESCRIPTION
Looked like a small typo - not sure what the interaction there was, but basically `:req` wasn't being evaluated at `:end-run`
 fixes #5652