### PR TITLE
Fixes atmans counters being payable with the wrong type of recurring credits

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -407,12 +407,11 @@
                                               (continue :runner nil))}]}))
 
 (defcard "Atman"
-  {:on-install {:prompt "How many power counters?"
-                :choices {:number (req (total-available-credits state :runner eid card))}
-                :msg (msg "add " target " power counters")
-                :async true
-                :effect (effect (add-counter card :power target)
-                                (lose-credits eid target))}
+  {:on-install {:effect (effect
+                          (continue-ability {:eid (assoc eid :source-type :ability :source card)
+                                             :cost [:x-credits]
+                                             :msg (msg "add " (cost-value eid :x-credits) " power counters")
+                                             :effect (effect (add-counter card :power (cost-value eid :x-credits)))} card targets))}
    :abilities [(break-sub 1 1 "All" {:req (req (= (get-strength current-ice) (get-strength card)))})]
    :strength-bonus (req (get-counters card :power))})
 

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -411,7 +411,8 @@
                           (continue-ability {:eid (assoc eid :source-type :ability :source card)
                                              :cost [:x-credits]
                                              :msg (msg "add " (cost-value eid :x-credits) " power counters")
-                                             :effect (effect (add-counter card :power (cost-value eid :x-credits)))} card targets))}
+                                             :effect (effect (add-counter card :power (cost-value eid :x-credits)))}
+                                            card targets))}
    :abilities [(break-sub 1 1 "All" {:req (req (= (get-strength current-ice) (get-strength card)))})]
    :strength-bonus (req (get-counters card :power))})
 

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -408,7 +408,20 @@
       (is (= 3 (core/available-mu state)))
       (let [atman (get-program state 0)]
         (is (= 2 (get-counters atman :power)) "2 power counters")
-        (is (= 2 (get-strength atman)) "2 current strength")))))
+        (is (= 2 (get-strength atman)) "2 current strength"))))
+  (testing "Paying for install with multithreader"
+    (do-game
+      (new-game {:runner {:deck ["Atman" "Multithreader"] :credits 8}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Multithreader")
+      (play-from-hand state :runner "Atman")
+      (click-prompt state :runner "4")
+      (click-card state :runner (get-program state 0))
+      (click-card state :runner (get-program state 0))
+      (is (= 2 (core/available-mu state)))
+      (let [atman (get-program state 1)]
+        (is (= 4 (get-counters atman :power)) "4 power counters")
+        (is (= 4 (get-strength atman)) "4 current strength")))))
 
 (deftest au-revoir
   ;; Au Revoir - Gain 1 credit every time you jack out


### PR DESCRIPTION
Closes #5772 Atman was using install credits (.e.g sahasrara) for its ability. Using continue-ability with the :source type set properly is the same way engolo's on encounter ability handles this. 