### PR TITLE
Don't merge: Attempt at fixing scroll bars appearing mid run

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -633,6 +633,9 @@
         flex-direction(column)
         min-width: 90px
         overflow: visible
+        position:relative
+        overflow-x:auto
+        overflow-y:visible
 
         .card-wrapper
             margin: 3px 6px
@@ -649,6 +652,18 @@
         // Then once both card-wrapper _and_ card are hovered, the z-index gets bumped to 1 to pull the card to the front.
         .card-wrapper:hover .card:hover, .stacked:hover .card:hover
             z-index: 1
+
+        .outer-corp-board,.runner-board
+            overflow: visible
+            position: absolute
+
+            &.me
+                bottom: 0
+                width: 100%
+
+            &.opponent
+                top: 0
+                width: 100%
 
         .runner-board
             flex(1)
@@ -677,11 +692,6 @@
 
             > div:last-child
                 margin-bottom: auto
-
-        .outer-corp-board.me
-            overflow: auto
-            margin-top: -100%
-            padding-top: 100%
 
         .corp-board
             flex(1)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -46,6 +46,9 @@
         top: 100%
         transform: translate(0, -100%)
 
+    .card-frame, .deck, .identity, .discard
+        pointer-events: auto
+
     .card-frame
         position: relative
 
@@ -656,6 +659,7 @@
         .outer-corp-board,.runner-board
             overflow: visible
             position: absolute
+            pointer-events: none
 
             &.me
                 bottom: 0


### PR DESCRIPTION
When the run arrow gets drawn typically at around 4-5 ice, the window gets a vertical scrollbar and the entire board becomes very jumpy. Unfortunately this approach of fixing it leads to the player not being able to click on certain cards on the opponent side...