### PR TITLE
Fix Command Pop-up

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -587,7 +587,7 @@
 
                                 >div:first-child
                                     display:inline
-                                    width: 168px!important
+                                    width: 168px !important
                                     height: 234.833px
 
                                     >img.card
@@ -949,14 +949,14 @@
                 flex(1)
                 margin: 0
                 min-height: 20px
-                overflow-x:clip
-                overflow-y:auto
 
                 >div
                     animation: fadein 0.5s
+                    overflow-x:clip
+                    overflow-y:auto
+                    height:100%
 
                 .log
-                    height:100%
                     display-flex()
                     flex-direction(column)
                     // width: 225px
@@ -974,7 +974,7 @@
 
                     .messages
                         flex(1)
-                        overflow: auto!important
+                        overflow: auto !important
                         -webkit-overflow-scrolling: touch
 
                         div


### PR DESCRIPTION
The command pop-up no longer displayed after PR #5885. The overflow settings that were used to prevent clipping prevented the command pop-up from displaying. I moved the overflow settings down a level to the first div of the content panel. This displays all of the inner content correctly while allowing the command pop-up to appear. From my research, this was an issue because the position property and overflow properties were on the same level ([an example I found](https://css-tricks.com/popping-hidden-overflow/)) 

fixes #5945