### PR TITLE
Pay Algernon Using Credit Sources

### DIFF
--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -201,7 +201,22 @@
       (run-jack-out state)
       (take-credits state :runner)
       (is (empty? (:discard (get-runner))) "No cards trashed")
-      (is (= "Algernon" (:title (get-program state 0))) "Algernon still installed"))))
+      (is (= "Algernon" (:title (get-program state 0))) "Algernon still installed")))
+  (testing "Allows payment from recurring sources"
+    (do-game
+     (new-game {:runner {:deck ["Algernon" "Multithreader"]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Algernon")
+     (play-from-hand state :runner "Multithreader")
+     (take-credits state :runner)
+     (take-credits state :corp)
+     (is (= 4 (:credit (get-runner))) "Runner starts with 4 credit")
+     (click-prompt state :runner "Yes")
+     (is (= "Choose a credit providing card (0 of 2 [Credits])" (:msg (prompt-map :runner))) "Runner prompted to choose credit sources")
+     (click-card state :runner (get-program state 1))
+     (click-card state :runner (get-program state 1))
+     (is (= 4 (:credit (get-runner))) "Runner pays 0 credits from their pool")
+     (is (= 5 (:click (get-runner))) "Runner gains 1 click"))))
 
 (deftest ^{:card-title "alias"}
   alias-breaker


### PR DESCRIPTION
resolves https://github.com/mtgred/netrunner/issues/5990

I was unable to recreate this issue, so I just added a test using Multithreader to pay for Algernon's ability at the start of a turn so we can catch this problem if it were to resurface. 