### PR TITLE
Changes Related to Azmari

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -758,6 +758,7 @@
 
 (defcard "Direct Access"
   {:makes-run true
+   ;;this :effect is used in card-init as a temporary solution for blanking IDs like Azmari or Ken Tenma before they can trigger
    :effect (req (doseq [s [:corp :runner]]
                   (disable-identity state s)))
    :on-play {:async true

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -758,16 +758,12 @@
 
 (defcard "Direct Access"
   {:makes-run true
+   :effect (req (doseq [s [:corp :runner]]
+                  (disable-identity state s)))
    :on-play {:async true
-             :effect (req (doseq [s [:corp :runner]]
-                            (disable-identity state s))
-                          (continue-ability
-                            state side
-                            {:prompt "Choose a server"
-                             :choices (req runnable-servers)
-                             :async true
-                             :effect (effect (make-run eid target card))}
-                            card nil))}
+             :prompt "Choose a server"
+             :choices (req runnable-servers)
+             :effect (effect (make-run eid target card))}
    :events [{:event :run-ends
              :unregister-once-resolved true
              :async true

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -274,23 +274,25 @@
 
 (defcard "Azmari EdTech: Shaping the Future"
   {:events [{:event :corp-turn-ends
-             :prompt "Name a Runner card type"
-             :choices ["Event" "Resource" "Program" "Hardware"]
-             :effect (effect (update! (assoc card :az-target target))
+             :prompt "Name a card type"
+             :choices ["Event" "Resource" "Program" "Hardware" "None"]
+             :effect (effect (update! (assoc card :card-target (if (= "None" target) nil target)))
                              (system-msg (str "uses Azmari EdTech: Shaping the Future to name " target)))}
             {:event :runner-install
-             :req (req (and (is-type? (:card context) (:az-target card))
+             :req (req (and (:card-target card)
+                            (is-type? (:card context) (:card-target card))
                             (not (:facedown context))))
              :async true
              :effect (effect (gain-credits :corp eid 2))
              :once :per-turn
-             :msg (msg "gain 2 [Credits] from " (:az-target card))}
+             :msg (msg "gain 2 [Credits] from " (:card-target card))}
             {:event :play-event
-             :req (req (is-type? (:card context) (:az-target card)))
+             :req (req (and (:card-target card)
+                            (is-type? (:card context) (:card-target card))))
              :async true
              :effect (effect (gain-credits :corp eid 2))
              :once :per-turn
-             :msg (msg "gain 2 [Credits] from " (:az-target card))}]})
+             :msg (msg "gain 2 [Credits] from " (:card-target card))}]})
 
 (defcard "Blue Sun: Powering the Future"
   {:flags {:corp-phase-12 (req (and (not (:disabled card))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -882,13 +882,13 @@
     {:on-install {:prompt "Choose a server"
                   :msg (msg "target " target)
                   :choices (req servers)
-                  :effect (effect (update! (assoc card :server-target target)))}
-     :leave-play (effect (update! (dissoc card :server-target)))
-     :abilities [(break-sub 1 1 "Code Gate" {:req (req (if (:server-target card)
-                                                         (#{(last (server->zone state (:server-target card)))} (target-server run))
+                  :effect (effect (update! (assoc card :card-target target)))}
+     :leave-play (effect (update! (dissoc card :card-target)))
+     :abilities [(break-sub 1 1 "Code Gate" {:req (req (if (:card-target card)
+                                                         (#{(last (server->zone state (:card-target card)))} (target-server run))
                                                          true))})
-                 (strength-pump 1 1 :end-of-encounter {:req (req (if (:server-target card)
-                                                                   (#{(last (server->zone state (:server-target card)))} (target-server run))
+                 (strength-pump 1 1 :end-of-encounter {:req (req (if (:card-target card)
+                                                                   (#{(last (server->zone state (:card-target card)))} (target-server run))
                                                                    true))})]}))
 
 (defcard "D4v1d"
@@ -1047,10 +1047,10 @@
 (defcard "Diwan"
   {:on-install {:prompt "Choose the server that this copy of Diwan is targeting:"
                 :choices (req servers)
-                :effect (effect (update! (assoc card :server-target target)))}
+                :effect (effect (update! (assoc card :card-target target)))}
    :constant-effects [{:type :install-cost
                        :req (req (let [serv (:server (second targets))]
-                                   (= serv (:server-target card))))
+                                   (= serv (:card-target card))))
                        :value 1}]
    :events [{:event :purge
              :async true
@@ -2055,11 +2055,11 @@
   {:on-install {:prompt "Choose a server for Plague"
                 :choices (req servers)
                 :msg (msg "target " target)
-                :req (req (not (get-in card [:special :server-target])))
-                :effect (effect (update! (assoc-in card [:special :server-target] target)))}
+                :req (req (not (:card-target card)))
+                :effect (effect (update! (assoc card :card-target target)))}
    :events [{:event :successful-run
              :req (req (= (zone->name (:server context))
-                          (get-in (get-card state card) [:special :server-target])))
+                          (:card-target (get-card state card))))
              :msg "gain 2 virus counters"
              :effect (effect (add-counter :runner card :virus 2))}]})
 
@@ -2466,18 +2466,18 @@
   (let [ability {:prompt "Choose a server for Tracker"
                  :choices (req servers)
                  :msg (msg "target " target)
-                 :req (req (not (:server-target card)))
-                 :effect (effect (update! (assoc card :server-target target)))}]
+                 :req (req (not (:card-target card)))
+                 :effect (effect (update! (assoc card :card-target target)))}]
     {:implemention "Doesn't preveent subroutine from resolving"
      :abilities [{:label "Make a run on targeted server"
                   :cost [:click 1 :credit 2]
-                  :req (req (some #(= (:server-target card) %) runnable-servers))
-                  :msg (msg "make a run on " (:server-target card) ". Prevent the first subroutine that would resolve from resolving")
+                  :req (req (some #(= (:card-target card) %) runnable-servers))
+                  :msg (msg "make a run on " (:card-target card) ". Prevent the first subroutine that would resolve from resolving")
                   :async true
-                  :effect (effect (make-run eid (:server-target card) card))}]
+                  :effect (effect (make-run eid (:card-target card) card))}]
      :events [(assoc ability :event :runner-turn-begins)
               {:event :runner-turn-ends
-               :effect (effect (update! (dissoc card :server-target)))}]}))
+               :effect (effect (update! (dissoc card :card-target)))}]}))
 
 (defcard "Tranquilizer"
   (let [action (req (add-counter state side card :virus 1)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1943,7 +1943,7 @@
                                 (not (used-this-turn? (:cid card) state))))
                  :msg (msg "target " target)
                  :effect (req (when (not= target "No server")
-                                (update! state side (assoc card :server-target target))))}]
+                                (update! state side (assoc card :card-target target))))}]
     {:abilities [ability]
      :events [(assoc ability :event :runner-turn-begins)
               (assoc
@@ -1954,14 +1954,14 @@
                     :async true
                     :effect (effect (draw eid 2))}})
                 :req (req (when-let [card (get-card state card)]
-                            (and (= (zone->name (:server context)) (:server-target card))
+                            (and (= (zone->name (:server context)) (:card-target card))
                                  (first-event? state side :successful-run
                                                (fn [targets]
                                                  (let [context (first targets)]
                                                    (= (zone->name (:server context))
-                                                      (:server-target card)))))))))
+                                                      (:card-target card)))))))))
               {:event :runner-turn-ends
-               :effect (effect (update! (dissoc (get-card state card) :server-target)))}]}))
+               :effect (effect (update! (dissoc (get-card state card) :card-target)))}]}))
 
 (defcard "Paule's Café"
   {:abilities [{:label "Host a program or piece of hardware"
@@ -2367,7 +2367,7 @@
                  :req (req (and (:runner-phase-12 @state)
                                 (not (used-this-turn? (:cid card) state))))
                  :effect (req (when (not= target "No server")
-                                (update! state side (assoc card :server-target target))))}]
+                                (update! state side (assoc card :card-target target))))}]
     {:events [(assoc ability :event :runner-turn-begins)
               (assoc
                 (successful-run-replace-breach
@@ -2377,15 +2377,15 @@
                     :async true
                     :effect (effect (gain-credits eid 2))}})
                 :req (req (when-let [card (get-card state card)]
-                            (and (= (zone->name (:server context)) (:server-target card))
+                            (and (= (zone->name (:server context)) (:card-target card))
                                  (first-event? state side :successful-run
                                                (fn [targets]
                                                  (let [context (first targets)]
                                                    (= (zone->name (:server context))
-                                                      (:server-target card)))))))))
+                                                      (:card-target card)))))))))
               {:event :runner-turn-ends
                :silent (req true)
-               :effect (effect (update! (dissoc card :server-target)))}]
+               :effect (effect (update! (dissoc card :card-target)))}]
      :abilities [ability]}))
 
 (defcard "Smartware Distributor"
@@ -2596,10 +2596,10 @@
    :on-install {:prompt "Choose a server for Temüjin Contract"
                 :choices (req servers)
                 :msg (msg "target " target)
-                :effect (effect (update! (assoc card :server-target target)))}
+                :effect (effect (update! (assoc card :card-target target)))}
    :events [(trash-on-empty :credit)
             {:event :successful-run
-             :req (req (= (zone->name (:server context)) (:server-target (get-card state card))))
+             :req (req (= (zone->name (:server context)) (:card-target (get-card state card))))
              :msg (msg "gain " (min 4 (get-counters card :credit)) " [Credits]")
              :async true
              :effect (req (let [credits (min 4 (get-counters card :credit))]

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -102,6 +102,7 @@
    :advanceable
    :advancementcost
    :agendapoints
+   :card-target
    :cid
    :code
    :corp-abilities
@@ -129,7 +130,6 @@
    :runner-abilities
    :seen
    :selected
-   :server-target
    :side
    :strength
    :subroutines

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -41,7 +41,7 @@
         c (dissoc card
                   :current-strength :current-advancement-requirement :current-points
                   :runner-abilities :corp-abilities :rezzed :new
-                  :subtype-target :server-target :extra-advance-counter :special)
+                  :subtype-target :card-target :extra-advance-counter :special)
         c (assoc c :subroutines (subroutines-init c cdef) :abilities (ability-init cdef))
         c (if keep-counter c (dissoc c :counter :advance-counter))]
     (map->Card c)))

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -46,7 +46,7 @@
                           (if (:rfg-instead-of-trashing cdef)
                             (assoc card :rfg-instead-of-trashing true)
                             card)
