### PR TITLE
Remove alpha of typeahead in the Deckbuilder

### DIFF
--- a/src/css/deckbuilder.styl
+++ b/src/css/deckbuilder.styl
@@ -161,7 +161,7 @@
                     padding: 2px
                     margin: 2px 0 0 0
                     width: 308px
-                    background-color: alpha(white-solid, o-10)
+                    background-color: white-solid
                     color: black-solid
                     border-radius: 4px
                     border: 1px solid alpha(blue-dark, o-80)


### PR DESCRIPTION
Since this is a white dropdown with black text that appears over a white textbox with black text, I decided to remove the alpha entirely from the typeahead. Most of our other controls have at least an alpha of o-90. I did test the typeahead with an alpha of o-90 and I think it looks fine and could work if we wanted to go that way and I don't remember what it looked like before so if we want the alpha its an easy add.

Without alpha (committed)
![image](https://user-images.githubusercontent.com/5953664/120540949-dfb77480-c3ae-11eb-8fc1-ed1669ffd1f3.png)

Alpha of o-90
![image](https://user-images.githubusercontent.com/5953664/120540834-bdbdf200-c3ae-11eb-8f4d-925122ffbbe3.png)
