### PR TITLE
Rework Retrieving Card Images

### DIFF
--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -198,7 +198,9 @@
    (let [lang (get-in @app-state [:options :language] "en")
          res (get-in @app-state [:options :card-resolution] "default")
          alt-versions (remove #{:prev} (map keyword (map :version (:alt-info @app-state))))
-         images (select-keys (get-in (:images card) [(keyword lang) (keyword res)]) alt-versions)
+         images (select-keys (merge (get-in (:images card) [(keyword lang) :default])
+                                    (get-in (:images card) [(keyword lang) (keyword res)]))
+                             alt-versions)
          alt-only (alt-version-from-string only-version)
          filtered-images (cond
                            (= :prev alt-only) nil

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -328,14 +328,17 @@
     (reset! scroll-top-atom h)))
 
 (defn get-image-path
+  "Image search priority: Language > Art > Resolution"
   [images lang res art]
-  (let [path (get-in images [lang res art])]
-    (cond
-      path path
-      (not= art :stock) (get-image-path images lang res :stock)
-      (not= res :default) (get-image-path images lang :default art)
-      (not= lang :en) (get-image-path images :en res art)
-      :else "/img/missing.png")))
+  (or (get-in images [lang res art])
+      (and (not= res :default)
+           (get-in images [lang :default art])) ;; check for default res version of art
+      (and (not= art :stock)
+           (or (get-in images [lang res :stock]) ;; check for high res version of stock image
+               (get-in images [lang :default :stock]))) ;; check for default res version of stock image
+      (and (not= lang :en)
+           (get-image-path images :en res art)) ;; repeat search for eng version of the art and resolution
+      "/img/missing.png"))
 
 (defn image-or-face [card]
   (cond


### PR DESCRIPTION
Reworked how we retrieve card images so users with the "High Resolution Card Art" setting checked can still use alt arts and previous version art that do not have high resolution images.

Card search priority is: Language > Art > Resolution
The user's selected language will be the highest priority and will override resolution and art selection.
Choosing a specific art will use the highest quality version of the art
Otherwise get the highest quality image of the stock art 

Also changed the card browser so it did not filter out alt arts that only have default resolutions