### PR TITLE
Fix Anoetic Void message

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,8 @@
                  [cond-plus "1.0.1"]
                  [com.taoensso/tempura "1.2.1"]
                  [org.clojure/data.csv "1.0.0"]
-                 [medley "1.3.0"]]
+                 [medley "1.3.0"]
+                 [ch.qos.logback/logback-classic "1.2.3"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-figwheel "0.5.16"]

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration scan="false">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -535,7 +535,9 @@
                               (complete-with-result
                                 state side eid
                                 {:msg (str "trashes " (quantify (count async-result) "card")
-                                           " (" (string/join ", " (map #(card-str state %) targets)) ")"
+                                           (when (and (= :runner side)
+                                                      (pos? (count async-result)))
+                                             " (" (string/join ", " (map #(card-str state %) targets)) ")")
                                            " from " hand)
                                  :type :trash-from-hand
                                  :value (count async-result)


### PR DESCRIPTION
Fixes #5751 

Updated `project.clj` to use `logback` to address SL4J warning messages.