### PR TITLE
Various stability improvements

### DIFF
--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -183,25 +183,46 @@
             side (some #(when (= client-id (:ws-id %)) (:side %)) players)
             spectator (spectator? client-id game)]
         (if (and state side)
-          (do
-            (main/handle-action user command state (side-from-str side) args)
-            (lobby/refresh-lobby-assoc-in gameid [:last-update] (t/now))
-            (swap-and-send-diffs! game))
-          (when-not spectator
-            (println "handle-game-action unknown state or side")
-            (println "\tGameID:" gameid)
-            (println "\tGameID by ClientID:" (:gameid (lobby/game-for-client client-id)))
-            (println "\tClientID:" client-id)
-            (println "\tSide:" side)
-            (println "\tPlayers:" (map #(select-keys % [:ws-id :side]) players))
-            (println "\tSpectators" (map #(select-keys % [:ws-id]) (:spectators game)))
-            (println "\tCommand:" command)
-            (println "\tArgs:" args "\n"))))
-      (catch clojure.lang.ExceptionInfo e
-        (println "Caught custom exception")
-        (println (str "Exception Data: " (ex-data e)))
+            (let [old-state @state]
+              (try
+                (do (main/handle-action user command state (side-from-str side) args)
+                    (lobby/refresh-lobby-assoc-in gameid [:last-update] (t/now))
+                    (swap-and-send-diffs! game))
+                (catch Exception e
+                  (reset! state old-state)
+                  (throw e))))
+            (when-not spectator
+              (println "handle-game-action unknown state or side")
+              (println "\tGameID:" gameid)
+              (println "\tGameID by ClientID:" (:gameid (lobby/game-for-client client-id)))
+              (println "\tClientID:" client-id)
+              (println "\tSide:" side)
+              (println "\tPlayers:" (map #(select-keys % [:ws-id :side]) players))
+              (println "\tSpectators" (map #(select-keys % [:ws-id]) (:spectators game)))
+              (println "\tCommand:" command)
+              (println "\tArgs:" args "\n"))))
+      (catch Exception e
+        (ws/broadcast-to! [client-id] :netrunner/error nil)
+        (println "Caught exception")
+        (println (str "Exception Data: " (or (ex-data e) (.getMessage e))))
         (println (str "Command: " command))
         (println (str "GameId: " gameid-str))))))
+
+(defmethod ws/-msg-handler :netrunner/resync
+  [{{user :user} :ring-req
+    client-id    :client-id
+    {:keys [gameid-str]} :?data}]
+  (when (active-game? gameid-str client-id)
+    (let [gameid (java.util.UUID/fromString gameid-str)
+          {:keys [players state] :as game} (lobby/game-for-id gameid)]
+      (if state
+          (send-state! :netrunner/state game (public-states (:state game)) client-id)
+          (do (println "resync request unknown state")
+              (println "\tGameID:" gameid)
+              (println "\tGameID by ClientID:" (:gameid (lobby/game-for-client client-id)))
+              (println "\tClientID:" client-id)
+              (println "\tPlayers:" (map #(select-keys % [:ws-id :side]) players))
+              (println "\tSpectators" (map #(select-keys % [:ws-id]) (:spectators game))))))))
 
 (defmethod ws/-msg-handler :lobby/watch
   ;; Handles a watch command when a game has started.

--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -51,6 +51,8 @@
                                 (:update diff))
                   delete-diff (apply dissoc update-diff (:delete diff))]
               (sort-games-list (vals delete-diff)))))
+  (when-let [current-game (first (filter :selected (:games @app-state)))]
+    (swap! app-state update :gameid #(:gameid current-game)))
   (when (and notification (not (:gameid @app-state)))
     (play-sound notification)))
 


### PR DESCRIPTION
There are a bunch of different things here, all with the intent of improving stability.

The simplest is the fix to the zombie games problem. The response to a game being created getting dropped will put the client in a bad state, which allows you to spam the new game button actually causing the problem. Now the server ignores new game requests if you already have a game. 

We still want something in the client to help with the bad state though so the full game list now includes a :selected property, this indicates that this is the game the client should be in. 

Then there's the error handling and state rollback. If there's an error in an action handler the client will be informed and the state will be rolled back to before the action started. When the client gets the error it displays a toast and releases the interface lock. There's no actual error detail being sent to the client, just that an error happened. This does mean all exceptions will now use the error reporting stuff that was previously only used by the one custom exception. There's no stack trace there but I'm not sure how much use a stack trace in the logs has been. It can always be added again if wanted. I also worry a little about the performance impact of snapshotting the state before every action for rollback. I'm not sure how clojure handles that internally. Whatever the case it shouldn't be too bad, no more than the snapshots taken for /undo-click etc. 

Upon disconnect the client will lock itself. When reconnecting it will request the full game list and state of any game it's in. When it gets the new state it will release the lock. The game state is sent via a new netrunner/resync request followed by a previously deprecated netrunner/state response. 
