### PR TITLE
Auto pump and break variable cost and strength

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2554,16 +2554,12 @@
                               :effect (effect (gain-credits :corp eid 2))}]}))
 
 (defcard "Unity"
-  {:abilities [(break-sub 1 1 "Code Gate")
-               {:label "1 [Credits]: Add 1 strength for each installed icebreaker"
-                :async true
-                :effect (effect (continue-ability
-                                  (strength-pump
-                                    1
-                                    (count (filter #(and (program? %)
-                                                         (has-subtype? % "Icebreaker"))
-                                                   (all-active-installed state :runner))))
-                                  card nil))}]})
+  (auto-icebreaker {:abilities [(break-sub 1 1 "Code Gate")
+                                (strength-pump 1 0 :end-of-encounter
+                                               {:label "Add 1 strength for each installed icebreaker"
+                                                :pump-bonus (req (count (filter #(and (program? %)
+                                                                                      (has-subtype? % "Icebreaker"))
+                                                                                (all-active-installed state :runner))))})]}))
 
 (defcard "Upya"
   {:implementation "Power counters added automatically"

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -234,9 +234,10 @@
                                  (get-strength card))
                         (max 0 (- (get-strength current-ice)
                                   (get-strength card))))
-        times-pump (when (and strength-diff
+        times-pump (if (and strength-diff
                               (pos? pump-strength))
-                     (int (Math/ceil (/ strength-diff pump-strength))))
+                     (int (Math/ceil (/ strength-diff pump-strength)))
+                     0)
         total-pump-cost (when (and pump-ability
                                    times-pump)
                           (repeat times-pump (cost-req [(:cost pump-ability)])))]
@@ -376,9 +377,10 @@
                                    (get-strength card))
                           (max 0 (- (get-strength current-ice)
                                     (get-strength card))))
