### PR TITLE
Loki fixes

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1950,7 +1950,7 @@
           :yes-ability {:async true
                         :effect (effect (jack-out eid))}
           :no-ability {:effect (effect (system-msg :runner "chooses to continue"))}}}]
-    {:subroutines [{:label "Do 2 net damage"
+    {:subroutines [{:label "Do 2 net damage. The Runner may jack out."
                     :async true
                     :effect (req (wait-for (resolve-ability state side (do-net-damage 2) card nil)
                                            (continue-ability state side offer-jack-out card nil)))}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2039,7 +2039,8 @@
                          :effect (effect (remove-subs! (get-card state card) #(= cid (:from-cid %))))}]))))}
    :subroutines [{:label "End the run unless the Runner shuffles their Grip into the Stack"
                   :async true
-                  :effect (req (if (zero? (count (:hand runner)))
+                  :effect (req (if (and (zero? (count (:hand runner)))
+                                        (< (count (:deck runner)) 2)) ; UFAQ 24
                                  (do (system-msg state :corp (str "uses Loki to end the run"))
                                      (end-run state side eid card))
                                  (continue-ability

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2027,6 +2027,7 @@
                       :duration :end-of-run
                       :req (req (same-card? card target))
                       :value (:subtypes target)})
+                   (system-msg state :corp (str "chooses " (card-str state target) " for Loki's ability"))
                    (doseq [sub (:subroutines target)]
                      (add-sub! state side (get-card state card) sub (:cid target) {:front true}))
                    (register-events

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -54,7 +54,9 @@
                     :else 0)
          new-sub {:label (make-label sub)
                   :from-cid cid
-                  :sub-effect (dissoc sub :breakable)
+                  :sub-effect (if (:sub-effect sub)
+                                (:sub-effect sub)
+                                (dissoc sub :breakable))
                   :position position
                   :variable (or variable false)
                   :printed (or printed false)

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2695,24 +2695,33 @@
 (deftest loki
   (do-game
     (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Loki" "Archer"]
-                      :credits 100}})
-    (play-from-hand state :corp "Archer" "HQ")
+                      :hand ["Loki" "Karunā"]
+                      :credits 100}
+               :runner {:hand [(qty "Sure Gamble" 3) (qty "Easy Mark" 3)]}})
+    (play-from-hand state :corp "Karunā" "HQ")
     (rez state :corp (get-ice state :hq 0) {:ignore-cost :all-costs})
     (play-from-hand state :corp "Loki" "R&D")
     (rez state :corp (get-ice state :rd 0) {:ignore-cost :all-costs})
     (take-credits state :corp)
     (run-on state "R&D")
     (run-continue state)
-    (click-card state :corp "Archer")
-    (is (last-log-contains? state "Corp chooses Archer protecting HQ at position 0 for Loki's ability.")
+    (click-card state :corp "Karunā")
+    (is (last-log-contains? state "Corp chooses Karunā protecting HQ at position 0 for Loki's ability.")
         "The message correctly prints")
-    (is (= ["Gain 2 [Credits]" "Trash a program" "Trash a program" "End the run"
+    (is (= ["Do 2 net damage. The Runner may jack out."
+            "Do 2 net damage"
             "End the run unless the Runner shuffles their Grip into the Stack"]
            (map :label (:subroutines (get-ice state :rd 0))))
-        "Loki gains all of Archer's subroutines")
-    (is (= #{"Sentry" "Destroyer" "Bioroid"} (into #{} (:subtypes (get-ice state :rd 0)))))
-    (run-jack-out state)
+        "Loki gains all of Karunā's subroutines")
+    (is (= #{"AP" "Sentry" "Bioroid"} (into #{} (:subtypes (get-ice state :rd 0)))))
+    (is (= 0 (count (:discard (get-runner)))) "Heap Empty")
+    (fire-subs state (get-ice state :rd 0))
+    (is (= 2 (count (:discard (get-runner)))) "2 cards trashed")
+    (click-prompt state :runner "No")
+    (is (= 4 (count (:discard (get-runner)))) "4 cards trashed")
+    (click-prompt state :runner "No")
+    (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
+    (is (not (:run @state)) "Run is ended")
     (is (= ["End the run unless the Runner shuffles their Grip into the Stack"]
            (map :label (:subroutines (get-ice state :rd 0))))
         "Loki's subroutines revert to printed after the run ends")

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2693,39 +2693,56 @@
           "New turn ends prevention; remaining 3 cards drawn from Stack"))))
 
 (deftest loki
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Loki" "Karunā"]
-                      :credits 100}
-               :runner {:hand [(qty "Sure Gamble" 3) (qty "Easy Mark" 3)]}})
-    (play-from-hand state :corp "Karunā" "HQ")
-    (rez state :corp (get-ice state :hq 0) {:ignore-cost :all-costs})
-    (play-from-hand state :corp "Loki" "R&D")
-    (rez state :corp (get-ice state :rd 0) {:ignore-cost :all-costs})
-    (take-credits state :corp)
-    (run-on state "R&D")
-    (run-continue state)
-    (click-card state :corp "Karunā")
-    (is (last-log-contains? state "Corp chooses Karunā protecting HQ at position 0 for Loki's ability.")
-        "The message correctly prints")
-    (is (= ["Do 2 net damage. The Runner may jack out."
-            "Do 2 net damage"
-            "End the run unless the Runner shuffles their Grip into the Stack"]
-           (map :label (:subroutines (get-ice state :rd 0))))
-        "Loki gains all of Karunā's subroutines")
-    (is (= #{"AP" "Sentry" "Bioroid"} (into #{} (:subtypes (get-ice state :rd 0)))))
-    (is (= 0 (count (:discard (get-runner)))) "Heap Empty")
-    (fire-subs state (get-ice state :rd 0))
-    (is (= 2 (count (:discard (get-runner)))) "2 cards trashed")
-    (click-prompt state :runner "No")
-    (is (= 4 (count (:discard (get-runner)))) "4 cards trashed")
-    (click-prompt state :runner "No")
-    (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
-    (is (not (:run @state)) "Run is ended")
-    (is (= ["End the run unless the Runner shuffles their Grip into the Stack"]
-           (map :label (:subroutines (get-ice state :rd 0))))
-        "Loki's subroutines revert to printed after the run ends")
-    (is (= ["Bioroid"] (:subtypes (get-ice state :rd 0))))))
+  (testing "Runner does not shuffle cards"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Loki" "Karunā"]
+                        :credits 100}
+                 :runner {:hand [(qty "Sure Gamble" 3) (qty "Easy Mark" 3)]}})
+      (play-from-hand state :corp "Karunā" "HQ")
+      (rez state :corp (get-ice state :hq 0) {:ignore-cost :all-costs})
+      (play-from-hand state :corp "Loki" "R&D")
+      (rez state :corp (get-ice state :rd 0) {:ignore-cost :all-costs})
+      (take-credits state :corp)
+      (run-on state "R&D")
+      (run-continue state)
+      (click-card state :corp "Karunā")
+      (is (last-log-contains? state "Corp chooses Karunā protecting HQ at position 0 for Loki's ability.")
+          "The message correctly prints")
+      (is (= ["Do 2 net damage. The Runner may jack out."
+              "Do 2 net damage"
+              "End the run unless the Runner shuffles their Grip into the Stack"]
+             (map :label (:subroutines (get-ice state :rd 0))))
+          "Loki gains all of Karunā's subroutines")
+      (is (= #{"AP" "Sentry" "Bioroid"} (into #{} (:subtypes (get-ice state :rd 0)))))
+      (is (= 0 (count (:discard (get-runner)))) "Heap Empty")
+      (fire-subs state (get-ice state :rd 0))
+      (is (= 2 (count (:discard (get-runner)))) "2 cards trashed")
+      (click-prompt state :runner "No")
+      (is (= 4 (count (:discard (get-runner)))) "4 cards trashed")
+      (click-prompt state :runner "No")
+      (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
+      (is (not (:run @state)) "Run is ended")
+      (is (= ["End the run unless the Runner shuffles their Grip into the Stack"]
+             (map :label (:subroutines (get-ice state :rd 0))))
+          "Loki's subroutines revert to printed after the run ends")
+      (is (= ["Bioroid"] (:subtypes (get-ice state :rd 0))))))
+  (testing "Runner does shuffle cards"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Loki"]
+                        :credits 100}
+                 :runner {:hand [(qty "Sure Gamble" 3) (qty "Easy Mark" 3)]}})
+      (play-from-hand state :corp "Loki" "R&D")
+      (rez state :corp (get-ice state :rd 0) {:ignore-cost :all-costs})
+      (take-credits state :corp)
+      (run-on state "R&D")
+      (run-continue state)
+      (fire-subs state (get-ice state :rd 0))
+      (click-prompt state :runner "Yes")
+      (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+      (is (= 6 (count (:deck (get-runner)))) "Runner has 6 cards in stack")
+      (is (:run @state) "Run is still live"))))
 
 (deftest loot-box
   ;; Loot Box

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2742,7 +2742,40 @@
       (click-prompt state :runner "Yes")
       (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
       (is (= 6 (count (:deck (get-runner)))) "Runner has 6 cards in stack")
-      (is (:run @state) "Run is still live"))))
+      (is (:run @state) "Run is still live")))
+  (testing "Runner can shuffle cards with zero in hand"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Loki"]
+                        :credits 100}
+                 :runner {:hand []
+                          :deck [(qty "Sure Gamble" 3)]}})
+      (play-from-hand state :corp "Loki" "R&D")
+      (rez state :corp (get-ice state :rd 0) {:ignore-cost :all-costs})
+      (take-credits state :corp)
+      (run-on state "R&D")
+      (run-continue state)
+      (fire-subs state (get-ice state :rd 0))
+      (click-prompt state :runner "Yes")
+      (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+      (is (= 3 (count (:deck (get-runner)))) "Runner has 3 card in stack")
+      (is (:run @state) "Run is still live")))
+  (testing "Runner cannot shuffle cards"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Loki"]
+                        :credits 100}
+                 :runner {:hand []
+                          :deck ["Sure Gamble"]}})
+      (play-from-hand state :corp "Loki" "R&D")
+      (rez state :corp (get-ice state :rd 0) {:ignore-cost :all-costs})
+      (take-credits state :corp)
+      (run-on state "R&D")
+      (run-continue state)
+      (fire-subs state (get-ice state :rd 0))
+      (is (= 0 (count (:hand (get-runner)))) "Runner has 0 cards in hand")
+      (is (= 1 (count (:deck (get-runner)))) "Runner has 1 card in stack")
+      (is (not (:run @state)) "Run is ended"))))
 
 (deftest loot-box
   ;; Loot Box

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2705,6 +2705,8 @@
     (run-on state "R&D")
     (run-continue state)
     (click-card state :corp "Archer")
+    (is (last-log-contains? state "Corp chooses Archer protecting HQ at position 0 for Loki's ability.")
+        "The message correctly prints")
     (is (= ["Gain 2 [Credits]" "Trash a program" "Trash a program" "End the run"
             "End the run unless the Runner shuffles their Grip into the Stack"]
            (map :label (:subroutines (get-ice state :rd 0))))


### PR DESCRIPTION
When using Loki the other day, we noticed that the additional subs were not firing. They would get the green check as if fired, but there was no effect.

The problem was due to the `add-sub` function not working on subs that had already been added via `add-sub` during init. See the commit message for more details.

A few other Loki fixes:
 * Add a message when the card is chosen, because otherwise it is not obvious. 
 * Fix a FAQ entry regarding empty runner hand.

Finally, fix a Karuna sub label that I noticed was wrong when switching the test to use it.