### PR TITLE
Updating cards to align with Card Updates 1.1

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -121,8 +121,7 @@
                 :async true
                 :req (req (and run
                                (= :approach-ice (:phase run))
-                               (not (rezzed? current-ice))
-                               (can-rez? state side current-ice {:ignore-unique true})))
+                               (not (rezzed? current-ice))))
                 :prompt "Choose another server and redirect the run to its outermost position"
                 :choices (req (cancellable (remove #{(-> @state :run :server central->name)} servers)))
                 :msg (msg "trash the approached piece of ice. The Runner is now running on " target)
@@ -222,9 +221,7 @@
                                :choices {:card #(and (in-hand? %)
                                                      (corp? %)
                                                      (corp-installable-type? %)
-                                                     (not (agenda? %))
-                                                     (or (is-remote? z)
-                                                         (ice? %)))}
+                                                     (not (agenda? %)))}
                                :async true
                                :effect (effect (corp-install eid target (zone->name z) nil))}
                               card nil)))}]})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -689,7 +689,7 @@
             {:event :successful-run
              :req (req (and (= :rd (target-server context))
                             this-card-run))
-             :effect (effect (register-events 
+             :effect (effect (register-events
                               card [(breach-access-bonus :rd (max 0 (get-virus-counters state card)) {:duration :end-of-run})]))}]
    :abilities [{:cost [:click 1]
                 :msg "make a run on R&D"
@@ -1030,9 +1030,7 @@
                 :effect (effect (update! (assoc card :server-target target)))}
    :constant-effects [{:type :install-cost
                        :req (req (let [serv (:server (second targets))]
-                                   (and (= serv (:server-target card))
-                                        (not (and (is-central? serv)
-                                                  (upgrade? target))))))
+                                   (= serv (:server-target card))))
                        :value 1}]
    :events [{:event :purge
              :async true

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -381,10 +381,10 @@
           {:prompt (str "Choose a card to swap with " (:title to-swap))
            :choices {:not-self true
                      :card #(and (corp? %)
-                                 (not (operation? %))
+                                 (not (or (operation? %)
+                                          (ice? %)))
                                  (or (in-hand? %) ; agenda, asset or upgrade from HQ
-                                     (and (installed? %) ; card installed in a server
-                                          (not (in-root? %)))))} ; central upgrades are not in a server
+                                     (installed? %)))} ; card installed in a server
            :cost [:trash]
            :msg (msg "swap " (card-str state to-swap)
                      " with " (card-str state target))
@@ -534,7 +534,7 @@
    {:optional
     {:req (req (and (not (in-discard? card))
                     (some #(and (ice? %)
-                                (protecting-same-server? card %)) 
+                                (protecting-same-server? card %))
                           (all-active-installed state :corp))))
      :waiting-prompt "Corp to make a decision"
      :prompt "Trash Ganked! to force the Runner to encounter a piece of ice?"
@@ -1324,8 +1324,6 @@
              :optional
              {:req (req (let [target (:card context)]
                           (and (same-server? card target)
-                               (not (and (upgrade? target)
-                                         (is-central? (second (get-zone target)))))
                                (not (same-card? target card))
                                (some #(and (not (rezzed? %))
                                            (not (agenda? %))
@@ -1504,8 +1502,7 @@
                                         card nil))}}})]
     {:on-trash {:async true
                 :once-per-instance true
-                :req (req (and (= side :runner)
-                               (not (in-root? card))))
+                :req (req (= side :runner))
                 :effect (effect (continue-ability (ability) card nil))}
      :events [{:event :runner-trash
                :async true
@@ -1515,9 +1512,8 @@
                                       (let [target-zone (get-zone (:card target))
                                             target-zone (or (central->zone target-zone) target-zone)
                                             warroid-zone (get-zone card)]
-                                        (and (not (is-root? target-zone))
-                                             (= (second warroid-zone)
-                                                (second target-zone))))))
+                                        (= (second warroid-zone)
+                                           (second target-zone)))))
                                targets))
                :effect (effect (continue-ability (ability) card nil))}]}))
 

--- a/src/clj/game/core/servers.clj
+++ b/src/clj/game/core/servers.clj
@@ -115,7 +115,7 @@
        ice
        (let [zone1 (get-zone card)
              zone2 (get-zone ice)]
-         (and (= (second (or (central->zone zone1) zone1)) 
+         (and (= (second (or (central->zone zone1) zone1))
                  (second zone2))
               (= :ices (last zone2))))))
 