-          times-pump (when (and strength-diff
+          times-pump (if (and strength-diff
                                 (pos? pump-strength))
-                       (int (Math/ceil (/ strength-diff pump-strength))))
+                       (int (Math/ceil (/ strength-diff pump-strength)))
+                       0)
           total-pump-cost (when (and pump-ability
                                      times-pump)
                             (repeat times-pump (pump-cost-req [(:cost pump-ability)])))

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -123,7 +123,7 @@
 (defn break-sub-ability-cost
   ([state side ability card] (break-sub-ability-cost state side ability card nil))
   ([state side ability card targets]
-   (concat (:cost ability)
+   (concat (:break-cost ability)
            (:additional-cost ability)
            (when-let [break-fn (:break-cost-bonus ability)]
              (break-fn state side (make-eid state) card targets))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -666,7 +666,8 @@
                           (if (and (seq total-cost)
                                    (rezzed? current-ice)
                                    (= :encounter-ice (:phase run))
-                                   break-ability)
+                                   (or break-ability
+                                       pump-ability))
                             (vec (concat abs
                                          (when (and break-ability
                                                     (or pump-ability (zero? strength-diff))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -632,9 +632,10 @@
                                        (get-strength card))
                               (max 0 (- (get-strength current-ice)
                                         (get-strength card))))
-              times-pump (when (and strength-diff
-                                    (pos? pump-strength))
-                           (int (Math/ceil (/ strength-diff pump-strength))))
+              times-pump (if (and strength-diff
+                                  (pos? pump-strength))
+                           (int (Math/ceil (/ strength-diff pump-strength)))
+                           0)
               total-pump-cost (when (and pump-ability
                                          times-pump)
                                 (repeat times-pump (:cost pump-ability)))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -477,7 +477,7 @@
                            total-cost (when (seq broken-subs)
                                         (break-sub-ability-cost state side
                                                                 (assoc args
-                                                                       :cost cost
+                                                                       :break-cost cost
                                                                        :broken-subs broken-subs)
                                                                 card ice))
                            message (when (seq broken-subs)
@@ -546,6 +546,7 @@
         :breaks subtype
         :break-cost cost
         :cost-req (:cost-req args)
+        :break-cost-bonus (:break-cost-bonus args)
         :additional-ability (:additional-ability args)
         :label (str (or (:label args)
                         (str "break "
@@ -559,7 +560,7 @@
                                           card nil
                                           (break-sub-ability-cost
                                             state side
-                                            (assoc args :cost cost :broken-subs (take n (:subroutines current-ice)))
+                                            (assoc args :break-cost cost :broken-subs (take n (:subroutines current-ice)))
                                             card current-ice))
                             (break-subroutines current-ice card cost n (assoc args :ability-idx (:ability-idx (:source-info eid)))))
                           card nil))}))))
@@ -622,6 +623,7 @@
                           (when (:break-req ability)
                             ((:break-req ability) state side eid card nil)))
               break-ability (some #(when (can-break %) %) (:abilities (card-def card)))
+              break-cost (break-sub-ability-cost state side break-ability card current-ice)
               subs-broken-at-once (when break-ability
                                     (:break break-ability 1))
               unbroken-subs (count (remove :broken (:subroutines current-ice)))
@@ -634,9 +636,9 @@
                             (if (pos? subs-broken-at-once)
                               (int (Math/ceil (/ unbroken-subs subs-broken-at-once)))
                               1))
-              total-break-cost (when (and break-ability
+              total-break-cost (when (and break-cost
                                           times-break)
-                                 (repeat times-break (:break-cost break-ability)))
+                                 (repeat times-break break-cost))
               total-cost (merge-costs (conj total-pump-cost total-break-cost))]
           (update! state side
                    (assoc card :abilities

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -3,7 +3,7 @@
     [game.core.board :refer [all-active all-active-installed]]
     [game.core.card :refer [get-card get-counters has-subtype? program? runner? map->Card]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.cost-fns :refer [card-ability-cost]]
+    [game.core.cost-fns :refer [card-ability-cost break-sub-ability-cost]]
     [game.core.effects :refer [register-constant-effects register-floating-effect unregister-constant-effects]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [is-ability? register-events resolve-ability unregister-events]]
@@ -146,7 +146,7 @@
   [state side card ability-kw]
   (into [] (for [ab (get card ability-kw)
                  :let [ab-cost (if (:break-cost ab)
-                                 (assoc ab :cost (:break-cost ab))
+                                 (assoc ab :cost (break-sub-ability-cost state side ab card))
                                  ab)]]
              (add-cost-label-to-ability ab (card-ability-cost state side ab-cost card)))))
 

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3652,6 +3652,7 @@
           -2 (:credit (get-runner))
           "Break costs 2"
           (card-ability state :runner marjanah 0)
+          (is (= "2 [Credits]" (get-in (refresh marjanah) [:abilities 0 :cost-label])) "Break label lists cost as 2 credits")
           (click-prompt state :runner "End the run"))))
     (testing "discount after successful run"
       (do-game state
@@ -3663,6 +3664,7 @@
           -1 (:credit (get-runner))
           "Break costs 1 after run"
           (card-ability state :runner marjanah 0)
+          (is (= "1 [Credits]" (get-in (refresh marjanah) [:abilities 0 :cost-label])) "Break label lists cost as 1 credit")
           (click-prompt state :runner "End the run"))))))
 
 (deftest mass-driver

--- a/test/clj/game/core/ice_test.clj
+++ b/test/clj/game/core/ice_test.clj
@@ -83,7 +83,106 @@
         (run-continue state)
         (is (not-empty (filter #(= :auto-pump-and-break (:dynamic %)) (:abilities (refresh gord)))) "Autobreak is active")
         (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh gord)})
-        (is (empty? (remove :broken (:subroutines (refresh afshar)))) "All subroutines broken")))))
+        (is (empty? (remove :broken (:subroutines (refresh afshar)))) "All subroutines broken"))))
+  (testing "Auto break handles pump abilities with variable strength"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["DNA Tracker"]
+                        :credits 20}
+                 :runner {:deck [(qty "Unity" 3)]
+                          :credits 20}})
+      (play-from-hand state :corp "DNA Tracker" "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Unity")
+      (play-from-hand state :runner "Unity")
+      (play-from-hand state :runner "Unity")
+      (let [unity (get-program state 0)
+            ice (get-ice state :hq 0)]
+        (run-on state :hq)
+        (run-continue state)
+        (is (= "5 [Credits]" (get-in (refresh unity) [:abilities 2 :cost-label])) "Auto Break label lists cost as 5 credits")
+        (changes-val-macro
+          -5 (:credit (get-runner))
+          "Auto break costs 5"
+          (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh unity)}))
+        (is (= 7 (:current-strength (refresh unity))) "Unity's strength is 7 after pumping twice")
+        (is (zero? (count (remove :broken (:subroutines (refresh ice))))) "All subroutines have been broken"))))
+  (testing "Auto break handles break abilities with variable cost"
+    (do-game
+      (new-game {:runner {:hand [(qty "Marjanah" 2)]
+                          :credits 20}
+                 :corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]
+                        :credits 20}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Marjanah")
+      (run-on state :hq)
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state :encounter-ice)
+      (let [marjanah (get-program state 0)]
+        (is (= "2 [Credits]" (get-in (refresh marjanah) [:abilities 2 :cost-label])) "Auto Break label lists cost as 2 credits")
+        (changes-val-macro
+          -2 (:credit (get-runner))
+          "Break costs 2"
+          (card-ability state :runner (refresh marjanah) 2))
+        (run-continue state :approach-server)
+        (run-continue state nil)
+        (run-on state :hq)
+        (run-continue state :encounter-ice)
+        (is (= "1 [Credits]" (get-in (refresh marjanah) [:abilities 2 :cost-label])) "Auto Break label lists cost as 1 credit")
+        (changes-val-macro
+          -1 (:credit (get-runner))
+          "Break costs 1 after run"
+          (card-ability state :runner (refresh marjanah) 2)))))
+  (testing "Basic auto pump test"
+    (do-game
+      (new-game {:runner {:hand ["Corroder"]
+                          :credits 20}
+                 :corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Fire Wall"]
+                        :credits 20}})
+      (play-from-hand state :corp "Fire Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Corroder")
+      (run-on state :hq)
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state :encounter-ice)
+      (let [corroder (get-program state 0)
+            fire-wall (get-ice state :hq 0)]
+        (is (not-empty (filter #(= :auto-pump (:dynamic %)) (:abilities (refresh corroder)))) "Auto pump is active")
+        (is (= "3 [Credits]" (get-in (refresh corroder) [:abilities 3 :cost-label])) "Auto pump label lists cost as 3 credits")
+        (changes-val-macro
+          -3 (:credit (get-runner))
+          "Pump costs 3"
+          (core/play-dynamic-ability state :runner {:dynamic "auto-pump" :card (refresh corroder)}))
+        (is (= 5 (:current-strength (refresh corroder))) "Breaker strength equals ice strength")
+        (is (not (some #{:broken} (:subroutines fire-wall))) "No subroutines have been broken")
+        (is (empty (filter #(= :auto-pump (:dynamic %)) (:abilities (refresh corroder)))) "No auto pump ability since breaker is at strength"))))
+  (testing "Auto pump handles pump abilities with variable strength"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["DNA Tracker"]
+                        :credits 20}
+                 :runner {:deck [(qty "Unity" 3)]
+                          :credits 20}})
+      (play-from-hand state :corp "DNA Tracker" "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Unity")
+      (play-from-hand state :runner "Unity")
+      (play-from-hand state :runner "Unity")
+      (let [unity (get-program state 0)
+            ice (get-ice state :hq 0)]
+        (run-on state :hq)
+        (run-continue state)
+        (is (= "2 [Credits]" (get-in (refresh unity) [:abilities 3 :cost-label])) "Auto Break label lists cost as 2 credits")
+        (changes-val-macro
+          -2 (:credit (get-runner))
+          "Auto pump costs 2"
+          (core/play-dynamic-ability state :runner {:dynamic "auto-pump" :card (refresh unity)}))
+        (is (= 7 (:current-strength (refresh unity))) "Unity's strength is 7 after pumping twice")))))
 
 (deftest bioroid-break-abilities
   ;; The click-to-break ablities on bioroids shouldn't create an undo-click

--- a/test/clj/game/core/ice_test.clj
+++ b/test/clj/game/core/ice_test.clj
@@ -173,8 +173,7 @@
       (play-from-hand state :runner "Unity")
       (play-from-hand state :runner "Unity")
       (play-from-hand state :runner "Unity")
-      (let [unity (get-program state 0)
-            ice (get-ice state :hq 0)]
+      (let [unity (get-program state 0)]
         (run-on state :hq)
         (run-continue state)
         (is (= "2 [Credits]" (get-in (refresh unity) [:abilities 3 :cost-label])) "Auto Break label lists cost as 2 credits")
@@ -182,7 +181,23 @@
           -2 (:credit (get-runner))
           "Auto pump costs 2"
           (core/play-dynamic-ability state :runner {:dynamic "auto-pump" :card (refresh unity)}))
-        (is (= 7 (:current-strength (refresh unity))) "Unity's strength is 7 after pumping twice")))))
+        (is (= 7 (:current-strength (refresh unity))) "Unity's strength is 7 after pumping twice"))))
+  (testing "Auto pump available even with no active break ability"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["DNA Tracker"]
+                        :credits 20}
+                 :runner {:deck ["Utae"]
+                          :credits 20}})
+      (play-from-hand state :corp "DNA Tracker" "HQ")
+      (rez state :corp (get-ice state :hq 0))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Utae")
+      (let [utae (get-program state 0)]
+        (run-on state :hq)
+        (run-continue state)
+        (is (not-empty (filter #(= :auto-pump (:dynamic %)) (:abilities (refresh utae)))) "Auto pump is active")
+        (is (empty? (filter #(= :auto-pump-and-break (:dynamic %)) (:abilities (refresh utae)))) "No auto break dynamic ability")))))
 
 (deftest bioroid-break-abilities
   ;; The click-to-break ablities on bioroids shouldn't create an undo-click


### PR DESCRIPTION
Expanded out the usage of `:break-cost-bonus` so cost changes will display properly in the abilities window and be taken into account when calculating auto pump and break abilities.
![image](https://user-images.githubusercontent.com/5953664/126852087-cc99b6bb-3264-4095-ad47-332933ecdee6.png) ![image](https://user-images.githubusercontent.com/5953664/126851993-04fd2876-dfaf-4238-8ffc-b554513e0dfe.png)

Following a similar pattern, I expanded this out to the pump strength with `:pump-bonus` so breakers with non-static pump strength such as Unity can use auto pump and break abilities.
![image](https://user-images.githubusercontent.com/5953664/126852122-911504ec-76a5-48f6-b816-a25031996897.png) ![image](https://user-images.githubusercontent.com/5953664/126852038-403b4056-7e69-4b22-a928-b57f077c441a.png)

fixes #5736 
fixes #5994 
resolves #5734 