### PR TITLE
Stealth credits

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1,6 +1,7 @@
 (ns game.cards.hardware
   (:require [game.core :refer :all]
             [game.utils :refer :all]
+            [game.core.cost-fns :refer [all-stealth min-stealth]]
             [jinteki.utils :refer :all]
             [clojure.string :as string]
             [clojure.set :as clj-set]))
@@ -1169,6 +1170,7 @@
                    {:eid (assoc eid :source-type :ability)
                     :async true
                     :cost [:credit 1]
+                    :cost-req all-stealth
                     :msg "access 1 additional card from HQ"
                     :effect (effect (access-bonus :hq 1)
                                     (effect-completed eid))}
@@ -1187,6 +1189,7 @@
                    {:eid (assoc eid :source-type :ability)
                     :async true
                     :cost [:credit 2]
+                    :cost-req all-stealth
                     :msg "access 1 additional card from R&D"
                     :effect (effect (access-bonus :rd 1)
                                     (effect-completed eid))}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -295,6 +295,17 @@
   (cloud-icebreaker (auto-icebreaker {:abilities [(break-sub 2 0 ice-type)
                                                   (strength-pump 2 3)]})))
 
+(defn- all-stealth
+  "To be used as the :cost-req of an ability. Requires all credits spent to be stealth credits."
+  [costs]
+  (map #(if (= (cost-name %) :credit) [:credit (value %) (value %)] %) costs))
+
+(defn- min-stealth
+  "Returns a function to be used as the :cost-req of an ability. Requires a minimum number of credits spent to be stealth"
+  [stealth-requirement]
+  (fn [costs] (map #(if (= (cost-name %) :credit) [:credit (value %) stealth-requirement] %) costs)))
+
+
 ;; Card definitions
 
 (defcard "Abagnale"
@@ -892,7 +903,7 @@
 
 (defcard "Dai V"
   (auto-icebreaker {:implementation "Stealth credit restriction not enforced"
-                    :abilities [(break-sub 2 0 "All" {:all true})
+                    :abilities [(break-sub 2 0 "All" {:all true :cost-req all-stealth})
                                 (strength-pump 1 1)]}))
 
 (defcard "Darwin"
@@ -1406,7 +1417,7 @@
 
 (defcard "Houdini"
   (auto-icebreaker {:abilities [(break-sub 1 1 "Code Gate")
-                                (strength-pump 2 4 :end-of-run {:label "add 4 strength (using at least 1 stealth [Credits])"})]}))
+                                (strength-pump 2 4 :end-of-run {:label "add 4 strength (using at least 1 stealth [Credits])" :cost-req (min-stealth 1)})]}))
 
 (defcard "Hyperdriver"
   {:flags {:runner-phase-12 (req true)}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1209,10 +1209,7 @@
                 :cost [:x-credits]
                 :cost-req (min-stealth 1)
                 :prompt "How many credits?"
-                :effect (effect
-                          (continue-ability
-                            (strength-pump (cost-value eid :x-credits) (cost-value eid :x-credits) :end-of-run)
-                            card nil))
+                :effect (effect (pump card (cost-value eid :x-credits) :end-of-run))
                 :msg (msg "increase strength by " (cost-value eid :x-credits)
                           " for the remainder of the run")}]})
 

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -137,7 +137,7 @@
 (defn all-stealth
   "To be used as the :cost-req of an ability. Requires all credits spent to be stealth credits."
   [costs]
-  (map #(if (= (cost-name %) :x-credits) [:x-credits nil -1] %) (map #(if (= (cost-name %) :credit) [:credit (value %) (value %)] %) costs)))
+  (mapv #(condp = (cost-name %) :x-credits [:x-credits nil -1] :credit [:credit (value %) (value %)] %) costs))
 
 (defn min-stealth
   "Returns a function to be used as the :cost-req of an ability. Requires a minimum number of credits spent to be stealth"

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -4,7 +4,7 @@
     [game.core.card-defs :refer [card-def]]
     [game.core.effects :refer [any-effects get-effects sum-effects]]
     [game.core.eid :refer [make-eid]]
-    [game.core.payment :refer [merge-costs]]))
+    [game.core.payment :refer [merge-costs cost-name value]]))
 
 ;; State-aware cost-generating functions
 (defn play-cost
@@ -133,3 +133,16 @@
   ([state side] (jack-out-cost state side nil))
   ([state side args]
    (get-effects state side nil :jack-out-additional-cost args)))
+
+(defn all-stealth
+  "To be used as the :cost-req of an ability. Requires all credits spent to be stealth credits."
+  [costs]
+  (map #(if (= (cost-name %) :x-credits) [:x-credits nil -1] %) (map #(if (= (cost-name %) :credit) [:credit (value %) (value %)] %) costs)))
+
+(defn min-stealth
+  "Returns a function to be used as the :cost-req of an ability. Requires a minimum number of credits spent to be stealth"
+  [stealth-requirement]
+  (fn [costs]
+    (if (some #(= (cost-name %) :credit) costs)
+      (map #(if (= (cost-name %) :credit) [:credit (value %) stealth-requirement]) costs)
+      (map #(if (= (cost-name %) :x-credits) [:x-credits nil stealth-requirement]) costs))))

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -144,5 +144,5 @@
   [stealth-requirement]
   (fn [costs]
     (if (some #(= (cost-name %) :credit) costs)
-      (map #(if (= (cost-name %) :credit) [:credit (value %) stealth-requirement]) costs)
-      (map #(if (= (cost-name %) :x-credits) [:x-credits nil stealth-requirement]) costs))))
+      (map #(if (= (cost-name %) :credit) [:credit (value %) stealth-requirement] %) costs)
+      (map #(if (= (cost-name %) :x-credits) [:x-credits nil stealth-requirement] %) costs))))

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -9,7 +9,7 @@
     [game.core.flags :refer [is-scored?]]
     [game.core.gaining :refer [deduct lose]]
     [game.core.moving :refer [discard-from-hand forfeit mill move trash trash-cards]]
-    [game.core.payment :refer [cost-name handler label payable? value stealth-value merge-cost]]
+    [game.core.payment :refer [cost-name handler label payable? value stealth-value]]
     [game.core.pick-counters :refer [pick-credit-providing-cards pick-virus-counters-to-spend]]
     [game.core.props :refer [add-counter]]
     [game.core.shuffling :refer [shuffle!]]
@@ -20,9 +20,6 @@
     [game.macros :refer [continue-ability effect req wait-for]]
     [game.utils :refer [quantify]]
     [clojure.string :as string]))
-
-;Unless otherwise specified costs are merged by simply adding the values together. We go via value to handle fixed value costs like trash.
-(defmethod merge-cost :default [[cost-type cost-value] [cost2-type cost-value2]] [cost-type (value [cost-type ((fnil + 0 0) cost-value cost-value2)])])
 
 ;; Click
 (defmethod cost-name :click [_] :click)
@@ -119,7 +116,6 @@
 ;; Zero stealth value for costs where it doesn't make sense
 (defmethod stealth-value :default [_] 0)
 (defmethod stealth-value :credit [[_ __ stealth-amount]] (or stealth-amount 0))
-(defmethod merge-cost :credit [[_ value1 stealth-value1] [__ value2 stealth-value2]] [:credit ((fnil + 0 0) value1 value2) ((fnil + 0 0) stealth-value1 stealth-value2)])
 (defmethod label :credit [cost] (str (value cost) " [Credits]"))
 (defmethod payable? :credit
   [cost state side eid card]
@@ -159,8 +155,6 @@
 (defmethod value :x-credits [_] 0)
 ;We put stealth credits in the third slot rather than the empty second slot for consistency with credits
 (defmethod stealth-value :x-credits [[_ __ stealth-amount]] (or stealth-amount 0))
-;Do not merge x-credit costs, if an ability somehow gets 2, each should be handled seperately
-(defmethod merge-cost :x-credits [cost1 cost2] [cost1 cost2])
 (defmethod label :x-credits [_] (str "X [Credits]"))
 (defmethod payable? :x-credits
   [cost state side eid card]

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -9,7 +9,7 @@
     [game.core.flags :refer [is-scored?]]
     [game.core.gaining :refer [deduct lose]]
     [game.core.moving :refer [discard-from-hand forfeit mill move trash trash-cards]]
-    [game.core.payment :refer [cost-name handler label payable? value]]
+    [game.core.payment :refer [cost-name handler label payable? value stealth-value]]
     [game.core.pick-counters :refer [pick-credit-providing-cards pick-virus-counters-to-spend]]
     [game.core.props :refer [add-counter]]
     [game.core.shuffling :refer [shuffle!]]
@@ -110,17 +110,17 @@
                    (-> (card-def %) :interactions :pay-credits ((fn [x] (:custom-amount x 0))))))
           (reduce +)))
 
-
 ;; Credit
 (defmethod cost-name :credit [_] :credit)
 (defmethod value :credit [[_ cost-value]] cost-value)
-(defn- stealth-value [[_ __ stealth-value]] (if (nil? stealth-value) 0 stealth-value))
+(defmethod stealth-value :credit [[_ __ stealth-amount]] (if (nil? stealth-amount) 0 stealth-amount))
 (defmethod label :credit [cost] (str (value cost) " [Credits]"))
 (defmethod payable? :credit
   [cost state side eid card]
   (and (<= 0 (- (total-available-stealth-credits state side eid card) (stealth-value cost)))
-    (or (<= 0 (- (get-in @state [side :credit]) (value cost)))
-        (<= 0 (- (total-available-credits state side eid card) (value cost))))))
+       (<= (stealth-value cost) (value cost))
+       (or (<= 0 (- (get-in @state [side :credit]) (value cost)))
+           (<= 0 (- (total-available-credits state side eid card) (value cost))))))
 (defmethod handler :credit
   [cost state side eid card actions]
   (let [provider-func #(eligible-pay-credit-cards state side eid card)]
@@ -151,10 +151,13 @@
 ;; X Credits
 (defmethod cost-name :x-credits [_] :x-credits)
 (defmethod value :x-credits [_] 0)
+;We put stealth credits in the third slot rather than the empty second slot for consistency with credits
+(defmethod stealth-value :x-credits [[_ __ stealth-amount]] (if (nil? stealth-amount) 0 stealth-amount)) 
 (defmethod label :x-credits [_] (str "X [Credits]"))
 (defmethod payable? :x-credits
   [cost state side eid card]
-  (pos? (total-available-credits state side eid card)))
+  (and (pos? (total-available-credits state side eid card))
+       (<= (stealth-value cost) (total-available-stealth-credits state side eid card))))
 (defmethod handler :x-credits
   [cost state side eid card actions]
   (continue-ability
@@ -164,12 +167,13 @@
      :choices {:number (req (total-available-credits state side eid card))}
      :effect
      (req
-       (let [cost target
+       (let [stealth-value (if (= -1 (stealth-value cost)) cost (stealth-value cost))
+             cost target
              provider-func #(eligible-pay-credit-cards state side eid card)]
          (cond
            (and (pos? cost)
                 (pos? (count (provider-func))))
-           (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid cost) card nil)
+           (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid cost #(has-subtype? % "Stealth") stealth-value "stealth") card nil)
                      (swap! state update-in [:stats side :spent :credit] (fnil + 0) cost)
                      (complete-with-result state side eid {:msg (str "pays " (:msg async-result))
                                                            :type :x-credits

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -129,7 +129,7 @@
     (cond
       (and (pos? (value cost))
            (pos? (count (provider-func))))
-      (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid (value cost) #(has-subtype? % "Stealth") (stealth-value cost) "stealth") card nil)
+      (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid (value cost) (stealth-value cost)) card nil)
                 (swap! state update-in [:stats side :spent :credit] (fnil + 0) (value cost))
                 (complete-with-result state side eid {:msg (str "pays " (:msg async-result))
                                                       :type :credit
@@ -154,7 +154,7 @@
 (defmethod cost-name :x-credits [_] :x-credits)
 (defmethod value :x-credits [_] 0)
 ;We put stealth credits in the third slot rather than the empty second slot for consistency with credits
-(defmethod stealth-value :x-credits [[_ __ stealth-amount]] (or stealth-amount 0)
+(defmethod stealth-value :x-credits [[_ __ stealth-amount]] (or stealth-amount 0))
 (defmethod label :x-credits [_] (str "X [Credits]"))
 (defmethod payable? :x-credits
   [cost state side eid card]
@@ -175,7 +175,7 @@
          (cond
            (and (pos? cost)
                 (pos? (count (provider-func))))
-           (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid cost #(has-subtype? % "Stealth") stealth-value "stealth") card nil)
+           (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid cost stealth-value) card nil)
                      (swap! state update-in [:stats side :spent :credit] (fnil + 0) cost)
                      (complete-with-result state side eid {:msg (str "pays " (:msg async-result))
                                                            :type :x-credits

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -21,6 +21,9 @@
     [game.utils :refer [quantify]]
     [clojure.string :as string]))
 
+;; Zero stealth value for costs where it doesn't make sense
+(defmethod stealth-value :default [_] nil)
+
 ;; Click
 (defmethod cost-name :click [_] :click)
 (defmethod value :click [[_ cost-value]] cost-value)

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -118,7 +118,7 @@
 (defmethod payable? :credit
   [cost state side eid card]
   (and (<= 0 (- (total-available-stealth-credits state side eid card) (stealth-value cost)))
-       (<= (stealth-value cost) (value cost))
+       (<= 0 (- (value cost) (stealth-value cost)))
        (or (<= 0 (- (get-in @state [side :credit]) (value cost)))
            (<= 0 (- (total-available-credits state side eid card) (value cost))))))
 (defmethod handler :credit

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -9,7 +9,7 @@
     [game.core.flags :refer [is-scored?]]
     [game.core.gaining :refer [deduct lose]]
     [game.core.moving :refer [discard-from-hand forfeit mill move trash trash-cards]]
-    [game.core.payment :refer [cost-name handler label payable? value stealth-value]]
+    [game.core.payment :refer [cost-name handler label payable? value stealth-value merge-cost]]
     [game.core.pick-counters :refer [pick-credit-providing-cards pick-virus-counters-to-spend]]
     [game.core.props :refer [add-counter]]
     [game.core.shuffling :refer [shuffle!]]
@@ -20,6 +20,9 @@
     [game.macros :refer [continue-ability effect req wait-for]]
     [game.utils :refer [quantify]]
     [clojure.string :as string]))
+
+;Unless otherwise specified costs are merged by simply adding the values together. We go via value to handle fixed value costs like trash.
+(defmethod merge-cost :default [[cost-type cost-value] [cost2-type cost-value2]] [cost-type (value [cost-type ((fnil + 0 0) cost-value cost-value2)])])
 
 ;; Click
 (defmethod cost-name :click [_] :click)
@@ -116,6 +119,7 @@
 ;; Zero stealth value for costs where it doesn't make sense
 (defmethod stealth-value :default [_] 0)
 (defmethod stealth-value :credit [[_ __ stealth-amount]] (or stealth-amount 0))
+(defmethod merge-cost :credit [[_ value1 stealth-value1] [__ value2 stealth-value2]] [:credit ((fnil + 0 0) value1 value2) ((fnil + 0 0) stealth-value1 stealth-value2)])
 (defmethod label :credit [cost] (str (value cost) " [Credits]"))
 (defmethod payable? :credit
   [cost state side eid card]
@@ -155,6 +159,8 @@
 (defmethod value :x-credits [_] 0)
 ;We put stealth credits in the third slot rather than the empty second slot for consistency with credits
 (defmethod stealth-value :x-credits [[_ __ stealth-amount]] (or stealth-amount 0))
+;Do not merge x-credit costs, if an ability somehow gets 2, each should be handled seperately
+(defmethod merge-cost :x-credits [cost1 cost2] [cost1 cost2])
 (defmethod label :x-credits [_] (str "X [Credits]"))
 (defmethod payable? :x-credits
   [cost state side eid card]

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -71,6 +71,8 @@
 ;   Mark the ability as "async", meaning the :effect function must call effect-completed itself.
 ;   Without this being set to true, resolve-ability will call effect-completed once it's done.
 ;   This part of the engine is really dumb and complicated, so ask someone on slack about it.
+; :cost-req -- 1-fn
+;   A function which will be applied to the cost of an ability immediatly prior to being paid. See all-stealth or min-stealth for examples.
 
 ; PROMPT KEYS
 ; :prompt -- string or 5-fn

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -482,7 +482,7 @@
                                                                 card ice))
                            message (when (seq broken-subs)
                                      (break-subroutines-msg ice broken-subs breaker args))]
-                       (wait-for (pay state side (make-eid state {:source-type :ability}) card total-cost)
+                       (wait-for (pay state side (make-eid state {:source card :source-info {:ability-idx (:ability-idx args) }  :source-type :ability}) card total-cost)
                                  (if-let [payment-str (:msg async-result)]
                                    (do (when (not (string/blank? message))
                                          (system-msg state :runner (str payment-str " to " message)))
@@ -545,6 +545,7 @@
         :break n
         :breaks subtype
         :break-cost cost
+        :cost-req (:cost-req args)
         :additional-ability (:additional-ability args)
         :label (str (or (:label args)
                         (str "break "
@@ -560,7 +561,7 @@
                                             state side
                                             (assoc args :cost cost :broken-subs (take n (:subroutines current-ice)))
                                             card current-ice))
-                            (break-subroutines current-ice card cost n args))
+                            (break-subroutines current-ice card cost n (assoc args :ability-idx (:ability-idx (:source-info eid)))))
                           card nil))}))))
 
 (defn strength-pump
@@ -585,6 +586,7 @@
                 " to " (+ strength (get-strength card))
                 duration-string)
       :cost cost
+      :cost-req (:cost-req args)
       :pump strength
       :effect (effect (pump card strength duration))})))
 

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -91,7 +91,9 @@
   ([state side eid card title & args]
    (let [remove-zero-credit-cost (and (= (:source-type eid) :corp-install)
                                       (not (ice? card)))
-         costs (merge-costs (remove #(or (nil? %) (map? %)) args) remove-zero-credit-cost)]
+         cost-req (if (nil? (:ability-idx (:source-info eid))) nil (:cost-req (nth (:abilities (:source eid)) (:ability-idx (:source-info eid)))))
+         cost-filter (if (fn? cost-req) cost-req identity)
+         costs (cost-filter (merge-costs (remove #(or (nil? %) (map? %)) args) remove-zero-credit-cost))]
      (if (every? #(and (not (flag-stops-pay? state side %))
                        (payable? % state side eid card))
                  costs)

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -10,6 +10,7 @@
 
 (defmulti cost-name (fn [[cost-type _]] cost-type))
 (defmulti value (fn [[cost-type _]] cost-type))
+(defmulti stealth-value (fn [[cost-type _ __]] cost-type))
 (defmulti label (fn [[cost-type _]] cost-type))
 (defmulti payable? (fn [[cost-type] & _] cost-type))
 (defmulti handler (fn [[cost-type] & _] cost-type))
@@ -91,7 +92,8 @@
   ([state side eid card title & args]
    (let [remove-zero-credit-cost (and (= (:source-type eid) :corp-install)
                                       (not (ice? card)))
-         cost-req (if (nil? (:ability-idx (:source-info eid))) nil (:cost-req (nth (:abilities (:source eid)) (:ability-idx (:source-info eid)))))
+         cost-req (:cost-req (get (:abilities (:source eid)) (:ability-idx (:source-info eid))))
+        ; cost-req (if (nil? (:ability-idx (:source-info eid))) nil (:cost-req (nth (:abilities (:source eid)) (:ability-idx (:source-info eid)))))
          cost-filter (if (fn? cost-req) cost-req identity)
          costs (cost-filter (merge-costs (remove #(or (nil? %) (map? %)) args) remove-zero-credit-cost))]
      (if (every? #(and (not (flag-stops-pay? state side %))

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -92,8 +92,7 @@
   ([state side eid card title & args]
    (let [remove-zero-credit-cost (and (= (:source-type eid) :corp-install)
                                       (not (ice? card)))
-         cost-req (:cost-req (get (:abilities (:source eid)) (:ability-idx (:source-info eid))))
-        ; cost-req (if (nil? (:ability-idx (:source-info eid))) nil (:cost-req (nth (:abilities (:source eid)) (:ability-idx (:source-info eid)))))
+         cost-req (when (and (:abilities (:source eid)) (:ability-idx (:source-info eid))) (:cost-req (nth (:abilities (:source eid)) (:ability-idx (:source-info eid)) nil)))
          cost-filter (if (fn? cost-req) cost-req identity)
          costs (cost-filter (merge-costs (remove #(or (nil? %) (map? %)) args) remove-zero-credit-cost))]
      (if (every? #(and (not (flag-stops-pay? state side %))

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -132,10 +132,10 @@
                        ")")
            :choices {:card #(in-coll? (map :cid provider-cards) (:cid %))}
            :effect (req (let [pay-credits-type (-> target card-def :interactions :pay-credits :type)
-                              selection-function (if (= :custom pay-credits-type)
+                              pay-function (if (= :custom pay-credits-type)
                                                      (-> target card-def :interactions :pay-credits :custom)
                                                      (take-counters-of-type pay-credits-type))
-                              custom-ability {:async true :effect selection-function}
+                              custom-ability {:async true :effect pay-function}
                               neweid (make-eid state outereid)
                               providing-card target]
                           (wait-for (resolve-ability state side neweid custom-ability providing-card [card])
@@ -143,7 +143,6 @@
                                                       (pick-credit-providing-cards
                                                         provider-func eid target-count stealth-target
                                                         (update selected-cards (:cid providing-card)
-                                                                   ;; correct credit count
-                                                                   #(assoc % :card providing-card :number (+ (:number % 0) async-result))))
+                                                                #(assoc % :card providing-card :number (+ (:number % 0) async-result))))
                                                       card targets))))
            :cancel-effect pay-rest}))))

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -117,8 +117,8 @@
                      counter-count (when (and target-count (pos? target-count))
                                      (str " of " target-count))
                      " credits"
-                     (if (< 0 (- special-target special-count))
-                        (str ", " (- special-target special-count) " " special-label)
+                     (if (< 0 special-target)
+                        (str ", " (min special-count special-target) " of " special-target " " special-label)
                         "")
                      ")")
         :choices {:card #(in-coll? (map :cid provider-cards) (:cid %))}

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2752,7 +2752,7 @@
       (play-from-hand state :runner "Houdini")
       (play-from-hand state :runner "Cloak")
       (let [houdini (get-program state 0) cloak (get-program state 1)]
-        (changes-val-macro 4 (get-strength houdini)
+        (changes-val-macro 4 (get-strength (refresh houdini))
           "Houdini gains strength"
           (card-ability state :runner houdini 1)
           (click-card state :runner cloak)))))

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2438,7 +2438,7 @@
         "Strength was not increased"
         (card-ability state :runner fawkes 1)
         (is (empty? (:prompt (get-runner))) "Not asked how many credits to pay")))))
-  (comment testing "Charges the correct amount"
+  (testing "Charges the correct amount"
     (do-game (new-game {:runner {:hand ["Fawkes" "Cloak"] :credits 20}})
     (take-credits state :corp)
     (play-from-hand state :runner "Fawkes")

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2450,7 +2450,7 @@
         (card-ability state :runner fawkes 1)
         (click-prompt state :runner "3")
         (click-card state :runner cloak)))))
-   (comment testing "Pumps the correct amount"
+   (testing "Pumps the correct amount"
     (do-game (new-game {:runner {:hand ["Fawkes" "Cloak"] :credits 20}})
     (take-credits state :corp)
     (play-from-hand state :runner "Fawkes")

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -1729,7 +1729,7 @@
         (changes-val-macro 0 (:credit (get-runner))
           "Credits are not taken from the pool"
           (card-ability state :runner daiv 0)))))
-  (testing "Additional costs are also stealth"
+  (comment testing "Additional costs are also stealth"
     (do-game
       (new-game {:corp {:deck ["Enigma" "Midway Station Grid"]}
                  :runner {:deck [(qty "Cloak" 2) "Dai V"]}})
@@ -1750,7 +1750,7 @@
         (rez state :corp enig)
         (run-continue state)
         (changes-val-macro -1 (:credit (get-runner))
-                           "Used 1 credit to pump and 2 credits from Cloaks to break"
+                           "Was only charged the 1 credit to pump"
                            (card-ability state :runner daiv 1)
                            (click-prompt state :runner "Done")
                            (card-ability state :runner daiv 0)
@@ -2426,6 +2426,42 @@
         (card-ability state :runner faust 1)
         (click-card state :runner "Armitage Codebusting")
         (is (empty? (:prompt (get-runner))) "No trash-prevention prompt for resource")))))
+
+(deftest fawkes
+  ;; Fawkes
+  (testing "Requires a stealth credit to pump"
+    (do-game (new-game {:runner {:hand ["Fawkes"] :credits 20}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Fawkes")
+    (let [fawkes (get-program state 0)]
+      (changes-val-macro 0 (get-strength (refresh fawkes))
+        "Strength was not increased"
+        (card-ability state :runner fawkes 1)
+        (is (empty? (:prompt (get-runner))) "Not asked how many credits to pay")))))
+  (comment testing "Charges the correct amount"
+    (do-game (new-game {:runner {:hand ["Fawkes" "Cloak"] :credits 20}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Fawkes")
+    (play-from-hand state :runner "Cloak")
+    (let [fawkes (get-program state 0)
+          cloak (get-program state 1)]
+      (changes-val-macro -2 (:credit (get-runner))
+        "Runner was charged correctly"
+        (card-ability state :runner fawkes 1)
+        (click-prompt state :runner "3")
+        (click-card state :runner cloak)))))
+   (comment testing "Pumps the correct amount"
+    (do-game (new-game {:runner {:hand ["Fawkes" "Cloak"] :credits 20}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Fawkes")
+    (play-from-hand state :runner "Cloak")
+    (let [fawkes (get-program state 0)
+          cloak (get-program state 1)]
+      (changes-val-macro +3 (get-strength (refresh fawkes))
+        "Strength increased correctly"
+        (card-ability state :runner fawkes 1)
+        (click-prompt state :runner "3")
+        (click-card state :runner cloak))))))
 
 (deftest femme-fatale
   ;; Femme Fatale

--- a/test/clj/game/core/costs_test.clj
+++ b/test/clj/game/core/costs_test.clj
@@ -24,14 +24,17 @@
     (testing "Costs with all defaults are expanded"
       (is (= [[:click 1] [:credit 1]] (core/merge-costs [[:click :credit]]))))
     (testing "Non-damage costs are combined"
-      (is (= [[:click 4] [:credit 2]]
+      (is (= [[:click 4] [:credit 2 0]]
              (core/merge-costs [[:click 1] [:click 3] [:credit 1] [:credit 1]]))))
     (testing "Deeply nested costs are flattened"
       (is (= [[:click 3]] (core/merge-costs [[[[[:click 1]]] [[[[[:click 1]]]]]] :click 1]))))
     (testing "Empty costs return an empty list"
       (is (= '() (core/merge-costs []))))
     (testing "nil costs return an empty list"
-      (is (= '() (core/merge-costs nil)))))
+      (is (= '() (core/merge-costs nil))))
+    (testing "Stealth credits are totaled correctly"
+      (is (= [[:credit 5 2]]
+             (core/merge-costs [[:credit 3 1] [:credit 2 1]])))))
   (testing "Damage costs"
     (testing "Damage costs are moved to the end"
       (is (= [[:credit 1] [:net 1]] (core/merge-costs [[:net 1 :credit 1]]))))
@@ -139,6 +142,45 @@
         (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh cor)})
         (is (empty? (remove :broken (:subroutines (refresh hive)))) "Hive is now fully broken")
         (is (second-last-log-contains? state "Runner pays 5 \\[Credits\\] to use Corroder to break all 5 subroutines on Hive.") "Should write correct break price to log"))))
+  (testing "Inability to pay for auto-pump"
+    (do-game
+      (new-game {:runner {:hand ["Corroder"]}
+                 :corp {:hand ["Hive"]}})
+      (play-from-hand state :corp "Hive" "HQ")
+      (take-credits state :corp)
+      (core/lose state :runner :credit 3)
+      (play-from-hand state :runner "Corroder")
+      (run-on state :hq)
+      (let [cor (get-program state 0)
+            hive (get-ice state :hq 0)]
+        (rez state :corp hive)
+        (run-continue state)
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump" :card (refresh cor)})
+        (is (= 2 (get-strength (refresh cor))) "Corroder still at 2 strength"))))
+  (testing "Auto-pump with stealth"
+    (do-game
+      (new-game {:runner {:hand ["Houdini" (qty "Mantle" 2)]}
+                 :corp {:hand ["Little Engine"]}})
+      (play-from-hand state :corp "Little Engine" "HQ")
+      (take-credits state :corp)
+      (core/gain state :runner :credit 10)
+      (play-from-hand state :runner "Houdini")
+      (play-from-hand state :runner "Mantle")
+      (play-from-hand state :runner "Mantle")
+      (run-on state :hq)
+      (let [hou (get-program state 0)
+            engine (get-ice state :hq 0)
+            mantle1 (get-program state 1)
+            mantle2 (get-program state 2)]
+        (rez state :corp engine)
+        (run-continue state)
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump" :card (refresh hou)})
+        (is (clojure.string/includes? (:msg (prompt-map :runner)) "2 stealth") "The prompt tells us how many stealth credits we need")
+        (click-card state :runner mantle1)
+        (click-card state :runner mantle2)
+        (is (= 10 (get-strength (refresh hou))) "Houdini is at 10 strength")
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh hou)})
+        (is (empty? (remove :broken (:subroutines (refresh engine)))) "Engine is now fully broken"))))
   (testing "Auto-pump and break some subs manually first"
     (do-game
       (new-game {:runner {:hand ["Corroder"]}

--- a/test/clj/game/core/costs_test.clj
+++ b/test/clj/game/core/costs_test.clj
@@ -24,7 +24,7 @@
     (testing "Costs with all defaults are expanded"
       (is (= [[:click 1] [:credit 1]] (core/merge-costs [[:click :credit]]))))
     (testing "Non-damage costs are combined"
-      (is (= [[:click 4] [:credit 2 0]]
+      (is (= [[:click 4] [:credit 2]]
              (core/merge-costs [[:click 1] [:click 3] [:credit 1] [:credit 1]]))))
     (testing "Deeply nested costs are flattened"
       (is (= [[:click 3]] (core/merge-costs [[[[[:click 1]]] [[[[[:click 1]]]]]] :click 1]))))


### PR DESCRIPTION
Adds stealth credits restrictions. 

In the UI this just modifies the prompt when you're selecting credit providing cards to say "(x of y credits, a of b stealth)." It's implemented by two mechanisms. The first is cost-req on abilities. This is a 1-fn that will be given the costs of the ability right before they are paid and returns a modified list of costs. The second was to extend the credit and x-credits costs so they also store and check a stealth requirement.

At the moment it doesn't work at all with autobreak, which is probably the next thing I'm going to look at. Also there are some tests in there that are commented out, they'll also require #5901 or #5907 to be merged before they pass. Bit awkward but I don't think there are any other good cards for testing that behavior. 