### PR TITLE
Rejigs the successful run logic to better account for sneakdoor/crisium

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1251,10 +1251,8 @@
              :prompt "Treat as a successful run on which server?"
              :choices ["HQ" "R&D"]
              :effect (req (let [target-server (if (= target "HQ") :hq :rd)]
-                            (swap! state update-in [:runner :register :successful-run] next)
                             (swap! state assoc-in [:run :server] [target-server])
                             (trigger-event state :corp :no-action)
-                            (swap! state update-in [:runner :register :successful-run] conj target-server)
                             (system-msg state side (str "uses Omar Keung: Conspiracy Theorist to make a successful run on " target))))}
             {:event :run-ends
              :effect (effect (update! (dissoc-in card [:special :omar-run])))}]})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2311,10 +2311,8 @@
                                     :unregister-once-resolved true
                                     :interactive (req true)
                                     :req (req (= :archives (-> run :server first)))
-                                    :effect (req (swap! state update-in [:runner :register :successful-run] next)
-                                                 (swap! state assoc-in [:run :server] [:hq])
+                                    :effect (req (swap! state assoc-in [:run :server] [:hq])
                                                  (trigger-event state :corp :no-action)
-                                                 (swap! state update-in [:runner :register :successful-run] conj :hq)
                                                  (system-msg state side (str "uses Sneakdoor Beta to make a successful run on HQ")))}])
                                 (make-run eid :archives (get-card state card)))}]})
 

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -531,14 +531,15 @@
 
 (defn- register-successful-run
   [state side eid server]
-  (swap! state update-in [:runner :register :successful-run] conj (first server))
-  (swap! state assoc-in [:run :successful] true)
   ;; TODO: :pre-successful-run exists merely for Omar Keung and Sneakdoor Beta
   ;; Needs prevention system to remove
   (queue-event state :pre-successful-run (select-keys (:run @state) [:server :run-id]))
   (wait-for (checkpoint state nil (make-eid state eid))
-            (queue-event state :successful-run (select-keys (:run @state) [:server :run-id]))
-            (checkpoint state nil eid)))
+            (when (not (any-effects state side :block-successful-run))
+              (swap! state update-in [:runner :register :successful-run] conj (-> @state :run :server first))
+              (swap! state assoc-in [:run :successful] true)
+              (queue-event state :successful-run (select-keys (:run @state) [:server :run-id]))
+              (checkpoint state nil eid))))
 
 (defn successful-run
   "The real 'successful run' trigger."

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -5075,6 +5075,22 @@
         (is (= 3 (:credit (get-runner))) "Gained 2 credits from Gabe's ability")
         (is (= (:cid ash) (-> (prompt-map :runner) :card :cid)) "Ash interrupted HQ access after Sneakdoor run")
         (is (= :hq (-> (get-runner) :register :successful-run first)) "Successful Run on HQ recorded"))))
+   (testing "Crisium grid on HQ should prevent Gabriel gaining credits"
+    (do-game
+      (new-game {:corp {:deck ["Crisium Grid"]}
+                 :runner {:id "Gabriel Santiago: Consummate Professional"
+                          :deck ["Sneakdoor Beta"]}})
+      (play-from-hand state :corp "Crisium Grid" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Sneakdoor Beta")
+      (is (= 1 (:credit (get-runner))) "Sneakdoor cost 4 credits")
+      (let [sb (get-program state 0)
+            crisium (get-content state :hq 0)]
+        (rez state :corp crisium)
+        (card-ability state :runner sb 0)
+        (run-continue state)
+        (is (= 1 (:credit (get-runner))) "Did not gain 2 credits from Gabe's ability")
+        (is (not= :hq (-> (get-runner) :register :successful-run first)) "Successful Run on HQ was not recorded"))))
   (testing "do not switch to HQ if Archives has Crisium Grid. Issue #1229."
     (do-game
       (new-game {:corp {:deck ["Crisium Grid" "Priority Requisition" "Private Security Force"]}


### PR DESCRIPTION
Closes #5713 #5764. This changes the flow of declaring a run successful. 

Previously it would check the server didn't have crisium, then mark the run as successful and register it. Then it would run sneakdoor/omar, which would remove the registration, change the server, then add a new registration, then the run code would trigger any run successful events. I haven't looked too closely into this as I've removed the code here anyway but I believe the "remove the registration" step was bugged in that it removed the first registration in the list rather than the last. 

The new flow starts with the same check for crisium, if we don't find it we go straight to running sneakdoor. Sneakdoor just changes the server. Then we check again for crisium, if we don't find it we do everything like marking the run successful, registering it and running any events. 