### PR TITLE
Remove Run Restrictions From Encounter Abilities

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1383,7 +1383,7 @@
      :optional
      {:prompt "Rez Formicary?"
       :yes-ability
-      {:msg "rez and move Formicary. The Runner is now approaching Formicary"
+      {:msg "rez and move Formicary. The Runner is now encountering Formicary"
        :async true
        :effect (req (wait-for (rez state side card)
                               (move state side (get-card state card)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -77,14 +77,13 @@
    :abilities [(set-autoresolve :auto-419 "419")]})
 
 (defcard "Acme Consulting: The Truth You Need"
-  (letfn [(outermost? [run-position run-ices]
-            (and run-position
-                 (pos? run-position)
-                 (= run-position (count run-ices))))]
+  (letfn [(outermost? [state ice]
+            (let [server-ice (:ices (card->server state ice))]
+              (same-card? ice (last server-ice))))]
     {:constant-effects [{:type :tags
-                         :req (req (and (rezzed? current-ice)
-                                        (= :encounter-ice (:phase run))
-                                        (outermost? run-position run-ices)))
+                         :req (req (and (get-current-encounter state)
+                                        (rezzed? current-ice)
+                                        (outermost? state current-ice)))
                          :value 1}]}))
 
 (defcard "Adam: Compulsive Hacker"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -65,9 +65,8 @@
   [f]
   (let [selector (resolve f)
         descriptor (str f)]
-    {:abilities [{:req (req (and current-ice
+    {:abilities [{:req (req (and (get-current-encounter state)
                                  (rezzed? current-ice)
-                                 (= :encounter-ice (:phase run))
                                  (not (:broken (selector (:subroutines current-ice))))))
                   :break 1
                   :breaks "All"
@@ -244,9 +243,8 @@
              :effect (effect (add-counter card :power 1))}]
    :abilities [{:label "Derez a piece of ice currently being encountered"
                 :msg "derez a piece of ice currently being encountered and take 1 tag"
-                :req (req (and current-ice
+                :req (req (and (get-current-encounter state)
                                (rezzed? current-ice)
-                               (= :encounter-ice (:phase run))
                                (<= (get-strength current-ice) (get-counters (get-card state card) :power))))
                 :cost [:trash]
                 :async true
@@ -1303,7 +1301,7 @@
 
 (defcard "Ice Carver"
   {:constant-effects [{:type :ice-strength
-                       :req (req (and (= :encounter-ice (:phase run))
+                       :req (req (and (get-current-encounter state)
                                       (same-card? current-ice target)))
                        :value -1}]})
 
@@ -1560,7 +1558,7 @@
 
 (defcard "Logic Bomb"
   {:abilities [{:label "Bypass the encountered ice"
-                :req (req (and (= :encounter-ice (:phase run))
+                :req (req (and (get-current-encounter state)
                                (rezzed? current-ice)))
                 :msg (msg "bypass "
                           (:title current-ice)

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -307,7 +307,31 @@
       (take-credits state :runner)
       (trash-resource state)
       (click-card state :corp (get-resource state 0))
-      (is (= "Xanadu" (:title (get-discarded state :runner 0)))))))
+      (is (= "Xanadu" (:title (get-discarded state :runner 0))))))
+  (testing "Tagged when encountering outermost ice on a different server than the attacked server"
+    (do-game
+     (new-game {:corp {:id "Acme Consulting: The Truth You Need"
+                       :deck [(qty "Hedge Fund" 5)]
+                       :hand ["Konjin" "Ice Wall" "Enigma"]
+                       :credits 10}})
+     (play-from-hand state :corp "Konjin" "HQ")
+     (play-from-hand state :corp "Enigma" "HQ")
+     (play-from-hand state :corp "Ice Wall" "R&D")
+     (take-credits state :corp)
+     (let [konjin (get-ice state :hq 0)
+           iw (get-ice state :rd 0)]
+       (rez state :corp konjin)
+       (rez state :corp iw)
+       (run-on state "HQ")
+       (run-continue-until state :encounter-ice konjin)
+       (is (not (is-tagged? state)) "Runner is not tagged while encountering Konjin")
+       (click-prompt state :corp "0 [Credits]")
+       (click-prompt state :runner "1 [Credits]")
+       (click-card state :corp iw)
+       (is (is-tagged? state) "Runner should be tagged while encountering Ice Wall")
+       (encounter-continue state)
+       (is (= :encounter-ice (:phase (get-run))) "Still encountering Konjin")
+       (is (not (is-tagged? state)) "Runner is no longer tagged")))))
 
 (deftest adam-compulsive-hacker
   ;; Adam

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2532,9 +2532,10 @@
 (deftest ice-carver
   ;; Ice Carver - lower ice strength on encounter
   (do-game
-    (new-game {:corp {:deck ["Ice Wall"]}
+    (new-game {:corp {:deck ["Ice Wall" "Ganked!"]}
                :runner {:deck ["Ice Carver"]}})
     (play-from-hand state :corp "Ice Wall" "Archives")
+    (play-from-hand state :corp "Ganked!" "Archives")
     (take-credits state :corp 2)
     (let [iwall (get-ice state :archives 0)]
       (play-from-hand state :runner "Ice Carver")
@@ -2543,7 +2544,12 @@
       (run-continue state)
       (is (zero? (get-strength (refresh iwall))) "Ice Wall strength at 0 for encounter")
       (run-continue state :movement)
-      (run-jack-out state)
+      (is (= 1 (get-strength (refresh iwall))) "Ice Wall strength at 1 after encounter")
+      (run-continue state)
+      (click-prompt state :corp "Yes")
+      (click-card state :corp iwall)
+      (is (zero? (get-strength (refresh iwall))) "Ice Wall strength at 0 for encounter")
+      (run-continue state)
       (is (= 1 (get-strength (refresh iwall))) "Ice Wall strength at 1 after encounter"))))
 
 (deftest inside-man


### PR DESCRIPTION
For cards like Ice Carver than only care that an ice encounter is happening, I removed any restrictions on it needing to be in the Encounter Ice phase of a run. In addition, updated Acme and a few other cards to properly work when encountering the outermost piece of ice through a card ability like Konjin or Ganked!