### PR TITLE
Adds some registrations to the turning wheel's bounce ability

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2857,7 +2857,10 @@
              :cost [:click 1]
              :keep-menu-open :while-clicks-left
              :msg (msg "bounce off of " name " for a token (shortcut)")
-             :effect (effect (add-counter card :power 1))})]
+             :effect (req (add-counter state :runner card :power 1)
+                          (swap! state assoc-in [:runner :register :made-click-run] true)
+                          (swap! state update-in [:runner :register :unsuccessful-run] conj server)
+                          (swap! state update-in [:runner :register :made-run] conj server))})]
     {:events [{:event :agenda-stolen
                :effect (effect (update! (assoc card :agenda-stolen true)))
                :silent (req true)}

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -5399,7 +5399,7 @@
   (testing "Bounce test"
     (do-game
       (new-game {:corp {:deck [(qty "Ice Wall" 5)]
-                        :hand [(qty "Fire Wall" 5)]}
+                        :hand [(qty "Hard-Hitting News" 5)]}
                  :runner {:hand ["The Turning Wheel"]
                           :credits 10}})
       (take-credits state :corp)
@@ -5409,7 +5409,12 @@
         (card-ability state :runner ttw 2) ;; Bounce HQ ability
         (is (= 1 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 1 power counter")
         (card-ability state :runner ttw 3) ;; Bounce R&D ability
-        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 2 power counter")))))
+        (is (= 2 (get-counters (refresh ttw) :power)) "The Turning Wheel ability has 2 power counter")
+        (take-credits state :runner)
+        (play-from-hand state :corp "Hard-Hitting News")
+        (click-prompt state :corp "0")
+        (click-prompt state :runner "0")
+        (is (= 4 (count-tags state)) "Bouncing enables Hard-Hitting News")))))
 
 (deftest theophilius-bagbiter
   ;; Theophilius Bagbiter - hand size is equal to credit pool


### PR DESCRIPTION
Logs a few common things such as a run being made in turning wheel's bounce ability so it still enables cards like hhn. Closes #5910  