### PR TITLE
Make run abilities persist after trash

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -371,22 +371,22 @@
                               :effect (effect (lose-credits :corp eid 1))}]}))
 
 (defcard "Analog Dreamers"
-  {:abilities [{:cost [:click 1]
-                :msg "make a run on R&D"
-                :makes-run true
-                :async true
-                :effect (effect (make-run eid :rd card))}]
-   :events [(successful-run-replace-breach
-              {:target-server :rd
-               :this-card-run true
-               :ability
-               {:prompt "Choose a card to shuffle into R&D"
-                :choices {:card #(and (not (ice? %))
-                                      (not (rezzed? %))
-                                      (zero? (get-counters % :advancement)))}
-                :msg (msg "shuffle " (card-str state target) " into R&D")
-                :effect (effect (move :corp target :deck)
-                                (shuffle! :corp :deck))}})]})
+  (let [ability (successful-run-replace-breach
+                 {:target-server :rd
+                  :ability
+                  {:prompt "Choose a card to shuffle into R&D"
+                   :choices {:card #(and (not (ice? %))
+                                         (not (rezzed? %))
+                                         (zero? (get-counters % :advancement)))}
+                   :msg (msg "shuffle " (card-str state target) " into R&D")
+                   :effect (effect (move :corp target :deck)
+                                   (shuffle! :corp :deck))}})]
+    {:abilities [{:cost [:click 1]
+                  :msg "make a run on R&D"
+                  :makes-run true
+                  :async true
+                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                                  (make-run eid :rd card))}]}))
 
 (defcard "Ankusa"
   (auto-icebreaker {:abilities [(break-sub 2 1 "Barrier")
@@ -689,7 +689,7 @@
             {:event :successful-run
              :req (req (and (= :rd (target-server context))
                             this-card-run))
-             :effect (effect (register-events 
+             :effect (effect (register-events
                               card [(breach-access-bonus :rd (max 0 (get-virus-counters state card)) {:duration :end-of-run})]))}]
    :abilities [{:cost [:click 1]
                 :msg "make a run on R&D"
@@ -1139,19 +1139,19 @@
              :effect (effect (trash eid card {:cause :purge}))}]})
 
 (defcard "Expert Schedule Analyzer"
-  {:abilities [{:cost [:click 1]
-                :msg "make a run on HQ"
-                :makes-run true
-                :async true
-                :effect (effect (make-run eid :hq card))}]
-   :events [(successful-run-replace-breach
-              {:target-server :hq
-               :this-card-run true
-               :ability
-               {:msg (msg "reveal all of the cards cards in HQ: "
-                          (string/join ", " (map :title (:hand corp))))
-                :async true
-                :effect (effect (reveal eid (:hand corp)))}})]})
+  (let [ability (successful-run-replace-breach
+                 {:target-server :hq
+                  :ability
+                  {:msg (msg "reveal all of the cards cards in HQ: "
+                             (string/join ", " (map :title (:hand corp))))
+                   :async true
+                   :effect (effect (reveal eid (:hand corp)))}})]
+    {:abilities [{:cost [:click 1]
+                  :msg "make a run on HQ"
+                  :makes-run true
+                  :async true
+                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                                  (make-run eid :hq card))}]}))
 
 (defcard "Faerie"
   (auto-icebreaker {:abilities [(break-sub 0 1 "Sentry")
@@ -1473,23 +1473,23 @@
              :effect (effect (trash eid card {:cause :purge}))}]})
 
 (defcard "Keyhole"
-  {:abilities [{:cost [:click 1]
-                :msg "make a run on R&D"
-                :makes-run true
-                :async true
-                :effect (effect (make-run eid :rd card))}]
-   :events [(successful-run-replace-breach
-              {:target-server :rd
-               :this-card-run true
-               :mandatory true
-               :ability
-               {:prompt "Choose a card to trash"
-                :not-distinct true
-                :msg (msg "trash " (:title target))
-                :choices (req (take 3 (:deck corp)))
-                :async true
-                :effect (effect (shuffle! :corp :deck)
-                                (trash eid (assoc target :seen true) nil))}})]})
+  (let [ability (successful-run-replace-breach
+                 {:target-server :rd
+                  :mandatory true
+                  :ability
+                  {:prompt "Choose a card to trash"
+                   :not-distinct true
+                   :msg (msg "trash " (:title target))
+                   :choices (req (take 3 (:deck corp)))
+                   :async true
+                   :effect (effect (shuffle! :corp :deck)
+                                   (trash eid (assoc target :seen true) nil))}})]
+    {:abilities [{:cost [:click 1]
+                  :msg "make a run on R&D"
+                  :makes-run true
+                  :async true
+                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                                  (make-run eid :rd card))}]}))
 
 (defcard "Knight"
   (let [knight-req (req (and (same-card? current-ice (get-nested-host card))
@@ -2317,42 +2317,42 @@
   (break-and-enter "Barrier"))
 
 (defcard "Stargate"
-  {:abilities [{:cost [:click 1]
-                :once :per-turn
-                :msg "make a run on R&D"
-                :makes-run true
-                :async true
-                :effect (effect (make-run eid :rd card))}]
-   :events [(successful-run-replace-breach
-              {:target-server :rd
-               :this-card-run true
-               :mandatory true
-               :ability
-               {:async true
-                :msg (msg "reveal " (->> (:deck corp)
-                                         (take 3)
-                                         (map :title)
-                                         (string/join ", ")))
-                :effect (req (wait-for
-                               (reveal state side (take 3 (:deck corp)))
-                               (continue-ability
-                                 state side
-                                 {:async true
-                                  :prompt "Choose a card to trash"
-                                  :not-distinct true
-                                  :choices (req (take 3 (:deck corp)))
-                                  :msg (msg (let [card-titles (map :title (take 3 (:deck corp)))
-                                                  target-position (first (positions #{target} (take 3 (:deck corp))))
-                                                  position (case target-position
-                                                             0 "top "
-                                                             1 "middle "
-                                                             2 "bottom "
-                                                             "this-should-not-happen ")]
-                                              (if (= 1 (count (filter #{(:title target)} card-titles)))
-                                                (str "trash " (:title target))
-                                                (str "trash " position (:title target)))))
-                                  :effect (effect (trash :runner eid (assoc target :seen true) nil))}
-                                 card nil)))}})]})
+  (let [ability (successful-run-replace-breach
+                 {:target-server :rd
+                  :mandatory true
+                  :ability
+                  {:async true
+                   :msg (msg "reveal " (->> (:deck corp)
+                                            (take 3)
+                                            (map :title)
+                                            (string/join ", ")))
+                   :effect (req (wait-for
+                                 (reveal state side (take 3 (:deck corp)))
+                                 (continue-ability
+                                  state side
+                                  {:async true
+                                   :prompt "Choose a card to trash"
+                                   :not-distinct true
+                                   :choices (req (take 3 (:deck corp)))
+                                   :msg (msg (let [card-titles (map :title (take 3 (:deck corp)))
+                                                   target-position (first (positions #{target} (take 3 (:deck corp))))
+                                                   position (case target-position
+                                                              0 "top "
+                                                              1 "middle "
+                                                              2 "bottom "
+                                                              "this-should-not-happen ")]
+                                               (if (= 1 (count (filter #{(:title target)} card-titles)))
+                                                 (str "trash " (:title target))
+                                                 (str "trash " position (:title target)))))
+                                   :effect (effect (trash :runner eid (assoc target :seen true) nil))}
+                                  card nil)))}})]
+    {:abilities [{:cost [:click 1]
+                  :once :per-turn
+                  :msg "make a run on R&D"
+                  :makes-run true
+                  :async true
+                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                                  (make-run eid :rd card))}]}))
 
 (defcard "Study Guide"
   (auto-icebreaker {:abilities [(break-sub 1 1 "Code Gate")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -373,6 +373,7 @@
 (defcard "Analog Dreamers"
   (let [ability (successful-run-replace-breach
                  {:target-server :rd
+                  :duration :end-of-run
                   :ability
                   {:prompt "Choose a card to shuffle into R&D"
                    :choices {:card #(and (not (ice? %))
@@ -385,7 +386,7 @@
                   :msg "make a run on R&D"
                   :makes-run true
                   :async true
-                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                  :effect (effect (register-events card [ability])
                                   (make-run eid :rd card))}]}))
 
 (defcard "Ankusa"
@@ -1141,6 +1142,7 @@
 (defcard "Expert Schedule Analyzer"
   (let [ability (successful-run-replace-breach
                  {:target-server :hq
+                  :duration :end-of-run
                   :ability
                   {:msg (msg "reveal all of the cards cards in HQ: "
                              (string/join ", " (map :title (:hand corp))))
@@ -1150,7 +1152,7 @@
                   :msg "make a run on HQ"
                   :makes-run true
                   :async true
-                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                  :effect (effect (register-events card [ability])
                                   (make-run eid :hq card))}]}))
 
 (defcard "Faerie"
@@ -1476,6 +1478,7 @@
   (let [ability (successful-run-replace-breach
                  {:target-server :rd
                   :mandatory true
+                  :duration :end-of-run
                   :ability
                   {:prompt "Choose a card to trash"
                    :not-distinct true
@@ -1488,7 +1491,7 @@
                   :msg "make a run on R&D"
                   :makes-run true
                   :async true
-                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                  :effect (effect (register-events card [ability])
                                   (make-run eid :rd card))}]}))
 
 (defcard "Knight"
@@ -2320,6 +2323,7 @@
   (let [ability (successful-run-replace-breach
                  {:target-server :rd
                   :mandatory true
+                  :duration :end-of-run
                   :ability
                   {:async true
                    :msg (msg "reveal " (->> (:deck corp)
@@ -2351,7 +2355,7 @@
                   :msg "make a run on R&D"
                   :makes-run true
                   :async true
-                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                  :effect (effect (register-events card [ability])
                                   (make-run eid :rd card))}]}))
 
 (defcard "Study Guide"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -621,6 +621,7 @@
 (defcard "Counter Surveillance"
   (let [ability (successful-run-replace-breach
                   {:mandatory true
+                   :duration :end-of-run
                    :ability
                    {:async true
                     :effect (req (let [tags (count-tags state)]
@@ -650,7 +651,7 @@
                   :msg (msg "make a run on " target)
                   :choices (req runnable-servers)
                   :async true
-                  :effect (effect (register-events card [(assoc ability :duration :end-of-run)])
+                  :effect (effect (register-events card [ability])
                                   (make-run eid target card))}]}))
 
 (defcard "Crash Space"

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -387,7 +387,7 @@
                                                  (not (same-card? ice (nth (get-run-ices state) (dec pos) nil))))
                                             (check-for-empty-server state)))})
               (reset-all-ice state side)
-              (cond 
+              (cond
                 ;; run ended
                 (or (check-for-empty-server state)
                     (:ended (:end-run @state)))
@@ -506,8 +506,10 @@
   [props]
   (let [ability (:ability props)
         attacked-server (:target-server props)
-        use-this-card-run (:this-card-run props)]
+        use-this-card-run (:this-card-run props)
+        duration (:duration props)]
     {:event :successful-run
+     :duration duration
      :req (req (and (if use-this-card-run this-card-run true)
                     (case attacked-server
                       (:archives :rd :hq)


### PR DESCRIPTION
Updated Stargate, Keyhole, Analog Dreamers, and Expert Schedule Analyzer to have their effects persist even if they are trashed during the course of the run. Modeled the fix off of how we implemented Counter Surveillance.

fix #5754
fix #6049

