### PR TITLE
Added overflow to corp's board area. 

### DIFF
--- a/src/cljs/nr/gameboard/main.cljs
+++ b/src/cljs/nr/gameboard/main.cljs
@@ -1044,42 +1044,44 @@
 
 (defn board-view-corp [player-side identity deck deck-count hand hand-count discard servers run]
   (let [rs (:server @run)
-        server-type (first rs)]
-    [:div.corp-board {:class (if (= player-side :runner) "opponent" "me")}
-     (doall
-       (for [server (reverse (get-remotes @servers))
-             :let [num (remote->num (first server))
-                   similar-servers (filter #((compare-servers-for-stacking server) %) (get-remotes @servers))
-                   all-servers (conj similar-servers server)]
-             :when (or (empty? similar-servers)                                     ; it is a normal server-view
-                       (not (get-in @app-state [:options :stacked-servers] false))  ; we're not in stacked mode
-                       ; otherwise only show one view for the stacked remote
-                       (< num (remote->num (first (first similar-servers)))))]
-         (if (or (empty? similar-servers)
-                 (not (get-in @app-state [:options :stacked-servers] false)))
-           [server-view {:key num
-                         :server (second server)
-                         :run (when (= server-type (str "remote" num)) @run)}
-            {:opts {:name (remote->name (first server))}}]
-           [stacked-view {:key num
+        server-type (first rs)
+        side-class (if (= player-side :runner) "opponent" "me")]
+    [:div.outer-corp-board {:class side-class}
+     [:div.corp-board {:class side-class}
+      (doall
+        (for [server (reverse (get-remotes @servers))
+              :let [num (remote->num (first server))
+                    similar-servers (filter #((compare-servers-for-stacking server) %) (get-remotes @servers))
+                    all-servers (conj similar-servers server)]
+              :when (or (empty? similar-servers)            ; it is a normal server-view
+                      (not (get-in @app-state [:options :stacked-servers] false)) ; we're not in stacked mode
+                      ; otherwise only show one view for the stacked remote
+                      (< num (remote->num (first (first similar-servers)))))]
+          (if (or (empty? similar-servers)
+                (not (get-in @app-state [:options :stacked-servers] false)))
+            [server-view {:key num
                           :server (second server)
-                          :similar-servers similar-servers
-                          :run (when
-                                 (some #(= server-type (str "remote" %)) (map #(remote->num (first %)) all-servers))
-                                 (= server-type (str "remote" num)) @run)}
-            {:opts {:name (remote->name (first server))}}])))
-     [server-view {:key "hq"
-                   :server (:hq @servers)
-                   :central-view [identity-view :corp identity hand-count]
-                   :run (when (= server-type "hq") @run)}]
-     [server-view {:key "rd"
-                   :server (:rd @servers)
-                   :central-view [deck-view :corp player-side identity deck deck-count]
-                   :run (when (= server-type "rd") @run)}]
-     [server-view {:key "archives"
-                   :server (:archives @servers)
-                   :central-view [discard-view-corp player-side discard]
-                   :run (when (= server-type "archives") @run)}]]))
+                          :run (when (= server-type (str "remote" num)) @run)}
+             {:opts {:name (remote->name (first server))}}]
+            [stacked-view {:key num
+                           :server (second server)
+                           :similar-servers similar-servers
+                           :run (when
+                                  (some #(= server-type (str "remote" %)) (map #(remote->num (first %)) all-servers))
+                                  (= server-type (str "remote" num)) @run)}
+             {:opts {:name (remote->name (first server))}}])))
+      [server-view {:key "hq"
+                    :server (:hq @servers)
+                    :central-view [identity-view :corp identity hand-count]
+                    :run (when (= server-type "hq") @run)}]
+      [server-view {:key "rd"
+                    :server (:rd @servers)
+                    :central-view [deck-view :corp player-side identity deck deck-count]
+                    :run (when (= server-type "rd") @run)}]
+      [server-view {:key "archives"
+                    :server (:archives @servers)
+                    :central-view [discard-view-corp player-side discard]
+                    :run (when (= server-type "archives") @run)}]]]))
 
 (defn board-view-runner [player-side identity deck deck-count hand hand-count discard rig run]
   (let [is-me (= player-side :runner)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -582,6 +582,11 @@
             > div:last-child
                 margin-bottom: auto
 
+        .outer-corp-board.me
+            overflow: auto
+            margin-top: -100%
+            padding-top: 100%
+
         .corp-board
             flex(1)
             display-flex()


### PR DESCRIPTION
This is a bit hacky due to the fact that you can't actually set overflow-x and overflow-y independently of each other (eg overflow-y: visible is not valid with overflow-x: auto) https://www.w3.org/TR/css-overflow-3/#overflow-properties 'computed values' 
This just gives enough padding to the corp-board area to have any content and subtracts a margin so that the content isn't too tall

I'm not 100% that this fix is worth it since you can just zoom out like a madman to see those servers. Fixes #5732 