### PR TITLE
Fix Keiko trigger condition

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -942,10 +942,12 @@
    :events [{:event :spent-credits-from-card
              :req (req (and (not (facedown? target))
                             (has-subtype? target "Companion")
-                            (let [f #(and (not (facedown? (first %)))
-                                          (has-subtype? (first %) "Companion"))]
-                              (= 1 (+ (event-count state :runner :spent-credits-from-card f)
-                                      (event-count state :runner :runner-install f))))))
+                            (= 1 (+ (event-count state :runner :spent-credits-from-card
+                                                 #(and (not (facedown? (first %)))
+                                                       (has-subtype? (first %) "Companion")))
+                                    (event-count state :runner :runner-install
+                                                 #(and (not (:facedown (first %)))
+                                                       (has-subtype? (:card (first %)) "Companion")))))))
              :msg "gain 1 [Credit]"
              :async true
              :effect (effect (gain-credits :runner eid 1))}


### PR DESCRIPTION
Fix for #5892 

Keiko gave credits a second time in a turn, when credits where used from
a companion after a companion was installed that turn.

`event-count` with `:runner-install` now gets a different filter
predicate than the call with `:spent-credits-from-card`.