### PR TITLE
Chief Slee Fix and Minor Update

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -350,7 +350,9 @@
 
 (defcard "Chief Slee"
   {:events [{:event :end-of-encounter
-             :msg "add 1 power counter to Chief Slee"
+             :req (req (pos? (count (remove :broken (:subroutines (:ice context))))))
+             :msg (req (let [unbroken-count (count (remove :broken (:subroutines (:ice context))))]
+                        (str "add " (quantify unbroken-count "power counter") " to Chief Slee")))
              :effect (effect (add-counter :corp card :power (count (remove :broken (:subroutines (:ice context))))))}]
    :abilities [{:cost [:click 1 :power 5]
                 :keep-open :while-5-power-tokens-left


### PR DESCRIPTION
resolves #6043

I was unable to reproduce Slee gaining counters after a Miraju redirect. I think that aspect of this might have been fixed by either PR #6038 or #6028. This mostly adds a req so we only trigger Chief Slee if there are unbroken subs. Also updated her message to properly display the number of counters added.