### PR TITLE
Fix ping on-rez ability

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2672,7 +2672,7 @@
    :strength-bonus (req (if (wonder-sub card 3) 5 0))})
 
 (defcard "Ping"
-  {:on-rez {:req (req (= (first (:server run)) (second (get-zone card))))
+  {:on-rez {:req (req (and run this-server))
             :msg "give the Runner 1 tag"
             :async true
             :effect (effect (gain-tags :corp eid 1))}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2672,7 +2672,7 @@
    :strength-bonus (req (if (wonder-sub card 3) 5 0))})
 
 (defcard "Ping"
-  {:on-rez {:req (req run)
+  {:on-rez {:req (req (= (first (:server run)) (second (get-zone card))))
             :msg "give the Runner 1 tag"
             :async true
             :effect (effect (gain-tags :corp eid 1))}


### PR DESCRIPTION
Ping's on-rez ability now checks that the run is against the server it is installed in. Fixes #5730 