### PR TITLE
Use icons for player stats

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -40,6 +40,7 @@
   (swap! app-state assoc-in [:options :pin-zoom] (:pin-zoom @s))
   (swap! app-state assoc-in [:options :show-alt-art] (:show-alt-art @s))
   (swap! app-state assoc-in [:options :card-resolution] (:card-resolution @s))
+  (swap! app-state assoc-in [:options :player-stats-icons] (:player-stats-icons @s))
   (swap! app-state assoc-in [:options :stacked-cards] (:stacked-cards @s))
   (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
   (swap! app-state assoc-in [:options :log-width] (:log-width @s))
@@ -53,6 +54,7 @@
   (.setItem js/localStorage "sounds_volume" (:volume @s))
   (.setItem js/localStorage "log-width" (:log-width @s))
   (.setItem js/localStorage "log-top" (:log-top @s))
+  (.setItem js/localStorage "player-stats-icons" (:player-stats-icons @s))
   (.setItem js/localStorage "stacked-cards" (:stacked-cards @s))
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
   (.setItem js/localStorage "card-back" (:card-back @s))
@@ -311,6 +313,12 @@
            [:div
             [:label [:input {:type "checkbox"
                              :value true
+                             :checked (:player-stats-icons @s)
+                             :on-change #(swap! s assoc-in [:player-stats-icons] (.. % -target -checked))}]
+             (tr [:settings.player-stats-icons "Use icons for player stats"])]]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
                              :checked (:stacked-cards @s)
                              :on-change #(swap! s assoc-in [:stacked-cards] (.. % -target -checked))}]
              (tr [:settings.stacked-cards "Card stacking (on by default)"])]]
@@ -510,6 +518,7 @@
                        :all-art-select "wc2015"
                        :card-resolution (get-in @app-state [:options :card-resolution])
                        :stacked-cards (get-in @app-state [:options :stacked-cards])
+                       :player-stats-icons (get-in @app-state [:options :player-stats-icons])
                        :runner-board-order (get-in @app-state [:options :runner-board-order])
                        :log-width (get-in @app-state [:options :log-width])
                        :log-top (get-in @app-state [:options :log-top])

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -335,6 +335,7 @@
               (tr [:settings.runner-reverse "Runner rig layout is reversed (Top to bottom: Resources, Hardware, Programs)"])]]]
 
            [:br]
+           [:h4 (tr [:settings.log-size "Log size"])]
            [:div
             [log-width-option s]
             [log-top-option s]]]

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -19,6 +19,7 @@
                             :language "en"
                             :show-alt-art true
                             :card-resolution "default"
+                            :player-stats-icons (= (get-local-value "player-stats-icons" "true") "true")
                             :stacked-servers (= (get-local-value "stacked-servers" "true") "true")
                             :runner-board-order (let [value (get-local-value "runner-board-order" "irl")]
                                                   (case value

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -926,7 +926,7 @@
                        [:div [card-view card]]])
                     @scored))
      [label @scored {:opts {:name (tr [:game.scored-area "Scored Area"])}}]
