### PR TITLE
Start of Turn Runs

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2113,37 +2113,41 @@
                    :choices (req runnable-servers)
                    :async true
                    :effect (effect (make-run eid target card))}
-        ashes-recur (fn ashes-recur [n]
+        ashes-recur (fn ashes-recur []
                       {:optional
                        {:req (req (not (zone-locked? state :runner :discard)))
                         :prompt "Remove Out of the Ashes from the game to make a run?"
                         :yes-ability
-                        {:msg "removes Out of the Ashes from the game to make a run"
+                        {:async true
+                         :msg "removes Out of the Ashes from the game to make a run"
                          :effect
-                         (req (let [card (some #(when (= "Out of the Ashes" (:title %)) %) (:discard runner))]
-                                (move state side card :rfg)
-                                (unregister-events state side card {:events [{:event :runner-phase-12}]})
-                                (wait-for (resolve-ability state side ashes-run card nil)
-                                          (if (< 1 n)
-                                            (continue-ability state side (ashes-recur (dec n)) card nil)
-                                            (effect-completed state side eid)))))}}})
-        ashes-flag [{:event :runner-phase-12
-                     :location :discard
-                     :condition :in-discard
-                     :once :per-turn
-                     :once-key :out-of-ashes
-                     :effect (effect (continue-ability
-                                       (ashes-recur (count (filter #(= "Out of the Ashes" (:title %))
-                                                                   (:discard runner))))
-                                       card nil))}]]
+                         (req (move state side card :rfg)
+                              (wait-for (resolve-ability state side (make-eid state eid) ashes-run card nil)
+                                        (if-let [next-out-of-ashes (some #(when (and (= "Out of the Ashes" (:title %))
+                                                                                     (not (same-card? card %))) %)
+                                                                         (:discard runner))]
+                                          (resolve-ability state side eid (ashes-recur) (get-card state next-out-of-ashes) nil)
+                                          (effect-completed state side eid))))}}})]
     {:makes-run true
      :on-play {:prompt "Choose a server"
                :choices (req runnable-servers)
                :async true
                :effect (effect (make-run eid target card))}
-     :move-zone (req (if (in-discard? card)
-                       (register-events state side card ashes-flag)
-                       (unregister-events state side card {:events [{:event :runner-phase-12}]})))}))
+     :events [{:event :runner-turn-begins
+               :async true
+               :interactive (req true)
+               :silent (req (let [ashes (filter #(= "Out of the Ashes" (:title %))
+                                                (:discard runner))]
+                              (or (not= card (first ashes))
+                                  (not (not-used-once? state {:once :per-turn
+                                                              :once-key :out-of-ashes}
+                                                       card)))))
+               :location :discard
+               :condition :in-discard
+               :once :per-turn
+               :once-key :out-of-ashes
+               :effect (req (wait-for (resolve-ability state side (make-eid state eid) (ashes-recur) card nil)
+                                      (effect-completed state side eid)))}]}))
 
 (defcard "Overclock"
   {:makes-run true

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2126,7 +2126,7 @@
                                         (if-let [next-out-of-ashes (some #(when (and (= "Out of the Ashes" (:title %))
                                                                                      (not (same-card? card %))) %)
                                                                          (:discard runner))]
-                                          (resolve-ability state side eid (ashes-recur) (get-card state next-out-of-ashes) nil)
+                                          (continue-ability state side (ashes-recur) (get-card state next-out-of-ashes) nil)
                                           (effect-completed state side eid))))}}})]
     {:makes-run true
      :on-play {:prompt "Choose a server"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1371,18 +1371,13 @@
                  :msg (msg "make a run on " target " during which no programs can be used")
                  :makes-run true
                  :async true
-                 ;; TODO: This is a hack to avoid failures in tests
-                 :effect (req (let [wait-prompt
-                                    (find-first #(= (:msg %) "Waiting for Runner to resolve runner-turn-begins triggers")
-                                                (get-in @state [:corp :prompt]))]
-                                (remove-from-prompt-queue state :corp wait-prompt))
-                              (wait-for (make-run state :runner (make-eid state eid) target card)
-                                        (show-wait-prompt state :corp "Runner to resolve runner-turn-begins triggers")
+                 :effect (req (wait-for (make-run state :runner (make-eid state eid) target card)
                                         (effect-completed state side eid)))}]
     {:implementation "Doesn't prevent program use"
      :flags {:runner-phase-12 (req true)}
      :install-cost-bonus (req (- (get-link state)))
      :events [{:event :runner-turn-begins
+               :interactive (req true)
                :optional
                {:once :per-turn
                 :prompt "Use Jak Sinclair to make a run?"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -646,10 +646,10 @@
   [game.core.prompts
    cancellable
    choice-parser
-   clear-encounter-prompts
+   clear-run-prompts
    clear-wait-prompt
    resolve-select
-   show-encounter-prompts
+   show-run-prompts
    show-prompt
    show-prompt-with-dice
    show-select

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -681,7 +681,7 @@
               (let [handlers (when-not (and cancel-fn (cancel-fn state))
                                (filter #(and (card-for-ability state %)
                                              (not (:disabled (card-for-ability state %))))
-                                handlers))
+                                       handlers))
                     non-silent (filter #(let [silent-fn (:silent (:ability %))
                                               card (card-for-ability state %)]
                                           (not (and silent-fn
@@ -694,7 +694,7 @@
                                                 (interactive-fn state side (make-eid state) card event-targets)))
                                         handlers)]
                 ;; If there is only 1 non-silent ability, resolve that then recurse on the rest
-                (if (or (= 1 (count handlers)) (empty? interactive) (= 1 (count non-silent)))
+                (if (or (= 1 (count handlers)) (empty? interactive) (>= 1 (count non-silent)))
                   (let [to-resolve (if (= 1 (count non-silent))
                                      (first non-silent)
                                      (first handlers))

--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -36,7 +36,7 @@
                   :cancel-effect cancel-effect
                   :end-effect end-effect}]
      (when (or (= prompt-type :waiting)
-               (= prompt-type :encounter)
+               (= prompt-type :run)
                (:number choices)
                (:card-title choices)
                (#{:credit :counter} choices)
@@ -166,19 +166,19 @@
   (when-let [wait (find-first #(= :waiting (:prompt-type %)) (-> @state side :prompt))]
     (remove-from-prompt-queue state side wait)))
 
-(defn show-encounter-prompts
+(defn show-run-prompts
   "Adds a dummy prompt to both side's prompt queues.
-   The prompt cannot be closed except by a later call to clear-encounter-prompts."
-  [state card]
-  (show-prompt state :runner card (str "You are encountering " (:title card)) nil nil {:prompt-type :encounter})
-  (show-prompt state :corp card (str "The Runner is encountering " (:title card)) nil nil {:prompt-type :encounter}))
+   The prompt cannot be closed except by a later call to clear-run-prompts."
+  [state msg card]
+  (show-prompt state :runner card (str "You are " msg) nil nil {:prompt-type :run})
+  (show-prompt state :corp card (str "The Runner is " msg) nil nil {:prompt-type :run}))
 
-(defn clear-encounter-prompts
+(defn clear-run-prompts
   [state]
-  (when-let* [runner-encounter (find-first #(= :encounter (:prompt-type %)) (-> @state :runner :prompt))
-              corp-encounter (find-first #(= :encounter (:prompt-type %)) (-> @state :corp :prompt))]
-             (remove-from-prompt-queue state :runner runner-encounter)
-             (remove-from-prompt-queue state :corp corp-encounter)))
+  (when-let* [runner-prompt (find-first #(= :run (:prompt-type %)) (-> @state :runner :prompt))
+              corp-prompt (find-first #(= :run (:prompt-type %)) (-> @state :corp :prompt))]
+             (remove-from-prompt-queue state :runner runner-prompt)
+             (remove-from-prompt-queue state :corp corp-prompt)))
 
 (defn cancellable
   "Wraps a vector of prompt choices with a final 'Cancel' option. Optionally sorts the vector alphabetically,

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1791,7 +1791,7 @@
                             :on-mouse-out  #(card-preview-mouse-out % zoom-channel)}
           (cond
             (and @prompt-state
-                 (not= "encounter" @prompt-type))
+                 (not= "run" @prompt-type))
             [prompt-div me @prompt-state]
             (or @run
                 @encounters)
@@ -1929,7 +1929,7 @@
               (or @run
                   @encounters)
               (when (and (or (not prompt-state)
-                             (= :encounter prompt-type))
+                             (= :run prompt-type))
                          (not= @side no-action))
                 (send-command "continue")
                 (.stopPropagation e))

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -65,8 +65,8 @@
     (is (= ["Enigma" "Done"] (map #(or (:title %) (identity %)) (prompt-buttons :corp))))
     (click-prompt state :corp "Enigma")
     (click-prompt state :corp "HQ")
-    (is (empty? (:prompt (get-corp))))
-    (is (empty? (:prompt (get-runner))))
+    (is (no-prompt? state :corp))
+    (is (no-prompt? state :runner))
     (is (some? (get-ice state :hq 0)))
     (is (= 2 (count (:discard (get-corp)))))
     (move state :corp (find-card "Accelerated Beta Test" (:scored (get-corp))) :hand)
@@ -417,7 +417,7 @@
       (click-prompt state :corp "Yes")
       (is (= 1 (count-tags state)) "Runner takes 1 tag for playing a Run event")
       (play-from-hand state :runner "Wyrm")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't get a prompt to use Better Citizen Program")
+      (is (no-prompt? state :corp) "Corp shouldn't get a prompt to use Better Citizen Program")
       (is (= 1 (count-tags state)) "Runner doesn't gain a tag from installing an icebreaker after playing a Run event")
       (take-credits state :runner)
       (take-credits state :corp)
@@ -425,7 +425,7 @@
       (click-prompt state :corp "Yes")
       (is (= 2 (count-tags state)) "Runner gains 1 tag for installing an Icebreaker")
       (play-from-hand state :runner "The Maker's Eye")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't get a prompt to use Better Citizen Program")
+      (is (no-prompt? state :corp) "Corp shouldn't get a prompt to use Better Citizen Program")
       (is (= 2 (count-tags state)) "Runner doesn't gain a tag from playing a Run event after installing an Icebreaker")))
   (testing "Should only trigger on Run events. #3619"
     (do-game
@@ -436,7 +436,7 @@
       (run-empty-server state "HQ")
       (play-from-hand state :runner "Mining Accident")
       (click-prompt state :corp "Pay 5 [Credits]")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't get a prompt to use Better Citizen Program")
+      (is (no-prompt? state :corp) "Corp shouldn't get a prompt to use Better Citizen Program")
       (is (zero? (count-tags state)) "Runner should not gain a tag from playing a non-Run event")))
   (testing "Shouldn't trigger Apex #5175"
     (do-game
@@ -447,7 +447,7 @@
       (take-credits state :corp)
       (end-phase-12 state :runner)
       (click-card state :runner "Wyrm")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't get a prompt to use Better Citizen Program"))))
+      (is (no-prompt? state :corp) "Corp shouldn't get a prompt to use Better Citizen Program"))))
 
 (deftest bifrost-array
   ;; Bifrost Array
@@ -470,11 +470,11 @@
     (starting-hand state :runner ["Sure Gamble" "Sure Gamble"])
     (play-and-score state "Brain Rewiring")
     (click-prompt state :corp "Yes")
-    (is (not (empty? (:prompt (get-runner)))) "Runner waiting for Corp resolve Brain Rewiring")
+    (is (not (no-prompt? state :runner)) "Runner waiting for Corp resolve Brain Rewiring")
     (click-prompt state :corp "2")
     (is (= 1 (count (:hand (get-runner)))))
-    (is (empty? (:prompt (get-runner))) "Runner not waiting for Corp resolve Brain Rewiring")
-    (is (empty? (:prompt (get-corp))) "Corp done resolving Brain Rewiring")))
+    (is (no-prompt? state :runner) "Runner not waiting for Corp resolve Brain Rewiring")
+    (is (no-prompt? state :corp) "Corp done resolving Brain Rewiring")))
 
 (deftest braintrust
   ;; Braintrust
@@ -614,7 +614,7 @@
     (play-and-score state "Character Assassination")
     (let [kati (get-resource state 0)]
       (click-card state :corp kati)
-      (is (empty? (:prompt (get-runner))) "Fall Guy prevention didn't occur")
+      (is (no-prompt? state :runner) "Fall Guy prevention didn't occur")
       (is (= 1 (count (:discard (get-runner)))) "Kati Jones trashed"))))
 
 (deftest chronos-project
@@ -808,8 +808,8 @@
       (click-prompt state :runner "No action")
       (click-card state :corp "Domestic Sleepers")
       (click-prompt state :runner "Steal")
-      (is (nil? (prompt-map :runner)) "No further prompts for Runner")
-      (is (nil? (prompt-map :corp)) "No further prompts for Corp")
+      (is (no-prompt? state :runner) "No further prompts for Runner")
+      (is (no-prompt? state :corp) "No further prompts for Corp")
       (is (nil? (:run @state)) "Run has ended")))
   (testing "Can access upgrades between cards in hand"
     (do-game
@@ -949,7 +949,7 @@
       (click-prompt state :corp "No")
       (run-empty-server state "HQ")
       (click-prompt state :runner "Steal")
-      (is (empty? (:prompt (get-corp))) "Corp doesn't get opportunity to use Divested Trust")
+      (is (no-prompt? state :corp) "Corp doesn't get opportunity to use Divested Trust")
       (is (= :runner (:winner @state)) "Runner should win")
       (is (= "Agenda" (:reason @state)) "Win condition reports points")))
   (testing "Interaction with Turntable. Issue #4789"
@@ -1257,7 +1257,7 @@
         (is (= "Brainstorm" (:title (first (:deck (get-corp))))) "Brainstorm now on top")
         (is (= 4 (get-counters (refresh fs) :agenda)) "Spent agenda token on Flower Sermon")
         (card-ability state :corp fs 0)
-        (is (empty? (:prompt (get-corp))) "Can only use once per turn"))))
+        (is (no-prompt? state :corp) "Can only use once per turn"))))
   (testing "Hyoubu interaction"
     (do-game
       (new-game {:corp {:id "Hyoubu Institute: Absolute Clarity"
@@ -1392,12 +1392,12 @@
         (card-ability state :corp gs-scored 0)
         (click-card state :corp "Ice Wall")
         (card-ability state :corp gs-scored 0)
-        (is (empty? (:prompt (get-corp))))))
+        (is (no-prompt? state :corp))))
     (testing "Requires at least 1 card in hand to host"
       (do-game state
         (starting-hand state :corp [])
         (card-ability state :corp gs-scored 0)
-        (is (empty? (:prompt (get-corp))))))
+        (is (no-prompt? state :corp))))
     (testing "Can take a hosted card"
       (do-game state
         (card-ability state :corp gs-scored 0)
@@ -1409,7 +1409,7 @@
     (testing "Can't take a hosted card if none exist"
       (do-game state
         (card-ability state :corp gs-scored 1)
-        (is (empty? (:prompt (get-corp))))))
+        (is (no-prompt? state :corp))))
     (testing "Can host a single corp card even if a runner card is hosted"
       (do-game state
         (take-credits state :corp)
@@ -1430,7 +1430,7 @@
         (click-card state :runner "Glenn Station")
         (take-credits state :runner)
         (card-ability state :corp (refresh gs-scored) 1)
-        (is (empty? (:prompt (get-corp))))))
+        (is (no-prompt? state :corp))))
     (testing "Can take a hosted card even if a runner card is hosted"
       (do-game state
         (take-credits state :corp)
@@ -2490,7 +2490,7 @@
     (play-from-hand state :runner "Clone Chip")
     (take-credits state :runner)
     (play-and-score state "Project Ares")
-    (is (empty? (:prompt (get-runner))) "No prompt for Runner if scored with 4 advancement tokens")
+    (is (no-prompt? state :runner) "No prompt for Runner if scored with 4 advancement tokens")
     (core/gain state :corp :click 5)
     (play-from-hand state :corp "Project Ares" "New remote")
     (let [ares (get-content state :remote2 0)]
@@ -2500,7 +2500,7 @@
       (is (= "Choose 2 installed cards installed cards to trash" (:msg (prompt-map :runner)))
           "Runner has Ares prompt to trash installed cards"))
     (click-card state :runner "Clone Chip")
-    (is (empty? (:prompt (get-runner))) "Runner must trash 2 cards but only has 1 card in rig, prompt ended")
+    (is (no-prompt? state :runner) "Runner must trash 2 cards but only has 1 card in rig, prompt ended")
     (is (= 1 (count (:discard (get-runner)))))
     (is (= 1 (count-bad-pub state)))))
 
@@ -2913,7 +2913,7 @@
     (take-credits state :corp)
     (run-empty-server state :archives)
     (click-prompt state :corp "Done")
-    (is (empty? (:prompt (get-runner))) "Runner's waiting prompt resolved")))
+    (is (no-prompt? state :runner) "Runner's waiting prompt resolved")))
 
 (deftest quantum-predictive-model
   ;; Quantum Predictive Model
@@ -3166,7 +3166,7 @@
     (do-game
       (new-game {:corp {:hand ["SDS Drone Deployment"]}})
       (play-and-score state "SDS Drone Deployment")
-      (is (empty? (:prompt (get-corp))) "Corp doesn't get any choices when runner has no installed programs")))
+      (is (no-prompt? state :corp) "Corp doesn't get any choices when runner has no installed programs")))
   (testing "Runner steal, a program is installed"
     (do-game
       (new-game {:corp {:hand ["SDS Drone Deployment"]}
@@ -3216,8 +3216,8 @@
       (click-card state :corp "Corroder")
       (click-card state :corp "NGO Front")
       (click-prompt state :corp "New remote")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner)))))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner)))))
 
 (deftest self-destruct-chips
   ;; Self-Destruct Chips
@@ -3237,7 +3237,7 @@
        (play-and-score state "Send a Message")
        (click-card state :corp archer)
        (is (rezzed? (refresh archer)))
-       (is (empty? (:prompt (get-runner))) "Ability finished resolving"))))
+       (is (no-prompt? state :runner) "Ability finished resolving"))))
   (testing "Basic test - steal"
     (do-game
      (new-game {:corp {:deck ["Send a Message" "Archer"]}})
@@ -3249,8 +3249,8 @@
        (click-prompt state :runner "Steal")
        (click-card state :corp archer)
        (is (rezzed? (refresh archer)))
-       (is (empty? (:prompt (get-runner))) "Ability finished resolving")
-       (is (empty? (:prompt (get-corp))) "Ability finished resolving")))))
+       (is (no-prompt? state :runner) "Ability finished resolving")
+       (is (no-prompt? state :corp) "Ability finished resolving")))))
 
 (deftest sensor-net-activation
   ;; Sensor Net Activation
@@ -3340,7 +3340,7 @@
       (click-prompt state :corp "Yes")
       (is (= 14 (:credit (get-corp))) "Corp gains 3 credits")
       (take-credits state :runner)
-      (is (empty? (:prompt (get-corp))) "Not prompted when out of money")))
+      (is (no-prompt? state :corp) "Not prompted when out of money")))
   (testing "gain credits when in runner score area before turn begins"
     (do-game
       (new-game {:corp {:deck ["SSL Endorsement"]}})
@@ -3366,7 +3366,7 @@
       (click-prompt state :corp "Yes")
       (is (= 16 (:credit (get-corp))) "Corp gains 3 credits")
       (take-credits state :runner)
-      (is (empty? (:prompt (get-corp))) "Not prompted when out of money")))
+      (is (no-prompt? state :corp) "Not prompted when out of money")))
   (testing "register event when agenda swapped with Turntable"
     ;; Regression test for #3114
     (do-game
@@ -3406,7 +3406,7 @@
       (take-credits state :runner)
       (is (= 9 (:credit (get-corp))) "Corp starts with 9 credits")
       (click-prompt state :corp "No")
-      (is (empty? (:prompt (get-corp))) "Not double prompted for credits")
+      (is (no-prompt? state :corp) "Not double prompted for credits")
       (is (= 9 (:credit (get-corp))) "Corp doesn't gain 3 credits")
       (take-credits state :runner)
       (is (= 9 (:credit (get-corp))) "Corp starts with 9 credits")
@@ -3417,7 +3417,7 @@
       (click-prompt state :corp "Yes")
       (is (= 15 (:credit (get-corp))) "Corp gains 3 credits")
       (take-credits state :runner)
-      (is (empty? (:prompt (get-corp))) "Not prompted when out of money"))))
+      (is (no-prompt? state :corp) "Not prompted when out of money"))))
 
 (deftest standoff
   ;; Standoff
@@ -3588,7 +3588,7 @@
       (is (= 1 (count (:hand (get-corp)))))
       (is (zero? (count (:deck (get-corp)))))
       (play-and-score state "The Future is Now")
-      (is (empty? (:prompt (get-corp))) "Ability shouldn't fire if deck is empty")
+      (is (no-prompt? state :corp) "Ability shouldn't fire if deck is empty")
       (is (zero? (count (:hand (get-corp)))))
       (is (zero? (count (:deck (get-corp))))))))
 
@@ -3754,7 +3754,7 @@
         (card-ability state :corp (refresh tm) 0)
         (run-continue state)
         (is (empty? (-> (get-runner) :register :successful-run)))
-        (is (empty? (:prompt (get-runner))) "No omar prompt"))))
+        (is (no-prompt? state :runner) "No omar prompt"))))
   (testing "Stargate interaction. Issue #4713"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -235,7 +235,7 @@
       (click-prompt state :runner "0")
       (click-card state :corp "Gang Sign")
       (click-prompt state :runner "Done") ; Leela trigger, no Gang Sign prompt
-      (is (empty? (:prompt (get-runner))) "Runner doesn't get an access prompt")))
+      (is (no-prompt? state :runner) "Runner doesn't get an access prompt")))
   (testing "with SanSan City Grid #5344"
     (do-game
       (new-game {:corp {:deck ["Amani Senai" "Merger" "SanSan City Grid"]
@@ -418,7 +418,7 @@
       (click-prompt state :runner "End the run")
       (run-continue state)
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "Boomerang shuffle prompt did not come up")
+      (is (no-prompt? state :runner) "Boomerang shuffle prompt did not come up")
       (is (find-card "Boomerang" (:discard (get-runner))))
       (is (not (find-card "Boomerang" (:deck (get-runner)))))))
   (testing "Blocks installing cards from heap"
@@ -432,7 +432,7 @@
       (take-credits state :corp)
       (run-on state "HQ")
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "Paperclip prompt did not come up")))
+      (is (no-prompt? state :runner) "Paperclip prompt did not come up")))
   (testing "Need to allow steal. #2426"
     (do-game
       (new-game {:corp {:deck [(qty "Fetal AI" 3) "Blacklist"]}})
@@ -698,7 +698,7 @@
       (click-prompt state :runner "Pay 1 [Credits]")
       (is (= 4 (:credit (get-runner))) "Runner paid 1 credit")
       (is (zero? (count-tags state)) "Runner didn't take a tag")
-      (is (empty? (:prompt (get-runner))) "City Surveillance only fired once")
+      (is (no-prompt? state :runner) "City Surveillance only fired once")
       (take-credits state :runner)
       (core/lose state :runner :credit (:credit (get-runner))) ;; Set Runner's credits to 0 so they can't choose to pay
       (take-credits state :corp)
@@ -706,7 +706,7 @@
       (click-prompt state :runner "Take 1 tag")
       (is (zero? (:credit (get-runner))) "Runner paid no credits")
       (is (= 1 (count-tags state)) "Runner took 1 tag"))
-      (is (empty? (:prompt (get-runner))) "City Surveillance only fired once")))
+      (is (no-prompt? state :runner) "City Surveillance only fired once")))
 
 (deftest clearinghouse
   ;; Clearinghouse
@@ -837,7 +837,7 @@
         (card-ability state :corp clyde 0)
         (is (zero? (:credit (get-runner))))
         (is (zero? (count (:deck (get-runner)))))
-        (is (empty? (:prompt (get-corp))))))))
+        (is (no-prompt? state :corp))))))
 
 (deftest commercial-bankers-group
   ;; Commercial Bankers Group - Gain 3 credits at turn start if unprotected by ice
@@ -883,7 +883,7 @@
         (is (zero? (get-counters (refresh iw) :advancement)))
         (is (= 2 (get-counters (refresh fw) :advancement)))
         (end-phase-12 state :corp)
-        (is (empty? (:prompt (get-runner)))))))
+        (is (no-prompt? state :runner)))))
   (testing "Variable number of advanceable cards"
     (do-game
       (new-game {:corp {:deck ["Constellation Protocol" "Ice Wall" "Hive"]}})
@@ -1044,7 +1044,7 @@
       (click-card state :corp (find-card "Resistor" (:hand (get-corp))))
       (click-card state :corp (find-card "Product Placement" (:hand (get-corp))))
       (click-card state :corp (find-card "Breaking News" (:hand (get-corp))))
-      (is (empty? (:prompt (get-runner))) "Runner prompt cleared")
+      (is (no-prompt? state :runner) "Runner prompt cleared")
       (is (= 2 (count (:hand (get-corp)))))
       (is (= "Hedge Fund" (:title (first (:hand (get-corp))))))
       (is (= "Jackson Howard" (:title (second (:hand (get-corp))))))
@@ -1081,7 +1081,7 @@
             "Resistor second last card in deck")
         ;; Try to use first Sensie again
         (card-ability state :corp sensie1 0)
-        (is (empty? (:prompt (get-runner))) "Sensie didn't activate")
+        (is (no-prompt? state :runner) "Sensie didn't activate")
         (is (= 3 (count (:hand (get-corp)))))
         ;; Use second Sensie
         (starting-hand state :corp ["Hedge Fund" "Jackson Howard"])
@@ -1099,7 +1099,7 @@
       (rez state :corp (get-content state :remote1 0))
       (draw state :corp)
       (is (= 1 (count (:hand (get-corp)))) "DBS did not fire on manual draw")
-      (is (empty? (:prompt (get-corp))) "Corp is not being asked to bury a card with DBS")))
+      (is (no-prompt? state :corp) "Corp is not being asked to bury a card with DBS")))
   (testing "Fire on Runner turn"
     (do-game
       (new-game {:corp {:deck ["Daily Business Show" "Hedge Fund"
@@ -1114,7 +1114,7 @@
       (is (= 4 (count (:hand (get-corp)))) "Drew an additional card from FIS")
       (is (not-empty (:prompt (get-runner))) "Runner is waiting for Corp to use DBS")
       (click-card state :corp (find-card "Resistor" (:hand (get-corp))))
-      (is (empty? (:prompt (get-runner))) "Runner prompt cleared")
+      (is (no-prompt? state :runner) "Runner prompt cleared")
       (is (= 3 (count (:hand (get-corp)))))))
   (testing "Interaction with Rashida and Start of Turn effects. Issue #4582"
     (do-game
@@ -1132,7 +1132,7 @@
       (is (nil? (get-content state :remote2 0)) "Rashida is trashed")
       (click-card state :corp (find-card "Hedge Fund" (:hand (get-corp))))
       (end-phase-12 state :corp)
-      (is (empty? (:prompt (get-corp))) "DBS doesn't trigger on mandatory draw")))
+      (is (no-prompt? state :corp) "DBS doesn't trigger on mandatory draw")))
   (testing "Interaction with NEH and Political Dealings and nested draws. Issue #5974"
     (testing "DBS first"
       (do-game
@@ -1149,7 +1149,7 @@
         (take-credits state :runner)
         (click-prompt state :corp "Daily Business Show")
         (click-card state :corp "Merger")
-        (is (empty? (:prompt (get-corp))))))
+        (is (no-prompt? state :corp))))
     (testing "Political Dealings first"
       (do-game
         (new-game {:corp {:identity "Near-Earth Hub: Broadcast Center"
@@ -1168,7 +1168,7 @@
         (click-prompt state :corp "Yes")
         (click-prompt state :corp "New remote")
         (click-card state :corp "Ice Wall")
-        (is (empty? (:prompt (get-corp))))))
+        (is (no-prompt? state :corp))))
     (testing "further interactions that could happen"
       (do-game
         (new-game {:corp {:identity "Near-Earth Hub: Broadcast Center"
@@ -1197,7 +1197,7 @@
         (click-prompt state :corp "Jinja City Grid")
         (is (= ["Ice Wall" "None"] (prompt-buttons :corp)))
         (click-prompt state :corp "Ice Wall")
-        (is (empty? (:prompt (get-corp))) "No DBS prompt cuz all drawn cards have been installed")))))
+        (is (no-prompt? state :corp) "No DBS prompt cuz all drawn cards have been installed")))))
 
 (deftest daily-quest
   ;; Daily Quest
@@ -2031,7 +2031,7 @@
         ; use Mr. Li with 0 draws allowed
         (card-ability state :runner mrli 0)
         (is (= 1 (count (:hand (get-runner)))))
-        (is (empty? (:prompt (get-runner))) "No runner prompt open")
+        (is (no-prompt? state :runner) "No runner prompt open")
         (take-credits state :runner)
         (take-credits state :corp)
         (draw state :runner)
@@ -2564,7 +2564,7 @@
         (take-credits state :corp)
         (take-credits state :runner)
         (card-ability state :corp (refresh ll) 0)
-        (is (empty? (:prompt (get-corp))) "No prompt if no matching agenda")
+        (is (no-prompt? state :corp) "No prompt if no matching agenda")
         (take-credits state :corp)
         (take-credits state :runner)
         (card-ability state :corp (refresh ll) 0)
@@ -2771,7 +2771,7 @@
         (rez state :corp malia1)
         (click-card state :corp (get-resource state 0))
         (click-prompt state :runner "Pay 3 [Credits] to trash")
-        (is (empty? (:prompt (get-runner))) "Choose credit source prompt did not come up")
+        (is (no-prompt? state :runner) "Choose credit source prompt did not come up")
         (is (nil? (refresh malia1)) "Malia has been trashed")))))
 
 (deftest marilyn-campaign
@@ -2820,13 +2820,13 @@
         (rez state :corp pad)
         (take-credits state :corp)
         (take-credits state :runner)
-        (is (empty? (:prompt (get-corp))) "No interactive prompt")
+        (is (no-prompt? state :corp) "No interactive prompt")
         (take-credits state :corp)
         (take-credits state :runner)
-        (is (empty? (:prompt (get-corp))) "No interactive prompt")
+        (is (no-prompt? state :corp) "No interactive prompt")
         (take-credits state :corp)
         (take-credits state :runner)
-        (is (empty? (:prompt (get-corp))) "No interactive prompt")
+        (is (no-prompt? state :corp) "No interactive prompt")
         (take-credits state :corp)
         (take-credits state :runner)
         (is (not-empty (:prompt (get-corp))) "Interactive prompt")))))
@@ -3005,7 +3005,7 @@
                            "Used 1 credit from Mumba"
                            (rez state :corp iw)
                            (click-card state :corp mumba))
