### PR TITLE
Runner can only spend virus counters on their cards

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -453,7 +453,7 @@
      :req (req (and (not (:disabled card))
                     (not (agenda? target))
                     (<= (play-cost state side target)
-                        (number-of-virus-counters state))))
+                        (number-of-runner-virus-counters state))))
      :waiting-prompt "Runner to use Freedom Khumalo's ability"
      :effect (req (let [accessed-card target
                         play-or-rez (:cost target)]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2761,7 +2761,7 @@
                        :optional
                        {:prompt "Spend 2 virus counters on The Nihilist?"
                         :yes-ability
-                        {:req (req (<= 2 (number-of-virus-counters state)))
+                        {:req (req (<= 2 (number-of-runner-virus-counters state)))
                          :async true
                          :effect (req (wait-for (resolve-ability state side (pick-virus-counters-to-spend 2) card nil)
                                                 (if (:number async-result)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -733,7 +733,8 @@
   [game.core.virus
    count-virus-programs
    get-virus-counters
-   number-of-virus-counters]
+   number-of-virus-counters
+   number-of-runner-virus-counters]
 
   [game.core.winning
    check-win-by-agenda

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -1,6 +1,6 @@
 (ns game.core.pick-counters
   (:require
-    [game.core.card :refer [get-card get-counters installed?]]
+    [game.core.card :refer [get-card get-counters installed? runner?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.eid :refer [effect-completed make-eid complete-with-result]]
     [game.core.engine :refer [resolve-ability trigger-event-sync]]
@@ -40,7 +40,7 @@
                                 (= "Hivemind" (:title %)))
                             true)
                           (installed? %)
-                          (= "Runner" (:side %))
+                          (runner? %)
                           (pos? (get-counters % :virus)))}
     :effect (req (let [target (update! state :runner (update-in target [:counter :virus] dec))
                        selected-cards (update selected-cards (:cid target)

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -40,6 +40,7 @@
                                 (= "Hivemind" (:title %)))
                             true)
                           (installed? %)
+                          (= "Runner" (:side %))
                           (pos? (get-counters % :virus)))}
     :effect (req (let [target (update! state :runner (update-in target [:counter :virus] dec))
                        selected-cards (update selected-cards (:cid target)

--- a/src/clj/game/core/virus.clj
+++ b/src/clj/game/core/virus.clj
@@ -1,6 +1,6 @@
 (ns game.core.virus
   (:require
-    [game.core.board :refer [all-active-installed get-all-installed]]
+    [game.core.board :refer [all-active-installed get-all-installed all-installed]]
     [game.core.card :refer [get-counters virus-program?]]))
 
 (defn get-virus-counters
@@ -19,3 +19,8 @@
   "Returns number of actual virus counters (excluding virtual counters from Hivemind)"
   [state]
   (reduce + (map #(get-counters % :virus) (get-all-installed state))))
+
+(defn number-of-runner-virus-counters
+  "Returns the number of actual virus counters on Runner cards (excluding virtual counters from Hivemind)"
+  [state]
+  (reduce + (map #(get-counters % :virus) (all-installed state :runner))))

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -44,7 +44,23 @@
         (changes-val-macro 3 (:credit (get-runner))
                            "Runner got Acacia credits"
                            (click-prompt state :runner "Done"))
-        (is (zero? (count (:discard (get-runner)))) "Acacia has not been trashed")))))
+        (is (zero? (count (:discard (get-runner)))) "Acacia has not been trashed"))))
+  (testing "Effect counts both Runner and Corp virus counters"
+    (do-game
+      (new-game {:runner {:deck ["Acacia"]}
+                 :corp {:deck ["Sandstone"]}})
+      (play-from-hand state :corp "Sandstone" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Acacia")
+      (take-credits state :runner)
+      (let [sandstone (get-ice state :hq 0)]
+        (rez state :corp sandstone)
+        (core/add-counter state :corp sandstone :virus 1)
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone has 1 virus counter")
+        (is (= 7 (:credit (get-runner))) "Runner credits should be 7")
+        (core/purge state :corp)
+        (click-prompt state :runner "Yes")
+        (is (= 8 (:credit (get-runner))) "Runner gained 1 credit from Sandstone's virus counter")))))
 
 (deftest adjusted-matrix
   ;; Adjusted Matrix

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -1293,7 +1293,26 @@
       (play-from-hand state :runner "Cache")
       (run-empty-server state "HQ")
       (is (= 1 (count (prompt-buttons :runner))) "Should only have 1 option")
-      (is (= ["No action"] (prompt-buttons :runner)) "Only option should be 'Done'"))))
+      (is (= ["No action"] (prompt-buttons :runner)) "Only option should be 'Done'")))
+  (testing "Cannot remove virus counters from Corp cards"
+    (do-game
+      (new-game {:runner {:id "Freedom Khumalo: Crypto-Anarchist"
+                          :deck ["Cache"]}
+                 :corp {:deck ["Sandstone" "Ice Wall"]}})
+      (play-from-hand state :corp "Sandstone" "R&D")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Cache")
+      (let [sandstone (get-ice state :rd 0)]
+        (rez state :corp sandstone)
+        (run-on state "R&D")
+        (run-continue state)
+        (card-subroutine state :corp sandstone 0)
+        (is (not (:run @state)) "Run Ended")
+        (run-empty-server state "HQ")
+        (click-prompt state :runner "[Freedom Khumalo] Trash card")
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone has 1 virus counter")
+        (click-card state :runner (refresh sandstone))
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone should still have 1 virus counter")))))
 
 (deftest gabriel-santiago-consummate-professional
   ;; Gabriel Santiago - Gain 2c on first successful HQ run each turn

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -1312,7 +1312,20 @@
         (click-prompt state :runner "[Freedom Khumalo] Trash card")
         (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone has 1 virus counter")
         (click-card state :runner (refresh sandstone))
-        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone should still have 1 virus counter")))))
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone should still have 1 virus counter"))))
+  (testing "Ability activation trigger only counts Runner virus counters"
+    (do-game
+      (new-game {:runner {:id "Freedom Khumalo: Crypto-Anarchist"}
+                 :corp {:deck ["Sandstone" "Ice Wall"]}})
+      (play-from-hand state :corp "Sandstone" "R&D")
+      (let [sandstone (get-ice state :rd 0)]
+        (rez state :corp sandstone)
+        (core/add-counter state :corp sandstone :virus 1)
+        (take-credits state :corp)
+        (run-empty-server state "HQ")
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone has 1 virus counter")
+        (is (= 1 (count (prompt-buttons :runner))) "Should only have 1 option")
+        (is (= ["No action"] (prompt-buttons :runner)) "Only option should be 'Done'")))))
 
 (deftest gabriel-santiago-consummate-professional
   ;; Gabriel Santiago - Gain 2c on first successful HQ run each turn

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -5183,7 +5183,25 @@
         (click-prompt state :runner "Yes") ; spend 2 tokens?
         (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone has 1 virus counter")
         (click-card state :runner (refresh sandstone))
-        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone should still have 1 virus counter")))))
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone should still have 1 virus counter"))))
+  (testing "Ability activation trigger only counts Runner virus counters"
+    (do-game
+      (new-game {:runner {:deck ["The Nihilist"]}
+                 :corp {:deck ["Sandstone"]}})
+      (starting-hand state :runner ["The Nihilist"])
+      (starting-hand state :corp ["Sandstone"])
+      (play-from-hand state :corp "Sandstone" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Nihilist")
+      (take-credits state :runner)
+      (let [sandstone (get-ice state :hq 0)
+            nihilist (get-resource state 0)]
+        (rez state :corp sandstone)
+        (core/purge state :corp)
+        (core/add-counter state :corp sandstone :virus 2)
+        (is (= 0 (get-counters (refresh nihilist) :virus)) "The Nihilist has 0 virus counters")
+        (is (= 2 (get-counters (refresh sandstone) :virus)) "Sandstone has 2 virus counters")
+        (is (= 0 (count (prompt-buttons :runner))) "The Nihilist did not trigger")))))
 
 (deftest the-shadow-net
   ;; The Shadow Net

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -5161,7 +5161,29 @@
        (take-credits state :runner)
        (core/purge state :corp)
        (take-credits state :corp)
-       (is (seq (:prompt (get-runner))) "Runner gets a prompt cuz we don't know what they have")))))
+       (is (seq (:prompt (get-runner))) "Runner gets a prompt cuz we don't know what they have"))))
+  (testing "Cannot remove virus counters from Corp cards"
+    (do-game
+      (new-game {:runner {:deck ["The Nihilist" "Cache"]}
+                 :corp {:deck [(qty "Sandstone" 10)]}})
+      (starting-hand state :runner ["The Nihilist" "Cache"])
+      (starting-hand state :corp ["Sandstone"])
+      (play-from-hand state :corp "Sandstone" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Nihilist")
+      (play-from-hand state :runner "Cache")
+      (let [sandstone (get-ice state :hq 0)]
+        (rez state :corp sandstone)
+        (run-on state "HQ")
+        (run-continue state)
+        (card-subroutine state :corp sandstone 0)
+        (is (not (:run @state)) "Run Ended")
+        (take-credits state :runner)
+        (take-credits state :corp)
+        (click-prompt state :runner "Yes") ; spend 2 tokens?
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone has 1 virus counter")
+        (click-card state :runner (refresh sandstone))
+        (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone should still have 1 virus counter")))))
 
 (deftest the-shadow-net
   ;; The Shadow Net


### PR DESCRIPTION
Now that we have a Corp card that has virus counters on it (Sandstone), we needed to filter out corp cards when selecting cards to take virus counters from via The Nihilist or Freedom. 

Another issue I discovered while looking into this is that several cards including The Nihilist and Freedom use the function "number-of-virus-counters" in game.core.virus to determine if they should be able to activate their abilities. That function includes viruses on Corp cards as well which means The Nihilist will trigger if Sandstone has 2 virus counters. We'll want to make a new function or pass in an additional parameter so we only check for runner viruses where appropriate. 