-     [:div.stats
+     [:div.stats-area
       (ctrl :agenda-point [:div (tr [:game.agenda-count] @agenda-point)])]]))
 
 (defn run-arrow [run]

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -17,7 +17,7 @@
             [nr.gameboard.log :refer [log-panel log-mode send-msg card-preview-mouse-over card-preview-mouse-out
                                       card-highlight-mouse-over card-highlight-mouse-out resize-card-zoom
                                       zoom-channel should-scroll]]
-            [nr.gameboard.player-stats :refer [controls stats-view]]
+            [nr.gameboard.player-stats :refer [stat-controls stats-view]]
             [nr.gameboard.replay :refer [init-replay replay-panel update-notes get-remote-annotations
                                          load-remote-annotations delete-remote-annotations publish-annotations
                                          load-annotations-file save-annotations-file]]
@@ -775,8 +775,7 @@
              [:a {:on-click #(close-popup % (:hand-popup @s) nil false false)} (tr [:game.close "Close"])]
              [:label (tr [:game.card-count] size)]
              (let [{:keys [total]} @hand-size]
-               [:div.hand-size (str total " " (tr [:game.max-hand "Max hand size"]))
-                (controls :hand-size)])
+               (stat-controls :hand-size [:div.hand-size (str total " " (tr [:game.max-hand "Max hand size"]))]))
              [build-hand-card-view filled-hand size prompt "card-popup-wrapper"]]])]))))
 
 (defn show-deck [event ref]
@@ -917,7 +916,8 @@
          [label @cards {:opts {:name name}}]]))))
 
 (defn scored-view [scored agenda-point me?]
-  (let [size (count @scored)]
+  (let [size (count @scored)
+        ctrl (if me? stat-controls (fn [key content] content))]
     [:div.panel.blue-shade.scored.squeeze
      (doall
        (map-indexed (fn [i card]
@@ -927,8 +927,7 @@
                     @scored))
      [label @scored {:opts {:name (tr [:game.scored-area "Scored Area"])}}]
      [:div.stats
-      [:div (tr [:game.agenda-count] @agenda-point)
-       (when me? (controls :agenda-point))]]]))
+      (ctrl :agenda-point [:div (tr [:game.agenda-count] @agenda-point)])]]))
 
 (defn run-arrow [run]
   [:div.run-arrow [:div {:class (cond

--- a/src/cljs/nr/gameboard/player-stats.cljs
+++ b/src/cljs/nr/gameboard/player-stats.cljs
@@ -1,0 +1,88 @@
+(ns nr.gameboard.player-stats
+  (:require [clojure.string :as s :refer [capitalize join lower-case]]
+            [nr.avatar :refer [avatar]]
+            [nr.gameboard.actions :refer [send-command]]
+            [nr.gameboard.state :refer [game-state]]
+            [nr.translations :refer [tr tr-pronouns]]))
+
+(defn controls
+  "Create the control buttons for the side displays."
+  ([key] (controls key 1 -1))
+  ([key increment decrement]
+   [:div.controls
+    [:button.small {:on-click #(send-command "change" {:key key :delta decrement}) :type "button"} "-"]
+    [:button.small {:on-click #(send-command "change" {:key key :delta increment}) :type "button"} "+"]]))
+
+(defn- name-area
+  [user]
+  [:div.namearea [avatar user {:opts {:size 32}}]
+   [:div.namebox
+    [:div.username (:username user)]
+    (if-let [pronouns (get-in user [:options :pronouns])]
+      (let [pro-str (if (= "blank" pronouns) "" (tr-pronouns pronouns))]
+        [:div.pronouns (lower-case pro-str)]))]])
+
+(defmulti stats-view #(get-in @% [:identity :side]))
+
+(defn- display-memory
+  [memory]
+  (let [me? (= (:side @game-state) :runner)]
+    (fn [memory]
+      (let [{:keys [available used only-for]} memory
+            unused (- available used)]
+        [:div (tr [:game.mu-count] unused available)
+         (when (neg? unused) [:div.warning "!"])
+         (when me? (controls :memory))]))))
+
+(defn- display-special-memory
+  [memory]
+  (when-let [only-for (->> (:only-for memory)
+                           (filter #(pos? (:available (second %))))
+                           (into {})
+                           not-empty)]
+    [:div
+     (str "("
+          (join "), (" (for [[mu-type {:keys [available used]}] only-for
+                             :let [unused (max 0 (- available used))]]
+                         (str unused " of " available
+                              " " (capitalize (name mu-type))
+                              " MU unused")))
+          ")")]))
+
+(defmethod stats-view "Runner" [runner]
+  (let [me? (= (:side @game-state) :runner)]
+    (fn [runner]
+      (let [{:keys [user click credit run-credit memory link tag
+                    brain-damage active]} @runner]
+        [:div.panel.blue-shade.stats {:class (when active "active-player")}
+         (name-area user)
+         [:div (tr [:game.click-count] click)
+          (when me? (controls :click))]
+         [:div (tr [:game.credit-count] credit run-credit)
+          (when me? (controls :credit))]
+         [display-memory memory]
+         [display-special-memory memory]
+         [:div (str link " " (tr [:game.link-strength "Link Strength"]))
+          (when me? (controls :link))]
+         (let [{:keys [base total is-tagged]} tag
+               additional (- total base)
+               show-tagged (or is-tagged (pos? total))]
+           [:div (tr [:game.tag-count] base additional total)
+            (when show-tagged [:div.warning "!"])
+            (when me? (controls :tag))])
+         [:div (str brain-damage " " (tr [:game.brain-damage "Brain Damage"]))
+          (when me? (controls :brain-damage))]]))))
+
+(defmethod stats-view "Corp" [corp]
+  (let [me? (= (:side @game-state) :corp)]
+    (fn [corp]
+      (let [{:keys [user click credit bad-publicity active]} @corp]
+        [:div.panel.blue-shade.stats {:class (when active "active-player")}
+         (name-area user)
+         [:div (tr [:game.click-count] click)
+          (when me? (controls :click))]
+         [:div (tr [:game.credit-count] credit -1)
+          (when me? (controls :credit))]
+         (let [{:keys [base additional]} bad-publicity]
+           [:div (tr [:game.bad-pub-count] base additional)
+            (when me? (controls :bad-publicity))])]))))

--- a/src/cljs/nr/gameboard/player-stats.cljs
+++ b/src/cljs/nr/gameboard/player-stats.cljs
@@ -5,13 +5,21 @@
             [nr.gameboard.state :refer [game-state]]
             [nr.translations :refer [tr tr-pronouns]]))
 
-(defn controls
-  "Create the control buttons for the side displays."
-  ([key] (controls key 1 -1))
-  ([key increment decrement]
-   [:div.controls
-    [:button.small {:on-click #(send-command "change" {:key key :delta decrement}) :type "button"} "-"]
-    [:button.small {:on-click #(send-command "change" {:key key :delta increment}) :type "button"} "+"]]))
+(defn stat-controls
+  "Create an overlay to increase/decrease a player attribute (e.g. credits)."
+  ([key content] (stat-controls key 1 -1 content))
+  ([key increment decrement content]
+   [:div.stat-controls
+    content
+    [:div.controls
+     [:button.small {:on-click #(send-command "change" {:key key :delta decrement}) :type "button"} "-"]
+     [:button.small {:on-click #(send-command "change" {:key key :delta increment}) :type "button"} "+"]]]))
+
+(defn- stat-controls-for-side
+  [side]
+  (if (= (:side @game-state) side)
+    stat-controls
+    (fn [key content] content)))
 
 (defn- name-area
   [user]
@@ -26,13 +34,12 @@
 
 (defn- display-memory
   [memory]
-  (let [me? (= (:side @game-state) :runner)]
+  (let [ctrl (stat-controls-for-side :runner)]
     (fn [memory]
       (let [{:keys [available used only-for]} memory
             unused (- available used)]
-        [:div (tr [:game.mu-count] unused available)
-         (when (neg? unused) [:div.warning "!"])
-         (when me? (controls :memory))]))))
+        (ctrl :memory [:div (tr [:game.mu-count] unused available)
+                       (when (neg? unused) [:div.warning "!"])])))))
 
 (defn- display-special-memory
   [memory]
@@ -50,39 +57,33 @@
           ")")]))
 
 (defmethod stats-view "Runner" [runner]
-  (let [me? (= (:side @game-state) :runner)]
+  (let [ctrl (stat-controls-for-side :runner)]
     (fn [runner]
       (let [{:keys [user click credit run-credit memory link tag
                     brain-damage active]} @runner]
         [:div.panel.blue-shade.stats {:class (when active "active-player")}
          (name-area user)
-         [:div (tr [:game.click-count] click)
-          (when me? (controls :click))]
-         [:div (tr [:game.credit-count] credit run-credit)
-          (when me? (controls :credit))]
+         (ctrl :click [:div (tr [:game.click-count] click)])
+         (ctrl :credit [:div (tr [:game.credit-count] credit run-credit)])
          [display-memory memory]
          [display-special-memory memory]
-         [:div (str link " " (tr [:game.link-strength "Link Strength"]))
-          (when me? (controls :link))]
+         (ctrl :link [:div (str link " " (tr [:game.link-strength "Link Strength"]))])
          (let [{:keys [base total is-tagged]} tag
                additional (- total base)
                show-tagged (or is-tagged (pos? total))]
-           [:div (tr [:game.tag-count] base additional total)
-            (when show-tagged [:div.warning "!"])
-            (when me? (controls :tag))])
-         [:div (str brain-damage " " (tr [:game.brain-damage "Brain Damage"]))
-          (when me? (controls :brain-damage))]]))))
+           (ctrl :tag [:div (tr [:game.tag-count] base additional total)
+                       (when show-tagged [:div.warning "!"])]))
+         (ctrl
+          :brain-damage
+          [:div (str brain-damage " " (tr [:game.brain-damage "Brain Damage"]))])]))))
 
 (defmethod stats-view "Corp" [corp]
-  (let [me? (= (:side @game-state) :corp)]
+  (let [ctrl (stat-controls-for-side :corp)]
     (fn [corp]
       (let [{:keys [user click credit bad-publicity active]} @corp]
         [:div.panel.blue-shade.stats {:class (when active "active-player")}
          (name-area user)
-         [:div (tr [:game.click-count] click)
-          (when me? (controls :click))]
-         [:div (tr [:game.credit-count] credit -1)
-          (when me? (controls :credit))]
+         (ctrl :click [:div (tr [:game.click-count] click)])
+         (ctrl :credit [:div (tr [:game.credit-count] credit -1)])
          (let [{:keys [base additional]} bad-publicity]
-           [:div (tr [:game.bad-pub-count] base additional)
-            (when me? (controls :bad-publicity))])]))))
+           (ctrl :bad-publicity [:div (tr [:game.bad-pub-count] base additional)]))]))))

--- a/src/cljs/nr/gameboard/player-stats.cljs
+++ b/src/cljs/nr/gameboard/player-stats.cljs
@@ -15,8 +15,8 @@
 
 (defn- name-area
   [user]
-  [:div.namearea [avatar user {:opts {:size 32}}]
-   [:div.namebox
+  [:div.name-area [avatar user {:opts {:size 32}}]
+   [:div.name-box
     [:div.username (:username user)]
     (if-let [pronouns (get-in user [:options :pronouns])]
       (let [pro-str (if (= "blank" pronouns) "" (tr-pronouns pronouns))]

--- a/src/cljs/nr/gameboard/player-stats.cljs
+++ b/src/cljs/nr/gameboard/player-stats.cljs
@@ -1,5 +1,6 @@
 (ns nr.gameboard.player-stats
   (:require [clojure.string :as s :refer [capitalize join lower-case]]
+            [nr.appstate :refer [app-state]]
             [nr.avatar :refer [avatar]]
             [nr.gameboard.actions :refer [send-command]]
             [nr.gameboard.state :refer [game-state]]
@@ -30,16 +31,16 @@
       (let [pro-str (if (= "blank" pronouns) "" (tr-pronouns pronouns))]
         [:div.pronouns (lower-case pro-str)]))]])
 
-(defmulti stats-view #(get-in @% [:identity :side]))
-
 (defn- display-memory
-  [memory]
-  (let [ctrl (stat-controls-for-side :runner)]
-    (fn [memory]
-      (let [{:keys [available used only-for]} memory
-            unused (- available used)]
-        (ctrl :memory [:div (tr [:game.mu-count] unused available)
-                       (when (neg? unused) [:div.warning "!"])])))))
+  ([memory] (display-memory memory false))
+  ([memory icon?]
+   (let [ctrl (stat-controls-for-side :runner)]
+     (fn [memory]
+       (let [{:keys [available used only-for]} memory
+             unused (- available used)
+             label (if icon? [:<> unused "/" available " " [:span.anr-icon.mu]]
+                       (tr [:game.mu-count] unused available))]
+         (ctrl :memory [:div label (when (neg? unused) [:div.warning "!"])]))))))
 
 (defn- display-special-memory
   [memory]
@@ -56,18 +57,32 @@
                               " MU unused")))
           ")")]))
 
-(defmethod stats-view "Runner" [runner]
+(defmulti stats-area
+  (fn [player] (get-in @player [:identity :side])))
+
+(defmethod stats-area "Runner" [runner]
   (let [ctrl (stat-controls-for-side :runner)]
     (fn [runner]
       (let [{:keys [user click credit run-credit memory link tag
-                    brain-damage active]} @runner]
-        [:div.panel.blue-shade.stats {:class (when active "active-player")}
-         (name-area user)
-         (ctrl :click [:div (tr [:game.click-count] click)])
-         (ctrl :credit [:div (tr [:game.credit-count] credit run-credit)])
-         [display-memory memory]
-         [display-special-memory memory]
-         (ctrl :link [:div (str link " " (tr [:game.link-strength "Link Strength"]))])
+                    brain-damage active]} @runner
+            base-credit (- credit run-credit)
+            plus-run-credit (when (pos? run-credit) (str "+" run-credit))
+            icons? (get-in @app-state [:options :player-stats-icons] true)]
+        [:div.stats-area
+         (if icons?
+           [:<>
+            [:div.icon-grid
+             (ctrl :click [:div click " " [:span.anr-icon.click]])
+             (ctrl :credit [:div base-credit plus-run-credit " " [:span.anr-icon.credit]])
+             [display-memory memory true]
+             (ctrl :link [:div link " " [:span.anr-icon.link]])]
+            [display-special-memory memory]]
+           [:<>
+            (ctrl :click [:div (tr [:game.click-count] click)])
+            (ctrl :credit [:div (tr [:game.credit-count] credit run-credit)])
+            [display-memory memory]
+            [display-special-memory memory]
+            (ctrl :link [:div (str link " " (tr [:game.link-strength "Link Strength"]))])])
          (let [{:keys [base total is-tagged]} tag
                additional (- total base)
                show-tagged (or is-tagged (pos? total))]
@@ -77,13 +92,25 @@
           :brain-damage
           [:div (str brain-damage " " (tr [:game.brain-damage "Brain Damage"]))])]))))
 
-(defmethod stats-view "Corp" [corp]
+(defmethod stats-area "Corp" [corp]
   (let [ctrl (stat-controls-for-side :corp)]
     (fn [corp]
-      (let [{:keys [user click credit bad-publicity active]} @corp]
-        [:div.panel.blue-shade.stats {:class (when active "active-player")}
-         (name-area user)
-         (ctrl :click [:div (tr [:game.click-count] click)])
-         (ctrl :credit [:div (tr [:game.credit-count] credit -1)])
+      (let [{:keys [user click credit bad-publicity active]} @corp
+            icons? (get-in @app-state [:options :player-stats-icons] true)]
+        [:div.stats-area
+         (if icons?
+           [:div.icon-grid
+            (ctrl :click [:div click " " [:span.anr-icon.click]])
+            (ctrl :credit [:div credit " " [:span.anr-icon.credit]])]
+           [:<>
+            (ctrl :click [:div (tr [:game.click-count] click)])
+            (ctrl :credit [:div (tr [:game.credit-count] credit -1)])])
          (let [{:keys [base additional]} bad-publicity]
            (ctrl :bad-publicity [:div (tr [:game.bad-pub-count] base additional)]))]))))
+
+(defn stats-view
+  [player]
+  (fn [player]
+    [:div.panel.blue-shade.stats {:class (when (:active @player) "active-player")}
+     (name-area (:user @player))
+     [stats-area player]]))

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -180,7 +180,7 @@ button.off
 .dragover
     border-color: orange !important
 
-.namearea
+.name-area
     flex(1)
     display-flex()
     flex-direction(row)
@@ -190,7 +190,7 @@ button.off
     .avatar
         height: 32px
 
-    .namebox
+    .name-box
         flex(1)
         display-flex()
         flex-direction(column)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -244,13 +244,31 @@
             display: inline-block
             margin: 0 10px 8px 4px
 
-            &:hover .controls
-                opacity: 1
+        .stat-controls
+            display: inline-block
+            width: 30%
+
+    .stat-controls
+        position: relative
 
         .controls
-            display: inline-block
-            margin-left: 10px
-            opacity: 0
+            display: none
+            height: 100%
+            position: absolute
+            right: 2px
+            text-align: right
+            top: 0
+            width: 100%
+
+            button
+                margin: 0 2px
+
+        &:hover
+            > :not(.controls)
+                color: #00aeff
+
+            .controls
+                display: block
 
     .playable
         cursor: pointer
@@ -330,14 +348,6 @@
     .stats > div
         height: 20px
         font-size: 12px
-
-        .controls
-            float: right
-            display: none
-            margin-top: -1px
-
-        &:hover .controls
-            display: block
 
     .start-game
         width: 750px

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -325,7 +325,7 @@
     .scored
         height: 116px
 
-    .scored > .stats
+    .scored > .stats-area
         bottom: 0
         padding: 3px 6px
         position: absolute
@@ -345,9 +345,20 @@
     .squeeze .card-wrapper
         position: absolute
 
-    .stats > div
-        height: 20px
+    .name-area
+        margin-bottom: 3px
+
+    .stats-area
         font-size: 12px
+        line-height: 24px
+
+        .icon-grid
+            margin-left: -6px
+
+            > div
+                display: inline-block
+                padding-left: 6px
+                width: 50%
 
     .start-game
         width: 750px


### PR DESCRIPTION
![jnet-player-stats-icons-comparison](https://user-images.githubusercontent.com/3992739/114656356-362cfe80-9cee-11eb-9500-8b3f145a6437.png)

## Summary

Add a new setting "Use icons for player stats" (default: `true`) and if it's `true`, use the icons embedded in the already existing font to reduce the amount of text in the stats panels.

The other changes are small refactorings that I deemed useful to keep the differences between the two versions as small as possible.

## Changes to the previous default layout
("Use icons for player stats" = `false`)

- Change stat color to blue on hover to indicate which stat will be changed by clicking the buttons.
- Slightly increased line height in the stats panel.

## Questions

- How do we handle translations? I've not touched `translations.cljs` in this PR at all. I could add the translations for english, but unfortunately not for the other languages.