### PR TITLE
Fix midway station ignoring break all abilities

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -933,7 +933,7 @@
                                       (has-subtype? target "Icebreaker")
                                       ; and is using a break ability
                                       (contains? (second targets) :break)
-                                      (pos? (:break (second targets) 0))
+                                      (pos? (count (:broken-subs (second targets))))
                                       ; during a run on this server
                                       this-server))
                        :value [:credit 1]}]})

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -2013,12 +2013,12 @@
 
 (deftest midway-station-grid
   ;; Midway Station Grid
-  (do-game
-    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Midway Station Grid" (qty "Battlement" 2)]
-                      :credits 20}
-               :runner {:hand ["Corroder"]
-                        :credits 10}})
+  (testing "Addtional cost on single sub break"
+    (do-game (new-game {:corp  {:deck [(qty "Hedge Fund" 5)]
+                                :hand ["Midway Station Grid" (qty "Battlement" 2)]
+                                :credits 20}
+                        :runner {:hand ["Corroder"]
+                                 :credits 10}})
     (play-from-hand state :corp "Midway Station Grid" "HQ")
     (rez state :corp (get-content state :hq 0))
     (play-from-hand state :corp "Battlement" "HQ")
@@ -2047,6 +2047,21 @@
         -1 (:credit (get-runner))
         "Runner loses 1 credit only for running on a different server"
         (card-ability state :runner corroder 0)
+        (click-prompt state :runner "End the run")))))
+   (testing "Addtional cost when breaking all"
+    (do-game (new-game {:corp {:hand ["Midway Station Grid" "Quandary"] :credits 20} :runner {:hand ["Cradle"] :credits 20} })
+      (play-from-hand state :corp "Midway Station Grid" "HQ")
+      (rez state :corp (get-content state :hq 0))
+      (play-from-hand state :corp "Quandary" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Cradle")
+      (run-on state "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (changes-val-macro
+        -3 (:credit (get-runner))
+        "Runner loses 3 credits, 2 for cradle 1 for midway"
+        (card-ability state :runner (get-program state 0) 0)
         (click-prompt state :runner "End the run")))))
 
 (deftest mumbad-city-grid


### PR DESCRIPTION
Just a small bugfix for a rotated card that nobody ever played. I noticed it when testing the interaction with dai v for stealth credits. It seems it's looking at the number of subs that the ability could break rather than the number it actually did. Since break all is encoded as 0, it would ignore these abilities as if they'd broken nothing. 