### PR TITLE
Move agenda points and hand size to more natural positions

### DIFF
--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1423,6 +1423,14 @@
      (str (get-in opts [:opts :name])
           (when (not (get-in opts [:opts :hide-cursor])) (str " (" (fn cursor) ")")))]))
 
+(defn controls
+  "Create the control buttons for the side displays."
+  ([key] (controls key 1 -1))
+  ([key increment decrement]
+   [:div.controls
+    [:button.small {:on-click #(send-command "change" {:key key :delta decrement}) :type "button"} "-"]
+    [:button.small {:on-click #(send-command "change" {:key key :delta increment}) :type "button"} "+"]]))
+
 (defn- this-user?
   [user]
   (if (:replay @game-state)
@@ -1614,14 +1622,6 @@
                        [:div [card-view card]]])
                     @scored))
      [label @scored {:opts {:name (tr [:game.scored-area "Scored Area"])}}]]))
-
-(defn controls
-  "Create the control buttons for the side displays."
-  ([key] (controls key 1 -1))
-  ([key increment decrement]
-   [:div.controls
-    [:button.small {:on-click #(send-command "change" {:key key :delta decrement}) :type "button"} "-"]
-    [:button.small {:on-click #(send-command "change" {:key key :delta increment}) :type "button"} "+"]]))
 
 (defn name-area
   [user]

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1459,16 +1459,17 @@
                    [facedown-card (:side card)])])
               @hand))]))
 
-(defn hand-view [user name translated-name hand prompt remotes popup popup-direction]
+(defn hand-view [user name translated-name hand hand-size prompt remotes popup popup-direction]
   (let [s (r/atom {})]
-    (fn [user name translated-name hand prompt remotes popup popup-direction]
+    (fn [user name translated-name hand hand-size prompt remotes popup popup-direction]
       (let [size (count @hand)]
         [:div.hand-container
          [:div.hand-controls
           [:div.panel.blue-shade.hand
            (drop-area name {:class (when (> size 6) "squeeze")})
            [build-hand-card-view user hand prompt remotes "card-wrapper"]
-           [label @hand {:opts {:name translated-name}}]]
+           [label @hand {:opts {:name translated-name
+                                :fn (fn [cursor] (str (count cursor) "/" (:total @hand-size)))}}]]
           (when popup
             [:div.panel.blue-shade.hand-expand
              {:on-click #(-> (:hand-popup @s) js/$ .fadeToggle)}
@@ -2425,6 +2426,8 @@
                    opponent (r/cursor game-state [op-side])
                    me-hand (r/cursor game-state [me-side :hand])
                    op-hand (r/cursor game-state [op-side :hand])
+                   me-hand-size (r/cursor game-state [me-side :hand-size])
+                   op-hand-size (r/cursor game-state [op-side :hand-size])
                    me-deck (r/cursor game-state [me-side :deck])
                    op-deck (r/cursor game-state [op-side :deck])
                    me-discard (r/cursor game-state [me-side :discard])
@@ -2482,7 +2485,7 @@
                  [:div.leftpane [:div.opponent
                                  (let [srv (if (= :corp op-side) "HQ" "Grip")
                                        translated-srv (if (= :corp op-side) (tr [:game.hq "HQ"]) (tr [:game.grip "Grip"]))]
-                                   [hand-view op-user srv translated-srv op-hand op-prompt corp-remotes
+                                   [hand-view op-user srv translated-srv op-hand op-hand-size op-prompt corp-remotes
                                     (= @side :spectator) "opponent"])]
 
                   [:div.inner-leftpane
@@ -2519,7 +2522,7 @@
                   [:div.me
                    (let [srv (if (= :corp me-side) "HQ" "Grip")
                          translated-srv (if (= :corp me-side) (tr [:game.hq "HQ"]) (tr [:game.grip "Grip"]))]
-                     [hand-view me-user srv translated-srv me-hand me-prompt
+                     [hand-view me-user srv translated-srv me-hand me-hand-size me-prompt
                       corp-remotes true "me"])]]]
                 (when (:replay @game-state)
                   [:div.bottompane

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1478,6 +1478,9 @@
             [:div
              [:a {:on-click #(close-popup % (:hand-popup @s) nil false false)} (tr [:game.close "Close"])]
              [:label (tr [:game.card-count] size)]
+             (let [{:keys [total]} @hand-size]
+               [:div.hand-size (str total " " (tr [:game.max-hand "Max hand size"]))
+                (controls :hand-size)])
              [build-hand-card-view user hand prompt remotes "card-popup-wrapper"]]])]))))
 
 (defn show-deck [event ref]
@@ -1666,7 +1669,7 @@
   (let [me? (= (:side @game-state) :runner)]
     (fn [runner]
       (let [{:keys [user click credit run-credit memory link tag
-                    brain-damage hand-size active]} @runner]
+                    brain-damage active]} @runner]
         [:div.panel.blue-shade.stats {:class (when active "active-player")}
          (name-area user)
          [:div (tr [:game.click-count] click)
@@ -1684,15 +1687,12 @@
             (when show-tagged [:div.warning "!"])
             (when me? (controls :tag))])
          [:div (str brain-damage " " (tr [:game.brain-damage "Brain Damage"]))
-          (when me? (controls :brain-damage))]
-         (let [{:keys [total]} hand-size]
-           [:div (str total " " (tr [:game.max-hand "Max hand size"]))
-            (when me? (controls :hand-size))])]))))
+          (when me? (controls :brain-damage))]]))))
 
 (defmethod stats-view "Corp" [corp]
   (let [me? (= (:side @game-state) :corp)]
     (fn [corp]
-      (let [{:keys [user click credit bad-publicity hand-size active]} @corp]
+      (let [{:keys [user click credit bad-publicity active]} @corp]
         [:div.panel.blue-shade.stats {:class (when active "active-player")}
          (name-area user)
          [:div (tr [:game.click-count] click)
@@ -1701,10 +1701,7 @@
           (when me? (controls :credit))]
          (let [{:keys [base additional]} bad-publicity]
            [:div (tr [:game.bad-pub-count] base additional)
-            (when me? (controls :bad-publicity))])
-         (let [{:keys [total]} hand-size]
-           [:div (str total " " (tr [:game.max-hand "Max hand size"]))
-            (when me? (controls :hand-size))])]))))
+            (when me? (controls :bad-publicity))])]))))
 
 (defn run-arrow [run]
   [:div.run-arrow [:div {:class (cond

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -274,6 +274,15 @@
         float: right
         margin-left: 2px
 
+    .scored
+        height: 116px
+
+    .scored > .stats
+        bottom: 0
+        padding: 3px 6px
+        position: absolute
+        width: 100%
+
     .card-wrapper
         display: inline-block
         margin-right: 4px
@@ -830,4 +839,3 @@
 
             .log-input form input, .indicate-action
                 width: 100%
-

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -219,8 +219,18 @@
             margin: 2px
 
         a
+        label
+        .hand-size
             display: inline-block
             margin: 0 10px 8px 4px
+
+            &:hover .controls
+                opacity: 1
+
+        .controls
+            display: inline-block
+            margin-left: 10px
+            opacity: 0
 
     .playable
         cursor: pointer


### PR DESCRIPTION
This PR combines three small changes to the gameboard:

- Moving the "Agenda Points" line from the stats table to the scored area, directly under the scored agendas.
- Moving the "Max hand size" line from the stats table to the hand popup.
- Adding the current hand size to the hand panel's label (e.g. "HQ (4/5)").

See the screenshots below for details. I know we've discussed adding UI changes behind an option in settings, but I felt these changes here should be uncontroversal enough to just go through with them. For the other more radical changes (icons instead of text), I thought about introducing a "Compact UI" setting.

![jnet-stats-ui](https://user-images.githubusercontent.com/3992739/111910133-6d4a2000-8a60-11eb-8e54-f0d0539b1e34.png)
![jnet-stats-ui-new-popup](https://user-images.githubusercontent.com/3992739/111910143-763af180-8a60-11eb-871b-36dc0a0c14eb.png)
