### PR TITLE
Adds gain/lose-clicks

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -614,7 +614,7 @@
   {:on-score {:silent (req true)
               :effect (effect (add-counter card :agenda 3))}
    :abilities [{:cost [:click 1 :agenda 1]
-                :effect (effect (gain :click 2)
+                :effect (effect (gain-clicks 2)
                                 (register-turn-flag!
                                   card :can-advance
                                   (fn [state side card]
@@ -628,7 +628,7 @@
               :effect (effect (add-counter card :agenda 2))}
    :abilities [{:cost [:click 1 :agenda 1]
                 :once :per-turn
-                :effect (effect (gain :click 2))
+                :effect (effect (gain-clicks 2))
                 :msg "gain [Click][Click]"}]})
 
 (defcard "Encrypted Portals"
@@ -666,7 +666,7 @@
                 :label "runner loses [Click][Click]"
                 :msg "force the Runner to lose [Click][Click]"
                 :cost [:forfeit-self]
-                :effect (effect (lose :runner :click 2))}]})
+                :effect (effect (lose-clicks :runner 2))}]})
 
 (defcard "Fetal AI"
   {:flags {:rd-reveal (req true)}
@@ -966,7 +966,7 @@
 (defcard "Luminal Transubstantiation"
   {:on-score
    {:silent (req true)
-    :effect (req (gain state :corp :click 3)
+    :effect (req (gain-clicks state :corp 3)
                  (register-turn-flag!
                    state side card :can-score
                    (fn [state side card]
@@ -999,7 +999,7 @@
               :effect (req (gain state :corp :click-per-turn 1))}
    :swapped {:msg "gain an additional [Click] per turn"
              :effect (req (when (= (:active-player @state) :corp)
-                            (gain state :corp :click 1))
+                            (gain-clicks state :corp 1))
                           (gain state :corp :click-per-turn 1))}
    :leave-play (req (lose state :corp
                           :click 1
@@ -1805,7 +1805,7 @@
               :prompt "Use Voting Machine Initiative to make the Runner lose 1 [Click]?"
               :yes-ability
               {:msg "make the Runner lose 1 [Click]"
-               :effect (effect (lose :runner :click 1)
+               :effect (effect (lose-clicks :runner 1)
                                (add-counter card :agenda -1))}}}]})
 
 (defcard "Vulcan Coverup"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -242,7 +242,7 @@
 (defcard "Bass CH1R180G4"
   {:abilities [{:cost [:click 1 :trash]
                 :msg "gain [Click][Click]"
-                :effect (effect (gain :click 2))}]})
+                :effect (effect (gain-clicks 2))}]})
 
 (defcard "Bio-Ethics Association"
   (let [ability {:req (req unprotected)
@@ -882,7 +882,7 @@
                 :once :per-turn
                 :msg "gain [Click][Click]"
                 :cost [:click 1 :advancement 1]
-                :effect (effect (gain :click 2))}]})
+                :effect (effect (gain-clicks 2))}]})
 
 (defcard "Honeyfarm"
   {:flags {:rd-reveal (req true)}
@@ -1000,7 +1000,7 @@
   (let [ability {:label "Gain [Click]"
                  :msg "gain [Click]"
                  :once :per-turn
-                 :effect (effect (gain :click 1))}
+                 :effect (effect (gain-clicks 1))}
         cleanup (effect (update! (dissoc card :seen-this-turn)))]
     {:abilities [ability]
      :leave-play cleanup
@@ -1232,11 +1232,15 @@
   {:abilities [{:cost [:click 1]
                 :once :per-turn
                 :msg "to force the Runner to lose a [Click] next turn and place a power counter on itself"
-                :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil dec 0))
+                :effect (req (register-events state side card
+                                              [{:event :runner-turn-begins
+                                                :unregister-once-resolved true
+                                                :duration :until-runner-turn-begins
+                                                :effect (effect (lose-clicks :runner 1))}])
                              (add-counter state side card :power 1))}
                {:cost [:click 1 :power 3 :trash]
                 :msg "gain 4 [Click] and trash itself"
-                :effect (effect (gain :click 4))}]})
+                :effect (effect (gain-clicks 4))}]})
 
 (defcard "Melange Mining Corp."
   {:abilities [{:cost [:click 3]
@@ -1701,7 +1705,7 @@
                                (not-empty (turn-events state side :corp-draw))))
                 :async true
                 :effect (effect
-                          (lose :corp :click 1)
+                          (lose-clicks :corp 1)
                           (continue-ability
                             (let [drawn (get-in @state [:corp :register :most-recent-drawn])]
                               {:prompt "Choose a card in HQ that you just drew to swap for a card of the same type in Archives"
@@ -1837,7 +1841,7 @@
                  :req (req (and (corp? (:card target))
                                 (pos? (:click runner))))
                  :msg "force the runner to lose 1 [Click]"
-                 :effect (effect (lose :runner :click 1))}]
+                 :effect (effect (lose-clicks :runner 1))}]
     {:events [ability]
      :on-trash ability}))
 
