### PR TITLE
Corp Double Draw Issue

### DIFF
--- a/src/clj/game/core/drawing.clj
+++ b/src/clj/game/core/drawing.clj
@@ -53,6 +53,7 @@
                                    (min n (remaining-draws state side))
                                    n)
              deck-count (count (get-in @state [side :deck]))]
+         (swap! state update :bonus dissoc :draw);; clear bonus draws
          (when (and (= side :corp) (< deck-count draws-after-prevent))
            (win-decked state))
          (when (< draws-after-prevent draws-wanted)
@@ -69,7 +70,6 @@
                  drawn-count (count drawn)]
              (swap! state update-in [side :register :drawn-this-turn] (fnil #(+ % drawn-count) 0))
              (swap! state update-in [:stats side :gain :card] (fnil + 0) n)
-             (swap! state update :bonus dissoc :draw)
              (if suppress-event
                (effect-completed state side eid)
                (let [draw-event (if (= side :corp) :corp-draw :runner-draw)]

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -5409,6 +5409,23 @@
    (is (no-prompt? state :runner) "No prompt from The Class Act")
    (is (empty? (find-card "Sure Gamble" (:hand (:runner @state)))) "Sure Gamble has not been drawn")))
 
+(deftest the-class-act-no-lingering-bonus-draw-effect-if-no-cards-in-deck
+  ;; The Class Act - Issue #6132 - No lingering bonus draw effect if no cards in deck
+  (do-game
+   (new-game {:corp {:deck [(qty "Hedge Fund" 10)]}
+              :runner {:hand ["The Class Act", "Obelus"]
+                       :credits 10}})
+   (take-credits state :corp)
+   (click-card state :corp (first (:hand (get-corp))))
+   (play-from-hand state :runner "The Class Act")
+   (play-from-hand state :runner "Obelus")
+   (run-empty-server state :hq)
+   (click-prompt state :runner "No action")
+   (changes-val-macro
+    1 (count (:hand (get-corp)))
+    "Draw 1 card at the start of turn"
+    (take-credits state :runner))))
+
 (deftest the-helpful-ai
   ;; The Helpful AI - +1 link; trash to give an icebreaker +2 str until end of turn
   (do-game


### PR DESCRIPTION
fixes https://github.com/mtgred/netrunner/issues/6132

This issue was caused by the Runner triggering a draw with zero cards left in deck and The Class Act on the table. The Class Act's bonus draw would be applied but never cleared because draw would early out before clearing bonus draws from the state. This bonus would stay in the state until the Corp's mandatory draw.