### PR TITLE
remove every reference of the "NVRAM" terminology

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -230,23 +230,23 @@
                               card nil)))}]})
 
 (defcard "Ayla \"Bios\" Rahim: Simulant Specialist"
-  {:abilities [{:label "Add 1 card from NVRAM to your grip"
+  {:abilities [{:label "Add 1 hosted card to your grip"
                 :cost [:click 1]
                 :async true
-                :prompt "Choose a card from NVRAM"
+                :prompt "Choose a hosted card"
                 :choices (req (cancellable (:hosted card)))
-                :msg "move a card from NVRAM to their Grip"
+                :msg "move a hosted card to their Grip"
                 :effect (effect (move target :hand)
                                 (effect-completed eid))}]
    :events [{:event :pre-start-game
              :req (req (= side :runner))
              :async true
-             :waiting-prompt "Runner to choose cards for NVRAM"
+             :waiting-prompt "Runner to choose cards to be hosted"
              :effect (req (doseq [c (take 6 (:deck runner))]
                             (move state side c :play-area))
                           (continue-ability
                             state side
-                            {:prompt "Select 4 cards for NVRAM"
+                            {:prompt "Select 4 cards to be hosted"
                              :choices {:max 4
                                        :all true
                                        :card #(and (runner? %)

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -637,7 +637,7 @@
         (is (= 6 (count (:servers (get-corp)))) "There are six servers, including centrals")))))
 
 (deftest ayla-bios-rahim-simulant-specialist
-  ;; Ayla - choose & use cards for NVRAM
+  ;; Ayla - choose & use hosted cards
   (do-game
     (new-game {:runner {:id "Ayla \"Bios\" Rahim: Simulant Specialist"
                         :deck ["Sure Gamble" "Desperado"
@@ -650,7 +650,7 @@
     (click-card state :runner (find-card "Desperado" (get-in @state [:runner :play-area])))
     (click-card state :runner (find-card "Bank Job" (get-in @state [:runner :play-area])))
     (click-card state :runner (find-card "Eater" (get-in @state [:runner :play-area])))
-    (is (= 4 (count (:hosted (:identity (get-runner))))) "4 cards in NVRAM")
+    (is (= 4 (count (:hosted (:identity (get-runner))))) "4 hosted cards")
     (is (zero? (count (get-in @state [:runner :play-area]))) "The play area is empty")
     (click-prompt state :corp "Keep")
     (click-prompt state :runner "Keep")


### PR DESCRIPTION
[SU Ayla](https://netrunnerdb.com/en/card/31025) doesn't reference `NVRAM` anymore, so I thought it would be confusing for new players to see it mentioned in the logs and in the dialog at the beginning of the game.