@@ -2371,7 +2375,7 @@
        :leave-play (req (system-msg state :corp "loses Warden Fatuma additional subroutines")
                      (update-all state (partial remove-one (:cid card))))
        :sub-effect {:msg "force the Runner to lose 1 [Click], if able"
-                    :effect (req (lose state :runner :click 1))}
+                    :effect (req (lose-clicks state :runner 1))}
        :events [{:event :rez
                  :req (req (and (ice? (:card context))
                                 (has-subtype? (:card context) "Bioroid")))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -79,7 +79,7 @@
   {:on-play
    {:msg "gain [Click][Click][Click] and suffer 1 brain damage"
     :async true
-    :effect (effect (gain :click 3)
+    :effect (effect (gain-clicks 3)
                     (damage eid :brain 1 {:unpreventable true :card card}))}})
 
 (defcard "Another Day, Another Paycheck"
@@ -500,7 +500,7 @@
                          " and lose [Click]"))
              :async true
              :effect (req (when (pos? (:click runner))
-                            (lose state :runner :click 1))
+                            (lose-clicks state :runner 1))
                           (gain-credits state :runner eid 5))}})
 
 (defcard "Credit Crash"
@@ -846,7 +846,7 @@
     :choices (req runnable-servers)
     :msg (msg "make a run on " target " and gain [Click]")
     :async true
-    :effect (effect (gain :click 1)
+    :effect (effect (gain-clicks 1)
                     (make-run eid target card))}})
 
 (defcard "Easy Mark"
@@ -1917,7 +1917,7 @@
              :effect (req (prevent-run-on-server state card (first (:server target)))
                           (when (:successful target)
                             (system-msg state :runner "gains 1 [Click] and adds Marathon to their grip")
-                            (gain state :runner :click 1)
+                            (gain-clicks state :runner 1)
                             (move state :runner card :hand)
                             (unregister-events state side card)))}]})
 
@@ -3073,7 +3073,7 @@
                 " and lose [Click]"))
     :async true
     :effect (req (when (pos? (:click runner))
-                   (lose state :runner :click 1))
+                   (lose-clicks state :runner 1))
                  (draw state :runner eid 4 nil))}})
 
 (defcard "Wanton Destruction"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -96,7 +96,7 @@
                                             (and (some #{:hand} (:previous-zone (:card context)))
                                                  (program? (:card context)))))))
              :msg "gain [Click]"
-             :effect (effect (gain :click 1))}
+             :effect (effect (gain-clicks 1))}
             {:event :unsuccessful-run
              :async true
              :effect (effect (system-msg "trashes Autoscripter")
@@ -421,7 +421,7 @@
                               :choices {:card #(= cid (:cid %))}
                               :msg (msg "trigger the [Click] ability of " (:title target)
                                         " without spending [Click]")
-                              :effect (req (gain state :runner :click 1)
+                              :effect (req (gain-clicks state :runner 1)
                                            (play-ability state side {:card target :ability 0})
                                            (effect-completed state side eid))})
                            card nil))}}}]})