-                          {:resolve-effect false :init-data true})
+                          {:resolve-effect true :init-data true})
           play-event (if (= side :corp) :play-operation :play-event)]
       (queue-event state play-event {:card card :event play-event})
       (wait-for (checkpoint state nil (make-eid state eid) {:duration play-event})

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -46,7 +46,7 @@
                           (if (:rfg-instead-of-trashing cdef)
                             (assoc card :rfg-instead-of-trashing true)
                             card)
-                          {:resolve-effect true :init-data true})
+                          {:resolve-effect true :init-data true});;:resolve-effect is true as a temporary solution to allow Direct Access to blank IDs
           play-event (if (= side :corp) :play-operation :play-event)]
       (queue-event state play-event {:card card :event play-event})
       (wait-for (checkpoint state nil (make-eid state eid) {:duration play-event})

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -11,6 +11,7 @@
    agendapoints
    art
    baselink
+   card-target
    cid
    code
    corp-abilities
@@ -49,7 +50,6 @@
    runner-abilities
    seen
    selected
-   server-target
    set_code
    side
    special

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -666,7 +666,7 @@
 (defn card-view
   [{:keys [zone code type abilities counter
            subtypes strength current-strength title selected hosted
-           side facedown server-target icon new runner-abilities subroutines
+           side facedown card-target icon new runner-abilities subroutines
            corp-abilities]
     :as card} flipped disable-click]
   [:div.card-frame.menu-container
@@ -724,7 +724,7 @@
                (active? card))
       [:div.darkbg.strength (or current-strength strength)])
     (when-let [{:keys [char color]} icon] [:div.darkbg.icon {:class color} char])
-    (when server-target [:div.darkbg.server-target server-target])
+    (when card-target [:div.darkbg.card-target card-target])
     (when (active? card)
       (let [server-card (get @all-cards title)]
         [:div.darkbg.additional-subtypes

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -200,7 +200,7 @@
         &.green
             background-color: green-core
 
-    .server-target, .additional-subtypes
+    .card-target, .additional-subtypes
         position: absolute
         z-index: 10
         padding: 0
@@ -211,9 +211,6 @@
         right: 3px
         padding-left: 3px
         padding-right: 3px
-
-    .server-target
-        background-color: dark-gold
 
     .additional-subtypes
         background-color: gray-mid

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1494,10 +1494,24 @@
      (take-credits state :runner)
      (take-credits state :corp)
      (changes-val-macro
-       1 (count (:discard (get-corp)))
-       "Alice not permanently blanked"
-       (run-empty-server state "Archives")
-       (click-card state :corp (find-card "PAD Campaign" (:hand (get-corp))))))))
+      1 (count (:discard (get-corp)))
+      "Alice not permanently blanked"
+      (run-empty-server state "Archives")
+      (click-card state :corp (find-card "PAD Campaign" (:hand (get-corp)))))))
+  (testing "Blanks IDs before they can trigger #6108"
+    (do-game
+     (new-game {:corp {:id "Azmari EdTech: Shaping the Future"
+                       :deck [(qty "Hedge Fund" 5)]
+                       :hand [(qty "Hedge Fund" 5)]}
+                :runner {:id "Ken \"Express\" Tenma: Disappeared Clone"
+                         :hand ["Direct Access"]}})
+     (take-credits state :corp)
+     (click-prompt state :corp "Event")
+     (let [runner-credits (- (:credit (get-runner)) 1);; subtract 1 for the cost of Direct Access
+           corp-credits (:credit (get-corp))]
+       (play-from-hand state :runner "Direct Access")
+       (is (= runner-credits (:credit (get-runner))) "Ken did not trigger")
+       (is (= corp-credits (:credit (get-corp))) "Azmari did not trigger")))))
 
 (deftest dirty-laundry
   ;; Dirty Laundry - Gain 5 credits at the end of the run if it was successful

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -479,7 +479,7 @@
         (run-continue state)
         (card-ability state :runner (refresh boom) 0)
         (is (not-empty (:prompt (get-runner))) "Can use Boomerang on ice"))))
