### PR TITLE
standardize credits vs [Credits] usage in messages

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -566,7 +566,7 @@
                           stolen-agenda (find-latest state (:card context))
                           title (:title stolen-agenda)
                           prompt (str "Forfeit Divested Trust to add " title
-                                      " to HQ and gain 5[Credits]?")
+                                      " to HQ and gain 5 [Credits]?")
                           message (str "add " title " to HQ and gain 5 [Credits]")
                           agenda-side (if (in-runner-scored? state side stolen-agenda)
                                         :runner :corp)
@@ -1055,7 +1055,7 @@
   (let [nq {:async true
             :effect (req (let [extra (int (/ (:runner-spent target) 2))]
                            (if (pos? extra)
-                             (do (system-msg state :corp (str "uses Net Quarantine to gain " extra "[Credits]"))
+                             (do (system-msg state :corp (str "uses Net Quarantine to gain " extra " [Credits]"))
                                  (gain-credits state side eid extra))
                              (effect-completed state side eid))))}]
     {:events [{:event :pre-init-trace

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -298,7 +298,7 @@
   {:derezzed-events [corp-rez-toast]
    :flags {:corp-phase-12 (req (pos? (:credit corp)))}
    :abilities [{:label "Move up to 3 [Credit] from credit pool to C.I. Fund"
-                :prompt "Choose how many [Credit] to move"
+                :prompt "Choose how many credits to move"
                 :once :per-turn
                 :choices {:number (req (min (:credit corp) 3))}
                 :async true
@@ -1132,10 +1132,10 @@
 
 (defcard "Long-Term Investment"
   {:derezzed-events [corp-rez-toast]
-   :abilities [{:label "Move any number of [Credits] to your credit pool"
+   :abilities [{:label "Move any number of credits to your credit pool"
                 :req (req (>= (get-counters card :credit) 8))
                 :cost [:click 1]
-                :prompt "How many [Credits]?"
+                :prompt "How many credits?"
                 :choices {:counter :credit}
                 :msg (msg "gain " target " [Credits]")
                 :async true
@@ -1880,23 +1880,23 @@
    :leave-play (effect (update-all-ice))})
 
 (defcard "Sealed Vault"
-  {:abilities [{:label "Store any number of [Credits] on Sealed Vault"
+  {:abilities [{:label "Store any number of credits on Sealed Vault"
                 :cost [:credit 1]
-                :prompt "How many [Credits]?"
+                :prompt "How many credits?"
                 :choices {:number (req (- (:credit corp) 1))}
                 :msg (msg "store " target " [Credits]")
                 :async true
                 :effect (effect (add-counter card :credit target)
                                 (lose-credits eid target))}
-               {:label "Move any number of [Credits] to your credit pool"
+               {:label "Move any number of credits to your credit pool"
                 :cost [:click 1]
-                :prompt "How many [Credits]?"
+                :prompt "How many credits?"
                 :choices {:counter :credit}
                 :msg (msg "gain " target " [Credits]")
                 :async true
                 :effect (effect (gain-credits eid target))}
-               {:label "Move any number of [Credits] to your credit pool"
-                :prompt "How many [Credits]?"
+               {:label "Move any number of credits to your credit pool"
+                :prompt "How many credits?"
                 :choices {:counter :credit}
                 :msg (msg "trash it and gain " target " [Credits]")
                 :cost [:trash]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -21,7 +21,7 @@
                :effect (req (let [counters (- (get-in (get-card state card) [:special :numpurged])
                                               (number-of-virus-counters state))]
                               (wait-for (trash state side card nil)
-                                        (system-msg state side (str "trashes Acacia and gains " counters "[Credit]"))
+                                        (system-msg state side (str "trashes Acacia and gains " counters " [Credit]"))
                                         (gain-credits state side eid counters))))}}}]})
 
 (defcard "Adjusted Matrix"
@@ -633,7 +633,7 @@
                   :async true
                   :effect (req (let [credits (get-counters card :credit)]
                                  (update! state :runner (dissoc-in card [:counter :credit]))
-                                 (system-msg state :runner (str "takes " credits "[Credits] from Flame-out"))
+                                 (system-msg state :runner (str "takes " credits " [Credits] from Flame-out"))
                                  (register-events
                                    state :runner (get-card state card)
                                    [(assoc turn-end :event :runner-turn-ends)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1401,7 +1401,7 @@
              :msg "place 1 [Credits]"
              :effect (req (add-counter state :runner eid card :credit 1 nil))}]
    :abilities [{:cost [:click 1]
-                :label "Gain 1 [Credits]. Take all hosted [Credits]"
+                :label "Gain 1 [Credits]. Take all hosted credits"
                 :async true
                 :msg (msg "gain " (inc (get-counters card :credit)) " [Credits]")
                 :effect (req (let [credits (inc (get-counters card :credit))]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -465,7 +465,7 @@
                             (empty? (filter #(and (:broken %) (:printed %)) (:subroutines card)))
                             :unrestricted))]
     {:advanceable :always
-     :subroutines [{:label "Gain 1[Credit]. Place 1 advancement token."
+     :subroutines [{:label "Gain 1 [Credit]. Place 1 advancement token."
                     :breakable breakable-fn
                     :msg (msg "gain 1 [Credit] and place 1 advancement token on " (card-str state target))
                     :prompt "Choose an installed card"
@@ -1603,7 +1603,7 @@
                                                (system-msg state :corp (:msg async-result))
                                                (continue-ability
                                                  state side
-                                                 {:msg (msg "pay " c "[Credits] and place " (quantify c " advancement token")
+                                                 {:msg (msg "pay " c " [Credits] and place " (quantify c " advancement token")
                                                             " on " (card-str state target))
                                                   :choices {:card can-be-advanced?}
                                                   :effect (effect (add-prop target :advance-counter c {:placed true}))}
@@ -2090,8 +2090,8 @@
   {:subroutines [trash-program-sub
                  trash-program-sub
                  trash-hardware-sub
-                 {:label "Runner loses 3[credit], if able. End the run."
-                  :msg "make the Runner lose 3[credit] and end the run"
+                 {:label "Runner loses 3 [credit], if able. End the run."
+                  :msg "make the Runner lose 3 [credit] and end the run"
                   :async true
                   :effect (req (if (>= (:credit runner) 3)
                                  (wait-for (lose-credits state :runner 3)
@@ -2209,7 +2209,7 @@
 (defcard "Mausolus"
   {:advanceable :always
    :subroutines [{:label "Gain 1 [Credits] (Gain 3 [Credits])"
-                  :msg (msg "gain " (if (wonder-sub card 3) 3 1) "[Credits]")
+                  :msg (msg "gain " (if (wonder-sub card 3) 3 1) " [Credits]")
                   :async true
                   :effect (effect (gain-credits eid (if (wonder-sub card 3) 3 1)))}
                  {:label "Do 1 net damage (Do 3 net damage)"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1679,7 +1679,7 @@
               :async true
               :once :per-turn
               :yes-ability
-              {:msg (msg "gain " (total-cards-accessed context) "[Credits]")
+              {:msg (msg "gain " (total-cards-accessed context) " [Credits]")
                :once :per-turn
                :async true
                :effect (req (gain-credits state :runner eid (total-cards-accessed context)))}}}]})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -51,7 +51,7 @@
                    {:async true
                     :effect (req (if (not (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil :credit 1))
                                    (do
-                                     (toast state :corp "Cannot afford to pay 1 credit to block card exposure" "info")
+                                     (toast state :corp "Cannot afford to pay 1 [Credit] to block card exposure" "info")
                                      (expose state :runner eid (:card context)))
                                    (continue-ability
                                      state side
@@ -1385,15 +1385,15 @@
              :msg (msg "make the Runner lose 1 [Credits] by rezzing an Advertisement")}]})
 
 (defcard "Sportsmetal: Go Big or Go Home"
-  (let [ab {:prompt "Gain 2 credits or draw 2 cards?"
+  (let [ab {:prompt "Gain 2 [Credits] or draw 2 cards?"
             :player :corp
-            :choices ["Gain 2 credits" "Draw 2 cards"]
-            :msg (msg (if (= target "Gain 2 credits")
-                        "gain 2 credits"
+            :choices ["Gain 2 [Credits]" "Draw 2 cards"]
+            :msg (msg (if (= target "Gain 2 [Credits]")
+                        "gain 2 [Credits]"
                         "draw 2 cards"))
             :async true
             :interactive (req true)
-            :effect (req (if (= target "Gain 2 credits")
+            :effect (req (if (= target "Gain 2 [Credits]")
                            (gain-credits state :corp eid 2)
                            (draw state :corp eid 2 nil)))}]
     {:events [(assoc ab :event :agenda-scored)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -2529,7 +2529,7 @@
                        state side
                        {:async true
                         :prompt (str "Select a program with an install cost of no more than "
-                                     exceed "[Credits]")
+                                     exceed " [Credits]")
                         :choices {:card #(and (program? %)
                                               (installed? %)
                                               (>= exceed (:cost %)))}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -473,7 +473,7 @@
                 :async true
                 ;; Cannot trash unless there are counters (so game state changes)
                 :req (req (pos? (get-counters card :credit)))
-                :msg (msg "gain " (get-counters card :credit) " credits")
+                :msg (msg "gain " (get-counters card :credit) " [Credits]")
                 :cost [:trash]
                 :effect (effect (gain-credits eid (get-counters card :credit)))}]})
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -151,7 +151,7 @@
 (defcard "Algo Trading"
   {:flags {:runner-phase-12 (req (pos? (:credit runner)))}
    :abilities [{:label "Move up to 3 [Credit] from credit pool to Algo Trading"
-                :prompt "Choose how many [Credit] to move" :once :per-turn
+                :prompt "Choose how many credits to move" :once :per-turn
                 :choices {:number (req (min 3 (total-available-credits state :runner eid card)))}
                 :async true
                 :effect (effect (add-counter card :credit target)
@@ -1340,7 +1340,7 @@
                    :choices {:number (req (get-counters card :credit))}
                    :async true
                    :effect (req (wait-for (gain-credits state :runner target)
-                                          (system-msg state :runner (str "trashes Jackpot! to gain " target " credits"))
+                                          (system-msg state :runner (str "trashes Jackpot! to gain " target " [Credits]"))
                                           (trash state :runner eid card nil)))}}}]
     {:events [{:event :runner-turn-begins
                :effect (effect (add-counter :runner card :credit 1))}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2031,7 +2031,7 @@
                         :label "Remove 1 counter from a hosted card"
                         :cost [:credit 1])
                  {:async true
-                  :label "X[Credit]: Remove counters from a hosted card"
+                  :label "X [Credit]: Remove counters from a hosted card"
                   :choices {:card #(:host %)}
                   :req (req (not (empty? (:hosted card))))
                   :effect (effect

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -114,7 +114,7 @@
         :prompt (str "Select a credit providing card ("
                      counter-count (when (and target-count (pos? target-count))
                                      (str " of " target-count))
-                     " credits)")
+                     " [Credits])")
         :choices {:card #(in-coll? (map :cid provider-cards) (:cid %))}
         :effect (req (let [pay-credits-type (-> target card-def :interactions :pay-credits :type)
                            pay-credits-custom (when (= :custom pay-credits-type)

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -153,7 +153,7 @@
           (card-ability state :runner cor 0)
           (click-prompt state :runner "End the run")
           (is (not-empty (:prompt (get-runner))) "Prompt to break second sub open")
-          (click-prompt state :runner "Gain 1[Credit]. Place 1 advancement token.")
+          (click-prompt state :runner "Gain 1 [Credit]. Place 1 advancement token.")
           (is (empty? (:prompt (get-runner))) "Prompt now closed")
           (is (empty? (remove :broken (:subroutines (refresh akhet)))) "All subroutines broken")
           (run-jack-out state)

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3387,7 +3387,7 @@
       (play-from-hand state :corp "Merger" "New remote")
       (score-agenda state :corp (get-content state :remote1 0))
       (is (= 5 (:credit (get-corp))) "Corp starts with 5 credits")
-      (click-prompt state :corp "Gain 2 credits")
+      (click-prompt state :corp "Gain 2 [Credits]")
       (is (= 7 (:credit (get-corp))) "Corp gains 2 credits")))
   (testing "Gain 2 credits on steal"
     (do-game
@@ -3398,7 +3398,7 @@
       (run-empty-server state "Server 1")
       (is (= 7 (:credit (get-corp))) "Corp starts with 7 credits")
       (click-prompt state :runner "Steal")
-      (click-prompt state :corp "Gain 2 credits")
+      (click-prompt state :corp "Gain 2 [Credits]")
       (is (= 9 (:credit (get-corp))) "Corp gains 2 credits")))
   (testing "Draw 2 cards on score"
     (do-game


### PR DESCRIPTION
Fixes all places where "credits" and "[Credits]" were used wrong.