### PR TITLE
Fix Gatekeeper message. It now includes origin of chosen cards (issue 5753)

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1469,9 +1469,24 @@
                                            (effect-completed state :corp eid)))
                             :cancel-effect (effect (shuffle! :deck)
                                                    (effect-completed eid))
-                            :msg (msg "add "
-                                      (str (string/join ", " (map :title targets)))
-                                      " to R&D")}
+                            :msg (msg
+                                   "shuffle "
+                                   (string/join
+                                     " and "
+                                     (filter identity
+                                             [(when-let [h (->> targets
+                                                                (filter in-hand?)
+                                                                (map :title)
+                                                                not-empty)]
+                                                (str (enumerate-str h)
+                                                     " from HQ"))
+                                              (when-let [d (->> targets
+                                                                (filter in-discard?)
+                                                                (map :title)
+                                                                not-empty)]
+                                                (str (enumerate-str d)
+                                                     " from Archives"))]))
+                                   " into R&D")}
         draw-reveal-shuffle {:async true
                              :label "Draw cards, reveal and shuffle agendas"
                              :effect (req (wait-for (resolve-ability state side draw-ab card nil)

--- a/src/clj/game/utils.clj
+++ b/src/clj/game/utils.clj
@@ -177,6 +177,15 @@
   ([n string single-suffix plural-suffix]
    (str n " " (pluralize string single-suffix plural-suffix n))))
 
+(defn enumerate-str
+  "Joins a collection to a string, seperated by commas and 'and' in front of
+  the last item. If collection only has one item, justs returns that item
+  without seperators. Returns an empty string if coll is empty."
+  [coll]
+  (string/join " and "
+               (remove empty?
+                       [(string/join ", " (butlast coll)) (last coll)])))
+
 (defn in-coll?
   "true if coll contains elm"
   [coll elm]


### PR DESCRIPTION
Closes #5753.

I changed the message of Gatekeeper's first sub to include the zone (HQ or
Archives) of the chosen Agendas. It now works basically the same way
as Attitude Adjustment.

Which made me wonder if this should be a seperate function
`reveal-and-shuffle-into-rd-effect`, or even if `game.core.shuffling/shuffle-into-rd-effect` could
be enhanced. But AFIK only Attitude Adjustment and Drudge Work reveal and
shuffle from Archives and/or HQ. And these also have an additional credit gain
effect.

Maybe the `enemurate-str` helper function could be useful somewhere else. But I 
can also just do that in the card definition.
