### PR TITLE
Store last ice encounter info for a run

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -61,7 +61,7 @@
                         :yes-ability
                         {:effect (req (let [last-run (get-in @state [:runner :register :last-run])
                                             attacked-server (first (:server last-run))
-                                            ice (:last-encounter last-run)]
+                                            ice (:ice (ffirst (run-events last-run :encounter-ice)))]
                                         (update! state side (update card :special
                                                                     assoc
                                                                     :run-again attacked-server

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -48,9 +48,10 @@
              :async true
              :msg (msg "make a run on " target)
              :effect (req (wait-for (make-run state side target card)
-                                    (let [card (get-card state card)]
-                                      (if (get-in card [:special :run-again])
-                                        (make-run state side eid target card {:ignore-costs true})
+                                    (let [card (get-card state card)
+                                          run-again (get-in card [:special :run-again])]
+                                      (if run-again
+                                        (make-run state side eid run-again card {:ignore-costs true})
                                         (effect-completed state side eid)))))}
    :events [{:event :run-ends
              :optional {:req (req (and (not (get-in card [:special :run-again]))
@@ -59,15 +60,11 @@
                         :prompt "Make another run on the same server?"
                         :yes-ability
                         {:effect (req (let [last-run (get-in @state [:runner :register :last-run])
-                                            run-ice (get-in @state (concat [:corp :servers] (:server last-run) [:ices]))
-                                            pos (:position last-run)
-                                            ice (when (and pos
-                                                           (pos? pos)
-                                                           (<= pos (count run-ice)))
-                                                  (get-card state (nth run-ice (dec pos))))]
+                                            attacked-server (first (:server last-run))
+                                            ice (:last-encounter last-run)]
                                         (update! state side (update card :special
                                                                     assoc
-                                                                    :run-again true
+                                                                    :run-again attacked-server
                                                                     :run-again-ice ice))))}}}
             {:event :encounter-ice
              :once :per-run

--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -91,9 +91,11 @@
 ;; Functions for run event parsing
 (defn run-events
   "Returns the targets vectors of each run event with the given key that was triggered this run."
-  [state _ ev]
-  (when (:run @state)
-    (mapcat rest (filter #(= ev (first %)) (get-in @state [:run :events])))))
+  ([state _ ev]
+   (when (:run @state)
+     (run-events (:run @state) ev)))
+  ([run ev]
+   (mapcat rest (filter #(= ev (first %)) (:events run)))))
 
 (defn no-run-event?
   "Returns true if the given run event has not happened yet this run.

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -306,6 +306,8 @@
   [state side eid ice]
   (swap! state update :encounters conj {:eid eid
                                         :ice ice})
+  (when (:run @state)
+    (swap! state assoc-in [:run :last-encounter] ice))
   (check-auto-no-action state)
   (let [on-encounter (:on-encounter (card-def ice))]
     (system-msg state :runner (str "encounters " (card-str state ice {:visible (active-ice? state ice)})))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -306,8 +306,6 @@
   [state side eid ice]
   (swap! state update :encounters conj {:eid eid
                                         :ice ice})
-  (when (:run @state)
-    (swap! state assoc-in [:run :last-encounter] ice))
   (check-auto-no-action state)
   (let [on-encounter (:on-encounter (card-def ice))]
     (system-msg state :runner (str "encounters " (card-str state ice {:visible (active-ice? state ice)})))


### PR DESCRIPTION
fixes https://github.com/mtgred/netrunner/issues/6092

In addition, fixed Always Have a Backup Plan to make the second run on whatever server the last run was currently on. This matters if the run is redirected to another server.

Ruling
>If the first run with Always Have a Backup Plan is deflected to a new server, which server does the Runner run the second time?
"The second run is made against the server that is being attacked when the first run ends."
