### PR TITLE
Fix merge breaking player stats icons

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -353,9 +353,6 @@
     .stats-area
         font-size: .75rem
         line-height: 1.5rem
-    .stats > div
-        height: 20px
-        font-size: .75rem
 
         .icon-grid
             margin-left: -6px


### PR DESCRIPTION
`height: 20px` was removed before and added back accidentaly by the merge of #5867  .