-        (is (empty? (:prompt (get-corp))) "Rezzing done")
+        (is (no-prompt? state :corp) "Rezzing done")
         (changes-val-macro -1 (:credit (get-corp)) ; 1 credit left on Mumba
                            "Used 1 credit from Mumba"
                            (rez state :corp pad)
@@ -3153,7 +3153,7 @@
       (click-prompt state :corp "Yes") ; Draw from Net Analytics
       (click-prompt state :runner "Done")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner waiting prompt is cleared")
+      (is (no-prompt? state :runner) "Runner waiting prompt is cleared")
       (is (zero? (count-tags state)) "Avoided 1 Ghost Branch tag")
       (is (= 2 (count (:hand (get-corp)))) "Corp draw from NA")
       ; tag removal
@@ -3440,15 +3440,15 @@
      (is (empty? (:hand (get-runner))) "Runner's grip is still empty")
      (core/end-turn state :runner nil)
      (click-card state :runner "Motivation")
-     (is (empty? (:prompt (get-runner))) "Runner done being classy")
-     (is (empty? (:prompt (get-corp))) "Corp not waiting for Runner to be classy")
+     (is (no-prompt? state :runner) "Runner done being classy")
+     (is (no-prompt? state :corp) "Corp not waiting for Runner to be classy")
      (core/start-turn state :corp nil) ;; this causes portals to trigger
      (is (= 4 (:credit (get-corp))) "Corp has not gained credits yet")
      (click-card state :runner "Motivation")
      (is (= 5 (count (:hand (get-runner)))) "Runner is sitting on 5 cards after bottoming a card")
      (is (= 6 (:credit (get-corp))) "Corp only gained 5/2 = 2 credits, not 3")
-     (is (empty? (:prompt (get-runner))) "Runner not prompted")
-     (is (empty? (:prompt (get-corp))) "Corp not waiting for Runner to be classy"))))
+     (is (no-prompt? state :runner) "Runner not prompted")
+     (is (no-prompt? state :corp) "Corp not waiting for Runner to be classy"))))
 
 (deftest plan-b
   ;; Plan B - score agenda with adv cost <= # of adv counters
@@ -3552,7 +3552,7 @@
         (run-empty-server state :hq)
         (card-ability state :runner (get-resource state 0) 0)
         (is (= 4 (count (:hand (get-runner)))) "Runner took no damage")
-        (is (empty? (:prompt (get-corp))) "No Prana prompt for Corp"))))
+        (is (no-prompt? state :corp) "No Prana prompt for Corp"))))
   (testing "Corp gets Prana prompt first"
     (do-game
       (new-game {:corp {:hand ["Prāna Condenser" "Neural EMP"]}
@@ -3579,9 +3579,9 @@
           (take-credits state :corp)
           (play-from-hand state :runner "Zer0")
           (card-ability state :runner (get-hardware state 0) 0)
-          (is (empty? (:prompt (get-corp))) "Prana condenser doesn't proc on 'unpreventable' net damage")
+          (is (no-prompt? state :corp) "Prana condenser doesn't proc on 'unpreventable' net damage")
           (damage state :runner :net 1)
-          (is (empty? (:prompt (get-corp))) "Prana condenser doesn't proc on net damage of the runner"))))
+          (is (no-prompt? state :corp) "Prana condenser doesn't proc on net damage of the runner"))))
     (testing "PAD Tap gains credits from Prana trigger. Issue #5250"
       (do-game
         (new-game {:corp {:hand ["Prāna Condenser" "Bio-Ethics Association"]}
@@ -3805,7 +3805,7 @@
           beale (get-content state :remote2 0)]
       (rez state :corp qs)
       (card-ability state :corp qs 0)
-      (is (empty? (:prompt (get-corp))) "No prompt to rez ice")
+      (is (no-prompt? state :corp) "No prompt to rez ice")
       (score-agenda state :corp beale)
       ; 1 on rez
       (is (= 101 (:credit (get-corp))) "Corp has 101 creds")
@@ -3816,7 +3816,7 @@
       (click-card state :corp ch3)
       ; pay 8 per Chiyashi - 24 total
       (is (= 77 (:credit (get-corp))) "Corp has 77 creds")
-      (is (empty? (:prompt (get-corp))) "No prompt to rez ice"))))
+      (is (no-prompt? state :corp) "No prompt to rez ice"))))
 
 (deftest raman-rai
   ;; Raman Rai
@@ -4013,7 +4013,7 @@
         (take-credits state :corp)
         (run-empty-server state :remote1)
         (click-prompt state :runner "Pay 3 [Credits] to trash")
-        (is (empty? (:prompt (get-corp))) "No prompt to trigger Rex Campaign when trashed by the Runner")))))
+        (is (no-prompt? state :corp) "No prompt to trigger Rex Campaign when trashed by the Runner")))))
 
 (deftest ronald-five
   ;; Ronald Five - Runner loses a click every time they trash a Corp card
@@ -4074,7 +4074,7 @@
       (is (zero? (count-bad-pub state)) "Start with no bad pub")
       (card-ability state :corp rrs 0)
       (is (= (:credit (get-corp)) (+ 6 start-credits)) "Gained 6 credits")
-      (is (empty? (:prompt (get-corp))) "No prompt if no bad pub")
+      (is (no-prompt? state :corp) "No prompt if no bad pub")
       (core/gain state :corp :bad-publicity 1)
       (is (= 1 (count-bad-pub state)) "Start with 1 bad pub")
       (card-ability state :corp rrs 0)
@@ -4276,7 +4276,7 @@
       (take-credits state :corp)
       (run-empty-server state :remote1)
       (click-prompt state :corp "Yes")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't get Shattered Remains ability prompt when no counters")
+      (is (no-prompt? state :corp) "Corp shouldn't get Shattered Remains ability prompt when no counters")
       (click-prompt state :runner "No action")
       (run-empty-server state :remote2)
       (let [credits (:credit (get-corp))]
@@ -4398,7 +4398,7 @@
       (click-prompt state :corp "Yes")
       (is (zero? (count-tags state)) "Runner has 0 tags")
       (click-prompt state :runner "Pay 0 [Credits] to trash")
-      (is (empty? (:prompt (get-runner))) "Runner waiting prompt is cleared")
+      (is (no-prompt? state :runner) "Runner waiting prompt is cleared")
       (is (zero? (count (:discard (get-runner)))) "Runner took no damage")))
   (testing "with Dedicated Response Team"
     (do-game
@@ -4848,7 +4848,7 @@
     (card-ability state :corp (get-content state :remote1 0) 0)
     (click-card state :corp (get-ice state :rd 0))
     (click-card state :corp (get-ice state :hq 1))
-    (is (empty? (:prompt (get-corp))))
+    (is (no-prompt? state :corp))
     (is (zero? (:click (get-corp))) "Spent 1 click")
     (is (= "Aimor" (:title (get-ice state :rd 0))) "Aimor swapped to R&D")
     (is (= "Lockdown" (:title (get-ice state :hq 1))) "Lockdown swapped to HQ outer position")))
@@ -5331,7 +5331,7 @@
         (changes-val-macro 2 (count (:hand (get-corp)))
                            "Added this asset to HQ (and took mandatory draw)"
                            (click-prompt state :corp "Add this asset to HQ"))
