### PR TITLE
advance_placed_fix

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -684,7 +684,7 @@
                 :req (req (pos? (get-counters card :agenda)))
                 :msg (msg "place 1 advancement token on " (card-str state target))
                 :once :per-turn
-                :effect (effect (add-prop target :advance-counter 1))}]})
+                :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]})
 
 (defcard "Flower Sermon"
   {:on-score {:silent (req true)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2098,7 +2098,7 @@
   {:on-encounter {:cost [:credit 1]
                   :choices {:card can-be-advanced?}
                   :msg (msg "place 1 advancement token on " (card-str state target))
-                  :effect (effect (add-prop target :advance-counter 1))}
+                  :effect (effect (add-prop target :advance-counter 1 {:placed true}))}
    :subroutines [(tag-trace 2)]})
 
 (defcard "Mausolus"


### PR DESCRIPTION
Related to #5659
Fixes rest of cards that places advancement counters and should not trigger Build to Last.