### PR TITLE
Prevents an infinite loop in toasts

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -35,7 +35,7 @@
                   (operation? card))
               (can-play-instant?
                 state side {:source :action :source-type :play}
-                card {:base-cost [:click 1]})])
+                card {:base-cost [:click 1] :silent true})])
            true)
     (assoc card :playable true)
     card))

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -271,12 +271,13 @@
 
 (defn can-run?
   "Checks if the runner is allowed to run"
-  [state side]
+  ([state side] (can-run? state side false))
+  ([state side silent]
   (let [cards (->> @state :stack :current-turn :can-run (map :card))]
     (if (empty? cards)
       true
-      (do (toast state side (str "Cannot run due to " (string/join ", " (map :title cards))))
-        false))))
+      (do (when-not silent (toast state side (str "Cannot run due to " (string/join ", " (map :title cards))))
+        false))))))
 
 (defn can-access?
   "Checks if the runner can access the specified card"

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -94,7 +94,7 @@
 
 (defn can-play-instant?
   ([state side eid card] (can-play-instant? state side eid card nil))
-  ([state side eid card {:keys [targets] :as args}]
+  ([state side eid card {:keys [targets silent] :as args}]
    (let [on-play (or (:on-play (card-def card)) {})
          costs (play-instant-costs state side eid card args)]
      (and ;; req is satisfied
@@ -109,7 +109,7 @@
           ;; This is a run event or makes a run, and running is allowed
           (not (and (or (:makes-run (card-def card))
                         (has-subtype? card "Run"))
-                    (not (can-run? state :runner))))
+                    (not (can-run? state :runner silent))))
           ;; if priority, have not spent a click
           (not (and (has-subtype? card "Priority")
                     (get-in @state [side :register :spent-click])))


### PR DESCRIPTION
Currently it's possible for diff generation to cause a toast. playable? checks if you can run to play a run event. If you can't it will toast you telling you why. This leads to out of place toasts when you can't run with run events in hand. If you generate some other toast while in this state it will lead to an infinite loop. The client will acknowledge the toast, this will cause a diff and a new toast to be generated and it loops forever. 

Easiest way to reproduce is to play as liza and run a central through excalibur with a run event in hand. When you get the toast for taking the liza tag the loop will begin. 

This patch adds a silent argument to the can-run? function that suppresses the toast and passes it through when generating diffs. 