### PR TITLE
Fix set for previous cards

### DIFF
--- a/src/clj/tasks/images.clj
+++ b/src/clj/tasks/images.clj
@@ -54,7 +54,7 @@
         prev-k (string/join "." ["faces" face "images" (name lang) (name resolution) prev-k-root])
         path (string/join "/" [base-path (name lang) (name resolution) (name art-set) filename])]
     (mc/update db card-collection {:code code} {$set {k path}})
-    (mc/update db card-collection {:previous-versions code} {$set {prev-k path}})))
+    (mc/update db card-collection {:previous-versions {$elemMatch {:code code}}} {$set {prev-k path}})))
 
 (defn- add-card-image
   "Add an image to a card in the db"
@@ -69,7 +69,7 @@
              prev-k (string/join "." ["images" (name lang) (name resolution) prev-k-root])
              path (string/join "/" [base-path (name lang) (name resolution) (name art-set) filename])]
          (mc/update db card-collection {:code code} {$set {k path}})
-         (mc/update db card-collection {:previous-versions code} {$set {prev-k path}}))))))
+         (mc/update db card-collection {:previous-versions {$elemMatch {:code code}}} {$set {prev-k path}}))))))
 
 (defn- add-alt-images
   "All all images in the specified alt directory"

--- a/src/clj/tasks/nrdb.clj
+++ b/src/clj/tasks/nrdb.clj
@@ -55,7 +55,7 @@
 (defn- expand-card
   "Make a card stub for all previous versions specified in a card."
   [acc card]
-  (reduce #(conj %1 {:title (:title card) :code %2}) acc (:previous-versions card)))
+  (reduce #(conj %1 {:title (:title card) :code (:code %2)}) acc (:previous-versions card)))
 
 (defn- generate-previous-card-stubs
   "The cards database only has the latest version of a card. Create stubs for previous versions of a card."

--- a/src/clj/web/nrdb.clj
+++ b/src/clj/web/nrdb.clj
@@ -25,7 +25,7 @@
 (defn- lookup-card [id]
   (if-let [c (mc/find-one-as-map db "cards" {:code id})]
     c
-    (mc/find-one-as-map db "cards" {:previous-versions id})))
+    (mc/find-one-as-map db "cards" {:previous-versions {$elemMatch {:code id}}})))
 
 (defn- reduce-card [m k v]
   (let [card (lookup-card (name k))]

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -120,13 +120,12 @@
 
 (defn- expand-one
   "Reducer function to create a previous card from a newer card definition."
-  [acc version c]
-  (let [number (str->int (subs version 3))
-        cycle-pos (str->int (subs version 0 2))
-        prev-set (find-first #(= cycle-pos (:cycle_position %)) @cards/sets)
+  [acc {:keys [code set_code] :as version} c]
+  (let [number (str->int (subs code 3))
+        prev-set (find-first #(= set_code (:code %)) @cards/sets)
         prev (-> c
                  (assoc
-                   :code version
+                   :code code
                    :rotated true
                    :cycle_code (:cycle_code prev-set)
                    :setname (:name prev-set)


### PR DESCRIPTION
Previous versions of a card were being assigned to the previous Set incorrectly.
Requires that `netrunner-data` have PR https://github.com/NoahTheDuke/netrunner-data/pull/18 merged and `lein fetch` run to pick up the new data.