### PR TITLE
Fix fawkes double charging

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1210,10 +1210,7 @@
                {:label "+X strength for the remainder of the run (using at least 1 stealth [Credits])"
                 :cost [:x-credits]
                 :prompt "How many credits?"
-                :effect (effect
-                          (continue-ability
-                            (strength-pump (cost-value eid :x-credits) (cost-value eid :x-credits) :end-of-run)
-                            card nil))
+                :effect (effect (pump card (cost-value eid :x-credits) :end-of-run))
                 :msg (msg "increase strength by " (cost-value eid :x-credits)
                           " for the remainder of the run")}]})
 

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2361,6 +2361,22 @@
         (click-card state :runner "Armitage Codebusting")
         (is (empty? (:prompt (get-runner))) "No trash-prevention prompt for resource")))))
 
+(deftest fawkes
+  ;; Fawkes
+  (testing "Costs the correct amount to pump"
+    (do-game (new-game {:runner {:hand ["Fawkes"] :credits 20}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Fawkes")
+    (let [fawkes (get-program state 0)]
+      (changes-val-macro 3 (get-strength (refresh fawkes))
+        "Strength was increased"
+        (card-ability state :runner fawkes 1)
+        (click-prompt state :runner "3"))
+      (changes-val-macro -3 (:credit (get-runner))
+        "Runner was charged correctly"
+        (card-ability state :runner fawkes 1)
+        (click-prompt state :runner "3"))))))
+
 (deftest femme-fatale
   ;; Femme Fatale
   (testing "Bypass functionality"

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2364,18 +2364,16 @@
 (deftest fawkes
   ;; Fawkes
   (testing "Costs the correct amount to pump"
-    (do-game (new-game {:runner {:hand ["Fawkes"] :credits 20}})
+    (do-game (new-game {:runner {:hand ["Fawkes" "Cloak"] :credits 20}})
     (take-credits state :corp)
     (play-from-hand state :runner "Fawkes")
-    (let [fawkes (get-program state 0)]
-      (changes-val-macro 3 (get-strength (refresh fawkes))
-        "Strength was increased"
-        (card-ability state :runner fawkes 1)
-        (click-prompt state :runner "3"))
-      (changes-val-macro -3 (:credit (get-runner))
+    (play-from-hand state :runner "Cloak")
+    (let [fawkes (get-program state 0) cloak (get-program state 1)]
+      (changes-val-macro -2 (:credit (get-runner))
         "Runner was charged correctly"
         (card-ability state :runner fawkes 1)
-        (click-prompt state :runner "3"))))))
+        (click-prompt state :runner "3")
+        (click-card state :runner cloak))))))
 
 (deftest femme-fatale
   ;; Femme Fatale


### PR DESCRIPTION
Fawkes double charges you when you try to pump it. This is due to its x-credit cost ability firing another ability that's given that same cost. 