### PR TITLE
Fix repeated text on Fully Operational's on-play message

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -841,7 +841,7 @@
                                         (continue-ability state side (repeat-choice (inc current) total)
                                                           card nil))))}))]
     {:on-play
-     {:msg (msg "uses Fully Operational to make " (quantify (inc (count (full-servers state))) "gain/draw decision"))
+     {:msg (msg "make " (quantify (inc (count (full-servers state))) "gain/draw decision"))
       :async true
       :effect (effect (continue-ability (repeat-choice 1 (inc (count (full-servers state))))
                                         card nil))}}))


### PR DESCRIPTION
Fixes mtgred#5681 by removing the repeated text.

