### PR TITLE
Implement point system for Eternal

### DIFF
--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -71,6 +71,14 @@
 (defmethod ig/init-key :game/quotes [_ opts]
   (load-quotes!))
 
+(defn- format-card-key->string
+  [format]
+  (assoc format :cards
+                (reduce-kv
+                  (fn [m k v]
+                    (assoc m (name k) v))
+                  {} (:cards format))))
+
 (defmethod ig/init-key :jinteki/cards [_ {{:keys [db]} :db}]
   (let [cards (mc/find-maps db "cards" nil)
         stripped-cards (map #(update % :_id str) cards)
@@ -79,16 +87,13 @@
         cycles (mc/find-maps db "cycles" nil)
         mwl (mc/find-maps db "mwls" nil)
         latest-mwl (->> mwl
-                        (filter #(= "standard" (:format %)))
                         (map (fn [e] (update e :date-start #(f/parse (f/formatters :date) %))))
-                        (sort-by :date-start)
-                        (last))
-        ;; Gotta turn the card names back to strings
-        latest-mwl (assoc latest-mwl
-                          :cards (reduce-kv
-                                   (fn [m k v] (assoc m (name k) v))
-                                   {}
-                                   (:cards latest-mwl)))]
+                        (group-by #(keyword (:format %)))
+                        (mapv (fn [[k, v]] [k (->> v
+                                                  (sort-by :date-start)
+                                                  (last)
+                                                  (format-card-key->string))]))
+                        (into {}))]
     (reset! cards/all-cards all-cards)
     (reset! cards/sets sets)
     (reset! cards/cycles cycles)

--- a/src/cljc/jinteki/cards.cljc
+++ b/src/cljc/jinteki/cards.cljc
@@ -6,7 +6,8 @@
 (defonce all-cards #?(:clj (atom {})
                       :cljs (r/atom {})))
 
-(defonce mwl (atom []))
+(defonce mwl #?(:clj (atom {})
+                :cljs (r/atom {})))
 
 (defonce sets (atom []))
 

--- a/src/cljs/nr/deck_status.cljs
+++ b/src/cljs/nr/deck_status.cljs
@@ -6,13 +6,15 @@
 
 (defn- build-deck-status-label [deck-status violation-details?]
   [:div.status-tooltip.blue-shade
-   (doall (for [[status-key {:keys [legal reason description]}] deck-status
-                :when description]
-            ^{:key status-key}
-            [:div {:class (if legal "legal" "invalid")
-                   :title (when violation-details? (or reason "Unknown"))}
-             [:span.tick (if legal "✔" "✘")]
-             description]))])
+   (doall (for [format (keys slug->format)]
+            (let [{{:keys [legal reason description]} (keyword format)} deck-status]
+              ^{:key format}
+              [:div {:class (if legal "legal" "invalid")
+                     :title (when (and violation-details?
+                                       (not legal))
+                              (or reason "Unknown"))}
+               [:span.tick (if legal "✔" "✘")]
+               description])))])
 
 (defn- deck-status-details
   [deck use-trusted-info]

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -12,7 +12,7 @@
             [nr.deck-status :refer [deck-status-span]]
             [nr.history :refer [history]]
             [nr.utils :refer [alliance-dots banned-span dots-html influence-dot set-scroll-top store-scroll-top
-                              influence-dots make-dots restricted-span rotated-span num->percent
+                              influence-dots restricted-span rotated-span deck-points-card-span num->percent
                               slug->format format->slug checkbox-button cond-button non-game-toast]]
             [nr.translations :refer [tr tr-type tr-side tr-format tr-faction]]
             [nr.ws :as ws]
@@ -26,7 +26,7 @@
 
 (defn- format-status-impl
   [format card]
-  (keyword (get-in card [:format (keyword format)] "unknown")))
+  (get-in card [:format (keyword format)] "unknown"))
 
 (def format-status (fnil format-status-impl :standard {}))
 
@@ -373,9 +373,10 @@
   [format card qty in-faction allied?]
   (let [influence (* (:factioncost card) qty)
         card-status (format-status format card)
-        banned (= :banned card-status)
-        restricted (= :restricted card-status)
-        rotated (= :rotated card-status)]
+        banned (:banned card-status)
+        restricted (:restricted card-status)
+        rotated (:rotated card-status)
+        points (:points card-status)]
     [:span " "
      (when (and (not banned) (not in-faction))
        [:span.influence {:key "influence"
@@ -387,7 +388,8 @@
        banned-span
        [:span {:key "restricted"}
         (when restricted restricted-span)
-        (when rotated rotated-span)])]))
+        (when rotated rotated-span)
+        (when points (deck-points-card-span points))])]))
 
 (defn deck-influence-html
   "Returns hiccup-ready vector with dots colored appropriately to deck's influence."
@@ -631,17 +633,17 @@
    (if-let [name (:title card)]
      (let [infaction (no-inf-cost? identity card)
            card-status (format-status format card)
-           banned (= :banned card-status)
-           rotated (= :rotated card-status)
+           banned (:banned card-status)
+           rotated (:rotated card-status)
            allied (validator/alliance-is-free? cards line)
            valid (and (validator/allowed? card identity)
                       (validator/legal-num-copies? identity line))
            modqty (if (validator/is-prof-prog? deck card) (- qty 1) qty)]
        [:span
-        [:span {:class (cond
-                         (and valid (not rotated) (not banned)) "fake-link"
-                         valid "casual"
-                         :else "invalid")
+        [:span {:class (str "fake-link"
+                            (cond rotated " casual"
+                                  banned " invalid"
+                                  (not valid) " invalid"))
                 :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                 :on-mouse-leave #(put! zoom-channel false)} name]
         (card-influence-html format card modqty infaction allied)])
@@ -658,8 +660,8 @@
   [:span (if-let [name (:title card)]
            (let [infaction (no-inf-cost? identity card)
                  card-status (format-status format card)
-                 banned (= :banned card-status)
-                 rotated (= :rotated card-status)
+                 banned (:banned card-status)
+                 rotated (:rotated card-status)
                  allied (validator/alliance-is-free? cards line)
                  valid (and (validator/allowed? card identity)
                             (validator/legal-num-copies? identity line))
@@ -667,14 +669,38 @@
                           (- qty 1)
                           qty)]
              [:span
-              [:span {:class (cond
-                               (and valid (not rotated) (not banned)) "fake-link"
-                               valid "casual"
-                               :else "invalid")
+              [:span {:class (str "fake-link"
+                                  (cond rotated " casual"
+                                        banned " invalid"
+                                        (not valid) " invalid"))
                       :on-mouse-enter #(when (:setname card) (put! zoom-channel line))
                       :on-mouse-leave #(put! zoom-channel false)} name]
               (card-influence-html format card modqty infaction allied)])
            card)])
+
+(defn- build-deck-points-tooltip [deck]
+  (let [fmt (keyword (:format deck))
+        pointed-cards (->> (validator/filter-cards-by-legal-status deck :points)
+                           (map #(assoc {} :title (get-in % [:card :title])
+                                           :points (get-in % [:card :format fmt :points]))))]
+    [:div.status-tooltip.blue-shade
+     (doall (for [{:keys [title points]} (sort-by :title pointed-cards)]
+              ^{:key title}
+              [:div
+               [:span.tick.fake-link title ": " points [deck-points-card-span]]]))]))
+
+(defn deck-points-span [deck]
+  (let [deck-points (validator/deck-point-count deck)
+        point-limit (validator/format-point-limit (:format deck))]
+    [:span.deck-status.shift-tooltip
+     [:span (str (tr [:deck-builder.deck-points "Deck points"]) ": ")]
+     [:span {:class (if (> deck-points point-limit)
+                      "invalid"
+                      "legal")}
+      deck-points]
+     [:span "/" point-limit [deck-points-card-span]]
+     (when (pos? deck-points)
+       (build-deck-points-tooltip deck))]))
 
 (defn decklist-header
   [deck cards]
@@ -683,17 +709,20 @@
      [:img {:src (image-url id)
             :alt (:title id)}]
      [:div.header-text
-      [:h4 {:class (if (= :legal (format-status (:format deck) id)) "fake-link" "casual")
+      [:h4 {:class (str "fake-link"
+                        (let [status (format-status (:format deck) id)]
+                          (cond (:rotated status) " casual"
+                                (:banned status) " invalid")))
             :on-mouse-enter #(put! zoom-channel {:card id
                                                  :art (:art id)
                                                  :id (:id id)})
             :on-mouse-leave #(put! zoom-channel false) }
        (:title id)
-       (case (format-status (:format deck) id)
-         :banned banned-span
-         :restricted restricted-span
-         :rotated rotated-span
-         "")]
+       (let [status (format-status (:format deck) id)]
+         (cond (:banned status) banned-span
+               (:restricted status) restricted-span
+               (:rotated status) rotated-span
+               (:points status) (deck-points-card-span (:points status))))]
       (let [count (validator/card-count cards)
             min-count (validator/min-deck-size id)]
         [:div count (str " " (tr [:deck-builder.cards "cards"]))
@@ -721,6 +750,8 @@
              [:span.invalid " (" (tr [:deck-builder.min "minimum"]) " " min-point ")"])
            (when (> points (inc min-point))
              [:span.invalid " (" (tr [:deck-builder.max "maximum"]) " " (inc min-point) ")"])]))
+      (when (validator/format-point-limit (:format deck))
+        [:div [deck-points-span deck]])
       [:div [deck-status-span deck true true false]]
       (when (:hash deck) [:div (tr [:deck-builder.hash "Tournament hash"]) ": " (:hash deck)])]]))
 

--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -970,6 +970,7 @@
      :max "aximummay"
      :influence "Influenceyay"
      :agenda-points "Agendayay ointspay"
+     :deck-points "Eckday ointspay"
      :hash "Ournamenttay ashhay"
      :why "Whyay?"
      :legal "egallay"

--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -160,6 +160,7 @@
      :max "maximum"
      :influence "Influence"
      :agenda-points "Agenda points"
+     :deck-points "Deck points"
      :hash "Tournament hash"
      :why "Why?"
      :legal "legal"

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -13,6 +13,7 @@
 (def restricted-dot (str "🦄" zws)) ; on the restricted list
 (def alliance-dot (str "○" zws))    ; alliance free-inf dot
 (def rotated-dot (str "↻" zws))     ; on the rotation list
+(def deck-points-dot (str "❖" zws)) ; costs deck points
 
 (def banned-span
   [:span.invalid {:title "Removed"} " " banned-dot])
@@ -22,6 +23,11 @@
 
 (def rotated-span
   [:span.casual {:title "Rotated"} " " rotated-dot])
+
+(defn deck-points-card-span [points]
+  [:span.legal {:title (when points
+                         (str "Deck points: " points))}
+   " " deck-points-dot])
 
 (defn- make-dots
   "Returns string of specified dots and number. Uses number for n > 20"

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -238,10 +238,6 @@ button.off
     color: gold-base
     transition(all 0.2s ease-in-out)
 
-.standard, .eternal, .system-gateway, .startup, .snapshot, .snapshot-plus, .classic, .legal
-    color: green-bright
-    border-color: green-bright
-
 .smallwarning
     position: relative
     background: alpha(gold-base, o-40)
@@ -288,6 +284,10 @@ button.off
 
 button .fake-link
     color: white-solid
+
+.standard, .eternal, .system-gateway, .startup, .snapshot, .snapshot-plus, .classic, .legal
+    color: green-bright
+    border-color: green-bright
 
 .casual
     color: yellow-core

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -242,14 +242,6 @@ button.off
     color: green-bright
     border-color: green-bright
 
-.casual
-    color: yellow-core
-    border-color: yellow-core
-
-.invalid
-    color: orange-dark
-    border-color: orange-dark
-
 .smallwarning
     position: relative
     background: alpha(gold-base, o-40)
@@ -296,6 +288,14 @@ button.off
 
 button .fake-link
     color: white-solid
+
+.casual
+    color: yellow-core
+    border-color: yellow-core
+
+.invalid
+    color: orange-dark
+    border-color: orange-dark
 
 .darken
     background-color: black-solid


### PR DESCRIPTION
This implements the point system outlined [here](https://nisei.net/blog/a-new-beginning-for-eternal/) for the Eternal format. This fix assumes the changes made in [this PR](https://github.com/NoahTheDuke/netrunner-data/pull/20) are implemented in the netrunner-data repository since it assumes that format legality is represented in a map instead of just a value.

For example, Jinteki: Potential Unleashed's legality looks like this:
```clojure
:format{:standard {:banned true}, 
        :system-gateway {:rotated true}, 
        :startup {:rotated true}, 
        :eternal {:legal true, :points 3}, 
        :snapshot {:legal true, :restricted true}, 
        :snapshot-plus {:legal true, :restricted true}, 
        :classic {:banned true}}
```
This let's us store a point value for a format as well as mark cards that are playable with restrictions as legal cards. This let's us not need to check several different keywords when the card is essentially legal. 
 
I'm representing deck points in the UI as a green "❖" (U+2756) symbol. Absolutely open to suggestions on this one. 

Though cards can have different point values I didn't want to tack multiple on like influence dots as it could get very cluttered. Instead the point value will display if you hover over the symbol for a second or two. In addition, I list the current deck points and limit in the deck header. If you mouse over the line a tool tip will display giving you a breakdown.
![image](https://user-images.githubusercontent.com/5953664/128285253-668faff8-b284-4e4c-9861-62ce437d719f.png)

If your deck is invalid due to deck points, the "Why?" span will tell you on mouse over.
![image](https://user-images.githubusercontent.com/5953664/128290719-39c4fb1d-62ca-4079-a63b-838c7f624e0c.png)

Legality of cards viewed in the card browser will mark the card with the deck points symbol and will display the value on mouse over.
![image](https://user-images.githubusercontent.com/5953664/128291095-6abe3dae-eccf-4552-87f8-a64fa6b2562a.png)

As I was updating the code to use the new legality structure, I ended up fixing some miscellaneous style issues. This includes changing the color of the ID text if the ID is banned or rotated from the format in the same way we color those cards in the main deck building section, keeping the pointer look when mousing over card text that isn't the standard link color, and sorting the format status legality for a deck in the order we typically display formats around jnet.
(basic deck building was in the middle of this list before) 
![image](https://user-images.githubusercontent.com/5953664/128290928-c52f1da6-dc0e-442b-9a60-bce2ab0b3018.png)