-  (testing "Update server-target on ice swap"
+  (testing "Update card-target on ice swap"
     (do-game
       (new-game {:runner {:deck ["Boomerang"]}
                  :corp {:deck ["Ice Wall" "Thimblerig"]}})
@@ -496,7 +496,7 @@
           (take-credits state :runner)
           (click-prompt state :corp "Yes")
           (click-card state :corp (refresh icew))))))
-  (testing "Update server-target on ice trash"
+  (testing "Update card-target on ice trash"
     (do-game
       (new-game {:runner {:deck ["Boomerang"]}
                  :corp {:deck ["Ice Wall"]}})
@@ -508,7 +508,7 @@
         (click-card state :runner icew)
         (let [boom (get-hardware state 0)]
           (trash state :runner icew)
-          (is (nil? (:server-target (refresh boom))) "No more target message")
+          (is (nil? (:card-target (refresh boom))) "No more target message")
           (is (some? (get-in (refresh boom) [:special :boomerang-target])) "Still targetting a card")))))
   (testing "Does not fire on Crisium runs. Issue #4734"
     (do-game

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3526,13 +3526,13 @@
       (click-prompt state :runner "Temüjin Contract")
       (click-card state :runner (get-content state :remote1 0))
       (click-prompt state :runner "No action")
-      (is (= "HQ" (:server-target (get-resource state 0))) "Temujin still targeting HQ")
+      (is (= "HQ" (:card-target (get-resource state 0))) "Temujin still targeting HQ")
       (is (= 16 (get-counters (get-resource state 0) :credit)) "16 cr on Temujin")
       (is (= 8 (:credit (get-runner))) "Gained 4cr")
       ;; second run
       (run-empty-server state :hq)
       (click-prompt state :runner "No action")
-      (is (= "HQ" (:server-target (get-resource state 0))) "Temujin still targeting HQ")
+      (is (= "HQ" (:card-target (get-resource state 0))) "Temujin still targeting HQ")
       (is (= 12 (:credit (get-runner))) "Gained 4cr")
       (is (= 12 (get-counters (get-resource state 0) :credit)) "12 cr on Temujin"))))
 


### PR DESCRIPTION
Added a "None" option for Azmari as a stand in for the Corp player choosing a non-Runner card type like Operation.

Updated usages of `:server-target` to be called `:card-target` so we can display persistent chosen information on cards other than cards that choose a server.

To fix the issue with Direct Access not blanking IDs before they can trigger, I took advantage of the `:resolve-effect` argument in `card-init` to trigger the disabling effect as soon as the card becomes active. Noah and I discussed that this might not be the best way to handle it in the long run, but is a decent solution for now.

resolves https://github.com/mtgred/netrunner/issues/6098
resolves https://github.com/mtgred/netrunner/issues/6105
fixes https://github.com/mtgred/netrunner/issues/6108