### PR TITLE
Implements gamenet. 

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -316,7 +316,7 @@
       :async true
       :effect (req (if (pos? target)
                      (wait-for
-                       (pay state :corp card :credit target)
+                       (pay state :corp (make-eid state eid) card :credit target)
                        (let [from (take target (shuffle (:hand runner)))]
                          (doseq [c from]
                            (move state :runner c :deck))
@@ -1770,7 +1770,7 @@
   {:events [{:event :pre-steal-cost
              :req (req (pos? (get-counters target :advancement)))
              :effect (req (let [counter (get-counters target :advancement)]
-                            (steal-cost-bonus state side [:credit (* 2 counter)])))}]})
+                            (steal-cost-bonus state side [:credit (* 2 counter)] {:source card :source-type :ability})))}]})
 
 (defcard "Vanity Project"
   ;; No special implementation

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -371,7 +371,7 @@
              :async true
              :effect (req (case target
                             "Pay 1 [Credits]"
-                            (wait-for (pay state :runner card :credit 1)
+                            (wait-for (pay state :runner (make-eid state eid) card :credit 1)
                                       (when-let [payment-str (:msg async-result)]
                                         (system-msg state :runner payment-str))
                                       (effect-completed state side eid))
@@ -427,7 +427,7 @@
                  :msg "make the Runner pay 1 [Credits] or trash the top card of the Stack"
                  :effect (req (case target
                                 "Pay 1 [Credits]"
-                                (wait-for (pay state side card :credit 1)
+                                (wait-for (pay state side (make-eid state eid) card :credit 1)
                                           (when-let [payment-str (:msg async-result)]
                                             (system-msg state side payment-str))
                                           (effect-completed state side eid))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2279,7 +2279,7 @@
              :async true
              :effect (req (let [correct-guess ((if (= target "Even") even? odd?) spent)]
                             (wait-for
-                              (lose-credits state :runner spent)
+                              (lose-credits state :runner (make-eid state eid) spent)
                               (system-msg state :runner (str "spends " spent " [Credit]"))
                               (system-msg state :corp (str (if correct-guess " " " in")
                                                            "correctly guesses " (string/lower-case target)))
@@ -2508,7 +2508,7 @@
              :choices choices
              :async true
              :effect (req (wait-for
-                            (lose-credits state :runner spent)
+                            (lose-credits state :runner (make-eid state eid) spent)
                             (system-msg state :runner (str "spends " spent " [Credit]"))
                             (system-msg state :corp (str " guesses " target " [Credit]"))
                             (wait-for (trigger-event-simult state side :reveal-spent-credits nil nil spent)
@@ -3063,7 +3063,7 @@
                 :prompt "How many [Credits]?"
                 :choices :credit
                 :msg (msg "take 1 tag and make the Corp lose " target " [Credits]")
-                :effect (req (wait-for (lose-credits state :corp target)
+                :effect (req (wait-for (lose-credits state :corp (make-eid state eid) target)
                                        (gain-tags state side eid 1)))}} )]})
 
 (defcard "VRcation"
@@ -3090,7 +3090,7 @@
                 :choices (req (map str (range 0 (inc (:click runner)))))
                 :async true
                 :effect (req (let [n (str->int target)]
-                               (wait-for (pay state :runner card :click n)
+                               (wait-for (pay state :runner (make-eid state eid) card :click n)
                                          (system-msg state :runner (:msg async-result))
                                          (trash-cards state :corp eid (take n (shuffle (:hand corp)))))))}})]})
 

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1165,18 +1165,10 @@
                                    (all-active state :runner))))
               :prompt "Pay 1 [Credits] to access 1 additional card?"
               :yes-ability
-              {:async true
-               :effect
-               (effect
-                 (continue-ability
-                   {:eid (assoc eid :source-type :ability)
-                    :async true
-                    :cost [:credit 1]
-                    :cost-req all-stealth
-                    :msg "access 1 additional card from HQ"
-                    :effect (effect (access-bonus :hq 1)
-                                    (effect-completed eid))}
-                   card nil))}}}
+              {:cost [:credit 1]
+               :cost-req all-stealth
+               :msg "access 1 additional card from HQ"
+               :effect (effect (access-bonus :hq 1))}}}
             {:event :successful-run
              :optional
              {:req (req (and (= :rd (target-server context))
@@ -1184,18 +1176,10 @@
                                    (all-active state :runner))))
               :prompt "Pay 2 [Credits] to access 1 additional card?"
               :yes-ability
-              {:async true
-               :effect
-               (effect
-                 (continue-ability
-                   {:eid (assoc eid :source-type :ability)
-                    :async true
-                    :cost [:credit 2]
-                    :cost-req all-stealth
-                    :msg "access 1 additional card from R&D"
-                    :effect (effect (access-bonus :rd 1)
-                                    (effect-completed eid))}
-                   card nil))}}}]})
+              {:cost [:credit 2]
+               :cost-req all-stealth
+               :msg "access 1 additional card from R&D"
+               :effect (effect (access-bonus :rd 1))}}}]})
 
 (defcard "Muresh Bodysuit"
   {:events [{:event :pre-damage

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -74,7 +74,7 @@
   "Ability to pay to avoid a subroutine by paying a resource"
   [cost]
   {:async true
-   :effect (req (wait-for (pay state :runner card cost)
+   :effect (req (wait-for (pay state :runner (make-eid state eid) card cost)
                           (when-let [payment-str (:msg async-result)]
                             (system-msg state :runner
                                         (str payment-str
@@ -105,7 +105,7 @@
              (str "Pay " amount " [Credits]")]
    :effect (req (if (= "End the run" target)
                   (end-run state :corp eid card)
-                  (wait-for (pay state :corp card [:credit amount])
+                  (wait-for (pay state :corp (make-eid state eid) card [:credit amount])
                             (when-let [payment-str (:msg async-result)]
                               (system-msg state :corp payment-str))
                             (effect-completed state side eid))))})
@@ -489,7 +489,7 @@
                       :prompt "Pay 2 [Credits] to draw 1 card?"
                       :yes-ability
                       {:async true
-                       :effect (req (wait-for (pay state :runner card [:credit 2])
+                       :effect (req (wait-for (pay state :runner (make-eid state eid) card [:credit 2])
                                               (if (:cost-paid async-result)
                                                 (do (system-msg state :runner "pays 2 [Credits] to draw 1 card")
                                                     (draw state :runner eid 1 nil))
@@ -1067,7 +1067,7 @@
                   :choices ["Pay 3 [Credits]" "Take 1 tag"]
                   :async true
                   :effect (req (if (= target "Pay 3 [Credits]")
-                                 (wait-for (pay state :runner card :credit 3)
+                                 (wait-for (pay state :runner (make-eid state eid) card :credit 3)
                                            (when-let [payment-str (:msg async-result)]
                                              (system-msg state :runner payment-str))
                                            (effect-completed state side eid))
@@ -1081,7 +1081,7 @@
 (defcard "Datapike"
   {:subroutines [{:msg "force the Runner to pay 2 [Credits] if able"
                   :async true
-                  :effect (req (wait-for (pay state :runner card :credit 2)
+                  :effect (req (wait-for (pay state :runner (make-eid state eid) card :credit 2)
                                          (when-let [payment-str (:msg async-result)]
                                            (system-msg state :runner payment-str))
                                          (effect-completed state side eid)))}
@@ -1156,7 +1156,7 @@
               {:async true
                :effect
                (req (if (seq unbroken-subs)
-                      (wait-for (pay state :runner (make-eid state {:source-type :subroutine}) card [:credit 1])
+                      (wait-for (pay state :runner (make-eid state (assoc eid :source-type :subroutine)) card [:credit 1])
                                 (system-msg state :runner (:msg async-result))
                                 (continue-ability
                                   state side
@@ -1291,7 +1291,7 @@
              :choices ["Pay 1 [Credits]" "Trash an installed card"]
              :async true
              :effect (req (if (= target "Pay 1 [Credits]")
-                            (wait-for (pay state side card :credit 1)
+                            (wait-for (pay state side (make-eid state eid) card :credit 1)
                                       (system-msg state side (:msg async-result))
                                       (effect-completed state side eid))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
@@ -1307,7 +1307,7 @@
              :choices ["Pay 2 [Credits]" "Trash an installed card"]
              :async true
              :effect (req (if (= target "Pay 2 [Credits]")
-                            (wait-for (pay state side card :credit 2)
+                            (wait-for (pay state side (make-eid state eid) card :credit 2)
                                       (system-msg state side (:msg async-result))
                                       (effect-completed state side eid))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
@@ -1324,7 +1324,7 @@
              :choices ["Pay 3 [Credits]" "Trash an installed card"]
              :async true
              :effect (req (if (= target "Pay 3 [Credits]")
-                            (wait-for (pay state side card :credit 3)
+                            (wait-for (pay state side (make-eid state eid) card :credit 3)
                                       (system-msg state side (:msg async-result))
                                       (effect-completed state side eid))
                             (continue-ability state :runner runner-trash-installed-sub card nil)))}]
@@ -1503,7 +1503,7 @@
 (defcard "Gold Farmer"
   (letfn [(gf-lose-credits [state side eid n]
             (if (pos? n)
-              (wait-for (lose-credits state :runner 1)
+              (wait-for (lose-credits state :runner (make-eid state eid) 1)
                         (gf-lose-credits state side eid (dec n)))
               (effect-completed state side eid)))]
     {:implementation "Auto breaking will break even with too few credits"
@@ -2111,7 +2111,7 @@
                   :msg "make the Runner lose 3 [credit] and end the run"
                   :async true
                   :effect (req (if (>= (:credit runner) 3)
-                                 (wait-for (lose-credits state :runner 3)
+                                 (wait-for (lose-credits state (make-eid state eid) :runner 3)
                                            (end-run state :corp eid card))
                                  (end-run state :corp eid card)))}]})
 
@@ -2626,7 +2626,7 @@
                                                 "pay 3 [Credits]"))
                                     :effect (req (if (= target "Access card")
                                                    (access-card state :runner eid c)
-                                                   (wait-for (pay state :runner card :credit 3)
+                                                   (wait-for (pay state :runner (make-eid state eid) card :credit 3)
                                                              (system-msg state :runner (:msg async-result))
                                                              (effect-completed state side eid))))}
                                    card nil)))}]})
@@ -2702,7 +2702,7 @@
                        "Pay 1 [Credits]"]
              :effect (req (if (= "Suffer 1 net damage" target)
                             (continue-ability state :corp (do-net-damage 1) card nil)
-                            (wait-for (pay state :runner card [:credit 1])
+                            (wait-for (pay state :runner (make-eid state eid) card [:credit 1])
                                       (system-msg state :runner (:msg async-result))
                                       (effect-completed state side eid))))}]
     {:subroutines [sub
@@ -3094,7 +3094,7 @@
                        "Pay 3 [Credits]"]
              :effect (req (if (= "Corp trash" target)
                             (continue-ability state :corp trash-program-sub card nil)
-                            (wait-for (pay state :runner card [:credit 3])
+                            (wait-for (pay state :runner (make-eid state eid) card [:credit 3])
                                       (system-msg state :runner (:msg async-result))
                                       (effect-completed state side eid))))}
         ability {:req (req (same-card? card target))
@@ -3237,7 +3237,7 @@
 
 (defcard "Tollbooth"
   {:on-encounter {:async true
-                  :effect (req (wait-for (pay state :runner card [:credit 3])
+                  :effect (req (wait-for (pay state :runner (make-eid state eid) card [:credit 3])
                                          (if (:cost-paid async-result)
                                            (do (system-msg state :runner (str (:msg async-result) " when encountering Tollbooth"))
                                                (effect-completed state side eid))
@@ -3289,7 +3289,7 @@
                      :choices ["Lose [Click]" "End the run"]
                      :async true
                      :effect (req (if (and (= target "Lose [Click]")
-                                           (can-pay? state :runner (assoc eid :source card :source-type :subroutine) card nil [:click 1]))
+                                           (can-pay? state :runner eid card nil [:click 1]))
                                     (do (system-msg state :runner "loses [Click]")
                                         (lose state :runner :click 1)
                                         (effect-completed state :runner eid))
@@ -3331,7 +3331,7 @@
                   :msg (msg "force the Runner to lose " (if tagged "all credits" "1 [Credits]"))
                   :async true
                   :effect (req (if tagged
-                                 (wait-for (lose-credits state :runner :all)
+                                 (wait-for (lose-credits state :runner (make-eid state eid) :all)
                                            (when current-ice
                                              (continue state :corp nil)
                                              (continue state :runner nil))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -49,7 +49,7 @@
                    :no-ability {:effect (req (clear-wait-prompt state :corp))}
                    :yes-ability
                    {:async true
-                    :effect (req (if (not (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil :credit 1))
+                    :effect (req (if (not (can-pay? state :corp eid card nil :credit 1))
                                    (do
                                      (toast state :corp "Cannot afford to pay 1 [Credit] to block card exposure" "info")
                                      (expose state :runner eid (:card context)))
@@ -66,7 +66,7 @@
                                        {:async true
                                         :effect
                                         (req (wait-for
-                                               (pay state :corp card [:credit 1])
+                                               (pay state :corp (make-eid state eid) card [:credit 1])
                                                (system-msg state :corp
                                                            (str (:msg async-result)
                                                                 " to prevent "
@@ -505,10 +505,18 @@
              :msg "make the Runner spend 1 [Credits] to access"}]})
 
 (defcard "GameNET: Where Dreams are Real"
-  {:implementation "Credit gain not implemented. You can use shortcut ability."
-   :abilities [{:msg "gain 1 [Credits] (shortcut)"
-                :async true
-                :effect (effect (gain-credits :corp eid 1))}]})
+  (let [gamenet-ability {:req (req (and (:run @state)
+                                        (= (:side (:source eid)) "Corp")
+                                        (or (and (not= (:source-type eid) :runner-trash-corp-cards)
+                                                 (not= (:source-type eid) :runner-steal))
+                                            (some (fn [[cost source]] (and (some #(or (= (first %) :credit) (= (first %) :x-credits)) (merge-costs cost))
+                                                                           (= (:side (:source source)) "Corp")))
+                                                  (:additional-costs eid)))))
+                         :async true
+                         :msg "gain 1 [Credits]"
+                         :effect (effect (gain-credits :corp eid 1))}]
+    {:events [(assoc gamenet-ability :event :runner-credit-loss)
+              (assoc gamenet-ability :event :runner-spent-credits)]}))
 
 (defcard "GRNDL: Power Unleashed"
   {:events [{:event :pre-start-game
@@ -665,7 +673,7 @@
                :req (req (:flipped card))
                :async true
                :effect (req (wait-for (draw state :runner 1 nil)
-                                      (wait-for (lose-credits state :runner 1)
+                                      (wait-for (lose-credits state :runner (make-eid state eid) 1)
                                                 (system-msg state :runner "uses Hoshiko Shiro: Mahou Shoujo to draw 1 card and lose 1 [Credits]")
                                                 (effect-completed state side eid))))}]
      :abilities [{:label "flip ID"
@@ -1076,7 +1084,7 @@
                              :msg (msg "lose all credits and gain " cost
                                        " [Credits] from the rez of " (:title ice))
                              :async true
-                             :effect (req (wait-for (lose-credits state :runner :all)
+                             :effect (req (wait-for (lose-credits state :runner (make-eid state eid) :all)
                                                     (gain-credits state :runner eid cost)))}])))}]})
 
 (defcard "Nathaniel \"Gnat\" Hall: One-of-a-Kind"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -509,7 +509,7 @@
                                         (= (:side (:source eid)) "Corp")
                                         (or (and (not= (:source-type eid) :runner-trash-corp-cards)
                                                  (not= (:source-type eid) :runner-steal))
-                                            (some (fn [[cost source]] (and (some #(or (= (first %) :credit) (= (first %) :x-credits)) (merge-costs cost))
+                                            (some (fn [[cost source]] (and (some #(or (= (cost-name %) :credit) (= (cost-name %) :x-credits)) (merge-costs cost))
                                                                            (= (:side (:source source)) "Corp")))
                                                   (:additional-costs eid)))))
                          :async true

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -870,7 +870,7 @@
                                           :card #(and (installed? %)
                                                       (is-type? % card-type)
                                                       (not (has-subtype? % "Icebreaker")))}
-                                :effect (req (wait-for (pay state :runner card :credit (* 3 (count targets)))
+                                :effect (req (wait-for (pay state :runner (make-eid state eid) card :credit (* 3 (count targets)))
                                                        (system-msg
                                                          state :runner
                                                          (str (:msg async-result) " to prevent the trashing of "
@@ -1280,7 +1280,7 @@
                   (str "make the runner lose " c " [Credits], and gain " c " [Credits]")))
       :async true
       :effect (req (let [c (credit-diff state)]
-                     (wait-for (lose-credits state :runner c)
+                     (wait-for (lose-credits state :runner (make-eid state eid) c)
                                (gain-credits state :corp eid c))))}}))
 
 (defcard "Mass Commercialization"
@@ -1406,7 +1406,7 @@
   {:on-play {:trash-after-resolving false}
    :events [{:event :pre-steal-cost
              :effect (req (let [counter (get-counters target :advancement)]
-                            (steal-cost-bonus state side [:credit (+ 4 (* 2 counter))])))}
+                            (steal-cost-bonus state side [:credit (+ 4 (* 2 counter))] {:source card :source-type :ability})))}
             {:event :corp-turn-begins
              :async true
              :effect (effect (trash eid card nil))}]})
@@ -1570,7 +1570,7 @@
 
 (defcard "Predictive Algorithm"
   {:events [{:event :pre-steal-cost
-             :effect (effect (steal-cost-bonus [:credit 2]))}]})
+             :effect (effect (steal-cost-bonus [:credit 2] {:source card :source-type :ability}))}]})
 
 (defcard "Predictive Planogram"
   {:on-play
@@ -1685,7 +1685,7 @@
                      "Pay 8 [Credits]")])
     :async true
     :effect (req (if (= target "Pay 8 [Credits]")
-                   (wait-for (pay state :runner card :credit 8)
+                   (wait-for (pay state :runner (make-eid state eid) card :credit 8)
                              (system-msg state :runner (:msg async-result))
                              (effect-completed state side eid))
                    (gain-tags state :corp eid 1)))}})
@@ -2374,7 +2374,7 @@
              :prompt "Pay 4 [Credits] or take 1 tag?"
              :choices ["Pay 4 [Credits]" "Take 1 tag"]
              :effect (req (if (= target "Pay 4 [Credits]")
-                            (wait-for (pay state :runner card :credit 4)
+                            (wait-for (pay state :runner (make-eid state eid) card :credit 4)
                                       (system-msg state :runner (:msg async-result))
                                       (effect-completed state side eid))
                             (gain-tags state :corp eid 1 nil)))}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -198,8 +198,7 @@
                :effect
                (effect
                  (continue-ability
-                   {:eid (assoc eid :source-type :ability)
-                    :optional
+                   {:optional
                     {:prompt (str "Pay " cost
                                   " [Credits] to make " (:title (:ice context))
                                   " gain " ice-type "?")
@@ -312,20 +311,14 @@
                               :interactive (req true)
                               :optional
                               {:req (req (and (has-subtype? (:ice context) "Sentry")
-                                              (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil [:credit 2])))
+                                              (can-pay? state :runner eid card nil [:credit 2])))
                                :once :per-turn
                                :prompt (msg "Pay 2 [Credits] to bypass " (:title (:ice context)))
                                :yes-ability
-                               {:async true
-                                :effect
-                                (effect
-                                  (continue-ability
-                                    {:eid (assoc eid :source-type :ability)
-                                     :cost [:credit 2]
-                                     :cost-req all-stealth
-                                     :msg (msg "bypass " (:title (:ice context)))
-                                     :effect (req (bypass-ice state))}
-                                    card targets))}}}]
+                               {:cost [:credit 2]
+                                :cost-req all-stealth
+                                :msg (msg "bypass " (:title (:ice context)))
+                                :effect (req (bypass-ice state))}}}]
                     :abilities [(break-sub 1 2 "Sentry")
                                 (strength-pump 1 2 {:cost-req (min-stealth 1)})]}))
 
@@ -408,12 +401,9 @@
                                               (continue :runner nil))}]}))
 
 (defcard "Atman"
-  {:on-install {:effect (effect
-                          (continue-ability {:eid (assoc eid :source-type :ability :source card)
-                                             :cost [:x-credits]
-                                             :msg (msg "add " (cost-value eid :x-credits) " power counters")
-                                             :effect (effect (add-counter card :power (cost-value eid :x-credits)))}
-                                            card targets))}
+  {:on-install {:cost [:x-credits]
+                :msg (msg "add " (cost-value eid :x-credits) " power counters")
+                :effect (effect (add-counter card :power (cost-value eid :x-credits)))}
    :abilities [(break-sub 1 1 "All" {:req (req (= (get-strength current-ice) (get-strength card)))})]
    :strength-bonus (req (get-counters card :power))})
 
@@ -785,7 +775,7 @@
                               :msg (msg "swap the positions of " (card-str state first-ice)
                                         " and " (card-str state target))
                               :async true
-                              :effect (req (wait-for (pay state side card [:virus 1])
+                              :effect (req (wait-for (pay state side (make-eid state eid) card [:virus 1])
                                                      (system-msg state side (:msg async-result))
                                                      (swap-ice state side first-ice target)
                                                      (effect-completed state side eid)))})
@@ -829,7 +819,7 @@
                                           "remove a virus token from Crypsis"
                                           "trash Crypsis"))
                               :async true
-                              :effect (req (wait-for (pay state :runner card [:virus 1])
+                              :effect (req (wait-for (pay state :runner (make-eid state eid) card [:virus 1])
                                                      (if-let [payment-str (:msg async-result)]
                                                        (do (system-msg state :runner payment-str)
                                                            (effect-completed state side eid))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -442,7 +442,7 @@
                        :yes-ability
                        {:async true
                         :effect (req (let [ice (:ice context)]
-                                       (wait-for (pay state :runner card [:credit (get-strength ice)])
+                                       (wait-for (pay state :runner (make-eid state eid) card [:credit (get-strength ice)])
                                                  (if-let [payment-str (:msg async-result)]
                                                    (do (system-msg state :runner
                                                                    (str (build-spend-msg payment-str "use")
@@ -1052,7 +1052,7 @@
      :effect (req (if (= target "Trash")
                     (do (system-msg state :runner "trashes Fencer Fueno")
                         (trash state :runner eid card nil))
-                    (wait-for (pay state :runner card :credit 1)
+                    (wait-for (pay state :runner (make-eid state eid) card :credit 1)
                               (system-msg state :runner (str (:msg async-result) " to avoid trashing Fencer Fueno"))
                               (effect-completed state side eid))))}
     ;; companion-builder: ability
@@ -2043,7 +2043,7 @@
                                  :choices {:number (req (min num-counters
                                                              (total-available-credits state :runner eid card)))}
                                  :effect (req (wait-for
-                                                (pay state :runner card [:credit target])
+                                                (pay state :runner (make-eid state eid) card [:credit target])
                                                 (if-let [payment-str (:msg async-result)]
                                                   (do (system-msg state side
                                                                   (str (build-spend-msg payment-str "use") (:title card)
@@ -2266,7 +2266,7 @@
                                          (filter #(not (has-subtype? % "Virtual"))
                                                  (get-in runner [:rig :resource]))
                                          (:hand runner)))
-                               (wait-for (lose-credits state side :all)
+                               (wait-for (lose-credits state side (make-eid state eid) :all)
                                          (lose-tags state side eid :all))))}]})
 
 (defcard "Sacrificial Construct"
@@ -2452,7 +2452,7 @@
              :effect (req (let [sub (first (filter #(and (not (:broken %))
                                                          (= target (make-label (:sub-effect %))))
                                                    (:subroutines current-ice)))]
-                            (wait-for (resolve-ability state :corp (make-eid state {:source-type :subroutine})
+                            (wait-for (resolve-ability state :corp (make-eid state {:source current-ice :source-type :subroutine})
                                                        (:sub-effect sub) current-ice nil)
                                       (if (and (:run @state)
                                                (not (:ended (:run @state)))
@@ -2797,7 +2797,7 @@
              :async true
              :effect (effect (trash eid card nil))}
             {:event :pre-steal-cost
-             :effect (effect (steal-cost-bonus [:credit 3]))}]})
+             :effect (effect (steal-cost-bonus [:credit 3] {:source card :source-type :ability}))}]})
 
 (defcard "The Supplier"
   (let [ability {:label "Install a hosted card (start of turn)"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -158,11 +158,11 @@
                         :req (req (or (= (get-zone target) (:previous-zone card))
                                       (= (central->zone (get-zone target))
                                          (butlast (:previous-zone card)))))
-                        :effect (effect (steal-cost-bonus [:net 2]))}]))}
+                        :effect (effect (steal-cost-bonus [:net 2] {:source card :source-type :ability}))}]))}
    :events [{:event :pre-steal-cost
              :req (req (or (in-same-server? card target)
                            (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:net 2]))}]})
+             :effect (effect (steal-cost-bonus [:net 2] {:source card :source-type :ability}))}]})
 
 (defcard "Bernice Mai"
   {:events [{:event :successful-run
@@ -296,7 +296,7 @@
                                   (str "force the runner to pay " cost " [Credits]")))
                       :effect (req (if (= target "End the run")
                                      (end-run state side eid card)
-                                     (wait-for (pay state :runner card :credit cost)
+                                     (wait-for (pay state :runner (make-eid state eid) card :credit cost)
                                                (system-msg state :runner (:msg async-result))
                                                (effect-completed state side eid))))})
                    card nil))}]
@@ -576,7 +576,7 @@
              :msg "force the Runner to pay or end the run"
              :effect (effect
                        (continue-ability
-                         (let [credits (total-available-credits state :runner (assoc eid :source-type :ability :source card) card)
+                         (let [credits (total-available-credits state :runner eid card)
                                cost (* 2 (count (:scored runner)))
                                pay-str (str "pay " cost " [Credits]")
                                c-pay-str (capitalize pay-str)]
@@ -588,7 +588,7 @@
                                         c-pay-str)
                                       "End the run"]
                             :effect (req (if (= c-pay-str target)
-                                           (wait-for (pay state :runner card :credit cost)
+                                           (wait-for (pay state :runner (make-eid state eid) card :credit cost)
                                                      (system-msg state :runner (:msg async-result))
                                                      (effect-completed state side eid))
                                            (do (system-msg state :corp "ends the run")
@@ -855,21 +855,21 @@
              :player :runner
              :prompt "Choose one"
              :req (req this-server)
-             :choices (req [(when (can-pay? state :runner (assoc eid :source card :source-type :subroutine) card nil [:click 2])
+             :choices (req [(when (can-pay? state :runner eid card nil [:click 2])
                               "Spend [Click][Click]")
-                            (when (can-pay? state :runner (assoc eid :source card :source-type :subroutine) card nil [:credit 5])
+                            (when (can-pay? state :runner eid card nil [:credit 5])
                               "Pay 5 [Credits]")
                             "End the run"])
              :async true
              :effect (req (cond+
                             [(and (= target "Spend [Click][Click]")
-                                  (can-pay? state :runner (assoc eid :source card :source-type :subroutine) card nil [:click 2]))
-                             (wait-for (pay state side card :click 2)
+                                  (can-pay? state :runner eid card nil [:click 2]))
+                             (wait-for (pay state side (make-eid state eid) card :click 2)
                                        (system-msg state side (:msg async-result))
                                        (effect-completed state :runner eid))]
                             [(and (= target "Pay 5 [Credits]")
-                                  (can-pay? state :runner (assoc eid :source card :source-type :subroutine) card nil [:credit 5]))
-                             (wait-for (pay state side card :credit 5)
+                                  (can-pay? state :runner eid card nil [:credit 5]))
+                             (wait-for (pay state side (make-eid state eid) card :credit 5)
                                        (system-msg state side (:msg async-result))
                                        (effect-completed state :runner eid))]
                             [:else
@@ -1185,11 +1185,11 @@
                         :req (req (or (= (get-zone target) (:previous-zone card))
                                       (= (central->zone (get-zone target))
                                          (butlast (:previous-zone card)))))
-                        :effect (effect (steal-cost-bonus [:credit 5]))}]))}
+                        :effect (effect (steal-cost-bonus [:credit 5] {:source card :source-type :ability}))}]))}
    :events [{:event :pre-steal-cost
              :req (req (or (in-same-server? card target)
                            (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:credit 5]))}]})
+             :effect (effect (steal-cost-bonus [:credit 5] {:source card :source-type :ability}))}]})
 
 (defcard "Reduced Service"
   {:constant-effects [{:type :run-additional-cost
@@ -1309,11 +1309,11 @@
                         :req (req (or (= (get-zone target) (:previous-zone card))
                                       (= (central->zone (get-zone target))
                                          (butlast (:previous-zone card)))))
-                        :effect (effect (steal-cost-bonus [:click 1]))}]))}
+                        :effect (effect (steal-cost-bonus [:click 1] {:source card :source-type :ability}))}]))}
    :events [{:event :pre-steal-cost
              :req (req (or (in-same-server? card target)
                            (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:click 1]))}]})
+             :effect (effect (steal-cost-bonus [:click 1] {:source card :source-type :ability}))}]})
 
 (defcard "Surat City Grid"
   {:events [{:event :rez
@@ -1414,7 +1414,7 @@
               {:async true
                :msg "do 1 brain damage instead of net damage"
                :effect (req (swap! state update :damage dissoc :damage-replace :defer-damage)
-                            (wait-for (pay state :corp card :credit 2)
+                            (wait-for (pay state :corp (make-eid state eid) card :credit 2)
                                       (system-msg state side (:msg async-result))
                                       (wait-for (damage state side :brain 1 {:card card})
                                                 (swap! state assoc-in [:damage :damage-replace] true)

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -618,8 +618,8 @@
   This is essentially Phase 9.3 and 9.6.7a of CR 1.1:
   http://nisei.net/files/Comprehensive_Rules_1.1.pdf"
   ([state side event targets] (gather-events state side event targets nil))
-  ([state side event targets card-abilities] (gather-events state side event targets nil (make-eid state)))
-  ([state side event targets card-abilities eid]
+  ([state side event targets card-abilities] (gather-events state side (make-eid state) event targets nil))
+  ([state side eid event targets card-abilities]
    (->> (:events @state)
         (filter #(= event (:event %)))
         (concat card-abilities)
@@ -668,7 +668,7 @@
   (if (nil? event)
     (effect-completed state side eid)
     (do (log-event state event targets)
-        (let [handlers (gather-events state side event targets nil eid)]
+        (let [handlers (gather-events state side eid event targets nil)]
           (trigger-event-sync-next state side eid handlers event targets)))))
 
 (defn- trigger-event-simult-player
@@ -804,7 +804,7 @@
                                       (not (sequential? card-abilities)))
                                [card-abilities]
                                card-abilities)
-              handlers (gather-events state side event targets card-abilities eid)
+              handlers (gather-events state side eid event targets card-abilities)
               get-handlers (fn [player-side]
                              (filterv (partial is-player player-side) handlers))
               active-player-events (get-handlers active-player)

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -242,7 +242,7 @@
 
 (defn resolve-subroutine!
   ([state side ice sub]
-   (let [eid (make-eid state {:source (:title ice)
+   (let [eid (make-eid state {:source ice
                               :source-type :subroutine})]
      (resolve-subroutine! state side eid ice sub)))
   ([state side eid ice sub]
@@ -251,7 +251,7 @@
 
 (defn- resolve-next-unbroken-sub
   ([state side ice subroutines]
-   (let [eid (make-eid state {:source (:title ice)
+   (let [eid (make-eid state {:source ice
                               :source-type :subroutine})]
      (resolve-next-unbroken-sub state side eid ice subroutines nil)))
   ([state side eid ice subroutines] (resolve-next-unbroken-sub state side eid ice subroutines nil))
@@ -272,7 +272,7 @@
 
 (defn resolve-unbroken-subs!
   ([state side ice]
-   (let [eid (make-eid state {:source (:title ice)
+   (let [eid (make-eid state {:source ice
                               :source-type :subroutine})]
      (resolve-unbroken-subs! state side eid ice)))
   ([state side eid ice]

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -1366,7 +1366,8 @@
 (deftest gamenet-where-dreams-are-real
   (testing "Gain credits from gold farmer"
     (do-game
-      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Gold Farmer"]} :runner {:hand ["Corroder"] :credits 10}})
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Gold Farmer"]}
+                 :runner {:hand ["Corroder"] :credits 10}})
       (play-from-hand state :corp "Gold Farmer" "HQ")
       (take-credits state :corp)
       (play-from-hand state :runner "Corroder")
@@ -1445,7 +1446,8 @@
         (click-prompt state :runner "Pay 4 [Credits] to trash"))))
   (testing "No credits from runner cards"
     (do-game
-      (new-game {:corp {:id "GameNET: Where Dreams are Real"} :runner {:hand ["Corroder"]}})
+      (new-game {:corp {:id "GameNET: Where Dreams are Real"}
+                 :runner {:hand ["Corroder"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Corroder")
       (run-on state "HQ")
@@ -1454,7 +1456,8 @@
         (card-ability state :runner (get-program state 0) 1))))
   (testing "No credits from the source"
     (do-game
-      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Send a Message"]} :runner {:hand ["The Source"]}})
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Send a Message"]}
+                 :runner {:hand ["The Source"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "The Source")
       (run-on state "HQ")

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -1363,6 +1363,106 @@
     (click-prompt state :runner "No action") ; Dismiss trash prompt
     (is (last-log-contains? state "Caprice") "Accessed card name was logged")))
 
+(deftest gamenet-where-dreams-are-real
+  (testing "Gain credits from gold farmer"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Gold Farmer"]} :runner {:hand ["Corroder"] :credits 10}})
+      (play-from-hand state :corp "Gold Farmer" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Corroder")
+      (run-on state "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (changes-val-macro 2 (:credit (get-corp))
+        "Corp gains credits when gold farmer is broken"
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (get-program state 0)}))))
+  (testing "Gain credits from F2P"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["F2P"]}})
+      (play-from-hand state :corp "F2P" "HQ")
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (changes-val-macro 1 (:credit (get-corp))
+        "Corp gains credits when F2P is used"
+        (card-side-ability state :runner (get-ice state :hq 0) 0)
+        (click-prompt state :runner "Add an installed Runner card to the grip"))))
+  (testing "Gain credits from Bellona steal"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Bellona"]}})
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (run-continue state)
+      (changes-val-macro 1 (:credit (get-corp))
+        "Corp gains credits when Bellona is stolen"
+        (click-prompt state :runner "Pay to steal"))))
+  (testing "Gain credits from NAPD cordon steal"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Send a Message" "NAPD Cordon"]}})
+      (play-from-hand state :corp "NAPD Cordon")
+      (take-credits state :corp)
+      (run-on state "HQ")
+      (run-continue state)
+      (changes-val-macro 1 (:credit (get-corp))
+        "Corp gains credits when agenda is stolen with NAPD Cordon"
+        (click-prompt state :runner "Pay to steal"))))
+  (testing "Gain credits from traces"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Uroboros"]}})
+      (play-from-hand state :corp "Uroboros" "HQ")
+      (let [uroboros (get-ice state :hq 0)]
+        (take-credits state :corp)
+        (run-on state "HQ")
+        (rez state :corp uroboros)
+        (run-continue state)
+        (changes-val-macro 1 (:credit (get-corp))
+          "Corp gains credits when a trace is paid into"
+          (card-subroutine state :corp (refresh uroboros) 0)
+          (click-prompt state :corp "0")
+          (click-prompt state :runner "1")))))
+  (testing "Gain credits from psi games"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Caprice Nisei"]}})
+      (play-from-hand state :corp "Caprice Nisei" "New remote")
+      (let [caprice (get-content state :remote1 0)]
+        (take-credits state :corp)
+        (rez state :corp caprice)
+        (run-on state "Server 1")
+        (changes-val-macro 1 (:credit (get-corp))
+          "Corp gains credits when a psi game is paid into"
+          (click-prompt state :corp "0 [Credits]")
+          (click-prompt state :runner "1 [Credits]")))))
+  (testing "No credits from trashing"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["PAD Campaign"]}})
+      (play-from-hand state :corp "PAD Campaign" "New remote")
+      (take-credits state :corp)
+      (run-on state "Server 1")
+      (run-continue state)
+      (changes-val-macro 0 (:credit (get-corp))
+        "Corp gains no credits when a trash cost is paid"
+        (click-prompt state :runner "Pay 4 [Credits] to trash"))))
+  (testing "No credits from runner cards"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real"} :runner {:hand ["Corroder"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Corroder")
+      (run-on state "HQ")
+      (changes-val-macro 0 (:credit (get-corp))
+        "Corp gains no credits when an icebreaker is used"
+        (card-ability state :runner (get-program state 0) 1))))
+  (testing "No credits from the source"
+    (do-game
+      (new-game {:corp {:id "GameNET: Where Dreams are Real" :hand ["Send a Message"]} :runner {:hand ["The Source"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "The Source")
+      (run-on state "HQ")
+      (run-continue state)
+      (changes-val-macro 0 (:credit (get-corp))
+        "Corp gains no credits when the source's additional cost is paid"
+        (click-prompt state :runner "Pay to steal")))))
+
 (deftest grndl-power-unleashed
   ;; GRNDL: Power Unleashed - start game with 10 credits and 1 bad pub.
   (testing "Basic test"


### PR DESCRIPTION
Changes to the engine are rather than merging up agenda steal costs as they come in, we store them as is alongside an optional source. They're then merged as usual when they're used but the stored list is also given to any events triggered.
Events now pass the source information from their eid through to their :req functions. To do this gather-events now takes an optional eid argument that it passes through to can-trigger? rather than just using (make-eid state). Neither is actually async of course, they just want the source info.
When a triggered event is resolved, it will now have its source info replaced with the correct info for the card the ability came from. 
There's also a bugfix where ice subroutines would have :source (:title card) instead of just :source card. 
Most of the changes to cards are just passing source info through to payment functions or agenda steal costs and removing now unneeded workarounds. Note that a lot of :req functions still need to use the workaround, mostly when calling can-pay?, because :req still has the info of the triggering event. 