### PR TITLE
System Gateway fixes

### DIFF
--- a/src/cljc/jinteki/validator.cljc
+++ b/src/cljc/jinteki/validator.cljc
@@ -66,7 +66,7 @@
   "Returns influence limit of an identity or INFINITY in case of special IDs."
   [identity]
   (let [inf (:influencelimit identity)]
-    (if (nil? inf) INFINITY inf)))
+    (if (or (nil? inf) (= "∞" inf)) INFINITY inf)))
 
 (defn legal-num-copies?
   "Returns true if there is a legal number of copies of a particular card."

--- a/src/cljc/jinteki/validator.cljc
+++ b/src/cljc/jinteki/validator.cljc
@@ -217,12 +217,23 @@
   [fmt deck]
   (mwl-legal? fmt (combine-id-and-cards deck)))
 
+(defn reject-system-gateway-neutral-ids
+  [fmt deck]
+  (let [id (:title (:identity deck))]
+    (when (and (not= :system-gateway fmt)
+               (or (= id "The Catalyst: Convention Breaker")
+                   (= id "The Syndicate: Profit over Principle")))
+      {:legal false
+       :reason (str "Illegal identity: " id)
+       :description (str "Legal for " (-> fmt name s/capitalize))})))
+
 (defn build-format-legality
   [valid fmt deck]
   (let [mwl (legal-format? fmt deck)]
-    {:legal (and (:legal valid) (:legal mwl))
-     :reason (or (:reason valid) (:reason mwl))
-     :description (str "Legal for " (-> fmt name s/capitalize))}))
+    (or (reject-system-gateway-neutral-ids fmt deck)
+        {:legal (and (:legal valid) (:legal mwl))
+         :reason (or (:reason valid) (:reason mwl))
+         :description (str "Legal for " (-> fmt name s/capitalize))})))
 
 (defn build-snapshot-plus-legality
   [valid deck]

--- a/src/cljc/jinteki/validator.cljc
+++ b/src/cljc/jinteki/validator.cljc
@@ -62,22 +62,11 @@
   [identity]
   (= "Draft" (:setname identity)))
 
-(defn multiplayer-id?
-  "Check if the specified id is a NAPD Multiplayer identity"
-  [identity]
-  (= "NAPD Multiplayer" (:setname identity)))
-
-(defn system-gateway-id?
-  "Check if the specified id is a System Gateway identity"
-  [identity]
-  (= "System Gateway" (:setname identity)))
-
 (defn id-inf-limit
   "Returns influence limit of an identity or INFINITY in case of special IDs."
   [identity]
-  (if (or (system-gateway-id? identity) (draft-id? identity) (multiplayer-id? identity))
-    INFINITY
-    (:influencelimit identity 0)))
+  (let [inf (:influencelimit identity)]
+    (if (nil? inf) INFINITY inf)))
 
 (defn legal-num-copies?
   "Returns true if there is a legal number of copies of a particular card."

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -38,7 +38,8 @@
 (defn no-inf-cost?
   [identity card]
   (or (= (:faction card) (:faction identity))
-      (= 0 (:factioncost card)) (= INFINITY (validator/id-inf-limit identity))))
+      (= 0 (:factioncost card))
+      (= INFINITY (validator/id-inf-limit identity))))
 
 (defn take-best-card
   "Returns a non-rotated card from the list of cards or a random rotated card from the list"

--- a/src/cljs/nr/gameboard/main.cljs
+++ b/src/cljs/nr/gameboard/main.cljs
@@ -676,7 +676,7 @@
     [:div
      (doall (map-indexed
               (fn [i card]
-                [:div {:key (:cid card)
+                [:div {:key (or (:cid card) i)
                        :class (str
                                 (if (and (not= "select" (-> @prompt first :prompt-type))
                                          (this-user? @user)
@@ -702,7 +702,7 @@
            (drop-area name {:class (when (> size 6) "squeeze")})
            [build-hand-card-view user side hand hand-count prompt remotes "card-wrapper"]
            [label @hand {:opts {:name translated-name
-                                :fn (fn [cursor] (str (count cursor) "/" (:total @hand-size)))}}]]
+                                :fn (fn [cursor] (str size "/" (:total @hand-size)))}}]]
           (when popup
             [:div.panel.blue-shade.hand-expand
              {:on-click #(-> (:hand-popup @s) js/$ .fadeToggle)}


### PR DESCRIPTION
Fixes influence for Gateway IDs.
Starter IDs only valid in System Gateway.
Starter Deck games are only to 6 agenda points.
Fix card count in opponents hand.


Fixes #5715 
Fixes #5716 