### PR TITLE
Prioritize non-silent handlers when resolving queued events

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1612,7 +1612,7 @@
      {:interactive (req true)
       :async true
       :effect (effect (show-wait-prompt (str (side-str (other-side side)) " to trash a card for Standoff"))
-                (continue-ability :runner (stand :runner) card nil))}}))
+                      (continue-ability :runner (stand :runner) card nil))}}))
 
 (defcard "Sting!"
   (letfn [(count-opp-stings [state side]

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -718,9 +718,9 @@
                                      (first non-silent)
                                      (first handlers))
                         ability-to-resolve (dissoc-req (:ability to-resolve))
-                        others (if (= 1 (count non-silent))
-                                 (remove-once #(= (get-cid to-resolve) (get-cid %)) handlers)
-                                 (rest handlers))]
+                        remaining-handlers (if (= 1 (count non-silent))
+                                             (remove-once #(= (get-cid to-resolve) (get-cid %)) handlers)
+                                             (rest handlers))]
                     (if-let [the-card (card-for-ability state to-resolve)]
                       {:async true
                        :effect (req (wait-for (resolve-ability state (to-keyword (:side the-card))
@@ -731,7 +731,7 @@
                                                 (unregister-event-by-uuid state side (:uuid to-resolve)))
                                               (if (should-continue state handlers)
                                                 (continue-ability state side
-                                                                  (choose-handler others) nil event-targets)
+                                                                  (choose-handler remaining-handlers) nil event-targets)
                                                 (effect-completed state side eid))))}
                       {:async true
                        :effect (req (if (should-continue state handlers)
@@ -890,12 +890,17 @@
                               non-silent)]
       (if (or (= 1 (count handlers))
               (empty? interactive)
-              (= 1 (count non-silent)))
-        (let [handler (first handlers)
+              (>= 1 (count non-silent)))
+        (let [handler (if (= 1 (count non-silent))
+                        (first non-silent)
+                        (first handlers))
               to-resolve (:handler handler)
               ability (:ability to-resolve)
               context (:context handler)
-              ability-card (card-for-ability state to-resolve)]
+              ability-card (card-for-ability state to-resolve)
+              remaining-handlers (if (= 1 (count non-silent))
+                                   (remove-once #(same-card? ability-card (card-for-ability state (:handler %))) handlers)
+                                   (rest handlers))]
           (if ability-card
             (wait-for (resolve-ability state (to-keyword (:side ability-card))
                                        (make-eid state (assoc eid :source ability-card :source-type :ability))
@@ -904,8 +909,8 @@
                                        context)
                       (when (:unregister-once-resolved to-resolve)
                         (unregister-event-by-uuid state side (:uuid to-resolve)))
-                      (trigger-queued-event-player state side eid (rest handlers) args))
-            (trigger-queued-event-player state side eid (rest handlers) args)))
+                      (trigger-queued-event-player state side eid remaining-handlers args))
+            (trigger-queued-event-player state side eid remaining-handlers args)))
         (continue-ability
           state side
           (when (pos? (count handlers))
@@ -925,8 +930,8 @@
                                                context)
                               (when (:unregister-once-resolved to-resolve)
                                 (unregister-event-by-uuid state side (:uuid to-resolve)))
-                              (let [handlers (remove-once #(same-card? target (card-for-ability state (:handler %))) handlers)]
-                                (trigger-queued-event-player state side eid handlers args)))))})
+                              (let [remaining-handlers (remove-once #(same-card? target (card-for-ability state (:handler %))) handlers)]
+                                (trigger-queued-event-player state side eid remaining-handlers args)))))})
           nil nil)))))
 
 (defn- is-player

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -711,9 +711,11 @@
                                                card (card-for-ability state %)]
                                            (and interactive-fn
                                                 (interactive-fn state side (make-eid state) card event-targets)))
-                                        handlers)]
+                                        non-silent)]
                 ;; If there is only 1 non-silent ability, resolve that then recurse on the rest
-                (if (or (= 1 (count handlers)) (empty? interactive) (>= 1 (count non-silent)))
+                (if (or (= 1 (count handlers))
+                        (empty? interactive)
+                        (<= (count non-silent) 1))
                   (let [to-resolve (if (= 1 (count non-silent))
                                      (first non-silent)
                                      (first handlers))
@@ -890,7 +892,7 @@
                               non-silent)]
       (if (or (= 1 (count handlers))
               (empty? interactive)
-              (>= 1 (count non-silent)))
+              (<= (count non-silent) 1))
         (let [handler (if (= 1 (count non-silent))
                         (first non-silent)
                         (first handlers))

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -3565,6 +3565,30 @@
         (is (= credits (:credit (get-corp))) "Corp should gain no credits from declining to trash an installed card")
         (is (zero? (-> (get-corp) :hand count)) "Corp should draw no cards from declining to trash an installed card"))))
 
+(deftest standoff-interactions-with-arella-salvatore
+  ;; Interactions with Arella Salvatore
+  (do-game
+   (new-game {:corp {:deck ["Standoff" "Arella Salvatore" "Ice Wall"]}
+              :runner {:deck ["Cache"]}})
+   (starting-hand state :corp ["Standoff" "Arella Salvatore"])
+   (play-from-hand state :corp "Arella Salvatore" "New remote")
+   (take-credits state :corp)
+   (play-from-hand state :runner "Cache")
+   (take-credits state :runner)
+   (play-from-hand state :corp "Standoff" "Server 1")
+   (starting-hand state :corp [])
+   (let [arella (get-content state :remote1 0)
+         standoff (get-content state :remote1 1)]
+     (rez state :corp (refresh arella))
+     (score-agenda state :corp (refresh standoff)))
+   (is (not (prompt-is-type? state :corp :choice)) "Arella is silent since no installable cards in hand")
+   (click-prompt state :runner "Done")
+   (is (= 1 (count (:hand (get-corp)))) "Standoff drew a card")
+   (click-card state :corp (find-card "Ice Wall" (:hand (get-corp))))
+   (click-prompt state :corp "Server 1")
+   (is (= 1 (count (get-ice state :remote1))) "Ice Wall installed protecting server 1")
+   (is (= 1 (get-counters (get-ice state :remote1 0) :advancement)) "Agenda has 1 advancement counter")))
+
 (deftest sting-corp-score-then-runner-steal-then-corp-score
     ;; Corp score, then Runner steal, then Corp score
     (do-game


### PR DESCRIPTION
Resolving queued events was not prioritizing non-silent handlers. Because of this, Arella was resolving before Standoff. I modified the code to act the same as `trigger-event-simult-player` where we will resolve non-silent handlers first before resolving any silent ones.

fixes https://github.com/mtgred/netrunner/issues/6078