### PR TITLE
Made click symbol click-through

### DIFF
--- a/src/css/replay.styl
+++ b/src/css/replay.styl
@@ -220,14 +220,13 @@
             top: 50%
             left: 0
             width: 100%
-            color: alpha(black-solid, o-10)
-
-        .click:after
+            color: alpha(white-solid, o-10)
             text-align: center
             font-family: "anr-icon" !important
             font-size: 8.75rem
             speak: none
             content: "\e611"
+            pointer-events: none
 
         .turn
             content: "";


### PR DESCRIPTION
In the replay annotation window, the click symbol was previously blocking access to the text area.