### PR TITLE
Aligned can-pay? usage in get-runnable-zones  with usage in make-run.

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2141,7 +2141,6 @@
                                (map unknown->kw)
                                (filter is-central?)
                                (remove (into #{} (:made-run runner-reg)))
-                               (map central->name)
                                not-empty))
                 :choices (req (->> runnable-servers
                                    (map unknown->kw)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -545,7 +545,7 @@
          permitted-zones (remove (set restricted-zones) (or zones (get-zones state)))]
      (if ignore-costs
        permitted-zones
-       (filter #(can-pay? state :runner eid (total-run-cost state side card {:server (unknown->kw %)}))
+       (filter #(can-pay? state :runner eid card nil (total-run-cost state side card {:server (unknown->kw %)}))
                permitted-zones)))))
 
 (defn generate-runnable-zones

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -96,9 +96,8 @@
                        (payable? % state side eid card))
                  costs)
        costs
-       (when title
-         (toast state side (str "Unable to pay for " title "."))
-         false)))))
+       (do (when title (toast state side (str "Unable to pay for " title ".")))
+           false)))))
 
 (defn cost-targets
   [eid cost-type]


### PR DESCRIPTION
Fixes #5669. 