### PR TITLE
Rework Pantograph

### DIFF
--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2996,46 +2996,50 @@
                                (card-ability state :runner inti 1)
                                (click-card state :runner omni))))))
 
-(deftest pantograph
-  ;; Pantograph - Gain 1 credit and may look at and move top card of Stack to bottom
+(deftest pantograph-trigger-on-steal
+  ;; Pantograph - Gain 1 credit and may install a card on steal
   (do-game
-      (new-game {:corp {:hand ["House of Knives"]}
-                 :runner {:hand ["Pantograph" "Bankroll"]}})
-      (take-credits state :corp)
-      (play-from-hand state :runner "Pantograph")
-      (is (= 5 (core/available-mu state)) "Gain 1 memory")
-      (run-empty-server state :hq)
-      (click-prompt state :runner "Steal")
-      (changes-val-macro
-        1 (:credit (get-runner))
-        "Gain 1 credit from Pantograph"
-        (click-prompt state :runner "Yes"))
-      (changes-val-macro
-        -1 (:credit (get-runner))
-        "Gain 1 credit from Pantograph"
-        (click-prompt state :runner "Yes")
-        (click-card state :runner (find-card "Bankroll" (:hand (get-runner)))))
-      (is (get-program state 0) "Bankroll is installed"))
-  (testing "Basic test - trigger on score"
-    (do-game
-      (new-game {:corp {:deck [(qty "Hedge Fund" 10)]
-                        :hand ["House of Knives"]}
-                 :runner {:hand ["Pantograph" "Bankroll"]}})
-      (play-from-hand state :corp "House of Knives" "New remote")
-      (take-credits state :corp)
-      (play-from-hand state :runner "Pantograph")
-      (take-credits state :runner)
-      (score-agenda state :corp (get-content state :remote1 0))
-      (changes-val-macro
-        1 (:credit (get-runner))
-        "Gain 1 credit from Pantograph"
-        (click-prompt state :runner "Yes"))
-      (changes-val-macro
-        -1 (:credit (get-runner))
-        "Gain 1 credit from Pantograph"
-        (click-prompt state :runner "Yes")
-        (click-card state :runner (find-card "Bankroll" (:hand (get-runner)))))
-      (is (get-program state 0) "Bankroll is installed"))))
+   (new-game {:corp {:hand [(qty "House of Knives" 3)]}
+              :runner {:hand ["Pantograph" "Bankroll"]}})
+   (take-credits state :corp)
+   (play-from-hand state :runner "Pantograph")
+   (is (= 5 (core/available-mu state)) "Gain 1 memory")
+   (run-empty-server state :hq)
+   (changes-val-macro
+    1 (:credit (get-runner))
+    "Gain 1 credit from Pantograph"
+    (click-prompt state :runner "Steal"))
+   (click-prompt state :runner "Done")
+   (run-empty-server state :hq)
+   (click-prompt state :runner "Steal")
+   (changes-val-macro
+    -1 (:credit (get-runner))
+    "Pay cost of Bankroll to install from Pantograph"
+    (click-card state :runner (find-card "Bankroll" (:hand (get-runner)))))
+   (is (get-program state 0) "Bankroll is installed")
+   (run-empty-server state :hq)
+   (click-prompt state :runner "Steal")
+   (is (no-prompt? state :runner) "No install prompt since no cards in hand")))
+
+(deftest pantograph-trigger-on-score
+  ;; Pantograph - Gain 1 credit and may install a card on score
+  (do-game
+   (new-game {:corp {:deck [(qty "Hedge Fund" 10)]
+                     :hand ["House of Knives"]}
+              :runner {:hand ["Pantograph" "Bankroll"]}})
+   (play-from-hand state :corp "House of Knives" "New remote")
+   (take-credits state :corp)
+   (play-from-hand state :runner "Pantograph")
+   (take-credits state :runner)
+   (changes-val-macro
+    1 (:credit (get-runner))
+    "Gain 1 credit from Pantograph"
+    (score-agenda state :corp (get-content state :remote1 0)))
+   (changes-val-macro
+    -1 (:credit (get-runner))
+    "Pay cost of Bankroll to install from Pantograph"
+    (click-card state :runner (find-card "Bankroll" (:hand (get-runner)))))
+   (is (get-program state 0) "Bankroll is installed")))
 
 (deftest paragon-vanilla-test
     ;; Vanilla test

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -4035,6 +4035,22 @@
         (play-from-hand state :runner "Penumbral Toolkit"))
       (is (= 3 (count (get-resource state))) "Installed all three cards")))
 
+(deftest penumbral-toolkit-install-cost-reduction-applies-during-success-phase
+  ;; install cost reduction applies during success phase
+  (do-game
+   (new-game {:corp {:hand ["Hostile Takeover"]}
+              :runner {:hand ["Penumbral Toolkit" "Pantograph"]}})
+   (take-credits state :corp)
+   (play-from-hand state :runner "Pantograph")
+   (run-empty-server state :hq)
+   (is (:successful (get-run)) "The Run is in the success phase")
+   (click-prompt state :runner "Steal")
+   (changes-val-macro
+    0 (:credit (get-runner))
+    "Cost reduction after run on HQ"
+    (click-card state :runner "Penumbral Toolkit"))
+   (is (= 1 (count (get-resource state))) "Installed Penumbral Toolkit")))
+
 (deftest penumbral-toolkit-pay-credits-prompt
     ;; Pay-credits prompt
     (do-game


### PR DESCRIPTION
I was looking into Issue #6133 and was unable to reproduce the issue. The cost reduction applied when installing Penumbral Toolkit through a Pantograph trigger. I wrote a test to make sure this continues to work in the future. As I was looking at this, I realized that Pantograph's ability could be streamlined to reduce the number of inputs needed per trigger, so I made those changes.

Pantograph changes:
1. Removed optional prompt for gaining a credit since gaining a credit is not optional 
2. Removed optional wrapper from the install ability as the select prompt itself is optional (clicking "Done")
3. Added message in the cancel function to indicate that the Runner declined to install a card

This reduced the number of inputs needed for Pantograph to just 1 per trigger.

resolves https://github.com/mtgred/netrunner/issues/6133