### PR TITLE
Only show format legal IDs for Rebirth

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2,6 +2,7 @@
   (:require [game.core :refer :all]
             [game.utils :refer :all]
             [jinteki.utils :refer :all]
+            [jinteki.validator :refer [legal?]]
             [clojure.string :as string]
             [clojure.set :as set]))
 
@@ -2368,12 +2369,15 @@
     :rfg-instead-of-trashing true
     :choices (req (let [is-draft-id? #(.startsWith (:code %) "00")
                         runner-identity (:identity runner)
+                        format (:format @state)
                         is-swappable #(and (= "Identity" (:type %))
                                            (= (:faction runner-identity) (:faction %))
                                            (not (is-draft-id? %))
-                                           (not= (:title runner-identity) (:title %)))
+                                           (not= (:title runner-identity) (:title %))
+                                           (or (= :casual format)
+                                               (legal? format :legal %)))
                         swappable-ids (filter is-swappable (server-cards))]
-                    (cancellable swappable-ids :sorted)))
+                    (sort-by :title swappable-ids)))
     :msg "change identities"
     :effect (req (let [old-runner-identity (:identity runner)]
                    ;; Handle hosted cards (Ayla) - Part 1

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -6,6 +6,7 @@
             [game.core-test :refer :all]
             [game.utils-test :refer :all]
             [game.macros-test :refer :all]
+            [jinteki.validator :refer [legal?]]
             [clojure.test :refer :all]))
 
 (deftest account-siphon-use-ability
@@ -4618,7 +4619,7 @@
     (click-card state :runner "Hostile Takeover")
     (click-prompt state :runner "Steal")))
 
