### PR TITLE
Added game count in game lobby, plus indication of filtering

### DIFF
--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -358,14 +358,20 @@
 
 (defn game-list [user {:keys [room games gameid password-game editing]}]
   (let [roomgames (r/track (fn [] (filter #(= (:room %) room) @games)))
-        filtered-games (r/track #(filter-blocked-games @user @roomgames (:visible-formats @app-state)))]
-    [:div.game-list
-     (if (empty? @filtered-games)
-       [:h4 (tr [:lobby.no-games "No games"])]
-       (doall
-         (for [game @filtered-games]
-           ^{:key (:gameid game)}
-           [game-row (assoc game :current-game @gameid :password-game password-game :editing editing)])))]))
+        filtered-games (r/track #(filter-blocked-games @user @roomgames (:visible-formats @app-state)))
+        is_filtered (not= (count slug->format) (count (:visible-formats @app-state)))
+        n (count @filtered-games)
+        game-count-str (tr [:lobby.game-count] n)]
+    [:<>
+     [:div.game-count
+      [:h4 (str game-count-str (when is_filtered (str "  " (tr [:lobby.filtered "(filtered)"]))))]]
+     [:div.game-list
+      (if (empty? @filtered-games)
+        [:h4 (tr [:lobby.no-games "No games"])]
+        (doall
+          (for [game @filtered-games]
+            ^{:key (:gameid game)}
+            [game-row (assoc game :current-game @gameid :password-game password-game :editing editing)])))]]))
 
 (defn format-visible? [slug] (contains? (:visible-formats @app-state) slug))
 

--- a/src/cljs/nr/gamelobby.cljs
+++ b/src/cljs/nr/gamelobby.cljs
@@ -359,12 +359,12 @@
 (defn game-list [user {:keys [room games gameid password-game editing]}]
   (let [roomgames (r/track (fn [] (filter #(= (:room %) room) @games)))
         filtered-games (r/track #(filter-blocked-games @user @roomgames (:visible-formats @app-state)))
-        is_filtered (not= (count slug->format) (count (:visible-formats @app-state)))
+        is-filtered? (not= (count slug->format) (count (:visible-formats @app-state)))
         n (count @filtered-games)
         game-count-str (tr [:lobby.game-count] n)]
     [:<>
      [:div.game-count
-      [:h4 (str game-count-str (when is_filtered (str "  " (tr [:lobby.filtered "(filtered)"]))))]]
+      [:h4 (str game-count-str (when is-filtered? (str "  " (tr [:lobby.filtered "(filtered)"]))))]]
      [:div.game-list
       (if (empty? @filtered-games)
         [:h4 (tr [:lobby.no-games "No games"])]

--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -218,7 +218,9 @@
      :not-allowed "Not allowed"
      :aborted "Connection aborted"
      :lobby.api-access "Allow API access to game information"
-     :lobby.api-requires-key "(Requires an API Key in Settings)"}
+     :lobby.api-requires-key "(Requires an API Key in Settings)"
+     :game-count (fn [[cnt]] (str cnt (if (= 1 cnt) " Game" " Games")))
+     :filtered "(filtered)"}
    :settings
    {:invalid-password "Invalid login or password"
     :invalid-email "No account with that email address exists"

--- a/src/css/lobby.styl
+++ b/src/css/lobby.styl
@@ -107,6 +107,9 @@
             &.current
                 color: gold-base
 
+    .game-count
+        padding: 0 15px
+
     .game-list
         padding: 0 15px
         overflow: auto


### PR DESCRIPTION
The number of games count in the upper navbar is currently using the filtered game count. I'm not sure if that should change to list all games. Might be good to have another indication that filtering is active, or it could be confusing because it's different than in the game lobby.