### PR TITLE
Playable Abilities Fixes

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1305,7 +1305,6 @@
    :leave-play (req (system-msg state :corp "trashes MCA Informant"))
    :runner-abilities [{:label "Trash MCA Informant host"
                        :cost [:click 1 :credit 2]
-                       :req (req (= :runner side))
                        :async true
                        :effect (effect (system-msg :runner (str "spends [Click] and 2 [Credits] to trash "
                                                                 (card-str state (:host card))))

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -137,7 +137,7 @@
 (defn player-summary
   [player state side same-side?]
   (-> (select-keys player (player-keys))
-      (update :identity prune-null-fields)
+      (update :identity card-summary state side)
       (update :basic-action-card card-abilities-playable? state side)
       (update :current card-summary-vec state side)
       (update :play-area card-summary-vec state side)

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -80,14 +80,16 @@
 (defn- corp-ability-init
   "Gets abilities associated with the card"
   [cdef]
-  (for [ab (:corp-abilities cdef)]
-    (assoc (select-keys ab [:cost]) :label (make-label ab))))
+  (into [] (for [ab (:corp-abilities cdef)
+                 :let [ab (assoc (select-keys ab [:cost]) :label (make-label ab))]]
+             (add-cost-label-to-ability ab))))
 
 (defn- runner-ability-init
   "Gets abilities associated with the card"
   [cdef]
-  (for [ab (:runner-abilities cdef)]
-    (assoc (select-keys ab [:cost :break-cost]) :label (make-label ab))))
+  (into [] (for [ab (:runner-abilities cdef)
+                 :let [ab (assoc (select-keys ab [:cost :break-cost]) :label (make-label ab))]]
+             (add-cost-label-to-ability ab (or (:break-cost ab) (:cost ab))))))
 
 (defn card-init
   "Initializes the abilities and events of the given card."

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -262,6 +262,7 @@
       (in-play-area? card)
       (in-current? card)
       (in-scored? card)
+      (condition-counter? card)
       (and (corp? card)
            (installed? card)
            (rezzed? card))


### PR DESCRIPTION
Identities with active abilities (Earth Station, Sync, etc.) need to check that their abilities can be used.