### PR TITLE
standardize waiting prompt messages

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -104,7 +104,7 @@
      :player :corp
      :once :per-turn
      :async true
-     :waiting-prompt "Corp to use Advanced Concept Hopper"
+     :waiting-prompt "Corp to choose an option"
      :prompt "Use Advanced Concept Hopper to draw 1 card or gain 1 [Credits]?"
      :choices ["Draw 1 card" "Gain 1 [Credits]" "No action"]
      :effect (req (case target
@@ -157,7 +157,7 @@
   {:on-score
    {:player :runner
     :async true
-    :waiting-prompt "Runner to choose an option for Armed Intimidation"
+    :waiting-prompt "Runner to choose an option"
     :prompt "Choose Armed Intimidation score effect"
     :choices ["Suffer 5 meat damage" "Take 2 tags"]
     :effect (req (case target
@@ -201,7 +201,7 @@
   {:flags {:rd-reveal (req true)}
    :access {:async true
             :req (req (not-empty (filter #(can-be-advanced? %) (all-installed state :corp))))
-            :waiting-prompt "Corp to use Award Bait"
+            :waiting-prompt "Corp to choose an option"
             :prompt "How many advancement tokens?"
             :choices ["0" "1" "2"]
             :effect (effect (continue-ability
@@ -244,7 +244,7 @@
     (let [arrange-rd
           {:interactive (req true)
            :optional
-           {:waiting-prompt "Corp to use Bacterial Programming"
+           {:waiting-prompt "Corp to make a decision"
             :prompt "Arrange top 7 cards of R&D?"
             :yes-ability
             {:async true
@@ -268,7 +268,7 @@
               :req (req (and (has-subtype? (:card context) "Run")
                              (first-event? state :runner :play-event #(has-subtype? (:card (first %)) "Run"))
                              (no-event? state :runner :runner-install #(has-subtype? (:card (first %)) "Icebreaker"))))
-              :waiting-prompt "Corp to use Better Citizen Program"
+              :waiting-prompt "Corp to choose an option"
               :prompt "Give the runner 1 tag?"
               :yes-ability
               {:async true
@@ -282,7 +282,7 @@
                              (has-subtype? (:card context) "Icebreaker")
                              (first-event? state :runner :runner-install #(has-subtype? (:card (first %)) "Icebreaker"))
                              (no-event? state :runner :play-event #(has-subtype? (:card (first %)) "Run"))))
-              :waiting-prompt "Corp to use Better Citizen Program"
+              :waiting-prompt "Corp to choose an option"
               :prompt "Give the runner 1 tag?"
               :yes-ability
               {:async true
@@ -307,7 +307,7 @@
 (defcard "Brain Rewiring"
   {:on-score
    {:optional
-    {:waiting-prompt "Corp to use Brain Rewiring"
+    {:waiting-prompt "Corp to make a decision"
      :prompt "Pay credits to add random cards from Runner's Grip to the bottom of their Stack?"
      :yes-ability
      {:prompt "How many credits do you want to pay?"
@@ -575,7 +575,7 @@
                       (continue-ability
                         state side
                         {:optional
-                         {:waiting-prompt "Corp to use Divested Trust"
+                         {:waiting-prompt "Corp to choose an option"
                           :prompt prompt
                           :yes-ability
                           {:msg message
@@ -654,7 +654,7 @@
 (defcard "Explode-a-palooza"
   {:flags {:rd-reveal (req true)}
    :access {:optional
-            {:waiting-prompt "Corp to use Explode-a-palooza"
+            {:waiting-prompt "Corp to choose an option"
              :prompt "Gain 5 [Credits] with Explode-a-palooza ability?"
              :yes-ability
              {:msg "gain 5 [Credits]"
@@ -696,7 +696,7 @@
                 :once :per-turn
                 :msg (msg "reveal " (:title (first (:deck corp))) " and draw 2 cards")
                 :async true
-                :waiting-prompt "Corp to use Flower Sermon"
+                :waiting-prompt "Corp to make a decision"
                 :effect (req (wait-for
                                (reveal state side (first (:deck corp)))
                                (wait-for
@@ -1212,7 +1212,7 @@
                 :silent (req true)
                 :req (req (and (< 4 (get-counters (:card context) :advancement))
                                (pos? (count (all-installed state :runner)))))
-                :waiting-prompt "Runner to decide on Project Ares"
+                :waiting-prompt "Runner to make a decision"
                 :prompt (msg "Select " (trash-count-str (:card context)) " installed cards to trash")
                 :choices {:max (req (min (- (get-counters (:card context) :advancement) 4)
                                          (count (all-installed state :runner))))
@@ -1349,7 +1349,7 @@
              :effect (effect (swap-cards to-swap target))
              :cancel-effect (effect (put-back-counter card))})
           (choose-card [run-server]
-            {:waiting-prompt "Corp to use Project Yagi-Uda"
+            {:waiting-prompt "Corp to make a decision"
              :prompt "Choose a card in or protecting the attacked server."
              :choices {:card #(= (first run-server) (second (get-zone %)))}
              :effect (effect (continue-ability (choose-swap target) card nil))
@@ -1366,7 +1366,7 @@
   {:events [{:event :successful-run
              :player :corp
              :interactive (req true)
-             :waiting-prompt "Corp to use Puppet Master"
+             :waiting-prompt "Corp to make a decision"
              :prompt "Select a card to place 1 advancement token on"
              :choices {:card can-be-advanced?}
              :msg (msg "place 1 advancement token on " (card-str state target))
@@ -1423,7 +1423,7 @@
                                 (do (system-msg state side "does not add any cards from HQ to bottom of R&D")
                                     (effect-completed state side eid))))))})]
     {:on-score {:async true
-                :waiting-prompt "Corp to use Reeducation"
+                :waiting-prompt "Corp to make a decision"
                 :effect (req (let [from (get-in @state [:corp :hand])]
                                (if (pos? (count from))
                                  (continue-ability state :corp (corp-choice from '() from) card nil)
@@ -1501,7 +1501,7 @@
 (defcard "SDS Drone Deployment"
   {:steal-cost-bonus (req [:program 1])
    :on-score {:req (req (seq (all-installed-runner-type state :program)))
-              :waiting-prompt "Corp to use SDS Drone Deployment"
+              :waiting-prompt "Corp to make a decision"
               :prompt "Select a program to trash"
               :choices {:card #(and (installed? %)
                                     (program? %))
@@ -1801,7 +1801,7 @@
              :optional
              {:player :corp
               :req (req (pos? (get-counters card :agenda)))
-              :waiting-prompt "Corp to use Voting Machine Initiative"
+              :waiting-prompt "Corp to choose an option"
               :prompt "Use Voting Machine Initiative to make the Runner lose 1 [Click]?"
               :yes-ability
               {:msg "make the Runner lose 1 [Click]"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -157,7 +157,7 @@
   {:on-score
    {:player :runner
     :async true
-    :waiting-prompt "Runner to suffer 5 meat damage or take 2 tags"
+    :waiting-prompt "Runner to choose an option for Armed Intimidation"
     :prompt "Choose Armed Intimidation score effect"
     :choices ["Suffer 5 meat damage" "Take 2 tags"]
     :effect (req (case target
@@ -201,7 +201,7 @@
   {:flags {:rd-reveal (req true)}
    :access {:async true
             :req (req (not-empty (filter #(can-be-advanced? %) (all-installed state :corp))))
-            :waiting-prompt "Corp to place advancement tokens with Award Bait"
+            :waiting-prompt "Corp to use Award Bait"
             :prompt "How many advancement tokens?"
             :choices ["0" "1" "2"]
             :effect (effect (continue-ability
@@ -1212,7 +1212,7 @@
                 :silent (req true)
                 :req (req (and (< 4 (get-counters (:card context) :advancement))
                                (pos? (count (all-installed state :runner)))))
-                :waiting-prompt "Runner to trash installed cards"
+                :waiting-prompt "Runner to decide on Project Ares"
                 :prompt (msg "Select " (trash-count-str (:card context)) " installed cards to trash")
                 :choices {:max (req (min (- (get-counters (:card context) :advancement) 4)
                                          (count (all-installed state :runner))))
@@ -1423,7 +1423,7 @@
                                 (do (system-msg state side "does not add any cards from HQ to bottom of R&D")
                                     (effect-completed state side eid))))))})]
     {:on-score {:async true
-                :waiting-prompt "Corp to add cards from HQ to bottom of R&D"
+                :waiting-prompt "Corp to use Reeducation"
                 :effect (req (let [from (get-in @state [:corp :hand])]
                                (if (pos? (count from))
                                  (continue-ability state :corp (corp-choice from '() from) card nil)
@@ -1501,7 +1501,7 @@
 (defcard "SDS Drone Deployment"
   {:steal-cost-bonus (req [:program 1])
    :on-score {:req (req (seq (all-installed-runner-type state :program)))
-              :waiting-prompt "Corp to trash a card"
+              :waiting-prompt "Corp to use SDS Drone Deployment"
               :prompt "Select a program to trash"
               :choices {:card #(and (installed? %)
                                     (program? %))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -93,7 +93,7 @@
                 :cost [:trash]
                 :effect (effect
                           (continue-ability
-                            {:waiting-prompt "Runner to decide whether or not to prevent Alexa Belsky"
+                            {:waiting-prompt "Runner to decide on Alexa Belsky"
                              :prompt "How many credits do you want to pay?"
                              :choices :credit
                              :player :runner
@@ -1055,7 +1055,7 @@
                             (some #(and (agenda? %)
                                         (= counters (:agendapoints %)))
                                   (:hand corp))))
-                :waiting-prompt "Corp to select an agenda for Lady Liberty"
+                :waiting-prompt "Corp to use Lady Liberty"
                 :prompt "Select an Agenda in HQ to move to score area"
                 :choices {:req (req (and (agenda? target)
                                          (= (:agendapoints target) (get-counters (get-card state card) :power))
@@ -1552,7 +1552,7 @@
   (advance-ambush
     0
     {:req (req (pos? (get-counters (get-card state card) :advancement)))
-     :waiting-prompt "Corp to select an agenda to score with Plan B"
+     :waiting-prompt "Corp to use Plan B"
      :prompt "Select an Agenda in HQ to score"
      :choices {:req (req (and (agenda? target)
                               (<= (get-advancement-requirement target)

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -77,7 +77,7 @@
 
 (defcard "Aggressive Secretary"
   (advance-ambush 2 {:req (req (pos? (get-counters (get-card state card) :advancement)))
-                     :waiting-prompt "Corp to use Aggressive Secretary"
+                     :waiting-prompt "Corp to make a decision"
                      :prompt (msg "Choose " (quantify (get-counters (get-card state card) :advancement) "program") " to trash")
                      :cost [:credit 2]
                      :choices {:max (req (get-counters (get-card state card) :advancement))
@@ -93,7 +93,7 @@
                 :cost [:trash]
                 :effect (effect
                           (continue-ability
-                            {:waiting-prompt "Runner to decide on Alexa Belsky"
+                            {:waiting-prompt "Runner to make a decision"
                              :prompt "How many credits do you want to pay?"
                              :choices :credit
                              :player :runner
@@ -151,7 +151,7 @@
                                    "card")
                          " in HQ and Archives")
                   :async true
-                  :waiting-prompt "Corp to use Allele Repression"
+                  :waiting-prompt "Corp to make a decision"
                   :effect (req (let [total (min (count (:discard corp))
                                                 (count (:hand corp))
                                                 (get-counters card :advancement))]
@@ -203,7 +203,7 @@
                               (continue-ability
                                 state side
                                 {:optional
-                                 {:waiting-prompt "Corp to use Anson Rose"
+                                 {:waiting-prompt "Corp to make a decision"
                                   :prompt (str "Move advancement tokens from Anson Rose to " icename "?")
                                   :yes-ability
                                   {:prompt "Choose how many advancement tokens to remove from Anson Rose"
@@ -324,7 +324,7 @@
    :on-trash {:interactive (req true)
               :optional
               {:req (req (= :runner side))
-               :waiting-prompt "Corp to use Calvin B4L3Y"
+               :waiting-prompt "Corp to choose an option"
                :prompt "Draw 2 cards?"
                :player :corp
                :yes-ability {:msg "draw 2 cards"
@@ -339,7 +339,7 @@
 
 (defcard "Cerebral Overwriter"
   (advance-ambush 3 {:async true
-                     :waiting-prompt "Corp to use Cerebral Overwriter"
+                     :waiting-prompt "Corp to choose an option"
                      :req (req (pos? (get-counters (get-card state card) :advancement)))
                      :msg (msg "do " (get-counters (get-card state card) :advancement) " brain damage")
                      :effect (effect (damage eid :brain (get-counters (get-card state card) :advancement) {:card card}))}))
@@ -408,7 +408,7 @@
    :abilities [(into
                  (corp-recur operation?)
                  {:label "Add 1 operation from Archives to HQ"
-                  :waiting-prompt "Corp to use Clone Suffrage Movement"
+                  :waiting-prompt "Corp to make a decision"
                   :prompt "Select an operation in Archives to add to HQ"
                   :once :per-turn})]})
 
@@ -470,7 +470,7 @@
                     (pos? it))))}
    :abilities [{:label "Move an advancement counter between 2 pieces of ice"
                 :once :per-turn
-                :waiting-prompt "Corp to use Constellation Protocol"
+                :waiting-prompt "Corp to make a decision"
                 :choices {:card #(and (ice? %)
                                       (get-counters % :advancement))}
                 :effect (effect
@@ -571,7 +571,7 @@
                                 drawn (get-in @state [:corp :register :most-recent-drawn])]
                             (continue-ability
                               state side
-                              {:waiting-prompt "Corp to use Daily Business Show"
+                              {:waiting-prompt "Corp to make a decision"
                                :prompt (str "Select " (quantify dbs "card") " to add to the bottom of R&D")
                                :choices {:max dbs
                                          :card #(some (fn [c] (same-card? c %)) drawn)
@@ -863,7 +863,7 @@
 
 (defcard "Ghost Branch"
   (advance-ambush 0 {:async true
-                     :waiting-prompt "Corp to use Ghost Branch"
+                     :waiting-prompt "Corp to choose an option"
                      :req (req (pos? (get-counters (get-card state card) :advancement)))
                      :msg (msg "give the Runner " (quantify (get-counters (get-card state card) :advancement) "tag"))
                      :effect (effect (gain-tags :corp eid (get-counters (get-card state card) :advancement)))}))
@@ -1055,7 +1055,7 @@
                             (some #(and (agenda? %)
                                         (= counters (:agendapoints %)))
                                   (:hand corp))))
-                :waiting-prompt "Corp to use Lady Liberty"
+                :waiting-prompt "Corp to make a decision"
                 :prompt "Select an Agenda in HQ to move to score area"
                 :choices {:req (req (and (agenda? target)
                                          (= (:agendapoints target) (get-counters (get-card state card) :power))
@@ -1190,7 +1190,7 @@
      :abilities [(set-autoresolve :auto-reshuffle "Marilyn reshuffle")]
      :on-trash {:interactive (req true)
                 :optional
-                {:waiting-prompt "Corp to use Marilyn Campaign"
+                {:waiting-prompt "Corp to choose an option"
                  :prompt "Shuffle Marilyn Campaign into R&D?"
                  :autoresolve (get-autoresolve :auto-reshuffle)
                  :player :corp
@@ -1345,7 +1345,7 @@
    :on-trash {:optional
               {:req (req (= :runner side))
                :player :corp
-               :waiting-prompt "Corp to use Nanoetching Matrix"
+               :waiting-prompt "Corp to choose an option"
                :prompt "Gain 2 [credits]?"
                :yes-ability
                {:msg (msg "gain 2 [Credits]")
@@ -1379,7 +1379,7 @@
 (defcard "Net Analytics"
   (let [ability {:optional
                  {:player :corp
-                  :waiting-prompt "Corp to use Net Analytics"
+                  :waiting-prompt "Corp to choose an option"
                   :prompt "Draw from Net Analytics?"
                   :yes-ability
                   {:msg "draw a card"
@@ -1398,7 +1398,7 @@
 
 (defcard "Neurostasis"
   (advance-ambush 3 {:req (req (pos? (get-counters (get-card state card) :advancement)))
-                     :waiting-prompt "Corp to use Neurostasis"
+                     :waiting-prompt "Corp to make a decision"
                      :async true
                      :effect (req (let [cnt (get-counters (get-card state card) :advancement)]
                                     (continue-ability
@@ -1552,7 +1552,7 @@
   (advance-ambush
     0
     {:req (req (pos? (get-counters (get-card state card) :advancement)))
-     :waiting-prompt "Corp to use Plan B"
+     :waiting-prompt "Corp to make a decision"
      :prompt "Select an Agenda in HQ to score"
      :choices {:req (req (and (agenda? target)
                               (<= (get-advancement-requirement target)
@@ -1628,7 +1628,7 @@
 
 (defcard "Project Junebug"
   (advance-ambush 1 {:req (req (pos? (get-counters (get-card state card) :advancement)))
-                     :waiting-prompt "Corp to use Project Junebug"
+                     :waiting-prompt "Corp to choose an option"
                      :msg (msg "do " (* 2 (get-counters (get-card state card) :advancement)) " net damage")
                      :async true
                      :effect (effect (damage eid :net (* 2 (get-counters (get-card state card) :advancement))
@@ -1974,7 +1974,7 @@
 
 (defcard "Shattered Remains"
   (advance-ambush 1 {:async true
-                     :waiting-prompt "Corp to use Shattered Remains"
+                     :waiting-prompt "Corp to make a decision"
                      :req (req (pos? (get-counters (get-card state card) :advancement)))
                      :prompt (msg "Select " (quantify (get-counters (get-card state card) :advancement) "piece") " of hardware to trash")
                      :msg (msg "trash " (string/join ", " (map :title targets)))
@@ -1988,7 +1988,7 @@
   {:access
    {:optional
     {:req (req (not (in-deck? card)))
-     :waiting-prompt "Corp to use Shi.Kyū"
+     :waiting-prompt "Corp to make a decision"
      :prompt "Pay [Credits] to use Shi.Kyū?"
      :yes-ability
      {:prompt "How many [Credits] for Shi.Kyū?"
@@ -2036,7 +2036,7 @@
   {:flags {:rd-reveal (req true)}
    :access {:optional
             {:req (req (not (in-discard? card)))
-             :waiting-prompt "Corp to use Snare!"
+             :waiting-prompt "Corp to choose an option"
              :prompt "Pay 4 [Credits] to use Snare! ability?"
              :yes-ability {:async true
                            :cost [:credit 4]
@@ -2047,7 +2047,7 @@
 (defcard "Space Camp"
   {:flags {:rd-reveal (req true)}
    :access {:optional
-            {:waiting-prompt "Corp to use Space Camp"
+            {:waiting-prompt "Corp to make a decision"
              :prompt "Place 1 advancement token with Space Camp?"
              :yes-ability {:msg (msg "place 1 advancement token on " (card-str state target))
                            :prompt "Select a card to place an advancement token on with Space Camp"
@@ -2236,7 +2236,7 @@
   (advance-ambush
     0
     {:async true
-     :waiting-prompt "Corp to use Toshiyuki Sakai"
+     :waiting-prompt "Corp to make a decision"
      :prompt "Select an asset or agenda in HQ"
      :choices {:card #(and (or (agenda? %)
                                (asset? %))
@@ -2398,7 +2398,7 @@
                 :async true
                 :cost [:trash-from-hand 1]
                 :effect (effect (continue-ability
-                                  {:waiting-prompt "Corp to use Whampoa Reclamation"
+                                  {:waiting-prompt "Corp to make a decision"
                                    :prompt "Select a card in Archives to add to the bottom of R&D"
                                    :show-discard true
                                    :choices {:card #(and (in-discard? %)

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -384,7 +384,7 @@
                  :ability
                  {:msg "force the Corp to add all cards in HQ to the top of R&D"
                   :player :corp
-                  :waiting-prompt "Corp to decide on CBI Raid"
+                  :waiting-prompt "Corp to make a decision"
                   :async true
                   :effect (effect
                             (continue-ability
@@ -525,7 +525,7 @@
                               (continue-ability
                                 state :corp
                                 {:optional
-                                 {:waiting-prompt "Corp to decide on Credit Crash"
+                                 {:waiting-prompt "Corp to choose an option"
                                   :prompt (msg "Spend " cost " [Credits] to prevent the trash of " title "?")
                                   :player :corp
                                   :yes-ability {:async true
@@ -1057,7 +1057,7 @@
                 :prompt "Advancements to remove from a card in or protecting this server?"
                 :choices ["0" "1" "2" "3"]
                 :async true
-                :waiting-prompt "Runner to use Exploratory Romp"
+                :waiting-prompt "Runner to choose an option"
                 :effect (req (let [c (str->int target)]
                                (continue-ability
                                  state side
@@ -1166,7 +1166,7 @@
                                    " of " serv " or trash it?")
                       :choices ["Rez" "Trash"]
                       :async true
-                      :waiting-prompt "Corp to choose an option for Forged Activation Orders"
+                      :waiting-prompt "Corp to choose an option"
                       :effect (effect (continue-ability
                                         (if (and (= target "Rez")
                                                  (<= (rez-cost state :corp ice)
@@ -1266,7 +1266,7 @@
                 :show-discard true
                 :async true
                 :player :corp
-                :waiting-prompt "Corp to decide on Glut Cipher"
+                :waiting-prompt "Corp to make a decision"
                 :prompt "Select 5 cards from Archives to add to HQ"
                 :choices {:max 5
                           :all true
@@ -1339,7 +1339,7 @@
                               (continue-ability state side (choose-next to-shuffle target remaining) card nil)))}))]
     {:on-play
      {:rfg-instead-of-trashing true
-      :waiting-prompt "Runner to use Harmony AR Therapy"
+      :waiting-prompt "Runner to make a decision"
       :async true
       :effect (req (if (and (not (zone-locked? state :runner :discard))
                             (pos? (count (:discard runner))))
@@ -1471,7 +1471,7 @@
                :this-card-run true
                :ability
                {:msg "rearrange the top 5 cards of R&D"
-                :waiting-prompt "Runner to use Indexing"
+                :waiting-prompt "Runner to make a decision"
                 :async true
                 :effect (effect
                           (continue-ability
@@ -1511,7 +1511,7 @@
                               (effect-completed state side eid))))})
           (which-pile [p1 p2]
             {:player :runner
-             :waiting-prompt "Runner to use Information Sifting"
+             :waiting-prompt "Runner to choose an option"
              :prompt "Choose a pile to access"
              :choices [(str "Pile 1 (" (quantify (count p1) "card") ")")
                        (str "Pile 2 (" (quantify (count p2) "card") ")")]
@@ -1526,7 +1526,7 @@
           {:player :corp
            :req (req (<= 1 (count (:hand corp))))
            :async true
-           :waiting-prompt "Corp to decide on Information Sifting"
+           :waiting-prompt "Corp to make a decision"
            :prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
            :choices {:card #(and (in-hand? %)
                                  (corp? %))
@@ -1602,7 +1602,7 @@
   {:on-play
    {:async true
     :player :corp
-    :waiting-prompt "Corp to decide on Insight"
+    :waiting-prompt "Corp to make a decision"
     :effect (req (wait-for
                    (resolve-ability state :corp (reorder-choice :corp (take 4 (:deck corp))) card targets)
                    (let [top-4 (take 4 (get-in @state [:corp :deck]))]
@@ -1903,7 +1903,7 @@
     {:on-play
      {:msg "look at and trash or rearrange the top 6 cards of their Stack"
       :async true
-      :waiting-prompt "Runner to use Making an Entrance"
+      :waiting-prompt "Runner to make a decision"
       :effect (effect (continue-ability (entrance-trash (take 6 (:deck runner))) card nil))}}))
 
 (defcard "Marathon"
@@ -1958,7 +1958,7 @@
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
     :rfg-instead-of-trashing true
     :msg "make the Corp pay 5 [Credits] or take 1 bad publicity"
-    :waiting-prompt "Corp to choose an option for Mining Accident"
+    :waiting-prompt "Corp to choose an option"
     :player :corp
     :prompt "Pay 5 [Credits] or take 1 Bad Publicity?"
     :choices (req [(when (can-pay? state :corp eid card "Mining Accident" :credit 5)
@@ -2273,7 +2273,7 @@
 (defcard "Push Your Luck"
   (letfn [(corp-choice [spent]
             {:player :corp
-             :waiting-prompt "Corp to choose an option for Push Your Luck"
+             :waiting-prompt "Corp to choose an option"
              :prompt "Even or odd?"
              :choices ["Even" "Odd"]
              :async true
@@ -2292,7 +2292,7 @@
           (runner-choice [choices]
             {:player :runner
              :prompt "How many credits do you want to spend?"
-             :waiting-prompt "Runner to use Push Your Luck"
+             :waiting-prompt "Runner to make a decision"
              :choices choices
              :async true
              :effect (effect (continue-ability :corp (corp-choice (str->int target)) card nil))})]
@@ -2488,7 +2488,7 @@
 (defcard "Rigged Results"
   (letfn [(choose-ice []
             {:player :runner
-             :waiting-prompt "Runner to use Rigged Results"
+             :waiting-prompt "Runner to make a decision"
              :prompt "Select a piece of ice to bypass"
              :choices {:card ice?}
              :msg (msg "make a run and bypass " (card-str state target))
@@ -2503,7 +2503,7 @@
                              (make-run eid (second (get-zone target)) card))})
           (corp-choice [choices spent]
             {:player :corp
-             :waiting-prompt "Corp to decide on Rigged Results"
+             :waiting-prompt "Corp to make a decision"
              :prompt "How many credits were spent?"
              :choices choices
              :async true
@@ -2517,7 +2517,7 @@
                                         (effect-completed state side eid)))))})
           (runner-choice [choices]
             {:player :runner
-             :waiting-prompt "Runner to use Rigged Results"
+             :waiting-prompt "Runner to make a decision"
              :prompt "How many credits do you want to spend?"
              :choices choices
              :async true
@@ -2828,7 +2828,7 @@
 (defcard "SYN Attack"
   {:on-play
    {:player :corp
-    :waiting-prompt "Corp to choose an option for SYN Attack"
+    :waiting-prompt "Corp to choose an option"
     :prompt "Discard 2 cards or draw 4 cards?"
     :choices (req [(when (<= 2 (count (:hand corp)))
                      "Discard 2")
@@ -3147,7 +3147,7 @@
 (defcard "Wildcat Strike"
   {:on-play
    {:player :corp
-    :waiting-prompt "Corp to choose an option for Wildcat Strike"
+    :waiting-prompt "Corp to choose an option"
     :prompt "Choose one"
     :choices ["Runner gains 6 [Credits]" "Runner draws 4 cards"]
     :async true

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -384,7 +384,7 @@
                  :ability
                  {:msg "force the Corp to add all cards in HQ to the top of R&D"
                   :player :corp
-                  :waiting-prompt "Corp to add all cards in HQ to the top of R&D"
+                  :waiting-prompt "Corp to decide on CBI Raid"
                   :async true
                   :effect (effect
                             (continue-ability
@@ -525,7 +525,7 @@
                               (continue-ability
                                 state :corp
                                 {:optional
-                                 {:waiting-prompt "Corp to decide whether or not to prevent the trash"
+                                 {:waiting-prompt "Corp to decide on Credit Crash"
                                   :prompt (msg "Spend " cost " [Credits] to prevent the trash of " title "?")
                                   :player :corp
                                   :yes-ability {:async true
@@ -1166,7 +1166,7 @@
                                    " of " serv " or trash it?")
                       :choices ["Rez" "Trash"]
                       :async true
-                      :waiting-prompt "Corp to decide to rez or trash ice"
+                      :waiting-prompt "Corp to choose an option for Forged Activation Orders"
                       :effect (effect (continue-ability
                                         (if (and (= target "Rez")
                                                  (<= (rez-cost state :corp ice)
@@ -1266,7 +1266,7 @@
                 :show-discard true
                 :async true
                 :player :corp
-                :waiting-prompt "Corp to choose which cards to pick up from Archives"
+                :waiting-prompt "Corp to decide on Glut Cipher"
                 :prompt "Select 5 cards from Archives to add to HQ"
                 :choices {:max 5
                           :all true
@@ -1471,7 +1471,7 @@
                :this-card-run true
                :ability
                {:msg "rearrange the top 5 cards of R&D"
-                :waiting-prompt "Runner to rearrange the top cards of R&D"
+                :waiting-prompt "Runner to use Indexing"
                 :async true
                 :effect (effect
                           (continue-ability
@@ -1511,7 +1511,7 @@
                               (effect-completed state side eid))))})
           (which-pile [p1 p2]
             {:player :runner
-             :waiting-prompt "Runner to select a pile"
+             :waiting-prompt "Runner to use Information Sifting"
              :prompt "Choose a pile to access"
              :choices [(str "Pile 1 (" (quantify (count p1) "card") ")")
                        (str "Pile 2 (" (quantify (count p2) "card") ")")]
@@ -1526,7 +1526,7 @@
           {:player :corp
            :req (req (<= 1 (count (:hand corp))))
            :async true
-           :waiting-prompt "Corp to create two piles"
+           :waiting-prompt "Corp to decide on Information Sifting"
            :prompt (msg "Select up to " (dec (count (:hand corp))) " cards for the first pile")
            :choices {:card #(and (in-hand? %)
                                  (corp? %))
@@ -1602,7 +1602,7 @@
   {:on-play
    {:async true
     :player :corp
-    :waiting-prompt "Corp to rearrange the top 4 cards of R&D"
+    :waiting-prompt "Corp to decide on Insight"
     :effect (req (wait-for
                    (resolve-ability state :corp (reorder-choice :corp (take 4 (:deck corp))) card targets)
                    (let [top-4 (take 4 (get-in @state [:corp :deck]))]
@@ -1903,7 +1903,7 @@
     {:on-play
      {:msg "look at and trash or rearrange the top 6 cards of their Stack"
       :async true
-      :waiting-prompt "Runner to rearrange the top cards of their stack"
+      :waiting-prompt "Runner to use Making an Entrance"
       :effect (effect (continue-ability (entrance-trash (take 6 (:deck runner))) card nil))}}))
 
 (defcard "Marathon"
@@ -1958,7 +1958,7 @@
    {:req (req (some #{:hq :rd :archives} (:successful-run runner-reg)))
     :rfg-instead-of-trashing true
     :msg "make the Corp pay 5 [Credits] or take 1 bad publicity"
-    :waiting-prompt "Corp to choose to pay or take bad publicity"
+    :waiting-prompt "Corp to choose an option for Mining Accident"
     :player :corp
     :prompt "Pay 5 [Credits] or take 1 Bad Publicity?"
     :choices (req [(when (can-pay? state :corp eid card "Mining Accident" :credit 5)
@@ -2273,8 +2273,8 @@
 (defcard "Push Your Luck"
   (letfn [(corp-choice [spent]
             {:player :corp
-             :waiting-prompt "Corp to guess even or odd"
-             :prompt "How many credits were spent?"
+             :waiting-prompt "Corp to choose an option for Push Your Luck"
+             :prompt "Even or odd?"
              :choices ["Even" "Odd"]
              :async true
              :effect (req (let [correct-guess ((if (= target "Even") even? odd?) spent)]
@@ -2292,7 +2292,7 @@
           (runner-choice [choices]
             {:player :runner
              :prompt "How many credits do you want to spend?"
-             :waiting-prompt "Runner to spend credits"
+             :waiting-prompt "Runner to use Push Your Luck"
              :choices choices
              :async true
              :effect (effect (continue-ability :corp (corp-choice (str->int target)) card nil))})]
@@ -2488,7 +2488,7 @@
 (defcard "Rigged Results"
   (letfn [(choose-ice []
             {:player :runner
-             :waiting-prompt "Runner to choose ice"
+             :waiting-prompt "Runner to use Rigged Results"
              :prompt "Select a piece of ice to bypass"
              :choices {:card ice?}
              :msg (msg "make a run and bypass " (card-str state target))
@@ -2503,7 +2503,7 @@
                              (make-run eid (second (get-zone target)) card))})
           (corp-choice [choices spent]
             {:player :corp
-             :waiting-prompt "Corp to guess credits spent"
+             :waiting-prompt "Corp to decide on Rigged Results"
              :prompt "How many credits were spent?"
              :choices choices
              :async true
@@ -2517,7 +2517,7 @@
                                         (effect-completed state side eid)))))})
           (runner-choice [choices]
             {:player :runner
-             :waiting-prompt "Runner to spend credits"
+             :waiting-prompt "Runner to use Rigged Results"
              :prompt "How many credits do you want to spend?"
              :choices choices
              :async true
@@ -3147,7 +3147,7 @@
 (defcard "Wildcat Strike"
   {:on-play
    {:player :corp
-    :waiting-prompt "Corp to choose Wildcat Strike effect"
+    :waiting-prompt "Corp to choose an option for Wildcat Strike"
     :prompt "Choose one"
     :choices ["Runner gains 6 [Credits]" "Runner draws 4 cards"]
     :async true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -15,7 +15,7 @@
             {:event :purge
              :optional
              {:player :runner
-              :waiting-prompt "Runner to use Acacia"
+              :waiting-prompt "Runner to choose an option"
               :prompt "Use Acacia?"
               :yes-ability
               {:async true
@@ -680,7 +680,7 @@
   {:events [{:event :pre-init-trace
              :optional
              {:req (req (= :runner (:active-player @state)))
-              :waiting-prompt "Runner to use Flip Switch"
+              :waiting-prompt "Runner to choose an option"
               :prompt "Use Flip Switch to reduce base trace strength to 0?"
               :player :runner
               :yes-ability {:msg "reduce the base trace strength to 0"
@@ -796,7 +796,7 @@
                   :cost [:trash]
                   :msg "install a card from the top of the stack"
                   :async true
-                  :waiting-prompt "Runner to use Gachapon"
+                  :waiting-prompt "Runner to make a decision"
                   :effect (req (let [set-aside (sort-by :title (take 6 (:deck runner)))]
                                  (wait-for
                                    (resolve-ability state side
@@ -1294,7 +1294,7 @@
 (defcard "Pantograph"
   (let [install-ability
         {:optional
-         {:waiting-prompt "Runner to use Pantograph"
+         {:waiting-prompt "Runner to make a decision"
           :prompt "Install card with Pantograph ability?"
           :player :runner
           :yes-ability
@@ -1338,7 +1338,7 @@
              {:req (req (first-event? state side :successful-run))
               :player :runner
               :autoresolve (get-autoresolve :auto-fire)
-              :waiting-prompt "Runner to use Paragon"
+              :waiting-prompt "Runner to make a decision"
               :prompt "Use Paragon?"
               :yes-ability
               {:msg "gain 1 [Credit] and look at the top card of Stack"
@@ -1865,7 +1865,7 @@
                 :async true
                 :label "Look at the top X cards of your Stack"
                 :msg "look at the top X cards of their Stack and rearrange them"
-                :waiting-prompt "Runner to use Spy Camera"
+                :waiting-prompt "Runner to make a decision"
                 :effect (req (let [n (count (filter #(= (:title %) (:title card))
                                                     (all-active-installed state :runner)))
                                    from (take n (:deck runner))]
@@ -1887,7 +1887,7 @@
              :silent (get-autoresolve :auto-fire never?)
              :optional
              {:req (req (= (:credit runner) (:credit corp)))
-              :waiting-prompt "Runner to use Supercorridor"
+              :waiting-prompt "Runner to choose an option"
               :prompt "Gain credits from Supercorridor?"
               :player :runner
               :autoresolve (get-autoresolve :auto-fire)
@@ -1964,7 +1964,7 @@
                               state :runner
                               (if (< (count hand) dmg)
                                 {:effect (effect (chosen-damage :runner hand))}
-                                {:waiting-prompt "Runner to use Titanium Ribs"
+                                {:waiting-prompt "Runner to make a decision"
                                  :prompt (msg "Select " dmg " cards to trash for the " (name dtype) " damage")
                                  :choices {:max dmg
                                            :all true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -15,7 +15,7 @@
             {:event :purge
              :optional
              {:player :runner
-              :waiting-prompt "Runner to decide if they will use Acacia"
+              :waiting-prompt "Runner to use Acacia"
               :prompt "Use Acacia?"
               :yes-ability
               {:async true
@@ -796,7 +796,7 @@
                   :cost [:trash]
                   :msg "install a card from the top of the stack"
                   :async true
-                  :waiting-prompt "Runner to resolve Gachapon"
+                  :waiting-prompt "Runner to use Gachapon"
                   :effect (req (let [set-aside (sort-by :title (take 6 (:deck runner)))]
                                  (wait-for
                                    (resolve-ability state side
@@ -1294,7 +1294,7 @@
 (defcard "Pantograph"
   (let [install-ability
         {:optional
-         {:waiting-prompt "Runner to decide if they will use Pantograph"
+         {:waiting-prompt "Runner to use Pantograph"
           :prompt "Install card with Pantograph ability?"
           :player :runner
           :yes-ability
@@ -1338,7 +1338,7 @@
              {:req (req (first-event? state side :successful-run))
               :player :runner
               :autoresolve (get-autoresolve :auto-fire)
-              :waiting-prompt "Runner to decide if they will use Paragon"
+              :waiting-prompt "Runner to use Paragon"
               :prompt "Use Paragon?"
               :yes-ability
               {:msg "gain 1 [Credit] and look at the top card of Stack"
@@ -1865,7 +1865,7 @@
                 :async true
                 :label "Look at the top X cards of your Stack"
                 :msg "look at the top X cards of their Stack and rearrange them"
-                :waiting-prompt "Runner to rearrange the top cards of their stack"
+                :waiting-prompt "Runner to use Spy Camera"
                 :effect (req (let [n (count (filter #(= (:title %) (:title card))
                                                     (all-active-installed state :runner)))
                                    from (take n (:deck runner))]
@@ -1887,7 +1887,7 @@
              :silent (get-autoresolve :auto-fire never?)
              :optional
              {:req (req (= (:credit runner) (:credit corp)))
-              :waiting-prompt "Runner to decide if they will gain credits from Supercorridor"
+              :waiting-prompt "Runner to use Supercorridor"
               :prompt "Gain credits from Supercorridor?"
               :player :runner
               :autoresolve (get-autoresolve :auto-fire)
@@ -1964,7 +1964,7 @@
                               state :runner
                               (if (< (count hand) dmg)
                                 {:effect (effect (chosen-damage :runner hand))}
-                                {:waiting-prompt "Runner to use Titanium Ribs to choose cards to be trashed"
+                                {:waiting-prompt "Runner to use Titanium Ribs"
                                  :prompt (msg "Select " dmg " cards to trash for the " (name dtype) " damage")
                                  :choices {:max dmg
                                            :all true

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -478,14 +478,14 @@
 
 (defcard "Anansi"
   (let [corp-draw {:optional
-                   {:waiting-prompt "Corp to draw a card"
+                   {:waiting-prompt "Corp to use Anansi"
                     :prompt "Draw 1 card?"
                     :yes-ability {:async true
                                   :msg "draw 1 card"
                                   :effect (effect (draw eid 1 nil))}}}
         runner-draw {:player :runner
                      :optional
-                     {:waiting-prompt "Runner to decide on card draw"
+                     {:waiting-prompt "Runner to choose an option for Anansi"
                       :prompt "Pay 2 [Credits] to draw 1 card?"
                       :yes-ability
                       {:async true
@@ -498,7 +498,7 @@
                       :no-ability {:effect (effect (system-msg :runner "does not draw 1 card"))}}}]
     {:subroutines [{:msg "rearrange the top 5 cards of R&D"
                     :async true
-                    :waiting-prompt "Corp to rearrange the top cards of R&D"
+                    :waiting-prompt "Corp to use Anansi"
                     :effect (req (let [from (take 5 (:deck corp))]
                                    (continue-ability
                                      state side
@@ -520,7 +520,7 @@
    :access
    {:optional
     {:req (req (not (in-discard? card)))
-     :waiting-prompt "Corp to decide to trigger Archangel"
+     :waiting-prompt "Corp to use Archangel"
      :prompt "Pay 3 [Credits] to force Runner to encounter Archangel?"
      :player :corp
      :yes-ability
@@ -867,7 +867,7 @@
    :access {:optional
             {:req (req (not (in-discard? card)))
              :player :runner
-             :waiting-prompt "Runner to decide to break Chrysalis subroutine"
+             :waiting-prompt "Runner to decide on Chrysalis"
              :prompt "You are encountering Chrysalis. Allow its subroutine to fire?"
              :yes-ability {:async true
                            :effect (effect (resolve-unbroken-subs! :corp eid card))}}}})
@@ -1008,7 +1008,7 @@
                      {:async true
                       :label "Look at the top of the stack"
                       :msg "look at top X cards of the stack"
-                      :waiting-prompt "Corp to rearrange the top cards of the stack"
+                      :waiting-prompt "Corp to use Data Hound"
                       :effect (req (let [c (- target (second targets))
                                          from (take c (:deck runner))]
                                      (system-msg state :corp
@@ -1627,7 +1627,7 @@
    :access {:optional
             {:req (req (not (in-discard? card)))
              :player :runner
-             :waiting-prompt "Runner to decide to break Herald subroutines"
+             :waiting-prompt "Runner to decide on Herald"
              :prompt "You are encountering Herald. Allow its subroutines to fire?"
              :yes-ability {:async true
                            :effect (effect (resolve-unbroken-subs! :corp eid card))}}}})
@@ -1903,7 +1903,7 @@
                   :effect (effect (continue-ability
                                     (when (= 2 (count targets))
                                       {:player :runner
-                                       :waiting-prompt "Runner to decide which card to move"
+                                       :waiting-prompt "Runner to decide on Jua"
                                        :prompt "Select a card to move to the Stack"
                                        :choices {:card #(some (partial same-card? %) targets)}
                                        :effect (req (move state :runner target :deck {:front true})
@@ -1933,7 +1933,7 @@
           (sub-map [kind]
             {:player :runner
              :async true
-             :waiting-prompt "Runner to decide on Kamali 1.0 action"
+             :waiting-prompt "Runner to choose an option for Kamali 1.0"
              :prompt "Choose one"
              :choices ["Take 1 brain damage" (str "Trash an installed " (better-name kind))]
              :effect (req (if (= target "Take 1 brain damage")
@@ -1954,7 +1954,7 @@
 (defcard "Karunā"
   (let [offer-jack-out
         {:optional
-         {:waiting-prompt "Runner to decide on jack out"
+         {:waiting-prompt "Runner to decide on Karunā"
           :player :runner
           :prompt "Jack out?"
           :yes-ability {:async true
@@ -2056,7 +2056,7 @@
                                  (continue-ability
                                    state :runner
                                    {:optional
-                                    {:waiting-prompt "Runner to decide to shuffle their Grip into the Stack"
+                                    {:waiting-prompt "Runner to decide on Loki"
                                      :prompt "Reshuffle your Grip into the Stack?"
                                      :player :runner
                                      :yes-ability
@@ -2082,7 +2082,7 @@
                                 (reveal state side (top-3 state))
                                 (continue-ability
                                   state side
-                                  {:waiting-prompt "Corp to choose a card to add to the Grip"
+                                  {:waiting-prompt "Corp to use Loot Box"
                                    :prompt "Choose a card to add to the Grip"
                                    :choices (req (top-3 state))
                                    :msg (msg "add " (:title target) " to the Grip, gain " (:cost target)
@@ -2613,7 +2613,7 @@
                                    state side
                                    {:player :runner
                                     :async true
-                                    :waiting-prompt "Runner to resolve Otoroshi"
+                                    :waiting-prompt "Runner to choose an option for Otoroshi"
                                     :prompt (str "Access " title " or pay 3 [Credits]?")
                                     :choices ["Access card"
                                               (when (>= (:credit runner) 3)
@@ -2755,7 +2755,7 @@
   (let [maybe-draw-effect
         {:optional
          {:player :corp
-          :waiting-prompt "Corp to decide on Sadaka card draw action"
+          :waiting-prompt "Corp to use Sadaka"
           :prompt "Draw 1 card?"
           :yes-ability
           {:async true
@@ -2768,7 +2768,7 @@
                     (effect (continue-ability
                               (let [top-cards (take 3 (:deck corp))
                                     top-names (map :title top-cards)]
-                                {:waiting-prompt "Corp to decide on Sadaka R&D card actions"
+                                {:waiting-prompt "Corp to use Sadaka"
                                  :prompt (str "Top 3 cards of R&D: " (string/join ", " top-names))
                                  :choices ["Arrange cards" "Shuffle R&D"]
                                  :async true
@@ -2791,7 +2791,7 @@
                     (req (wait-for
                            (resolve-ability
                              state side
-                             {:waiting-prompt "Corp to select cards to trash with Sadaka"
+                             {:waiting-prompt "Corp to use Sadaka"
                               :prompt "Choose a card in HQ to trash"
                               :choices (req (cancellable (:hand corp) :sorted))
                               :async true
@@ -2823,7 +2823,7 @@
                                         (do (system-msg state :corp "uses Saisentan to deal a second net damage")
                                             (damage state side eid :net 1 {:card card}))
                                         (effect-completed state side eid)))))}]
-    {:on-encounter {:waiting-prompt "Corp to choose Saisentan card type"
+    {:on-encounter {:waiting-prompt "Corp to use Saisentan"
                     :prompt "Choose a card type"
                     :choices ["Event" "Hardware" "Program" "Resource"]
                     :msg (msg "choose the card type " target)
@@ -2866,7 +2866,7 @@
             {:req (req (and (not (in-discard? card))
                             (some program? (all-active-installed state :runner))))
              :player :runner
-             :waiting-prompt "Runner to decide to break Sapper subroutine"
+             :waiting-prompt "Runner to decide on Sapper"
              :prompt "Allow Sapper subroutine to fire?"
              :yes-ability
              {:async true
@@ -2942,7 +2942,7 @@
   {:subroutines [{:label "Rearrange the top 3 cards of R&D"
                   :msg "rearrange the top 3 cards of R&D"
                   :async true
-                  :waiting-prompt "Corp to rearrange the top cards of R&D"
+                  :waiting-prompt "Corp to use Shiro"
                   :effect (effect (continue-ability
                                     (let [from (take 3 (:deck corp))]
                                       (when (pos? (count from))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -478,14 +478,14 @@
 
 (defcard "Anansi"
   (let [corp-draw {:optional
-                   {:waiting-prompt "Corp to use Anansi"
+                   {:waiting-prompt "Corp to choose an option"
                     :prompt "Draw 1 card?"
                     :yes-ability {:async true
                                   :msg "draw 1 card"
                                   :effect (effect (draw eid 1 nil))}}}
         runner-draw {:player :runner
                      :optional
-                     {:waiting-prompt "Runner to choose an option for Anansi"
+                     {:waiting-prompt "Runner to choose an option"
                       :prompt "Pay 2 [Credits] to draw 1 card?"
                       :yes-ability
                       {:async true
@@ -498,7 +498,7 @@
                       :no-ability {:effect (effect (system-msg :runner "does not draw 1 card"))}}}]
     {:subroutines [{:msg "rearrange the top 5 cards of R&D"
                     :async true
-                    :waiting-prompt "Corp to use Anansi"
+                    :waiting-prompt "Corp to make a decision"
                     :effect (req (let [from (take 5 (:deck corp))]
                                    (continue-ability
                                      state side
@@ -520,7 +520,7 @@
    :access
    {:optional
     {:req (req (not (in-discard? card)))
-     :waiting-prompt "Corp to use Archangel"
+     :waiting-prompt "Corp to choose an option"
      :prompt "Pay 3 [Credits] to force Runner to encounter Archangel?"
      :player :corp
      :yes-ability
@@ -670,7 +670,7 @@
                                      (mill state :runner eid :runner 2))
                                  (continue-ability
                                    state :runner
-                                   {:waiting-prompt "Runner to choose an option for Bloodletter"
+                                   {:waiting-prompt "Runner to choose an option"
                                     :prompt "Trash 1 program or trash top 2 cards of the Stack?"
                                     :choices (req [(when (seq (filter program? (all-active-installed state :runner)))
                                                      "Trash 1 program")
@@ -867,7 +867,7 @@
    :access {:optional
             {:req (req (not (in-discard? card)))
              :player :runner
-             :waiting-prompt "Runner to decide on Chrysalis"
+             :waiting-prompt "Runner to make a decision"
              :prompt "You are encountering Chrysalis. Allow its subroutine to fire?"
              :yes-ability {:async true
                            :effect (effect (resolve-unbroken-subs! :corp eid card))}}}})
@@ -1008,7 +1008,7 @@
                      {:async true
                       :label "Look at the top of the stack"
                       :msg "look at top X cards of the stack"
-                      :waiting-prompt "Corp to use Data Hound"
+                      :waiting-prompt "Corp to make a decision"
                       :effect (req (let [c (- target (second targets))
                                          from (take c (:deck runner))]
                                      (system-msg state :corp
@@ -1627,7 +1627,7 @@
    :access {:optional
             {:req (req (not (in-discard? card)))
              :player :runner
-             :waiting-prompt "Runner to decide on Herald"
+             :waiting-prompt "Runner to make a decision"
              :prompt "You are encountering Herald. Allow its subroutines to fire?"
              :yes-ability {:async true
                            :effect (effect (resolve-unbroken-subs! :corp eid card))}}}})
@@ -1903,7 +1903,7 @@
                   :effect (effect (continue-ability
                                     (when (= 2 (count targets))
                                       {:player :runner
-                                       :waiting-prompt "Runner to decide on Jua"
+                                       :waiting-prompt "Runner to make a decision"
                                        :prompt "Select a card to move to the Stack"
                                        :choices {:card #(some (partial same-card? %) targets)}
                                        :effect (req (move state :runner target :deck {:front true})
@@ -1933,7 +1933,7 @@
           (sub-map [kind]
             {:player :runner
              :async true
-             :waiting-prompt "Runner to choose an option for Kamali 1.0"
+             :waiting-prompt "Runner to choose an option"
              :prompt "Choose one"
              :choices ["Take 1 brain damage" (str "Trash an installed " (better-name kind))]
              :effect (req (if (= target "Take 1 brain damage")
@@ -1954,7 +1954,7 @@
 (defcard "Karunā"
   (let [offer-jack-out
         {:optional
-         {:waiting-prompt "Runner to decide on Karunā"
+         {:waiting-prompt "Runner to choose an option"
           :player :runner
           :prompt "Jack out?"
           :yes-ability {:async true
@@ -2056,7 +2056,7 @@
                                  (continue-ability
                                    state :runner
                                    {:optional
-                                    {:waiting-prompt "Runner to decide on Loki"
+                                    {:waiting-prompt "Runner to choose an option"
                                      :prompt "Reshuffle your Grip into the Stack?"
                                      :player :runner
                                      :yes-ability
@@ -2082,7 +2082,7 @@
                                 (reveal state side (top-3 state))
                                 (continue-ability
                                   state side
-                                  {:waiting-prompt "Corp to use Loot Box"
+                                  {:waiting-prompt "Corp to make a decision"
                                    :prompt "Choose a card to add to the Grip"
                                    :choices (req (top-3 state))
                                    :msg (msg "add " (:title target) " to the Grip, gain " (:cost target)
@@ -2243,7 +2243,7 @@
 
 (defcard "Meridian"
   {:subroutines [{:label "Gain 4 [Credits] and end the run"
-                  :waiting-prompt "Runner to choose an option for Meridian"
+                  :waiting-prompt "Runner to choose an option"
                   :prompt "Choose one"
                   :choices ["End the run" "Add Meridian to score area"]
                   :player :runner
@@ -2366,7 +2366,7 @@
   (letfn [(net-or-trash [net-dmg mill-cnt]
             {:label (str "Do " net-dmg " net damage")
              :player :runner
-             :waiting-prompt "Runner to choose an option for Mlinzi"
+             :waiting-prompt "Runner to choose an option"
              :prompt "Take net damage or trash cards from the stack?"
              :choices (req [(str "Take " net-dmg " net damage")
                             (when (<= mill-cnt (count (:deck runner)))
@@ -2613,7 +2613,7 @@
                                    state side
                                    {:player :runner
                                     :async true
-                                    :waiting-prompt "Runner to choose an option for Otoroshi"
+                                    :waiting-prompt "Runner to choose an option"
                                     :prompt (str "Access " title " or pay 3 [Credits]?")
                                     :choices ["Access card"
                                               (when (>= (:credit runner) 3)
@@ -2755,7 +2755,7 @@
   (let [maybe-draw-effect
         {:optional
          {:player :corp
-          :waiting-prompt "Corp to use Sadaka"
+          :waiting-prompt "Corp to choose an option"
           :prompt "Draw 1 card?"
           :yes-ability
           {:async true
@@ -2768,7 +2768,7 @@
                     (effect (continue-ability
                               (let [top-cards (take 3 (:deck corp))
                                     top-names (map :title top-cards)]
-                                {:waiting-prompt "Corp to use Sadaka"
+                                {:waiting-prompt "Corp to make a decision"
                                  :prompt (str "Top 3 cards of R&D: " (string/join ", " top-names))
                                  :choices ["Arrange cards" "Shuffle R&D"]
                                  :async true
@@ -2791,7 +2791,7 @@
                     (req (wait-for
                            (resolve-ability
                              state side
-                             {:waiting-prompt "Corp to use Sadaka"
+                             {:waiting-prompt "Corp to make a decision"
                               :prompt "Choose a card in HQ to trash"
                               :choices (req (cancellable (:hand corp) :sorted))
                               :async true
@@ -2823,7 +2823,7 @@
                                         (do (system-msg state :corp "uses Saisentan to deal a second net damage")
                                             (damage state side eid :net 1 {:card card}))
                                         (effect-completed state side eid)))))}]
-    {:on-encounter {:waiting-prompt "Corp to use Saisentan"
+    {:on-encounter {:waiting-prompt "Corp to choose an option"
                     :prompt "Choose a card type"
                     :choices ["Event" "Hardware" "Program" "Resource"]
                     :msg (msg "choose the card type " target)
@@ -2866,7 +2866,7 @@
             {:req (req (and (not (in-discard? card))
                             (some program? (all-active-installed state :runner))))
              :player :runner
-             :waiting-prompt "Runner to decide on Sapper"
+             :waiting-prompt "Runner to make a decision"
              :prompt "Allow Sapper subroutine to fire?"
              :yes-ability
              {:async true
@@ -2942,7 +2942,7 @@
   {:subroutines [{:label "Rearrange the top 3 cards of R&D"
                   :msg "rearrange the top 3 cards of R&D"
                   :async true
-                  :waiting-prompt "Corp to use Shiro"
+                  :waiting-prompt "Corp to make a decision"
                   :effect (effect (continue-ability
                                     (let [from (take 3 (:deck corp))]
                                       (when (pos? (count from))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -56,7 +56,7 @@
                                    (continue-ability
                                      state side
                                      {:optional
-                                      {:waiting-prompt "Corp to decide about 419: Amoral Scammer"
+                                      {:waiting-prompt "Corp to decide on 419: Amoral Scammer"
                                        :prompt "Pay 1 [Credits] to prevent exposure of installed card?"
                                        :player :corp
                                        :no-ability
@@ -150,7 +150,7 @@
              :req (req (and (= :archives (target-server context))
                             (first-successful-run-on-server? state :archives)
                             (not-empty (:hand corp))))
-             :waiting-prompt "Corp to trash 1 card from HQ"
+             :waiting-prompt "Corp to decide on Alice Merchant: Clan Agitator"
              :prompt "Choose a card in HQ to discard"
              :player :corp
              :choices {:all true
@@ -454,7 +454,7 @@
                     (not (agenda? target))
                     (<= (play-cost state side target)
                         (number-of-runner-virus-counters state))))
-     :waiting-prompt "Runner to use Freedom Khumalo's ability"
+     :waiting-prompt "Runner to use Freedom Khumalo: Crypto-Anarchist"
      :effect (req (let [accessed-card target
                         play-or-rez (:cost target)]
                     (if (zero? play-or-rez)
@@ -601,7 +601,7 @@
                             (not (:facedown context))))
              :once :per-turn
              :async true
-             :waiting-prompt "Runner to use Hayley's ability"
+             :waiting-prompt "Runner to use Hayley Kaplan: Universal Scholar"
              :effect
              (effect (continue-ability
                        (let [itarget (:card context)
@@ -735,7 +735,7 @@
 (defcard "Jemison Astronautics: Sacrifice. Audacity. Success."
   {:events [{:event :corp-forfeit-agenda
              :async true
-             :waiting-prompt "Corp to place advancement tokens"
+             :waiting-prompt "Corp to use Jemison Astronautics: Sacrifice. Audacity. Success."
              :effect
              (effect
                (continue-ability
@@ -1367,7 +1367,7 @@
 (defcard "Skorpios Defense Systems: Persuasive Power"
   {:implementation "Manually triggered, no restriction on which cards in Heap can be targeted. Cannot use on in progress run event"
    :abilities [{:label "Remove a card in the Heap that was just trashed from the game"
-                :waiting-prompt "Corp to use Skorpios' ability"
+                :waiting-prompt "Corp to use Skorpios Defense Systems: Persuasive Power"
                 :prompt "Choose a card in the Runner's Heap that was just trashed"
                 :once :per-turn
                 :choices (req (cancellable (:discard runner)))
@@ -1414,7 +1414,7 @@
                :optional
                {:req (req (and (not-empty (installed-faceup-agendas state))
                                (not-empty (ice-with-no-advancement-tokens state))))
-                :waiting-prompt "Corp to use SSO Industries"
+                :waiting-prompt "Corp to use SSO Industries: Fueling Innovation"
                 :prompt "Place advancement tokens?"
                 :autoresolve (get-autoresolve :auto-sso)
                 :yes-ability
@@ -1456,7 +1456,7 @@
                (effect (continue-ability
                          (let [c1 (first targets)
                                c2 (second targets)]
-                           {:waiting-prompt "Corp to choose which card to remove from the game"
+                           {:waiting-prompt "Corp to decide on Steve Cambridge: Master Grifter"
                             :prompt "Choose which card to remove from the game"
                             :player :corp
                             :choices [c1 c2]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -38,7 +38,7 @@
                             (pos? (:turn @state))
                             (not (rezzed? (:card context)))
                             (not (#{:rezzed-no-cost :rezzed-no-rez-cost :rezzed :face-up} (:install-state context)))))
-             :waiting-prompt "Runner to use 419: Amoral Scammer"
+             :waiting-prompt "Runner to choose an option"
              :effect
              (effect
                (continue-ability
@@ -56,7 +56,7 @@
                                    (continue-ability
                                      state side
                                      {:optional
-                                      {:waiting-prompt "Corp to decide on 419: Amoral Scammer"
+                                      {:waiting-prompt "Corp to choose an option"
                                        :prompt "Pay 1 [Credits] to prevent exposure of installed card?"
                                        :player :corp
                                        :no-ability
@@ -91,7 +91,7 @@
   {:events [{:event :pre-start-game
              :req (req (= side :runner))
              :async true
-             :waiting-prompt "Runner to choose starting directives"
+             :waiting-prompt "Runner to make a decision"
              :effect (req (let [directives (->> (server-cards)
                                                 (filter #(has-subtype? % "Directive"))
                                                 (map make-card)
@@ -150,7 +150,7 @@
              :req (req (and (= :archives (target-server context))
                             (first-successful-run-on-server? state :archives)
                             (not-empty (:hand corp))))
-             :waiting-prompt "Corp to decide on Alice Merchant: Clan Agitator"
+             :waiting-prompt "Corp to make a decision"
              :prompt "Choose a card in HQ to discard"
              :player :corp
              :choices {:all true
@@ -243,7 +243,7 @@
    :events [{:event :pre-start-game
              :req (req (= side :runner))
              :async true
-             :waiting-prompt "Runner to choose cards to be hosted"
+             :waiting-prompt "Runner to make a decision"
              :effect (req (doseq [c (take 6 (:deck runner))]
                             (move state side c :play-area))
                           (continue-ability
@@ -341,7 +341,7 @@
                              (pos? (last targets))
                              (empty? (filter #(= :net (first %)) (turn-events state :runner :damage)))
                              (pos? (count (:hand runner)))))
-              :waiting-prompt "Corp to use Chronos Protocol: Selective Mind-mapping"
+              :waiting-prompt "Corp to make a decision"
               :prompt "Use Chronos Protocol to select the first card trashed?"
               :yes-ability
               {:async true
@@ -454,7 +454,7 @@
                     (not (agenda? target))
                     (<= (play-cost state side target)
                         (number-of-runner-virus-counters state))))
-     :waiting-prompt "Runner to use Freedom Khumalo: Crypto-Anarchist"
+     :waiting-prompt "Runner to make a decision"
      :effect (req (let [accessed-card target
                         play-or-rez (:cost target)]
                     (if (zero? play-or-rez)
@@ -538,7 +538,7 @@
                                               (and (rezzed? ice)
                                                    (installed? ice)
                                                    (has-subtype? ice "Bioroid")))))))
-             :waiting-prompt "Corp to use Haas-Bioroid: Architects of Tomorrow"
+             :waiting-prompt "Corp to make a decision"
              :prompt "Select a Bioroid to rez"
              :player :corp
              :choices
@@ -601,7 +601,7 @@
                             (not (:facedown context))))
              :once :per-turn
              :async true
-             :waiting-prompt "Runner to use Hayley Kaplan: Universal Scholar"
+             :waiting-prompt "Runner to make a decision"
              :effect
              (effect (continue-ability
                        (let [itarget (:card context)
@@ -735,7 +735,7 @@
 (defcard "Jemison Astronautics: Sacrifice. Audacity. Success."
   {:events [{:event :corp-forfeit-agenda
              :async true
-             :waiting-prompt "Corp to use Jemison Astronautics: Sacrifice. Audacity. Success."
+             :waiting-prompt "Corp to make a decision"
              :effect
              (effect
                (continue-ability
@@ -1109,7 +1109,7 @@
                                              (some #(and (installed? (:card %))
                                                          (corp? (:card %)))
                                                    targets)))))
-              :waiting-prompt "Corp to use NBN: Controlling the Message"
+              :waiting-prompt "Corp to make a decision"
               :prompt "Trace the Runner with NBN: Controlling the Message?"
               :autoresolve (get-autoresolve :auto-ctm)
               :yes-ability
@@ -1130,7 +1130,7 @@
              :req (req (first-event? state :runner :runner-gain-tag))
              :player :corp
              :async true
-             :waiting-prompt "Corp to use NBN: Reality Plus"
+             :waiting-prompt "Corp to choose an option"
              :prompt "Select option"
              :choices ["Gain 2 [Credits]" "Draw 2 cards"]
              :msg (msg (decapitalize target))
@@ -1367,7 +1367,7 @@
 (defcard "Skorpios Defense Systems: Persuasive Power"
   {:implementation "Manually triggered, no restriction on which cards in Heap can be targeted. Cannot use on in progress run event"
    :abilities [{:label "Remove a card in the Heap that was just trashed from the game"
-                :waiting-prompt "Corp to use Skorpios Defense Systems: Persuasive Power"
+                :waiting-prompt "Corp to make a decision"
                 :prompt "Choose a card in the Runner's Heap that was just trashed"
                 :once :per-turn
                 :choices (req (cancellable (:discard runner)))
@@ -1414,7 +1414,7 @@
                :optional
                {:req (req (and (not-empty (installed-faceup-agendas state))
                                (not-empty (ice-with-no-advancement-tokens state))))
-                :waiting-prompt "Corp to use SSO Industries: Fueling Innovation"
+                :waiting-prompt "Corp to make a decision"
                 :prompt "Place advancement tokens?"
                 :autoresolve (get-autoresolve :auto-sso)
                 :yes-ability
@@ -1456,7 +1456,7 @@
                (effect (continue-ability
                          (let [c1 (first targets)
                                c2 (second targets)]
-                           {:waiting-prompt "Corp to decide on Steve Cambridge: Master Grifter"
+                           {:waiting-prompt "Corp to make a decision"
                             :prompt "Choose which card to remove from the game"
                             :player :corp
                             :choices [c1 c2]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -238,7 +238,7 @@
                      (wait-for
                        (resolve-ability
                          state :runner
-                         {:waiting-prompt "Runner to decide on Biased Reporting"
+                         {:waiting-prompt "Runner to make a decision"
                           :prompt (msg "Choose any number of cards of type " t " to trash")
                           :choices {:max n
                                     :card #(and (installed? %)
@@ -720,7 +720,7 @@
       {:req (req (and (<= 6 (:credit runner))
                       (pos? (count-resources state))))
        :player :runner
-       :waiting-prompt "Runner to decide on Financial Collapse"
+       :waiting-prompt "Runner to choose an option"
        :prompt "Trash a resource to prevent Financial Collapse?"
        :yes-ability
        {:prompt "Select a resource to trash"
@@ -864,7 +864,7 @@
                                state :runner
                                {:async true
                                 :req (req (<= 3 (:credit runner)))
-                                :waiting-prompt "Runner to decide on Game Over"
+                                :waiting-prompt "Runner to make a decision"
                                 :prompt (msg "Prevent any " typemsg " from being trashed? Pay 3 [Credits] per card.")
                                 :choices {:max (req (min numtargets (quot (total-available-credits state :runner eid card) 3)))
                                           :card #(and (installed? %)
@@ -924,7 +924,7 @@
               {:optional
                {:player :runner
                 :async true
-                :waiting-prompt "Runner to decide on Hangeki"
+                :waiting-prompt "Runner to choose an option"
                 :prompt "Access card? (If not, add Hangeki to your score area worth -1 agenda point)"
                 :yes-ability
                 {:async true
@@ -986,7 +986,7 @@
     {:on-play
      {:additional-cost [:trash-from-deck 1]
       :msg "trash the top card of R&D, draw 3 cards, and add 3 cards in HQ to the top of R&D"
-      :waiting-prompt "Corp to use Hasty Relocation"
+      :waiting-prompt "Corp to make a decision"
       :async true
       :effect (req (wait-for (draw state side 3 nil)
                              (let [from (get-in @state [:corp :hand])]
@@ -1448,7 +1448,7 @@
                    (continue-ability
                      state side
                      {:optional
-                      {:waiting-prompt "Runner to decide on O₂ Shortage"
+                      {:waiting-prompt "Runner to make a decision"
                        :prompt "Trash 1 random card from your Grip?"
                        :player :runner
                        :yes-ability {:async true
@@ -1559,7 +1559,7 @@
 (defcard "Precognition"
   {:on-play
    {:msg "rearrange the top 5 cards of R&D"
-    :waiting-prompt "Corp to use Precognition"
+    :waiting-prompt "Corp to make a decision"
     :async true
     :effect (effect (continue-ability
                       (let [from (take 5 (:deck corp))]
@@ -1666,7 +1666,7 @@
     {:on-play
      {:req (req (pos? (count (:deck corp))))
       :msg (msg "look at the top " (quantify (count (take 5 (:deck corp))) "card") " of R&D")
-      :waiting-prompt "Corp to use Psychokinesis"
+      :waiting-prompt "Corp to make a decision"
       :async true
       :effect (effect (continue-ability
                         (let [top-5 (take 5 (:deck corp))]
@@ -1793,7 +1793,7 @@
                                                (effect-completed state side eid)))
                                    (continue-ability state side (choice abis chose-once) card nil))))})]
     {:on-play
-     {:waiting-prompt "Corp to use Red Level Clearance"
+     {:waiting-prompt "Corp to make a decision"
       :async true
       :effect (effect (continue-ability (choice all false) card nil))}}))
 
@@ -1945,7 +1945,7 @@
    {:rfg-instead-of-trashing true
     :optional
     {:req (req (last-turn? state :runner :trashed-card))
-     :waiting-prompt "Runner to decide on Riot Suppression"
+     :waiting-prompt "Runner to choose an option"
      :prompt "Take 1 brain damage to prevent having 3 fewer clicks next turn?"
      :player :runner
      :yes-ability
@@ -2066,7 +2066,7 @@
 (defcard "Secure and Protect"
   {:on-play
    {:interactive (req true)
-    :waiting-prompt "Corp to use Secure and Protect"
+    :waiting-prompt "Corp to make a decision"
     :async true
     :effect (req (if (seq (filter ice? (:deck corp)))
                    (continue-ability
@@ -2175,7 +2175,7 @@
    {:trace
     {:base 3
      :successful
-     {:waiting-prompt "Corp to use Snatch and Grab"
+     {:waiting-prompt "Corp to make a decision"
       :msg "trash a connection"
       :choices {:card #(has-subtype? % "Connection")}
       :async true
@@ -2185,7 +2185,7 @@
           (let [c target]
             {:optional
              {:player :runner
-              :waiting-prompt "Runner to decide on Snatch and Grab"
+              :waiting-prompt "Runner to choose an option"
               :prompt (str "Take 1 tag to prevent " (:title c) " from being trashed?")
               :yes-ability
               {:async true
@@ -2429,7 +2429,7 @@
               (continue-ability
                 (let [chosen target]
                   {:player :runner
-                   :waiting-prompt "Runner to choose an option on Threat Assessment"
+                   :waiting-prompt "Runner to choose an option"
                    :prompt (str "Add " (:title chosen) " to the top of the Stack or take 2 tags?")
                    :choices [(str "Move " (:title chosen))
                              "Take 2 tags"]
@@ -2610,7 +2610,7 @@
                 (let [chosen target
                       wake card]
                   {:player :runner
-                   :waiting-prompt "Runner to choose an option on Wake Up Call"
+                   :waiting-prompt "Runner to choose an option"
                    :prompt (str "Trash " (:title chosen) " or suffer 4 meat damage?")
                    :choices [(str "Trash " (:title chosen))
                              "4 meat damage"]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -238,7 +238,7 @@
                      (wait-for
                        (resolve-ability
                          state :runner
-                         {:waiting-prompt "Runner to choose cards to trash"
+                         {:waiting-prompt "Runner to decide on Biased Reporting"
                           :prompt (msg "Choose any number of cards of type " t " to trash")
                           :choices {:max n
                                     :card #(and (installed? %)
@@ -720,7 +720,7 @@
       {:req (req (and (<= 6 (:credit runner))
                       (pos? (count-resources state))))
        :player :runner
-       :waiting-prompt "Runner to trash a resource to prevent Financial Collapse"
+       :waiting-prompt "Runner to decide on Financial Collapse"
        :prompt "Trash a resource to prevent Financial Collapse?"
        :yes-ability
        {:prompt "Select a resource to trash"
@@ -864,7 +864,7 @@
                                state :runner
                                {:async true
                                 :req (req (<= 3 (:credit runner)))
-                                :waiting-prompt "Runner to prevent trashes"
+                                :waiting-prompt "Runner to decide on Game Over"
                                 :prompt (msg "Prevent any " typemsg " from being trashed? Pay 3 [Credits] per card.")
                                 :choices {:max (req (min numtargets (quot (total-available-credits state :runner eid card) 3)))
                                           :card #(and (installed? %)
@@ -924,7 +924,7 @@
               {:optional
                {:player :runner
                 :async true
-                :waiting-prompt "Runner to resolve Hangeki"
+                :waiting-prompt "Runner to decide on Hangeki"
                 :prompt "Access card? (If not, add Hangeki to your score area worth -1 agenda point)"
                 :yes-ability
                 {:async true
@@ -986,7 +986,7 @@
     {:on-play
      {:additional-cost [:trash-from-deck 1]
       :msg "trash the top card of R&D, draw 3 cards, and add 3 cards in HQ to the top of R&D"
-      :waiting-prompt "Corp to add 3 cards in HQ to the top of R&D"
+      :waiting-prompt "Corp to use Hasty Relocation"
       :async true
       :effect (req (wait-for (draw state side 3 nil)
                              (let [from (get-in @state [:corp :hand])]
@@ -1448,7 +1448,7 @@
                    (continue-ability
                      state side
                      {:optional
-                      {:waiting-prompt "Runner to decide whether or not to trash a card from their Grip"
+                      {:waiting-prompt "Runner to decide on O₂ Shortage"
                        :prompt "Trash 1 random card from your Grip?"
                        :player :runner
                        :yes-ability {:async true
@@ -1559,7 +1559,7 @@
 (defcard "Precognition"
   {:on-play
    {:msg "rearrange the top 5 cards of R&D"
-    :waiting-prompt "Corp to rearrange the top cards of R&D"
+    :waiting-prompt "Corp to use Precognition"
     :async true
     :effect (effect (continue-ability
                       (let [from (take 5 (:deck corp))]
@@ -1666,7 +1666,7 @@
     {:on-play
      {:req (req (pos? (count (:deck corp))))
       :msg (msg "look at the top " (quantify (count (take 5 (:deck corp))) "card") " of R&D")
-      :waiting-prompt "Corp to look at the top cards of R&D"
+      :waiting-prompt "Corp to use Psychokinesis"
       :async true
       :effect (effect (continue-ability
                         (let [top-5 (take 5 (:deck corp))]
@@ -1945,7 +1945,7 @@
    {:rfg-instead-of-trashing true
     :optional
     {:req (req (last-turn? state :runner :trashed-card))
-     :waiting-prompt "Runner to decide if they will take 1 brain damage"
+     :waiting-prompt "Runner to decide on Riot Suppression"
      :prompt "Take 1 brain damage to prevent having 3 fewer clicks next turn?"
      :player :runner
      :yes-ability
@@ -2185,7 +2185,7 @@
           (let [c target]
             {:optional
              {:player :runner
-              :waiting-prompt "Runner to decide if they will take 1 tag"
+              :waiting-prompt "Runner to decide on Snatch and Grab"
               :prompt (str "Take 1 tag to prevent " (:title c) " from being trashed?")
               :yes-ability
               {:async true
@@ -2429,7 +2429,7 @@
               (continue-ability
                 (let [chosen target]
                   {:player :runner
-                   :waiting-prompt "Runner to resolve Threat Assessment"
+                   :waiting-prompt "Runner to choose an option on Threat Assessment"
                    :prompt (str "Add " (:title chosen) " to the top of the Stack or take 2 tags?")
                    :choices [(str "Move " (:title chosen))
                              "Take 2 tags"]
@@ -2610,7 +2610,7 @@
                 (let [chosen target
                       wake card]
                   {:player :runner
-                   :waiting-prompt "Runner to resolve Wake Up Call"
+                   :waiting-prompt "Runner to choose an option on Wake Up Call"
                    :prompt (str "Trash " (:title chosen) " or suffer 4 meat damage?")
                    :choices [(str "Trash " (:title chosen))
                              "4 meat damage"]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -691,7 +691,7 @@
              {:req (req (and (:successful context)
                              (= :rd (target-server context))))
               :player :runner
-              :waiting-prompt "Runner to decide if they will use Conduit"
+              :waiting-prompt "Runner to use Conduit"
               :autoresolve (get-autoresolve :auto-conduit)
               :prompt "Use Conduit?"
               :yes-ability {:msg "add 1 virus counter to Conduit"
@@ -852,7 +852,7 @@
     {:on-install {:async true
                   :interactive (req (some #(card-flag? % :runner-install-draw true) (all-active state :runner)))
                   :msg (msg "reveal the top 5 cards of their Stack: " (string/join ", " (map :title (take 5 (:deck runner)))))
-                  :waiting-prompt "Runner to host programs on Customized Secretary"
+                  :waiting-prompt "Runner to use Customized Secretary"
                   :effect (req (let [from (take 5 (:deck runner))]
                                  (wait-for (reveal state side from)
                                            (continue-ability state side (custsec-host from) card nil))))}
@@ -1382,7 +1382,7 @@
                 :async true
                 :effect (req (continue-ability
                                state :corp
-                               {:waiting-prompt "Corp to trash a card"
+                               {:waiting-prompt "Corp to decide on Hemorrhage"
                                 :prompt "Choose a card to trash"
                                 :choices (req (filter corp? (:hand corp)))
                                 :async true

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -691,7 +691,7 @@
              {:req (req (and (:successful context)
                              (= :rd (target-server context))))
               :player :runner
-              :waiting-prompt "Runner to use Conduit"
+              :waiting-prompt "Runner to choose an option"
               :autoresolve (get-autoresolve :auto-conduit)
               :prompt "Use Conduit?"
               :yes-ability {:msg "add 1 virus counter to Conduit"
@@ -852,7 +852,7 @@
     {:on-install {:async true
                   :interactive (req (some #(card-flag? % :runner-install-draw true) (all-active state :runner)))
                   :msg (msg "reveal the top 5 cards of their Stack: " (string/join ", " (map :title (take 5 (:deck runner)))))
-                  :waiting-prompt "Runner to use Customized Secretary"
+                  :waiting-prompt "Runner to make a decision"
                   :effect (req (let [from (take 5 (:deck runner))]
                                  (wait-for (reveal state side from)
                                            (continue-ability state side (custsec-host from) card nil))))}
@@ -932,7 +932,7 @@
                 :async true
                 :effect (effect
                           (continue-ability
-                            {:waiting-prompt "Runner to use DaVinci"
+                            {:waiting-prompt "Runner to make a decision"
                              :prompt "Choose a card to install from your Grip"
                              :msg (msg "install " (:title target) " at no cost")
                              :choices {:req (req (and (in-hand? target)
@@ -1028,7 +1028,7 @@
      :trash-icon true
      :optional
      {:player :runner
-      :waiting-prompt "Runner to use Disruptor"
+      :waiting-prompt "Runner to choose an option"
       :prompt "Use Disrupter's ability?"
       :yes-ability
       {:cost [:trash]
@@ -1134,7 +1134,7 @@
                :req (req (= :rd (target-server context)))
                :async true
                :interactive (req true)
-               :waiting-prompt "Runner to use Equivocation"
+               :waiting-prompt "Runner to make a decision"
                :effect (effect (continue-ability reveal card nil))}]}))
 
 (defcard "Euler"
@@ -1382,7 +1382,7 @@
                 :async true
                 :effect (req (continue-ability
                                state :corp
-                               {:waiting-prompt "Corp to decide on Hemorrhage"
+                               {:waiting-prompt "Corp to make a decision"
                                 :prompt "Choose a card to trash"
                                 :choices (req (filter corp? (:hand corp)))
                                 :async true
@@ -1791,7 +1791,7 @@
              :optional
              {:req (req (and (pos? (get-counters card :power))
                              (= target :rd)))
-              :waiting-prompt "Runner to use Nyashia"
+              :waiting-prompt "Runner to choose an option"
               :prompt "Spend a power counter on Nyashia to access 1 additional card?"
               :autoresolve (get-autoresolve :auto-nyashia)
               :yes-ability {:msg "access 1 additional card from R&D"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -871,7 +871,7 @@
                                                        (not (is-draft-id? %))))
                                          (sort-by :title)))
         fenris-effect {:async true
-                       :waiting-prompt "Runner to pick identity to host on DJ Fenris"
+                       :waiting-prompt "Runner to use DJ Fenris"
                        :prompt "Choose a g-mod identity to host on DJ Fenris"
                        :choices (req (sorted-id-list runner))
                        :msg (msg "host " (:title target))
@@ -1464,7 +1464,7 @@
 
 (defcard "Levy Advanced Research Lab"
   (letfn [(lab-keep [cards]
-            {:waiting-prompt "Runner to choose card to keep"
+            {:waiting-prompt "Runner to use Levy Advanced Research Lab"
              :prompt "Choose a Program to keep"
              :choices (cons "None" (filter program? cards))
              :async true
@@ -1530,7 +1530,7 @@
                 (effect (continue-ability
                           (if (seq (:scored corp))
                             {:optional
-                             {:waiting-prompt "Corp to decide whether or not to prevent Liberated Chela"
+                             {:waiting-prompt "Corp to decide on Liberated Chela"
                               :prompt "Forfeit an agenda to prevent Liberated Chela from being added to Runner's score area?"
                               :player :corp
                               :async true
@@ -1639,7 +1639,7 @@
 
 (defcard "Muertos Gang Member"
   {:on-install {:player :corp
-                :waiting-prompt "Corp to select a card to derez"
+                :waiting-prompt "Corp to decide on Muertos Gang Member"
                 :prompt "Select a card to derez"
                 :choices {:card #(and (corp? %)
                                       (not (agenda? %))
@@ -1649,7 +1649,7 @@
    (effect
      (continue-ability
        {:player :corp
-        :waiting-prompt "Corp to select a card to rez"
+        :waiting-prompt "Corp to decide on Muertos Gang Member"
         :prompt "Select a card to rez, ignoring the rez cost"
         :choices {:card (complement rezzed?)}
         :async true
@@ -2190,7 +2190,7 @@
 (defcard "Rolodex"
   {:on-install {:async true
                 :msg "look at the top 5 cards of their Stack"
-                :waiting-prompt "Runner to rearrange the top cards of their Stack"
+                :waiting-prompt "Runner to use Rolodex"
                 :effect (effect (continue-ability
                                   (let [from (take 5 (:deck runner))]
                                     (if (pos? (count from))
@@ -2748,7 +2748,7 @@
 (defcard "The Nihilist"
   (let [corp-choice {:optional
                      {:player :corp
-                      :waiting-prompt "Corp to decide"
+                      :waiting-prompt "Corp to decide on The Nihilist"
                       :prompt "Trash the top card of R&D to prevent the Runner drawing 2 cards?"
                       :yes-ability {:async true
                                     :effect (effect (system-msg :corp "trashes the top card of R&D to prevent the Runner drawing 2 cards")
@@ -3055,7 +3055,7 @@
                                   state side
                                   {:optional
                                    {:player :corp
-                                    :waiting-prompt "Corp to decide whether or not to draw with Woman in the Red Dress"
+                                    :waiting-prompt "Corp to decide on Woman in the Red Dress"
                                     :prompt (msg "Draw " (:title (first (:deck corp))) "?")
                                     :yes-ability
                                     {:async true

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -595,7 +595,7 @@
                (continue-ability
                  {:optional
                   {:player :runner
-                   :waiting-prompt "Runner to use Councilman"
+                   :waiting-prompt "Runner to choose an option"
                    :prompt (msg "Trash Councilman and pay " (rez-cost state :corp (:card context))
                                 " [Credits] to derez " (:title (:card context)) "?")
                    :yes-ability
@@ -871,7 +871,7 @@
                                                        (not (is-draft-id? %))))
                                          (sort-by :title)))
         fenris-effect {:async true
-                       :waiting-prompt "Runner to use DJ Fenris"
+                       :waiting-prompt "Runner to choose an option"
                        :prompt "Choose a g-mod identity to host on DJ Fenris"
                        :choices (req (sorted-id-list runner))
                        :msg (msg "host " (:title target))
@@ -1333,7 +1333,7 @@
 (defcard "Jackpot!"
   (let [jackpot {:interactive (req true)
                  :optional
-                 {:waiting-prompt "Runner to use Jackpot!"
+                 {:waiting-prompt "Runner to choose an option"
                   :prompt "Trash Jackpot!?"
                   :yes-ability
                   {:prompt "Choose how many [Credit] to take"
@@ -1464,7 +1464,7 @@
 
 (defcard "Levy Advanced Research Lab"
   (letfn [(lab-keep [cards]
-            {:waiting-prompt "Runner to use Levy Advanced Research Lab"
+            {:waiting-prompt "Runner to make a decision"
              :prompt "Choose a Program to keep"
              :choices (cons "None" (filter program? cards))
              :async true
@@ -1530,7 +1530,7 @@
                 (effect (continue-ability
                           (if (seq (:scored corp))
                             {:optional
-                             {:waiting-prompt "Corp to decide on Liberated Chela"
+                             {:waiting-prompt "Corp to make a decision"
                               :prompt "Forfeit an agenda to prevent Liberated Chela from being added to Runner's score area?"
                               :player :corp
                               :async true
@@ -1639,7 +1639,7 @@
 
 (defcard "Muertos Gang Member"
   {:on-install {:player :corp
-                :waiting-prompt "Corp to decide on Muertos Gang Member"
+                :waiting-prompt "Corp to make a decision"
                 :prompt "Select a card to derez"
                 :choices {:card #(and (corp? %)
                                       (not (agenda? %))
@@ -1649,7 +1649,7 @@
    (effect
      (continue-ability
        {:player :corp
-        :waiting-prompt "Corp to decide on Muertos Gang Member"
+        :waiting-prompt "Corp to make a decision"
         :prompt "Select a card to rez, ignoring the rez cost"
         :choices {:card (complement rezzed?)}
         :async true
@@ -1701,7 +1701,7 @@
    :events [{:event :spent-credits-from-card
              :req (req (and run (has-subtype? target "Stealth")))
              :once :per-run
-             :waiting-prompt "Runner to use Net Mercur"
+             :waiting-prompt "Runner to choose an option"
              :prompt "Place 1 [Credits] on Net Mercur or draw 1 card?"
              :player :runner
              :choices ["Place 1 [Credits]" "Draw 1 card"]
@@ -2190,7 +2190,7 @@
 (defcard "Rolodex"
   {:on-install {:async true
                 :msg "look at the top 5 cards of their Stack"
-                :waiting-prompt "Runner to use Rolodex"
+                :waiting-prompt "Runner to make a decision"
                 :effect (effect (continue-ability
                                   (let [from (take 5 (:deck runner))]
                                     (if (pos? (count from))
@@ -2311,7 +2311,7 @@
   {:events [{:event :damage
              :trash-icon true
              :optional
-             {:waiting-prompt "Runner to use Salvaged Vanadis Armory"
+             {:waiting-prompt "Runner to choose an option"
               :prompt "Use Salvaged Vanadis Armory?"
               :yes-ability {:async true
                             :cost [:trash]
@@ -2522,7 +2522,7 @@
              :optional
              {:req (req (or (has-subtype? (:card context) "Black Ops")
                             (has-subtype? (:card context) "Gray Ops")))
-              :waiting-prompt "Runner to use Tallie Perrault"
+              :waiting-prompt "Runner to choose an option"
               :prompt "Use Tallie Perrault to give the Corp 1 bad publicity and take 1 tag?"
               :player :runner
               :yes-ability {:msg "give the Corp 1 bad publicity and take 1 tag"
@@ -2696,7 +2696,7 @@
                            (let [n (+ target (get-in @state [:bonus :draw] 0))
                                  to-draw (take (inc n) (:deck (:runner @state)))]
                              {:player :runner
-                              :waiting-prompt "Runner to use The Class Act"
+                              :waiting-prompt "Runner to choose an option"
                               :prompt "Select 1 card to add to the bottom of the stack"
                               :choices to-draw
                               :effect (effect (move target :deck)
@@ -2748,7 +2748,7 @@
 (defcard "The Nihilist"
   (let [corp-choice {:optional
                      {:player :corp
-                      :waiting-prompt "Corp to decide on The Nihilist"
+                      :waiting-prompt "Corp to choose an option"
                       :prompt "Trash the top card of R&D to prevent the Runner drawing 2 cards?"
                       :yes-ability {:async true
                                     :effect (effect (system-msg :corp "trashes the top card of R&D to prevent the Runner drawing 2 cards")
@@ -3055,7 +3055,7 @@
                                   state side
                                   {:optional
                                    {:player :corp
-                                    :waiting-prompt "Corp to decide on Woman in the Red Dress"
+                                    :waiting-prompt "Corp to choose an option"
                                     :prompt (msg "Draw " (:title (first (:deck corp))) "?")
                                     :yes-ability
                                     {:async true

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -128,7 +128,7 @@
                 :async true
                 :msg (msg (str "reveal " (string/join ", " (map :title (take 3 (:deck corp)))) " from R&D"))
                 :label "Add 1 card from top 3 of R&D to HQ"
-                :waiting-prompt "Corp to use Bamboo Dome"
+                :waiting-prompt "Corp to make a decision"
                 :effect (req
                           (wait-for
                             (reveal state side (take 3 (:deck corp)))
@@ -286,7 +286,7 @@
                                    (* 2))]
                      {:async true
                       :player :runner
-                      :waiting-prompt "Runner to choose an option for Cayambe Grid"
+                      :waiting-prompt "Runner to choose an option"
                       :prompt (str "Pay " cost " [Credits] or end the run?")
                       :choices [(when (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil [:credit cost])
                                   (str "Pay " cost " [Credits]"))
@@ -360,7 +360,7 @@
 (defcard "Cyberdex Virus Suite"
   {:flags {:rd-reveal (req true)}
    :access {:optional
-            {:waiting-prompt "Corp to use Cyberdex Virus Suite"
+            {:waiting-prompt "Corp to choose an option"
              :prompt "Purge virus counters with Cyberdex Virus Suite?"
              :yes-ability {:msg (msg "purge virus counters")
                            :effect (effect (purge))}}}
@@ -385,7 +385,7 @@
            :effect (effect (swap-cards to-swap target))})
         ability
         {:optional
-         {:waiting-prompt "Corp to use Daruma"
+         {:waiting-prompt "Corp to make a decision"
           :prompt "Trash Daruma to swap a card in this server?"
           :yes-ability
           {:async true
@@ -438,7 +438,7 @@
                                card nil))})]
     {:flags {:rd-reveal (req true)}
      :access {:optional
-              {:waiting-prompt "Corp to use Disposable HQ"
+              {:waiting-prompt "Corp to make a decision"
                :prompt "Use Disposable HQ to add cards to the bottom of R&D?"
                :yes-ability
                {:async true
@@ -527,7 +527,7 @@
    {:optional
     {:req (req (and (not (in-discard? card))
                     (some ice? (all-active-installed state :corp))))
-     :waiting-prompt "Corp to use Ganked!"
+     :waiting-prompt "Corp to make a decision"
      :prompt "Trash Ganked! to force the Runner to encounter a piece of ice?"
      :yes-ability
      {:async true
@@ -672,7 +672,7 @@
    :access {:interactive (req true)
             :optional
             {:player :runner
-             :waiting-prompt "Runner to decide on Increased Drop Rates"
+             :waiting-prompt "Runner to choose an option"
              :prompt "Take 1 tag to prevent Corp from removing 1 bad publicity?"
              :yes-ability
              {:async true
@@ -690,7 +690,7 @@
                     :base 4
                     :label "add an installed program or virtual resource to the Grip"
                     :successful
-                    {:waiting-prompt "Corp to use Intake"
+                    {:waiting-prompt "Corp to make a decision"
                      :prompt "Select a program or virtual resource"
                      :player :corp
                      :choices {:card #(and (installed? %)
@@ -739,7 +739,7 @@
                :once :per-turn
                :once-key :jinja-city-grid-draw
                :async true
-               :waiting-prompt "Corp to use Jinja City Grid"
+               :waiting-prompt "Corp to make a decision"
                :req (req (not (find-cid (:cid card) (flatten (vals (get-in @state [:trash :trash-list]))))))
                :effect (req (cond
                               ;; if ice were drawn, do the full routine
@@ -772,7 +772,7 @@
   {:events [{:event :pass-all-ice
              :req (req this-server)
              :player :runner
-             :waiting-prompt "Runner to choose an option for K. P. Lynn"
+             :waiting-prompt "Runner to choose an option"
              :prompt "Choose one"
              :choices ["Take 1 tag" "End the run"]
              :async true
@@ -819,7 +819,7 @@
                    :once :per-run
                    :not-equal
                    {:optional
-                    {:waiting-prompt "Corp to use Letheia Nisei"
+                    {:waiting-prompt "Corp to choose an option"
                      :prompt "Trash to force re-approach outer ice?"
                      :autoresolve (get-autoresolve :auto-fire)
                      :yes-ability
@@ -1107,7 +1107,7 @@
                                        (or (in-same-server? card (:card %))
                                            (from-same-server? card (:card %))))
                                  targets))
-                 :waiting-prompt "Corp to use Overseer Matrix"
+                 :waiting-prompt "Corp to make a decision"
                  :prompt "How many credits do you want to pay?"
                  :player :corp
                  :choices {:number (req (min (->> targets
@@ -1158,7 +1158,7 @@
 (defcard "Prisec"
   {:access {:optional
             {:req (req (installed? card))
-             :waiting-prompt "Corp to use Prisec"
+             :waiting-prompt "Corp to choose an option"
              :prompt "Pay 2 [Credits] to use Prisec ability?"
              :yes-ability
              {:cost [:credit 2]
@@ -1200,7 +1200,7 @@
                             (is-central? (:server context))))
              :msg "remove a hosted power counter"
              :effect (effect (add-counter card :power -1))}]
-   :on-rez {:waiting-prompt "Corp to use Reduced Service"
+   :on-rez {:waiting-prompt "Corp to make a decision"
             :prompt "How many credits do you want to pay?"
             :choices (req (map str (range (inc (min 4 (get-in @state [:corp :credit]))))))
             :async true
@@ -1355,7 +1355,7 @@
                                         (damage state side eid :brain 1 {:card tempus}))
                                       (continue-ability
                                         state :runner
-                                        {:waiting-prompt "Runner to choose an option for Tempus"
+                                        {:waiting-prompt "Runner to choose an option"
                                          :prompt "Lose [Click][Click] or take 1 brain damage?"
                                          :player :runner
                                          :choices ["Lose [Click][Click]" "Take 1 brain damage"]
@@ -1407,7 +1407,7 @@
                                                  (and (= :net t)
                                                       (= :corp s))))
                              (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil [:credit 2])))
-              :waiting-prompt "Corp to use Tori Hanzō"
+              :waiting-prompt "Corp to choose an option"
               :prompt "Pay 2 [Credits] to do 1 brain damage with Tori Hanzō?"
               :player :corp
               :yes-ability
@@ -1477,7 +1477,7 @@
 
 (defcard "Warroid Tracker"
   (letfn [(wt [n]
-            {:waiting-prompt "Runner to decide on Warroid Tracker"
+            {:waiting-prompt "Runner to make a decision"
              :prompt "Choose an installed card to trash due to Warroid Tracker"
              :async true
              :interactive (req true)
@@ -1532,7 +1532,7 @@
              :optional
              {:req (req (and this-server
                              (some #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
-              :waiting-prompt "Corp to use Will-o'-the-Wisp"
+              :waiting-prompt "Corp to make a decision"
               :prompt "Trash Will-o'-the-Wisp?"
               :yes-ability {:async true
                             :prompt "Choose an icebreaker used to break at least 1 subroutine during this run"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -286,7 +286,7 @@
                                    (* 2))]
                      {:async true
                       :player :runner
-                      :waiting-prompt "Runner to choose for Cayambe Grid"
+                      :waiting-prompt "Runner to choose an option for Cayambe Grid"
                       :prompt (str "Pay " cost " [Credits] or end the run?")
                       :choices [(when (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil [:credit cost])
                                   (str "Pay " cost " [Credits]"))
@@ -438,7 +438,7 @@
                                card nil))})]
     {:flags {:rd-reveal (req true)}
      :access {:optional
-              {:waiting-prompt "Corp to finish using Disposable HQ"
+              {:waiting-prompt "Corp to use Disposable HQ"
                :prompt "Use Disposable HQ to add cards to the bottom of R&D?"
                :yes-ability
                {:async true
@@ -672,7 +672,7 @@
    :access {:interactive (req true)
             :optional
             {:player :runner
-             :waiting-prompt "Runner to decide if they will take 1 tag"
+             :waiting-prompt "Runner to decide on Increased Drop Rates"
              :prompt "Take 1 tag to prevent Corp from removing 1 bad publicity?"
              :yes-ability
              {:async true
@@ -690,7 +690,7 @@
                     :base 4
                     :label "add an installed program or virtual resource to the Grip"
                     :successful
-                    {:waiting-prompt "Corp to resolve Intake"
+                    {:waiting-prompt "Corp to use Intake"
                      :prompt "Select a program or virtual resource"
                      :player :corp
                      :choices {:card #(and (installed? %)
@@ -739,7 +739,7 @@
                :once :per-turn
                :once-key :jinja-city-grid-draw
                :async true
-               :waiting-prompt "Corp to resolve Jinja City Grid"
+               :waiting-prompt "Corp to use Jinja City Grid"
                :req (req (not (find-cid (:cid card) (flatten (vals (get-in @state [:trash :trash-list]))))))
                :effect (req (cond
                               ;; if ice were drawn, do the full routine
@@ -772,7 +772,7 @@
   {:events [{:event :pass-all-ice
              :req (req this-server)
              :player :runner
-             :waiting-prompt "Runner to choose for K. P. Lynn"
+             :waiting-prompt "Runner to choose an option for K. P. Lynn"
              :prompt "Choose one"
              :choices ["Take 1 tag" "End the run"]
              :async true
@@ -1200,7 +1200,7 @@
                             (is-central? (:server context))))
              :msg "remove a hosted power counter"
              :effect (effect (add-counter card :power -1))}]
-   :on-rez {:waiting-prompt "Corp to place credits on Reduced Service"
+   :on-rez {:waiting-prompt "Corp to use Reduced Service"
             :prompt "How many credits do you want to pay?"
             :choices (req (map str (range (inc (min 4 (get-in @state [:corp :credit]))))))
             :async true
@@ -1355,7 +1355,7 @@
                                         (damage state side eid :brain 1 {:card tempus}))
                                       (continue-ability
                                         state :runner
-                                        {:waiting-prompt "Runner to resolve Tempus"
+                                        {:waiting-prompt "Runner to choose an option for Tempus"
                                          :prompt "Lose [Click][Click] or take 1 brain damage?"
                                          :player :runner
                                          :choices ["Lose [Click][Click]" "Take 1 brain damage"]
@@ -1477,7 +1477,7 @@
 
 (defcard "Warroid Tracker"
   (letfn [(wt [n]
-            {:waiting-prompt "Runner to choose cards to trash"
+            {:waiting-prompt "Runner to decide on Warroid Tracker"
              :prompt "Choose an installed card to trash due to Warroid Tracker"
              :async true
              :interactive (req true)

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -1977,7 +1977,7 @@
       (is (= "Waiting for Runner to resolve pending triggers" (:msg (prompt-map :corp))) "No Marilyn Shuffle Prompt")
       (click-prompt state :runner "OK")
       (click-prompt state :runner "Pay 3 [Credits] to trash")
-      (is (= "Waiting for Corp to use Marilyn Campaign" (:msg (prompt-map :runner))) "Now Corp gets shuffle choice")
+      (is (= "Waiting for Corp to choose an option" (:msg (prompt-map :runner))) "Now Corp gets shuffle choice")
       (is (= "Shuffle Marilyn Campaign into R&D?" (:msg (prompt-map :corp))) "Now Corp gets shuffle choice")
       (is (= 2 (:credit (get-runner)))) #_ trashed_marilyn)))
 


### PR DESCRIPTION
Rationales:
- use `use` if the subject is who originally played the card
- use `choose an option for` if there is a finite number of choices
- use `decide on` if either there is a non-finite number of choices or there is only 1 (e.g. do X to prevent Y)
- always mention the name of the card in full, even for IDs.

Suggestions are welcomed on the wording for "ambush" ICEs (e.g. Archangel, Herald, Chrysalis, Sapper).