### PR TITLE
Lighten faction colors to be more distinct from background

### DIFF
--- a/src/css/palette.styl
+++ b/src/css/palette.styl
@@ -13,7 +13,7 @@ red-dark = hsl(0, 100%, 25%) // Apex
 red-core =hsl(0, 100%, 50%)
 red-light = hsl(5, 70%, 49%)
 
-crimson-core = hsl(339, 51%, 33%) // Nisei Jinteki
+crimson-core = hsl(339, 51%, 40%) // Nisei Jinteki
 
 //Oranges
 orange-dark = hsl(16, 100%, 55%)
@@ -33,7 +33,7 @@ yellow-core = hsl(52, 100%, 50%) //Nisei NBN
 yellow-light = hsl(61, 76%, 69%)
 
 //Greens
-green-dark = hsl(120, 11%, 28%) //Nisei Weyland Base
+green-dark = hsl(120, 11%, 45%) //Nisei Weyland Base
 green-mid =  hsl(120, 12%, 36%)
 green-core = hsl(118, 42%, 49%) //Nisei Shaper
 green-bright = hsl(120, 61%, 50%)
@@ -41,9 +41,9 @@ green-bright = hsl(120, 61%, 50%)
 //Blues
 blue-dark = hsl(212, 32%, 23%)
 blue-mid = hsl(197, 100%, 23%) //Nisei NBN Secondary
-blue-core = hsl(224, 50%, 39%) //Nisei Criminal
+blue-core = hsl(224, 50%, 50%) //Nisei Criminal
 blue-light = hsl(199, 100%, 50%)
 
 //Purples
 purple-dark = hsl(279, 100%, 20%)
-purple-core = hsl(272, 36%, 29%) // Nisei Haas-Bioroid
+purple-core = hsl(272, 36%, 50%) // Nisei Haas-Bioroid


### PR DESCRIPTION
I only increased the lightness of the color and did not touch Hue or Saturation to keep them in line with official Nisei colors as possible. 

![image](https://user-images.githubusercontent.com/5953664/123481454-5d932800-d5c9-11eb-8dbb-8f360a16e704.png)
![image](https://user-images.githubusercontent.com/5953664/123481467-63890900-d5c9-11eb-9b15-b19074dfce32.png)