@@ -1519,7 +1519,7 @@
              :effect (effect (update! (dissoc card :qianju-active)))}
             {:event :runner-turn-begins
              :req (req (:qianju-active card))
-             :effect (effect (lose :click 1))}
+             :effect (effect (lose-clicks 1))}
             {:event :pre-tag
              :async true
              :req (req (:qianju-active card))
@@ -1903,7 +1903,7 @@
              :req (req (and (has-subtype? (:card context) "Run")
                             (first-event? state side :play-event #(has-subtype? (:card (first %)) "Run"))))
              :msg "gain a [click]"
-             :effect (effect (gain :click 1))}]})
+             :effect (effect (gain-clicks 1))}]})
 
 (defcard "T400 Memory Diamond"
   {:constant-effects [(mu+ 1)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -191,7 +191,7 @@
   ; Runner loses a click effect
   {:label "Force the Runner to lose 1 [Click]"
    :msg "force the Runner to lose 1 [Click] if able"
-   :effect (effect (lose :runner :click 1))})
+   :effect (effect (lose-clicks :runner 1))})
 
 (defn runner-loses-credits
   "Runner loses credits effect"
@@ -2122,7 +2122,7 @@
                  {:label "Runner loses 1[click], if able. End the run."
                   :msg "make the Runner lose 1[click] and end the run"
                   :async true
-                  :effect (req (lose state :runner :click 1)
+                  :effect (req (lose-clicks state :runner 1)
                                (end-run state :corp eid card))}]})
 
 (defcard "Macrophage"
@@ -2568,7 +2568,7 @@
                          "You have an additional [Click] to spend during your next turn.")
              :msg (str "force the runner to lose a [Click], if able. "
                        "Corp gains an additional [Click] to spend during their next turn")
-             :effect (req (lose state :runner :click 1)
+             :effect (req (lose-clicks state :runner 1)
                           (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}]
     {:subroutines [sub
                    sub]}))
