### PR TITLE
Formicary Autoresolve + Disable Unplayable Abilities

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1382,18 +1382,22 @@
      :interactive (req true)
      :optional
      {:prompt "Rez Formicary?"
+      :autoresolve (get-autoresolve :auto-formicary)
+      :req (req (and (can-rez? state side card)
+                     (can-pay? state side eid card nil (get-rez-cost state side card nil))))
       :yes-ability
       {:msg "rez and move Formicary. The Runner is now encountering Formicary"
        :async true
        :effect (req (wait-for (rez state side card)
-                              (move state side (get-card state card)
-                                    [:servers (target-server run) :ices]
-                                    {:front true})
-                              (swap! state assoc-in [:run :position] 1)
-                              (set-next-phase state :encounter-ice)
-                              (set-current-ice state)
-                              (update-all-ice state side)
-                              (update-all-icebreakers state side)
+                              (when (rezzed? (:card async-result))
+                                (move state side (get-card state card)
+                                      [:servers (target-server run) :ices]
+                                      {:front true})
+                                (swap! state assoc-in [:run :position] 1)
+                                (set-next-phase state :encounter-ice)
+                                (set-current-ice state)
+                                (update-all-ice state side)
+                                (update-all-icebreakers state side))
                               (effect-completed state side eid)))}}}]
    :subroutines [{:label "End the run unless the Runner suffers 2 net damage"
                   :player :runner
@@ -1403,7 +1407,8 @@
                   :effect (req (if (= target "End the run")
                                  (do (system-msg state :runner "chooses to end the run")
                                      (end-run state :corp eid card))
-                                 (damage state :runner eid :net 2 {:card card :unpreventable true})))}]})
+                                 (damage state :runner eid :net 2 {:card card :unpreventable true})))}]
+   :abilities [(set-autoresolve :auto-formicary "Formicary")]})
 
 (defcard "Free Lunch"
   {:abilities [{:cost [:power 1]

--- a/src/clj/game/core/optional.clj
+++ b/src/clj/game/core/optional.clj
@@ -64,7 +64,8 @@
 (defn set-autoresolve
   "Makes a card ability which lets the user toggle auto-resolve on an ability. Setting is stored under [:special toggle-kw]."
   [toggle-kw ability-name]
-  {:label (str "Toggle auto-resolve on " ability-name)
+  {:autoresolve true
+   :label (str "Toggle auto-resolve on " ability-name)
    :prompt (str "Set auto-resolve on " ability-name " to:")
    :choices ["Always" "Never" "Ask"]
    :effect (effect (update! (assoc-in card [:special toggle-kw] (keyword (string/lower-case target))))

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -257,7 +257,8 @@
 (defn active?
   "Checks if the card is active and should receive game events/triggers."
   [card]
-  (or (identity? card)
+  (or (is-type? card "Basic Action")
+      (identity? card)
       (in-play-area? card)
       (in-current? card)
       (in-scored? card)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -246,12 +246,18 @@
             margin-bottom: 4px
             cursor: pointer
             outline: 0
-            
+
             &:last-child
                 margin-bottom: 0
 
             &:hover, &:focus
                 border-color: gold-base
+
+        .disabled
+            cursor: default
+
+            &:hover, &:focus
+                border-color: white-solid
 
     .popup
         display: none
@@ -654,12 +660,6 @@
                     .encounter-info
                         width: 100%
                         margin: 6px 0px
-        
-        .me
-            .card
-                &:hover, &:focus
-                    scale: 1.1
-                    z-index: 1
 
     .centralpane
         flex(1)

--- a/test/clj/game/core_test.clj
+++ b/test/clj/game/core_test.clj
@@ -181,14 +181,14 @@
         ability (cond
                   (number? ability) ability
                   (string? ability) (some #(when (= (:label (second %)) ability) (first %)) (map-indexed vector (:abilities card)))
-                  :else -1)]
-    (is' (active? card) (str (:title card) " is active"))
-    (is' (and (number? ability)
-              (nth (:abilities card) ability nil))
-         (str (:title card) " has ability #" ability))
-    (when (and (active? card)
-               (number? ability)
-               (nth (:abilities card) ability nil))
+                  :else -1)
+        hasAbility? (and (number? ability)
+                         (nth (:abilities card) ability nil))
+        playable? (or (active? card)
+                      (:autoresolve (nth (:abilities card) ability nil)))]
+    (is' hasAbility? (str (:title card) " has ability #" ability))
+    (is' playable? (str (:title card) " is active or ability #" ability " is an auto resolve toggle"))
+    (when (and hasAbility? playable?)
       (core/process-action "ability" state side {:card card
                                                  :ability ability
                                                  :targets (first targets)}))))

--- a/test/clj/game/core_test.clj
+++ b/test/clj/game/core_test.clj
@@ -182,13 +182,13 @@
                   (number? ability) ability
                   (string? ability) (some #(when (= (:label (second %)) ability) (first %)) (map-indexed vector (:abilities card)))
                   :else -1)
-        hasAbility? (and (number? ability)
-                         (nth (:abilities card) ability nil))
+        has-ability? (and (number? ability)
+                          (nth (:abilities card) ability nil))
         playable? (or (active? card)
                       (:autoresolve (nth (:abilities card) ability nil)))]
-    (is' hasAbility? (str (:title card) " has ability #" ability))
+    (is' has-ability? (str (:title card) " has ability #" ability))
     (is' playable? (str (:title card) " is active or ability #" ability " is an auto resolve toggle"))
-    (when (and hasAbility? playable?)
+    (when (and has-ability? playable?)
       (core/process-action "ability" state side {:card card
                                                  :ability ability
                                                  :targets (first targets)}))))


### PR DESCRIPTION
Added an auto-resolve toggle to Formicary so a Corp can choose to not trigger Formicary's prompt to hide that they have one installed. Resolves https://github.com/mtgred/netrunner/issues/5128

To get this to work, I needed to get some abilities to be considered active even if the card is not active. In the process, I expanded on the work we did on marking abilities as "playable" from https://github.com/mtgred/netrunner/pull/5966 to apply to card abilities. Unplayable abilities will be shown as disabled in the card menu.

![image](https://user-images.githubusercontent.com/5953664/135281791-60ffbcb3-6a00-4f97-a630-c2bf694675a4.png)

Unrelated, I removed scaling and bringing to the front hovered cards in hand. I like the idea of doing this to show exactly what card you are highlighting, but there area some visual quirks if there are a large number of cards in hand. Needs a more considered implementation, so I figured I'd just remove it for now.