### PR TITLE
Prevent using illegal decks outside of casual

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -4,10 +4,10 @@
             [web.ws :as ws]
             [web.stats :as stats]
             [web.diffs :refer [game-internal-view]]
-            [game.utils :refer [remove-once]]
+            [game.utils :refer [remove-once to-keyword]]
             [game.core :as core]
             [jinteki.cards :refer [all-cards]]
-            [jinteki.validator :refer [calculate-deck-status]]
+            [jinteki.validator :refer [calculate-deck-status legal-deck?]]
             [jinteki.utils :refer [superuser?]]
             [crypto.password.bcrypt :as bcrypt]
             [monger.collection :as mc]
@@ -412,7 +412,9 @@
                    (update-in d [:identity] #(@all-cards (:title %)))
                    (assoc d :status (calculate-deck-status d)))]
     (when (and (:identity deck)
-               (player? client-id game))
+               (player? client-id game)
+               (or (= (:format game) "casual")
+                   (legal-deck? deck (:format game))))
       (when (= "tournament" (:room game))
         (lobby-say gameid {:user "__system__"
                            :text (str username " has selected deck with tournament hash " (:hash deck))}))

--- a/src/cljc/jinteki/validator.cljc
+++ b/src/cljc/jinteki/validator.cljc
@@ -280,3 +280,13 @@
     (if status
       status
       (calculate-deck-status deck)))
+
+(defn legal-deck?
+ ([deck] (legal-deck? deck (:format deck)))
+ ([deck fmt]
+   (get-in deck
+     [:status (keyword fmt) :legal]
+     (get-in (trusted-deck-status (assoc deck :format fmt))
+         [(keyword fmt) :legal]
+         false))))
+  

--- a/src/cljc/jinteki/validator.cljc
+++ b/src/cljc/jinteki/validator.cljc
@@ -284,9 +284,8 @@
 (defn legal-deck?
  ([deck] (legal-deck? deck (:format deck)))
  ([deck fmt]
-   (get-in deck
-     [:status (keyword fmt) :legal]
+   (if-let [deck (get-in deck [:status (keyword fmt) :legal])]
+     deck
      (get-in (trusted-deck-status (assoc deck :format fmt))
-         [(keyword fmt) :legal]
-         false))))
-  
+       [(keyword fmt) :legal]
+       false))))

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -774,7 +774,10 @@
    (when (and (:stats deck)
               (not= "none" (get-in @app-state [:options :deckstats])))
      [:button {:on-click #(clear-deck-stats s)} (tr [:deck-builder.clear-stats "Clear Stats"])])
-   (let [disabled (or (:editing-game @app-state false) (:gameid @app-state false))]
+   (let [disabled (or (:editing-game @app-state false)
+                      (:gameid @app-state false)
+                      (and (not= (:format deck) "casual")
+                           (not (validator/legal-deck? deck))))]
      [:button.float-right {:on-click #(do
                                         (swap! app-state assoc :create-game-deck (:deck @s))
                                         (.setToken history "/play"))


### PR DESCRIPTION
What it says on the tin. Just checks that the decks are legal for the format (or that you're playing casual) when listing them for selecting, accepting them as a selection server side or disabling the create game button in the deck builder. 