### PR TITLE
Mark abilities as Playable

### DIFF
--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -16,6 +16,7 @@
                                        (play-sfx state side "click-credit")
                                        (effect-completed state side eid)))}
                {:label "Draw 1 card"
+                :req (req (not-empty (:deck corp)))
                 :cost [:click]
                 :msg "draw 1 card"
                 :async true
@@ -27,6 +28,11 @@
                {:label "Install 1 agenda, asset, upgrade, or piece of ice from HQ"
                 :async true
                 :req (req (and (not-empty (:hand corp))
+                               (in-hand? target)
+                               (or (agenda? target)
+                                   (asset? target)
+                                   (ice? target)
+                                   (upgrade? target))
                                (if-let [server (second targets)]
                                  (corp-can-pay-and-install?
                                    state side (assoc eid :source server :source-type :corp-install)
@@ -49,6 +55,8 @@
                {:label "Play 1 operation"
                 :async true
                 :req (req (and (not-empty (:hand corp))
+                               (in-hand? target)
+                               (operation? target)
                                (can-play-instant? state :corp (assoc eid :source :action :source-type :play)
                                                   target {:base-cost [:click 1]})))
                 :effect (req (play-instant state :corp (assoc eid :source :action :source-type :play)
@@ -90,6 +98,7 @@
                                        (play-sfx state side "click-credit")
                                        (effect-completed state side eid)))}
                {:label "Draw 1 card"
+                :req (req (not-empty (:deck runner)))
                 :cost [:click]
                 :msg "draw 1 card"
                 :effect (req (wait-for (trigger-event-simult state side (make-eid state eid) :pre-runner-click-draw nil nil)
@@ -100,6 +109,10 @@
                {:label "Install 1 program, resource, or piece of hardware from the grip"
                 :async true
                 :req (req (and (not-empty (:hand runner))
+                               (in-hand? target)
+                               (or (hardware? target)
+                                   (program? target)
+                                   (resource? target))
                                (runner-can-pay-and-install?
                                  state :runner (assoc eid :source :action :source-type :runner-install)
                                  target {:base-cost [:click 1]})))
@@ -110,6 +123,8 @@
                {:label "Play 1 event"
                 :async true
                 :req (req (and (not-empty (:hand runner))
+                               (in-hand? target)
+                               (event? target)
                                (can-play-instant? state :runner (assoc eid :source :action :source-type :play)
                                                   target {:base-cost [:click 1]})))
                 :effect (req (play-instant state :runner (assoc eid :source :action :source-type :play)

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -91,7 +91,9 @@
   ([state side eid card title & args]
    (let [remove-zero-credit-cost (and (= (:source-type eid) :corp-install)
                                       (not (ice? card)))
-         cost-req (when (and (:abilities (:source eid)) (:ability-idx (:source-info eid))) (:cost-req (nth (:abilities (:source eid)) (:ability-idx (:source-info eid)) nil)))
+         cost-req (when (and (:abilities (:source eid))
+                             (:ability-idx (:source-info eid)))
+                    (:cost-req (nth (:abilities (:source eid)) (:ability-idx (:source-info eid)) nil)))
          cost-filter (if (fn? cost-req) cost-req identity)
          costs (cost-filter (merge-costs (remove #(or (nil? %) (map? %)) args) remove-zero-credit-cost))]
      (if (every? #(and (not (flag-stops-pay? state side %))

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1501,24 +1501,25 @@
             [:div.panel.blue-shade
              (when-let [card (:card prompt)]
                (when (not= "Basic Action" (:type card))
-                 (let [get-nested-host (fn [card] (if (:host card)
-                                                    (recur (:host card))
-                                                    card))
-                       get-zone (fn [card] (:zone (get-nested-host card)))
-                       in-play-area? (fn [card] (= (get-zone card) ["play-area"]))
-                       in-scored? (fn [card] (= (get-zone card) ["scored"]))
-                       installed? (fn [card] (or (:installed card)
-                                                 (= "servers" (first (get-zone card)))))]
-                   (if (or (nil? (:side card))
-                           (installed? card)
-                           (in-scored? card)
-                           (in-play-area? card))
-                     [:div {:style {:text-align "center"}
-                            :on-mouse-over #(card-highlight-mouse-over % card button-channel)
-                            :on-mouse-out #(card-highlight-mouse-out % card button-channel)}
-                      (tr [:game.card "Card"]) ": " (render-message (:title card))]
-                     [:div.prompt-card-preview [card-view card false]])
-                   [:hr])))
+                 [:<>
+                  (let [get-nested-host (fn [card] (if (:host card)
+                                                     (recur (:host card))
+                                                     card))
+                        get-zone (fn [card] (:zone (get-nested-host card)))
+                        in-play-area? (fn [card] (= (get-zone card) ["play-area"]))
+                        in-scored? (fn [card] (= (get-zone card) ["scored"]))
+                        installed? (fn [card] (or (:installed card)
+                                                  (= "servers" (first (get-zone card)))))]
+                    (if (or (nil? (:side card))
+                            (installed? card)
+                            (in-scored? card)
+                            (in-play-area? card))
+                      [:div {:style {:text-align "center"}
+                             :on-mouse-over #(card-highlight-mouse-over % card button-channel)
+                             :on-mouse-out #(card-highlight-mouse-out % card button-channel)}
+                       (tr [:game.card "Card"]) ": " (render-message (:title card))]
+                      [:div.prompt-card-preview [card-view card false]]))
+                  [:hr]]))
              [:h4 (render-message (:msg prompt))]
              (cond
                ;; number prompt
@@ -1605,8 +1606,9 @@
                         (pos? (get-in @me [:tag :base])))
                    #(send-command "remove-tag")]
                   [:div.run-button
-                   [cond-button (tr [:game.run "Run"]) (and (not (or @runner-phase-12 @corp-phase-12))
-                                                            (pos? (:click @me)))
+                   [cond-button (tr [:game.run "Run"])
+                    (and (not (or @runner-phase-12 @corp-phase-12))
+                         (pos? (:click @me)))
                     #(do (send-command "generate-runnable-zones")
                          (swap! s update :servers not))]
                    [:div.panel.blue-shade.servers-menu {:style (when (:servers @s) {:display "inline"})}


### PR DESCRIPTION
Like how we mark cards as playable, mark abilities as playable. This lets us disable abilities in the UI easily. For now, I only apply this to basic abilities as hard coding the costs on the client-side did not let us check for additional costs or cost reduction via cards like SYNC. I did not apply this to initiating a run since that seemed to be handled differently. Might look into that more in the future. This fix should allow us to disable any abilities. I chose not to implement that in this pull request as I was worried about side effects and want to do more extensive testing.

Fixes #5858