-        (is (empty? (:prompt (get-corp))) "No further options because PAD Campaign is rezzed")))))
+        (is (no-prompt? state :corp) "No further options because PAD Campaign is rezzed")))))
 
 (deftest warden-fatuma
   ;; Warden Fatuma - rezzed bioroid ice gains an additional sub

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -4018,42 +4018,42 @@
   ;; Out of the Ashes - ensure card works when played/trashed/milled
   (testing "Happy Path"
     (do-game
-    (new-game {:corp {:deck ["Kala Ghoda Real TV" "Underway Renovation"]}
-               :runner {:deck [(qty "Out of the Ashes" 6)]}})
-    (play-from-hand state :corp "Underway Renovation" "New remote")
-    (take-credits state :corp)
-    (play-from-hand state :runner "Out of the Ashes")
-    (click-prompt state :runner "Archives")
-    (run-continue state)
-    (trash-from-hand state :runner "Out of the Ashes")
-    (trash-from-hand state :runner "Out of the Ashes")
-    (trash-from-hand state :runner "Out of the Ashes")
-    (trash-from-hand state :runner "Out of the Ashes")
-    (is (zero? (count (:hand (get-runner)))))
-    (is (= 5 (count (:discard (get-runner)))))
-    (take-credits state :runner)
-    (let [underway (get-content state :remote1 0)]
-      (core/advance state :corp {:card (refresh underway)}))
-    (is (= 6 (count (:discard (get-runner)))))
-    (take-credits state :corp)
-    ;; remove 5 Out of the Ashes from the game
-    (dotimes [_ 5]
+      (new-game {:corp {:deck ["Kala Ghoda Real TV" "Underway Renovation"]}
+                 :runner {:deck [(qty "Out of the Ashes" 6)]}})
+      (play-from-hand state :corp "Underway Renovation" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Out of the Ashes")
+      (click-prompt state :runner "Archives")
+      (run-continue state)
+      (trash-from-hand state :runner "Out of the Ashes")
+      (trash-from-hand state :runner "Out of the Ashes")
+      (trash-from-hand state :runner "Out of the Ashes")
+      (trash-from-hand state :runner "Out of the Ashes")
+      (is (zero? (count (:hand (get-runner)))))
+      (is (= 5 (count (:discard (get-runner)))))
+      (take-credits state :runner)
+      (let [underway (get-content state :remote1 0)]
+        (core/advance state :corp {:card (refresh underway)}))
+      (is (= 6 (count (:discard (get-runner)))))
+      (take-credits state :corp)
+      ;; remove 5 Out of the Ashes from the game
+      (dotimes [_ 5]
+        (is (seq (:prompt (get-runner))))
+        (click-prompt state :runner "Yes")
+        (click-prompt state :runner "Archives")
+        (run-continue state))
+      (click-prompt state :runner "No")
+      (is (= 1 (count (:discard (get-runner)))))
+      (is (= 5 (count (:rfg (get-runner)))))
+      (take-credits state :runner)
+      (take-credits state :corp)
+      ;; ensure that if you decline the rfg, game will still ask the next turn
       (is (seq (:prompt (get-runner))))
       (click-prompt state :runner "Yes")
       (click-prompt state :runner "Archives")
-      (run-continue state))
-    (click-prompt state :runner "No")
-    (is (= 1 (count (:discard (get-runner)))))
-    (is (= 5 (count (:rfg (get-runner)))))
-    (take-credits state :runner)
-    (take-credits state :corp)
-    ;; ensure that if you decline the rfg, game will still ask the next turn
-    (is (seq (:prompt (get-runner))))
-    (click-prompt state :runner "Yes")
-    (click-prompt state :runner "Archives")
-    (run-continue state)
-    (is (zero? (count (:discard (get-runner)))))
-    (is (= 6 (count (:rfg (get-runner)))))))
+      (run-continue state)
+      (is (zero? (count (:discard (get-runner)))))
+      (is (= 6 (count (:rfg (get-runner)))))))
   (testing "Heap Locked"
     (do-game
       (new-game {:corp   {:deck [(qty "Hedge Fund" 5)]
@@ -4064,7 +4064,32 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (take-credits state :corp)
-      (is (no-prompt? state :runner) "OOTA prompt did not come up"))))
+      (is (no-prompt? state :runner) "OOTA prompt did not come up")))
+  (testing "Interactive with other start of turn triggers"
+    (do-game
+     (new-game {:corp   {:deck [(qty "Hedge Fund" 5)]}
+                :runner {:hand [(qty "Out of the Ashes" 3) "Rezeki" "Data Folding"]}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Rezeki")
+     (play-from-hand state :runner "Data Folding")
+     (trash-from-hand state :runner "Out of the Ashes")
+     (trash-from-hand state :runner "Out of the Ashes")
+     (trash-from-hand state :runner "Out of the Ashes")
+     (take-credits state :runner)
+     (take-credits state :corp)
+     (is (= `("Rezeki" "Data Folding" "Out of the Ashes") (prompt-titles :runner)) "Out of the Ashes reduced to a single choice")
+     (click-prompt state :runner "Rezeki")
+     (click-prompt state :runner "Out of the Ashes")
+     (click-prompt state :runner "Yes")
+     (click-prompt state :runner "Archives")
+     (run-continue state)
+     (click-prompt state :runner "Yes")
+     (click-prompt state :runner "Archives")
+     (run-continue state)
+     (click-prompt state :runner "No")
+     (is (= 1 (count (:discard (get-runner)))))
+     (is (no-prompt? state :runner) "No further start of turn prompts")
+     (is (no-prompt? state :corp) "No waiting for start of turn triggers prompt"))))
 
 (deftest overclock
   ;; Overclock - Gain 5 temporary credits

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -4045,6 +4045,7 @@
       (click-prompt state :runner "No")
       (is (= 1 (count (:discard (get-runner)))))
       (is (= 5 (count (:rfg (get-runner)))))
+      (is (not (:runner-phase-12 @state)) "Start of turn triggers have finished")
       (take-credits state :runner)
       (take-credits state :corp)
       ;; ensure that if you decline the rfg, game will still ask the next turn
@@ -4053,7 +4054,8 @@
       (click-prompt state :runner "Archives")
       (run-continue state)
       (is (zero? (count (:discard (get-runner)))))
-      (is (= 6 (count (:rfg (get-runner)))))))
+      (is (= 6 (count (:rfg (get-runner)))))
+      (is (not (:runner-phase-12 @state)) "Start of turn triggers have finished")))
   (testing "Heap Locked"
     (do-game
       (new-game {:corp   {:deck [(qty "Hedge Fund" 5)]
@@ -4083,13 +4085,11 @@
      (click-prompt state :runner "Yes")
      (click-prompt state :runner "Archives")
      (run-continue state)
-     (click-prompt state :runner "Yes")
-     (click-prompt state :runner "Archives")
-     (run-continue state)
      (click-prompt state :runner "No")
-     (is (= 1 (count (:discard (get-runner)))))
+     (is (= 2 (count (:discard (get-runner)))))
      (is (no-prompt? state :runner) "No further start of turn prompts")
-     (is (no-prompt? state :corp) "No waiting for start of turn triggers prompt"))))
+     (is (no-prompt? state :corp) "No waiting for start of turn triggers prompt")
+     (is (not (:runner-phase-12 @state)) "Start of turn triggers have finished"))))
 
 (deftest overclock
   ;; Overclock - Gain 5 temporary credits

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -115,7 +115,7 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Feedback Filter")
     (play-from-hand state :runner "Amped Up")
-    (is (empty? (:prompt (get-runner)))
+    (is (no-prompt? state :runner)
         "Feedback Filter brain damage prevention opportunity not given")
     (is (= 5 (:click (get-runner))) "Runner gained 2 clicks from Amped Up")
     (is (= 2 (count (:discard (get-runner)))) "Runner discarded 1 card from damage")
@@ -292,7 +292,7 @@
         (play-from-hand state :runner "Apocalypse")
         (click-prompt state :corp "Yes")
         (is (= (+ 2 hand) (count (:hand (get-corp)))) "Calvin Baley draws 2 cards")
-        (is (empty? (:prompt (get-corp))) "No Jinja City Grid")))))
+        (is (no-prompt? state :corp) "No Jinja City Grid")))))
 
 (deftest because-i-can
   ;; Because I Can
@@ -630,7 +630,7 @@
       (core/gain state :runner :credit 7)
       (is (= (:cost tb) (:credit (get-runner))) "Gain enough credits to derez Tollbooth normally")
       (play-from-hand state :runner "Brute-Force-Hack")
-      (is (empty? (:prompt (get-runner))) "Runner can't play Brute-Force-Hack when only available ice is too expensive"))))
+      (is (no-prompt? state :runner) "Runner can't play Brute-Force-Hack when only available ice is too expensive"))))
 
 (deftest build-script
   ;; Build Script
@@ -692,7 +692,7 @@
       (play-from-hand state :runner "By Any Means")
       (run-empty-server state "Server 1")
       (click-prompt state :corp "No") ;; Don't trigger CTM trace
-      (is (empty? (:prompt (get-runner))) "No prompt to steal since agenda was trashed")
+      (is (no-prompt? state :runner) "No prompt to steal since agenda was trashed")
       (is (= 1 (count (:discard (get-corp)))) "Agenda was trashed")
       (is (zero? (count (:hand (get-runner)))) "Took 1 meat damage")))
   (testing "alongside Film Critic: should get the option to trigger either"
@@ -720,7 +720,7 @@
              (into #{} (prompt-titles :runner)))
           "A choice of which to trigger first")
       (click-prompt state :runner "By Any Means")
-      (is (empty? (:prompt (get-runner))) "By Any Means trashes with no prompt")
+      (is (no-prompt? state :runner) "By Any Means trashes with no prompt")
       (is (= 2 (count (:discard (get-corp)))) "Agenda was trashed")
       (is (zero? (count (:hand (get-runner)))) "Took 1 meat damage")))
   (testing "Effect persists when moved from discard"
@@ -1145,7 +1145,7 @@
     (core/gain state :runner :credit 5 :click 1)
     (play-from-hand state :runner "Raymond Flint")
     (play-from-hand state :runner "Corporate Scandal")
-    (is (empty? (:prompt (get-runner))) "No BP taken, so no HQ access from Raymond")
+    (is (no-prompt? state :runner) "No BP taken, so no HQ access from Raymond")
     (play-from-hand state :runner "Investigative Journalism")
     (is (= "Investigative Journalism" (:title (get-resource state 1))) "IJ able to be installed")
     (run-on state "HQ")
@@ -1203,7 +1203,7 @@
         (click-prompt state :corp "No")
         (is (= credits (:credit (get-corp))) "Corp doesn't pay 5 credits to save Hedge Fund")
         (is (= (inc discard) (count (:discard (get-corp)))) "Corp has 1 card trashed"))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompts"))))
+      (is (no-prompt? state :runner) "Runner has no access prompts"))))
 
 (deftest credit-kiting
   ;; Credit Kiting - After successful central run lower install cost by 8 and gain a tag
@@ -1272,11 +1272,11 @@
       (is (= [:rd] (:server (:run @state))) "Second run on R&D triggered")
       (run-continue state)
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No prompt to run a third time")
+      (is (no-prompt? state :runner) "No prompt to run a third time")
       (is (not (:run @state)) "Run is over")
       (play-from-hand state :runner "Data Breach")
       (run-jack-out state)
-      (is (empty? (:prompt (get-runner))) "No option to run again on unsuccessful run")))
+      (is (no-prompt? state :runner) "No option to run again on unsuccessful run")))
   (testing "FAQ 4.1 - ensure runner gets choice of activation order"
     (do-game
       (new-game {:runner {:deck ["Doppelgänger" (qty "Data Breach" 3)]}})
@@ -1326,7 +1326,7 @@
     (play-run-event state "Deep Data Mining" :rd)
     (dotimes [_ 3] ; 1 normal access, 2 extra accesses from DDM because Magnum Opus takes 2 MU
       (click-prompt state :runner "No action"))
-    (is (empty? (:prompt (get-runner))) "No more accesses after 3")))
+    (is (no-prompt? state :runner) "No more accesses after 3")))
 
 (deftest deja-vu
   ;; Deja Vu - recur one non-virus or two virus cards
@@ -1342,7 +1342,7 @@
     (is (= 2 (count (:hand (get-runner)))) "Two cards in hand prior to playing Déjà Vu")
     (play-from-hand state :runner "Déjà Vu")
     (click-prompt state :runner (find-card "Dirty Laundry" (:discard (get-runner))))
-    (is (empty? (:prompt (get-runner))) "Recurring a non-virus card stops Déjà Vu prompting further")
+    (is (no-prompt? state :runner) "Recurring a non-virus card stops Déjà Vu prompting further")
     (is (= 2 (count (:hand (get-runner)))) "Two cards in after playing Déjà Vu")
     (play-from-hand state :runner "Déjà Vu")
     (click-prompt state :runner (find-card "Cache" (:discard (get-runner))))
@@ -1365,7 +1365,7 @@
       (trash-from-hand state :runner "Dirty Laundry")
       (is (= 2 (count (:hand (get-runner)))) "Two cards in hand prior to playing Déjà Vu")
       (play-from-hand state :runner "Déjà Vu")
-      (is (empty? (:prompt (get-runner))) "Prompt did not come up"))))
+      (is (no-prompt? state :runner) "Prompt did not come up"))))
 
 (deftest demolition-run
   ;; Demolition Run - Trash at no cost
@@ -1388,7 +1388,7 @@
     (click-prompt state :runner "[Demolition Run] Trash card")
     (is (zero? (:agenda-point (get-runner))) "Didn't steal False Lead")
     (is (= 2 (count (:discard (get-corp)))) "2 cards in Archives")
-    (is (empty? (:prompt (get-runner))) "Run concluded")))
+    (is (no-prompt? state :runner) "Run concluded")))
 
 (deftest deuces-wild
   ;; Deuces Wild
@@ -1404,14 +1404,14 @@
     (is (= 6 (:credit (get-runner))) "Gained 1 net credit")
     (click-prompt state :runner "Draw 2 cards")
     (is (= 3 (count (:hand (get-runner)))) "Drew 2 cards")
-    (is (empty? (:prompt (get-runner))) "Deuces Wild not showing a third choice option")
+    (is (no-prompt? state :runner) "Deuces Wild not showing a third choice option")
     (play-from-hand state :runner "Deuces Wild")
     (click-prompt state :runner "Expose 1 ice and make a run")
     (click-card state :runner (get-ice state :remote1 0))
     (click-prompt state :runner "HQ")
-    (is (empty? (:prompt (get-runner))) "Deuces prompt not queued")
+    (is (no-prompt? state :runner) "Deuces prompt not queued")
     (run-continue state)
-    (is (= 2 (count (:prompt (get-runner)))) "Deuces prompt not queued")
+    (is (= 3 (count (:prompt (get-runner)))) "Deuces prompt not queued")
     (click-prompt state :corp "0 [Credits]")
     (click-prompt state :runner "0 [Credits]")
     (click-prompt state :runner "Steal")
@@ -1552,7 +1552,7 @@
       (play-run-event state "Diversion of Funds" :hq)
       (click-prompt state :runner "Breach HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Prompt is closed")
+      (is (no-prompt? state :runner) "Prompt is closed")
       (is (= 4 (:credit (get-runner))) "Runner is down a credit")
       (is (= 8 (:credit (get-corp))) "Corp did not lose any credits")
       (is (not (:run @state)) "Run finished"))))
@@ -1598,7 +1598,7 @@
             "The Turning Wheel should provide 1 additional access on R&D")
         (dotimes [_ 2]
           (click-prompt state :runner "No action"))
-        (is (empty? (:prompt (get-runner))) "No prompts after all accesses are complete")
+        (is (no-prompt? state :runner) "No prompts after all accesses are complete")
         (is (= 6 (-> (get-runner) :register :last-run core/total-cards-accessed))
             "Runner should access 2 cards in Archives, 1 + 1 in R&D, and 1 + 1 in HQ"))))
   (testing "The Turning Wheel gains counters after using D&C. Issue #3810"
@@ -1632,7 +1632,7 @@
         (play-from-hand state :runner "Divide and Conquer")
         (is (= :movement (:phase (:run @state))) "In Movement phase before Success")
         (card-ability state :corp (refresh scored-nisei) 0)
-        (is (empty? (:prompt (get-runner))) "No access prompts for runner")
+        (is (no-prompt? state :runner) "No access prompts for runner")
         (is (not (:run @state)) "Run ended by using Nisei counter")
         (is (zero? (-> (get-runner) :register :last-run core/total-cards-accessed))
             "Runner should access 0 cards"))))
@@ -1653,7 +1653,7 @@
         (click-prompt state :runner (-> (prompt-map :runner) :choices first :value)))
       (dotimes [_ 3]
         (click-prompt state :runner (-> (prompt-map :runner) :choices first :value)))
-      (is (empty? (:prompt (get-runner))) "No prompts after all accesses are complete")
+      (is (no-prompt? state :runner) "No prompts after all accesses are complete")
       (is (= 7 (-> (get-runner) :register :last-run core/total-cards-accessed)))))
   (testing "interaction with no cards in archives. Issue #4473"
     (do-game
@@ -1676,7 +1676,7 @@
      (take-credits state :corp)
      (play-run-event state "Divide and Conquer" :archives)
      (click-prompt state :runner "No action")
-     (is (empty? (:prompt (get-runner))) "There's no prompt for accessing R&D"))))
+     (is (no-prompt? state :runner) "There's no prompt for accessing R&D"))))
 
 (deftest drive-by
   ;; Drive By - Expose card in remote server and trash if asset or upgrade
@@ -1798,7 +1798,7 @@
       (take-credits state :corp)
       (run-empty-server state :archives)
       (play-from-hand state :runner "Emergency Shutdown")
-      (is (empty? (:prompt (get-runner))) "Runner has no derez prompt")
+      (is (no-prompt? state :runner) "Runner has no derez prompt")
       (run-empty-server state :hq)
       (play-from-hand state :runner "Emergency Shutdown")
       (is (seq (:prompt (get-runner))) "Runner has a derez prompt")
@@ -1911,7 +1911,7 @@
       (click-card state :runner (refresh iw))
       (is (not (refresh iw)) "Ice Wall on HQ has been trashed")
       (play-from-hand state :runner "En Passant")
-      (is (empty? (:prompt (get-runner))) "Runner has no prompt as En Passant can't be played"))))
+      (is (no-prompt? state :runner) "Runner has no prompt as En Passant can't be played"))))
 
 (deftest encore
   ;; Encore - Run all 3 central servers successfully to take another turn.  Remove Encore from game.
@@ -2037,7 +2037,7 @@
       (rez state :corp hunter)
       (take-credits state :corp)
       (play-from-hand state :runner "Exploit")
-      (is (empty? (:prompt (get-runner))) "No prompt as runner has fulfilled req yet")
+      (is (no-prompt? state :runner) "No prompt as runner has fulfilled req yet")
       (run-empty-server state :archives)
       (run-empty-server state :rd)
       (click-prompt state :runner "No action")
@@ -2425,7 +2425,7 @@
     (is (:prompt (get-corp)) "There is still a prompt")
     (click-card state :corp "Enigma")
     (click-card state :corp "Rototurret")
-    (is (empty? (:prompt (get-corp))) "Selecting 5 cards closed prompt")
+    (is (no-prompt? state :corp) "Selecting 5 cards closed prompt")
     (let [discard (:discard (get-corp))]
       (is (find-card "Beanstalk Royalties" discard) "Beanstalk Royalties is still in Archives")
       (is (= 6 (count discard)) "There are 6 cards in Archives")
@@ -2734,7 +2734,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Immolation Script")
       (run-continue state)
-      (is (empty? (prompt-map :runner)) "No prompt for runner")))
+      (is (no-prompt? state :runner)) "No prompt for runner"))
   (testing "with no ice installed"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -2743,7 +2743,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Immolation Script")
       (run-continue state)
-      (is (empty? (prompt-map :runner)) "No prompt for runner"))))
+      (is (no-prompt? state :runner)) "No prompt for runner")))
 
 (deftest in-the-groove
   ;; In the Groove - whenever you install cost >0 stuff, draw or gain 1
@@ -2766,11 +2766,11 @@
      (is (changes-credits (get-runner) 1
                           (click-prompt state :runner "Gain 1 [Credits]")))
      (play-from-hand state :runner "Sacrificial Construct")
-     (is (empty? (:prompt (get-runner))) "No prompt because Sacrificial Construct is not expensive")
+     (is (no-prompt? state :runner) "No prompt because Sacrificial Construct is not expensive")
      (take-credits state :runner)
      (take-credits state :corp)
      (play-from-hand state :runner "Clone Chip")
-     (is (empty? (:prompt (get-runner))) "No prompt because In the Groove does not last between turns")))
+     (is (no-prompt? state :runner) "No prompt because In the Groove does not last between turns")))
   (testing "Cybernetics interaction"
     (do-game
      (new-game {:runner {:deck [(qty "In the Groove" 3) "Brain Cage"]}})
@@ -2894,8 +2894,8 @@
         (click-prompt state :runner "Pile 2 (3 cards)")
         (click-prompt state :runner "Card from pile 2")
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No prompt to access further cards.")
-        (is (empty? (:prompt (get-corp))) "No more Info Sifting prompts")))))
+        (is (no-prompt? state :runner) "No prompt to access further cards.")
+        (is (no-prompt? state :corp) "No more Info Sifting prompts")))))
 
 (deftest inject
   ;; Inject - Draw 4 cards from Stack and gain 1 credit per trashed program
@@ -3146,7 +3146,7 @@
       (is (last-log-contains? state "Accelerated Beta Test, Brainstorm, Chiyashi") "Revealed correct 3 cards from R&D")
       (click-prompt state :runner "Brainstorm")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No access prompt on C or D, so no other cards were accessed")))
+      (is (no-prompt? state :runner) "No access prompt on C or D, so no other cards were accessed")))
   (testing "When played with no installed cards"
     (do-game
       (new-game {:corp {:deck ["Accelerated Beta Test" "Brainstorm" "Chiyashi" "Dedicated Technician Team"]}
@@ -3159,7 +3159,7 @@
       (take-credits state :corp)
       (play-run-event state "Khusyuk" :rd)
       (click-prompt state :runner "1 [Credit]: 0 cards")
-      (is (empty? (:prompt (get-runner))) "Runner shouldn't get any access prompt when nothing is installed")))
+      (is (no-prompt? state :runner) "Runner shouldn't get any access prompt when nothing is installed")))
  (testing "Interaction with The Turning Wheel"
     (do-game
       (new-game {:corp {:deck ["Accelerated Beta Test" "Brainstorm" "Chiyashi" "Dedicated Technician Team"]}
@@ -3196,7 +3196,7 @@
         (click-prompt state :runner "0") ; lose Ash trace
         (click-prompt state :runner "1 [Credit]: 3 cards")
         (is (second-last-log-contains? state "Accelerated Beta Test, Brainstorm, Chiyashi") "Revealed correct 3 cards from R&D")
-        (is (empty? (:prompt (get-runner))) "No prompt to access cards."))))
+        (is (no-prompt? state :runner) "No prompt to access cards."))))
   (testing "Eater interaction"
     (do-game
       (new-game {:corp {:hand ["Accelerated Beta Test" "Brainstorm" "Chiyashi" "Ice Wall"]}
@@ -3225,7 +3225,7 @@
       (run-continue state)
       (click-prompt state :runner "1 [Credit]: 3 cards")
       (is (second-last-log-contains? state "Accelerated Beta Test, Brainstorm, Chiyashi") "Revealed correct 3 cards from R&D")
-      (is (empty? (:prompt (get-runner))) "No prompt to access cards."))))
+      (is (no-prompt? state :runner) "No prompt to access cards."))))
 
 (deftest knifed
   ;; Knifed - Make a run, trash a barrier if all subs broken
@@ -3278,7 +3278,7 @@
     (play-from-hand state :corp "Hostile Takeover" "New remote")
     (take-credits state :corp)
     (play-from-hand state :runner "Kraken")
-    (is (empty? (prompt-map :runner)) "No prompt as the runner hasn't stolen an agenda yet")
+    (is (no-prompt? state :runner) "No prompt as the runner hasn't stolen an agenda yet")
     (run-empty-server state :remote1)
     (click-prompt state :runner "Steal")
     (play-from-hand state :runner "Kraken")
@@ -3327,7 +3327,7 @@
       (is (= 7 (count (:deck (get-runner)))) "Starts with 7 cards in deck")
       (play-from-hand state :runner "Labor Rights")
       (take-credits state :runner)
-      (is (empty? (:prompt (get-runner))) "Shuffle prompt did not come up")
+      (is (no-prompt? state :runner) "Shuffle prompt did not come up")
       (is (= 3 (count (:deck (get-runner)))) "3 cards in deck")
       (is (= 3 (count (:discard (get-runner)))) "3 cards in discard")
       (is (= 1 (count (:hand (get-runner)))) "1 card in hand")
@@ -3477,7 +3477,7 @@
                  :runner {:hand ["Leverage"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Leverage")
-      (is (empty? (prompt-map :corp)) "No prompt as runner didn't run HQ")
+      (is (no-prompt? state :corp) "No prompt as runner didn't run HQ")
       (run-empty-server state :hq)
       (click-prompt state :runner "No action")
       (is (zero? (count-bad-pub state)) "Corp has no bad pub")
@@ -3493,7 +3493,7 @@
       (is (not (:winner @state)) "No winner is declared yet")
       (take-credits state :corp)
       (play-from-hand state :runner "Leverage")
-      (is (empty? (prompt-map :corp)) "No prompt as runner didn't run HQ")
+      (is (no-prompt? state :corp) "No prompt as runner didn't run HQ")
       (run-empty-server state :hq)
       (click-prompt state :runner "No action")
       (play-from-hand state :runner "Leverage")
@@ -3664,7 +3664,7 @@
     (is (= "Self-modifying Code" (:title (get-program state 1))) "SMC should be installed")
     (click-card state :runner "Cloak")
     (is (= "Cloak" (:title (get-program state 2))) "Cloak should be installed")
-    (is (empty? (prompt-map :runner)) "Runner should have no more prompts")))
+    (is (no-prompt? state :runner)) "Runner should have no more prompts"))
 
 (deftest mining-accident
   ;; Mining Accident
@@ -3709,7 +3709,7 @@
       (run-continue state)
       (click-prompt state :runner "No action")
       (is (not (:run @state)) "Run is over")
-      (is (empty? (:prompt (get-runner))) "No prompt to run a third time")))
+      (is (no-prompt? state :runner) "No prompt to run a third time")))
   (testing "Gain 4 credits after succesful second run"
     (do-game
       (new-game {:runner {:deck [(qty "Möbius" 3)]}})
@@ -3731,7 +3731,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Möbius")
       (run-jack-out state)
-      (is (empty? (:prompt (get-runner))) "No option to run again on unsuccessful run")))
+      (is (no-prompt? state :runner) "No option to run again on unsuccessful run")))
   (testing "Normal rnd run does not gain cred"
     (do-game
       (new-game {:runner {:deck [(qty "Möbius" 3)]}})
@@ -3764,7 +3764,7 @@
       (is (= 9 (:credit (get-runner))))
       (play-from-hand state :runner "Déjà Vu")
       (click-prompt state :runner (find-card "Möbius" (:discard (get-runner))))
-      (is (empty? (:prompt (get-runner))) "Recurring a non-virus card stops Déjà Vu prompting further")
+      (is (no-prompt? state :runner) "Recurring a non-virus card stops Déjà Vu prompting further")
       (is (= 1 (count (:hand (get-runner)))))
       (play-from-hand state :runner "Möbius")
       (run-continue state)
@@ -4064,7 +4064,7 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (take-credits state :corp)
-      (is (empty? (:prompt (get-runner))) "OOTA prompt did not come up"))))
+      (is (no-prompt? state :runner) "OOTA prompt did not come up"))))
 
 (deftest overclock
   ;; Overclock - Gain 5 temporary credits
@@ -4607,7 +4607,7 @@
       (is (empty? (:rfg (get-runner))) "Runner starts with no discarded cards")
       (play-from-hand state :runner "Reboot")
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "Reboot prompt did not come up"))))
+      (is (no-prompt? state :runner) "Reboot prompt did not come up"))))
 
 
 (deftest recon
@@ -4712,7 +4712,7 @@
     (click-card state :runner (get-ice state :hq 0))
     (is (:prompt (get-runner)) "Can't target rezzed Vanilla, prompt still open")
     (click-card state :runner (get-ice state :hq 1))
-    (is (empty? (:prompt (get-runner))))
+    (is (no-prompt? state :runner))
     (is (= "Vanilla" (:title (get-ice state :rd 0))) "Vanilla swapped to R&D")
     (is (= "Paper Wall" (:title (get-ice state :hq 1))) "Paper Wall swapped to HQ outer position")))
 
@@ -4742,7 +4742,7 @@
       (trash-from-hand state :runner "Morning Star")
       (play-run-event state "Retrieval Run" :archives)
       (click-prompt state :runner "Retrieval Run")
-      (is (empty? (:prompt (get-runner))) "Retrieval run didn't attempt to install from heap.")
+      (is (no-prompt? state :runner) "Retrieval run didn't attempt to install from heap.")
       (is (not (:run @state)) "Run is complete"))))
 
 (deftest rigged-results
@@ -4756,8 +4756,8 @@
       (play-from-hand state :runner "Rigged Results")
       (click-prompt state :runner "0")
       (click-prompt state :corp "0")
-      (is (empty? (:prompt (get-runner))) "Rigged Results failed for runner")
-      (is (empty? (:prompt (get-corp))) "Rigged Results failed for runner")))
+      (is (no-prompt? state :runner) "Rigged Results failed for runner")
+      (is (no-prompt? state :corp) "Rigged Results failed for runner")))
   (testing "Corp guesses incorrectly"
     (do-game
       (new-game {:corp {:deck ["Ice Wall"]}
@@ -4793,8 +4793,8 @@
       (click-card state :runner "Easy Mark")
       (is (= 1 (-> (get-runner) :hand count)))
       (is (= "Easy Mark" (-> (get-runner) :hand first :title)))
-      (is (nil? (prompt-map :corp)) "Corp should have no more prompts")
-      (is (nil? (prompt-map :runner)) "Runner should have no more prompts")
+      (is (no-prompt? state :corp) "Corp should have no more prompts")
+      (is (no-prompt? state :runner) "Runner should have no more prompts")
       (is (nil? (get-run)) "Run is ended")))
   (testing "with Gauntlet #2942"
     (do-game
@@ -4828,8 +4828,8 @@
       (click-card state :runner "Sure Gamble")
       (is (= 2 (-> (get-runner) :hand count)))
       (is (= ["Easy Mark" "Sure Gamble"] (->> (get-runner) :hand (map :title) (into []))))
-      (is (nil? (prompt-map :corp)) "Corp should have no more prompts")
-      (is (nil? (prompt-map :runner)) "Runner should have no more prompts")
+      (is (no-prompt? state :corp) "Corp should have no more prompts")
+      (is (no-prompt? state :runner) "Runner should have no more prompts")
       (is (nil? (get-run)) "Run is ended")))
   (testing "Can still access upgrades"
     (do-game
@@ -4860,7 +4860,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Rip Deal")
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "Rip Deal prompt did not come up"))))
+      (is (no-prompt? state :runner) "Rip Deal prompt did not come up"))))
 
 (deftest rumor-mill
   ;; Rumor Mill - interactions with rez effects, additional costs, general event handlers, and trash-effects
@@ -4903,7 +4903,7 @@
       (rez state :corp (get-content state :remote1 0))
       (run-on state :remote1)
       (run-continue state)
-      (is (empty? (:prompt (get-corp))) "Caprice prompt is not showing")
+      (is (no-prompt? state :corp) "Caprice prompt is not showing")
       (click-prompt state :runner "No action")
       ;; Trashable execs
       (run-empty-server state :remote2)
@@ -4959,7 +4959,7 @@
     (click-card state :runner "Ice Wall")
     (is (prompt-map :runner) "Prompt should still be active as Ice Wall wasn't rezzed this run")
     (click-card state :runner "Enigma")
-    (is (empty? (prompt-map :runner)) "Enigma should be trashed")
+    (is (no-prompt? state :runner) "Enigma should be trashed")
     (is (= "Enigma" (-> (get-corp) :discard first :title)) "Enigma should be trashed")))
 
 (deftest running-interference
@@ -4979,7 +4979,7 @@
           credits (:credit (get-corp))]
       (rez state :corp archer)
       (click-card state :corp (get-scored state :corp 0))
-      (is (empty? (:prompt (get-corp))) "Only 1 agenda required to rez")
+      (is (no-prompt? state :corp) "Only 1 agenda required to rez")
       (is (= (- credits (* 2 (:cost archer))) (:credit (get-corp))) "Rezzing Archer costs double")
       (is (rezzed? (refresh archer)) "Archer is rezzed"))
     (run-continue-until state :movement)
@@ -4988,7 +4988,7 @@
           credits (:credit (get-corp))]
       (run-on state "HQ")
       (rez state :corp iw)
-      (is (empty? (:prompt (get-corp))))
+      (is (no-prompt? state :corp))
       (is (= (- credits (:cost iw)) (:credit (get-corp))) "Rezzing Ice Wall costs normal"))))
 
 (deftest satellite-uplink
@@ -5254,7 +5254,7 @@
       (play-from-hand state :runner "Security Testing")
       (let [st (get-resource state 0)]
         (play-from-hand state :runner "Surge")
-        (is (empty? (:prompt (get-runner))) "Surge does not fire on Security Testing"))))
+        (is (no-prompt? state :runner) "Surge does not fire on Security Testing"))))
   (testing "Don't fire surge if target does not have virus counter flag set"
     (do-game
       (new-game {:runner {:deck ["Imp" "Surge"]}})
@@ -5265,7 +5265,7 @@
         (take-credits state :runner)
         (take-credits state :corp)
         (play-from-hand state :runner "Surge")
-        (is (empty? (:prompt (get-runner))) "Surge does not fire on Imp turn after install"))))
+        (is (no-prompt? state :runner) "Surge does not fire on Imp turn after install"))))
   (testing "Don't allow surging Gorman Drip, since it happens on the corp turn"
     (do-game
       (new-game {:runner {:deck ["Gorman Drip v1" "Surge"]}})
@@ -5278,7 +5278,7 @@
         (is (= 3 (get-counters (refresh gd) :virus))
             "Gorman Drip gains 3 counters after Corp clicks 3 times for credits")
         (play-from-hand state :runner "Surge")
-        (is (empty? (:prompt (get-runner))) "Surge does not trigger on Gorman Drip")))))
+        (is (no-prompt? state :runner) "Surge does not trigger on Gorman Drip")))))
 
 (deftest syn-attack
   ;; SYN Attack

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -96,7 +96,7 @@
         (card-ability state :runner (first (:hosted (refresh corroder))) 0)
         (click-prompt state :runner "End the run")
         (is (:broken (first (:subroutines (refresh hive)))) "The break ability worked")
-        (is (empty? (:prompt (get-runner))) "Break ability is one at a time")))))
+        (is (no-prompt? state :runner) "Break ability is one at a time")))))
 
 (deftest akamatsu-mem-chip
   ;; Akamatsu Mem Chip - Gain 1 memory
@@ -442,7 +442,7 @@
         (run-continue state)
         (run-continue state)
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No prompt for shuffling Boomerang in"))))
+        (is (no-prompt? state :runner) "No prompt for shuffling Boomerang in"))))
   (testing "Cannot use Boomerang on other ice"
     (do-game
       (new-game {:runner {:deck ["Boomerang"]}
@@ -459,7 +459,7 @@
         (rez state :corp enig)
         (run-continue state)
         (card-ability state :runner (refresh boom) 0)
-        (is (empty? (:prompt (get-runner))) "Cannot use Boomerang on other ice"))))
+        (is (no-prompt? state :runner) "Cannot use Boomerang on other ice"))))
   (testing "Assimilator frees target restriction"
     (do-game
       (new-game {:runner {:id "Apex: Invasive Predator"
@@ -531,7 +531,7 @@
         (run-continue state)
         (run-continue state)
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No prompt for shuffling Boomerang in"))))
+        (is (no-prompt? state :runner) "No prompt for shuffling Boomerang in"))))
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                         :hand ["Surveyor" "Ice Wall"]}
@@ -552,7 +552,7 @@
         (run-continue state)
         (click-prompt state :runner "No action")
         (click-prompt state :runner "Yes")
-        (is (empty? (:prompt (get-runner))) "No second prompt for shuffling Boomerang in")))
+        (is (no-prompt? state :runner) "No second prompt for shuffling Boomerang in")))
   (testing "Multiple Boomerangs used during single run are shuffled correctly. Issue #5112"
     (do-game
       (new-game {:corp {:deck ["Spiderweb"]}
@@ -632,7 +632,7 @@
         (run-continue state :movement)
         (run-continue state :success)
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "Boomerang prompt did not come up")
+        (is (no-prompt? state :runner) "Boomerang prompt did not come up")
         (is (= 1 (count (:discard (get-runner)))) "Boomerang in heap")
         (is (last-log-contains? state "Runner accesses Wraparound from HQ."))))))
 
@@ -723,7 +723,7 @@
       (rez state :corp (refresh (get-content state :remote1 0)))
       (let [bufferdrive (get-hardware state 0)]
         (card-ability state :runner bufferdrive 0)
-        (is (empty? (:prompt (get-runner))) "Buffer Drive Prompt did not come up"))))
+        (is (no-prompt? state :runner) "Buffer Drive Prompt did not come up"))))
   (testing "After a runner effect trashes a card, a corp effect must not cause Buffer Drive to trigger again"
     (do-game
       (new-game {:runner {:hand ["Buffer Drive" "Corroder" "Yog.0" "Mimic"]
@@ -742,7 +742,7 @@
       (play-from-hand state :runner "Buffer Drive")
       (run-empty-server state "HQ")
       (click-prompt state :runner "Pay 0 [Credits] to trash")
-      (is (empty? (:prompt (get-runner))))))
+      (is (no-prompt? state :runner))))
   (testing "The player may not move a card trashed while installed to the bottom of the Stack"
     (do-game
       (new-game {:runner {:hand ["Buffer Drive" "Spy Camera"]}})
@@ -751,7 +751,7 @@
       (play-from-hand state :runner "Spy Camera")
       (card-ability state :runner (get-hardware state 1) 1) ; pop spy camera
       (click-prompt state :runner "OK")
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :runner))
       (is (= 1 (count (:discard (get-runner)))))))
   (testing "Buffer Drive must not trigger a second time in one turn"
     (do-game
@@ -763,7 +763,7 @@
       (click-prompt state :runner "No action")
       (let [remaining-grip-cids (set (map :cid (:hand (get-runner))))]
         (trash-from-hand state :runner "Yog.0")
-        (is (empty? (:prompt (get-runner))))
+        (is (no-prompt? state :runner))
         (is (= 1 (count (:deck (get-runner)))))
         (is (= 2 (count (:discard (get-runner))))))))
   (testing "Buffer Drive must not trigger on the second trash of the turn if it was installed after the first trash"
@@ -773,28 +773,28 @@
       (trash-from-hand state :runner "Buffer Drive")
       (play-from-hand state :runner "Buffer Drive")
       (trash-from-hand state :runner "Buffer Drive")
-      (is (empty? (:prompt (get-runner))))))
+      (is (no-prompt? state :runner))))
   (testing "The effect triggers on meat damage"
     (do-game
       (new-game {:runner {:hand [(qty "Buffer Drive" 3)]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Buffer Drive")
       (damage state :runner :meat 1)
-      (is (not (empty? (:prompt (get-runner)))))))
+      (is (not (no-prompt? state :runner)))))
   (testing "The effect triggers on net damage"
     (do-game
       (new-game {:runner {:hand [(qty "Buffer Drive" 3)]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Buffer Drive")
       (damage state :runner :net 1)
-      (is (not (empty? (:prompt (get-runner)))))))
+      (is (not (no-prompt? state :runner)))))
   (testing "The effect triggers on brain damage"
     (do-game
       (new-game {:runner {:hand [(qty "Buffer Drive" 3)]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Buffer Drive")
       (damage state :runner :brain 1)
-      (is (not (empty? (:prompt (get-runner)))))))
+      (is (not (no-prompt? state :runner)))))
   (testing "The player may remove Buffer Drive from the game to move any card in the Heap to the top of the Stack"
     (do-game
       (new-game {:runner {:hand ["Buffer Drive"]
@@ -816,7 +816,7 @@
       (play-from-hand state :runner "Buffer Drive")
       (card-ability state :runner (get-hardware state 0) 0) ; pop buffer drive
       (click-prompt state :runner "Done")
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :runner))
       (is (= 1 (count (:hardware (:rig (get-runner))))))
       (is (= 0 (count (:rfg (get-runner)))))
       (is (= 2 (count (:discard (get-runner)))))))
@@ -828,7 +828,7 @@
       (play-from-hand state :runner "Buffer Drive")
       (trash state :runner (first (:hand (get-runner))))
       (is (= 2 (count (:discard (get-runner)))))
-      (is (empty? (:prompt (get-runner))))))
+      (is (no-prompt? state :runner))))
   (testing "Runner trash -> install -> Corp trash should not cause Buffer Drive to trigger"
     (do-game
       (new-game {:runner {:hand [(qty "Buffer Drive" 5)]}})
@@ -837,7 +837,7 @@
       (play-from-hand state :runner "Buffer Drive")
       (trash state :corp (first (:hand (get-runner))))
       (is (= 2 (count (:discard (get-runner)))))
-      (is (empty? (:prompt (get-runner))))))
+      (is (no-prompt? state :runner))))
   (testing "Doesn't activate on trashed corp card. Issue #4908"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -865,7 +865,7 @@
       (click-prompt state :runner "Trash a program")
       (click-prompt state :runner "End the run")
       (click-prompt state :runner "Yes")
-      (is (empty? (:prompt (get-runner))))))
+      (is (no-prompt? state :runner))))
   (testing "Trashing a played event doesn't trigger it. Issue #4922"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -882,7 +882,7 @@
       (is (prompt-is-card? state :runner (get-hardware state 0))
           "Buffer Drive prompt is open")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner has no open prompt")
+      (is (no-prompt? state :runner) "Runner has no open prompt")
       (is (not (prompt-is-card? state :runner (get-hardware state 0)))
           "Buffer Drive doesn't open a prompt")))
   (testing "The effect triggers on nested interactions"
@@ -996,7 +996,7 @@
       (play-from-hand state :runner "Clone Chip")
       (let [chip (get-hardware state 0)]
         (card-ability state :runner chip 0)
-        (is (not (empty? (:prompt (get-runner)))) "Clone Chip Prompt came up")
+        (is (not (no-prompt? state :runner)) "Clone Chip Prompt came up")
         (click-card state :runner "Datasucker")
         (let [ds (get-program state 0)]
           (is (not (nil? ds)))
@@ -1029,7 +1029,7 @@
       (play-from-hand state :runner "Clone Chip")
       (let [chip (get-hardware state 0)]
         (card-ability state :runner chip 0)
-        (is (empty? (:prompt (get-runner))) "Clone Chip Prompt did not came up")
+        (is (no-prompt? state :runner) "Clone Chip Prompt did not came up")
         (is (= 1 (count (:discard (get-runner)))) "Datasucker in still in heap")))))
 
 
@@ -1096,7 +1096,7 @@
       (play-from-hand state :runner "Cyberfeeder")
       (play-from-hand state :runner "Equivocation")
       (is (= 1 (:credit (get-runner))) "No pay-credits prompt if non-virus program installed")
-      (is (empty? (:prompt (get-runner))) "No pay-credits prompt if non-virus program installed")
+      (is (no-prompt? state :runner) "No pay-credits prompt if non-virus program installed")
       (play-from-hand state :runner "Clot")
       (let [cyb (get-hardware state 0)]
         (changes-val-macro -1 (:credit (get-runner))
@@ -1266,11 +1266,11 @@
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner done with run after 2 accesses")
+      (is (no-prompt? state :runner) "Runner done with run after 2 accesses")
       (is (not (:run @state)) "2 access run over")
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Second run is over after 1 access")
+      (is (no-prompt? state :runner) "Second run is over after 1 access")
       (is (not (:run @state)) "1 access run over")))
   (testing "No bonus access when playing Docklands Pass after first run"
     (do-game
@@ -1280,12 +1280,12 @@
       (take-credits state :corp)
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner done with run after 1 accesses")
+      (is (no-prompt? state :runner) "Runner done with run after 1 accesses")
       (is (not (:run @state)) "1 access run over")
       (play-from-hand state :runner "Docklands Pass")
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No bonus access on second run")
+      (is (no-prompt? state :runner) "No bonus access on second run")
       (is (not (:run @state)) "1 access run over"))))
 
 (deftest doppelganger
@@ -1648,8 +1648,8 @@
       (is (= 1 (count (:discard (get-runner)))) "Still just Gachapon in heap")
       (is (= 3 (count (:deck (get-runner)))) "3 cards remain in deck")
       (is (= 2 (count (:rfg (get-runner)))) "Removed 2 cards from game")
-      (is (empty? (:prompt (get-runner))) "No more prompts")
-      (is (empty? (:prompt (get-corp))) "Waiting prompt cleared")))
+      (is (no-prompt? state :runner) "No more prompts")
+      (is (no-prompt? state :corp) "Waiting prompt cleared")))
   (testing "Shuffling with less than 3 cards set aside"
     (do-game
       (new-game {:runner {:hand ["Au Revoir" "Bankroll" "Clone Chip" "Gachapon"]}})
@@ -1671,8 +1671,8 @@
       (is (= 1 (count (:discard (get-runner)))) "Just Gachapon in heap")
       (is (= 2 (count (:deck (get-runner)))) "2 cards remain in deck")
       (is (= 0 (count (:rfg (get-runner)))) "Removed no cards from game")
-      (is (empty? (:prompt (get-runner))) "No more prompts")
-      (is (empty? (:prompt (get-corp))) "Waiting prompt cleared")))
+      (is (no-prompt? state :runner) "No more prompts")
+      (is (no-prompt? state :corp) "Waiting prompt cleared")))
   (testing "No programs or virtual resources are revealed. Issue #4826"
     (do-game
       (new-game {:runner {:hand ["Acacia" "Blackmail" "Capstone" "Daredevil" "Easy Mark" "Frame Job" "Gachapon"]}})
@@ -1815,7 +1815,7 @@
      (rez state :corp iw)
      (card-ability state :runner gpi 0)
      (is (not (last-log-contains? state "exposes Ice Wall")) "Cannot use ability since ice is rezzed")
-     (is (nil? (prompt-map :runner))))))
+     (is (no-prompt? state :runner)))))
 
 (deftest grimoire
   ;; Grimoire - Gain 2 MU, add a free virus counter to installed virus programs
@@ -1912,7 +1912,7 @@
       (play-from-hand state :runner "Hippo")
       (run-on state "HQ")
       (is (not-empty (get-hardware state)) "Hippo installed")
-      (is (empty? (:prompt (get-runner))) "No prompt")
+      (is (no-prompt? state :runner) "No prompt")
       (is (empty? (:rfg (get-runner))) "Hippo not RFGed")
       (is (not-empty (get-hardware state)) "Hippo still installed")))
   (testing "Single ice"
@@ -1980,7 +1980,7 @@
       (click-prompt state :runner "Done")
       (run-continue state)
       (is (not-empty (get-hardware state)) "Hippo installed")
-      (is (empty? (:prompt (get-runner))) "no prompt")))
+      (is (no-prompt? state :runner) "no prompt")))
   (testing "Can't be used after first ice. Issue #4792"
     (do-game
       (new-game {:corp {:hand [(qty "Ice Wall" 2)]}
@@ -2005,7 +2005,7 @@
       (run-continue state)
       (card-ability state :runner (get-program state 0) 0)
       (click-prompt state :runner "End the run")
-      (is (empty? (:prompt (get-runner))) "No Hippo prompt on later ice")))
+      (is (no-prompt? state :runner) "No Hippo prompt on later ice")))
   (testing "Interaction with Nfr #4782"
     (do-game
       (new-game {:corp {:deck ["Ice Wall"]}
@@ -2049,7 +2049,7 @@
       (run-continue state)
       (card-ability state :runner (get-program state 0) 0)
       (click-prompt state :runner "End the run")
-      (is (empty? (:prompt (get-runner))) "No Hippo prompt on later ice"))))
+      (is (no-prompt? state :runner) "No Hippo prompt on later ice"))))
 
 (deftest keiko
   ;; Keiko
@@ -2138,7 +2138,7 @@
       (play-from-hand state :runner "Eater")
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No prompt if not virus program installed")
+      (is (no-prompt? state :runner) "No prompt if not virus program installed")
       (take-credits state :runner)
       (take-credits state :corp)
       (play-from-hand state :runner "Hivemind")
@@ -2151,7 +2151,7 @@
         (is (= 2 (get-counters (refresh hv) :virus)) "Hivemind gains a counter on successful run")
         (run-empty-server state "HQ")
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No prompt after first run")
+        (is (no-prompt? state :runner) "No prompt after first run")
         (is (= 2 (get-counters (refresh hv) :virus)) "Hivemind doesn't gain a counter after first run"))))
   (testing "Interaction with Cordyceps. Issue #4781"
     (do-game
@@ -2175,7 +2175,7 @@
       (click-card state :runner "Ice Wall")
       (is (= "Ice Wall" (:title (get-ice state :hq 0))) "Ice Wall is now protecting HQ")
       (is (= "Enigma" (:title (get-ice state :rd 0))) "Enigma is now protecting R&D")
-      (is (empty? (:prompt (get-runner))) "No prompt if not virus program installed"))))
+      (is (no-prompt? state :runner) "No prompt if not virus program installed"))))
 
 (deftest llds-processor
   ;; LLDS Processor - Add 1 strength until end of turn to an icebreaker upon install
@@ -2222,24 +2222,24 @@
      (core/gain state :runner :click 100)
      (play-from-hand state :runner "Lucky Charm")
      (run-empty-server state "HQ")
-     (is (empty? (:prompt (get-runner))) "No prompt messing with runner when run naturally ends successfully")
+     (is (no-prompt? state :runner) "No prompt messing with runner when run naturally ends successfully")
      (doseq [serv ["Archives" "HQ" "R&D"]]
        (run-on state serv)
        (is (:run @state) "Run is ongoing")
        (run-jack-out state)
-       (is (empty? (:prompt (get-runner))) (str "No prompt messing with runner when jacking out from run on " serv))
+       (is (no-prompt? state :runner) (str "No prompt messing with runner when jacking out from run on " serv))
        (is (not (:run @state)) "Run is finished"))
      (doseq [serv ["Archives" "HQ"]]    ; R&D, server 1 has cards
        (run-on state serv)
        (is (:run @state) "Run is ongoing")
        (run-continue state)
        (is (not (:run @state)) "Run is ended")
-       (is (empty? (:prompt (get-runner))) (str "No prompt messing with runner on a successful run on " serv)))
+       (is (no-prompt? state :runner) (str "No prompt messing with runner on a successful run on " serv)))
      (run-on state "Server 1")
      (run-continue-until state :success)
      (click-prompt state :runner "No action") ;access batty
      (is (not (:run @state)) "Run is ended")
-     (is (empty? (:prompt (get-runner))) "No prompt messing with runner on a successful run on remote")
+     (is (no-prompt? state :runner) "No prompt messing with runner on a successful run on remote")
      (let [bc (get-ice state :remote1 0)
            iw (get-ice state :remote1 1)
            mb (get-content state :remote1 0)]
@@ -2254,7 +2254,7 @@
        (is (seq (:prompt (get-runner))) "Runner prompted to ETR")
        (click-prompt state :runner "Done")
        (is (not (:run @state)) "Run ended yet")
-       (is (empty? (:prompt (get-runner))) "Prevent prompt gone")
+       (is (no-prompt? state :runner) "Prevent prompt gone")
        ;; run into border control, have its subroutine ETR, do use lucky charm
        (run-on state "Server 1")
        (run-continue state)
@@ -2265,7 +2265,7 @@
        (click-prompt state :runner "Done")
        (is (= 1 (count (:rfg (get-runner)))) "Lucky Charm RFGed")
        (is (:run @state) "Run prevented from ending")
-       (is (empty? (:prompt (get-runner))) "Prevent prompt gone")
+       (is (no-prompt? state :runner) "Prevent prompt gone")
        ;; trigger border control
        (play-from-hand state :runner "Lucky Charm")
        (card-ability state :corp (refresh bc) 0)
@@ -2366,8 +2366,8 @@
         (is (= credits (:credit (get-runner))) "Runner shouldn't spend any credits until hardware is actually installed")
         (click-card state :runner "Acacia")
         (is (= (- credits 2) (:credit (get-runner))) "Runner should spend 1 for Masterwork and 1 for Acacia"))
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't be waiting anymore")
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :corp) "Corp shouldn't be waiting anymore")
+      (is (no-prompt? state :runner))
       (run-continue state)
       (click-prompt state :runner "No action")
       (run-on state "HQ")
@@ -2420,7 +2420,7 @@
       (click-prompt state :runner "Yes")
       (click-card state :runner (find-card "Clone Chip" (:hand (get-runner))))
       (is (= 6 (count (:hand (get-runner)))) "Hayley install")
-      (is (empty? (:prompt (get-runner)))))))
+      (is (no-prompt? state :runner)))))
 
 (deftest maui
   ;; Maui (Māui)
@@ -2436,7 +2436,7 @@
       (let [maui (get-hardware state 0)
             inti (get-program state 0)]
         (card-ability state :runner inti 1)
-        (is (empty? (:prompt (get-runner))) "Not enough money to pay for Inti pump")
+        (is (no-prompt? state :runner) "Not enough money to pay for Inti pump")
         (run-on state "HQ")
         (changes-val-macro 0 (:credit (get-runner))
                            "Used 2 credits from Maui"
@@ -2521,7 +2521,7 @@
       (run-empty-server state :rd)
       (click-prompt state :runner "Pay 1 [Credits] to trash")
       (is (= 3 (count (:discard (get-corp)))) "Ice Wall, CVS, and Rashida")
-      (is (empty? (:prompt (get-runner))) "No more prompts for runner")))
+      (is (no-prompt? state :runner) "No more prompts for runner")))
   (testing "Maw should trigger when declining to steal. #3388"
     (do-game
       (new-game {:corp {:deck [(qty "Ice Wall" 4)]
@@ -2575,7 +2575,7 @@
       (click-prompt state :runner "Steal")
       (is (= "Move Hostile Takeover to the bottom of R&D?" (:msg (prompt-map :runner))))
       (click-prompt state :runner "Yes")
-      (is (empty? (:prompt (get-runner))) "No more prompts for runner")
+      (is (no-prompt? state :runner) "No more prompts for runner")
       (is (not (:run @state)) "Run is ended")
       (is (= "Hostile Takeover" (:title (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")
       (take-credits state :runner)
@@ -2587,7 +2587,7 @@
       (is (= "You accessed Snare!." (:msg (prompt-map :runner))))
       (click-prompt state :runner "Pay 0 [Credits] to trash")
       (click-prompt state :runner "Yes")
-      (is (empty? (:prompt (get-runner))) "No more prompts for runner")
+      (is (no-prompt? state :runner) "No more prompts for runner")
       (is (not (:run @state)) "Run is ended")
       (is (= "Snare!" (:title (last (:deck (get-corp))))) "Maya moved the accessed card to the bottom of R&D")))
   (testing "Does not interrupt multi-access"
@@ -2736,7 +2736,7 @@
       (play-from-hand state :runner "Net-Ready Eyes")
       (is (= 3 (count (:discard (get-runner)))) "Took 2 damage on NRE install")
       (run-on state "HQ")
-      (is (empty? (:prompt (get-runner))) "No NRE prompt"))))
+      (is (no-prompt? state :runner) "No NRE prompt"))))
 
 (deftest obelus
   ;; Obelus - Increase max hand size with tags, draw cards on first successful HQ/R&D run
@@ -2926,7 +2926,7 @@
          (is (changes-credits (get-runner) 0
                               (do (toggle-paragon set-to)
                                   (run-empty-server state "Archives") ; on first loop this actually triggers paragon, but we say 'no'
-                                  (is (empty? (:prompt (get-runner))) "No Paragon prompt")))
+                                  (is (no-prompt? state :runner) "No Paragon prompt")))
              "Paragon does not fire"))
        (take-credits state :runner)
        (take-credits state :corp)
@@ -2934,7 +2934,7 @@
        (is (changes-credits (get-runner) 1
                               (do (run-empty-server state "Archives") ; on first loop this actually triggers paragon, but we say 'no'
                                   (click-prompt state :runner "Yes") ; prompt to add a card to bottom
-                                  (is (empty? (:prompt (get-runner))) "No Paragon prompt")))
+                                  (is (no-prompt? state :runner) "No Paragon prompt")))
              "Paragon fires automatically")))))
 
 (deftest patchwork
@@ -3088,10 +3088,10 @@
       (click-prompt state :runner "Yes")
       (is (= "Au Revoir" (:title (get-program state 0))) "Installed Au Revoir")
       (card-ability state :runner (get-hardware state 0) 1)
-      (is (empty? (:prompt (get-runner))) "Can use ability only once per turn")
+      (is (no-prompt? state :runner) "Can use ability only once per turn")
       (run-jack-out state)
       (run-on state :hq)
-      (is (empty? (:prompt (get-runner))) "Only trigger on the first run of the turn")))
+      (is (no-prompt? state :runner) "Only trigger on the first run of the turn")))
   (testing "Does not reveal if first run has been before install"
     (do-game
       (new-game {:runner {:hand ["Au Revoir" "Bankroll" "Prognostic Q-Loop"]}})
@@ -3102,7 +3102,7 @@
       (run-empty-server state :archives)
       (play-from-hand state :runner "Prognostic Q-Loop")
       (run-on state :hq)
-      (is (empty? (:prompt (get-runner))) "Does not trigger on second run even if installed later")))
+      (is (no-prompt? state :runner) "Does not trigger on second run even if installed later")))
   (testing "Auto-resolve"
     (do-game
       (new-game {:runner {:hand ["Au Revoir" "Bankroll" "Prognostic Q-Loop"]}})
@@ -3114,24 +3114,24 @@
       (letfn [(toggle-q-loop [setting]
                 (card-ability state :runner (get-hardware state 0) 0)
                 (click-prompt state :runner setting)
-                (is (empty? (:prompt (get-runner))) "Prompt closed"))]
+                (is (no-prompt? state :runner) "Prompt closed"))]
         (doseq [set-to ["Never" "Ask" "Always"]]
           (toggle-q-loop set-to)
           (run-on state "Archives")
           (case set-to
             "Never"
-            (is (empty? (:prompt (get-runner))) "Does not show prompt")
+            (is (no-prompt? state :runner) "Does not show prompt")
             "Always"
             (do (last-log-contains? state "Runner uses Prognostic Q-Loop to look at the top 2 cards of the stack.")
                 (click-prompt state :runner "OK")
-                (is (empty? (:prompt (get-runner))) "Look prompt closed"))
+                (is (no-prompt? state :runner) "Look prompt closed"))
             "Ask"
             (do (is (not-empty (:prompt (get-runner))) "Does show trigger prompt")
                 (click-prompt state :runner "Yes")
                 (last-log-contains? state "Runner uses Prognostic Q-Loop to look at the top 2 cards of the stack.")
                 (is (not-empty (:prompt (get-runner))) "Does show look prompt")
                 (click-prompt state :runner "OK")
-                (is (empty? (:prompt (get-runner))) "Look prompt closed")))
+                (is (no-prompt? state :runner) "Look prompt closed")))
           (run-jack-out state)
           (take-credits state :runner)
           (take-credits state :corp)))))
@@ -3724,7 +3724,7 @@
         (core/gain state :runner :click 4)
         (play-from-hand state :runner "Simulchip")
         (card-ability state :runner (get-hardware state 0) 0)
-        (is (empty? (:prompt (get-runner))) "No Simulchip prompt")))
+        (is (no-prompt? state :runner) "No Simulchip prompt")))
     (testing "and not enough credits"
       (do-game
         (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -3741,7 +3741,7 @@
         (click-card state :runner "Mass-Driver")
         (is (= 4 (:credit (get-runner))) "Need 5 credits to install Mass-Driver, only have 4")
         (card-ability state :runner (get-hardware state 0) 0)
-        (is (empty? (:prompt (get-runner))) "No Simulchip prompt")))
+        (is (no-prompt? state :runner) "No Simulchip prompt")))
     (testing "Heap Locked Test"
       (do-game
         (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -3759,12 +3759,12 @@
         (click-prompt state :runner "Pay to steal")
         (click-card state :runner "Corroder")
         (card-ability state :runner (get-hardware state 0) 0)
-        (is (not (empty? (:prompt (get-runner)))) "Simulchip prompt came up")
+        (is (not (no-prompt? state :runner)) "Simulchip prompt came up")
         (click-prompt state :runner "Done")
         (rez state :corp (refresh (get-content state :remote2 0)))
         (play-from-hand state :runner "Simulchip")
         (card-ability state :runner (get-hardware state 0) 0)
-        (is (empty? (:prompt (get-runner))) "Simulchip prompt did not come up"))))
+        (is (no-prompt? state :runner) "Simulchip prompt did not come up"))))
   (testing "with no programs in the heap"
     (testing "and a program trashed this turn"
       (do-game
@@ -3798,7 +3798,7 @@
         (play-from-hand state :runner "Corroder")
         (play-from-hand state :runner "Simulchip")
         (card-ability state :runner (get-hardware state 0) 0)
-        (is (empty? (:prompt (get-runner))) "No Simulchip prompt"))))
+        (is (no-prompt? state :runner) "No Simulchip prompt"))))
   (testing "No additional cost when hosted program is trashed. Issue #4897"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -3998,7 +3998,7 @@
       (run-continue-until state :success)
       (is (= 1 (:random-access-limit (core/num-cards-to-access state :runner :hq nil))) "Only access 1 card from HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Access prompts are done")
+      (is (no-prompt? state :runner) "Access prompts are done")
       (is (not (:run @state)) "Run has ended")))
   (testing "Access additional cards when breaking ice protecting HQ"
     (do-game
@@ -4019,7 +4019,7 @@
       (is (= 2 (:random-access-limit (core/num-cards-to-access state :runner :hq nil))) "Access 2 cards from HQ")
       (click-prompt state :runner "No action")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Access prompts are done")
+      (is (no-prompt? state :runner) "Access prompts are done")
       (is (not (:run @state)) "Run has ended")))
   (testing "Only access additional cards for fully-broken ice"
     (do-game
@@ -4047,7 +4047,7 @@
       (is (= 2 (:random-access-limit (core/num-cards-to-access state :runner :hq nil))) "Access 2 cards from HQ")
       (click-prompt state :runner "No action")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Access prompts are done")
+      (is (no-prompt? state :runner) "Access prompts are done")
       (is (not (:run @state)) "Run has ended")))
   (testing "Only access additional cards when breaking ice protecting HQ"
     (do-game
@@ -4068,7 +4068,7 @@
       (run-continue-until state :success)
       (is (= 1 (:random-access-limit (core/num-cards-to-access state :runner :hq nil))) "Access 1 cards from HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Access prompts are done")
+      (is (no-prompt? state :runner) "Access prompts are done")
       (is (not (:run @state)) "Run has ended")))
   (testing "Access additional cards when fully broken ice is derezzed"
     (do-game
@@ -4091,7 +4091,7 @@
       (is (= 2 (:random-access-limit (core/num-cards-to-access state :runner :hq nil))) "Access 2 cards from HQ")
       (click-prompt state :runner "No action")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Access prompts are done")
+      (is (no-prompt? state :runner) "Access prompts are done")
       (is (not (:run @state)) "Run has ended")))
   (testing "Don't access additional cards when fully broken ice is trashed"
     (do-game
@@ -4113,7 +4113,7 @@
       (run-continue-until state :success)
       (is (= 1 (:random-access-limit (core/num-cards-to-access state :runner :hq nil))) "Access 1 card from HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Access prompts are done")
+      (is (no-prompt? state :runner) "Access prompts are done")
       (is (not (:run @state)) "Run has ended")))
   (testing "Access additional cards on run on HQ, not with Gang Sign. Issue #2749"
     (do-game
@@ -4185,7 +4185,7 @@
     (play-from-hand state :runner "Titanium Ribs")
     (click-card state :runner (find-card "Titanium Ribs" (:hand (get-runner))))
     (click-card state :runner (find-card "Kati Jones" (:hand (get-runner))))
-    (is (empty? (:prompt (get-runner))) "Fall Guy didn't try to prevent trashing of Kati")
+    (is (no-prompt? state :runner) "Fall Guy didn't try to prevent trashing of Kati")
     (is (= 2 (count (:discard (get-runner)))) "2 cards trashed for Ribs installation meat damage")
     (run-on state "HQ")
     (let [pup (get-ice state :hq 0)]
@@ -4253,7 +4253,7 @@
         (click-prompt state :runner "0") ; lose Ash trace
         (click-prompt state :runner "Top Hat") ; Top Hat activation
         (click-prompt state :runner "1") ; Top Hat
-        (is (empty? (:prompt (get-runner))) "Can't trash Ash"))))
+        (is (no-prompt? state :runner) "Can't trash Ash"))))
   (testing "Mad Dash interaction issue #4542"
     (do-game
       (new-game {:corp {:deck ["Accelerated Beta Test" "Brainstorm" "Chiyashi" "Dedicated Neural Net"]}

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -38,9 +38,9 @@
         (is (empty? (filter #(:dynamic %) (:abilities (refresh gord)))) "No auto break dynamic ability")
         (card-ability state :runner gord 0)
         (click-prompt state :runner "End the run")
-        (is (empty? (:prompt (get-runner))) "No prompt for further breaking")
+        (is (no-prompt? state :runner) "No prompt for further breaking")
         (card-ability state :runner gord 0)
-        (is (empty? (:prompt (get-runner))) "Can't use break ability"))))
+        (is (no-prompt? state :runner) "Can't use break ability"))))
   (testing "No breaking restriction on other servers"
     (do-game
       (new-game {:corp {:hand ["Afshar"]}
@@ -82,9 +82,9 @@
         (run-continue state)
         (card-ability state :runner gord 0)
         (click-prompt state :runner "Make the Runner lose 2 [Credits]")
-        (is (empty? (:prompt (get-runner))) "No prompt for further breaking")
+        (is (no-prompt? state :runner) "No prompt for further breaking")
         (card-ability state :runner gord 0)
-        (is (empty? (:prompt (get-runner))) "Can't use break ability")))))
+        (is (no-prompt? state :runner) "Can't use break ability")))))
 
 (deftest aimor
   ;; Aimor - trash the top 3 cards of the stack, trash Aimor
@@ -154,7 +154,7 @@
           (click-prompt state :runner "End the run")
           (is (not-empty (:prompt (get-runner))) "Prompt to break second sub open")
           (click-prompt state :runner "Gain 1 [Credit]. Place 1 advancement token.")
-          (is (empty? (:prompt (get-runner))) "Prompt now closed")
+          (is (no-prompt? state :runner) "Prompt now closed")
           (is (empty? (remove :broken (:subroutines (refresh akhet)))) "All subroutines broken")
           (run-continue state :movement)
           (run-jack-out state)
@@ -169,7 +169,7 @@
           (core/play-dynamic-ability state :runner {:dynamic "auto-pump" :card (refresh cor)})
           (card-ability state :runner (refresh cor) 0)
           (click-prompt state :runner "End the run")
-          (is (empty? (:prompt (get-runner))) "No option to break second sub"))))))
+          (is (no-prompt? state :runner) "No option to break second sub"))))))
 
 (deftest anansi
   ;; Anansi
@@ -250,7 +250,7 @@
        (changes-val-macro 0 (count (:hand (get-runner)))
                           "No new card from Anansi"
                           (click-prompt state :runner "Yes"))
-       (is (empty? (:prompt (get-corp))) "corp has no prompts from Anansi"))))
+       (is (no-prompt? state :corp) "corp has no prompts from Anansi"))))
   (testing "2nd sub test - runner clicks YES"
     (do-game
      (new-game {:corp {:hand ["Anansi"]
@@ -268,7 +268,7 @@
        (changes-val-macro 1 (count (:hand (get-runner)))
                           "New card from Anansi"
                           (click-prompt state :runner "Yes"))
-       (is (empty? (:prompt (get-corp))) "corp has no prompts from Anansi"))))
+       (is (no-prompt? state :corp) "corp has no prompts from Anansi"))))
   (testing "2nd sub test - runner clicks NO"
     (do-game
      (new-game {:corp {:hand ["Anansi"]
@@ -286,7 +286,7 @@
        (changes-val-macro 0 (count (:hand (get-runner)))
                           "No new card from Anansi"
                           (click-prompt state :runner "No"))
-       (is (empty? (:prompt (get-corp))) "corp has no prompts from Anansi")))))
+       (is (no-prompt? state :corp) "corp has no prompts from Anansi")))))
 
 (deftest ansel-1-0
   ;; Ansel 1.0
@@ -1128,7 +1128,7 @@
                (:msg (prompt-map :runner)))
             "Runner is prompted")
         (click-card state :runner "Sure Gamble")
-        (is (empty? (:prompt (get-runner))) "Runner only selects 1 card")
+        (is (no-prompt? state :runner) "Runner only selects 1 card")
         (is (= "Sure Gamble" (:title (first (:deck (get-runner))))))))
     (testing "Empty hand"
       (do-game
@@ -1144,7 +1144,7 @@
         (run-on state "HQ")
         (rez state :corp (get-ice state :hq 0))
         (run-continue state)
-        (is (empty? (:prompt (get-runner))) "Runner doesn't have a prompt")))))
+        (is (no-prompt? state :runner) "Runner doesn't have a prompt")))))
 
 (deftest data-mine
   ;; Data Mine - do one net and trash
@@ -1174,7 +1174,7 @@
         (changes-val-macro -3 (:credit (get-runner))
               "Runner pays 3 credits on Data Ward encounter"
               (click-prompt state :runner "Pay 3 [Credits]"))
-        (is (empty? (:prompt (get-runner))) "Runner doesn't have a prompt"))))
+        (is (no-prompt? state :runner) "Runner doesn't have a prompt"))))
   (testing "Runner takes 1 tag on encounter"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -1188,7 +1188,7 @@
         (changes-val-macro 1 (count-tags state)
               "Runner takes 1 tag on Data Ward encounter"
               (click-prompt state :runner "Take 1 tag"))
-        (is (empty? (:prompt (get-runner))) "Runner doesn't have a prompt"))))
+        (is (no-prompt? state :runner) "Runner doesn't have a prompt"))))
   (testing "Data Ward ends run only if runner is tagged"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -1398,7 +1398,7 @@
         (is (not (find-card "Corroder" (:hand (get-runner)))) "Corroder got trashed")
         (is (= 1 (count (:discard (get-runner)))) "Corroder in heap")
         (card-subroutine state :corp ef 0)
-        (is (empty? (:prompt (get-corp))) "No prompt because no more fitting cards in grip")))))
+        (is (no-prompt? state :corp) "No prompt because no more fitting cards in grip")))))
 
 (deftest enigma
   ;; Enigma - Force Runner to lose 1 click if able
@@ -1487,7 +1487,7 @@
                            "Bounce Scrubber to hand"
                            (click-card state :corp "Scrubber"))
         (card-subroutine state :corp (refresh f2p) 0)
-        (is (empty? (:prompt (get-corp))) "F2P doesn't fire if no installed cards")))))
+        (is (no-prompt? state :corp) "F2P doesn't fire if no installed cards")))))
 
 (deftest fairchild-1-0
   ;; Fairchild 1.0
@@ -1605,7 +1605,7 @@
       (click-prompt state :runner "0")
       (click-card state :corp cc)
       (is (= 1 (count (get-hardware state))) "Clone Chip trashed")
-      (is (empty? (:prompt (get-runner))) "Plascrete didn't try preventing meat damage")
+      (is (no-prompt? state :runner) "Plascrete didn't try preventing meat damage")
       (is (= 1 (count (:hand (get-runner)))))
       (is (= 3 (count (:discard (get-runner)))) "Clone Chip plus 2 cards lost from damage in discard")
       (is (not (:run @state)) "Run ended"))))
@@ -2201,7 +2201,7 @@
         (run-on state "HQ")
         (run-continue state)
         (card-subroutine state :corp hs 0)
-        (is (empty? (:prompt (get-corp))) "RFG prompt did not come up")
+        (is (no-prompt? state :corp) "RFG prompt did not come up")
         (card-subroutine state :corp hs 1)
         (is (nil? (:run @state)))
         (is (= ["Sure Gamble"] (->> (get-runner) :discard (map :title))) "Sure Gamble should be in heap")))))
@@ -2222,15 +2222,15 @@
       (is (= 4 (count (:hand (get-runner)))) "Runner has 4 cards in hand")
       (card-subroutine state :corp harv 0)
       (is (= "The Class Act" (-> (prompt-map :runner) :card :title)) "The Class Act prompt showing")
-      (is (= 1 (count (:prompt (get-runner)))) "Harvester prompt not open yet")
+      (is (= 2 (count (:prompt (get-runner)))) "Harvester prompt not open yet")
       (click-card state :runner (last (:hand (get-runner))))
       (is (= 7 (count (:hand (get-runner)))) "Runner bottomed Class Act draw")
       (is (= "Harvester" (-> (prompt-map :runner) :card :title)) "Harvester prompt showing")
       (click-card state :runner (last (:hand (get-runner))))
       (click-card state :runner (first (:hand (get-runner))))
       (is (= 5 (count (:hand (get-runner)))) "Harvester discarded some cards")
-      (is (empty? (:prompt (get-runner))) "No more prompts for the Runner")
-      (is (empty? (:prompt (get-corp))) "No more prompts for the Corp"))))
+      (is (no-prompt? state :runner) "No more prompts for the Runner")
+      (is (no-prompt? state :corp) "No more prompts for the Corp"))))
 
 (deftest herald
   ;; Herald
@@ -2480,7 +2480,7 @@
        (run-continue state)
        ;; Inazuma subs prevented break on next piece of ice
        (card-ability state :runner bukhgalter "Break 1 Sentry subroutine")
-       (is (empty? (:prompt (get-runner))) "Bukhgalter can't break so no prompt")
+       (is (no-prompt? state :runner) "Bukhgalter can't break so no prompt")
        (changes-val-macro -2 (count (:hand (get-runner)))
                           "2 net damage from Cortex Lock"
                           (fire-subs state (refresh cortex-lock)))
@@ -2648,7 +2648,7 @@
         (rez state :corp jua)
         (run-continue state)
         (card-subroutine state :corp (refresh jua) 0)
-        (is (empty? (:prompt (get-corp))) "Can't fire for 1 installed card")
+        (is (no-prompt? state :corp) "Can't fire for 1 installed card")
         (run-continue state :movement)
         (run-jack-out state)
         (take-credits state :runner)
@@ -2686,7 +2686,7 @@
         (is (empty? (:hand (get-corp))) "Kakugo removed from HQ")
         (rez state :corp (get-ice state :hq 0))
         (run-continue state :encounter-ice)
-        (is (empty? (:prompt (get-runner))) "Runner can't install Paperclip because of Jua encounter ability")
+        (is (no-prompt? state :runner) "Runner can't install Paperclip because of Jua encounter ability")
         (run-continue state :movement)
         (is (= 2 (-> (get-runner) :discard count)) "Runner should take 1 net damage from Kakugo")))))
 
@@ -3160,7 +3160,7 @@
         (is (= 2 (:base (prompt-map :corp))) "Trace is base 2")
         (click-prompt state :corp "0")
         (click-prompt state :runner "0")
-        (is (empty? (:prompt (get-corp))) "RFG prompt did not come up")
+        (is (no-prompt? state :corp) "RFG prompt did not come up")
         (is (= ["Cache"] (->> (get-runner) :discard (map :title))) "Cache in heap after RFG sub")
         (is (not (= ["Cache"] (->> (get-runner) :rfg (map :title)))) "Cache should not be rfg'd")
         (card-subroutine state :corp mp 3)
@@ -3219,7 +3219,7 @@
         (run-jack-out state)
         (take-credits state :runner)
         (take-credits state :corp)
-        (is (empty? (:prompt (get-runner))) "No Trypano prompt")
+        (is (no-prompt? state :runner) "No Trypano prompt")
         (is (zero? (core/get-virus-counters state (first (:hosted (refresh m)))))
           "Trypano does not gain a virus counter"))))
   (testing "Derezzed ice"
@@ -4538,7 +4538,7 @@
         (changes-val-macro 0 (count (:hand (get-runner)))
           "Prevent third sub damage"
           (card-ability state :runner cal 0))
-        (is (empty? (:prompt (get-runner))) "No more damage prevention triggers")))))
+        (is (no-prompt? state :runner) "No more damage prevention triggers")))))
 
 (deftest salvage
   ;; Salvage
@@ -4605,7 +4605,7 @@
       (click-card state :corp "Scrubber")
       (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
       (card-subroutine state :corp (refresh sand) 0)
-      (is (empty? (:prompt (get-corp))) "Sandman doesn't fire if no installed cards"))))
+      (is (no-prompt? state :corp) "Sandman doesn't fire if no installed cards"))))
 
 (deftest sandstone
   ;; Sandstone - gain virus counter on run reducing strength by 1
@@ -5061,7 +5061,7 @@
             (rez state :corp sm)
             (run-continue state)
             (card-subroutine state :corp sm 2)
-            (is (empty? (:prompt (get-corp))) "No target prompt as effect didn't happen"))))
+            (is (no-prompt? state :corp) "No target prompt as effect didn't happen"))))
       (testing "Enough cards in deck"
         (do-game
           (new-game {:corp {:hand ["Slot Machine" "Ice Wall"]}
@@ -5257,7 +5257,7 @@
         (run-continue state)
         (card-ability state :runner alpha "Add 1 strength")
         (card-ability state :runner alpha "Break 1 subroutine")
-        (is (empty? (:prompt (get-runner))) "Alpha can't break so no prompt")
+        (is (no-prompt? state :runner) "Alpha can't break so no prompt")
         (card-ability state :runner faerie "Break 1 Sentry subroutine")
         (is (= "Break a subroutine" (:msg (prompt-map :runner)))
             "Runner has Faerie break prompt"))))
@@ -5664,7 +5664,7 @@
       (run-continue state)
       (card-subroutine state :corp tsurugi 0)
       (is (seq (:prompt (get-corp))) "Corp is prompted to pay")
-      (is (empty? (:prompt (get-runner))) "Runner is not prompted to pay"))))
+      (is (no-prompt? state :runner) "Runner is not prompted to pay"))))
 
 (deftest turing
   ;; Turing
@@ -5701,7 +5701,7 @@
         (run-continue state)
         (card-ability state :runner alpha "Add 1 strength")
         (card-ability state :runner alpha "Break 1 subroutine")
-        (is (empty? (:prompt (get-runner))) "Alpha can't break so no prompt")
+        (is (no-prompt? state :runner) "Alpha can't break so no prompt")
         (card-ability state :runner abagnale "Break 1 Code Gate subroutine")
         (is (= "Break a subroutine" (:msg (prompt-map :runner)))
             "Runner has Abagnale break prompt")))))
@@ -5998,7 +5998,7 @@
       (card-subroutine state :corp wormhole 0)
       (is (:fired (first (:subroutines (refresh wormhole))))
           "Subroutine fires even when there are no viable ice.")
-      (is (empty? (:prompt (get-corp))) "No choice prompt for the Corp")
+      (is (no-prompt? state :corp) "No choice prompt for the Corp")
       (run-continue state :movement)
       (run-jack-out state)
       (run-on state :hq)

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -21,12 +21,12 @@
       (click-prompt state :corp "Yes")
       (is (= 4 (:credit (get-corp))) "Pays 1 credit to not expose card")
       (play-from-hand state :corp "Pup" "HQ")
-      (is (empty? (:prompt (get-runner))) "No option on second install")
+      (is (no-prompt? state :runner) "No option on second install")
       (take-credits state :corp)
       (take-credits state :runner)
       (play-from-hand state :corp "Pup" "Archives")
       (click-prompt state :runner "No")
-      (is (empty? (:prompt (get-corp))) "No prompt if Runner chooses No")
+      (is (no-prompt? state :corp) "No prompt if Runner chooses No")
       (take-credits state :corp)
       (take-credits state :runner)
       (play-from-hand state :corp "The Cleaners" "New remote")
@@ -36,14 +36,14 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (play-from-hand state :corp "Oaktown Renovation" "New remote")
-      (is (empty? (:prompt (get-corp))) "Cannot expose faceup agendas")
+      (is (no-prompt? state :corp) "Cannot expose faceup agendas")
       (take-credits state :corp)
       (take-credits state :runner)
       (core/lose state :corp :credit (:credit (get-corp)))
       (is (zero? (:credit (get-corp))) "Corp has no credits")
       (play-from-hand state :corp "PAD Campaign" "New remote")
       (click-prompt state :runner "Yes")
-      (is (empty? (:prompt (get-corp))) "No prompt if Corp has no credits")
+      (is (no-prompt? state :corp) "No prompt if Corp has no credits")
       (is (last-log-contains? state "exposes PAD Campaign") "Installed card was exposed")))
   (testing "Verify expose can be blocked"
     (do-game
@@ -115,7 +115,7 @@
       (play-from-hand state :corp "Building Blocks")
       (click-card state :corp "Ice Wall")
       (click-prompt state :corp "HQ")
-      (is (empty? (:prompt (get-runner))) "419 doesn't trigger on installed and rezzed cards")))
+      (is (no-prompt? state :runner) "419 doesn't trigger on installed and rezzed cards")))
   (testing "419 vs Sportsmetal Jinja Grid. Issue #3806"
     (do-game
       (new-game {:corp {:id "Sportsmetal: Go Big or Go Home"
@@ -408,8 +408,8 @@
       (run-continue state)
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner))))
   (testing "Works with passing effects"
     (do-game
       (new-game {:corp {:id "AgInfusion: New Miracles for a New World"
@@ -660,7 +660,7 @@
         (click-prompt state :corp "New remote")
         (click-card state :corp pup)
         (click-prompt state :corp "New remote")
-        (is (empty? (:prompt (get-corp))) "No more prompts")
+        (is (no-prompt? state :corp) "No more prompts")
         (is (= 6 (count (:servers (get-corp)))) "There are six servers, including centrals")))))
 
 (deftest ayla-bios-rahim-simulant-specialist
@@ -784,7 +784,7 @@
         (click-prompt state :corp imp)
         (is (= 1 (count (:discard (get-runner)))))
         (damage state :corp :net 1)
-        (is (empty? (:prompt (get-corp))) "No choice on second net damage")
+        (is (no-prompt? state :corp) "No choice on second net damage")
         (is (= 2 (count (:discard (get-runner)))))
         (run-empty-server state "Archives")
         (take-credits state :runner)
@@ -793,7 +793,7 @@
         (click-prompt state :corp "No")
         (is (= 2 (count (:discard (get-runner)))) "Damage dealt after declining ability")
         (play-from-hand state :corp "Neural EMP")
-        (is (empty? (:prompt (get-corp))) "No choice after declining on first damage")
+        (is (no-prompt? state :corp) "No choice after declining on first damage")
         (is (= 3 (count (:discard (get-runner))))))))
   (testing "with Obokata: Pay 4 net damage to steal. Only 3 damage left after Chronos. No trigger of damage prevent."
     (do-game
@@ -808,7 +808,7 @@
       (click-prompt state :runner "Pay to steal")
       (click-prompt state :corp "Yes")
       (click-prompt state :corp (find-card "Inti" (:hand (get-runner))))
-      (is (empty? (:prompt (get-runner))) "Feedback Filter net damage prevention opportunity not given")
+      (is (no-prompt? state :runner) "Feedback Filter net damage prevention opportunity not given")
       (is (= 4 (count (:discard (get-runner)))) "Runner paid 4 net damage")))
   (testing "vs Employee Strike. Issue #1958"
     (do-game
@@ -819,7 +819,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Employee Strike")
       (damage state :corp :net 1)
-      (is (empty? (:prompt (get-corp))) "No choice because of Employee Strike")
+      (is (no-prompt? state :corp) "No choice because of Employee Strike")
       (take-credits state :runner)
       (take-credits state :corp)
       (play-from-hand state :runner "Scrubbed")
@@ -835,7 +835,7 @@
       (run-empty-server state "Archives")
       (take-credits state :runner)
       (play-from-hand state :corp "Neural EMP")
-      (is (empty? (:prompt (get-corp))) "No choice because grip is empty")
+      (is (no-prompt? state :corp) "No choice because grip is empty")
       (is (= :corp (:winner @state))))))
 
 (deftest earth-station-sea-headquarters
@@ -996,8 +996,8 @@
       (run-empty-server state "Archives")
       (run-empty-server state "HQ")
       (is (= 2 (count (:discard (get-corp)))) "1 operation trashed from HQ; accessed non-operation in Archives first")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner))
       (is (nil? (get-run)))))
   (testing "Interaction with Eater"
     (do-game
@@ -1055,8 +1055,8 @@
       (play-from-hand state :runner "Gang Sign")
       (take-credits state :runner)
       (play-and-score state "Hostile Takeover")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner))
       (is (nil? (get-run)) "No run has been created")))
   (testing "Interaction with Aumakua and accessing an operation in archives #5054"
     (do-game
@@ -1384,7 +1384,7 @@
     (is (last-log-contains? state "PAD Campaign") "Accessed card name was logged")
     (run-empty-server state :remote1)
     (click-prompt state :runner "OK") ; Could not afford message dismissed
-    (is (empty? (:prompt (get-runner))) "Runner cannot access so no trash prompt")
+    (is (no-prompt? state :runner) "Runner cannot access so no trash prompt")
     (is (not (last-log-contains? state "PAD Campaign")) "No card name was logged")
     (run-empty-server state :hq)
     (click-prompt state :runner "No action") ; Dismiss trash prompt
@@ -1592,7 +1592,7 @@
       (rez state :corp (get-ice state :hq 0))
       (run-continue state)
       (run-continue state)
-      (is (not (empty? (:prompt (get-runner)))) "Architects of Tomorrow is still available"))))
+      (is (not (no-prompt? state :runner)) "Architects of Tomorrow is still available"))))
 
 (deftest haas-bioroid-engineering-the-future
   ;; Engineering the Future
@@ -1650,7 +1650,7 @@
       (click-card state :runner (find-card "Cache" (:hand (get-runner))))
       (is (= 2 (count (:hand (get-runner)))) "Installed Corroder and Cache.")
       (play-from-hand state :runner "Fan Site")
-      (is (empty? (:prompt (get-runner))) "No Hayley prompt if not first install this turn.")))
+      (is (no-prompt? state :runner) "No Hayley prompt if not first install this turn.")))
   (testing "Pay-credits prompt"
     (do-game
       (new-game {:runner {:id "Hayley Kaplan: Universal Scholar"
@@ -1676,8 +1676,8 @@
       (click-prompt state :runner "Carry on!")
       (is (= 2 (count (:hand (get-runner)))) "Installed Corroder and Cache.")
       (play-from-hand state :runner "Fan Site")
-      (is (empty? (:prompt (get-corp))) "No Hayley wait prompt if not first install this turn.")
-      (is (empty? (:prompt (get-runner))) "No Hayley prompt if not first install this turn.")))
+      (is (no-prompt? state :corp) "No Hayley wait prompt if not first install this turn.")
+      (is (no-prompt? state :runner) "No Hayley prompt if not first install this turn.")))
   (testing "Facedown installs do not prompt for Hayley install"
     (do-game
       (new-game {:runner {:id "Hayley Kaplan: Universal Scholar"
@@ -1689,7 +1689,7 @@
       (take-credits state :runner)
       (take-credits state :corp)
       (card-ability state :runner (get-resource state 0) 1)
-      (is (empty? (:prompt (get-corp))) "No Hayley wait prompt for facedown installs."))))
+      (is (no-prompt? state :corp) "No Hayley wait prompt for facedown installs."))))
 
 (deftest hoshiko-shiro-untold-protagonist
   ;; Hoshiko Shiro
@@ -1985,7 +1985,7 @@
         (let [dd (get-resource state 0)]
           (card-ability state :runner dd 0)
           (click-card state :runner (get-in (get-runner) [:scored 0]))
-          (is (empty? (:prompt (get-corp))) "No Jemison prompt for Runner forfeit")
+          (is (no-prompt? state :corp) "No Jemison prompt for Runner forfeit")
           (take-credits state :runner)
           (play-from-hand state :corp "Global Food Initiative" "New remote")
           (score-agenda state :corp (get-content state :remote2 0))
@@ -2295,7 +2295,7 @@
       (take-credits state :corp)
       (run-on state "Archives")
       (run-continue state)
-      (is (and (= 1 (count (:prompt (get-runner))))
+      (is (and (= 2 (count (:prompt (get-runner))))
                (= "Khan: Savvy Skiptracer" (-> (prompt-map :runner) :card :title)))
           "Only Khan prompt showing")
       (click-card state :runner "Corroder")
@@ -2359,7 +2359,7 @@
                  :options {:start-as :runner}})
       (core/lose state :runner :click 4)
       (core/end-turn state :runner nil)
-      (is (empty? (:prompt (get-runner))) "No prompt"))))
+      (is (no-prompt? state :runner) "No prompt"))))
 
 (deftest leela-patel-trained-pragmatist
   ;; Leela Patel
@@ -2524,7 +2524,7 @@
       (play-from-hand state :runner "Dummy Box")
       (take-credits state :runner)
       (take-credits state :corp)
-      (is (empty? (:prompt (get-runner))) "Dummy Box not fired from mill")))
+      (is (no-prompt? state :runner) "Dummy Box not fired from mill")))
   (testing "with Wyldside - using Wyldside during Step 1.2 should lose 1 click"
     (do-game
       (new-game {:runner {:id "MaxX: Maximum Punk Rock"
@@ -2678,13 +2678,13 @@
               mm (get-in @state [:corp :identity])]
           (rez state :corp ci)
           (dotimes [_ 2] (card-ability state :corp (refresh ci) 0))
-          (is (empty? (:prompt (get-corp))) "No MM trigger"))))
+          (is (no-prompt? state :corp) "No MM trigger"))))
     (testing "Using different operations"
       (do-game
         (new-game {:corp {:id "MirrorMorph: Endless Iteration"
                           :deck [(qty "Hedge Fund" 10)]}})
         (dotimes [_ 3] (play-from-hand state :corp "Hedge Fund"))
-        (is (empty? (:prompt (get-corp))) "No MM trigger")))
+        (is (no-prompt? state :corp) "No MM trigger")))
     (testing "Installing different cards"
       (do-game
         (new-game {:corp {:id "MirrorMorph: Endless Iteration"
@@ -2692,7 +2692,7 @@
         (play-from-hand state :corp "PAD Campaign" "New remote")
         (play-from-hand state :corp "NASX" "New remote")
         (play-from-hand state :corp "Wall to Wall" "New remote")
-        (is (empty? (:prompt (get-corp))) "No MM trigger")))))
+        (is (no-prompt? state :corp) "No MM trigger")))))
 
 (deftest mti-mwekundu-life-improved
   ;; Mti Mwekundu: Life Improved - when server is approached, install ice from HQ at the innermost position
@@ -2835,12 +2835,12 @@
       (click-prompt state :corp "Yes")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (empty? (:prompt (get-runner))) "Forger can't avoid the tag")
+      (is (no-prompt? state :runner) "Forger can't avoid the tag")
       (is (= 1 (count-tags state)) "Runner took 1 unpreventable tag")
       (core/gain state :runner :credit 2)
       (run-empty-server state "Server 2")
       (click-prompt state :runner "Pay 2 [Credits] to trash")
-      (is (empty? (:prompt (get-corp))) "No trace chance on 2nd trashed card of turn")))
+      (is (no-prompt? state :corp) "No trace chance on 2nd trashed card of turn")))
   (testing "Interaction with Dedicated Response Team"
     (do-game
       (new-game {:corp {:id "NBN: Controlling the Message"
@@ -2872,8 +2872,8 @@
       (click-prompt state :runner "Yes")
       (run-empty-server state "Server 2")
       (click-prompt state :runner "Pay 2 [Credits] to trash")
-      (is (empty? (:prompt (get-corp))) "CtM shouldn't fire")
-      (is (empty? (:prompt (get-runner))) "Runner shouldn't have prompt")
+      (is (no-prompt? state :corp) "CtM shouldn't fire")
+      (is (no-prompt? state :runner) "Runner shouldn't have prompt")
       (is (zero? (count-tags state)) "Runner took 1 unpreventable tag")))
  (testing "Trace should fire on first trash of a Corp card after a Runner card is trashed"
     (do-game
@@ -2952,7 +2952,7 @@
        (rez state :corp (refresh dr))
        (run-continue state)
        (click-prompt state :runner "Take 1 tag")
-       (is (empty? (:prompt (get-corp))) "No prompt for the Corp for second tag"))))
+       (is (no-prompt? state :corp) "No prompt for the Corp for second tag"))))
   (testing "Basic test - draw cards"
     (do-game
      (new-game {:corp {:id "NBN: Reality Plus"
@@ -2976,7 +2976,7 @@
        (rez state :corp (refresh dr))
        (run-continue state)
        (click-prompt state :runner "Take 1 tag")
-       (is (empty? (:prompt (get-corp))) "No prompt for the Corp for second tag")))))
+       (is (no-prompt? state :corp) "No prompt for the Corp for second tag")))))
 
 (deftest nero-severn-information-broker
   ;; Nero Severn: Information Broker
@@ -3142,7 +3142,7 @@
       (run-on state "HQ")
       (let [wrap1 (get-ice state :hq 0)
             wrap2 (get-ice state :hq 1)]
-        (is (empty? (:prompt (get-runner))) "Ability won't work on unrezzed ice")
+        (is (no-prompt? state :runner) "Ability won't work on unrezzed ice")
         (rez state :corp wrap2)
         (run-continue state)
         (click-prompt state :runner "Yes")
@@ -3151,7 +3151,7 @@
         (run-continue-until state :approach-ice)
         (rez state :corp wrap1)
         (run-continue state)
-        (is (empty? (:prompt (get-runner))) "Ability already used this turn")
+        (is (no-prompt? state :runner) "Ability already used this turn")
         (run-continue state :movement)
         (run-jack-out state)
         (is (= 7 (get-strength (refresh wrap2))) "Outer Wraparound back to 7 strength"))))
@@ -3295,8 +3295,8 @@
         (click-prompt state :corp "R&D")
         (is (= [:rd] (:server (get-run))))
         (run-continue state)
-        (is (empty? (prompt-map :corp)))
-        (is (empty? (prompt-map :runner)))))))
+        (is (no-prompt? state :corp))
+        (is (no-prompt? state :runner))))))
 
 (deftest quetzal-free-spirit
   ;; Quetzal
@@ -3347,7 +3347,7 @@
         (run-continue state)
         (card-ability state :runner q 0)
         (click-prompt state :runner "End the run")
-        (is (empty? (:prompt (get-runner))) "No prompt for further breaking")))))
+        (is (no-prompt? state :runner) "No prompt for further breaking")))))
 
 (deftest reina-roja-freedom-fighter
   ;; Reina Roja - Increase cost of first rezzed piece of ice
@@ -3463,7 +3463,7 @@
       (new-game {:corp {:id "Seidr Laboratories: Destiny Defined"
                         :discard ["Hedge Fund"]}})
       (card-ability state :corp (get-in @state [:corp :identity]) 0)
-      (is (empty? (prompt-map :corp)))
+      (is (no-prompt? state :corp))
       (take-credits state :corp)
       (run-on state :hq)
       (card-ability state :corp (get-in @state [:corp :identity]) 0)
@@ -3475,7 +3475,7 @@
       (take-credits state :corp)
       (run-on state :hq)
       (card-ability state :corp (get-in @state [:corp :identity]) 0)
-      (is (empty? (prompt-map :corp))))))
+      (is (no-prompt? state :corp)))))
 
 (deftest silhouette-stealth-operative
   ;; Silhouette
@@ -3564,7 +3564,7 @@
     (click-prompt state :corp (find-card "The Maker's Eye" (:discard (get-runner))))
     (is (= 1 (count (get-in @state [:runner :rfg]))) "One card RFGed")
     (card-ability state :corp (get-in @state [:corp :identity]) 0)
-    (is (empty? (:prompt (get-corp))) "Cannot use Skorpios twice")))
+    (is (no-prompt? state :corp) "Cannot use Skorpios twice")))
 
 (deftest spark-agency-worldswide-reach
   ;; Spark Agency - Rezzing advertisements
@@ -3641,11 +3641,11 @@
                       :deck [(qty "Hortum" 2) (qty "Oaktown Renovation" 2) "Braintrust"]}})
     (play-from-hand state :corp "Braintrust" "New remote")
     (take-credits state :corp)
-    (is (empty? (:prompt (get-corp))) "Not prompted when no faceup agenda available")
+    (is (no-prompt? state :corp) "Not prompted when no faceup agenda available")
     (take-credits state :runner)
     (play-from-hand state :corp "Oaktown Renovation" "New remote")
     (take-credits state :corp)
-    (is (empty? (:prompt (get-corp))) "Not prompted when no ice available")
+    (is (no-prompt? state :corp) "Not prompted when no ice available")
     (take-credits state :runner)
     (play-from-hand state :corp "Hortum" "HQ")
     (play-from-hand state :corp "Hortum" "R&D")
@@ -3667,7 +3667,7 @@
       (is (= 4 (get-counters (refresh h1) :advancement)) "Gains 4 tokens")
       (take-credits state :runner)
       (take-credits state :corp)
-      (is (empty? (:prompt (get-corp))) "Not prompted when all ice advanced"))))
+      (is (no-prompt? state :corp) "Not prompted when all ice advanced"))))
 
 (deftest steve-cambridge-master-grifter
   ;; Steve
@@ -3858,7 +3858,7 @@
           (is (zero? (get-counters (refresh scored) :agenda)) "Agenda counter used by Mark Yale")
           (is (= 10 (get-counters (refresh scored) :credit)) "Credits not used by Mark Yale")
           (card-ability state :corp my 1)
-          (is (empty? (:prompt (get-corp))) "No prompt for the Corp as no counters exist to spend")
+          (is (no-prompt? state :corp) "No prompt for the Corp as no counters exist to spend")
           (is (= 10 (get-counters (refresh scored) :credit)) "Credits not used by Mark Yale"))))))
 
 (deftest weyland-consortium-because-we-built-it
@@ -3896,7 +3896,7 @@
       (run-continue state)
       (run-continue state)
       (is (= 1 (count (:discard (get-runner)))) "Runner took only 1 meat damage from BoN total")
-      (is (zero? (count (:prompt (get-corp)))))))
+      (is (= 1 (count (:prompt (get-corp)))) "Only run prompt is active")))
   (testing "2 meat damage from ID ability when The Cleaners is scored"
     (do-game
       (new-game {:corp {:id "Weyland Consortium: Builder of Nations"
@@ -3954,7 +3954,7 @@
       (run-continue state)
       (run-continue state)
       (is (zero? (count (:discard (get-runner)))) "Runner takes no damage at the second encounter")
-      (is (empty? (:prompt (get-corp)))))))
+      (is (no-prompt? state :corp)))))
 
 (deftest weyland-consortium-built-to-last
   ;; Weyland Consortium: Built to Last

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -156,7 +156,7 @@
     (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                       :hand ["Aggressive Negotiation" "Hostile Takeover"]}})
     (play-from-hand state :corp "Aggressive Negotiation")
-    (is (empty? (:prompt (get-corp))) "Corp should have no prompt")
+    (is (no-prompt? state :corp) "Corp should have no prompt")
     (play-and-score state "Hostile Takeover")
     (play-from-hand state :corp "Aggressive Negotiation")
     (click-prompt state :corp "Hedge Fund")
@@ -251,7 +251,7 @@
       (play-from-hand state :corp "Blacklist" "New remote")
       (rez state :corp (refresh (get-content state :remote1 0)))
       (play-from-hand state :corp "Ark Lockdown")
-      (is (empty? (:prompt (get-corp))) "RFG prompt did not come up")
+      (is (no-prompt? state :corp) "RFG prompt did not come up")
       (is (empty? (->> (get-runner) :rfg (map :title))) "No cards should be rfg'd"))))
 
 (deftest attitude-adjustment
@@ -298,13 +298,13 @@
                         :hand [(qty "Audacity" 2) "Ice Wall"]}})
       (play-from-hand state :corp "Ice Wall" "HQ")
       (play-from-hand state :corp "Audacity")
-      (is (empty? (:prompt (get-corp))) "Can't play Audacity with too few cards in HQ")))
+      (is (no-prompt? state :corp) "Can't play Audacity with too few cards in HQ")))
   (testing "when placing counters on 1 card"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                         :hand [(qty "Audacity" 3) "Ice Wall" "Hostile Takeover"]}})
       (play-from-hand state :corp "Audacity")
-      (is (empty? (:prompt (get-corp))) "Can't play Audacity without an advanceable card")
+      (is (no-prompt? state :corp) "Can't play Audacity without an advanceable card")
       (play-from-hand state :corp "Ice Wall" "HQ")
       (play-from-hand state :corp "Audacity")
       (click-card state :corp "Ice Wall")
@@ -375,7 +375,7 @@
                :runner {:hand ["Dorm Computer" "Mass-Driver"]
                         :credits 10}})
     (play-from-hand state :corp "Best Defense")
-    (is (empty? (:prompt (get-corp))) "Corp can't play Best Defense without installed runner cards")
+    (is (no-prompt? state :corp) "Corp can't play Best Defense without installed runner cards")
     (take-credits state :corp)
     (play-from-hand state :runner "Dorm Computer")
     (play-from-hand state :runner "Mass-Driver")
@@ -485,7 +485,7 @@
       (new-game {:corp {:deck ["Building Blocks" "Hedge Fund" "Cortex Lock"]}})
       (core/gain state :corp :credit 1)
       (play-from-hand state :corp "Building Blocks")
-      (is (empty? (:prompt (get-corp))) "Can't play Building Blocks without a Barrier in hand"))))
+      (is (no-prompt? state :corp) "Can't play Building Blocks without a Barrier in hand"))))
 
 (deftest casting-call
   ;; Casting Call - Only do card-init on the Public agendas.  Issue #1128
@@ -639,7 +639,7 @@
       (click-prompt state :corp "Sure Gamble")
       (is (seq (:prompt (get-corp))) "Even when the runner has no cards in hand, Corp must choose again")
       (click-prompt state :corp "Sure Gamble")
-      (is (empty? (:prompt (get-corp))) "Runner is flatlined so no more choices")
+      (is (no-prompt? state :corp) "Runner is flatlined so no more choices")
       (is (= 5 (-> (get-runner) :discard count)) "Runner's heap should have 5 cards")))
   (testing "Incorrectly guessing"
     (do-game
@@ -654,7 +654,7 @@
       (play-from-hand state :corp "Complete Image")
       (is (-> (get-runner) :discard count zero?) "Runner's heap should be empty")
       (click-prompt state :corp "Easy Mark")
-      (is (empty? (:prompt (get-corp))) "Corp guessed incorrectly so shouldn't have another choice")
+      (is (no-prompt? state :corp) "Corp guessed incorrectly so shouldn't have another choice")
       (is (= 1 (-> (get-runner) :discard count)) "Runner's heap should have 1 card")))
   (testing "Not enough agenda points"
     (do-game
@@ -667,7 +667,7 @@
       (click-prompt state :runner "Steal")
       (take-credits state :runner)
       (play-from-hand state :corp "Complete Image")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't be able to play Complete Image")))
+      (is (no-prompt? state :corp) "Corp shouldn't be able to play Complete Image")))
   (testing "Didn't run last turn"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -681,7 +681,7 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (play-from-hand state :corp "Complete Image")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't be able to play Complete Image")))
+      (is (no-prompt? state :corp) "Corp shouldn't be able to play Complete Image")))
   (testing "Interaction with Chronos Protocol"
     (do-game
       (new-game {:corp {:id "Chronos Protocol: Selective Mind-mapping"
@@ -705,7 +705,7 @@
       (is (seq (:prompt (get-corp))) "Even when the runner has no cards in hand, Corp must choose again")
       (click-prompt state :corp "Sure Gamble") ;; Complete Image
       (click-prompt state :corp "Sure Gamble") ;; Complete Image
-      (is (empty? (:prompt (get-corp))) "Runner is flatlined so no more choices")
+      (is (no-prompt? state :corp) "Runner is flatlined so no more choices")
       (is (= 5 (-> (get-runner) :discard count)) "Runner's heap should have 5 cards"))))
 
 (deftest consulting-visit
@@ -926,7 +926,7 @@
       (click-prompt state :runner "No action")
       (take-credits state :runner)
       (play-from-hand state :corp "Digital Rights Management")
-      (is (empty? (:prompt (get-corp))) "No prompt displayed"))))
+      (is (no-prompt? state :corp) "No prompt displayed"))))
 
 (deftest distract-the-masses
   (do-game
@@ -1056,8 +1056,8 @@
       (run-on state :rd)
       (rez state :corp (get-ice state :rd 0))
       (run-continue state)
-      (is (nil? (seq (:prompt (get-corp)))) "Corp should have no prompts")
-      (is (nil? (seq (:prompt (get-runner)))) "Runner should have no prompts")
+      (is (no-prompt? state :corp) "Corp should have no prompts")
+      (is (no-prompt? state :runner) "Runner should have no prompts")
       (is (zero? (count-tags state)) "Runner should have no tags"))))
 
 (deftest economic-warfare
@@ -1402,7 +1402,7 @@
       (click-card state :corp (find-card "Rime" (:hand (get-corp))))
       (click-prompt state :corp "Done")
       (is (= (- credits 2) (:credit (get-corp))) "Corp should pay 2 credits to install third Ice Wall")
-      (is (empty? (:prompt (get-corp))) "Corp should be able to stop installing early"))))
+      (is (no-prompt? state :corp) "Corp should be able to stop installing early"))))
 
 (deftest fast-track
   ;; Fast Track
@@ -1494,7 +1494,7 @@
       (play-from-hand state :corp "Focus Group")
       (is (= 5 (:credit (get-corp))))
       (click-prompt state :corp "Hardware")
-      (is (empty? (:prompt (get-corp))) "No hardware in Runner's Grip so just end the interaction")
+      (is (no-prompt? state :corp) "No hardware in Runner's Grip so just end the interaction")
       (is (= 5 (:credit (get-corp))))))
   (testing "Can't afford to pay to place advancement tokens, gracefully end"
     (do-game
@@ -1508,7 +1508,7 @@
       (core/lose state :corp :credit 3)
       (is (= 2 (:credit (get-corp))))
       (click-prompt state :corp "3") ;; want to place 3 advancement tokens
-      (is (empty? (:prompt (get-corp))) "Corp can't afford to pay so just end the interaction")
+      (is (no-prompt? state :corp) "Corp can't afford to pay so just end the interaction")
       (is (= 2 (:credit (get-corp))) "Didn't pay to place advancement tokens"))))
 
 (deftest foxfire
@@ -1573,7 +1573,7 @@
       (is (= 4 (:credit (get-corp))) "Cost 1 credit to play")
       (click-prompt state :corp "Gain 2 [Credits]")
       (is (= 6 (:credit (get-corp))) "Corp gained 2 credits")
-      (is (empty? (:prompt (get-corp))) "No lingering prompt after making single choice")))
+      (is (no-prompt? state :corp) "No lingering prompt after making single choice")))
   (testing "Draw 2 cards"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 3) "Fully Operational"]}})
@@ -1581,7 +1581,7 @@
       (play-from-hand state :corp "Fully Operational")
       (click-prompt state :corp "Draw 2 cards")
       (is (= 2 (count (:hand (get-corp)))) "Corp drew 2 cards")
-      (is (empty? (:prompt (get-corp))) "No lingering prompt after making single choice")))
+      (is (no-prompt? state :corp) "No lingering prompt after making single choice")))
   (testing "Extra choices from remote servers"
     (do-game
       (new-game {:corp {:deck [(qty "Ice Wall" 3) (qty "Breaker Bay Grid" 2) "Fully Operational"]}})
@@ -1595,7 +1595,7 @@
       (dotimes [_ 3]
         (click-prompt state :corp "Gain 2 [Credits]"))
       (is (= 10 (:credit (get-corp))) "Corp gained 6 credits")
-      (is (empty? (:prompt (get-corp))) "No lingering prompt after making repeated choices"))))
+      (is (no-prompt? state :corp) "No lingering prompt after making repeated choices"))))
 
 (deftest game-changer
   (letfn [(game-changer-test [num-agenda]
@@ -1671,7 +1671,7 @@
       (take-credits state :runner)
       (play-from-hand state :corp "Game Over")
       (click-prompt state :corp "Program")
-      (is (empty? (:prompt (get-runner))) "No prevention prompt for the Runner")
+      (is (no-prompt? state :runner) "No prevention prompt for the Runner")
       (is (= 2 (:credit (get-runner))))
       (is (= 2 (-> (get-runner) :discard count)) "2 programs trashed")
       (is (some? (find-card "Nyashia" (:discard (get-runner)))) "Nyashia trashed")
@@ -1733,7 +1733,7 @@
           (do (click-prompt state :runner "Steal")
               (is (= 1 (:agenda-point (get-runner))) "Runner should steal Hostile Takeover")
               (is (= 1 (-> (get-corp) :rfg count)) "Hangeki should be removed from the game"))
-          (do (is (empty? (:prompt (get-runner))) "Runner should have no more prompts as access ended")
+          (do (is (no-prompt? state :runner) "Runner should have no more prompts as access ended")
               (is (= -1 (:agenda-point (get-runner))) "Runner should add Hangeki to their score area worth -1 agenda point")
               (is (zero? (-> (get-corp) :rfg count)) "Hangeki shouldn't be removed from the game")))))))
 
@@ -1929,10 +1929,10 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Cache")
       (click-card state :runner (find-card "Mr. Li" (:hand (get-runner))))
-      (is (empty? (:prompt (get-runner))) "Fall Guy prevention didn't trigger")
+      (is (no-prompt? state :runner) "Fall Guy prevention didn't trigger")
       (is (= 1 (count (:discard (get-runner)))) "Card trashed")
       (play-from-hand state :runner "Cache")
-      (is (empty? (:prompt (get-runner))) "Housekeeping didn't trigger on 2nd install")))
+      (is (no-prompt? state :runner) "Housekeeping didn't trigger on 2nd install")))
   (testing "Interaction with Hayley (issue #1869)"
     (do-game
       (new-game {:corp {:deck ["Housekeeping"]}
@@ -1944,7 +1944,7 @@
       (click-prompt state :runner "Yes")
       (click-card state :runner (find-card "Cache" (:hand (get-runner))))
       (click-card state :runner "Fall Guy")
-      (is (empty? (:prompt (get-runner))) "No second trash prompt from Housekeeping"))))
+      (is (no-prompt? state :runner) "No second trash prompt from Housekeeping"))))
 
 (deftest hunter-seeker
   ;; Hostile Takeover
@@ -1957,7 +1957,7 @@
     (play-from-hand state :runner "Kati Jones")
     (take-credits state :runner)
     (play-from-hand state :corp "Hunter Seeker")
-    (is (empty? (:prompt (get-corp))) "Corp should have no prompt without agenda stolen")
+    (is (no-prompt? state :corp) "Corp should have no prompt without agenda stolen")
     (take-credits state :corp)
     (run-empty-server state :remote1)
     (click-prompt state :runner "Steal")
@@ -2016,7 +2016,7 @@
     (is (= 3 (count (:hand (get-runner)))))
     (is (= ["Fall Guy" nil] (prompt-titles :corp)))
     (click-prompt state :corp (find-card "Fall Guy" (:hand (get-runner))))
-    (is (empty? (:prompt (get-corp))) "No prompt for second card")
+    (is (no-prompt? state :corp) "No prompt for second card")
     (is (= 2 (count (:hand (get-runner)))))
     ;; failed trace - take the bad publicity
     (play-from-hand state :corp "Invasion of Privacy")
@@ -2100,7 +2100,7 @@
       (click-prompt state :corp "Done")
       (click-prompt state :corp "Done")
       (is (= 1 (count (:rfg (get-corp)))) "Kakurenbo was removed from game")
-      (is (empty? (:prompt (get-corp))) "No more prompts"))))
+      (is (no-prompt? state :corp) "No more prompts"))))
 
 
 (deftest kill-switch
@@ -2201,7 +2201,7 @@
     (click-prompt state :runner "No action")
     (is (not (:run @state)) "Run ended")
     (run-empty-server state "HQ")
-    (is (empty? (:prompt (get-corp))) "No Manhunt trace on second run")
+    (is (no-prompt? state :corp) "No Manhunt trace on second run")
     (click-prompt state :runner "No action")
     (is (not (:run @state)) "Run ended")))
 
@@ -2485,9 +2485,9 @@
         (rez state :corp (get-ice state :hq 0))
         (run-continue state)
         (card-ability state :runner d4 0)
-        (is (empty? (:prompt (get-runner))) "Can't use D4v1d")
+        (is (no-prompt? state :runner) "Can't use D4v1d")
         (card-side-ability state :runner eli 0)
-        (is (empty? (:prompt (get-runner))) "Can't use break ability on Eli")
+        (is (no-prompt? state :runner) "Can't use break ability on Eli")
         (card-ability state :runner smc 0) ; Can still use SMC
         (click-prompt state :runner "No install")
         (changes-val-macro -6 (:credit (get-runner))
@@ -2941,7 +2941,7 @@
       (is (= ["Draw 2 cards" "Gain [Click]" "Install a non-agenda from hand"]
              (prompt-buttons :corp)))
       (click-prompt state :corp "Gain [Click]")
-      (is (empty? (:prompt (get-runner))) "Runner should have no more prompt"))))
+      (is (no-prompt? state :runner) "Runner should have no more prompt"))))
 
 (deftest red-planet-couriers
   ;; Red Planet Couriers
@@ -3260,7 +3260,7 @@
         (new-game {:corp {:deck ["Scapenet"]}
                    :runner {:deck [title]}})
         (play-from-hand state :corp "Scapenet")
-        (is (empty? (:prompt (get-corp))) "Couldn't play Scapenet without a successful run.")
+        (is (no-prompt? state :corp) "Couldn't play Scapenet without a successful run.")
         (take-credits state :corp)
         (play-from-hand state :runner title)
         (run-empty-server state :archives)
@@ -3271,7 +3271,7 @@
         (let [c (func state 0)]
           (click-card state :corp c))
         (if (= "Misdirection" title)
-          (is (not (empty? (:prompt (get-corp)))) "Scapenet doesn't work on non-virtual non-chip card.")
+          (is (not (no-prompt? state :corp)) "Scapenet doesn't work on non-virtual non-chip card.")
           (do (is (= 1 (count (:rfg (get-runner)))) "Card removed from game.")
               (is (find-card "Scapenet" (:discard (get-corp))))))))))
 
@@ -3333,7 +3333,7 @@
      (new-game {:corp {:hand ["Seamless Launch" "Project Atlas"]}})
      (play-from-hand state :corp "Project Atlas" "New remote")
      (play-from-hand state :corp "Seamless Launch")
-     (is (nil? (seq (:prompt (get-corp)))) "No valid target for Seamless Launch")
+     (is (no-prompt? state :corp) "No valid target for Seamless Launch")
      (take-credits state :corp)
      (take-credits state :runner)
      (play-from-hand state :corp "Seamless Launch")
@@ -3357,7 +3357,7 @@
       (new-game {:corp {:hand ["Secure and Protect"]
                         :deck [(qty "Hedge Fund" 10)]}})
       (play-from-hand state :corp "Secure and Protect")
-      (is (nil? (seq (:prompt (get-corp)))) "Corp should have no prompts")))
+      (is (no-prompt? state :corp) "Corp should have no prompts")))
   (testing "With varying install costs"
     (letfn [(sp-test [amt]
               (do-game
@@ -3600,7 +3600,7 @@
                       :hand ["Shoot the Moon" "Ice Wall"]}})
     (play-from-hand state :corp "Ice Wall" "New remote")
     (play-from-hand state :corp "Shoot the Moon")
-    (is (empty? (:prompt (get-corp))) "Shouldn't be able to play without runner being tagged")
+    (is (no-prompt? state :corp) "Shouldn't be able to play without runner being tagged")
     (gain-tags state :runner 1)
     (play-from-hand state :corp "Shoot the Moon")
     (let [credits (:credit (get-corp))]
@@ -3732,7 +3732,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (is (= 5 (count-tags state)) "Runner has 5 tags")
-      (is (empty? (:prompt (get-corp))) "Corp does not have a second Subcontract selection prompt"))))
+      (is (no-prompt? state :corp) "Corp does not have a second Subcontract selection prompt"))))
 
 (deftest subliminal-messaging
   ;; Subliminal Messaging - Playing/trashing/milling will all prompt returning to hand
@@ -3773,7 +3773,7 @@
       (run-on state "R&D")
       (run-jack-out state)
       (take-credits state :runner)
-      (is (empty? (:prompt (get-corp))) "No prompt here because runner made a run last turn")
+      (is (no-prompt? state :corp) "No prompt here because runner made a run last turn")
       (take-credits state :corp)
       (is (= 2 (count (:hand (get-corp)))))
       (is (= 1 (count (:discard (get-corp)))) "1 Subliminal not returned because runner made a run last turn")))
@@ -3789,13 +3789,13 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (click-prompt state :corp "No")
-      (is (empty? (:prompt (get-corp))) "Only 1 Subliminal prompt")
+      (is (no-prompt? state :corp) "Only 1 Subliminal prompt")
       (play-from-hand state :corp "Subliminal Messaging")
       (take-credits state :corp)
       (take-credits state :runner)
       (click-prompt state :corp "Yes")
       (click-prompt state :corp "Yes")
-      (is (empty? (:prompt (get-corp)))
+      (is (no-prompt? state :corp)
           "Only 2 Subliminal prompts - there will be a third if flag not cleared")))
   (testing "Scenario involving Subliminal being reshuffled into R&D with Jackson"
     (do-game
@@ -3815,7 +3815,7 @@
       (take-credits state :runner)
       (click-prompt state :corp "Yes")
       (is (= 1 (count (:hand (get-corp)))) "Subliminal returned to HQ")
-      (is (empty? (:prompt (get-corp)))
+      (is (no-prompt? state :corp)
           "Subliminal prompt cleared - there will be a second prompt if flag not cleared")))
   (testing "Runner made run, ensure game asks again next turn"
     (do-game
@@ -3826,7 +3826,7 @@
       (run-on state "R&D")
       (run-jack-out state)
       (take-credits state :runner)
-      (is (empty? (:prompt (get-corp))) "No prompt here because runner made a run last turn")
+      (is (no-prompt? state :corp) "No prompt here because runner made a run last turn")
       (take-credits state :corp)
       (take-credits state :runner)
       (click-prompt state :corp "Yes")
@@ -4180,7 +4180,7 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (play-from-hand state :corp "Threat Assessment")
-      (is (empty? (:prompt (get-corp))) "Threat Assessment triggered with no trash")))
+      (is (no-prompt? state :corp) "Threat Assessment triggered with no trash")))
   (testing "interaction with Hippo. Issue #4049"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -4205,7 +4205,7 @@
       (click-card state :corp "Corroder")
       (click-prompt state :runner "Move Corroder")
       (is (zero? (count-tags state)) "Runner didn't take tags")
-      (is (empty? (:prompt (get-corp)))))))
+      (is (no-prompt? state :corp)))))
 
 (deftest threat-level-alpha
   ;; Threat Level Alpha - Win trace to give tags = Runner tags; or 1 tag if 0

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -96,7 +96,7 @@
       (run-jack-out state)
       (run-on state "HQ")
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "No bypass prompt"))))
+      (is (no-prompt? state :runner) "No bypass prompt"))))
 
 (deftest aghora
   ;; Aghora
@@ -108,7 +108,7 @@
         (take-credits state :corp)
         (play-from-hand state :runner "Aghora")
         (card-ability state :runner (get-program state 0) 2)
-        (is (empty? (:prompt (get-runner))) "No select prompt as there's no Deva in hand")))
+        (is (no-prompt? state :runner) "No select prompt as there's no Deva in hand")))
     (testing "Works with another deva in hand"
       (doseq [deva ["Aghora" "Sadyojata" "Vamadeva"]]
         (do-game
@@ -137,7 +137,7 @@
       (rez state :corp (get-ice state :hq 0))
       (run-continue state)
       (card-ability state :runner (get-program state 0) 0)
-      (is (empty? (:prompt (get-runner))) "No break prompt")
+      (is (no-prompt? state :runner) "No break prompt")
       (run-continue state :movement)
       (run-jack-out state)
       (run-on state "R&D")
@@ -250,7 +250,7 @@
       (rez state :corp (refresh zed2))
       (run-continue state)
       (card-ability state :runner (refresh alias) 0)
-      (is (empty? (:prompt (get-runner))) "No break prompt because we're running a remote"))))
+      (is (no-prompt? state :runner) "No break prompt because we're running a remote"))))
 
 (deftest amina
   ;; Amina ability
@@ -597,7 +597,7 @@
         (run-continue state)
         (card-ability state :runner bo 0)
         (card-ability state :runner bo 0)
-        (is (empty? (:prompt (get-runner))) "Has no break prompt as strength isn't high enough")
+        (is (no-prompt? state :runner) "Has no break prompt as strength isn't high enough")
         (card-ability state :runner bo 0)
         (is (= 8 (get-strength (refresh bo))) "Pumped Black Orchestra up to str 8")
         (click-prompt state :runner "Trace 4 - Purge virus counters")
@@ -708,7 +708,7 @@
       (run-on state "Archives")
       (rez state :corp (get-ice state :archives 0))
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "Black Orchestra prompt did not come up"))))
+      (is (no-prompt? state :runner) "Black Orchestra prompt did not come up"))))
 
 (deftest botulus
   ;; Botulus
@@ -1029,7 +1029,7 @@
           (card-ability state :runner carmen 0)
           (click-prompt state :runner "Trash an AI program"))
         (click-prompt state :runner "Do 1 net damage")
-        (is (empty? (:prompt (get-runner))) "Only breaks 1 sub at a time"))))))
+        (is (no-prompt? state :runner) "Only breaks 1 sub at a time"))))))
 
 (deftest cerberus-rex-h2
   ;; Cerberus "Rex" H2 - boost 1 for 1 cred, break for 1 counter
@@ -1155,19 +1155,19 @@
         (run-continue state)
         (card-ability state :runner (get-program state 0) 0)
         (click-prompt state :runner "End the run")
-        (is (empty? (:prompt (get-runner))) "Broke all subroutines on Ice Wall")
+        (is (no-prompt? state :runner) "Broke all subroutines on Ice Wall")
         (run-continue state :movement)
         (run-jack-out state)
         (run-on state :hq)
         (run-continue state)
         (card-ability state :runner (get-program state 0) 0)
-        (is (empty? (:prompt (get-runner))) "Can't use Chameleon on Enigma")
+        (is (no-prompt? state :runner) "Can't use Chameleon on Enigma")
         (run-continue state :movement)
         (run-jack-out state)
         (run-on state :rd)
         (run-continue state)
         (card-ability state :runner (get-program state 0) 0)
-        (is (empty? (:prompt (get-runner))) "Can't use Chameleon on Rototurret")
+        (is (no-prompt? state :runner) "Can't use Chameleon on Rototurret")
         (run-continue state :movement)
         (run-jack-out state))
       (take-credits state :runner)
@@ -1178,7 +1178,7 @@
         (run-on state :archives)
         (run-continue state)
         (card-ability state :runner (get-program state 0) 0)
-        (is (empty? (:prompt (get-runner))) "Can't use Chameleon on Ice Wall")
+        (is (no-prompt? state :runner) "Can't use Chameleon on Ice Wall")
         (run-continue state :movement)
         (run-jack-out state)
         (run-on state :hq)
@@ -1186,13 +1186,13 @@
         (card-ability state :runner (get-program state 0) 0)
         (click-prompt state :runner "Force the Runner to lose 1 [Click]")
         (click-prompt state :runner "End the run")
-        (is (empty? (:prompt (get-runner))) "Broke all subroutines on Engima")
+        (is (no-prompt? state :runner) "Broke all subroutines on Engima")
         (run-continue state :movement)
         (run-jack-out state)
         (run-on state :rd)
         (run-continue state)
         (card-ability state :runner (get-program state 0) 0)
-        (is (empty? (:prompt (get-runner))) "Can't use Chameleon on Rototurret")
+        (is (no-prompt? state :runner) "Can't use Chameleon on Rototurret")
         (run-continue state :movement)
         (run-jack-out state))
       (take-credits state :runner)
@@ -1203,13 +1203,13 @@
         (run-on state :archives)
         (run-continue state)
         (card-ability state :runner (get-program state 0) 0)
-        (is (empty? (:prompt (get-runner))) "Can't use Chameleon on Ice Wall")
+        (is (no-prompt? state :runner) "Can't use Chameleon on Ice Wall")
         (run-continue state :movement)
         (run-jack-out state)
         (run-on state :hq)
         (run-continue state)
         (card-ability state :runner (get-program state 0) 0)
-        (is (empty? (:prompt (get-runner))) "Can't use Chameleon on Enigma")
+        (is (no-prompt? state :runner) "Can't use Chameleon on Enigma")
         (run-continue state :movement)
         (run-jack-out state)
         (run-on state :rd)
@@ -1217,7 +1217,7 @@
         (card-ability state :runner (get-program state 0) 0)
         (click-prompt state :runner "Trash a program")
         (click-prompt state :runner "End the run")
-        (is (empty? (:prompt (get-runner))) "Broke all subroutines on Rototurret")))))
+        (is (no-prompt? state :runner) "Broke all subroutines on Rototurret")))))
 
 (deftest chisel
   ;; Chisel
@@ -1351,7 +1351,7 @@
         (run-continue state)
         (click-prompt state :runner "No action")
         (click-prompt state :runner "Yes")
-        (is (empty? (:prompt (get-runner))) "Prompt closed")
+        (is (no-prompt? state :runner) "Prompt closed")
         (is (= 1 (get-counters (refresh conduit) :virus)))
         (is (not (:run @state)) "Run ended")
         (card-ability state :runner conduit 0)
@@ -1492,7 +1492,7 @@
       (run-on state "R&D")
       (run-continue state)
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No prompt on uniced server")))
+      (is (no-prompt? state :runner) "No prompt on uniced server")))
   (testing "No prompt with less than 2 ice installed"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -1504,7 +1504,7 @@
       (run-on state "HQ")
       (run-continue-until state :success)
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No prompt with only 1 installed ice")))
+      (is (no-prompt? state :runner) "No prompt with only 1 installed ice")))
   (testing "No prompt when empty"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -1520,7 +1520,7 @@
       (run-continue-until state :success)
       (is (= "You accessed Hedge Fund." (:msg (prompt-map :runner))))
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No prompt with no virus counters")))
+      (is (no-prompt? state :runner) "No prompt with no virus counters")))
   (testing "Works with Hivemind installed"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -1546,7 +1546,7 @@
       (is (= "Enigma" (:title (get-ice state :hq 0))))
       (is (= "Ice Wall" (:title (get-ice state :hq 1))))
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "No prompt with only 1 installed ice"))))
+      (is (no-prompt? state :runner) "No prompt with only 1 installed ice"))))
 
 (deftest corroder
   ;; Corroder
@@ -1713,7 +1713,7 @@
       (core/update! state :runner (assoc (refresh cc) :current-strength 7))
       (is (= 7 (get-strength (refresh cc))) "Manually set equal strength")
       (card-ability state :runner cc 0)
-      (is (empty? (:prompt (get-runner))) "Can't break subs on a different server")
+      (is (no-prompt? state :runner) "Can't break subs on a different server")
       (is (zero? (count (filter :broken (:subroutines (get-ice state :rd 0))))) "No subs are broken"))))
 
 (deftest d4v1d
@@ -1742,7 +1742,7 @@
         (rez state :corp iw)
         (run-continue state)
         (card-ability state :runner d4 0)
-        (is (empty? (:prompt (get-runner))) "No prompt for breaking 1 strength Ice Wall")))))
+        (is (no-prompt? state :runner) "No prompt for breaking 1 strength Ice Wall")))))
 
 (deftest dai-v
   ;; Dai V
@@ -1791,7 +1791,7 @@
         (card-ability state :runner daiv 1)
         (click-prompt state :runner "Done")
         (card-ability state :runner daiv 0)
-        (is (nil? (prompt-map :runner)) "We are incapable of paying"))))
+        (is (no-prompt? state :runner)) "We are incapable of paying")))
   (testing "Can't pay from credit pool"
     (do-game
       (new-game {:corp {:deck ["Enigma"]}
@@ -1836,7 +1836,7 @@
                            (card-ability state :runner daiv 0)
                            (click-prompt state :runner "Force the Runner to lose 1 [Click]")
                            (click-prompt state :runner "End the run")
-                           (is (nil? (prompt-map :runner)) "We are incapable of paying")
+                           (is (no-prompt? state :runner) "We are incapable of paying")
                            (is (= 0 (count (filter :broken (:subroutines (refresh enig))))) "No subroutines were broken"))))))
 
 (deftest darwin
@@ -2160,7 +2160,7 @@
         (click-prompt state :runner "End the run")
         (run-continue state)
         (run-continue state)
-        (is (empty? (:prompt (get-runner))) "No prompt for accessing cards"))))
+        (is (no-prompt? state :runner) "No prompt for accessing cards"))))
   (testing "Eater interaction with remote server. Issue #4536"
     (do-game
       (new-game {:corp {:deck [(qty "Rototurret" 2) "NGO Front"]}
@@ -2184,7 +2184,7 @@
         (run-continue state)
         (run-continue state)
         (is (find-card "Eater" (:discard (get-runner))) "Eater is trashed")
-        (is (empty? (:prompt (get-runner))) "No prompt for accessing cards")))))
+        (is (no-prompt? state :runner) "No prompt for accessing cards")))))
 
 (deftest echelon
   ;; Echelon
@@ -2223,7 +2223,7 @@
             "Break costs 1"
             (card-ability state :runner echelon 0)
             (click-prompt state :runner "Add installed program to the top of the Runner's Stack"))
-          (is (empty? (:prompt (get-runner))) "Only breaks 1 sub at a time"))))
+          (is (no-prompt? state :runner) "Only breaks 1 sub at a time"))))
     (testing "Gains str per icebreaker"
       (do-game state
         (take-credits state :corp)
@@ -2304,8 +2304,8 @@
         (run-continue state :movement)
         (run-jack-out state)
         (is (nil? (get-run)))
-        (is (empty? (:prompt (get-corp))))
-        (is (empty? (:prompt (get-runner))))))))
+        (is (no-prompt? state :corp))
+        (is (no-prompt? state :runner))))))
 
 (deftest equivocation
   ;; Equivocation - interactions with other successful-run events.
@@ -2499,13 +2499,13 @@
       (let [faust (get-program state 0)]
         (card-ability state :runner faust 1)
         (click-card state :runner "Astrolabe")
-        (is (empty? (:prompt (get-runner))) "No trash-prevention prompt for hardware")
+        (is (no-prompt? state :runner) "No trash-prevention prompt for hardware")
         (card-ability state :runner faust 1)
         (click-card state :runner "Gordian Blade")
-        (is (empty? (:prompt (get-runner))) "No trash-prevention prompt for program")
+        (is (no-prompt? state :runner) "No trash-prevention prompt for program")
         (card-ability state :runner faust 1)
         (click-card state :runner "Armitage Codebusting")
-        (is (empty? (:prompt (get-runner))) "No trash-prevention prompt for resource")))))
+        (is (no-prompt? state :runner) "No trash-prevention prompt for resource")))))
 
 (deftest fawkes
   ;; Fawkes
@@ -2518,7 +2518,7 @@
           0 (get-strength (refresh fawkes))
           "Strength was not increased"
           (card-ability state :runner fawkes 1)
-          (is (empty? (:prompt (get-runner))) "Not asked how many credits to pay")))))
+          (is (no-prompt? state :runner) "Not asked how many credits to pay")))))
   (testing "Charges the correct amount"
     (do-game (new-game {:runner {:hand ["Fawkes" "Cloak"] :credits 20}})
       (take-credits state :corp)
@@ -2580,7 +2580,7 @@
         (run-on state "HQ")
         (rez state :corp iw)
         (run-continue state)
-        (is (nil? (prompt-map :runner)) "Femme ability doesn't fire after uninstall"))))
+        (is (no-prompt? state :runner)) "Femme ability doesn't fire after uninstall")))
   (testing "Bypass doesn't persist if ice is uninstalled and reinstalled"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -2598,7 +2598,7 @@
       (run-on state "HQ")
       (rez state :corp (get-ice state :hq 0))
       (run-continue state)
-      (is (nil? (prompt-map :runner)) "Femme ability doesn't fire after uninstall"))))
+      (is (no-prompt? state :runner)) "Femme ability doesn't fire after uninstall")))
 
 (deftest fermenter
   ;; Fermenter - click, trash to get 2c per counter.
@@ -2703,12 +2703,12 @@
         (rez state :corp iw)
         (run-continue state)
         (card-ability state :runner gh1 0)
-        (is (empty? (:prompt (get-runner))) "No break prompt as Ice Wall only has 1 subroutine")
+        (is (no-prompt? state :runner) "No break prompt as Ice Wall only has 1 subroutine")
         (is (refresh gh1) "Grappling Hook isn't trashed")
         (card-ability state :runner cor 0)
         (click-prompt state :runner "End the run")
         (card-ability state :runner gh1 0)
-        (is (empty? (:prompt (get-runner))) "No break prompt as Ice Wall has no unbroken subroutines")
+        (is (no-prompt? state :runner) "No break prompt as Ice Wall has no unbroken subroutines")
         (is (refresh gh1) "Grappling Hook isn't trashed")
         (run-continue state :movement)
         (run-jack-out state)
@@ -2730,7 +2730,7 @@
         (click-prompt state :runner "End the run")
         (click-prompt state :runner "Done")
         (card-ability state :runner gh2 0)
-        (is (empty? (:prompt (get-runner))) "No break prompt as Little Engine has more than 1 broken sub")
+        (is (no-prompt? state :runner) "No break prompt as Little Engine has more than 1 broken sub")
         (is (refresh gh2) "Grappling Hook isn't trashed"))))
   (testing "Interaction with Fairchild 3.0"
     (do-game
@@ -2770,8 +2770,8 @@
       (click-prompt state :corp "1")
       (is (zero? (count-tags state)) "Runner gained no tags")
       (is (get-run) "Run hasn't ended")
-      (is (empty? (:prompt (get-corp))) "Corp shouldn't have a prompt")
-      (is (empty? (:prompt (get-runner))) "Runner shouldn't have a prompt")))
+      (is (no-prompt? state :corp) "Corp shouldn't have a prompt")
+      (is (no-prompt? state :runner) "Runner shouldn't have a prompt")))
   (testing "Selecting a sub when multiple of the same title exist #5291"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -3148,8 +3148,8 @@
         (click-prompt state :runner "End the run")
         (run-continue state)
         (is (not (prompt-is-card? state :runner inv)) "Prompt shouldn't be Inversificator")
-        (is (empty? (:prompt (get-corp))) "Corp shouldn't have a prompt")
-        (is (empty? (:prompt (get-runner))) "Runner shouldn't have a prompt"))))
+        (is (no-prompt? state :corp) "Corp shouldn't have a prompt")
+        (is (no-prompt? state :runner) "Runner shouldn't have a prompt"))))
   (testing "Inversificator shouldn't fire when ice is unrezzed. Issue #4859"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -3174,8 +3174,8 @@
         (run-continue state)
         (run-continue state)
         (is (not (prompt-is-card? state :runner inv)) "Prompt shouldn't be Inversificator")
-        (is (empty? (:prompt (get-corp))) "Corp shouldn't have a prompt")
-        (is (empty? (:prompt (get-runner))) "Runner shouldn't have a prompt"))))
+        (is (no-prompt? state :corp) "Corp shouldn't have a prompt")
+        (is (no-prompt? state :runner) "Runner shouldn't have a prompt"))))
   (testing "shouldn't fire ice's on-pass ability #5143"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -3228,8 +3228,8 @@
       (click-card state :runner "Drafter")
       (is (= ["Border Control" "Thimblerig"] (map :title (get-ice state :rd))))
       (is (= ["Vanilla" "Drafter"] (map :title (get-ice state :hq))))
-      (is (empty? (:prompt (get-corp))) "Corp gets no Thimblerig prompt")
-      (is (empty? (:prompt (get-runner))) "No more prompts open")))
+      (is (no-prompt? state :corp) "Corp gets no Thimblerig prompt")
+      (is (no-prompt? state :runner) "No more prompts open")))
   (testing "Swap vs subtype issues #5170"
     (do-game
       (new-game {:corp {:hand ["Drafter" "Data Raven" "Vanilla"]
@@ -3309,7 +3309,7 @@
       (run-continue state)
       (let [number-of-shuffles (count (core/turn-events state :corp :corp-shuffle-deck))]
         (click-prompt state :runner "Troll")
-        (is (empty? (:prompt (get-runner))) "Prompt closed")
+        (is (no-prompt? state :runner) "Prompt closed")
         (is (not (:run @state)) "Run ended")
         (is (-> (get-corp) :discard first :seen) "Troll is faceup")
         (is (= "Troll" (-> (get-corp) :discard first :title)) "Troll was trashed")
@@ -3787,7 +3787,7 @@
         (click-prompt state :runner "Pay 1 [Credits]")
         (click-prompt state :runner "Pay 1 [Credits]")
         (click-prompt state :runner "Pay 1 [Credits]")
-        (is (empty? (:prompt (get-runner))) "No more prompts open"))))
+        (is (no-prompt? state :runner) "No more prompts open"))))
   (testing "Interaction with Spooned"
     (do-game
       (new-game {:corp {:deck ["Enigma" "Endless EULA"]}
@@ -3818,7 +3818,7 @@
         (click-prompt state :runner "Pay 1 [Credits]")
         (click-prompt state :runner "Pay 1 [Credits]")
         (click-prompt state :runner "Pay 1 [Credits]")
-        (is (empty? (:prompt (get-runner))) "No more prompts open")))))
+        (is (no-prompt? state :runner) "No more prompts open")))))
 
 (deftest maven
   ;; Maven
@@ -4026,7 +4026,7 @@
       (run-on state "Archives")
       (rez state :corp (get-ice state :archives 0))
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "MKUltra prompt did not come up"))))
+      (is (no-prompt? state :runner) "MKUltra prompt did not come up"))))
 
 (deftest multithreader
   ;; Multithreader
@@ -4071,7 +4071,7 @@
       (click-card state :runner imp)
       (is (= 1 (get-counters (refresh imp) :virus)) "Imp lost 1 virus counter to pump")
       (is (= 2 (get-strength (refresh musaazi))) "Musaazi strength 2")
-      (is (empty? (:prompt (get-runner))) "No prompt open")
+      (is (no-prompt? state :runner) "No prompt open")
       (card-ability state :runner musaazi 0)
       (click-prompt state :runner "Trash a program")
       (click-card state :runner musaazi)
@@ -4331,7 +4331,7 @@
       (trash-from-hand state :runner "Paperclip")
       (run-on state "Archives")
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "No prompt to install second Paperclip")))
+      (is (no-prompt? state :runner) "No prompt to install second Paperclip")))
   (testing "firing on facedown ice shouldn't crash"
     (do-game
       (new-game {:corp {:deck ["Vanilla"]}
@@ -4357,20 +4357,20 @@
       (rez state :corp (get-ice state :archives 1))
       (run-continue state)
       (click-prompt state :runner "No")
-      (is (empty? (:prompt (get-runner))) "No additional prompts to rez other copies of Paperclip")
+      (is (no-prompt? state :runner) "No additional prompts to rez other copies of Paperclip")
       (run-continue-until state :approach-ice)
       (rez state :corp (get-ice state :archives 0))
       (run-continue state)
       ;; we should get the prompt on a second ice even after denying the first
       (click-prompt state :runner "No")
-      (is (empty? (:prompt (get-runner))) "No additional prompts to rez other copies of Paperclip")
+      (is (no-prompt? state :runner) "No additional prompts to rez other copies of Paperclip")
       (run-continue state :movement)
       (run-jack-out state)
       ;; Run again, make sure we get the prompt to install again
       (run-on state "Archives")
       (run-continue state)
       (click-prompt state :runner "No")
-      (is (empty? (:prompt (get-runner))) "No additional prompts to rez other copies of Paperclip")))
+      (is (no-prompt? state :runner) "No additional prompts to rez other copies of Paperclip")))
   (testing "auto-pump"
     (testing "Pumping and breaking for 1"
       (do-game
@@ -4481,7 +4481,7 @@
         (click-prompt state :runner "No")
         (click-prompt state :runner "No")
         (click-prompt state :runner "No")
-        (is (empty? (:prompt (get-runner))) "No further prompts to install heap breakers"))))
+        (is (no-prompt? state :runner) "No further prompts to install heap breakers"))))
   (testing "Heap Locked"
     (do-game
       (new-game {:corp {:deck ["Vanilla" "Blacklist"]}
@@ -4494,7 +4494,7 @@
       (run-on state "Archives")
       (rez state :corp (get-ice state :archives 0))
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "Paperclip prompt did not come up")
+      (is (no-prompt? state :runner) "Paperclip prompt did not come up")
       (fire-subs state (get-ice state :archives 0))
       (is (not (:run @state)) "Run ended")))
   (testing "Breaking some subs"
@@ -4547,7 +4547,7 @@
       (take-credits state :corp)
       (end-phase-12 state :runner)
       (click-card state :runner (find-card "Parasite" (:hand (get-runner))))
-      (is (empty? (:prompt (get-runner))) "No prompt to host Parasite")
+      (is (no-prompt? state :runner) "No prompt to host Parasite")
       (is (= 1 (count (get-runner-facedown state))) "Parasite installed face down")))
   (testing "Installed on untrashable Architect should keep gaining counters past 3 and make strength go negative"
     (do-game
@@ -4695,7 +4695,7 @@
           paricia (get-program state 0)]
       (run-empty-server state :remote2)
       (click-prompt state :runner "Pay 3 [Credits] to trash")
-      (is (empty? (:prompt (get-runner))) "No pay-credit prompt as it's an upgrade")
+      (is (no-prompt? state :runner) "No pay-credit prompt as it's an upgrade")
       (is (nil? (refresh shell)) "Shell Corporation successfully trashed")
       (run-empty-server state :remote1)
       (is (= 2 (:credit (get-runner))) "Runner can't afford to trash PAD Campaign")
@@ -4729,7 +4729,7 @@
       (trash-from-hand state :runner "Knight")
       (play-from-hand state :runner "Pawn")
       (card-ability state :runner (get-program state 0) 2)
-      (is (empty? (:prompt (get-runner))) "Install prompt did not come up")
+      (is (no-prompt? state :runner) "Install prompt did not come up")
       (is (nil? (find-card "Pawn" (:discard (get-runner)))))
       (is (not (nil? (find-card "Knight" (:discard (get-runner)))))))))
 
@@ -4794,7 +4794,7 @@
         (run-continue state :encounter-ice)
         (is (= 3 (count (:abilities (refresh penr)))) "Auto pump and break ability on Penrose is not active")
         (card-ability state :runner (refresh penr) 0)
-        (is (empty? (:prompt (get-runner))) "No cloak prompt because the ability to break barriers is not active anymore")))))
+        (is (no-prompt? state :runner) "No cloak prompt because the ability to break barriers is not active anymore")))))
 
 (deftest peregrine
   ;; Peregrine - 2c to return to grip and derez an encountered code gate
@@ -5122,7 +5122,7 @@
         (take-credits state :corp)
         (play-from-hand state :runner "Sadyojata")
         (card-ability state :runner (get-program state 0) 2)
-        (is (empty? (:prompt (get-runner))) "No select prompt as there's no Deva in hand")))
+        (is (no-prompt? state :runner) "No select prompt as there's no Deva in hand")))
     (testing "Works with another deva in hand"
       (doseq [deva ["Aghora" "Sadyojata" "Vamadeva"]]
         (do-game
@@ -5151,7 +5151,7 @@
       (rez state :corp (get-ice state :hq 0))
       (run-continue state)
       (card-ability state :runner (get-program state 0) 0)
-      (is (empty? (:prompt (get-runner))) "No break prompt")
+      (is (no-prompt? state :runner) "No break prompt")
       (run-continue state :movement)
       (run-jack-out state)
       (run-on state "R&D")
@@ -5483,7 +5483,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Snitch")
       (run-on state "HQ")
-      (is (empty? (:prompt (get-runner))) "No option to jack out")
+      (is (no-prompt? state :runner) "No option to jack out")
       (run-continue-until state :movement)
       (run-jack-out state)))
   (testing "Doesn't work if there is no ice"
@@ -5494,7 +5494,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Snitch")
       (run-on state "Archives")
-      (is (empty? (:prompt (get-runner))) "No option to jack out")
+      (is (no-prompt? state :runner) "No option to jack out")
       (run-continue state))))
 
 (deftest snowball
@@ -5573,7 +5573,7 @@
      (is (:run @state) "Run initiated")
      (run-continue state)
      (click-prompt state :runner "Troll")
-     (is (empty? (:prompt (get-runner))) "Prompt closed")
+     (is (no-prompt? state :runner) "Prompt closed")
      (is (not (:run @state)) "Run ended")
      (is (-> (get-corp) :discard first :seen) "Troll is faceup")
      (is (= "Troll" (-> (get-corp) :discard first :title)) "Troll was trashed")
@@ -5668,7 +5668,7 @@
        (is (not (installed? (refresh stargate))) "Stargate is trashed")
        (run-continue-until state :success)
        (click-prompt state :runner "Troll")
-       (is (empty? (:prompt (get-runner))) "Prompt closed")
+       (is (no-prompt? state :runner) "Prompt closed")
        (is (not (:run @state)) "Run ended")
        (is (-> (get-corp) :discard first :seen) "Troll is faceup")
        (is (= "Troll" (-> (get-corp) :discard first :title)) "Troll was trashed")
@@ -5785,7 +5785,7 @@
         (card-ability state :runner gord 0)
         (click-prompt state :runner "End the run")
         (click-prompt state :runner "Done")
-        (is (empty? (:prompt (get-runner))) "No prompt because not all subs were broken")
+        (is (no-prompt? state :runner) "No prompt because not all subs were broken")
         (is (= 0 (get-counters (refresh tako) :power)) "No counter gained because not all subs were broken")
         (run-continue-until state :approach-ice icew)
         (rez state :corp icew)
@@ -5818,11 +5818,11 @@
         (click-card state :runner (refresh faus))
         (is (not-empty (:prompt (get-runner))) "Can't choose AI breakers")
         (click-card state :runner (refresh corr))
-        (is (empty? (:prompt (get-runner))) "Can choose non-AI breakers")
+        (is (no-prompt? state :runner) "Can choose non-AI breakers")
         (is (= 5 (get-strength (refresh corr))) "Corroder at +3 strength")
         (is (= 1 (get-counters (refresh tako) :power)) "1 counter on Takobi")
         (card-ability state :runner tako 0)
-        (is (empty? (:prompt (get-runner))) "No prompt when too few power counters")
+        (is (no-prompt? state :runner) "No prompt when too few power counters")
         (run-continue-until state :success)
         (is (= 2 (get-strength (refresh corr))) "Corroder returned to normal strength")))))
 
@@ -5893,7 +5893,7 @@
       (is (zero? (count (:deck (get-runner)))) "0 cards in deck")
       (is (= 3 (count (:discard (get-runner)))) "3 cards in discard")
       (card-ability state :runner (get-program state 0) 0)
-      (is (not (empty? (:prompt (get-runner)))) "Shuffle prompt came up")
+      (is (not (no-prompt? state :runner)) "Shuffle prompt came up")
       (click-card state :runner (find-card "Easy Mark" (:discard (get-runner))))
       (click-card state :runner (find-card "Dirty Laundry" (:discard (get-runner))))
       (click-card state :runner (find-card "Sure Gamble" (:discard (get-runner))))
@@ -5917,7 +5917,7 @@
       (is (zero? (count (:deck (get-runner)))) "0 cards in deck")
       (is (= 3 (count (:discard (get-runner)))) "3 cards in discard")
       (card-ability state :runner (get-program state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Shuffle prompt did not come up"))))
+      (is (no-prompt? state :runner) "Shuffle prompt did not come up"))))
 
 (deftest trypano
   (testing "Hivemind and Architect interactions"
@@ -6138,7 +6138,7 @@
         (is (= (- credits 2) (:credit (get-runner))) "Spent 2 credits"))
       (let [credits (:credit (get-runner))]
         (card-ability state :runner utae 0)
-        (is (empty? (:prompt (get-runner))) "Can only use ability once per run")
+        (is (no-prompt? state :runner) "Can only use ability once per run")
         (card-ability state :runner utae 1)
         (is (= credits (:credit (get-runner))) "Cannot use this ability without 3 installed virtual resources"))
       (run-continue state :movement)
@@ -6166,7 +6166,7 @@
         (take-credits state :corp)
         (play-from-hand state :runner "Vamadeva")
         (card-ability state :runner (get-program state 0) 2)
-        (is (empty? (:prompt (get-runner))) "No select prompt as there's no Deva in hand")))
+        (is (no-prompt? state :runner) "No select prompt as there's no Deva in hand")))
     (testing "Works with another deva in hand"
       (doseq [deva ["Aghora" "Sadyojata" "Vamadeva"]]
         (do-game
@@ -6195,7 +6195,7 @@
       (rez state :corp (get-ice state :hq 0))
       (run-continue state)
       (card-ability state :runner (get-program state 0) 0)
-      (is (empty? (:prompt (get-runner))) "No break prompt")
+      (is (no-prompt? state :runner) "No break prompt")
       (run-continue state :movement)
       (run-jack-out state)
       (run-on state "R&D")
@@ -6266,7 +6266,7 @@
         (is (= 2 (get-counters (refresh cache) :virus)) "Cache lost 1 virus counter to pump")
         (is (= 5 (get-strength (refresh yusuf))) "Yusuf strength 5")
         (is (zero? (get-counters (refresh yusuf) :virus)) "Yusuf lost 1 virus counter to pump")
-        (is (empty? (:prompt (get-runner))) "No prompt open")
+        (is (no-prompt? state :runner) "No prompt open")
         (card-ability state :runner yusuf 0)
         (click-prompt state :runner "End the run")
         (click-card state :runner cache)

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -270,7 +270,7 @@
       (is (= 6 (:credit (get-runner))))
       (run-empty-server state "Server 1")
       (click-prompt state :runner "Security Testing")
-      (is (empty? (:prompt (get-runner))) "No Bank Job replacement choice")
+      (is (no-prompt? state :runner) "No Bank Job replacement choice")
       (is (= 8 (:credit (get-runner))) "Security Testing paid 2c"))))
 
 (deftest bazaar
@@ -286,7 +286,7 @@
       (let [peddler (get-resource state 1)]
         (card-ability state :runner peddler 0)
         (click-prompt state :runner (first (:hosted peddler)))
-        (is (empty? (:prompt (get-runner))) "No Bazaar prompt from install off Peddler"))))
+        (is (no-prompt? state :runner) "No Bazaar prompt from install off Peddler"))))
   (testing "bazaar with kate test"
     (do-game
       (new-game {:runner {:id "Kate \"Mac\" McCaffrey: Digital Tinker"
@@ -331,8 +331,8 @@
       (is (= "Install another copy of Replicator?" (:msg (prompt-map :runner))))
       (click-prompt state :runner "Yes")
       (click-prompt state :runner "Draw 1 card")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner)))))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner)))))
 
 (deftest beach-party
   ;; Beach Party - Lose 1 click when turn begins; hand size increased by 5
@@ -407,7 +407,7 @@
         (click-prompt state :runner "HQ")
         (click-prompt state :runner "Yes")
         (run-continue state)
-        (is (empty? (:prompt (get-runner))))))
+        (is (no-prompt? state :runner))))
   (testing "Only works if ice is already rezzed"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -420,7 +420,7 @@
       (card-ability state :runner (get-resource state 0) 0)
       (click-prompt state :runner "HQ")
       (rez state :corp (get-ice state :hq 0))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :runner))
       (run-continue state)
       (is (last-log-contains? state "Runner encounters Ice Wall protecting HQ at position 0.")))))
 
@@ -433,7 +433,7 @@
     (take-credits state :corp)
     (play-from-hand state :runner "Chrome Parlor")
     (play-from-hand state :runner "Titanium Ribs")
-    (is (empty? (:prompt (get-runner))) "Damage prevented, no Ribs prompt to choose cards")
+    (is (no-prompt? state :runner) "Damage prevented, no Ribs prompt to choose cards")
     (is (= 3 (count (:hand (get-runner)))))
     (play-from-hand state :runner "Brain Cage")
     (is (= 2 (count (:hand (get-runner)))) "No cards lost")
@@ -466,8 +466,8 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Citadel Sanctuary")
       (take-credits state :runner)
-      (is (empty? (:prompt (get-runner))) "No Runner prompt because not tagged")
-      (is (empty? (:prompt (get-corp))) "No Corp prompt because runner not tagged")
+      (is (no-prompt? state :runner) "No Runner prompt because not tagged")
+      (is (no-prompt? state :corp) "No Corp prompt because runner not tagged")
       (take-credits state :corp)
       (gain-tags state :runner 2)
       (core/end-turn state :runner nil)
@@ -507,8 +507,8 @@
       (take-credits state :corp)
       (take-credits state :runner)
       (is (= "Climactic Showdown" (-> (get-runner) :rfg first :title)) "Climactic Showdown RFGed")
-      (is (empty? (:prompt (get-runner))) "No Runner prompt because no eligible servers")
-      (is (empty? (:prompt (get-corp))) "No Corp prompt because no eligible servers")))
+      (is (no-prompt? state :runner) "No Runner prompt because no eligible servers")
+      (is (no-prompt? state :corp) "No Corp prompt because no eligible servers")))
   (testing "Corp trashes ice"
     (do-game
       (new-game {:runner {:deck ["Climactic Showdown"]}
@@ -521,12 +521,12 @@
       (is (= "Climactic Showdown" (-> (get-runner) :rfg first :title)) "Climactic Showdown RFGed")
       (click-prompt state :runner "HQ")
       (click-card state :corp (get-ice state :hq 0))
-      (is (empty? (:prompt (get-corp))) "Corp trashed their ice and corp prompt is gone")
-      (is (empty? (:prompt (get-runner))) "Corp trashed their ice and runner prompt is gone")
+      (is (no-prompt? state :corp) "Corp trashed their ice and corp prompt is gone")
+      (is (no-prompt? state :runner) "Corp trashed their ice and runner prompt is gone")
       (is (= "Kitsune" (-> (get-corp) :discard first :title)) "Kitsune trashed")
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner done with run after 1 access")
+      (is (no-prompt? state :runner) "Runner done with run after 1 access")
       (is (not (:run @state)) "Run over")))
   (testing "Corp doesn't trash, access HQ"
     (do-game
@@ -542,25 +542,25 @@
       (is (= "Climactic Showdown" (-> (get-runner) :rfg first :title)) "Climactic Showdown RFGed")
       (click-prompt state :runner "Archives")
       (click-prompt state :corp "Done")
-      (is (empty? (:prompt (get-corp))) "Corp refused trash and corp prompt is gone")
-      (is (empty? (:prompt (get-runner))) "Corp refused trash and runner prompt is gone")
+      (is (no-prompt? state :corp) "Corp refused trash and corp prompt is gone")
+      (is (no-prompt? state :runner) "Corp refused trash and runner prompt is gone")
       (is (empty? (:discard (get-corp))) "Nothing trashed")
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
       (click-prompt state :runner "No action")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner done with run after 3 accesses")
+      (is (no-prompt? state :runner) "Runner done with run after 3 accesses")
       (is (not (:run @state)) "3 access run over")
       (run-empty-server state "R&D")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner done with 2nd run after 1 accesses")
+      (is (no-prompt? state :runner) "Runner done with 2nd run after 1 accesses")
       (is (not (:run @state)) "Single access run over")
       (take-credits state :runner)
       (core/move state :corp (find-card "Vanilla" (:hand (get-corp))) :deck)
       (take-credits state :corp)
       (run-empty-server state "R&D")
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner done with second turns run after 1 access")
+      (is (no-prompt? state :runner) "Runner done with second turns run after 1 access")
       (is (not (:run @state)) "2nd turn run over"))
     (testing "Corp doesn't trash, mid-run access"
       (do-game
@@ -587,7 +587,7 @@
         (run-continue state)
         (run-continue state)
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "Runner done with run after 3 accesses")
+        (is (no-prompt? state :runner) "Runner done with run after 3 accesses")
         (is (not (:run @state)) "Run over")))))
 
 (deftest compromised-employee
@@ -843,7 +843,7 @@
       (new-game {:runner {:discard ["Crowdfunding"]}})
       (take-credits state :corp)
       (take-credits state :runner)
-      (is (empty? (:prompt (get-runner))) "No install prompt if no runs")
+      (is (no-prompt? state :runner) "No install prompt if no runs")
       (is (= 1 (count (:discard (get-runner)))) "1 card in discard")
       (is (empty? (get-resource state)) "Crowdfunding not installed")
       (take-credits state :corp)
@@ -886,7 +886,7 @@
           (run-empty-server state :archives)
           (run-empty-server state :archives)
           (take-credits state :runner)
-          (is (empty? (:prompt (get-runner))) "Crowdfunding shouldn't prompt for install"))))
+          (is (no-prompt? state :runner) "Crowdfunding shouldn't prompt for install"))))
   (testing "Heap locked test"
     (do-game
       (new-game {:corp {:hand ["Blacklist"]}
@@ -895,7 +895,7 @@
       (rez state :corp (refresh (get-content state :remote1 0)))
       (take-credits state :corp)
       (take-credits state :runner)
-      (is (empty? (:prompt (get-runner))) "No install prompt if no runs")
+      (is (no-prompt? state :runner) "No install prompt if no runs")
       (is (= 1 (count (:discard (get-runner)))) "1 card in discard")
       (is (empty? (get-resource state)) "Crowdfunding not installed")
       (take-credits state :corp)
@@ -903,7 +903,7 @@
       (run-empty-server state :archives)
       (run-empty-server state :archives)
       (take-credits state :runner)
-      (is (empty? (:prompt (get-runner))) "No install prompt if no runs")
+      (is (no-prompt? state :runner) "No install prompt if no runs")
       (is (not (empty? (:discard (get-runner)))) "Crowdfunding is in discard")
       (is (zero? (count (get-resource state))) "Crowdfunding not installed"))))
 
@@ -924,7 +924,7 @@
         (run-empty-server state "R&D")
         (click-prompt state :runner "No action")
         (is (not (:run @state)) "Run has ended")
-        (is (empty? (:prompt (get-runner))) "No prompt for virus tokens")
+        (is (no-prompt? state :runner) "No prompt for virus tokens")
         (is (= 1 (get-counters (refresh crypt) :virus))))))
   (testing "Ability can install a virus card"
     (do-game
@@ -938,7 +938,7 @@
       (let [crypt (get-resource state 0)]
         (core/add-counter state :runner (refresh crypt) :virus 2)
         (card-ability state :runner (refresh crypt) 0)
-        (is (empty? (:prompt (get-runner))) "Crypt ability costs 3 virus counters")
+        (is (no-prompt? state :runner) "Crypt ability costs 3 virus counters")
         (core/add-counter state :runner (refresh crypt) :virus 1)
         (changes-val-macro
           -1 (:click (get-runner))
@@ -1295,7 +1295,7 @@
       (is (= 1 (count (prompt-buttons :runner))) "Only 1 card shown")
       (click-prompt state :runner "Corroder")
       (is (find-card "Corroder" (:hand (get-runner))))
-      (is (empty? (:prompt (get-runner))) "Shuffle prompt did not come up")))
+      (is (no-prompt? state :runner) "Shuffle prompt did not come up")))
   (testing "No faction cards in heap"
     (do-game
       (new-game {:corp {:hand ["Blacklist"]}
@@ -1306,7 +1306,7 @@
       (play-from-hand state :runner "District 99")
       (core/add-counter state :runner (get-resource state 0) :power 3)
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Add to hand prompt did not come up")))
+      (is (no-prompt? state :runner) "Add to hand prompt did not come up")))
   (testing "Heap Locked Test"
     (do-game
       (new-game {:corp {:hand ["Blacklist"]}
@@ -1319,7 +1319,7 @@
       (play-from-hand state :runner "District 99")
       (core/add-counter state :runner (get-resource state 0) :power 3)
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Add to hand prompt did not come up"))))
+      (is (no-prompt? state :runner) "Add to hand prompt did not come up"))))
 
 (let [;; Start id for dj-fenris
       sunny "Sunny Lebeau: Security Specialist"
@@ -1468,8 +1468,8 @@
         (click-prompt state :runner "Yes")
         (click-prompt state :runner "2")
         (click-prompt state :runner chaos)
-        (is (empty? (:prompt (get-corp))))
-        (is (empty? (:prompt (get-runner))))))
+        (is (no-prompt? state :corp))
+        (is (no-prompt? state :runner))))
     (testing "IDs disabled if DJ Fenris is facedown #6058"
       (do-game
        (new-game {:runner {:id sunny
@@ -1623,7 +1623,7 @@
       (play-from-hand state :runner "Clot")
       (take-credits state :runner)
       (core/purge state :corp)
-      (is (empty? (:prompt (get-runner))) "Dummy Box not prompting to prevent purge trash")))
+      (is (no-prompt? state :runner) "Dummy Box not prompting to prevent purge trash")))
   (testing "don't prevent trashing from hand"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -1641,7 +1641,7 @@
       (card-ability state :corp (get-content state :remote2 0) 0)
       (click-prompt state :corp "Program")
       (click-prompt state :corp "Cache")
-      (is (empty? (:prompt (get-runner))) "Dummy Box not prompting to prevent trashing from hand"))))
+      (is (no-prompt? state :runner) "Dummy Box not prompting to prevent trashing from hand"))))
 
 (deftest earthrise-hotel
   ;; Earthrise Hotel
@@ -1676,8 +1676,8 @@
       (is (zero? (count (:hand (get-runner)))) "Runner has no cards in hand")
       (take-credits state :runner)
       (take-credits state :corp)
-      (is (empty? (:prompt (get-runner))) "Runner has no prompts open")
-      (is (empty? (:prompt (get-corp))) "Corp has no prompts open")
+      (is (no-prompt? state :runner) "Runner has no prompts open")
+      (is (no-prompt? state :corp) "Corp has no prompts open")
       (is (= 2 (count (:hand (get-runner)))) "Runner draws 2 cards"))))
 
 (deftest eden-shard
@@ -1840,7 +1840,7 @@
         (core/play-runner-ability state :runner {:card popup
                                                  :ability 0
                                                  :targets nil})
-        (is (empty? (:prompt (get-runner))) "No prompt for Fueno")
+        (is (no-prompt? state :runner) "No prompt for Fueno")
         (run-continue state)
         (run-continue state)
         (changes-val-macro 0 (:credit (get-runner))
@@ -1976,8 +1976,8 @@
       (let [fc (get-resource state 0)]
         (run-empty-server state "HQ")
         (click-prompt state :runner "Yes")
-        (is (empty? (:prompt (get-corp))))
-        (is (empty? (:prompt (get-corp)))))))
+        (is (no-prompt? state :corp))
+        (is (no-prompt? state :corp)))))
   (testing "Shouldn't register events unless marked. #5019"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -2244,7 +2244,7 @@
       (play-from-hand state :corp "Punitive Counterstrike")
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
-      (is (empty? (:prompt (get-runner)))
+      (is (no-prompt? state :runner)
           "There is no prompt for 0 damage")))
   (testing "cannot steal Obokata while installed"
     (do-game
@@ -2508,7 +2508,7 @@
       (let [credits (:credit (get-runner))]
         (run-on state "Server 1")
         (run-continue state)
-        (is (empty? (:prompt (get-runner))) "No Hunting Grounds prompt")
+        (is (no-prompt? state :runner) "No Hunting Grounds prompt")
         (is (= (- credits 3) (:credit (get-runner))) "Runner loses credits to Tollbooth"))))
   (testing "Only prevents the on-encounter effects once per turn, mixed-use case"
     (do-game
@@ -2529,7 +2529,7 @@
       (let [credits (:credit (get-runner))]
         (run-on state "Server 1")
         (run-continue state)
-        (is (empty? (:prompt (get-runner))) "No Hunting Grounds prompt")
+        (is (no-prompt? state :runner) "No Hunting Grounds prompt")
         (is (= (- credits 3) (:credit (get-runner))) "Runner loses credits to Tollbooth"))))
   (testing "Preventing an on-encounter effect #5037"
     (do-game
@@ -2698,10 +2698,11 @@
         (rez state :corp eni)
         (run-continue state)
         (card-subroutine state :corp (refresh eni) 0)
-        (run-continue state)
-        (run-continue state)
+        (run-continue-until state :success)
+        (click-prompt state :runner "No action")
         (end-phase-12 state :runner)
-        (is (= 3 (:click (get-runner))) "Enigma took a click"))))
+        (is (= 3 (:click (get-runner))) "Enigma took a click")
+        (is (no-prompt? state :runner) "Jak Sinclair did not trigger at :runner-turn-begins"))))
   (testing "Calls make-run async #5612"
     (do-game
       (new-game {:corp {:hand ["Hedge Fund"]
@@ -2721,12 +2722,15 @@
       (take-credits state :corp)
       (is (:runner-phase-12 @state) "Runner in Step 1.2")
       (end-phase-12 state :runner)
+      (click-prompt state :runner "Data Folding")
+      (click-prompt state :runner "Jak Sinclair")
       (click-prompt state :runner "Yes")
       (click-prompt state :runner "R&D")
       (run-continue state :success)
       (is (= "You accessed Hedge Fund." (:msg (prompt-map :runner))))
       (click-prompt state :runner "No action")
-      (is (not (get-run)) "Run has ended"))))
+      (is (not (get-run)) "Run has ended")
+      (is (no-prompt? state :corp) "Corp does not have a start of turn wait prompt"))))
 
 (deftest john-masanori
   ;; John Masanori - Draw 1 card on first successful run, take 1 tag on first unsuccessful run
@@ -3174,15 +3178,15 @@
             nm (get-resource state 0)
             gr (get-resource state 1)]
         (card-ability state :runner nm 0)
-        (is (empty? (:prompt (get-runner))) "Net Mercur doesn't stack overflow if you click on it")
+        (is (no-prompt? state :runner) "Net Mercur doesn't stack overflow if you click on it")
         (card-ability state :runner gr 0)
-        (is (empty? (:prompt (get-runner))) "No Net Mercur prompt from stealth spent outside of run")
+        (is (no-prompt? state :runner) "No Net Mercur prompt from stealth spent outside of run")
         (run-on state :hq)
         (card-ability state :runner sil 0)
         (click-prompt state :runner "Place 1 [Credits]")
         (is (= 1 (get-counters (refresh nm) :credit)) "1 credit placed on Net Mercur")
         (card-ability state :runner gr 0)
-        (is (empty? (:prompt (get-runner))) "No Net Mercur prompt for 2nd stealth in run")
+        (is (no-prompt? state :runner) "No Net Mercur prompt for 2nd stealth in run")
         (run-jack-out state)
         (take-credits state :runner)
         (take-credits state :corp)
@@ -3572,7 +3576,7 @@
       (let [credits (:credit (get-runner))]
         (rez state :corp (get-content state :remote1 0))
         (card-ability state :corp (get-content state :remote1 0) 0)
-        (is (empty? (:prompt (get-corp))) "No optional prompt as we've not started the turn yet")
+        (is (no-prompt? state :corp) "No optional prompt as we've not started the turn yet")
         (core/start-turn state :corp nil)
         (card-ability state :corp (get-content state :remote1 0) 0)
         (click-prompt state :corp "Yes")
@@ -3634,8 +3638,8 @@
       (click-prompt state :runner "Gordian Blade")
       (click-prompt state :runner "Bank Job")
       (click-prompt state :runner "Done")
-      (is (empty? (:prompt (get-corp))) "Corp has no wait prompts")
-      (is (empty? (:prompt (get-runner))) "Runner has no ability prompts"))))
+      (is (no-prompt? state :corp) "Corp has no wait prompts")
+      (is (no-prompt? state :runner) "Runner has no ability prompts"))))
 
 (deftest paladin-poemu
   ;; Paladin Poemu
@@ -3666,7 +3670,7 @@
         (is (= 3 (get-counters (refresh pp) :credit)) "+1c from start of turn")
         (take-credits state :runner)
         (click-card state :runner fs)
-        (is (empty? (:prompt (get-runner))) "No prompt to prevent trashing with Dummy Box")
+        (is (no-prompt? state :runner) "No prompt to prevent trashing with Dummy Box")
         (take-credits state :corp)
         (take-credits state :runner)
         (click-card state :runner (refresh misd))
@@ -3680,7 +3684,7 @@
                            (click-card state :runner pp)
                            (click-card state :runner pp))
         (play-from-hand state :runner "Hernando Cortez")
-        (is (empty? (:prompt (get-runner))) "No pay-credits prompt on the install of a Connection"))))
+        (is (no-prompt? state :runner) "No pay-credits prompt on the install of a Connection"))))
   (testing "Async issues are handled properly. Issue #4784"
     (do-game
       (new-game {:corp {:deck ["Project Vitruvius"]}
@@ -3696,8 +3700,8 @@
       (take-credits state :runner)
       (click-card state :runner "Paladin Poemu")
       (is (find-card "Paladin Poemu" (:discard (get-runner))) "Paladin Poemu should be trashed")
-      (is (empty? (:prompt (get-runner))) "Runner has no prompt")
-      (is (empty? (:prompt (get-corp))) "Corp has no prompt")))
+      (is (no-prompt? state :runner) "Runner has no prompt")
+      (is (no-prompt? state :corp) "Corp has no prompt")))
   (testing "Bin breakers trigger Paladin Poemu"
     (do-game
       (new-game {:corp {:hand ["Lotus Field"]}
@@ -3768,7 +3772,7 @@
         (click-prompt state :runner "Archives")
         (run-continue state)
         (end-phase-12 state :runner)
-        (is (empty? (:prompt (get-runner))) "No second prompt for Patron - used already")))))
+        (is (no-prompt? state :runner) "No second prompt for Patron - used already")))))
 
 (deftest paule-s-cafe
   (testing "Basic test"
@@ -4054,14 +4058,14 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Reclaim")
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "No Reclaim prompt")))
+      (is (no-prompt? state :runner) "No Reclaim prompt")))
   (testing "Cannot use if no valid targets in Heap already"
     (do-game
       (new-game {:runner {:deck ["Reclaim" "Mimic"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Reclaim")
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "No Reclaim prompt")))
+      (is (no-prompt? state :runner) "No Reclaim prompt")))
   (testing "Can't afford to install card"
     (do-game
       (new-game {:runner {:deck ["Reclaim" "Alpha" "Sure Gamble"]}})
@@ -4069,7 +4073,7 @@
       (core/move state :runner (find-card "Alpha" (:hand (get-runner))) :discard)
       (play-from-hand state :runner "Reclaim")
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "No Reclaim prompt")))
+      (is (no-prompt? state :runner) "No Reclaim prompt")))
   (testing "Heap Locked"
     (do-game
       (new-game {:corp {:deck ["Blacklist"]}
@@ -4082,7 +4086,7 @@
       (is (empty? (get-program state)) "No programs installed")
       (is (= 5 (:credit (get-runner))) "Runner starts with 5c.")
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Reclaim prompt did not come up"))))
+      (is (no-prompt? state :runner) "Reclaim prompt did not come up"))))
 
 (deftest red-team
   ;; Red Team
@@ -4180,7 +4184,7 @@
     (play-from-hand state :runner "Astrolabe")
     (take-credits state :runner)
     (trash state :runner (get-resource state 2))
-    (is (empty? (:prompt (get-runner))) "Sac Con not prompting to prevent resource trash")
+    (is (no-prompt? state :runner) "Sac Con not prompting to prevent resource trash")
     (trash state :runner (get-program state 0))
     (card-ability state :runner (get-resource state 0) 0)
     (is (= 2 (count (:discard (get-runner)))) "Sac Con trashed")
@@ -4226,7 +4230,7 @@
       (run-empty-server state "Server 1")
       (is (seq (:prompt (get-runner))) "Prompting to trash.")
       (click-prompt state :runner "[Salsette Slums] Remove card from game")
-      (is (empty? (:prompt (get-runner))) "All prompts done")
+      (is (no-prompt? state :runner) "All prompts done")
       (is (= 3 (count (:hand (get-runner)))) "On-trash ability of other Hostile didn't fire")
       (is (= "Tech Startup" (:title (last (:rfg (get-corp))))) "Tech Startup was removed from game")
       (is (= 2 (:credit (get-runner))) "Runner paid the trash cost.")
@@ -4392,7 +4396,7 @@
       (rez state :corp (get-ice state :hq 1))
       (run-continue state)
       (run-continue state)
-      (is (empty? (:prompt (get-runner))) "No Slipstream prompt")))
+      (is (no-prompt? state :runner) "No Slipstream prompt")))
   (testing "You can only choose the correct ice"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -4524,7 +4528,7 @@
         0 (get-counters (get-hardware state 0) :virus)
         "Friday Chip shouldn't gain counters from Spoilers"
         (score-agenda state :corp (get-content state :remote1 0))
-        (is (empty? (:prompt (get-runner))) "Runner has no Friday Chip prompt")))))
+        (is (no-prompt? state :runner) "Runner has no Friday Chip prompt")))))
 
 (deftest stim-dealer
   ;; Stim Dealer - Take 1 brain damage when it accumulates 2 power counters
@@ -4546,7 +4550,7 @@
       (take-credits state :runner)
       (take-credits state :corp)
       (is (zero? (get-counters (refresh sd) :power)) "Lost all counters")
-      (is (empty? (:prompt (get-runner))) "No Feedback Filter brain dmg prevention possible")
+      (is (no-prompt? state :runner) "No Feedback Filter brain dmg prevention possible")
       (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")
       (is (= 4 (:click (get-runner))) "Didn't gain extra click"))))
 
@@ -4649,7 +4653,7 @@
         (rez state :corp jh)
         (card-ability state :runner sp 0)
         (click-prompt state :runner (find-card "Street Peddler" (:hosted sp))) ; choose to another Peddler
-        (is (empty? (:prompt (get-corp))) "Corp not prompted to rez Jackson")
+        (is (no-prompt? state :corp) "Corp not prompted to rez Jackson")
         (is (= 4 (core/available-mu state)) "Runner has 4 MU"))))
   (testing "Installing Parasite with only 1cr. Issue #491."
     (do-game
@@ -4944,7 +4948,7 @@
       (is (= 1 (count (get-program state))) "1 Program installed")
       (is (= 3 (:credit (get-runner))) "Artist discount applied")
       (card-ability state :runner artist 1)
-      (is (empty? (:prompt (get-runner))) "Second use of Artist for install not allowed")
+      (is (no-prompt? state :runner) "Second use of Artist for install not allowed")
       (take-credits state :runner)
       (take-credits state :corp)
       (card-ability state :runner artist 0)
@@ -4988,7 +4992,7 @@
       (let [the-back (get-resource state 0)]
         (core/add-counter state :runner (refresh the-back) :power 2)
         (card-ability state :runner (refresh the-back) 1)
-        (is (empty? (:prompt (get-runner))) "The Back prompt did not come up")))))
+        (is (no-prompt? state :runner) "The Back prompt did not come up")))))
 (deftest-pending the-back-automated
   ;; TODO: Enable this once card is fully implemented
   (testing "Basic test"
@@ -5102,34 +5106,34 @@
      (play-from-hand state :runner "The Class Act")
      (is (empty? (get-program state)) "No programs installed")
      (is (= 1 (:credit (get-runner))))
-     (is (empty? (:prompt (get-runner))) "The Class Act has done nothing yet, so there is no Runner prompt")
-     (is (empty? (:prompt (get-corp))) "The Class Act has done nothing yet, so there is no Corp prompt")
+     (is (no-prompt? state :runner) "The Class Act has done nothing yet, so there is no Runner prompt")
+     (is (no-prompt? state :corp) "The Class Act has done nothing yet, so there is no Corp prompt")
      (is (= 6 (count (:deck (get-runner)))) "4 cards in deck to be drawn")
      (take-credits state :runner)
      (is (seq (:prompt (get-runner))) "The Class Act triggered its draw ability, so Runner needs to choose")
      (is (seq (:prompt (get-corp))) "The Class Act triggered its draw ability, so Corp must wait while Runner chooses")
      (is (not= "Easy Mark" (-> (get-runner) :deck last :title)) "Easy Mark is not on the bottom of the deck yet")
      (click-card state :runner "Easy Mark")
-     (is (empty? (:prompt (get-corp))) "The Class Act has bottomed a card, so there is no Corp prompt")
-     (is (empty? (:prompt (get-runner))) "The Class Act has has bottomed a card, so there is no Runner prompt")
+     (is (no-prompt? state :corp) "The Class Act has bottomed a card, so there is no Corp prompt")
+     (is (no-prompt? state :runner) "The Class Act has has bottomed a card, so there is no Runner prompt")
      (is (= "Easy Mark" (-> (get-runner) :deck last :title)) "Easy Mark was put on bottom of deck")
      (is (= 2 (count (:deck (get-runner)))) "2 cards in deck")
      (take-credits state :corp)
      (take-credits state :runner)
      (is (= 2 (count (:deck (get-runner)))) "The Class Act does not trigger at the end of a turn it wasn't installed, so no cards were drawn")
-     (is (empty? (:prompt (get-runner))) "The Class Act does not trigger at the end of a turn it wasn't installed, so there is no prompt")
+     (is (no-prompt? state :runner) "The Class Act does not trigger at the end of a turn it wasn't installed, so there is no prompt")
      (take-credits state :corp)
      (click-draw state :runner)
      (is (seq (:prompt (get-runner))) "The Class Act is prompting the runner to choose")
      (is (seq (:prompt (get-corp))) "The Class Act is insisting the corp waits")
      (click-card state :runner "Easy Mark")
-     (is (empty? (:prompt (get-runner))) "The Class Act is no longer prompting the runner to choose")
-     (is (empty? (:prompt (get-corp))) "The Class Act is no longer insisting the corp waits")
+     (is (no-prompt? state :runner) "The Class Act is no longer prompting the runner to choose")
+     (is (no-prompt? state :corp) "The Class Act is no longer insisting the corp waits")
      (is (= "Easy Mark" (-> (get-runner) :deck last :title)) "Easy Mark was bottomed again")
      (click-draw state :runner)
      (is (zero? (count (:deck (get-runner)))) "Runner only drew one")
-     (is (empty? (:prompt (get-runner))) "The Class Act did not trigger")
-     (is (empty? (:prompt (get-corp))) "The Class Act is no longer insisting the corp waits")))
+     (is (no-prompt? state :runner) "The Class Act did not trigger")
+     (is (no-prompt? state :corp) "The Class Act is no longer insisting the corp waits")))
   (testing "Interaction with other sources of draw"
     (do-game
      (new-game {:runner {:deck [(qty "Sure Gamble" 3)]
@@ -5143,8 +5147,8 @@
      (is (seq (:prompt (get-runner))) "The Class Act is prompting the runner to choose")
      (is (seq (:prompt (get-corp))) "The Class Act is insisting the corp waits")
      (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))
-     (is (empty? (:prompt (get-runner))) "The Class Act is done prompting the runner to choose")
-     (is (empty? (:prompt (get-corp))) "The Class Act is not insisting the corp waits")
+     (is (no-prompt? state :runner) "The Class Act is done prompting the runner to choose")
+     (is (no-prompt? state :corp) "The Class Act is not insisting the corp waits")
      (is (= 1 (count (:deck (get-runner)))) "1 card put back")))
   (testing "Ensure draw filtering is properly awaited"
     (do-game
@@ -5158,15 +5162,15 @@
      (is (= 3 (count (:deck (get-runner)))) "3 cards in deck")
      (run-empty-server state "Archives")
      (click-prompt state :runner "John Masanori") ; runner should be prompted for which to trigger first
-     (is (= 1 (count (:prompt (get-runner)))) "The Class Act is prompting the runner to choose, but Paragon prompt is not open yet")
+     (is (= 2 (count (:prompt (get-runner)))) "The Class Act is prompting the runner to choose, but Paragon prompt is not open yet")
      (is (seq (:prompt (get-corp))) "The Class Act is insisting the corp waits")
      (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))
      (is (= 2 (count (:deck (get-runner)))) "The Class Act put a card back")
      (is (changes-credits (get-runner) 1
                           (do (click-prompt state :runner "Yes") ; runner prompted to trigger Paragon
                               (click-prompt state :runner "Yes"))))
-     (is (empty? (:prompt (get-runner))) "The Class Act is done prompting the runner to choose")
-     (is (empty? (:prompt (get-corp))) "The Class Act is not insisting the corp waits")
+     (is (no-prompt? state :runner) "The Class Act is done prompting the runner to choose")
+     (is (no-prompt? state :corp) "The Class Act is not insisting the corp waits")
      (is (= 2 (count (:deck (get-runner)))) "Deck still has 2 cards"))))
 
 (deftest the-helpful-ai
@@ -5212,12 +5216,12 @@
        (click-card state :runner (refresh cache1))
        (is (= 1 (get-counters (refresh nihi) :virus)) "The Nihilist spent 1 counter")
        (is (= 2 (get-counters (refresh cache1) :virus)) "Cache 1 spent 1")
-       (is (not (empty? (:prompt (get-runner)))) "Runner is waiting for Corp to pick their Nihilist poison")
+       (is (not (no-prompt? state :runner)) "Runner is waiting for Corp to pick their Nihilist poison")
        (is (= 0 (count (:discard (get-corp)))) "No cards in Archives")
        (click-prompt state :corp "Yes")  ; mill 1
        (is (= 1 (count (:discard (get-corp)))) "1 card milled")
-       (is (empty? (:prompt (get-runner))) "Runner is done waiting for Corp to pick their Nihilist poison")
-       (is (empty? (:prompt (get-corp))) "No more Corp prompts")
+       (is (no-prompt? state :runner) "Runner is done waiting for Corp to pick their Nihilist poison")
+       (is (no-prompt? state :corp) "No more Corp prompts")
        (take-credits state :runner)
        (take-credits state :corp)
        (click-prompt state :runner "Yes")  ; spend 2 tokens?
@@ -5229,12 +5233,12 @@
        (is (= 1 (get-counters (refresh cache1) :virus)) "Cache 1 spent 1")
        (is (= 0 (count (:hand (get-runner)))) "Runner has no cards in hand")
        (is (= 1 (count (:discard (get-corp)))) "1 card in discard")
-       (is (not (empty? (:prompt (get-runner)))) "Runner is waiting for Corp to pick their Nihilist poison")
+       (is (not (no-prompt? state :runner)) "Runner is waiting for Corp to pick their Nihilist poison")
        (click-prompt state :corp "No")  ; don't mill 1
        (is (= 2 (count (:hand (get-runner)))) "Runner drew 2 cards")
        (is (= 1 (count (:discard (get-corp)))) "No extra cards milled")
-       (is (empty? (:prompt (get-runner))) "Runner done waiting for Corp to pick their Nihilist poison")
-       (is (empty? (:prompt (get-corp))) "Corp has no more prompts")
+       (is (no-prompt? state :runner) "Runner done waiting for Corp to pick their Nihilist poison")
+       (is (no-prompt? state :corp) "Corp has no more prompts")
        (take-credits state :runner)
        (core/purge state :corp)
        (take-credits state :corp)
@@ -5289,11 +5293,11 @@
       (take-credits state :corp)
       (play-from-hand state :runner "The Shadow Net")
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Shadow Net prompt did not come up, no agenda and no target")
+      (is (no-prompt? state :runner) "Shadow Net prompt did not come up, no agenda and no target")
       (run-empty-server state :hq)
       (click-prompt state :runner "Steal")
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Shadow Net prompt did not come up, no target")
+      (is (no-prompt? state :runner) "Shadow Net prompt did not come up, no target")
       (play-from-hand state :runner "Titanium Ribs")
       (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))
       (click-card state :runner (find-card "Easy Mark" (:hand (get-runner))))
@@ -5305,7 +5309,7 @@
       (take-credits state :corp)
       (click-credit state :runner)
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Shadow Net prompt did not come up, no agenda")))
+      (is (no-prompt? state :runner) "Shadow Net prompt did not come up, no agenda")))
   (testing "Heap locked"
     (do-game
       (new-game {:corp {:deck ["Hostile Takeover" "Blacklist"]}
@@ -5321,7 +5325,7 @@
       (click-card state :runner (find-card "Easy Mark" (:hand (get-runner))))
       (is (= 4 (:credit (get-runner))) "Paid 1c to install ribs")
       (card-ability state :runner (get-resource state 0) 0)
-      (is (empty? (:prompt (get-runner))) "Shadow Net prompt did not come up, heap is locked"))))
+      (is (no-prompt? state :runner) "Shadow Net prompt did not come up, heap is locked"))))
 
 (deftest the-source
   ;; The Source - Increase advancement requirement of agendas by 1; 3c additional cost to steal
@@ -5511,7 +5515,7 @@
         (is (zero? (core/access-bonus-count state :runner :hq)) "Runner should access 0 additional card")
         (is (= "You accessed Fire Wall." (:msg (prompt-map :runner))))
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "Runner should have no more access prompts available"))))
+        (is (no-prompt? state :runner) "Runner should have no more access prompts available"))))
   (testing "Bounce test"
     (do-game
       (new-game {:corp {:deck [(qty "Ice Wall" 5)]
@@ -5857,7 +5861,7 @@
       (click-prompt state :runner "Yes")
       (click-prompt state :runner "Fetal AI")
       (is (find-card "Whistleblower" (:discard (get-runner))) "Whistleblower trashed")
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :runner))
       (is (not (:run @state)) "Run ended")
       (is (= 1 (count (:scored (get-runner)))) "Agenda added to runner score area")
       (is (= 4 (count (:hand (get-runner)))) "No damage dealt")
@@ -5878,7 +5882,7 @@
       (click-prompt state :runner "Yes") ; trigger Whistleblower
       (click-prompt state :runner "Fetal AI")
       (is (= 0 (count (:hand (get-runner)))) "Fetal AI deals net before Whistleblower triggers on Corp turn")
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :runner))
       (is (not (:run @state)) "Run ended")
       (is (= 3 (count (:scored (get-runner)))) "Agenda added to runner score area without needing to pay")))
   (testing "Autoresolve functionality"
@@ -5897,7 +5901,7 @@
      (click-prompt state :runner "Always") ; auto-trigger whistleblower
      (run-empty-server state "Server 1")
      (click-prompt state :runner "NAPD Contract")
-     (is (empty? (:prompt (get-runner))))
+     (is (no-prompt? state :runner))
      (is (not (:run @state)) "Run ended")
      (is (= 1 (count (:scored (get-runner)))) "Stole agenda")))
   (testing "Steal triggers happen on Whistleblowing"
@@ -5912,7 +5916,7 @@
      (run-empty-server state "Server 1")
      (click-prompt state :runner "Yes")
      (click-prompt state :runner "Project Beale")
-     (is (not (empty? (:prompt (get-runner)))) "There is an open prompt, as Leela triggers")
+     (is (not (no-prompt? state :runner)) "There is an open prompt, as Leela triggers")
      (is (= "Leela Patel: Trained Pragmatist" (:title (:card (prompt-map :runner))))
          "Leela triggers, as Whistleblower does not eat steal trigger")))
   (doseq [agenda-name ["The Future Perfect" "NAPD Contract" "Degree Mill" "Ikawah Project" "Obokata Protocol"]]
@@ -5927,13 +5931,13 @@
        (click-prompt state :runner "Yes")
        (click-prompt state :runner agenda-name)
        (is (find-card "Whistleblower" (:discard (get-runner))) "Whistleblower trashed")
-       (is (empty? (:prompt (get-runner))))
+       (is (no-prompt? state :runner))
        (is (not (:run @state)) "Run ended")
        (is (= 1 (count (:scored (get-runner)))) "Agenda added to runner score area")
        (take-credits state :runner)
        (take-credits state :corp)
        (run-empty-server state "HQ")
-       (is (not (empty? (:prompt (get-runner)))) "Whistleblower does not persist between runs, so agenda not autostolen")
+       (is (not (no-prompt? state :runner)) "Whistleblower does not persist between runs, so agenda not autostolen")
        (is (:run @state) "Run not ended yet")
        (is (= 1 (count (:scored (get-runner)))) "Agenda not added to runner score area yet")))))
 

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -100,7 +100,7 @@
             diff-tg (get-content state :remote2 0)]
         (rez state :corp arella)
         (score-agenda state :corp (refresh diff-tg))
-        (is (empty? (:prompt (get-corp))) "Arella not triggered for different remote score")
+        (is (no-prompt? state :corp) "Arella not triggered for different remote score")
         (is (= 1 (count (get-scored state :corp))) "1 Agenda scored")
         (score-agenda state :corp (refresh same-tg))
         (click-card state :corp (find-card "Bryan Stinson" (:hand (get-corp))))
@@ -205,7 +205,7 @@
         (click-prompt state :corp "0")
         (click-prompt state :runner "0")
         (click-prompt state :runner "Pay 3 [Credits] to trash")
-        (is (empty? (:prompt (get-runner))) "Runner gets no further access prompts")))))
+        (is (no-prompt? state :runner) "Runner gets no further access prompts")))))
 
 (deftest awakening-center
   ;; Awakening Center
@@ -594,7 +594,7 @@
       (take-credits state :corp)
       ;; Check Caprice triggers properly on multiple ice
       (run-on state "Server 1")
-      (is (empty? (:prompt (get-corp))) "Caprice not trigger on first ice")
+      (is (no-prompt? state :corp) "Caprice not trigger on first ice")
       (run-continue-until state :movement) ; pass first Quandary
       (run-continue-until state :movement) ; Caprice should trigger here
       (is (prompt-is-card? state :corp caprice)
@@ -603,10 +603,10 @@
       (click-prompt state :corp "0 [Credits]")
       (click-prompt state :runner "1 [Credits]")
       (is (not (:run @state)) "Run ended by Caprice")
-      (is (empty? (:prompt (get-corp))) "Caprice prompted cleared")
+      (is (no-prompt? state :corp) "Caprice prompted cleared")
       ;; Check Caprice does not trigger on other servers
       (run-on state "HQ")
-      (is (empty? (:prompt (get-corp))) "Caprice does not trigger on other servers"))))
+      (is (no-prompt? state :corp) "Caprice does not trigger on other servers"))))
 
 (deftest cayambe-grid
   ;; Cayambe Grid
@@ -620,7 +620,7 @@
           (rez state :corp cg))
         (take-credits state :corp)
         (take-credits state :runner)
-        (is (empty? (:prompt (get-corp))) "corp has no prompts when no ice is installed in this server")))
+        (is (no-prompt? state :corp) "corp has no prompts when no ice is installed in this server")))
     (testing "1 ice in same server"
       (do-game
         (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -648,7 +648,7 @@
         (take-credits state :runner)
         (let [enigma (get-ice state :remote1 0)]
           (is (zero? (get-counters (refresh enigma) :advancement)) "Enigma has 0 counters to start")
-          (is (empty? (:prompt (get-corp))) "corp has no prompts when no ice is installed in this server")))))
+          (is (no-prompt? state :corp) "corp has no prompts when no ice is installed in this server")))))
   (testing "Payment ability"
     (testing "No ice"
       (do-game
@@ -864,7 +864,7 @@
        (rez state :corp cr)
        (is (= 5 (:credit (get-corp))))
        (rez state :corp i3)
-       (run-continue state)
+       (run-continue state :encounter-ice)
        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card corr})
        (core/continue state :corp nil)
        (is (= 2 (:position (get-in @state [:run]))) "Passed Ice Wall")
@@ -1188,8 +1188,8 @@
       (click-card state :corp "Hedge Fund")
       (click-card state :corp "Spiderweb")
       (click-prompt state :runner "Pay 5 [Credits] to trash")
-      (is (empty? (:prompt (get-corp))) "Corp should be waiting on Runner")
-      (is (empty? (:prompt (get-runner))) "Runner should be able to take actions")
+      (is (no-prompt? state :corp) "Corp should be waiting on Runner")
+      (is (no-prompt? state :runner) "Runner should be able to take actions")
       (is (= ["Ice Wall" "Fire Wall" "Hedge Fund" "Spiderweb"]
              (->> (get-corp) :deck (take 4) (map :title) (into [])))
           "Deck should be ordered top to bottom")))
@@ -1203,8 +1203,8 @@
       (click-prompt state :corp "Yes")
       (click-prompt state :corp "Done")
       (click-prompt state :runner "Pay 5 [Credits] to trash")
-      (is (empty? (:prompt (get-corp))) "Corp should be waiting on Runner")
-      (is (empty? (:prompt (get-runner))) "Runner should be able to take actions"))))
+      (is (no-prompt? state :corp) "Corp should be waiting on Runner")
+      (is (no-prompt? state :runner) "Runner should be able to take actions"))))
 
 (deftest drone-screen
   ;; Drone Screen
@@ -1405,8 +1405,8 @@
      (is (= "You accessed Ganked!." (:msg (prompt-map :runner))) "Runner has normal access prompt")
      (click-prompt state :runner "No action")
      (is (not (get-run)) "Run has been ended")
-     (is (empty? (:prompt (get-corp))) "No more prompts")
-     (is (empty? (:prompt (get-runner))) "No more prompts"))))
+     (is (no-prompt? state :corp) "No more prompts")
+     (is (no-prompt? state :runner) "No more prompts"))))
 
 (deftest georgia-emelyov
   ;; Georgia Emelyov
@@ -1609,7 +1609,7 @@
        (run-jack-out state)
        (run-empty-server state :hq)
        (run-on state :remote1)
-       (is (empty? (:prompt (get-runner))) "No Hired Help prompt"))))
+       (is (no-prompt? state :runner) "No Hired Help prompt"))))
   (testing "Crisium Grid, fake agenda interactions"
     (do-game
      (new-game {:corp {:deck ["Hired Help" "Crisium Grid"]}
@@ -1692,7 +1692,7 @@
     (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")
     (click-prompt state :runner "Pay 0 [Credits] to trash") ; trash
     (run-empty-server state "Archives")
-    (is (empty? (:prompt (get-corp))) "No prompt from Archives access")
+    (is (no-prompt? state :corp) "No prompt from Archives access")
     (is (= 1 (count (:hand (get-runner)))) "Runner has 1 card in hand")
     (run-empty-server state "Server 1")
     (click-prompt state :corp "0") ; trace
@@ -1706,12 +1706,12 @@
     (click-prompt state :runner "0")
     (click-prompt state :corp "Done")
     (click-prompt state :runner "No action") ; trash
-    (is (empty? (:prompt (get-corp))) "Prompt closes after done")
+    (is (no-prompt? state :corp) "Prompt closes after done")
     (is (= 2 (count (:hand (get-runner)))) "Runner has 2 cards in hand")
     (run-empty-server state "HQ")
     (click-prompt state :corp "0") ; trace
     (click-prompt state :runner "5")
-    (is (empty? (:prompt (get-corp))) "Prompt closes after lost trace")))
+    (is (no-prompt? state :corp) "Prompt closes after lost trace")))
 
 (deftest jinja-city-grid
   ;; Jinja City Grid - install drawn ice, lowering install cost by 4
@@ -1820,7 +1820,7 @@
         (rez state :corp la-costa)
         (take-credits state :corp)
         (take-credits state :runner)
-        (is (not (empty? (:prompt (get-corp)))) "The Corp is prompted to place one advancement token on a card")
+        (is (not (no-prompt? state :corp)) "The Corp is prompted to place one advancement token on a card")
         (click-card state :corp la-costa)
         (is (= 1 (get-counters (refresh la-costa) :advancement)) "Clicking on La Costa Grid advances it")
         (take-credits state :corp)
@@ -1838,35 +1838,35 @@
           (take-credits state :corp)
           (take-credits state :runner)
           (click-card state :corp remote-mvt)
-          (is (not (empty? (:prompt (get-corp)))) "Clicking a card in a different remote does not clear the prompt")
+          (is (not (no-prompt? state :corp)) "Clicking a card in a different remote does not clear the prompt")
           (is (zero? (get-counters (refresh remote-mvt) :advancement)) "Clicking a card in a different remote does not advance it"))
         (play-from-hand state :corp "Mumbad Virtual Tour" "HQ")
         (let [[central-mvt] (get-content state :hq)]
           (take-credits state :corp)
           (take-credits state :runner)
           (click-card state :corp central-mvt)
-          (is (not (empty? (:prompt (get-corp)))) "Clicking a card in a central does not clear the prompt")
+          (is (not (no-prompt? state :corp)) "Clicking a card in a central does not clear the prompt")
           (is (zero? (get-counters (refresh central-mvt) :advancement)) "Clicking a card in a central does not advance it"))
         (play-from-hand state :corp "Vanilla" "Server 1")
         (let [[vanilla] (get-ice state :remote1)]
           (take-credits state :corp)
           (take-credits state :runner)
           (click-card state :corp vanilla)
-          (is (not (empty? (:prompt (get-corp)))) "Clicking an ice protecting La Costa Grid does not clear the prompt")
+          (is (not (no-prompt? state :corp)) "Clicking an ice protecting La Costa Grid does not clear the prompt")
           (is (zero? (get-counters (refresh vanilla) :advancement)) "Clicking a an ice protecting La Costa Grid does not advance it"))
         (play-from-hand state :corp "Vanilla" "Server 2")
         (let [[remote-vanilla] (get-ice state :remote2)]
           (take-credits state :corp)
           (take-credits state :runner)
           (click-card state :corp remote-vanilla)
-          (is (not (empty? (:prompt (get-corp)))) "Clicking an ice protecting La Costa Grid does not clear the prompt")
+          (is (not (no-prompt? state :corp)) "Clicking an ice protecting La Costa Grid does not clear the prompt")
           (is (zero? (get-counters (refresh remote-vanilla) :advancement)) "Clicking a an ice protecting La Costa Grid does not advance it"))
         (play-from-hand state :corp "Vanilla" "HQ")
         (let [[central-vanilla] (get-ice state :hq)]
           (take-credits state :corp)
           (take-credits state :runner)
           (click-card state :corp central-vanilla)
-          (is (not (empty? (:prompt (get-corp)))) "Clicking an ice protecting HQ does not clear the prompt")
+          (is (not (no-prompt? state :corp)) "Clicking an ice protecting HQ does not clear the prompt")
           (is (zero? (get-counters (refresh central-vanilla) :advancement)) "Clicking a an ice protecting HQ does not advance it")))))
   (testing "The Corp may advance hosted cards in La Costa Grid's server"
     (do-game
@@ -1901,8 +1901,8 @@
       (is (= "Choose 1 card to add to the bottom of R&D" (:msg (prompt-map :corp))))
       (click-card state :corp "Ice Wall")
       (last-log-contains? state "Daily Business Show to add 1 card to the bottom of R&D")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner)))))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner)))))
 
 (deftest letheia-nisei
   ;; Letheia Nisei
@@ -2031,7 +2031,7 @@
         (rez state :corp encryption)
         (take-credits state :corp)
         (run-empty-server state "HQ")
-        (is (empty? (:prompt (get-runner))) "Manegarm Skunkworks didn't trigger")))))
+        (is (no-prompt? state :runner) "Manegarm Skunkworks didn't trigger")))))
 
 (deftest manta-grid
   ;; If the Runner has fewer than 6 or no unspent clicks on successful run, corp gains a click next turn.
@@ -2153,8 +2153,8 @@
      (is (= :waiting (:prompt-type (prompt-map :corp))) "Corp waiting for Runner to jack out")
      (click-prompt state :runner "Yes")
      (is (empty? (:run @state)))
-     (is (empty? (prompt-map :runner)) "No open runner prompts")
-     (is (empty? (prompt-map :corp)) "No open corp prompts"))))
+     (is (no-prompt? state :runner) "No open runner prompts")
+     (is (no-prompt? state :corp)) "No open corp prompts")))
 
 (deftest midway-station-grid
   ;; Midway Station Grid
@@ -2222,7 +2222,7 @@
       (run-on state "Server 1")
       (is (= 1 (count (get-in @state [:corp :servers :remote1 :ices]))) "1 ice on server")
       (run-continue state)
-      (is (empty? (:prompt (get-corp))))
+      (is (no-prompt? state :corp))
       (run-jack-out state)
       (is (= 1 (count (get-in @state [:corp :servers :remote1 :ices]))) "Still 1 ice on server")))
   (testing "fire before pass"
@@ -2253,7 +2253,7 @@
       (rez state :corp (get-ice state :hq 0))
       (run-continue state)
       (run-continue state)
-      (is (empty? (:prompt (get-corp))) "Mumbad doesn't trigger on other servers"))))
+      (is (no-prompt? state :corp) "Mumbad doesn't trigger on other servers"))))
 
 (deftest mumbad-virtual-tour
   ;; Tests that Mumbad Virtual Tour forces trash
@@ -2383,7 +2383,7 @@
         (click-prompt state :runner "No action")
         (dotimes [c 4]
           (click-prompt state :runner "No action"))
-        (is (empty? (:prompt (get-runner))) "Prompt closed after accessing cards")
+        (is (no-prompt? state :runner) "Prompt closed after accessing cards")
         (is (= 17 (:credit (get-corp))) "Corp gains 10 credits"))))
   (testing "effect persists through current run after trash"
     (do-game
@@ -2399,7 +2399,7 @@
         (click-prompt state :runner "Pay 5 [Credits] to trash")
         (dotimes [c 4]
           (click-prompt state :runner "No action"))
-        (is (empty? (:prompt (get-runner))) "Prompt closed after accessing cards")
+        (is (no-prompt? state :runner) "Prompt closed after accessing cards")
         (is (= 17 (:credit (get-corp))) "Corp gains 10 credits"))))
   (testing "works well with replacement effects"
     ;; Regression test for #3456
@@ -2482,7 +2482,7 @@
         (rez state :corp fire)
         (run-continue state)
         (card-ability state :runner d4 0)
-        (is (empty? (:prompt (get-runner))) "Could not use D4v1d")
+        (is (no-prompt? state :runner) "Could not use D4v1d")
         (card-ability state :runner ddos 0)
         (is (empty? (:discard (get-runner))) "DDoS not trashed")
         (changes-val-macro -4 (:credit (get-runner))
@@ -2838,7 +2838,7 @@
         (run-on state "Server 1")
         (run-continue state)
         (click-prompt state :runner "Pay 1 [Credits] to trash")
-        (is (empty? (:prompt (get-corp))) "No prompt for Overseer Matrix")
+        (is (no-prompt? state :corp) "No prompt for Overseer Matrix")
         (is (= 1 (count-tags state)) "Runner doesn't take a tag"))))
   (testing "Takes into account apocalypse-like full-server trashes"
     (do-game
@@ -2892,7 +2892,7 @@
       (play-from-hand state :corp "Overseer Matrix" "R&D")
       (rez state :corp (get-content state :rd 0))
       (take-credits state :corp)
-      (is (empty? (:prompt (get-corp)))))))
+      (is (no-prompt? state :corp)))))
 
 (deftest panic-button
   (do-game
@@ -2946,7 +2946,7 @@
       ;; Runner trashes Prisec
       (click-prompt state :runner "Pay 3 [Credits] to trash")
       (run-empty-server state "HQ")
-      (is (empty? (:prompt (get-corp))) "Prisec does not trigger from HQ")))
+      (is (no-prompt? state :corp) "Prisec does not trigger from HQ")))
   (testing "Multiple unrezzed upgrades in Archives interaction with DRT"
     (do-game
       (new-game {:corp {:deck [(qty "Prisec" 2) "Dedicated Response Team"]}
@@ -3270,7 +3270,7 @@
       (run-on state "HQ")
       (card-ability state :corp sj 0)
       (card-ability state :runner smc1 0)
-      (is (empty? (:prompt (get-runner))) "SJ blocking SMC")
+      (is (no-prompt? state :runner) "SJ blocking SMC")
       (run-jack-out state)
       (card-ability state :runner smc2 0)
       (click-prompt state :runner "Reaver"))))
@@ -3556,7 +3556,7 @@
       (let [thg (get-content state :remote1 0)]
         (rez state :corp thg)
         (play-from-hand state :corp "PAD Campaign" "Server 1")
-        (is (empty? (:prompt (get-corp))) "THG didn't trigger on the PAD Campaign install, because its own install was the first install this turn")
+        (is (no-prompt? state :corp) "THG didn't trigger on the PAD Campaign install, because its own install was the first install this turn")
         (take-credits state :corp)
         (take-credits state :runner)
         (play-from-hand state :corp "PAD Campaign" "Server 1")
@@ -3583,7 +3583,7 @@
       (play-from-hand state :corp "Restore")
       (click-card state :corp (find-card "Tranquility Home Grid" (:discard (get-corp))))
       (click-prompt state :corp "New remote")
-      (is (empty? (:prompt (get-corp))) "No prompt from THG on its own install, because it was inactive at the point of install triggers")))
+      (is (no-prompt? state :corp) "No prompt from THG on its own install, because it was inactive at the point of install triggers")))
   (testing "THG interaction with ice install"
     (do-game
       (new-game {:corp {:deck [(qty "PAD Campaign" 5)]
@@ -3592,11 +3592,11 @@
       (let [thg (get-content state :remote1 0)]
         (rez state :corp thg)
         (play-from-hand state :corp "PAD Campaign" "Server 1")
-        (is (empty? (:prompt (get-corp))) "THG didn't trigger on the PAD Campaign install, because its own install was the first install this turn")
+        (is (no-prompt? state :corp) "THG didn't trigger on the PAD Campaign install, because its own install was the first install this turn")
         (take-credits state :corp)
         (take-credits state :runner)
         (play-from-hand state :corp "Ice Wall" "Server 1")
-        (is (empty? (:prompt (get-corp))) "No prompt from Ice Wall install")
+        (is (no-prompt? state :corp) "No prompt from Ice Wall install")
         (play-from-hand state :corp "PAD Campaign" "Server 1")
         (click-prompt state :corp "OK") ; Trash existing PAD Campaign
         (changes-val-macro 2 (:credit (get-corp))
@@ -3731,8 +3731,8 @@
         (take-credits state :runner)
         (take-credits state :corp)
         (is (= 2 (count (:hand (get-runner)))) "MaxX draws 2 cards")
-        (is (empty? (:prompt (get-corp))) "Corp has no prompt")
-        (is (empty? (:prompt (get-runner))) "Runner has no prompt"))))
+        (is (no-prompt? state :corp) "Corp has no prompt")
+        (is (no-prompt? state :runner) "Runner has no prompt"))))
   (testing "Interactions with IG. Issue #4329"
     (do-game
       (new-game {:corp {:id "Industrial Genomics: Growing Solutions"
@@ -3782,7 +3782,7 @@
       (click-prompt state :runner "0") ; Corp wins trace
       (click-card state :runner (get-program state 0))
       (click-card state :runner (get-program state 1))
-      (is (empty? (:prompt (get-corp))) "Warroid Tracker can't trash anything else")
+      (is (no-prompt? state :corp) "Warroid Tracker can't trash anything else")
       (is (= 3 (-> (get-runner) :discard count)) "Runner should trash 2 installed cards")))
   (testing "Should trigger from self-trash in root of central server"
     (do-game
@@ -3848,7 +3848,7 @@
         (click-prompt state :runner "0")
         (click-card state :corp mar1)
         (click-card state :corp war)
-        (is (empty? (:prompt (get-corp))) "Corp has no prompt")))))
+        (is (no-prompt? state :corp) "Corp has no prompt")))))
 
 (deftest will-o-the-wisp
   ;; Will-o'-the-Wisp

--- a/test/clj/game/core/access_test.clj
+++ b/test/clj/game/core/access_test.clj
@@ -14,8 +14,8 @@
       (take-credits state :corp)
       (run-empty-server state "R&D")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")
-      (is (empty? (:prompt (get-corp))))))
+      (is (no-prompt? state :runner) "Runner has no access prompt")
+      (is (no-prompt? state :corp))))
   (testing "Something in R&D, no upgrades"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -25,8 +25,8 @@
       (is (= ["No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")
-      (is (empty? (:prompt (get-corp))))))
+      (is (no-prompt? state :runner) "Runner has no access prompt")
+      (is (no-prompt? state :corp))))
   (testing "Nothing in R&D, an unrezzed upgrade"
     (do-game
       (new-game {:corp {:deck []
@@ -37,8 +37,8 @@
       (is (= ["Pay 5 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")
-      (is (empty? (:prompt (get-corp))))))
+      (is (no-prompt? state :runner) "Runner has no access prompt")
+      (is (no-prompt? state :corp))))
   (testing "Something in R&D, an upgrade"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -52,8 +52,8 @@
       (is (= ["Pay 5 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")
-      (is (empty? (:prompt (get-corp))))))
+      (is (no-prompt? state :runner) "Runner has no access prompt")
+      (is (no-prompt? state :corp))))
   (testing "Accessing multiple cards from R&D"
     (do-game
       (new-game {:corp {:deck []
@@ -77,8 +77,8 @@
       (click-prompt state :runner "No action")
       ;; No more accesses
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")
-      (is (empty? (:prompt (get-corp))))))
+      (is (no-prompt? state :runner) "Runner has no access prompt")
+      (is (no-prompt? state :corp))))
   (testing "Accessing multiple cards from R&D with multiple upgrades upgrades"
     (do-game
       (new-game {:corp {:deck ["Keegan Lane" "Midway Station Grid"
@@ -114,7 +114,7 @@
       (click-prompt state :runner "No action")
       (is (= "You accessed Manhunt." (:msg (prompt-map :runner))))
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")
+      (is (no-prompt? state :runner) "Runner has no access prompt")
       (is (nil? (get-run)) "Run has ended normally")))
   (testing "Looping Ganked! and Ansel"
     (do-game
@@ -144,7 +144,7 @@
       (take-credits state :corp)
       (run-empty-server state "HQ")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")))
+      (is (no-prompt? state :runner) "Runner has no access prompt")))
   (testing "Something in HQ, no upgrades"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -154,7 +154,7 @@
       (is (= ["No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")))
+      (is (no-prompt? state :runner) "Runner has no access prompt")))
   (testing "Nothing in HQ, an unrezzed upgrade"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -165,7 +165,7 @@
       (is (= ["Pay 5 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")))
+      (is (no-prompt? state :runner) "Runner has no access prompt")))
   (testing "Nothing in HQ, multiple unrezzed upgrades"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -180,7 +180,7 @@
       (is (= ["Pay 3 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")))
+      (is (no-prompt? state :runner) "Runner has no access prompt")))
   (testing "Something in HQ, an upgrade"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -194,7 +194,7 @@
       (is (= ["Pay 5 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")))
+      (is (no-prompt? state :runner) "Runner has no access prompt")))
   (testing "when access is limited to a single card, access only it"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -208,8 +208,8 @@
       (run-continue state)
       (is (= ["Pay 5 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "Pay 5 [Credits] to trash")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner))
       (is (nil? (get-run)))))
   (testing "Looping Ganked! and Ansel"
     (do-game
@@ -238,7 +238,7 @@
                         :hand ["Hedge Fund"]}})
       (take-credits state :corp)
       (run-empty-server state "Archives")
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")))
+      (is (no-prompt? state :runner) "Runner has no access prompt")))
   (testing "only non-interactive cards"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -246,7 +246,7 @@
                         :discard ["Hedge Fund" "Beanstalk Royalties"]}})
       (take-credits state :corp)
       (run-empty-server state "Archives")
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")))
+      (is (no-prompt? state :runner) "Runner has no access prompt")))
   (testing "contains one agenda"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -270,7 +270,7 @@
       (is (= "You accessed 15 Minutes." (:msg (prompt-map :runner))))
       (click-prompt state :runner "Steal")
       (is (nil? (get-run)))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :runner))
       (is (= 2 (:agenda-point (get-runner))))))
   (testing "contains one access ability"
     (do-game
@@ -321,8 +321,8 @@
       (click-prompt state :runner "Hostile Takeover")
       (click-prompt state :runner "Steal")
       (is (= 1 (:agenda-point (get-runner))))
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner))
       (is (nil? (get-run)))))
   (testing "when access count is reduced"
     (testing "by 1"
@@ -343,8 +343,8 @@
         (is (= ["Hostile Takeover" "Everything else"] (prompt-buttons :runner)))
         (click-prompt state :runner "Everything else")
         (is (zero? (:agenda-point (get-runner))) "Runner doesn't access last card in Archives")
-        (is (empty? (:prompt (get-corp))))
-        (is (empty? (:prompt (get-runner))))
+        (is (no-prompt? state :corp))
+        (is (no-prompt? state :runner))
         (is (nil? (get-run)))))
     (testing "by more than 1"
       (do-game
@@ -365,8 +365,8 @@
         (click-prompt state :runner "Everything else")
         (is (zero? (:agenda-point (get-runner))) "Runner didn't access Hostile Takeover")
         (is (zero? (count (:discard (get-runner)))) "Runner didn't access Shock!")
-        (is (empty? (:prompt (get-corp))))
-        (is (empty? (:prompt (get-runner))))
+        (is (no-prompt? state :corp))
+        (is (no-prompt? state :runner))
         (is (nil? (get-run))))))
   (testing "when access is limited to a single card, access only it #5015"
     (do-game
@@ -382,8 +382,8 @@
       (run-continue state)
       (is (= ["Pay 5 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "Pay 5 [Credits] to trash")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner))
       (is (nil? (get-run)))))
   (testing "when a card is turned facedown mid-access"
     (do-game
@@ -408,8 +408,8 @@
       (is (= "You accessed Bryan Stinson." (:msg (prompt-map :runner))))
       (is (= ["Pay 5 [Credits] to trash" "No action"] (prompt-buttons :runner)))
       (click-prompt state :runner "No action")
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner))
       (is (nil? (get-run)))))
   (testing "stealing multiple agendas from archives"
       (do-game
@@ -469,8 +469,8 @@
       (run-on state "Server 1")
       (core/access-bonus state :runner :total -1)
       (run-continue state)
-      (is (empty? (:prompt (get-corp))))
-      (is (empty? (:prompt (get-runner))) "Runner has no access prompt")
+      (is (no-prompt? state :corp))
+      (is (no-prompt? state :runner) "Runner has no access prompt")
       (is (nil? (get-run)))))
   (testing "Looping Ganked! and Ansel"
     (do-game

--- a/test/clj/game/core/actions_test.clj
+++ b/test/clj/game/core/actions_test.clj
@@ -170,6 +170,6 @@
       (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters")
       (core/command-counter state :corp [4])
       (click-card state :corp (refresh hok-scored)) ;; doesn't crash with unknown counter type
-      (is (empty? (:prompt (get-corp))) "Counter prompt closed")
+      (is (no-prompt? state :corp) "Counter prompt closed")
       (is (= 4 (get-counters (refresh hok-scored) :agenda)) "House of Knives should have 4 agenda counters")
       (is (= 2 (get-counters (refresh hok-scored) :virus)) "House of Knives should have 2 virus counters"))))

--- a/test/clj/game/core/rules_test.clj
+++ b/test/clj/game/core/rules_test.clj
@@ -464,11 +464,11 @@
          (run-jackson)
          (is (changes-credits (get-runner) 1 ; triggering Aeneas should grant a credit
                               (click-prompt state :runner "Yes")))
-         (is (empty? (:prompt (get-runner))) "No Aeneas prompt displaying")
+         (is (no-prompt? state :runner) "No Aeneas prompt displaying")
          (run-jackson)
          (is (changes-credits (get-runner) 0 ; not triggering Aeneas should not grant a credit
                               (click-prompt state :runner "No")))
-         (is (empty? (:prompt (get-runner))) "No Aeneas prompt displaying")
+         (is (no-prompt? state :runner) "No Aeneas prompt displaying")
          (card-ability state :runner (get-aeneas1) 0)
          (click-prompt state :runner "Ask"))
        ;; if aeneas is set to always/never fire, we should get to run without being prompted
@@ -476,23 +476,23 @@
        (click-prompt state :runner "Never")
        (is (changes-credits (get-runner) 0
                             (run-jackson)))
-       (is (empty? (:prompt (get-runner))) "No Aeneas prompt displaying")
+       (is (no-prompt? state :runner) "No Aeneas prompt displaying")
        (card-ability state :runner (get-aeneas1) 0)
        (click-prompt state :runner "Always")
        (is (changes-credits (get-runner) 1
                             (run-jackson)))
-       (is (empty? (:prompt (get-runner))) "No Aeneas prompt displaying")
+       (is (no-prompt? state :runner) "No Aeneas prompt displaying")
        ;; should also be able to play a new aeneas which doesn't care about the first one's autoresolve
        (play-from-hand state :runner "Aeneas Informant")
        (is (changes-credits (get-runner) 2
                             (do (run-jackson)
                                 (click-prompt state :runner "Yes"))))
-       (is (empty? (:prompt (get-runner))) "No Aeneas prompt displaying")
+       (is (no-prompt? state :runner) "No Aeneas prompt displaying")
        (card-ability state :runner (get-resource state 1) 0)
        (click-prompt state :runner "Never")
        (is (changes-credits (get-runner) 1
                             (run-jackson)))
-       (is (empty? (:prompt (get-runner))) "No Aeneas prompt displaying"))))
+       (is (no-prompt? state :runner) "No Aeneas prompt displaying"))))
   (testing "Fisk + FTT with and without autoresolve"
     (do-game
      (new-game {:corp {:deck [(qty "Archer" 30)]}
@@ -536,18 +536,18 @@
        ;; if either is set to 'never', we should not need simult event resolution
        (set-fisk-autoresolve "Ask")
        (set-ftt-autoresolve "Never")
-       (is (empty? (:prompt (get-runner))) "No prompts displaying")
+       (is (no-prompt? state :runner) "No prompts displaying")
        (run-empty-server state "Archives")
        (is (= "Laramy Fisk: Savvy Investor" (-> @state :runner :prompt first :card :title)) "Fisk prompt is open")
        (click-prompt state :runner "No")
-       (is (empty? (:prompt (get-runner))) "No prompts displaying")
+       (is (no-prompt? state :runner) "No prompts displaying")
        (pass-turn-runner-corp)
        ;; if one is 'never' and the other is 'always', still do not need simult resolution
        (set-fisk-autoresolve "Never")
        (set-ftt-autoresolve "Always")
        (run-empty-server state "Archives")
        (click-prompt state :runner "OK")
-       (is (empty? (:prompt (get-runner))) "No prompts displaying")
+       (is (no-prompt? state :runner) "No prompts displaying")
        (pass-turn-runner-corp)
        ;; if one is set to 'always', and the other to 'Ask' we do need simult event resolution
        (set-fisk-autoresolve "Always")
@@ -558,7 +558,7 @@
        (changes-val-macro 1 (count (get-in @state [:corp :hand]))
                           "Fisk triggers after closing FTT prompt"
                           (click-prompt state :runner "OK"))
-       (is (empty? (:prompt (get-runner))) "No prompts displaying"))))
+       (is (no-prompt? state :runner) "No prompts displaying"))))
   (testing "Ensure autoresolve does not break prompts with a :req"
     (do-game
      (new-game {:corp {:id "SSO Industries: Fueling Innovation"
@@ -569,12 +569,12 @@
        (toggle-sso "Always")
        (play-from-hand state :corp "Underway Renovation" "New remote")
        (take-credits state :corp)
-       (is (empty? (:prompt (get-corp))) "No prompts displaying, as conditions are not satisfied")
+       (is (no-prompt? state :corp) "No prompts displaying, as conditions are not satisfied")
        (take-credits state :runner)
        (play-from-hand state :corp "Ice Wall" "New remote")
        (toggle-sso "Never")
        (take-credits state :corp)
-       (is (empty? (:prompt (get-corp))) "No prompts displaying, as conditions are not satisfied")
+       (is (no-prompt? state :corp) "No prompts displaying, as conditions are not satisfied")
        (take-credits state :runner)
        (toggle-sso "Always")
        (take-credits state :corp)
@@ -583,10 +583,10 @@
            "SSO autoresolved first prompt")
        (click-card state :corp (get-ice state :remote2 0))
        (is (= 1 (get-counters (get-ice state :remote2 0) :advancement)) "A token was added")
-       (is (empty? (:prompt (get-corp))) "No prompt displaying")
+       (is (no-prompt? state :corp) "No prompt displaying")
        (take-credits state :runner)
        (take-credits state :corp)
-       (is (empty? (:prompt (get-corp))) "No prompt displaying, as conditions are not met"))))
+       (is (no-prompt? state :corp) "No prompt displaying, as conditions are not met"))))
   (testing "CtM autoresolve"
     (do-game
       (new-game {:corp {:id "NBN: Controlling the Message"
@@ -611,8 +611,8 @@
         (click-prompt state :runner "Pay 1 [Credits] to trash")
         (click-prompt state :corp "0")
         (click-prompt state :runner "0")
-        (is (empty? (:prompt (get-corp))) "No prompt displaying for Corp")
-        (is (empty? (:prompt (get-runner))) "No prompt displaying for Runner")))))
+        (is (no-prompt? state :corp) "No prompt displaying for Corp")
+        (is (no-prompt? state :runner) "No prompt displaying for Runner")))))
 
 (deftest no-scoring-after-terminal
   (do-game

--- a/test/clj/game/core/runs_test.clj
+++ b/test/clj/game/core/runs_test.clj
@@ -248,7 +248,7 @@
         (click-prompt state :runner "Account Siphon")
         (is (second-last-log-contains? state "Runner uses the replacement effect from Account Siphon")
             "Replacement effect is noted")
-        (is (empty? (:prompt (get-runner))) "No access, no replacement effects")))
+        (is (no-prompt? state :runner) "No access, no replacement effects")))
     (testing "and choosing to access cards"
       (do-game
         (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -263,7 +263,7 @@
             "Not choosing replacement effect is noted")
         (is (= "You accessed Hedge Fund." (:msg (prompt-map :runner))) "Normal access prompt")
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No access, no replacement effects"))))
+        (is (no-prompt? state :runner) "No access, no replacement effects"))))
   (testing "must replacement effects only"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -275,10 +275,10 @@
       (take-credits state :corp)
       (click-prompt state :runner "HQ")
       (run-empty-server state :hq)
-      (is (empty? (:prompt (get-runner))))
+      (is (no-prompt? state :runner))
       (is (second-last-log-contains? state "Runner uses the replacement effect from Security Testing")
           "Replacement effect is noted")
-      (is (empty? (:prompt (get-runner))) "No access, no replacement effects")))
+      (is (no-prompt? state :runner) "No access, no replacement effects")))
   (testing "'You may' and must replacement effects"
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -295,7 +295,7 @@
       (click-prompt state :runner "Account Siphon")
       (is (second-last-log-contains? state "Runner uses the replacement effect from Account Siphon")
           "Replacement effect is noted")
-      (is (empty? (:prompt (get-runner))) "No access, no replacement effects"))))
+      (is (no-prompt? state :runner) "No access, no replacement effects"))))
 
 (deftest buffered-continue
   (testing "Buffered continue on approaching ice"
@@ -565,7 +565,7 @@
         (click-prompt state :runner "No action")
         (is (= "You accessed Fire Wall." (-> (get-runner) :prompt first :msg)) "Accessed F")
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No more accesses")
+        (is (no-prompt? state :runner) "No more accesses")
         (is (= "DNA Tracker" (-> (get-corp) :deck first :title)) "D on top")))
     (testing "Drawing cards above the currently accessed card"
       (do-game
@@ -598,7 +598,7 @@
         (is (count (filter #(= "Brainstorm" %) (:hand (get-corp)))) "Drawn C")
         (is (= "You accessed Excalibur." (-> (get-runner) :prompt first :msg)) "Accessed E")
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No more accesses")
+        (is (no-prompt? state :runner) "No more accesses")
         (is (= "Chiyashi" (-> (get-corp) :deck first :title)) "C on top"))))
   (testing "Correct handling of multi accesses with shuffle in between accesses"
     (testing "Shuffle from Bacterial Programming"
@@ -641,7 +641,7 @@
         (click-prompt state :runner "No action")
         (is (= "You accessed DNA Tracker." (-> (get-runner) :prompt first :msg)) "Accessed D")
         (click-prompt state :runner "No action")
-        (is (empty? (:prompt (get-runner))) "No more accesses")
+        (is (no-prompt? state :runner) "No more accesses")
         (is (= "Advanced Assembly Lines" (-> (get-corp) :deck first :title)) "A on top")))
     (testing "Shuffle from paid ability during accesses"
       (do-game
@@ -681,7 +681,7 @@
                      (-> (get-runner) :prompt first :msg))
                   "Accessing top card of R&D")
               (click-prompt state :runner "No action")))
-          (is (empty? (:prompt (get-runner))) "No more accesses")))))
+          (is (no-prompt? state :runner) "No more accesses")))))
   (testing "Reordering cards during multi access"
     (testing "Reorder through Anansi sub"
       (do-game
@@ -728,7 +728,7 @@
           (click-prompt state :runner "No action")
           (is (= "You accessed Advanced Assembly Lines." (:msg (prompt-map :runner))) "Accessed A")
           (click-prompt state :runner "No action")
-          (is (empty? (:prompt (get-runner))) "No more accesses"))))))
+          (is (no-prompt? state :runner) "No more accesses"))))))
 
 (deftest forced-encounters
   (testing "Forced encounters - During run"
@@ -779,7 +779,7 @@
          (is (= (refresh iw) (core/get-current-ice state)) "The runner should be encountering Ice Wall")
          (is (not= (:msg (prompt-map :runner)) "You accessed Hedge Fund.") "Access paused while encounter is active")
          (fire-subs state (refresh iw))
-         (is (empty? (prompt-map :runner)) "Encounter has ended and not accessing additional cards")
+         (is (no-prompt? state :runner) "Encounter has ended and not accessing additional cards")
          (is (empty? (:run @state)) "The run has ended")
          (is (nil? (get-in @state [:end-run :ended])) "Ended status cleared")
          (is (-> @state :runner :register :accessed-cards) "The runner accessed cards this run")
@@ -814,7 +814,7 @@
          (is (= 2 (count (:encounters @state))))
          (is (not= (:msg (prompt-map :runner)) "You accessed Hedge Fund.") "Access paused while encounter is active")
          (fire-subs state (refresh iw))
-         (is (empty? (prompt-map :runner)) "Encounter has ended and not accessing additional cards")
+         (is (no-prompt? state :runner) "Encounter has ended and not accessing additional cards")
          (is (empty? (:run @state)) "The run has ended")
          (is (nil? (get-in @state [:end-run :ended])) "Ended status cleared")
          (is (-> @state :runner :register :accessed-cards) "The runner accessed cards this run")
@@ -840,7 +840,7 @@
           (is (core/get-current-encounter state) "The runner should be encountering an ice")
           (is (= (refresh iw) (core/get-current-ice state)) "The runner should be encountering Ice Wall")
           (fire-subs state (refresh iw))
-          (is (empty? (prompt-map :runner)) "Encounter has ended and not accessing additional cards")
+          (is (no-prompt? state :runner) "Encounter has ended and not accessing additional cards")
           (is (empty? (:run @state)) "The run has ended")))))
   (testing "Ice breakers and broken subroutines reset after a forced encounter ends"
     (do-game
@@ -915,7 +915,7 @@
           (is (= 2 (:current-strength (refresh cor))) "Corroder's strength reset to 2")
           (is (= 2 (:current-strength (refresh gord))) "Gordian Blade's strength reset to 2")
           (is (not (-> (refresh iw) :subroutines first :broken)) "Ice Wall's subroutine is no longer broken")
-          (is (empty? (prompt-map :runner)) "Encounter has ended"))))
+          (is (no-prompt? state :runner)) "Encounter has ended")))
     (testing "Forced encounters outside of a run end properly when an 'End the run' subroutine is fired"
       (do-game
         (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
@@ -947,7 +947,7 @@
           (fire-subs state (refresh le))
           (is (= 2 (:current-strength (refresh cor))) "Corroder's strength reset to 2")
           (is (not= 8 (@state :runner :credits)) "Little Engine's third subroutine should not have fired")
-          (is (empty? (prompt-map :runner)) "Encounter has ended")
+          (is (no-prompt? state :runner) "Encounter has ended")
           (is (nil? (get-in @state [:end-run :ended])) "Ended status cleared")
           (is (not (get-in @state [:runner :register :unsuccessful-run :remote1])) "Not a run"))))
     (testing "Forced encounters outside of a run end properly when a 'Jack out' event occurs"
@@ -978,7 +978,7 @@
           (is (last-log-contains? state "Runner encounters Little Engine protecting Server 1 at position 0.") "Encounter message sent")
           (card-ability state :runner fs 0)
           (is (not= 9 (@state :runner :credits)) "Little Engine's third subroutine should not have fired")
-          (is (empty? (prompt-map :runner)) "Encounter has ended")
+          (is (no-prompt? state :runner) "Encounter has ended")
           (is (nil? (get-in @state [:end-run :ended])) "Ended status cleared")
           (is (not (get-in @state [:runner :register :unsuccessful-run :remote1])) "Not a run")))))
   (testing "Forced Encounters - Redirection"

--- a/test/clj/game/core_test.clj
+++ b/test/clj/game/core_test.clj
@@ -7,7 +7,7 @@
             [game.core.ice :refer [active-ice?]]
             [game.utils :as utils :refer [server-card]]
             [game.core.eid :as eid]
-            [game.utils-test :refer [click-prompt error-wrapper is']]
+            [game.utils-test :refer [click-prompt error-wrapper is' no-prompt?]]
             [game.macros :refer [wait-for]]
             [jinteki.cards :refer [all-cards]]
             [jinteki.utils :as jutils]))
@@ -364,16 +364,12 @@
   ([state phase]
    (let [encounter (core/get-current-encounter state)]
      (is' (some? encounter) "There is an encounter happening")
-     (is' (or (empty? (get-in @state [:runner :prompt]))
-              (= :encounter (-> @state :runner :prompt first :prompt-type))) "No open prompts for the runner")
-     (is' (or (empty? (get-in @state [:corp :prompt]))
-              (= :encounter (-> @state :corp :prompt first :prompt-type))) "No open prompts for the corp")
+     (is' (no-prompt? state :runner) "No open prompts for the runner")
+     (is' (no-prompt? state :corp) "No open prompts for the corp")
      (is' (not (:no-action encounter)) "No player has pressed continue yet")
      (when (and (some? encounter)
-                (or (empty? (get-in @state [:runner :prompt]))
-                    (= :encounter (-> @state :runner :prompt first :prompt-type)))
-                (or (empty? (get-in @state [:corp :prompt]))
-                    (= :encounter (-> @state :corp :prompt first :prompt-type)))
+                (no-prompt? state :runner)
+                (no-prompt? state :corp)
                 (not (:no-action encounter)))
        (core/process-action "continue" state :corp nil)
        (core/process-action "continue" state :runner nil)
@@ -392,14 +388,14 @@
      (encounter-continue-impl state)
      (let [run (:run @state)]
        (is' (some? run) "There is a run happening")
-       (is' (empty? (get-in @state [:runner :prompt])) "No open prompts for the runner")
-       (is' (empty? (get-in @state [:corp :prompt])) "No open prompts for the corp")
+       (is' (no-prompt? state :runner) "No open prompts for the runner")
+       (is' (no-prompt? state :corp) "No open prompts for the corp")
        (is' (not (:no-action run)) "No player has pressed continue yet")
        (is' (not= :success (:phase run))
             "The run has not reached the server yet")
        (when (and (some? run)
-                  (empty? (get-in @state [:runner :prompt]))
-                  (empty? (get-in @state [:corp :prompt]))
+                  (no-prompt? state :runner)
+                  (no-prompt? state :corp)
                   (not (:no-action run))
                   (not= :success (:phase run)))
          (core/process-action "continue" state :corp nil)
@@ -447,8 +443,8 @@
                        (not (utils/same-card? ice (core/get-current-ice state)))))
               (not (and (= :movement (:phase (:run @state)))
                         (zero? (:position (:run @state)))))
-              (empty? (get-in @state [:runner :prompt]))
-              (empty? (get-in @state [:corp :prompt]))
+              (no-prompt? state :runner)
+              (no-prompt? state :corp)
               (not (:no-action (:run @state)))
               (not= :success (:phase (:run @state))))
     (run-continue-impl state))

--- a/test/clj/game/utils_test.clj
+++ b/test/clj/game/utils_test.clj
@@ -65,6 +65,12 @@
          (get-in prompt [:card :cid])
          (= (:cid card) (get-in prompt [:card :cid])))))
 
+(defn no-prompt?
+  [state side]
+  (let [prompt (get-prompt state side)]
+    (or (empty? prompt)
+        (= :run (:prompt-type prompt)))))
+
 (defn expect-type
   [type-name choice]
   (str "Expected a " type-name ", received [ " choice

--- a/test/clj/game/utils_test.clj
+++ b/test/clj/game/utils_test.clj
@@ -243,3 +243,17 @@
         :expected card#
         :message ~msg})
      found#))
+
+(defmethod assert-expr 'no-prompt?
+  [msg form]
+  `(let [state# ~(nth form 1)
+         side# ~(nth form 2)
+         prompt# (-> @state# side# :prompt)
+         prompt-type# (-> @state# side# :prompt :prompt-type)
+         found# ~form]
+     (do-report
+      {:type (if found# :pass :fail)
+       :actual (select-keys (first prompt#) [:msg :prompt-type])
+       :expected "No prompt or :prompt-type of :run"
+       :message ~msg})
+     found#))


### PR DESCRIPTION
This updates runs so we can trigger cards like Jak Sinclair and Out of the Ashes properly at the start of the Runner's turn. I did this in the same way we handle forced encounters where we put up a prompt of type `:run` which the UI client will recognize and display standard run controls.

I kept the flag on Jak Sinclair which stops before the start of turn triggers for manually triggering Jak, though it might be worth removing it entirely since it also triggers at start of turn.
I moved Out of the Ashes to trigger at start of turn instead of `:runner-phase-12` which I believe was done to get around the UI not displaying run controls if a prompt was active. This is no longer the case, so it can be triggered at the proper timing.

There is a lot of code churn that's around the introduction of a `no-prompt?` function for tests. A lot of tests check that prompts are cleared out, but would fail during a run or a forced encounter since we use the `:run` prompts.

fixes https://github.com/mtgred/netrunner/issues/5646
fixes https://github.com/mtgred/netrunner/issues/5953
fixes https://github.com/mtgred/netrunner/issues/6091
