### PR TITLE
Keyboard controls and Card Menu Rework

### DIFF
--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -127,11 +127,10 @@
 
 (defn log-input-change-handler
   [s e]
-  (do (println "Fire?")
-      (reset-command-menu s)
-      (swap! s assoc :command-matches (-> e .-target .-value (find-command-matches commands)))
-      (swap! s assoc :msg (-> e .-target .-value))
-      (send-typing s)))
+  (reset-command-menu s)
+  (swap! s assoc :command-matches (-> e .-target .-value (find-command-matches commands)))
+  (swap! s assoc :msg (-> e .-target .-value))
+  (send-typing s))
 
 (defn log-input []
   (let [gameid (r/cursor game-state [:gameid])

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -99,32 +99,36 @@
 (defn command-menu-key-down-handler
   [state e]
   (when (show-command-menu? @state)
-    (let [key-code (-> e .-keyCode)
+    (let [key (-> e .-key)
           matches (:command-matches @state)
           match-count (count matches)]
-      (cond
+      (case key
         ;; ArrowDown
-        (#{40} key-code) (do (.preventDefault e)
-                             (swap! state update :command-highlight #(if % (mod (inc %) match-count) 0)))
+        "ArrowDown" (do (.preventDefault e)
+                        (swap! state update :command-highlight #(if % (mod (inc %) match-count) 0)))
         ;; ArrowUp
-        (#{38} key-code) (when (:command-highlight @state)
-                           (do (.preventDefault e)
-                               (swap! state update :command-highlight #(if % (mod (dec %) match-count) 0))))
+        "ArrowUp" (when (:command-highlight @state)
+                    (.preventDefault e)
+                    (swap! state update :command-highlight #(if % (mod (dec %) match-count) 0)))
         ;; Return, Space, ArrowRight, Tab
-        (#{13 32 39 9} key-code) (when (or (= 1 match-count) (:command-highlight @state))
-                                   (let [use-index (if (= 1 match-count) 0 (:command-highlight @state))
-                                         command (nth matches use-index)]
-                                     (do (.preventDefault e)
-                                         (swap! state assoc :msg (str command " "))
-                                         (reset-command-menu state)
-                                         ;; auto send when no args needed
-                                         (when (and (= key-code 13)
-                                                 (not (get-in command-info-map [command :has-args])))
-                                           (send-msg state)))))))))
+        ("Enter" "Space" "ArrowRight" "Tab")
+        (when (or (= 1 match-count) (:command-highlight @state))
+          (let [use-index (if (= 1 match-count) 0 (:command-highlight @state))
+                command (nth matches use-index)]
+            (.preventDefault e)
+            (swap! state assoc :msg (str command " "))
+            (reset-command-menu state)
+            ;; auto send when no args needed
+            (when (and (= key "Enter")
+                       (not (get-in command-info-map [command :has-args])))
+              (send-msg state))))
+        ;; else
+        nil))))
 
 (defn log-input-change-handler
   [s e]
-  (do (reset-command-menu s)
+  (do (println "Fire?")
+      (reset-command-menu s)
       (swap! s assoc :command-matches (-> e .-target .-value (find-command-matches commands)))
       (swap! s assoc :msg (-> e .-target .-value))
       (send-typing s)))
@@ -143,12 +147,13 @@
             [:form {:on-submit #(do (.preventDefault %)
                                     (reset-command-menu s)
                                     (send-msg s))}
-             [:input {:placeholder (tr [:chat.placeholder "Say something"])
-                      :type "text"
-                      :ref (partial reset! !input-ref)
-                      :value (:msg @s)
-                      :on-key-down (partial command-menu-key-down-handler s)
-                      :on-change (partial log-input-change-handler s)}]]]
+             [:input#log-input
+              {:placeholder (tr [:chat.placeholder "Say something"])
+               :type "text"
+               :ref (partial reset! !input-ref)
+               :value (:msg @s)
+               :on-key-down (partial command-menu-key-down-handler s)
+               :on-change (partial log-input-change-handler s)}]]]
            [indicate-action]
            (when (show-command-menu? @s)
              [:div.command-matches-container.panel.blue-shade

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -150,6 +150,20 @@
     :usage "/unique"
     :help "Toggles uniqueness of selected card (can be used to e.g. play with non-errata version of Wireless Net Pavillion)"}])
 
+(def keyboard-control-info
+  [{:name "Space"
+    :usage "Space"
+    :help "Performs a default action if there are no controls focused. Otherwise, activates the focused control. Default actions: Clicking for credits, Starting/Ending turns, and continuing a run"}
+   {:name "Enter"
+    :usage "Enter"
+    :help "Focuses the chat if there are no controls focused. Otherwise, activates the focused control"}
+   {:name "/"
+    :usage "/ (forward slash)"
+    :help "Focuses the chat and brings up the command menu"}
+   {:name "numbers"
+    :usage "Number keys"
+    :help "Activates options in the button panel or card menu. Numbers are mapped to options from top to bottom"}])
+
 (def help-data
   "List of maps with FAQ about jinteki.net. Every section MUST have an :id here, so the links can work."
   (list
@@ -194,8 +208,14 @@
             {:id "closemenu"
              :title "How do I close a card's menu?"
              :content [:ul
-                       [:p "Click that card again. If it isn't a menu, but a bugged prompt that shouldn't be there, "
+                       [:p "Click outside the menu or press Escape. If it isn't a menu, but a bugged prompt that shouldn't be there, "
                         "try using " [:code "/close-prompt"] "."]]}
+            {:id "keyboard"
+             :title "Are there any keyboard controls?"
+             :content [:ul
+                       [:div "The keyboard can control some basic functionality. "
+                        "List of available keyboard controls:"
+                        [:ul (doall (map-indexed (fn [idx {:keys [usage help]}] [:li {:key idx} [:code usage] " - " help]) keyboard-control-info))]]]}
             {:id "commands"
              :title "How do I use commands during a game?"
              :content [:ul

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -278,10 +278,12 @@
     (render-specials (render-icons (render-cards input)))
     input))
 
-(defn cond-button [text cond f]
+(defn cond-button
+  ([text cond f] (cond-button text cond f nil))
+  ([text cond f id]
   (if cond
-    [:button {:on-click f :key text} text]
-    [:button.disabled {:key text} text]))
+    [:button {:id id :on-click f :key text} text]
+    [:button.disabled {:id id :key text} text])))
 
 (defn checkbox-button [on-text off-text on-cond f]
   (if on-cond

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -279,15 +279,15 @@
     input))
 
 (defn cond-button
-  [text cond f id]
+  [text cond f]
   (if cond
-    [:button {:id id :on-click f :key text} text]
-    [:button.disabled {:id id :key text} text]))
+    [:button {:on-click f :key text} text]
+    [:button.disabled {:key text} text]))
 
-(defn checkbox-button [on-text off-text on-cond f id]
+(defn checkbox-button [on-text off-text on-cond f]
   (if on-cond
-    [:button.on {:id id :on-click f :key on-text} on-text]
-    [:button.off {:id id :on-click f :key off-text} off-text]))
+    [:button.on {:on-click f :key on-text} on-text]
+    [:button.off {:on-click f :key off-text} off-text]))
 
 (defn tristate-button [on-text off-text on-cond disable-cond f]
   (let [text (if on-cond on-text off-text)]

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -279,11 +279,10 @@
     input))
 
 (defn cond-button
-  ([text cond f] (cond-button text cond f nil))
-  ([text cond f id]
+  [text cond f id]
   (if cond
     [:button {:id id :on-click f :key text} text]
-    [:button.disabled {:id id :key text} text])))
+    [:button.disabled {:id id :key text} text]))
 
 (defn checkbox-button [on-text off-text on-cond f id]
   (if on-cond

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -285,10 +285,10 @@
     [:button {:id id :on-click f :key text} text]
     [:button.disabled {:id id :key text} text])))
 
-(defn checkbox-button [on-text off-text on-cond f]
+(defn checkbox-button [on-text off-text on-cond f id]
   (if on-cond
-    [:button.on {:on-click f :key on-text} on-text]
-    [:button.off {:on-click f :key off-text} off-text]))
+    [:button.on {:id id :on-click f :key on-text} on-text]
+    [:button.off {:id id :on-click f :key off-text} off-text]))
 
 (defn tristate-button [on-text off-text on-cond disable-cond f]
   (let [text (if on-cond on-text off-text)]

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -224,23 +224,27 @@
         width: 200px
         font-size: .75rem
         line-height: 1rem
-
+        
+        ul
+            list-style: none
+            
         > span
             margin: 2px
             &:last-child
                 margin-bottom: 0
 
-        > div
+        > div, li
             border: 1px solid white-solid
             padding: 3px 6px
             border-radius: 4px
             margin-bottom: 4px
             cursor: pointer
-
+            outline: 0
+            
             &:last-child
                 margin-bottom: 0
 
-            &:hover
+            &:hover, &:focus
                 border-color: gold-base
 
     .popup

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -57,6 +57,7 @@
         height: 84px
         width: 60px
         border-radius: 4px
+        outline: none
         display-flex()
 
         .cardname
@@ -105,7 +106,12 @@
     .card.hovered
         animation: hovered-card 1s cubic-bezier(0.25,1,0.5,1) forwards
         border-color: blue-light
-
+    
+    .card
+        &:focus
+            animation: hovered-card 1s cubic-bezier(0.25,1,0.5,1) forwards
+            border-color: blue-light
+            
     .counters
         position: absolute
         top: 0
@@ -297,10 +303,6 @@
 
     .playable
         cursor: pointer
-        border-radius: 4px
-
-        .card
-            box-shadow(0 0 1px 2px gold-base)
 
     .bg
         position: absolute
@@ -312,7 +314,7 @@
         height: 84px
         width: 60px
         border-radius: 4px
-
+    
     .server-card
         position: relative
         min-height: 84px
@@ -652,6 +654,12 @@
                     .encounter-info
                         width: 100%
                         margin: 6px 0px
+        
+        .me
+            .card
+                &:hover, &:focus
+                    scale: 1.1
+                    z-index: 1
 
     .centralpane
         flex(1)


### PR DESCRIPTION
Added several keyboard commands to control the game.

### Commands
**Space** - Performs a default action based on game state
- Start Turn
- End Turn
- Click for Credits
- Indicate to continue the run

**Number keys** - Clicks a button in the button pane associated with that number. Assigned from top to bottom. Pressing down a number will focus the button it is assigned to, but the click doesn't happen until key up so you can cancel by changing focus with Tab or Escape. This works for basic actions, runs, and choice prompts, but does not apply to text or number prompts.
![NumButtons](https://user-images.githubusercontent.com/5953664/132893799-ff2f7555-363e-4f0a-ad68-f199329d7f75.png)
(numbers in image are just for illustration)

**Escape**
- Clears focus from active element
- Closes any open card menus

**Enter** - Focuses the log's text box so you can quickly type something in the chat.
**/ (forward slash)** - Focuses the log's text box and inputs a "/" to quickly bring up commands

In the process of working on this I rewrote how we handle card menus (install server list, run server list, abilities). Now only one of these menus can be open at a time so we no longer get overlapping menus and needing to fumble around to close the other menu. Also clicking outside of one of these menus will now close the menu.