### PR TITLE
Add ability to override card images

### DIFF
--- a/src/clj/tasks/images.clj
+++ b/src/clj/tasks/images.clj
@@ -10,6 +10,7 @@
 
 (def ^:const alt-art-sets "data/promos.edn")
 (def ^:const img-directory ["resources" "public" "img" "cards"])
+(def ^:const overrides-img-directory ["resources" "public" "img" "cards" "overrides"])
 
 (def ^:const alt-collection "altarts")
 (def ^:const card-collection "cards")
@@ -43,7 +44,7 @@
   (mc/update db card-collection {} {$unset {:images 1}} {:multi true}))
 
 (defn- add-flip-card-image
-  [lang resolution art-set filename]
+  [base-path lang resolution art-set filename]
   (let [code-face (first (string/split filename #"\."))
         code-face-split (string/split code-face #"-")
         code (first code-face-split)
@@ -51,47 +52,47 @@
         k (string/join "." ["faces" face "images" (name lang) (name resolution) (name art-set)])
         prev-k-root (if (= :stock art-set) code (name art-set))
         prev-k (string/join "." ["faces" face "images" (name lang) (name resolution) prev-k-root])
-        path (string/join "/" ["/img/cards" (name lang) (name resolution) (name art-set) filename])]
+        path (string/join "/" [base-path (name lang) (name resolution) (name art-set) filename])]
     (mc/update db card-collection {:code code} {$set {k path}})
     (mc/update db card-collection {:previous-versions code} {$set {prev-k path}})))
 
 (defn- add-card-image
   "Add an image to a card in the db"
-  ([lang resolution f] (add-card-image lang resolution :stock f))
-  ([lang resolution art-set f]
+  ([base-path lang resolution f] (add-card-image base-path lang resolution :stock f))
+  ([base-path lang resolution art-set f]
    (let [filename (.getName f)]
      (if (string/includes? filename "-")
-       (add-flip-card-image lang resolution art-set filename)
+       (add-flip-card-image base-path lang resolution art-set filename)
        (let [code (first (string/split filename #"\."))
              k (string/join "." ["images" (name lang) (name resolution) (name art-set)])
              prev-k-root (if (= :stock art-set) code (name art-set))
              prev-k (string/join "." ["images" (name lang) (name resolution) prev-k-root])
-             path (string/join "/" ["/img/cards" (name lang) (name resolution) (name art-set) filename])]
+             path (string/join "/" [base-path (name lang) (name resolution) (name art-set) filename])]
          (mc/update db card-collection {:code code} {$set {k path}})
          (mc/update db card-collection {:previous-versions code} {$set {prev-k path}}))))))
 
 (defn- add-alt-images
   "All all images in the specified alt directory"
-  [lang resolution alt-dir]
+  [base-path lang resolution alt-dir]
   (let [alt (keyword (.getName alt-dir))
         images (find-files alt-dir)]
-    (doall (map #(add-card-image lang resolution alt %) images))
+    (doall (map #(add-card-image base-path lang resolution alt %) images))
     (println "Added" (count images) "images to" lang resolution alt)))
 
 (defn- add-resolution-images
   "Add all images in the specified resolution directory"
-  [lang res-dir]
+  [base-path lang res-dir]
   (let [resolution (keyword (.getName res-dir))
         alts (find-dirs res-dir)
         images (find-files res-dir)]
-    (doall (map #(add-alt-images lang resolution %) alts))))
+    (doall (map #(add-alt-images base-path lang resolution %) alts))))
 
 (defn- add-language-images
   "Add all images in the specified language directory"
-  [lang-dir]
+  [base-path lang-dir]
   (let [lang (keyword (.getName lang-dir))
         resolutions (find-dirs lang-dir)]
-    (doall (map #(add-resolution-images lang %) resolutions))))
+    (doall (map #(add-resolution-images base-path lang %) resolutions))))
 
 (defn add-images
   "Add alt art, alternate language, and high-res card images to the database"
@@ -99,10 +100,15 @@
   (try
     (let [alt-sets (read-alt-sets)
           card-dir (apply io/file img-directory)
-          langs (find-dirs card-dir)]
+          langs (remove #(= "overrides" (.getName %)) (find-dirs card-dir))
+          overrides-dir (apply io/file overrides-img-directory)]
       (replace-collection alt-collection alt-sets)
       (remove-old-images)
-      (doall (map add-language-images langs)))
+      (doall (map (partial add-language-images "/img/cards") langs))
+      (println "Adding override images...")
+      (doall (for [o (find-dirs overrides-dir)]
+               (let [overrides-langs (find-dirs o)]
+                 (doall (map (partial add-language-images (str "/img/cards/overrides/" (.getName o))) overrides-langs))))))
     (catch Exception e (do
                          (println "Image import failed:" (.getMessage e))
                          (.printStackTrace e)))))


### PR DESCRIPTION
Updated the image reading task to allow for overriding of card images. To use, places the preferred images in: `resources/public/images/cards/overrides/<override-set>/<language>/<resolution>/<set>/<card code>.png`.

Then run `lein fetch` and restart the server to pick up changed card data.

For example, if for some crazy reason you wanted to override the art of Accelerated Beta Test, copy the override image to:
`resources/public/images/cards/overrides/4121/en/high/stock/01055.png` and `resources/public/images/cards/overrides/4121/en/default/stock/01055.png`.

To remove the overrides, delete the files from the the `overrides` directory, re-run `lein fetch`, and restart the server.