### PR TITLE
Minor updates

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -877,7 +877,7 @@
 
 (defcard "GPI Net Tap"
   {:abilities [{:req (req (and (= :approach-ice (:phase run))
-                               (ice? current-ice) 
+                               (ice? current-ice)
                                (not (rezzed? current-ice))))
                 :label "expose approached ice"
                 :msg "expose the approached ice"
@@ -1074,6 +1074,7 @@
              :interactive (req true)
              :req (req (and (hardware? (:card context))
                             (first-event? state side :runner-install #(hardware? (:card (first %))))))
+             :msg "draw 1 card"
              :effect (effect (draw eid 1))}]})
 
 (defcard "Māui"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1555,7 +1555,8 @@
         {:interactive (req true)
          :optional
          {:req (req (<= 2 (count (filter ice? (all-installed state :corp)))))
-          :prompt "Swap ice with Tāo Salonga ability?"
+          :prompt "Swap ice with Tāo Salonga's ability?"
+          :waiting-prompt "the Runner to swap ice."
           :yes-ability
           {:prompt "Choose 2 ice"
            :choices {:req (req (and (installed? target)
@@ -1564,7 +1565,8 @@
                      :all true}
            :msg (msg "swap the positions of " (card-str state (first targets))
                      " and " (card-str state (second targets)))
-           :effect (req (swap-ice state side (first targets) (second targets)))}}}]
+           :effect (req (swap-ice state side (first targets) (second targets)))}
+          :no-ability {:effect (effect (system-msg "declines to use Tāo Salonga: Telepresence Magician"))}}}]
     {:events [(assoc swap-ability :event :agenda-scored)
               (assoc swap-ability :event :agenda-stolen)]}))
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2662,7 +2662,6 @@
                ; :effect (effect (system-msg (str "places 1 power token on " (:title card)))
                                  ; (add-counter card :power 1))}]
    :abilities [{:label "Manually place 1 power token"
-                :req (req (:run @state))
                 :effect (effect (system-msg (str "manually places 1 power token on " (:title card)))
                                 (add-counter card :power 1))}
                {:label "Shuffle back cards with [Trash] abilities"


### PR DESCRIPTION
Just a few minor updates I've noticed while playing or seen requested

1. Masterwork (v37) - Print message when it draws a card
2. Tāo Salonga - Display Waiting prompt for Corp. Print message if the Runner declines to use Tāo
3. The Back - Remove the Run requirement for manually adding counters for easier use until we can fully automate it