@@ -3291,7 +3291,7 @@
                      :effect (req (if (and (= target "Lose [Click]")
                                            (can-pay? state :runner (assoc eid :source card :source-type :subroutine) card nil [:click 1]))
                                     (do (system-msg state :runner "loses [Click]")
-                                        (lose state :runner :click 1)
+                                        (lose-clicks state :runner 1)
                                         (effect-completed state :runner eid))
                                     (do (system-msg state :corp "ends the run")
                                         (end-run state :corp eid card))))})})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1001,7 +1001,7 @@
                     :label "Manually trigger ability"
                     :async true
                     :effect (req (if (= "Gain [Click]" target)
-                                   (do (gain state side :click 1)
+                                   (do (gain-clicks state side 1)
                                        (update! state side (assoc-in (get-card state card) [:special :mm-click] true))
                                        (effect-completed state side eid))
                                    (gain-credits state side eid 1)))}]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -297,7 +297,7 @@
 (defcard "Biotic Labor"
   {:on-play
    {:msg "gain [Click][Click]"
-    :effect (effect (gain :click 2))}})
+    :effect (effect (gain-clicks 2))}})
 
 (defcard "Blue Level Clearance"
   {:on-play
@@ -844,7 +844,7 @@
 (defcard "Game Changer"
   {:on-play
    {:rfg-instead-of-trashing true
-    :effect (effect (gain :click (count (:scored runner))))}})
+    :effect (effect (gain-clicks (count (:scored runner))))}})
 
 (defcard "Game Over"
   {:on-play
@@ -1242,7 +1242,7 @@
    :events [{:event :runner-turn-begins
              :duration :until-runner-turn-begins
              :msg "make the Runner lose [Click]"
-             :effect (effect (lose :runner :click 1))}]})
+             :effect (effect (lose-clicks :runner 1))}]})
 
 (defcard "Localized Product Line"
   {:on-play
@@ -1442,7 +1442,7 @@
   {:on-play
    {:async true
     :effect (req (if (empty? (:hand runner))
-                   (do (gain state :corp :click 2)
+                   (do (gain-clicks state :corp 2)
                        (system-msg state side "uses O₂ Shortage to gain [Click][Click]")
                        (effect-completed state side eid))
                    (continue-ability
@@ -1454,7 +1454,7 @@
                        :yes-ability {:async true
                                      :effect (effect (trash-cards :runner eid (take 1 (shuffle (:hand runner))) nil))}
                        :no-ability {:msg "gain [Click][Click]"
-                                    :effect (effect (gain :corp :click 2))}}}
+                                    :effect (effect (gain-clicks :corp 2))}}}
                      card nil)))}})
 
 (defcard "Observe and Destroy"
@@ -1765,7 +1765,7 @@
               :async true
               :effect (effect (draw eid 2 nil))}
              {:msg "gain [Click]"
-              :effect (effect (gain :click 1))}
+              :effect (effect (gain-clicks 1))}
              {:prompt "Choose a non-agenda to install"
               :msg "install a non-agenda from hand"
               :choices {:card #(and (not (agenda? %))
@@ -2297,7 +2297,7 @@
                                       {:once :per-turn
                                        :once-key :subliminal-messaging
                                        :msg "gain [Click]"
-                                       :effect (effect (gain :corp :click 1))}
+                                       :effect (effect (gain-clicks :corp 1))}
                                       card nil)))}
    :events [{:event :corp-phase-12
              :location :discard

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -343,7 +343,7 @@
       :player :runner
       :yes-ability {:cost [:credit 2]
                     :msg "gain [Click]"
-                    :effect (req (gain state :runner :click 1)
+                    :effect (req (gain-clicks state :runner 1)
                                  (update! state :runner (assoc-in (get-card state card) [:special :used-algernon] true)))}}}
     {:event :runner-turn-ends
      :async true
@@ -1409,7 +1409,7 @@
    :abilities [{:label "Remove Hyperdriver from the game to gain [Click] [Click] [Click]"
                 :req (req (:runner-phase-12 @state))
                 :effect (effect (move card :rfg)
-                                (gain :click 3))
+                                (gain-clicks 3))
                 :msg "gain [Click][Click][Click]"}]})
 
 (defcard "Ika"
@@ -2574,7 +2574,7 @@
    :abilities [{:cost [:click 1 :power 3]
                 :once :per-turn
                 :msg "gain [Click][Click]"
-                :effect (effect (gain :click 2))}]})
+                :effect (effect (gain-clicks 2))}]})
 
 (defcard "Utae"
   (let [break-req (:break-req (break-sub 1 1 "Code Gate"))]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -108,14 +108,13 @@
                             (effect-completed state :runner eid)))}]})
 
 (defcard "Adjusted Chronotype"
-  {:events [{:event :runner-lose
-             :req (req (and (some #{:click} target)
-                            (let [click-losses (count (filter #(= :click %) (mapcat first (turn-events state side :runner-lose))))]
-                              (or (= 1 click-losses)
-                                  (and (= 2 click-losses)
-                                       (has-flag? state side :persistent :genetics-trigger-twice))))))
+  {:events [{:event :runner-click-loss
+             :req (req (let [click-losses (count (filter #(= :click %) (mapcat first (turn-events state side :runner-lose))))]
+                            (or (= 1 click-losses)
+                                (and (= 2 click-losses)
+                                     (has-flag? state side :persistent :genetics-trigger-twice)))))
              :msg "gain [Click]"
-             :effect (effect (gain :runner :click 1))}]})
+             :effect (effect (gain-clicks :runner 1))}]})
 
 (defcard "Aeneas Informant"
   {:events [{:event :no-trash
@@ -169,7 +168,7 @@
 
 (defcard "All-nighter"
   {:abilities [{:cost [:click 1 :trash]
-                :effect (effect (gain :click 2))
+                :effect (effect (gain-clicks 2))
                 :msg "gain [Click][Click]"}]})
 
 (defcard "Always Be Running"
@@ -303,7 +302,7 @@
   {:constant-effects [(runner-hand-size+ 5)]
    :events [{:event :runner-turn-begins
              :msg "lose [Click]"
-             :effect (effect (lose :click 1))}]})
+             :effect (effect (lose-clicks 1))}]})
 
 (defcard "Beth Kilrain-Chang"
   (let [ability {:once :per-turn
@@ -324,7 +323,7 @@
                                   ;; gain 1 click
                                   (<= 15 c)
                                   (do (system-msg state side (str "uses " b " to gain [Click]"))
-                                      (gain state side :click 1)
+                                      (gain-clicks state side 1)
                                       (effect-completed state side eid))
                                   :else (effect-completed state side eid))))}]
     {:flags {:drip-economy true}
@@ -1006,7 +1005,7 @@
                  :msg "gain [Click]"
                  :label "Gain [Click] (start of turn)"
                  :once :per-turn
-                 :effect (effect (gain :click 1))}]
+                 :effect (effect (gain-clicks 1))}]
     {:events [(assoc ability :event :runner-turn-begins)]
      :abilities [ability]}))
 
