### PR TITLE
feature(REM): font sizing to rem units for UI scaling

### DIFF
--- a/src/css/about.styl
+++ b/src/css/about.styl
@@ -7,7 +7,7 @@
         .qr
             display: none
             position: absolute
-            top: 25px
+            top: 1.5rem
             left: 0
             border: 10px solid white
             background-color: white

--- a/src/css/auth.styl
+++ b/src/css/auth.styl
@@ -4,7 +4,7 @@
     input
         width: 240px
         margin-bottom: 10px
-        font-size: 15px
+        font-size: 1rem
         border-color: orange
         height:auto
 
@@ -21,7 +21,7 @@
 
 .flash-message
     color: orangered
-    font-size: 14px
+    font-size: .875rem
     margin-bottom: 10px
 
 .block-link

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -12,25 +12,25 @@ body
     color: text-color
     background-color: black
     font-family: "Titillium Web", "Helvetica Neue", sans-serif
-    font-size: 13px
-    line-height: 18px
+    font-size: 1rem
+    line-height: 1rem
 
 h1, h2, h3, h4
     line-height: normal
     margin: 0 0 8px
 
 h1
-    font-size: 36px
+    font-size: 2.25rem
 
 h2
-    font-size: 24px
+    font-size: 1.5rem
 
 h3
-    font-size: 20px
+    font-size: 1.25rem
     margin: 0 0 6px
 
 h4
-    font-size: 14px
+    font-size: .875rem
     line-height: 18px
     margin: 0 0 4px
 
@@ -79,7 +79,7 @@ section
 
 input, select, textarea
     font-family: "Titillium Web", "Helvetica Neue", sans-serif
-    font-size: 13px
+    font-size: .75rem
     border-radius: 4px
     padding: 0 5px
     margin: 0
@@ -106,7 +106,7 @@ label
 button, a.button
     display: inline-block
     border-radius: 4px
-    font-size: 12px
+    font-size: .75rem
     padding: 4px 12px
     margin: 0 8px 0 0
     background-color: transparent-orange
@@ -114,7 +114,7 @@ button, a.button
     color: white
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9)
     cursor: pointer
-    height: 28px
+    height: 1.75rem
     outline: none
     transition(all 0.2s ease-in-out)
     cursor: pointer
@@ -125,8 +125,8 @@ button, a.button
 
 button.small
     padding: 0
-    font-size: 12px
-    line-height: 18px
+    font-size: .75rem
+    line-height: 1rem
     height: 20px
     width: 20px
     background-color: transparent
@@ -203,7 +203,7 @@ button.off
 
 .username
     font-weight: bold
-    font-size: 14px
+    font-size: .875rem
     margin-right: 5px
 
 // Scrollbars
@@ -308,7 +308,7 @@ button .fake-link
     font-style: italic
 
 span.small
-    font-size: 12px
+    font-size: .75rem
     font-weight: normal
     margin-left: 10px
 
@@ -342,7 +342,7 @@ span.small
     border: 1px solid white
     border-radius: 4px
     padding: 2px 5px
-    font-size: 12px
+    font-size: .75rem
     margin: 0 10px
 
 * html .clearfix
@@ -427,7 +427,7 @@ span.small
     left: 1px
     span
         color: gainsboro
-        font-size: smaller
+        font-size: .75rem
 
 
 @keyframes highlight

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -12,8 +12,8 @@ body
     color: text-color
     background-color: black
     font-family: "Titillium Web", "Helvetica Neue", sans-serif
-    font-size: 1rem
-    line-height: 1rem
+    font-size: .75rem
+    line-height: 1.125rem
 
 h1, h2, h3, h4
     line-height: normal

--- a/src/css/chat.styl
+++ b/src/css/chat.styl
@@ -49,8 +49,8 @@
         position: absolute
         z-index: 30
         width: 200px
-        font-size: 12px
-        line-height: 16px
+        font-size: 3rem
+        line-height: 1rem
 
         > div
             border: 1px solid white
@@ -79,7 +79,7 @@
 
     .username
         font-weight: bold
-        font-size: 14px
+        font-size: .875rem
         margin-right: 0px
 
     .pronouns
@@ -87,7 +87,7 @@
 
     .date
         font-weight: 300
-        font-size: 12px
+        font-size: .75rem
         margin-left: 10px
 
 .msg-box

--- a/src/css/chat.styl
+++ b/src/css/chat.styl
@@ -49,7 +49,7 @@
         position: absolute
         z-index: 30
         width: 200px
