### PR TITLE
Fix Purging

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -689,7 +689,7 @@
             {:event :successful-run
              :req (req (and (= :rd (target-server context))
                             this-card-run))
-             :effect (effect (register-events 
+             :effect (effect (register-events
                               card [(breach-access-bonus :rd (max 0 (get-virus-counters state card)) {:duration :end-of-run})]))}]
    :abilities [{:cost [:click 1]
                 :msg "make a run on R&D"
@@ -2456,8 +2456,8 @@
 
 (defcard "Tranquilizer"
   (let [action (req (add-counter state side card :virus 1)
-                    (if (and (rezzed? (get-card state (:host card)))
-                             (<= 3 (get-virus-counters state (get-card state card))))
+                    (when (and (rezzed? (get-card state (:host card)))
+                               (<= 3 (get-virus-counters state (get-card state card))))
                       (derez state side (get-card state (:host card)))))]
     {:hosting {:card #(and (ice? %)
                            (can-host? %))}

--- a/src/clj/game/core/purging.clj
+++ b/src/clj/game/core/purging.clj
@@ -11,9 +11,8 @@
   [state side]
   (trigger-event state side :pre-purge)
   (let [installed-cards (concat (all-installed state :runner)
-                                (all-installed state :corp))
-        hosted-on-ice (->> (get-in @state [:corp :servers]) seq flatten (mapcat :ices) (mapcat :hosted))]
-    (doseq [card (concat installed-cards hosted-on-ice)]
+                                (all-installed state :corp))]
+    (doseq [card installed-cards]
       (when (or (has-subtype? card "Virus")
                 (contains? (:counter card) :virus))
         (add-counter state :runner card :virus (- (get-counters card :virus)))))

--- a/test/clj/game/cards/basic_test.clj
+++ b/test/clj/game/cards/basic_test.clj
@@ -71,12 +71,27 @@
         (is (= 1 (count (:discard (get-runner)))) "Fan Site got trashed"))))
   (testing "Purge"
     (do-game
-      (new-game {:runner {:deck ["Clot"]}
-                 :options {:start-as :runner}})
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Ice Wall"]}
+                 :runner {:deck ["Clot" "Imp" "Botulus"]
+                          :credits 10}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
       (play-from-hand state :runner "Clot")
+      (play-from-hand state :runner "Imp")
+      (play-from-hand state :runner "Botulus")
+      (click-card state :runner (get-ice state :hq 0))
       (take-credits state :runner)
-      (core/do-purge state :corp nil)
-      (is (= 1 (count (:discard (get-runner)))) "Clot got trashed"))))
+      (let [imp (get-program state 1)
+            bot (first (:hosted (get-ice state :hq 0)))]
+        (is (= 2 (get-counters (refresh imp) :virus)) "Imp starts with 2 virus counters")
+        (is (= 1 (get-counters (refresh bot) :virus)) "Botulus starts with 1 virus counter")
+        (core/do-purge state :corp nil)
+        (is (= 1 (count (:discard (get-runner)))) "Clot got trashed")
+        (is (= 0 (get-counters (refresh imp) :virus)) "Imp has zero counters after purge")
+        (is (= 0 (get-counters (refresh bot) :virus)) "Botulus has zero counters after purge")
+        (take-credits state :corp)
+        (is (= 1 (get-counters (refresh bot) :virus)) "Botulus gains 1 counter at start of turn")))))
 
 (deftest runner-basic-actions
   (testing "Gain 1 credit"

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -643,7 +643,7 @@
         (is (= 3 (get-counters (refresh imp) :virus)) "Imp received an extra virus counter on install"))))
   (testing "Grimoire and Cookbook both add counters"
     (do-game
-     (new-game {:runner {:hand ["Grimoire" "Cookbook" "Leech" "Imp"]
+     (new-game {:runner {:hand ["Grimoire" "Cookbook" "Leech" "Fermenter"]
                          :credits 10}})
      (take-credits state :corp)
      (play-from-hand state :runner "Grimoire")
@@ -653,8 +653,8 @@
      (is (= 2 (get-counters (get-program state 0) :virus)) "Leech has 2 counters from Grimoire and Cookbook")
      (card-ability state :runner (get-resource state 0) 0)
      (click-prompt state :runner "Always")
-     (play-from-hand state :runner "Imp")
-     (is (= 4 (get-counters (get-program state 1) :virus)) "Imp has 2 additional counters from Grimoire and Cookbook"))))
+     (play-from-hand state :runner "Fermenter")
+     (is (= 3 (get-counters (get-program state 1) :virus)) "Fermenter has 2 additional counters from Grimoire and Cookbook"))))
 
 (deftest councilman
   ;; Councilman


### PR DESCRIPTION
https://github.com/mtgred/netrunner/pull/6041 unfortunately broke purging for hosted viruses. Viruses like Botulus would not gain counters at the start of the turn and Chisel would not lose virus counters.

This was caused by purging getting `all-installed` cards and also getting all hosted cards separately. `all-installed` already finds hosted cards so we were performing the purge twice on all hosted viruses. Since we now always get the latest version of a card before updating counters the viruses would have the incorrect values.

fixes #6052
fixes #6057
fixes #6059