-;; rebirth
+;; Rebirth
 (let [akiko "Akiko Nisei: Head Case"
       kate "Kate \"Mac\" McCaffrey: Digital Tinker"
       kit "Rielle \"Kit\" Peddler: Transhuman"
@@ -4627,130 +4628,151 @@
       chaos "Chaos Theory: Wünderkind"
       whizzard "Whizzard: Master Gamer"
       reina "Reina Roja: Freedom Fighter"]
-  (deftest rebirth
+  (deftest rebirth-kate-discount
     ;; Rebirth - Kate's discount applies after rebirth
-    (testing "Kate"
-      (do-game
-        (new-game {:runner {:id professor
-                            :deck ["Magnum Opus" "Rebirth"]}
-                   :options {:start-as :runner}})
-        (play-from-hand state :runner "Rebirth")
-        (is (= (first (prompt-titles :runner)) akiko) "List is sorted")
-        (is (every? #(some #{%} (prompt-titles :runner))
-                    [kate kit]))
-        (is (not-any? #(some #{%} (prompt-titles :runner))
-                      [professor whizzard jamie]))
-        (click-prompt state :runner kate)
-        (is (= kate (-> (get-runner) :identity :title)))
-        (is (= 1 (get-link state)) "1 link")
-        (is (empty? (:discard (get-runner))))
-        (is (= "Rebirth" (-> (get-runner) :rfg first :title)))
-        (is (changes-credits (get-runner) -4
-                             (play-from-hand state :runner "Magnum Opus")))))
-    (testing "Whizzard works after rebirth"
-      (do-game
-        (new-game {:corp {:deck ["Ice Wall"]}
-                   :runner {:id reina
-                            :deck ["Rebirth"]}})
-        (play-from-hand state :corp "Ice Wall" "R&D")
-        (take-credits state :corp)
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner whizzard)
-        (card-ability state :runner (:identity (get-runner)) 0)
-        (is (= 6 (:credit (get-runner))) "Took a Whizzard credit")
-        (is (changes-credits (get-corp) -1
-                             (rez state :corp (get-ice state :rd 0)))
-            "Reina is no longer active")))
-    (testing "Lose link from ID"
-      (do-game
-        (new-game {:runner {:id kate
-                            :deck ["Rebirth" "Access to Globalsec"]}
-                   :options {:start-as :runner}})
-        (play-from-hand state :runner "Access to Globalsec")
-        (is (= 2 (get-link state)) "2 link before rebirth")
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner chaos)
-        (is (= 1 (get-link state)) "1 link after rebirth")))
-    (testing "Gain link from ID"
-      (do-game
-        (new-game {:runner {:id professor
-                            :deck ["Rebirth" "Access to Globalsec"]}
-                   :options {:start-as :runner}})
-        (play-from-hand state :runner "Access to Globalsec")
-        (is (= 1 (get-link state)) "1 link before rebirth")
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner kate)
-        (is (= 2 (get-link state)) "2 link after rebirth")))
-    (testing "Implementation notes are kept, regression test for #3722"
-      (do-game
-        (new-game {:runner {:id professor
-                            :deck ["Rebirth"]}
-                   :options {:start-as :runner}})
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner chaos)
-        (is (= :full (get-in (get-runner) [:identity :implementation])) "Implementation note kept as `:full`")))
-  (testing "Rebirth into Kate twice"
-    ;; Rebirth - Kate does not give discount after rebirth if Hardware or Program already installed
-    (testing "Installing Hardware before does prevent discount"
-      (do-game
-        (new-game {:runner {:id professor
-                            :deck ["Akamatsu Mem Chip" "Rebirth" "Clone Chip"]}
-                   :options {:start-as :runner}})
-        (play-from-hand state :runner "Clone Chip")
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner kate)
-        (is (= kate (get-in (get-runner) [:identity :title])) "Rebirthed into Kate")
-        (is (changes-credits (get-runner) -1
-                             (play-from-hand state :runner "Akamatsu Mem Chip"))
-            "Discount not applied for 2nd install")))
-    (testing "Installing Resource before does not prevent discount"
-      (do-game
-        (new-game {:runner {:id professor
-                            :deck ["Akamatsu Mem Chip" "Rebirth" "Same Old Thing"]}
-                   :options {:start-as :runner}})
-        (play-from-hand state :runner "Same Old Thing")
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner kate)
-        (is (= kate (get-in (get-runner) [:identity :title])) "Rebirthed into Kate")
-        (is (changes-credits (get-runner) 0
-                             (play-from-hand state :runner "Akamatsu Mem Chip"))
-            "Discount is applied for 2nd install (since it is the first Hardware / Program)"))))
-  (testing "Rebirth into Reina twice"
-    ;; Rebirth - Reina does not increase rez cost after rebirth if Ice already rezzed
-    (testing "Rezzing Ice before does prevent cost"
-      (do-game
-        (new-game {:corp {:deck [(qty "Ice Wall" 2)]}
-                   :runner {:id whizzard
-                            :deck ["Rebirth"]}})
-        (play-from-hand state :corp "Ice Wall" "HQ")
-        (play-from-hand state :corp "Ice Wall" "R&D")
-        (take-credits state :corp)
-        (is (changes-credits (get-corp) -1
-                             (rez state :corp (get-ice state :hq 0)))
-            "Only pay 1 to rez ice wall when against Whizzard")
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner reina)
-        (is (= reina (get-in (get-runner) [:identity :title])) "Rebirthed into Reina")
-        (is (changes-credits (get-corp) -1
-                             (rez state :corp (get-ice state :rd 0)))
-            "Additional cost from Reina not applied for 2nd ice rez")))
-    (testing "Rezzing Asset before does not prevent additional cost"
-      (do-game
-        (new-game {:corp {:deck ["Ice Wall" "Mark Yale"]}
-                   :runner {:id whizzard
-                            :deck ["Rebirth"]}})
-        (play-from-hand state :corp "Ice Wall" "HQ")
-        (play-from-hand state :corp "Mark Yale" "New remote")
-        (take-credits state :corp)
-        (is (changes-credits (get-corp) -1
-                             (rez state :corp (get-content state :remote1 0)))
-            "Only pay 1 to rez Mark Yale")
-        (play-from-hand state :runner "Rebirth")
-        (click-prompt state :runner reina)
-        (is (= reina (get-in (get-runner) [:identity :title])) "Rebirthed into Reina")
-        (is (changes-credits (get-corp) -2
-                             (rez state :corp (get-ice state :hq 0)))
-            "Additional cost from Reina applied for 1st ice rez"))))))
+    (do-game
+     (new-game {:runner {:id professor
+                         :deck ["Magnum Opus" "Rebirth"]}
+                :options {:start-as :runner}})
+     (play-from-hand state :runner "Rebirth")
+     (is (= (first (prompt-titles :runner)) akiko) "List is sorted")
+     (is (every? #(some #{%} (prompt-titles :runner))
+                 [kate kit]))
+     (is (not-any? #(some #{%} (prompt-titles :runner))
+                   [professor whizzard jamie]))
+     (click-prompt state :runner kate)
+     (is (= kate (-> (get-runner) :identity :title)))
+     (is (= 1 (get-link state)) "1 link")
+     (is (empty? (:discard (get-runner))))
+     (is (= "Rebirth" (-> (get-runner) :rfg first :title)))
+     (is (changes-credits (get-runner) -4
+                          (play-from-hand state :runner "Magnum Opus")))))
+
+  (deftest rebirth-kate-install-hardware-before-prevents-discount
+    ;; Rebirth - Installing Hardware before does prevent Kate's discount"
+    (do-game
+     (new-game {:runner {:id professor
+                         :deck ["Akamatsu Mem Chip" "Rebirth" "Clone Chip"]}
+                :options {:start-as :runner}})
+     (play-from-hand state :runner "Clone Chip")
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner kate)
+     (is (= kate (get-in (get-runner) [:identity :title])) "Rebirthed into Kate")
+     (is (changes-credits (get-runner) -1
+                          (play-from-hand state :runner "Akamatsu Mem Chip"))
+         "Discount not applied for 2nd install")))
+
+  (deftest rebirth-kate-install-resource-before-get-discount
+    ;; Rebirth - Installing Resource before does not prevent Kate's discount
+    (do-game
+     (new-game {:runner {:id professor
+                         :deck ["Akamatsu Mem Chip" "Rebirth" "Same Old Thing"]}
+                :options {:start-as :runner}})
+     (play-from-hand state :runner "Same Old Thing")
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner kate)
+     (is (= kate (get-in (get-runner) [:identity :title])) "Rebirthed into Kate")
+     (is (changes-credits (get-runner) 0
+                          (play-from-hand state :runner "Akamatsu Mem Chip"))
+         "Discount is applied for 2nd install (since it is the first Hardware / Program)")))
+
+  (deftest rebirth-whizzard
+    ;; Rebirth - Whizzard works after rebirth
+    (do-game
+     (new-game {:corp {:deck ["Ice Wall"]}
+                :runner {:id reina
+                         :deck ["Rebirth"]}})
+     (play-from-hand state :corp "Ice Wall" "R&D")
+     (take-credits state :corp)
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner whizzard)
+     (card-ability state :runner (:identity (get-runner)) 0)
+     (is (= 6 (:credit (get-runner))) "Took a Whizzard credit")
+     (is (changes-credits (get-corp) -1
+                          (rez state :corp (get-ice state :rd 0)))
+         "Reina is no longer active")))
+
+  (deftest rebirth-lose-link
+    ;; Rebirth - Lose link from ID
+    (do-game
+     (new-game {:runner {:id kate
+                         :deck ["Rebirth" "Access to Globalsec"]}
+                :options {:start-as :runner}})
+     (play-from-hand state :runner "Access to Globalsec")
+     (is (= 2 (get-link state)) "2 link before rebirth")
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner chaos)
+     (is (= 1 (get-link state)) "1 link after rebirth")))
+
+  (deftest rebirth-gain-link
+    ;; Rebirth - Gain link from ID
+    (do-game
+     (new-game {:runner {:id professor
+                         :deck ["Rebirth" "Access to Globalsec"]}
+                :options {:start-as :runner}})
+     (play-from-hand state :runner "Access to Globalsec")
+     (is (= 1 (get-link state)) "1 link before rebirth")
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner kate)
+     (is (= 2 (get-link state)) "2 link after rebirth")))
+
+  (deftest rebirth-implementation-notes
+    ;; Rebirth - Implementation notes are kept, regression test for #3722
+    (do-game
+     (new-game {:runner {:id professor
+                         :deck ["Rebirth"]}
+                :options {:start-as :runner}})
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner chaos)
+     (is (= :full (get-in (get-runner) [:identity :implementation])) "Implementation note kept as `:full`")))
+
+  (deftest rebirth-reina-rezzing-ice-before-prevents-additional-cost
+    ;; Rebirth - Rezzing Ice before prevents Reina's additional cost
+    (do-game
+     (new-game {:corp {:deck [(qty "Ice Wall" 2)]}
+                :runner {:id whizzard
+                         :deck ["Rebirth"]}})
+     (play-from-hand state :corp "Ice Wall" "HQ")
+     (play-from-hand state :corp "Ice Wall" "R&D")
+     (take-credits state :corp)
+     (is (changes-credits (get-corp) -1
+                          (rez state :corp (get-ice state :hq 0)))
+         "Only pay 1 to rez ice wall when against Whizzard")
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner reina)
+     (is (= reina (get-in (get-runner) [:identity :title])) "Rebirthed into Reina")
+     (is (changes-credits (get-corp) -1
+                          (rez state :corp (get-ice state :rd 0)))
+         "Additional cost from Reina not applied for 2nd ice rez")))
+
+  (deftest rebirth-reina-rezzing-asset-before-get-additional-cost
+    ;; Rebirth - Rezzing Asset before does not prevent Reina's additional cost
+    (do-game
+     (new-game {:corp {:deck ["Ice Wall" "Mark Yale"]}
+                :runner {:id whizzard
+                         :deck ["Rebirth"]}})
+     (play-from-hand state :corp "Ice Wall" "HQ")
+     (play-from-hand state :corp "Mark Yale" "New remote")
+     (take-credits state :corp)
+     (is (changes-credits (get-corp) -1
+                          (rez state :corp (get-content state :remote1 0)))
+         "Only pay 1 to rez Mark Yale")
+     (play-from-hand state :runner "Rebirth")
+     (click-prompt state :runner reina)
+     (is (= reina (get-in (get-runner) [:identity :title])) "Rebirthed into Reina")
+     (is (changes-credits (get-corp) -2
+                          (rez state :corp (get-ice state :hq 0)))
+         "Additional cost from Reina applied for 1st ice rez")))
+
+  (deftest rebirth-only-legal-identities
+    ;; Rebirth - Only shows legal IDs
+    (do-game
+     (new-game {:runner {:id reina
+                         :hand ["Rebirth"]}
+                :options {:format :standard}})
+     (take-credits state :corp)
+     (play-from-hand state :runner "Rebirth")
+     (is (every? #(legal? :standard :legal %) (prompt-buttons :runner)) "Only legal IDs are available"))))
 
 (deftest reboot-happy-path
     ;; Happy Path


### PR DESCRIPTION
Same solution I implemented for DJ Fenris. I also removed the Cancel button from the list of options. Once played you have to choose an ID and clicking Cancel does not undo the click, so I figured I would just remove the option entirely. It would be nice to have baked in Cancel options for cards like this that would return the card to hand and maybe not even hit the table until you've chosen a valid option, but if players will have to rely on `/undo-click` anyway I figure it's better to just remove the option.