### PR TITLE
Card Border UI Tweak

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -673,11 +673,11 @@
     :as card} flipped disable-click]
   (let [title (get-title card)]
     [:div.card-frame.menu-container
-     [:div.blue-shade.card {:class (str (when selected "selected")
-                                        (when (or new
-                                                  (playable? card)) " new")
-                                        (when (same-card? card (-> @game-state :encounters :ice)) " encountered")
-                                        (when (same-card? card (:button @app-state)) " hovered"))
+     [:div.blue-shade.card {:class (str (cond selected "selected"
+                                              (same-card? card (:button @app-state)) "hovered"
+                                              (same-card? card (-> @game-state :encounters :ice)) "encountered"
+                                              (playable? card) "playable"
+                                              new "new"))
                             :tab-index (when (and (not disable-click)
                                                   (or (active? card)
                                                       (playable? card)))
@@ -826,18 +826,12 @@
     (= (:_id user) (-> @app-state :user :_id))))
 
 (defn build-hand-card-view
-  [hand size prompt-state wrapper-class]
+  [hand size wrapper-class]
   [:div
    (doall (map-indexed
             (fn [i card]
               [:div {:key (or (:cid card) i)
-                     :class (str
-                              (if (and (not= "select" (:prompt-type @prompt-state))
-                                       (not (:selected card))
-                                       (playable? card))
-                                "playable" "")
-                              " "
-                              wrapper-class)
+                     :class (str wrapper-class)
                      :style {:left (when (< 1 size) (* (/ 320 (dec size)) i))}}
                (cond
                  (spectator-view-hidden?)
@@ -857,7 +851,7 @@
          [:div.hand-controls
           [:div.panel.blue-shade.hand
            (drop-area (if (= :corp side) "HQ" "Grip") {:class (when (> size 6) "squeeze")})
-           [build-hand-card-view filled-hand size prompt-state "card-wrapper"]
+           [build-hand-card-view filled-hand size "card-wrapper"]
            [label filled-hand {:opts {:name (if (= :corp side)
                                               (tr [:game.hq "HQ"])
                                               (tr [:game.grip "Grip"]))
@@ -873,7 +867,7 @@
              [:label (tr [:game.card-count] size)]
              (let [{:keys [total]} @hand-size]
                (stat-controls :hand-size [:div.hand-size (str total " " (tr [:game.max-hand "Max hand size"]))]))
-             [build-hand-card-view filled-hand size prompt-state "card-popup-wrapper"]]])]))))
+             [build-hand-card-view filled-hand size "card-popup-wrapper"]]])]))))
 
 (defn show-deck [event ref]
   (-> ((keyword (str ref "-content")) @board-dom) js/$ .fadeIn)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -103,15 +103,20 @@
         }
     }
 
+    .card.playable
+        box-shadow(0 0 1px 2px gold-base)
+        animation: none
+        
     .card.hovered
         animation: hovered-card 1s cubic-bezier(0.25,1,0.5,1) forwards
         border-color: blue-light
     
     .card
-        &:focus
-            animation: hovered-card 1s cubic-bezier(0.25,1,0.5,1) forwards
-            border-color: blue-light
-            
+        &:not(.selected)
+            &:focus
+                box-shadow(0 0 1px 2px blue-light)
+                animation: none
+        
     .counters
         position: absolute
         top: 0


### PR DESCRIPTION
Just a small tweak to how we draw different colored borders around cards. I noticed that the green selected border was being overridden by a couple of other colors so I changed it so it would always take top priority. It was especially annoying when using cards like Sprint where it could be hard to tell if you had a card selected or not.