-        font-size: 3rem
+        font-size: .75rem
         line-height: 1rem
 
         > div

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -30,7 +30,7 @@
         left: 0
         z-index: 2
         padding: 1px 4px
-        font-size: 12px
+        font-size: .75rem
 
     .darkbg
         background: rgba(0, 0, 0, 0.6)
@@ -57,8 +57,8 @@
 
         .cardname
             float: left
-            font-size: 10px
-            line-height: 14px
+            font-size: .625rem
+            line-height: .75rem
 
     @keyframes new-card {
         0% {
@@ -101,15 +101,18 @@
 
     .counter
         padding: 0
-        font-size: 12px
-        width: 24px
-        height: 24px
-        line-height: 24px
+        font-size: 1rem
+        width: 2rem
+        height: 2rem
+        border-radius: 100%
+        line-height: 2rem
         text-align: center
-        margin: 2px
+        box-shadow: 
 
     .advance-counter
         background-color: transparent-lightblue
+        border-color: white
+        border-width 1px
 
     .recurring-counter
         background-color: transparent-green
@@ -132,8 +135,8 @@
         padding: 0
         text-align: center
         background-color: transparent-orange-bright
-        line-height: 24px
-        font-size: 12px
+        line-height: 1.5rem
+        font-size: .75rem
         bottom: 3px
         left: 3px
         height: 24px
@@ -145,8 +148,8 @@
         padding: 0
         text-align: center
         background-color: transparent-dark-green
-        line-height: 24px
-        font-size: 12px
+        line-height: 1.5rem
+        font-size: .75rem
         top: 3px
         left: 3px
         height: 24px
@@ -157,8 +160,8 @@
         z-index: 10
         padding: 0
         text-align: center
-        line-height: 24px
-        font-size: 12px
+        line-height: 1.5rem
+        font-size: .75rem
         top: 3px
         left: 3px
         height: 24px
@@ -178,8 +181,8 @@
         z-index: 10
         padding: 0
         text-align: center
-        line-height: 16px
-        font-size: 10px
+        line-height: 1rem
+        font-size: .625rem
         top: 3px
         right: 3px
         padding-left: 3px
@@ -202,8 +205,8 @@
         position: absolute
         z-index: 30
         width: 200px
-        font-size: 12px
-        line-height: 16px
+        font-size: .75rem
+        line-height: 1rem
 
         > span
             margin: 2px
@@ -349,8 +352,11 @@
         margin-bottom: 3px
 
     .stats-area
-        font-size: 12px
-        line-height: 24px
+        font-size: .75rem
+        line-height: 1.5rem
+    .stats > div
+        height: 20px
+        font-size: .75rem
 
         .icon-grid
             margin-left: -6px
@@ -378,7 +384,7 @@
             position: absolute
             z-index:1
             font-family:Arial,sans-serif
-            font-size:40px
+            font-size:2.5rem
             color:#c00
             background: rgb(255, 255, 255, 0.5)
             border:solid 4px #c00
@@ -415,17 +421,17 @@
 
         .vs
             font-weight: bold
-            font-size: large
+            font-size: 1.125rem
             font-style: italic
             margin: 1em
 
         .contestants
-            font-size: xx-large
+            font-size: 2rem
             margin: 0
             flex: 1
 
         .intro-blurb
-            font-size: medium
+            font-size: 1rem
             font-style: italic
             margin-top: 3ex
 
@@ -606,12 +612,12 @@
                     .info
                         text-align: center
                         margin: 0 0 5px 0
-                        font-size: 10pt
+                        font-size: .625rem
                         font-style: italic
 
                     button
                         width: 100%
-                        font-size: 11px
+                        font-size: .75rem
                         margin: 0 0 5px 0
                         padding: 0 8px 1px
 
@@ -900,8 +906,8 @@
             top: 0
             right: 224px
             text-align: right
-            font-size: 12px
-            line-height: 12px
+            font-size: .75rem
+            line-height: .75rem
 
             .unimplemented
                 color: red
@@ -917,7 +923,7 @@
             bottom: 0
 
             .username
-                font-size: 12px
+                font-size: .75rem
                 margin-top: -2px
 
             .avatar
@@ -926,8 +932,8 @@
 
             > .panel
                 margin-left: 0
-                font-size: 12px
-                line-height: 15px
+                font-size: .75rem
+                line-height: 1rem
 
             .messages
                 flex(1)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -101,13 +101,12 @@
 
     .counter
         padding: 0
-        font-size: 1rem
-        width: 2rem
-        height: 2rem
-        border-radius: 100%
+        font-size: .75rem
+        width: 1.5rem
+        height: 1.5rem
         line-height: 2rem
         text-align: center
-        box-shadow: 
+        margin: 2px
 
     .advance-counter
         background-color: transparent-lightblue

--- a/src/css/lobby.styl
+++ b/src/css/lobby.styl
@@ -20,8 +20,8 @@
         position: absolute
         z-index: 30
         width: 200px
-        font-size: 12px
-        line-height: 16px
+        font-size: .75rem
+        line-height: 1rem
 
         > div
             border: 1px solid white
@@ -96,7 +96,7 @@
             display: block
             color: white
             margin: 0 10px
-            line-height: 24px
+            line-height: 1.5rem
             transition(all 0.2s ease-in-out)
 
             &:hover
@@ -181,7 +181,7 @@
                 margin: 8px 0
 
             .player
-                line-height: 22px
+                line-height: 1.375
 
             .label
                 text-align: center

--- a/src/css/replay.styl
+++ b/src/css/replay.styl
@@ -31,7 +31,7 @@
 
                 .step-label
                     text-align: center
-                    font-size: 20px
+                    font-size: 1.25rem
                     position: relative
                     background-color: rgb(39, 56, 76)
                     border-radius: 50%
@@ -50,8 +50,8 @@
                 .annotated-before:before, .annotated-after:after
                     text-align: center;
                     font-weight: bold;
-                    font-size: 10px
-                    line-height: 13px
+                    font-size: .625rem
+                    line-height: .75rem
                     position: absolute
                     width: 15px
                     height: 15px
@@ -76,7 +76,7 @@
                     background-color: transparent-blue
 
                 .active-step-label
-                    font-size: 32px
+                    font-size: 2rem
                     width: 45px
                     height: 45px
                     padding-top: 11px
@@ -146,7 +146,7 @@
 
             button.small
               margin: 0 4px 0 4px
-              font-size: 24px
+              font-size: 1.5rem
               height: 30px
               width: 30px
               background-color: transparent
@@ -223,7 +223,7 @@
         .click:after
             text-align: center
             font-family: "anr-icon" !important
-            font-size: 140px
+            font-size: 8.75rem
             speak: none
             content: "\e611"
 
@@ -261,8 +261,8 @@
     height: 15px
     text-align: center;
     font-weight: bold;
-    font-size: 10px
-    line-height: 13px
+    font-size: .625rem
+    line-height: .75rem
     border-radius: 50%
     border: 1px solid white
     color: white
@@ -308,7 +308,7 @@
     content: '⯀'
     color: white
     border-radius: 25%!important
-    line-height: 12px!important
+    line-height: .75rem!important
     background-color: note-a
     box-shadow(0 0 6px note-a)
 
@@ -316,7 +316,7 @@
     content: '⬥'
     color: white
     border-radius: 25%!important
-    line-height: 12px!important
+    line-height: .75rem!important
     background-color: note-b
     box-shadow(0 0 6px note-b)
 

--- a/src/css/win.styl
+++ b/src/css/win.styl
@@ -17,8 +17,8 @@
     top: 0px
     right: -8px
     padding: 0
-    font-size: 12px
-    line-height: 14px
+    font-size: .75rem
+    line-height: .825rem
     height: 15px
     width: 15px
     background-color: transparent


### PR DESCRIPTION
Per conversation and then my suggestion in #4050 to make the fonts more scalable in the browser, using the REM (Root Element) units, based on 16px.

Reasons:
- 16px is the default of browsers (1rem = 16px), and typically the smallest font size you should use if you can otherwise help it.
- EM units are based on their parents sizing, so you'll get weird relative sizing bugs quickly compared to REM, which scale off that default.
- Using .125rem steps resolve into simple integers keeping in the powers of 2, which means lining elements up in layouts becomes easier and simpler, especially if you base all your measurements off a REM scale.
 - That stops a lot of sizing bugs, and "magic numbers". _(e.g. when something is say 237px for no other reason than, "that's the number that worked")_

This doesn't make the UI Movable or Resize-able as per the issue above, but helps with the scaling, **and the REM values still resolve to current values**, except in a couple cases, and those changes typically are 1 pixel in difference, stepped upward for readability.