@@ -1158,7 +1157,7 @@
                                                    (:title (first (:deck corp)))) ["OK"] {}))}]
    :events [{:event :runner-turn-begins
              :req (req (get-in @state [:per-turn (:cid card)]))
-             :effect (effect (lose :click 1))}]})
+             :effect (effect (lose-clicks 1))}]})
 
 (defcard "Grifter"
   {:events [{:event :runner-turn-ends
@@ -1209,7 +1208,7 @@
   (let [ability {:msg "gain 2 [Credits] and lose [Click]"
                  :once :per-turn
                  :async true
-                 :effect (effect (lose :click 1)
+                 :effect (effect (lose-clicks 1)
                                  (gain-credits eid 2))}]
     {:flags {:drip-economy true}
      :events [(assoc ability :event :runner-turn-begins)]
@@ -1404,7 +1403,7 @@
   (let [ability {:msg "gain [Click]"
                  :once :per-turn
                  :label "Gain [Click] (start of turn)"
-                 :effect (effect (gain :click 1)
+                 :effect (effect (gain-clicks 1)
                                  (update! (assoc-in card [:special :joshua-b] true)))}]
     {:flags {:runner-phase-12 (req true)}
      :events [{:event :runner-turn-begins
@@ -1560,7 +1559,7 @@
                                  (apply str (repeat (:click runner) "[Click]")))))
                 :cost [:trash]
                 :effect (req (bypass-ice state)
-                             (lose state :runner :click (:click runner)))}]})
+                             (lose-clicks state :runner (:click runner)))}]})
 
 (defcard "London Library"
   {:abilities [{:async true
@@ -2431,7 +2430,7 @@
                 :effect (req (swap! state assoc-in [:runner :register :double-ignore-additional] true))}
    :events [{:event :runner-turn-begins
              :msg "lose [Click] and ignore additional costs on Double events"
-             :effect (req (lose state :runner :click 1)
+             :effect (req (lose-clicks state :runner 1)
                           (swap! state assoc-in [:runner :register :double-ignore-additional] true))}]
    :leave-play (req (swap! state update-in [:runner :register] dissoc :double-ignore-additional))})
 
@@ -2442,7 +2441,7 @@
                                 (damage state side eid :brain 1 {:unpreventable true :card card})
                                 (system-msg state side "takes 1 brain damage from Stim Dealer"))
                             (do (add-counter state side card :power 1)
-                                (gain state side :click 1)
+                                (gain-clicks state side 1)
                                 (system-msg state side "uses Stim Dealer to gain [Click]"))))}]})
 
 (defcard "Street Magic"
@@ -2573,7 +2572,7 @@
                 :cost [:power 1]
                 :req (req (= (:active-player @state) :runner))
                 :msg "gain [Click]" :once :per-turn
-                :effect (effect (gain :click 1))}]})
+                :effect (effect (gain-clicks 1))}]})
 
 (defcard "Temüjin Contract"
   {:data {:counter {:credit 20}}
@@ -2723,7 +2722,7 @@
                 :msg (msg "make a run on " target " and gain [click]")
                 :async true
                 :effect (effect
-                          (gain :runner :click 1)
+                          (gain-clicks :runner 1)
                           (register-events
                             card
                             [{:event :successful-run
@@ -2742,7 +2741,7 @@
                 :choices (req runnable-servers)
                 :msg (msg "make a run on " target " and gain [click]")
                 :async true
-                :effect (effect (gain :click 1)
+                :effect (effect (gain-clicks 1)
                                 (make-run eid target card))}]})
 
 (defcard "The Nihilist"
@@ -3074,7 +3073,7 @@
                                                            (all-active-installed state :runner))))))}
    :events [{:event :runner-turn-begins
              :async true
-             :effect (req (lose state side :click 1)
+             :effect (req (lose-clicks state side 1)
                           (if (get-in @state [:per-turn (:cid card)])
                             (effect-completed state side eid)
                             (do (system-msg state side "uses Wyldside to draw 2 cards and lose [Click]")

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -911,7 +911,7 @@
              :req (req (and this-server
                             (seq (filter :broken (:subroutines (:ice context))))))
              :msg "force the Runner to lose [Click]"
-             :effect (effect (lose :runner :click 1))}]})
+             :effect (effect (lose-clicks :runner 1))}]})
 
 (defcard "Midori"
   {:events [{:event :approach-ice
@@ -1367,7 +1367,7 @@
                                                   (damage state side eid :brain 1 {:card tempus}))
                                                 (do
                                                   (system-msg state side "chooses to lose [Click][Click]")
-                                                  (lose state :runner :click 2)
+                                                  (lose-clicks state :runner 2)
                                                   (effect-completed state side eid))))}
                                         card nil))))}}}})
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -416,8 +416,10 @@
    deduct
    gain
    gain-credits