@@ -127,7 +127,6 @@
     (and card1
          card2
          (= zone1 zone2)
-         (is-remote? (second zone1)) ; cards in centrals are in the server's root, not in the server.
          (= :content (last zone1)))))
 
 (defn from-same-server?

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2051,16 +2051,16 @@
     (play-from-hand state :corp "Ice Wall" "HQ")
     (is (= 7 (:credit (get-corp))) "Diwan charged 1cr to install ice protecting the named server")
     (play-from-hand state :corp "Crisium Grid" "HQ")
-    (is (= 7 (:credit (get-corp))) "Diwan didn't charge to install another upgrade in root of HQ")
+    (is (= 6 (:credit (get-corp))) "Diwan charged to install another upgrade in root of HQ")
     (take-credits state :corp)
     (take-credits state :runner)
     (play-from-hand state :corp "Ice Wall" "HQ")
-    (is (= 5 (:credit (get-corp))) "Diwan charged 1cr + 1cr to install a second ice protecting the named server")
+    (is (= 4 (:credit (get-corp))) "Diwan charged 1cr + 1cr to install a second ice protecting the named server")
     (core/gain state :corp :click 1)
     (core/purge state :corp)
     (play-from-hand state :corp "Fire Wall" "HQ") ; 2cr cost from normal install cost
     (is (= "Diwan" (-> (get-runner) :discard first :title)) "Diwan was trashed from purge")
-    (is (= 3 (:credit (get-corp))) "No charge for installs after Diwan purged")))
+    (is (= 2 (:credit (get-corp))) "No charge for installs after Diwan purged")))
 
 (deftest djinn
   ;; Djinn

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -507,7 +507,7 @@
             sbox (get-content state :rd 1)]
         (rez state :corp bbg2)
         (rez state :corp sbox)
-        (is (= 1 (:credit (get-corp))) "Paid full 3 credits to rez Strongbox")))))
+        (is (= 4 (:credit (get-corp))) "Paid 0 credits to rez Strongbox")))))
 
 (deftest bryan-stinson
   ;; Bryan Stinson - play a transaction from archives and remove from game. Ensure Currents are RFG and not trashed.
@@ -3365,7 +3365,8 @@
             enig (get-ice state :hq 0)]
         (rez state :corp scg2)
         (rez state :corp cvs2)
-        (is (empty? (:prompt (get-corp))) "SCG didn't trigger, upgrades in root of same central aren't considered in server")
+        (is (= (:cid scg2) (-> (prompt-map :corp) :card :cid)) "Surat City Grid triggered from upgrade in root of HQ")
+        (click-prompt state :corp "No")
         (derez state :corp (refresh wrap))
         (rez state :corp enig)
         (is (= (:cid scg2) (-> (prompt-map :corp) :card :cid)) "SCG did trigger for ice protecting HQ")))))
@@ -3783,7 +3784,7 @@
       (click-card state :runner (get-program state 1))
       (is (empty? (:prompt (get-corp))) "Warroid Tracker can't trash anything else")
       (is (= 3 (-> (get-runner) :discard count)) "Runner should trash 2 installed cards")))
-  (testing "Shouldn't trigger from self-trash in root of central server. Issue #4813"
+  (testing "Should trigger from self-trash in root of central server"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 3)]
                         :hand ["Warroid Tracker"]}
@@ -3798,9 +3799,9 @@
         (play-from-hand state :runner "Dyson Mem Chip")
         (run-empty-server state :hq)
         (click-prompt state :runner "Pay 4 [Credits] to trash")
-        (is (empty? (:prompt (get-corp))) "Corp has no prompt")
-        (is (empty? (:prompt (get-runner))) "Runner has no prompt"))))
-  (testing "Shouldn't trigger when trashed card is in root of central server."
+        (is (some? (:prompt (get-corp))) "Corp has prompt")
+        (is (some? (:prompt (get-runner))) "Runner has prompt"))))
+  (testing "Should trigger when trashed card is in root of central server."
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 3)]
                         :hand ["Warroid Tracker" "Crisium Grid"]
@@ -3821,9 +3822,9 @@
         (is (= ["Warroid Tracker" "Crisium Grid"] (prompt-buttons :runner)))
         (click-prompt state :runner "Crisium Grid")
         (click-prompt state :runner "Pay 5 [Credits] to trash")
-        (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-corp))) "Corp has no prompt")
-        (is (empty? (:prompt (get-runner))) "Runner has no prompt"))))
+        (click-prompt state :corp "0")
+        (click-prompt state :runner "5")
+        (click-prompt state :runner "No action"))))
   (testing "Shouldn't trigger when trashed by corp (via Hellion Beta Test). Issue #4941"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 3)]


### PR DESCRIPTION
[Card Updates 1.1](https://nisei.net/wp-content/uploads/2021/09/NISEI-Card-Updates-v1.1.pdf)

Most of these updates were about allowing cards to trigger off of upgrades installed in the root of centrals as now all servers have roots.

Aginfusion had its restriction that you needed to be able to rez the ice removed.

Fixed a bug with Daruma that let you swap ice into the root of a server.

