### PR TITLE
changed calls to is' with potential to print the whole state

### DIFF
--- a/test/clj/game/core_test.clj
+++ b/test/clj/game/core_test.clj
@@ -439,7 +439,7 @@
     (when (and (:run @state)
                (= [server] (get-in @state [:run :server]))
                (run-continue state))
-      (is' (some? (not-empty (get-in @state [:runner :prompt]))) "A prompt is shown")
+      (is' (seq (get-in @state [:runner :prompt])) "A prompt is shown")
       (is' (true? (get-in @state [:run :successful])) "Run is marked successful"))))
 
 (defmacro play-run-event

--- a/test/clj/game/core_test.clj
+++ b/test/clj/game/core_test.clj
@@ -439,8 +439,8 @@
     (when (and (:run @state)
                (= [server] (get-in @state [:run :server]))
                (run-continue state))
-      (is' (get-in @state [:runner :prompt]) "A prompt is shown")
-      (is' (get-in @state [:run :successful]) "Run is marked successful"))))
+      (is' (some? (not-empty (get-in @state [:runner :prompt]))) "A prompt is shown")
+      (is' (true? (get-in @state [:run :successful])) "Run is marked successful"))))
 
 (defmacro play-run-event
   "Play a run event with a replace-access effect on an unprotected server.

--- a/test/clj/game/utils_test.clj
+++ b/test/clj/game/utils_test.clj
@@ -90,10 +90,9 @@
                       " matching cards. Current prompt is: n" prompt)))))
       ;; Prompt isn't a select so click-card shouldn't be used
       (not (prompt-is-type? state side :select))
-      (let [prompt (prompt-is-type? state side :select)]
-        (is' (prompt-is-type? state side :select)
-             (str "click-card should only be used with prompts "
-                  "requiring the user to click on cards on table")))
+      (is' (true? (prompt-is-type? state side :select))
+           (str "click-card should only be used with prompts "
+                "requiring the user to click on cards on table"))
       ;; Prompt is a select, but card isn't correct type
       (not (or (map? card)
                (string? card)))


### PR DESCRIPTION
When `game.utils-test/is'` is called with a function in the first
position of the assertion (like in `(is' (prompt-is-type? state side
:select))`) and that test fails, the sub-forms of the assertion finally
get evaluated in `game.utils-test/error-wrapper` when given to
`do-report`. If state is one of those sub-forms, the whole state appears
in the report.

If tests get run in the repl or with lein, the whole state gets printed
into the console or log. `lein test` even crashes with a Java
OutOfMemory error after a while.

To prevent this, for all of the occurences of that pattern, we test the
assertion indirectly.

In addidtion, the test if a prompt is shown in `play-run-event-impl` did
not return an exception when no prompt is shown (because `(get-in @state
[:runner :prompt])` returns an empty list, when no prompt is shown).