+   gain-clicks
    lose
    lose-credits
+   lose-clicks
    safe-inc-n
    sub->0]
 

--- a/src/clj/game/core/gaining.clj
+++ b/src/clj/game/core/gaining.clj
@@ -102,6 +102,23 @@
          (trigger-event-sync state side eid (if (= :corp side) :corp-credit-loss :runner-credit-loss) amount args))
      (effect-completed state side eid))))
 
+(defn gain-clicks
+  ([state side amount] (gain-clicks state side amount nil))
+  ([state side amount args]
+    (when (and amount
+               (pos? amount))
+      (do (gain state side :click amount)
+          (trigger-event state side (if (= :corp side) :corp-click-gain :runner-click-gain) amount args)))))
+
+(defn lose-clicks
+  ([state side amount] (lose-clicks state side amount nil))
+  ([state side amount args]
+    (when (and amount
+               (or (= :all amount)
+                   (pos? amount)))
+      (do (lose state side :click amount)
+          (trigger-event state side (if (= :corp side) :corp-click-loss :runner-click-loss) amount args)))))
+
 ;;; Stuff for handling {:base x :mod y} data structures
 (defn base-mod-size
   "Returns the value of properties using the `base` and `mod` system"

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2839,7 +2839,25 @@
       ; Fire MCA
       (is (= 2 (:click (get-corp))))
       (card-ability state :corp (refresh mca) 1)
-      (is (= 5 (:click (get-corp)))))))
+      (is (= 5 (:click (get-corp))))))
+  (do-game
+    (new-game {:corp {:deck [(qty "MCA Austerity Policy" 2)]}})
+    (core/gain state :corp :click 1)
+    (play-from-hand state :corp "MCA Austerity Policy" "New remote")
+    (let [mca (get-content state :remote1 0)]
+      (rez state :corp mca)
+      (card-ability state :corp mca 0)
+      (is (= 1 (get-counters (refresh mca) :power)))
+      ; once per turn only
+      (card-ability state :corp mca 0)
+      (is (= 1 (get-counters (refresh mca) :power)))
+      (play-from-hand state :corp "MCA Austerity Policy" "Server 1")
+      (click-prompt state :corp "OK")
+      (let [mca (get-content state :remote1 0)]
+        (rez state :corp mca)
+        (card-ability state :corp mca 0)
+        (take-credits state :corp)
+        (is (= 2 (:click (get-runner))) "Runner loses 2 clicks")))))
 
 (deftest melange-mining-corp
   ;; Melange Mining Corp.

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -54,6 +54,19 @@
         (take-credits state :corp)
         ; runner does not lose a click
         (is (= 4 (:click (get-runner)))))))
+  (testing "Chronotype doesn't trigger from Riot Suppression"
+    (do-game
+      (new-game {:corp {:deck ["Riot Suppression" "Thomas Haas"]} :runner {:deck ["Adjusted Chronotype"]}})
+      (play-from-hand state :corp "Thomas Haas" "New remote")
+      (take-credits state :corp)
+      (run-empty-server state "Server 1")
+      (click-prompt state :runner "Pay 1 [Credits] to trash")
+      (play-from-hand state :runner "Adjusted Chronotype")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Riot Suppression")
+      (click-prompt state :runner "No")
+      (take-credits state :corp)
+      (is (= 1 (:click (get-runner))) "Runner still has 3 fewer clicks following turn")))
   (testing "Ensure adjusted chronotype gains 2 clicks when 2 clicks are lost and GCS is installed"
     (do-game
       (new-game {:runner {:deck ["Adjusted Chronotype"


### PR DESCRIPTION
Main change is adding gain/lose-clicks and making cards use them. They trigger the new events :corp/runner-click-gain/lose.

Changes to cards include adjusted chronotype using the new event, changes to mca austerity policy to be more in line with the card text and so still trigger chronotype. Also an incidental bugfix in that riot suppression will no longer incorrectly trigger chronotype and I've added a test for this. I also added a test for stacking mca. It's something I wanted to check with my changes and it's nice to have. 

I looked at making chronotype trigger from bioroids as well which isn't a problem, but apparently there's no ruling for if it should yet. 