### PR TITLE
Rely on clojure to compile required code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -76,11 +76,8 @@
   ;; Compilation.
   :source-paths ["src/clj" "src/cljs/nr" "src/cljc"]
   ;; aot only the namespaces needed for the main game in uberjar, notably ignoring the test and (most of the) task namespaces.
-  :aot [#"game\.*"
-        #"web\.*"
-        #"tasks.fetch"
-        #"jinteki\.*"
-        #"web.core"]
+  :aot [#"web.core"
+        #"tasks.fetch"]
   :jar-name "netrunner.jar"
   :jar-exclusions [#"public/img/cards/*"]
   :uberjar-name "netrunner-standalone.jar"


### PR DESCRIPTION
A long time ago (#5258, #5263), I tried to implement the cost multimethods as records + protocols but ran into issues where `lein uberjar` would compile the records and protocols twice, leading to unsolvable issues (as described here: https://clojure.atlassian.net/browse/CLJ-1544). However, it turns out that all I had to do was stop AOT compiling all of the code, relying on Clojure's ability to compile the necessary code through `require` blocks.

I feel real dumb, but I'm glad to have this solved lol.