### PR TITLE
Add a bogus prompt for Mti when the Corp has no ice in hand

### DIFF
--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -2737,7 +2737,15 @@
       (is (empty? (:hand (get-corp))) "Kakugo removed from HQ")
       (rez state :corp (get-ice state :hq 0))
       (run-continue-until state :movement)
-      (is (= 1 (-> (get-runner) :discard count)) "Runner should take 1 net damage from Kakugo"))))
+      (is (= 1 (-> (get-runner) :discard count)) "Runner should take 1 net damage from Kakugo")))
+  (testing "Bogus prompt when no ice in hand"
+    (do-game
+     (new-game {:corp {:id "Mti Mwekundu: Life Improved"
+                       :deck [(qty "Hedge Fund" 5)]}})
+     (take-credits state :corp)
+     (run-empty-server state "HQ")
+     (is (= :waiting (:prompt-type (prompt-map :runner))) "Runner waiting on Mti ability")
+     (click-prompt state :corp "Carry on!"))))
 
 (deftest nasir-meidan-cyber-explorer
   ;; Nasir


### PR DESCRIPTION
resolves #5988

Being able to Spin Doctor into Ice when a Runner runs an unprotected server so you can use Mti was resolved by PR #6038