### PR TITLE
remove redundant text from Embolus message

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -475,7 +475,7 @@
                                          {:prompt "Pay 1 [Credit] to place a power counter on Embolus?"
                                           :yes-ability {:effect (effect (add-counter card :power 1))
                                                         :cost [:credit 1]
-                                                        :msg "pay 1 [Credit] to place a power counter on Embolus"}}}
+                                                        :msg "place a power counter on Embolus"}}}
                                         card nil))}
         etr {:req (req this-server)
              :cost [:power 1]


### PR DESCRIPTION
Message was stating twice that the Corp had spent 1 Credit.