### PR TITLE
Splitting of the right-pane into multiple parts

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -172,7 +172,7 @@
 (defn profile-keys []
   [:background :pronouns :language :show-alt-art :blocked-users
    :alt-arts :card-resolution :deckstats :gamestats :card-zoom
-   :pin-zoom :card-back])
+   :pin-zoom :card-back :stacked-cards])
 
 (defn update-profile-handler
   [{db :system/db

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -172,7 +172,7 @@
 (defn profile-keys []
   [:background :pronouns :language :show-alt-art :blocked-users
    :alt-arts :card-resolution :deckstats :gamestats :card-zoom
-   :pin-zoom :card-back :stacked-cards])
+   :pin-zoom :card-back :stacked-cards :sides-overlap])
 
 (defn update-profile-handler
   [{db :system/db

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -42,6 +42,7 @@
   (swap! app-state assoc-in [:options :card-resolution] (:card-resolution @s))
   (swap! app-state assoc-in [:options :player-stats-icons] (:player-stats-icons @s))
   (swap! app-state assoc-in [:options :stacked-cards] (:stacked-cards @s))
+  (swap! app-state assoc-in [:options :sides-overlap] (:sides-overlap @s))
   (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
   (swap! app-state assoc-in [:options :log-width] (:log-width @s))
   (swap! app-state assoc-in [:options :log-top] (:log-top @s))
@@ -56,6 +57,7 @@
   (.setItem js/localStorage "log-top" (:log-top @s))
   (.setItem js/localStorage "player-stats-icons" (:player-stats-icons @s))
   (.setItem js/localStorage "stacked-cards" (:stacked-cards @s))
+  (.setItem js/localStorage "sides-overlap" (:sides-overlap @s))
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
   (.setItem js/localStorage "card-back" (:card-back @s))
   (.setItem js/localStorage "card-zoom" (:card-zoom @s))
@@ -322,6 +324,12 @@
                              :checked (:stacked-cards @s)
                              :on-change #(swap! s assoc-in [:stacked-cards] (.. % -target -checked))}]
              (tr [:settings.stacked-cards "Card stacking (on by default)"])]]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
+                             :checked (:sides-overlap @s)
+                             :on-change #(swap! s assoc-in [:sides-overlap] (.. % -target -checked))}]
+             (tr [:settings.sides-overlap "Runner and Corp board may overlap"])]]
 
            [:br]
            [:h4 (tr [:settings.runner-layout "Runner layout from Corp perspective"])]
@@ -518,6 +526,7 @@
                        :all-art-select "wc2015"
                        :card-resolution (get-in @app-state [:options :card-resolution])
                        :stacked-cards (get-in @app-state [:options :stacked-cards])
+                       :sides-overlap (get-in @app-state [:options :sides-overlap])
                        :player-stats-icons (get-in @app-state [:options :player-stats-icons])
                        :runner-board-order (get-in @app-state [:options :runner-board-order])
                        :log-width (get-in @app-state [:options :log-width])

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -21,6 +21,7 @@
                             :card-resolution "default"
                             :player-stats-icons (= (get-local-value "player-stats-icons" "true") "true")
                             :stacked-servers (= (get-local-value "stacked-servers" "true") "true")
+                            :sides-overlap (= (get-local-value "sides-overlap" "true") "true")
                             :runner-board-order (let [value (get-local-value "runner-board-order" "irl")]
                                                   (case value
                                                     "true" "jnet"

--- a/src/cljs/nr/chat.cljs
+++ b/src/cljs/nr/chat.cljs
@@ -7,7 +7,7 @@
             [nr.appstate :refer [app-state]]
             [nr.auth :refer [authenticated] :as auth]
             [nr.avatar :refer [avatar]]
-            [nr.gameboard.log :refer [card-preview-mouse-over card-preview-mouse-out]]
+            [nr.gameboard.card-preview :refer [card-preview-mouse-over card-preview-mouse-out]]
             [nr.news :refer [news]]
             [nr.cardbrowser :refer [image-url]]
             [nr.utils :refer [toastr-options render-message set-scroll-top store-scroll-top]]

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -1,7 +1,6 @@
 (ns nr.gameboard.actions
   (:require [differ.core :as differ]
             [nr.appstate :refer [app-state]]
-            [nr.gameboard.log :refer [log-mode]]
             [nr.gameboard.replay :refer [init-replay]]
             [nr.gameboard.state :refer [game-state last-state lock check-lock? parse-state get-side not-spectator?]]
             [nr.translations :refer [tr]]
@@ -11,7 +10,6 @@
 (defn init-game [state]
   (let [side (get-side state)]
     (.setItem js/localStorage "gameid" (:gameid @app-state))
-    (reset! log-mode :log)
     (reset! game-state (dissoc state :replay-diffs :replay-jump-to))
     (swap! game-state assoc :side side)
     (reset! last-state @game-state)

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1040,7 +1040,8 @@
         server-type (first rs)
         side-class (if (= player-side :runner) "opponent" "me")
         hand-count-number (if (nil? @hand-count) (count @hand) @hand-count)]
-    [:div.outer-corp-board {:class side-class}
+    [:div.outer-corp-board {:class [side-class
+                                    (when (get-in @app-state [:options :sides-overlap]) "overlap")]}
      [:div.corp-board {:class side-class}
       (doall
         (for [server (reverse (get-remotes @servers))
@@ -1088,7 +1089,8 @@
                           (= "irl" (get-in @app-state [:options :runner-board-order])))
                    reverse
                    seq)]
-    [:div.runner-board {:class (if is-me "me" "opponent")}
+    [:div.runner-board {:class [(if is-me "me" "opponent")
+                                (when (get-in @app-state [:options :sides-overlap]) "overlap")]}
      (when-not is-me centrals)
      (doall
        (for [zone (runner-f [:program :hardware :resource :facedown])]

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -16,8 +16,8 @@
             [nr.gameboard.actions :refer [send-command toast]]
             [nr.gameboard.log :refer [send-msg should-scroll]]
             [nr.gameboard.card-preview :refer [card-preview-mouse-over card-preview-mouse-out
-                                      card-highlight-mouse-over card-highlight-mouse-out]]
-            [nr.gameboard.right-pane :refer [content-pane log-mode resize-card-zoom zoom-channel]]
+                                      card-highlight-mouse-over card-highlight-mouse-out zoom-channel]]
+            [nr.gameboard.right-pane :refer [content-pane load-tab]]
             [nr.gameboard.player-stats :refer [stat-controls stats-view]]
             [nr.gameboard.replay :refer [init-replay replay-panel update-notes get-remote-annotations
                                          load-remote-annotations delete-remote-annotations publish-annotations
@@ -1783,8 +1783,10 @@
 
                  [:div.right-pane
                   [card-zoom-view zoom-card]
-                  [content-pane]]
-                 (do (resize-card-zoom) nil)
+
+                  (if (:replay @game-state)
+                    [content-pane :log :notes :notes-shared]
+                    [content-pane :log])]
 
                  [:div.centralpane
                   (if (= op-side :corp)

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1785,8 +1785,8 @@
                   [card-zoom-view zoom-card]
 
                   (if (:replay @game-state)
-                    [content-pane :log :notes :notes-shared]
-                    [content-pane :log])]
+                    [content-pane :log :settings :notes :notes-shared]
+                    [content-pane :log :settings])]
 
                  [:div.centralpane
                   (if (= op-side :corp)

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -14,9 +14,10 @@
             [nr.cardbrowser :refer [card-as-text]]
             [nr.end-of-game-stats :refer [build-game-stats]]
             [nr.gameboard.actions :refer [send-command toast]]
-            [nr.gameboard.log :refer [log-panel log-mode send-msg card-preview-mouse-over card-preview-mouse-out
-                                      card-highlight-mouse-over card-highlight-mouse-out resize-card-zoom
-                                      zoom-channel should-scroll]]
+            [nr.gameboard.log :refer [send-msg should-scroll]]
+            [nr.gameboard.card-preview :refer [card-preview-mouse-over card-preview-mouse-out
+                                      card-highlight-mouse-over card-highlight-mouse-out]]
+            [nr.gameboard.right-pane :refer [content-pane log-mode resize-card-zoom zoom-channel]]
             [nr.gameboard.player-stats :refer [stat-controls stats-view]]
             [nr.gameboard.replay :refer [init-replay replay-panel update-notes get-remote-annotations
                                          load-remote-annotations delete-remote-annotations publish-annotations
@@ -1780,9 +1781,9 @@
                                    :spectator @background)
                                  @background)}]
 
-                 [:div.rightpane
+                 [:div.right-pane
                   [card-zoom-view zoom-card]
-                  [log-panel send-command]]
+                  [content-pane]]
                  (do (resize-card-zoom) nil)
 
                  [:div.centralpane

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -16,13 +16,11 @@
             [nr.gameboard.actions :refer [send-command toast]]
             [nr.gameboard.log :refer [send-msg should-scroll]]
             [nr.gameboard.card-preview :refer [card-preview-mouse-over card-preview-mouse-out
-                                      card-highlight-mouse-over card-highlight-mouse-out zoom-channel]]
-            [nr.gameboard.right-pane :refer [content-pane load-tab]]
+                                               card-highlight-mouse-over card-highlight-mouse-out zoom-channel]]
+            [nr.gameboard.right-pane :refer [content-pane]]
             [nr.gameboard.player-stats :refer [stat-controls stats-view]]
-            [nr.gameboard.replay :refer [init-replay replay-panel update-notes get-remote-annotations
-                                         load-remote-annotations delete-remote-annotations publish-annotations
-                                         load-annotations-file save-annotations-file]]
-            [nr.gameboard.state :refer [game-state last-state lock replay-side parse-state get-side not-spectator?]]
+            [nr.gameboard.replay :refer [replay-panel]]
+            [nr.gameboard.state :refer [game-state replay-side not-spectator?]]
             [nr.translations :refer [tr tr-side]]
             [nr.utils :refer [banned-span influence-dot influence-dots map-longest
                               toastr-options render-icons render-message

--- a/src/cljs/nr/gameboard/card-preview.cljs
+++ b/src/cljs/nr/gameboard/card-preview.cljs
@@ -1,6 +1,8 @@
 (ns nr.gameboard.card-preview
-  (:require [cljs.core.async :refer [put!]]
+  (:require [cljs.core.async :refer [chan put!]]
             [nr.appstate :refer [app-state]]))
+
+(defonce zoom-channel (chan))
 
 (defn- get-card-data-title [e]
   (let [target (.. e -target)

--- a/src/cljs/nr/gameboard/card-preview.cljs
+++ b/src/cljs/nr/gameboard/card-preview.cljs
@@ -1,0 +1,35 @@
+(ns nr.gameboard.card-preview
+  (:require [cljs.core.async :refer [put!]]
+            [nr.appstate :refer [app-state]]))
+
+(defn- get-card-data-title [e]
+  (let [target (.. e -target)
+        title (.getAttribute target "data-card-title")]
+    (not-empty title)))
+
+(defn card-preview-mouse-over
+  [e channel]
+  (.preventDefault e)
+  (when-let [title (get-card-data-title e)]
+    (when-let [card (get (:all-cards-and-flips @app-state) title)]
+      (put! channel card)))
+  nil)
+
+(defn card-preview-mouse-out [e channel]
+  (.preventDefault e)
+  (when (get-card-data-title e)
+    (put! channel false))
+  nil)
+
+(defn card-highlight-mouse-over [e value channel]
+  (.preventDefault e)
+  (when (:cid value)
+    (put! channel (select-keys value [:cid])))
+  nil)
+
+(defn card-highlight-mouse-out [e value channel]
+  (.preventDefault e)
+  (when (:cid value)
+    (put! channel false))
+  nil)
+

--- a/src/cljs/nr/gameboard/card-preview.cljs
+++ b/src/cljs/nr/gameboard/card-preview.cljs
@@ -13,7 +13,7 @@
   [e channel]
   (.preventDefault e)
   (when-let [title (get-card-data-title e)]
-    (when-let [card (get (:all-cards-and-flips @app-state) title)]
+    (when-let [card (get-in @app-state [:all-cards-and-flips title])]
       (put! channel card)))
   nil)
 

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -1,10 +1,9 @@
 (ns nr.gameboard.log
-  (:require [cljs.core.async :refer [chan put!]]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [nr.appstate :refer [app-state]]
             [nr.avatar :refer [avatar]]
-            [nr.gameboard.replay :refer [update-notes replay-status get-remote-annotations load-remote-annotations
-                                         delete-remote-annotations publish-annotations load-annotations-file save-annotations-file]]
+            [nr.gameboard.actions :refer [send-command]]
+            [nr.gameboard.card-preview :refer [card-preview-mouse-over card-preview-mouse-out]]
             [nr.gameboard.state :refer [game-state not-spectator?]]
             [nr.help :refer [command-info]]
             [nr.translations :refer [tr]]
@@ -15,201 +14,11 @@
 (def commands (distinct (map :name command-info)))
 (def command-info-map (->> command-info (map (fn [{:keys [name has-args usage help]}] [name {:has-args has-args :usage usage :help help}])) (into {})))
 
-(defonce zoom-channel (chan))
-
-(defonce log-mode (r/atom :log))
-
-(defn- get-card-data-title [e]
-  (let [target (.. e -target)
-        title (.getAttribute target "data-card-title")]
-    (not-empty title)))
-
-(defn card-preview-mouse-over
-  [e channel]
-  (.preventDefault e)
-  (when-let [title (get-card-data-title e)]
-    (when-let [card (get (:all-cards-and-flips @app-state) title)]
-      (put! channel card)))
-  nil)
-
-(defn card-preview-mouse-out [e channel]
-  (.preventDefault e)
-  (when (get-card-data-title e)
-    (put! channel false))
-  nil)
-
-(defn card-highlight-mouse-over [e value channel]
-  (.preventDefault e)
-  (when (:cid value)
-    (put! channel (select-keys value [:cid])))
-  nil)
-
-(defn card-highlight-mouse-out [e value channel]
-  (.preventDefault e)
-  (when (:cid value)
-    (put! channel false))
-  nil)
-
 (defn scrolled-to-end?
   [el tolerance]
   (> tolerance (- (.-scrollHeight el) (.-scrollTop el) (.-clientHeight el))))
 
 (def should-scroll (r/atom {:update true :send-msg false}))
-
-(defn resize-card-zoom []
-  "Resizes the card zoom based on the values in the app-state"
-  (let [width (get-in @app-state [:options :log-width])
-        top (get-in @app-state [:options :log-top])
-        max-card-width (- width 5)
-        max-card-height (- top 10)
-        card-ratio (/ 418 300)]
-    (if (> (/ max-card-height max-card-width) card-ratio)
-      (-> ".card-zoom" js/$
-        (.css "width" max-card-width)
-        (.css "height" (int (* max-card-width card-ratio))))
-      (-> ".card-zoom" js/$
-        (.css "width" (int (/ max-card-height card-ratio)))
-        (.css "height" max-card-height)))
-    (-> ".rightpane" js/$ (.css "width" width))
-    (-> ".log" js/$
-      (.css "left" 0)
-      (.css "top" top)
-      (.css "width" width))))
-
-(defn log-resize [event ui]
-  "Resize the card zoom to fit the available space"
-  (let [width (.. ui -size -width)
-        top (.. ui -position -top)]
-    (swap! app-state assoc-in [:options :log-width] width)
-    (swap! app-state assoc-in [:options :log-top] top)
-    (.setItem js/localStorage "log-width" width)
-    (.setItem js/localStorage "log-top" top)
-    (resize-card-zoom)))
-
-(defn log-start-resize [event ui]
-  "Display a zoomed card when resizing so the user can visualize how the
-  resulting zoom will look."
-  (when-let [card (get-in @game-state [:runner :identity])]
-    (put! zoom-channel card)))
-
-(defn log-stop-resize [event ui]
-  (put! zoom-channel false))
-
-(defn log-selector []
-  (fn []
-    [:div.panel.panel-top.blue-shade.selector
-     [:a {:on-click #(reset! log-mode :log)} (tr [:log.game-log "Game Log"])]
-     " | "
-     [:a {:on-click #(reset! log-mode :notes)} (tr [:log.annotating "Annotating"])]
-     " | "
-     [:a {:on-click #(reset! log-mode :notes-shared)} (tr [:log.shared "Shared Annotations"])]]))
-
-(defn log-pane []
-  (r/create-class
-    (let [log (r/cursor game-state [:log])]
-      {:display-name "log-pane"
-
-       :component-did-mount
-       (fn [this]
-         (-> ".log" js/$ (.resizable #js {:handles "w, n, nw"
-                                          :resize log-resize
-                                          :start log-start-resize
-                                          :stop log-stop-resize}))
-         (resize-card-zoom)
-         (when (:update @should-scroll)
-           (let [n (r/dom-node this)]
-             (set! (.-scrollTop n) (.-scrollHeight n)))))
-
-       :component-will-update
-       (fn [this]
-         (let [n (r/dom-node this)]
-           (reset! should-scroll {:update (or (:send-msg @should-scroll)
-                                            (scrolled-to-end? n 15))
-                                  :send-msg false})))
-
-       :component-did-update
-       (fn [this]
-         (when (:update @should-scroll)
-           (let [n (r/dom-node this)]
-             (set! (.-scrollTop n) (.-scrollHeight n)))))
-
-       :reagent-render
-       (fn []
-         [:div.panel.blue-shade.messages {:class [(when (:replay @game-state)
-                                                    "panel-bottom")]
-                                          :style (when (not (:replay @game-state)) {:top 0})
-                                          :on-mouse-over #(card-preview-mouse-over % zoom-channel)
-                                          :on-mouse-out #(card-preview-mouse-out % zoom-channel)}
-          (case @log-mode
-            :log
-            (doall (map-indexed
-                     (fn [i msg]
-                       (when-not (and (= (:user msg) "__system__") (= (:text msg) "typing"))
-                         (if (= (:user msg) "__system__")
-                           [:div.system {:key i} (render-message (:text msg))]
-                           [:div.message {:key i}
-                            [avatar (:user msg) {:opts {:size 38}}]
-                            [:div.content
-                             [:div.username (get-in msg [:user :username])]
-                             [:div (render-message (:text msg))]]])))
-                     @log))
-            :notes
-            [:div.notes
-             [:div.turn [:textarea#notes-turn {:placeholder (tr [:annotations.turn-placeholder "Notes for this turn"])
-                                               :on-change #(update-notes)}]]
-             (letfn
-               [(create-buttons [types]
-                  (doall (for [icon types]
-                           ^{:key (str "notes-icon-" icon)}
-                           [:div {:class ["notes-icon" icon (when (= icon (:selected-note-type @replay-status)) "selected")]
-                                  :title (string/capitalize (subs (str icon) 1))
-                                  :on-click #(do (swap! replay-status assoc :selected-note-type icon)
-                                                 (update-notes))}])))]
-               [:div.notes-icons
-                (create-buttons [:none])
-                [:div.notes-separator]
-                (create-buttons [:blunder :mistake :inaccuracy :good :brilliant])
-                [:div.notes-separator]
-                (create-buttons [:a :b :c :d])])
-             [:div.click [:textarea#notes-click {:placeholder (tr [:annotations.click-placeholder "Notes for this click"])
-                                                 :on-change #(update-notes)}]]]
-            :notes-shared
-            (let [annotation-options (r/atom {:file ""})]
-              [:div.notes-shared
-               (when (not= "local-replay" (:gameid @game-state))
-                 [:div.remote-annotations
-                  [:h4 (tr [:annotations.available-annotations "Available annotations"]) " "
-                   [:button.small {:type "button"
-                                   :on-click #(get-remote-annotations (:gameid @game-state))} "⟳"]]
-                  (if (empty? (:remote-annotations @replay-status))
-                    (tr [:annotations-no-published-annotations "No published annotations."])
-                    [:ul
-                     (doall
-                       (for [[n anno] (map-indexed vector (:remote-annotations @replay-status))]
-                         ^{:key (str "annotation-" n)}
-                         [:li
-                          [:a {:on-click #(load-remote-annotations n)} (:username anno)]
-                          " - " (.toLocaleDateString (js/Date. (:date anno))) " "
-                          (when (:deletable anno)
-                            [:button.small {:type "button"
-                                            :on-click #(delete-remote-annotations n)} "X"])]))])
-                  [:div.button-row
-                   [:button {:type "button"
-                             :on-click #(publish-annotations)} (tr [:log.notes.publish "Publish"])]]
-                  [:hr]])
-               [:h4 (tr [:annotations.import-local "Import local annotation file"])]
-               [:input {:field :file
-                        :type :file
-                        :on-change #(swap! replay-status assoc :annotations-file (aget (.. % -target -files) 0))}]
-               [:div.button-row
-                [:button {:type "button" :on-click #(load-annotations-file)}
-                 (tr [:annotations.load-local "Load"])]
-                [:button {:type "button" :on-click #(save-annotations-file)}
-                 (tr [:annotations.save-local "Save"])]
-                [:button {:type "button" :on-click #(swap! replay-status assoc :annotations
-                                                      {:turns {:corp {} :runner {}}
-                                                       :clicks {}})}
-                 (tr [:annotations.clear "Clear"])]]]))])})))
 
 (defn log-typing []
   (let [typing (r/cursor game-state [:typing])
@@ -243,10 +52,10 @@
           (ws/ws-send! [:netrunner/typing {:gameid-str (:gameid @game-state)
                                            :typing true}]))))))
 
-(defn indicate-action [send]
+(defn indicate-action []
   (when (not-spectator?)
     [:button.indicate-action {:on-click #(do (.preventDefault %)
-                                             (send "indicate-action"))
+                                             (send-command "indicate-action"))
                               :key "Indicate action"}
      (tr [:game.indicate-action "Indicate action"])]))
 
@@ -319,7 +128,7 @@
       (swap! s assoc :msg (-> e .-target .-value))
       (send-typing s)))
 
-(defn log-input [send]
+(defn log-input []
   (let [gameid (r/cursor game-state [:gameid])
         games (r/cursor app-state [:games])
         !input-ref (r/atom nil)
@@ -339,7 +148,7 @@
                       :value (:msg @s)
                       :on-key-down (partial command-menu-key-down-handler s)
                       :on-change (partial log-input-change-handler s)}]]]
-           [indicate-action send]
+           [indicate-action]
            (when (show-command-menu? @s)
              [:div.command-matches-container.panel.blue-shade
               {:on-mouse-leave #(swap! s dissoc :command-highlight)}
@@ -358,11 +167,51 @@
                             (get-in command-info-map [match :usage])]])
                         (:command-matches @s)))]])])))))
 
-(defn log-panel [send]
+
+(defn log-messages [log zoom-channel]
+  (r/create-class
+    {:display-name "log-messages"
+
+     :component-did-mount
+     (fn [this]
+       (when (:update @should-scroll)
+         (let [n (r/dom-node this)]
+           (set! (.-scrollTop n) (.-scrollHeight n)))))
+
+     :component-will-update
+     (fn [this]
+       (let [n (r/dom-node this)]
+         (reset! should-scroll {:update (or (:send-msg @should-scroll)
+                                            (scrolled-to-end? n 15))
+                                :send-msg false})))
+
+     :component-did-update
+     (fn [this]
+       (when (:update @should-scroll)
+         (let [n (r/dom-node this)]
+           (set! (.-scrollTop n) (.-scrollHeight n)))))
+
+     :reagent-render
+     (fn []
+        [:div.panel.blue-shade.messages {:class [(when (:replay @game-state)
+                                                   "panel-bottom")]
+                                         :on-mouse-over #(card-preview-mouse-over % zoom-channel)
+                                         :on-mouse-out #(card-preview-mouse-out % zoom-channel)}
+         (doall (map-indexed
+                  (fn [i msg]
+                    (when-not (and (= (:user msg) "__system__") (= (:text msg) "typing"))
+                      (if (= (:user msg) "__system__")
+                        [:div.system {:key i} (render-message (:text msg))]
+                        [:div.message {:key i}
+                         [avatar (:user msg) {:opts {:size 38}}]
+                         [:div.content
+                          [:div.username (get-in msg [:user :username])]
+                          [:div (render-message (:text msg))]]])))
+                  @log))])}))
+
+(defn log-pane [log zoom-channel]
   (fn []
     [:div.log
-     (when (:replay @game-state)
-       [log-selector])
-     [log-pane]
+     [log-messages log zoom-channel]
      [log-typing]
-     [log-input send]]))
+     [log-input]]))

--- a/src/cljs/nr/gameboard/replay.cljs
+++ b/src/cljs/nr/gameboard/replay.cljs
@@ -450,7 +450,7 @@
         (doall (for [icon types]
                  ^{:key (str "notes-icon-" icon)}
                  [:div {:class ["notes-icon" icon (when (= icon (:selected-note-type @replay-status)) "selected")]
-                        :title (string/capitalize (subs (str icon) 1))
+                        :title (capitalize (subs (str icon) 1))
                         :on-click #(do (swap! replay-status assoc :selected-note-type icon)
                                        (update-notes))}])))]
      [:div.notes-icons

--- a/src/cljs/nr/gameboard/replay.cljs
+++ b/src/cljs/nr/gameboard/replay.cljs
@@ -440,3 +440,61 @@
         (swap! replay-status assoc :annotations new-annotations))
       (swap! replay-status assoc-in [:annotations :clicks click] {:notes click-notes :type (:selected-note-type @replay-status)}))))
 
+
+(defn notes-pane []
+  [:div.notes
+   [:div.turn [:textarea#notes-turn {:placeholder (tr [:annotations.turn-placeholder "Notes for this turn"])
+                                     :on-change #(update-notes)}]]
+   (letfn
+     [(create-buttons [types]
+        (doall (for [icon types]
+                 ^{:key (str "notes-icon-" icon)}
+                 [:div {:class ["notes-icon" icon (when (= icon (:selected-note-type @replay-status)) "selected")]
+                        :title (string/capitalize (subs (str icon) 1))
+                        :on-click #(do (swap! replay-status assoc :selected-note-type icon)
+                                       (update-notes))}])))]
+     [:div.notes-icons
+      (create-buttons [:none])
+      [:div.notes-separator]
+      (create-buttons [:blunder :mistake :inaccuracy :good :brilliant])
+      [:div.notes-separator]
+      (create-buttons [:a :b :c :d])])
+   [:div.click [:textarea#notes-click {:placeholder (tr [:annotations.click-placeholder "Notes for this click"])
+                                       :on-change #(update-notes)}]]])
+(defn notes-shared-pane []
+  (let [annotation-options (r/atom {:file ""})]
+    [:div.notes-shared
+     (when (not= "local-replay" (:gameid @game-state))
+       [:div.remote-annotations
+        [:h4 (tr [:annotations.available-annotations "Available annotations"]) " "
+         [:button.small {:type "button"
+                         :on-click #(get-remote-annotations (:gameid @game-state))} "⟳"]]
+        (if (empty? (:remote-annotations @replay-status))
+          (tr [:annotations-no-published-annotations "No published annotations."])
+          [:ul
+           (doall
+             (for [[n anno] (map-indexed vector (:remote-annotations @replay-status))]
+               ^{:key (str "annotation-" n)}
+               [:li
+                [:a {:on-click #(load-remote-annotations n)} (:username anno)]
+                " - " (.toLocaleDateString (js/Date. (:date anno))) " "
+                (when (:deletable anno)
+                  [:button.small {:type "button"
+                                  :on-click #(delete-remote-annotations n)} "X"])]))])
+        [:div.button-row
+         [:button {:type "button"
+                   :on-click #(publish-annotations)} (tr [:log.notes.publish "Publish"])]]
+        [:hr]])
+     [:h4 (tr [:annotations.import-local "Import local annotation file"])]
+     [:input {:field :file
+              :type :file
+              :on-change #(swap! replay-status assoc :annotations-file (aget (.. % -target -files) 0))}]
+     [:div.button-row
+      [:button {:type "button" :on-click #(load-annotations-file)}
+       (tr [:annotations.load-local "Load"])]
+      [:button {:type "button" :on-click #(save-annotations-file)}
+       (tr [:annotations.save-local "Save"])]
+      [:button {:type "button" :on-click #(swap! replay-status assoc :annotations
+                                                 {:turns {:corp {} :runner {}}
+                                                  :clicks {}})}
+       (tr [:annotations.clear "Clear"])]]]))

--- a/src/cljs/nr/gameboard/right-pane.cljs
+++ b/src/cljs/nr/gameboard/right-pane.cljs
@@ -1,0 +1,90 @@
+(ns nr.gameboard.right-pane
+  (:require [cljs.core.async :refer [chan put!]]
+            [clojure.string :as string]
+            [nr.appstate :refer [app-state]]
+            [nr.avatar :refer [avatar]]
+            [nr.gameboard.log :refer [log-pane should-scroll scrolled-to-end?]]
+            [nr.gameboard.replay :refer [notes-pane notes-shared-pane]]
+            [nr.gameboard.state :refer [game-state not-spectator?]]
+            [nr.help :refer [command-info]]
+            [nr.translations :refer [tr]]
+            [nr.utils :refer [influence-dot render-message]]
+            [nr.ws :as ws]
+            [reagent.core :as r]))
+
+(defonce zoom-channel (chan))
+
+(defonce log-mode (r/atom :log))
+
+(defn resize-card-zoom []
+  "Resizes the card zoom based on the values in the app-state"
+  (let [width (get-in @app-state [:options :log-width])
+        top (get-in @app-state [:options :log-top])
+        max-card-width (- width 5)
+        max-card-height (- top 10)
+        card-ratio (/ 418 300)]
+    (if (> (/ max-card-height max-card-width) card-ratio)
+      (-> ".card-zoom" js/$
+        (.css "width" max-card-width)
+        (.css "height" (int (* max-card-width card-ratio))))
+      (-> ".card-zoom" js/$
+        (.css "width" (int (/ max-card-height card-ratio)))
+        (.css "height" max-card-height)))
+    (-> ".right-pane" js/$ (.css "width" width))
+    (-> ".content-pane" js/$
+      (.css "left" 0)
+      (.css "top" top)
+      (.css "width" width))))
+
+(defn log-resize [event ui]
+  "Resize the card zoom to fit the available space"
+  (let [width (.. ui -size -width)
+        top (.. ui -position -top)]
+    (println "ui:" ui)
+    (swap! app-state assoc-in [:options :log-width] width)
+    (swap! app-state assoc-in [:options :log-top] top)
+    (.setItem js/localStorage "log-width" width)
+    (.setItem js/localStorage "log-top" top)
+    (resize-card-zoom)))
+
+(defn log-start-resize [event ui]
+  "Display a zoomed card when resizing so the user can visualize how the
+  resulting zoom will look."
+  (when-let [card (get-in @game-state [:runner :identity])]
+    (put! zoom-channel card)))
+
+(defn log-stop-resize [event ui]
+  (put! zoom-channel false))
+
+(defn log-selector []
+  (fn []
+    [:div.panel.panel-top.blue-shade.selector
+     [:a {:on-click #(reset! log-mode :log)} (tr [:log.game-log "Game Log"])]
+     " | "
+     [:a {:on-click #(reset! log-mode :notes)} (tr [:log.annotating "Annotating"])]
+     " | "
+     [:a {:on-click #(reset! log-mode :notes-shared)} (tr [:log.shared "Shared Annotations"])]]))
+
+(defn content-pane []
+  (r/create-class
+    (let [log (r/cursor game-state [:log])]
+      {:display-name "content-pane"
+
+       :component-did-mount
+       (fn [this]
+         (-> ".content-pane" js/$ (.resizable #js {:handles "w, n, nw"
+                                                   :resize log-resize
+                                                   :start log-start-resize
+                                                   :stop log-stop-resize}))
+         (resize-card-zoom))
+
+       :reagent-render
+       (fn []
+         [:div.content-pane
+          (case @log-mode
+            :log
+            [log-pane log zoom-channel]
+            :notes
+            [notes-pane]
+            :notes-shared
+            [notes-shared-pane])])})))

--- a/src/cljs/nr/gameboard/right-pane.cljs
+++ b/src/cljs/nr/gameboard/right-pane.cljs
@@ -7,6 +7,7 @@
             [nr.gameboard.log :refer [log-pane should-scroll scrolled-to-end?]]
             [nr.gameboard.replay :refer [notes-pane notes-shared-pane]]
             [nr.gameboard.state :refer [game-state not-spectator?]]
+            [nr.gameboard.settings :refer [settings-pane]]
             [nr.help :refer [command-info]]
             [nr.translations :refer [tr]]
             [nr.utils :refer [influence-dot render-message]]
@@ -75,6 +76,10 @@
           :notes-shared
           {:hiccup [notes-shared-pane]
            :label (tr [:log.shared "Shared Annotations"])}
+
+          :settings
+          {:hiccup [settings-pane]
+           :label (tr [:log.settings "Settings"])}
 
           {:hiccup [:div.error "This should not happen"]
            :label "???"})]

--- a/src/cljs/nr/gameboard/right-pane.cljs
+++ b/src/cljs/nr/gameboard/right-pane.cljs
@@ -29,6 +29,7 @@
     (-> ".content-pane" js/$
       (.css "left" 0)
       (.css "top" top)
+      (.css "height" "auto")
       (.css "width" width))))
 
 (defn- pane-resize [event ui]

--- a/src/cljs/nr/gameboard/right-pane.cljs
+++ b/src/cljs/nr/gameboard/right-pane.cljs
@@ -10,6 +10,22 @@
             [reagent.core :as r]))
 
 (defonce loaded-tabs (r/atom {}))
+(defonce available-tabs
+  {:log
+   {:hiccup [log-pane]
+    :label (tr [:log.game-log "Game Log"])}
+
+   :notes
+   {:hiccup [notes-pane]
+    :label (tr [:log.annotating "Annotating"])}
+
+   :notes-shared
+   {:hiccup [notes-shared-pane]
+    :label (tr [:log.shared "Shared Annotations"])}
+
+   :settings
+   {:hiccup [settings-pane]
+    :label (tr [:log.settings "Settings"])}})
 
 (defn- resize-card-zoom []
   "Resizes the card zoom based on the values in the app-state"
@@ -60,25 +76,9 @@
 
 (defn load-tab [tab]
   (let [{:keys [hiccup label]}
-        (case tab
-          :log
-          {:hiccup [log-pane]
-           :label (tr [:log.game-log "Game Log"])}
-
-          :notes
-          {:hiccup [notes-pane]
-           :label (tr [:log.annotating "Annotating"])}
-
-          :notes-shared
-          {:hiccup [notes-shared-pane]
-           :label (tr [:log.shared "Shared Annotations"])}
-
-          :settings
-          {:hiccup [settings-pane]
-           :label (tr [:log.settings "Settings"])}
-
-          {:hiccup [:div.error "This should not happen"]
-           :label "???"})]
+        (get available-tabs tab
+             {:hiccup [:div.error "This should not happen"]
+              :label "???"})]
     (swap! loaded-tabs assoc tab {:hiccup hiccup :label label})))
 
 (defn unload-tab [tab]

--- a/src/cljs/nr/gameboard/right-pane.cljs
+++ b/src/cljs/nr/gameboard/right-pane.cljs
@@ -1,17 +1,12 @@
 (ns nr.gameboard.right-pane
   (:require [cljs.core.async :refer [put!]]
-            [clojure.string :as string]
             [nr.appstate :refer [app-state]]
-            [nr.avatar :refer [avatar]]
             [nr.gameboard.card-preview :refer [zoom-channel]]
-            [nr.gameboard.log :refer [log-pane should-scroll scrolled-to-end?]]
+            [nr.gameboard.log :refer [log-pane]]
             [nr.gameboard.replay :refer [notes-pane notes-shared-pane]]
-            [nr.gameboard.state :refer [game-state not-spectator?]]
+            [nr.gameboard.state :refer [game-state]]
             [nr.gameboard.settings :refer [settings-pane]]
-            [nr.help :refer [command-info]]
             [nr.translations :refer [tr]]
-            [nr.utils :refer [influence-dot render-message]]
-            [nr.ws :as ws]
             [reagent.core :as r]))
 
 (defonce loaded-tabs (r/atom {}))

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -1,5 +1,6 @@
 (ns nr.gameboard.settings
   (:require [clojure.string :as string]
+            [nr.account :refer [post-options]]
             [nr.appstate :refer [app-state]]
             [nr.gameboard.actions :refer [stack-cards]]
             [nr.translations :refer [tr]]
@@ -11,12 +12,70 @@
     (let [s app-state]
       [:div.settings
        [:section
-        [:h3 (tr [:settings.sounds "Play area"])]
+        [:h4 (tr [:ingame-settings.card-stacking "Card stacking"])]
         [:div
          [:label [:input {:type "checkbox"
                           :value true
                           :checked (get-in @app-state [:options :stacked-cards])
                           :on-change #(swap! app-state assoc-in [:options :stacked-cards] (.. % -target -checked))}]
-          (tr [:game.stack-cards "Stack cards"])]]
-        ]
-       ])))
+          (tr [:ingame-settings.stack-cards "Stack cards"])]]]
+
+       [:section
+        [:h4 (tr [:ingame-settings.runner-board-order "Runner board order"])]
+        (doall (for [option [{:name (tr [:ingame-settings.runner-classic "classic"]) :ref "jnet"}
+                             {:name (tr [:ingame-settings.runner-reverse "reversed"]) :ref "irl"}]]
+                 [:div.radio {:key (:name option)}
+                  [:label [:input {:type "radio"
+                                   :name "runner-board-order"
+                                   :value (:ref option)
+                                   :on-change #(swap! app-state assoc-in [:options :runner-board-order] (.. % -target -value))
+                                   :checked (= (get-in @app-state [:options :runner-board-order]) (:ref option))}]
+                   (:name option)]]))]
+
+       [:section
+        [:h4 (tr [:ingame-settings.card-backs "Card backs"])]
+        (doall (for [option [{:name (tr [:settings.nisei "NISEI"]) :ref "nisei"}
+                             {:name (tr [:settings.ffg "FFG"]) :ref "ffg"}]]
+                 [:div.radio {:key (:name option)}
+                  [:label [:input {:type "radio"
+                                   :name "card-back"
+                                   :value (:ref option)
+                                   :on-change #(swap! app-state assoc-in [:options :card-back] (.. % -target -value))
+                                   :checked (= (get-in @app-state [:options :card-back]) (:ref option))}]
+                   (:name option)]]))]
+
+       [:section
+        [:h4 (tr [:ingame-settings.preview-zoom "Card preview zoom"])]
+        (doall (for [option [{:name "Card Image" :ref "image"}
+                             {:name "Card Text" :ref "text"}]]
+                 [:div.radio {:key (:name option)}
+                  [:label [:input {:type "radio"
+                                   :name "card-zoom"
+                                   :value (:ref option)
+                                   :on-change #(swap! app-state assoc-in [:options :card-zoom] (.. % -target -value))
+                                   :checked (= (get-in @app-state [:options :card-zoom]) (:ref option))}]
+                   (:name option)]]))
+        [:label [:input {:type "checkbox"
+                         :name "pin-zoom"
+                         :checked (get-in @app-state [:options :pin-zoom])
+                         :on-change #(swap! app-state assoc-in [:options :pin-zoom] (.. % -target -checked))}]
+         (tr [:settings.pin-zoom "Keep zoomed cards on screen"])]]
+
+       [:section
+        [:h4 (tr [:ingame-settings.card-images "Card images"])]
+        [:div
+         [:label [:input {:type "checkbox"
+                          :name "use-high-res"
+                          :checked (= "high" (get-in @app-state [:options :card-resolution]))
+                          :on-change #(swap! app-state assoc-in [:options :card-resolution] (if (.. % -target -checked) "high" "default"))}]
+          (tr [:ingame-settings.high-res "Enable high resolution card images"])]]]
+
+       [:section
+        [:h4 (tr [:ingame-settings.alt-art "Alt arts"])]
+        [:div
+         [:label [:input {:type "checkbox"
+                          :name "show-alt-art"
+                          :checked (get-in @app-state [:options :show-alt-art])
+                          :on-change #(swap! app-state assoc-in [:options :show-alt-art] (.. % -target -checked))}]
+          (tr [:ingame-settings.show-alt "Show alternate card arts"])]]]
+       [:button {:on-click #(post-options "/profile" (constantly nil))} (tr [:ingame-settings.save "Save"])]])))

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -33,6 +33,15 @@
                    (:name option)]]))]
 
        [:section
+        [:h4 (tr [:ingame-settings.runner-board-order "Board overlap"])]
+        [:div
+         [:label [:input {:type "checkbox"
+                          :value true
+                          :checked (get-in @app-state [:options :sides-overlap])
+                          :on-change #(swap! app-state assoc-in [:options :sides-overlap] (.. % -target -checked))}]
+          (tr [:ingame-settings.sides-overlap "Runner and Corp may overlap"])]]]
+
+       [:section
         [:h4 (tr [:ingame-settings.card-backs "Card backs"])]
         (doall (for [option [{:name (tr [:settings.nisei "NISEI"]) :ref "nisei"}
                              {:name (tr [:settings.ffg "FFG"]) :ref "ffg"}]]

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -1,0 +1,22 @@
+(ns nr.gameboard.settings
+  (:require [clojure.string :as string]
+            [nr.appstate :refer [app-state]]
+            [nr.gameboard.actions :refer [stack-cards]]
+            [nr.translations :refer [tr]]
+            [nr.ws :as ws]
+            [reagent.core :as r]))
+
+(defn settings-pane []
+  (fn []
+    (let [s app-state]
+      [:div.settings
+       [:section
+        [:h3 (tr [:settings.sounds "Play area"])]
+        [:div
+         [:label [:input {:type "checkbox"
+                          :value true
+                          :checked (get-in @app-state [:options :stacked-cards])
+                          :on-change #(swap! app-state assoc-in [:options :stacked-cards] (.. % -target -checked))}]
+          (tr [:game.stack-cards "Stack cards"])]]
+        ]
+       ])))

--- a/src/cljs/nr/main.cljs
+++ b/src/cljs/nr/main.cljs
@@ -42,14 +42,7 @@
             [:a.leave-button {:on-click #(leave-game)} (if (:replay game) (tr [:game.leave-replay "Leave replay"]) (tr [:game.leave "Leave game"]))]
             (when is-player
               [:a.mute-button {:on-click #(mute-spectators (not (:mute-spectators game)))}
-               (if (:mute-spectators game) (tr [:game.unmute "Unmute spectators"]) (tr [:game.mute "Mute spectators"]))])
-            [:a.stack-cards-button {:on-click #(stack-cards)}
-             (if (get-in @app-state [:options :stacked-cards])
-               (tr [:game.unstack-cards "Unstack cards"]) (tr [:game.stack-cards "Stack cards"]))]
-            (when (not= :runner (:side @game-state))
-              [:a.runner-board-order-button {:on-click #(flip-runner-board)}
-               (if (= "irl" (get-in @app-state [:options :runner-board-order]))
-                 (tr [:game.rig-irl "Rig layout: IRL"]) (tr [:game.rig-jnet "Rig layout: jnet"]))])]))
+               (if (:mute-spectators game) (tr [:game.unmute "Unmute spectators"]) (tr [:game.mute "Mute spectators"]))])]))
        (when (not (nil? @gameid))
          [:div.float-right
           [:a {:on-click #(leave-game)} (if (= "local-replay" @gameid) (tr [:game.leave-replay "Leave replay"]) (tr [:game.leave "Leave game"]))]
@@ -58,14 +51,7 @@
           (when (= "local-replay" @gameid)
             [:a.replay-button {:on-click #(set-replay-side :runner)} (tr [:game.runner-view "Runner View"])])
           (when (= "local-replay" @gameid)
-            [:a.replay-button {:on-click #(set-replay-side :spectator)} (tr [:game.spec-view "Spectator View"])])
-          [:a.stack-cards-button {:on-click #(stack-cards)}
-           (if (get-in @app-state [:options :stacked-cards])
-             (tr [:game.unstack-cards "Unstack cards"]) (tr [:game.stack-cards "Stack cards"]))]
-          (when (not= :runner (:side @game-state))
-            [:a.runner-board-order-button {:on-click #(flip-runner-board)}
-             (if (= "irl" (get-in @app-state [:options :runner-board-order]))
-               (tr [:game.rig-irl "Rig layout: IRL"]) (tr [:game.rig-jnet "Rig layout: jnet"]))])]))
+            [:a.replay-button {:on-click #(set-replay-side :spectator)} (tr [:game.spec-view "Spectator View"])])]))
      (when-let [game (some #(when (= @gameid (:gameid %)) %) @games)]
        (when (:started game)
          (let [c (:spectator-count game)]

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -936,6 +936,8 @@
                 flex(1)
                 margin: 0
                 min-height: 20px
+                overflow-x:clip
+                overflow-y:auto
 
                 >div
                     animation: fadein 0.5s

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -928,7 +928,7 @@
                 >a:not(:first-child)
                     margin-left:3ex
 
-            .content
+            &>.content
                 position: absolute
                 top: 24px
                 bottom: 0px

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -916,53 +916,75 @@
             position:absolute
             bottom: 0px
 
-        .log
-            height:100%
-            display-flex()
-            flex-direction(column)
-            // width: 225px
-            // position: absolute
-            // top: 317px
-            // bottom: 0
-
-            .username
-                font-size: .875rem
-                margin-top: -2px
-
-            .avatar
-                width: 28px
-                height: 28px
-
-            .messages
-                flex(1)
-                overflow: auto!important
-                -webkit-overflow-scrolling: touch
-                min-height: 20px
+            .selector
+                position: absolute
+                top: 0px
+                height:24px
+                left: 0
+                right: 0
                 margin: 0
+                padding-top: 2px
 
-                div
+                >a:not(:first-child)
+                    margin-left:3ex
+
+            .content
+                position: absolute
+                top: 24px
+                bottom: 0px
+                width: 100%
+                flex(1)
+                margin: 0
+                min-height: 20px
+
+                >div
                     animation: fadein 0.5s
 
-            .log-input form input, .indicate-action
-                width: 100%
+                .log
+                    height:100%
+                    display-flex()
+                    flex-direction(column)
+                    // width: 225px
+                    // position: absolute
+                    // top: 317px
+                    // bottom: 0
 
-            .command-matches-container
-                position: absolute !important
-                bottom: 24px
-                right: 100%
+                    .username
+                        font-size: .875rem
+                        margin-top: -2px
 
-                ::-webkit-scrollbar
-                    width 0
+                    .avatar
+                        width: 28px
+                        height: 28px
 
-                ul.command-matches
-                    list-style-type: none
-                    overflow-x: clip
-                    overflow-y: auto
-                    max-height: 300px
-                    white-space: nowrap
-                    width: max-content
-                    scrollbar-width: none
+                    .messages
+                        flex(1)
+                        overflow: auto!important
+                        -webkit-overflow-scrolling: touch
 
-                    li.command-match.highlight span
-                        color: gold-base
-                        cursor: pointer
+                        div
+                            animation: fadein 0.5s
+
+                    .log-input form input, .indicate-action
+                        width: 100%
+
+                    .command-matches-container
+                        position: absolute !important
+                        bottom: 24px
+                        right: 100%
+
+                        ::-webkit-scrollbar
+                            width 0
+
+                        ul.command-matches
+                            list-style-type: none
+                            overflow-x: clip
+                            overflow-y: auto
+                            max-height: 300px
+                            white-space: nowrap
+                            width: max-content
+                            scrollbar-width: none
+
+                            li.command-match.highlight span
+                                color: gold-base
+                                cursor: pointer

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -46,6 +46,9 @@
         top: 100%
         transform: translate(0, -100%)
 
+    .card-frame, .deck, .identity, .discard
+        pointer-events: auto
+
     .card-frame
         position: relative
 
@@ -632,7 +635,9 @@
         display-flex()
         flex-direction(column)
         min-width: 90px
-        overflow: visible
+        position:relative
+        overflow-x:auto
+        overflow-y:visible
 
         .card-wrapper
             margin: 3px 6px
@@ -649,6 +654,19 @@
         // Then once both card-wrapper _and_ card are hovered, the z-index gets bumped to 1 to pull the card to the front.
         .card-wrapper:hover .card:hover, .stacked:hover .card:hover
             z-index: 1
+
+        .outer-corp-board.overlap,.runner-board.overlap
+            overflow: visible
+            position: absolute
+            pointer-events: none
+
+            &.me
+                bottom: 0
+                width: 100%
+
+            &.opponent
+                top: 0
+                width: 100%
 
         .runner-board
             flex(1)
@@ -677,11 +695,6 @@
 
             > div:last-child
                 margin-bottom: auto
-
-        .outer-corp-board.me
-            overflow: auto
-            margin-top: -100%
-            padding-top: 100%
 
         .corp-board
             flex(1)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -870,7 +870,7 @@
                 .run-card
                     transform(initial)
 
-    .rightpane
+    .right-pane
         position: relative
         display-flex()
         flex-direction(column)
@@ -912,44 +912,36 @@
             .impl-msg
                 color: gold-base
 
+        .content-pane
+            position:absolute
+            bottom: 0px
+
         .log
-            width: 225px
-            position: absolute
-            top: 317px
-            bottom: 0
+            height:100%
+            display-flex()
+            flex-direction(column)
+            // width: 225px
+            // position: absolute
+            // top: 317px
+            // bottom: 0
 
             .username
-                font-size: .75rem
+                font-size: .875rem
                 margin-top: -2px
 
             .avatar
                 width: 28px
                 height: 28px
 
-            > .panel
-                margin-left: 0
-                font-size: .75rem
-                line-height: 1rem
-
             .messages
                 flex(1)
-                overflow: auto
+                overflow: auto!important
                 -webkit-overflow-scrolling: touch
-                position: absolute
-                top: 24px
-                bottom: 70px
-                left: 0
-                right: 4px
+                min-height: 20px
                 margin: 0
 
                 div
                     animation: fadein 0.5s
-
-            > div
-                position: absolute
-                bottom: 12px
-                left: 0
-                right: 4px
 
             .log-input form input, .indicate-action
                 width: 100%
@@ -958,15 +950,18 @@
                 position: absolute !important
                 bottom: 24px
                 right: 100%
-                width: fit-content
 
                 ::-webkit-scrollbar
                     width 0
 
                 ul.command-matches
                     list-style-type: none
-                    overflow: auto
+                    overflow-x: clip
+                    overflow-y: auto
                     max-height: 300px
+                    white-space: nowrap
+                    width: max-content
+                    scrollbar-width: none
 
                     li.command-match.highlight span
                         color: gold-base

--- a/src/css/netrunner.styl
+++ b/src/css/netrunner.styl
@@ -27,3 +27,4 @@
 @require "admin"
 @require "news"
 @require "replay"
+@require "ingame-settings"

--- a/src/css/netrunner.styl
+++ b/src/css/netrunner.styl
@@ -27,4 +27,3 @@
 @require "admin"
 @require "news"
 @require "replay"
-@require "ingame-settings"

--- a/src/css/replay.styl
+++ b/src/css/replay.styl
@@ -178,16 +178,7 @@
                 width: 400px
                 margin: 5px
 
-.rightpane .log
-    .selector
-        position: absolute
-        height:24px
-        top: 0px
-        left: 0
-        right: 4px
-        margin: 0
-        padding-top: 2px
-
+.right-pane
     .notes, .notes-shared
         height: 100%
         display-flex()


### PR DESCRIPTION
Goal is to move the visual settings into a tab on the log for easier access and immediate visibility of the result.

https://user-images.githubusercontent.com/1409906/118323993-b4eda500-b501-11eb-8af9-99988dad26c5.mp4


