### PR TITLE
Some small styling and UI updates. Addressed some missing imports from #5701

### DIFF
--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -460,7 +460,7 @@
 (defn handle-add [s card-state event]
   (.preventDefault event)
   (let [qty (str->int (:quantity @card-state))
-        card (nth (:matches @card-state) (:selected @card-state))
+        card (nth (:matches @card-state) (:selected @card-state) nil)
         best-card (lookup (:side card) card)]
     (if (js/isNaN qty)
       (swap! card-state assoc :quantity 3)
@@ -492,7 +492,10 @@
         [:input.qty {:type "text"
                      :value (:quantity @card-state)
                      :on-change #(swap! card-state assoc :quantity (.. % -target -value))}]
-        [:button (tr [:deck-builder.add-to-deck "Add to deck"])]
+        [:button (let [disabled (empty? (:matches @card-state))]
+                   {:disabled disabled
+                    :class (when disabled "disabled")})
+         (tr [:deck-builder.add-to-deck "Add to deck"])]
         (let [query (:query @card-state)
               matches (match (get-in @s [:deck :identity]) query)
               exact-match (= (:title (first matches)) query)]

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -69,6 +69,19 @@
   (when (not (:replay @game-state))
     (ws/ws-send! [:netrunner/concede {:gameid-str (:gameid @game-state)}])))
 
+(defn build-exception-msg [msg error]
+  (letfn [(build-report-url [error]
+            (js/escape (str "Please describe the circumstances of your error here.\n\n\nStack Trace:\n```clojure\n"
+                         error
+                         "\n```")))]
+    (str "<div>"
+      msg
+      "<br/>"
+      "<button type=\"button\" class=\"reportbtn\" style=\"margin-top: 5px\" "
+      "onclick=\"window.open('https://github.com/mtgred/netrunner/issues/new?body="
+      (build-report-url error)
+      "');\">Report on GitHub</button></div>")))
+
 (defn toast
   "Display a toast warning with the specified message.
   Sends a command to clear any server side toasts."

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -206,6 +206,20 @@ button.off
     font-size: 14px
     margin-right: 5px
 
+// Scrollbars
+
+::-webkit-scrollbar-thumb
+    background-color: #354456cc
+    border-radius: 3.5px
+    box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.4), inset 0 0 0 1px #ffffff5c
+
+::-webkit-scrollbar
+    width: 14px;
+
+::-webkit-scrollbar-thumb:hover
+    box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgb(255 165 0)
+    background: #ffa50045
+
 .active
     color: orange
     transition(all 0.2s ease-in-out)

--- a/src/css/cardbrowser.styl
+++ b/src/css/cardbrowser.styl
@@ -3,6 +3,8 @@
     display-flex()
     justify-content(space-between)
     height: 100vh
+    padding-top: 31px
+    margin-top: -31px
 
     .heading, .type
         font-weight: bold


### PR DESCRIPTION
- fixes #5609 - also resizes log when switching pages

- Changed the scrollbar styling to be a bit more in-line with the rest of the site (works on chrome, mac will allow it with system settings, but their scrollbars aren't so garish - firefox is a maybe I haven't checked it yet - I can't imagine this change will break it though)
![settings-scroll](https://user-images.githubusercontent.com/10727401/112711298-b86b9500-8e9d-11eb-8678-b071ef8dcad6.PNG)
![scroll-hover](https://user-images.githubusercontent.com/10727401/112711301-bacdef00-8e9d-11eb-8215-aa2386f229a4.png)
^ scroll bar hovered/active

- 'Add to Deck' button is disabled in the deck builder when no card input (before it would error out or include a card with no title)
- Fixes #5703 