### PR TITLE
Add recurring credit reset to initialization

### DIFF
--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -109,7 +109,7 @@
                      (fn? recurring) (recurring state side eid c nil)
                      (number? recurring) recurring
                      :else (throw (Exception. (str (:title card) " - Recurring isn't number or fn"))))}))
-         _ (when recurring (update! state side (assoc-in card [:counter :recurring] 0)))
+         _ (when recurring (update! state side (assoc-in c [:counter :recurring] 0)))
          _ (doseq [[c-type c-num] data]
              (add-counter state side (get-card state c) c-type c-num {:placed true}))
          c (get-card state c)]

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -109,6 +109,7 @@
                      (fn? recurring) (recurring state side eid c nil)
                      (number? recurring) recurring
                      :else (throw (Exception. (str (:title card) " - Recurring isn't number or fn"))))}))
+         _ (when recurring (update! state side (assoc-in card [:counter :recurring] 0)))
          _ (doseq [[c-type c-num] data]
              (add-counter state side (get-card state c) c-type c-num {:placed true}))
          c (get-card state c)]

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2907,7 +2907,17 @@
         (changes-val-macro -1 (:credit (get-corp)) ; 1 credit left on Mumba
                            "Used 1 credit from Mumba"
                            (rez state :corp pad)
-                           (click-card state :corp mumba))))))
+                           (click-card state :corp mumba)))))
+  (testing "Derez test"
+    (do-game
+      (new-game {:corp {:deck ["Mumba Temple"]}})
+      (play-from-hand state :corp "Mumba Temple" "New remote")
+      (let [mumba (get-content state :remote1 0)]
+        (rez state :corp mumba)
+        (is (= 2 (get-counters (refresh mumba) :recurring)) "Should have 2 recurring credits")
+        (derez state :corp mumba)
+        (rez state :corp mumba)
+        (is (= 2 (get-counters (refresh mumba) :recurring)) "Should still have 2 recurring credits")))))
 
 (deftest mumbad-city-hall
   ;; Mumbad City Hall


### PR DESCRIPTION
This adds the same update used when recurring credits are reset at the beginning of the turn to the initialization of recurring credits, preventing them from stacking up if you rez/derez a card multiple times. Closes #5686 