### PR TITLE
Fix Psych Mike trigger and optional ability

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2115,9 +2115,8 @@
 
 (defcard "Psych Mike"
   {:events [{:event :run-ends
-             :req (req (and (:successful target)
-                            (first-event? state side :run-ends #(and (= :rd (target-server (first %)))
-                                                                     (:successful (first %))))))
+             :req (req (and (= :rd (target-server context))
+                            (first-successful-run-on-server? state :rd)))
              :msg (msg "gain " (total-cards-accessed target :deck) " [Credits]")
              :async true
              :effect (effect (gain-credits :runner eid (total-cards-accessed target :deck)))}]})

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2115,11 +2115,15 @@
 
 (defcard "Psych Mike"
   {:events [{:event :run-ends
-             :req (req (and (= :rd (target-server context))
-                            (first-successful-run-on-server? state :rd)))
-             :msg (msg "gain " (total-cards-accessed target :deck) " [Credits]")
-             :async true
-             :effect (effect (gain-credits :runner eid (total-cards-accessed target :deck)))}]})
+             :optional {:req (req (and (= :rd (target-server context))
+                                       (first-successful-run-on-server? state :rd)
+                                       (pos? (total-cards-accessed target :deck))))
+                        :prompt "Gain 1 [Credits] for each card you accessed from R&D?"
+                        :async true
+                        :yes-ability
+                        {:msg (msg "gain " (total-cards-accessed target :deck) " [Credits]")
+                         :async true
+                         :effect (effect (gain-credits :runner eid (total-cards-accessed target :deck)))}}}]})
 
 (defcard "Public Sympathy"
   {:constant-effects [(runner-hand-size+ 2)]})

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -4189,6 +4189,7 @@
       (let [credits (:credit (get-runner))]
         (run-empty-server state "R&D")
         (click-prompt state :runner "No action")
+        (click-prompt state :runner "Yes")
         (is (= (inc credits) (:credit (get-runner))) "Psych Mike should give 1 credit for accessing 1 card"))
       (let [credits (:credit (get-runner))]
         (run-empty-server state "R&D")
@@ -4201,11 +4202,19 @@
         (run-continue state)
         (dotimes [_ 5]
           (click-prompt state :runner "No action"))
+        (click-prompt state :runner "Yes")
         (is (= (+ credits 5) (:credit (get-runner))) "Psych Mike should give 5 credits for DDM accesses"))
       (let [credits (:credit (get-runner))]
         (run-empty-server state "HQ")
         (click-prompt state :runner "No action")
         (is (not (last-log-contains? state "Psych Mike to gain 0")) "No log should be printed"))
+      (take-credits state :runner)
+      (take-credits state :corp)
+      (let [credits (:credit (get-runner))]
+        (run-empty-server state "R&D")
+        (click-prompt state :runner "No action")
+        (click-prompt state :runner "No")
+        (is (= credits (:credit (get-runner))) "Psych Mike should give 0 credits when declining to use her ability"))
       (testing "Regression test for #3828"
         (take-credits state :runner)
         (take-credits state :corp)
@@ -4216,6 +4225,7 @@
         (let [credits (:credit (get-runner))]
           (run-empty-server state "R&D")
           (click-prompt state :runner "No action")
+          (click-prompt state :runner "Yes")
           (is (= (inc credits) (:credit (get-runner)))
               "Psych Mike should give 1 credit for second run of the turn, if first on HQ")))))
 
@@ -4233,6 +4243,7 @@
         (click-prompt state :runner "Unrezzed upgrade")
         (click-prompt state :runner "No action")
         (click-prompt state :runner "No action")
+        (click-prompt state :runner "Yes")
         (is (= (inc credits) (:credit (get-runner))) "Psych Mike should give 1 credit for accessing 1 card"))))
 
 (deftest reclaim-basic-behavior

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -4202,6 +4202,10 @@
         (dotimes [_ 5]
           (click-prompt state :runner "No action"))
         (is (= (+ credits 5) (:credit (get-runner))) "Psych Mike should give 5 credits for DDM accesses"))
+      (let [credits (:credit (get-runner))]
+        (run-empty-server state "HQ")
+        (click-prompt state :runner "No action")
+        (is (not (last-log-contains? state "Psych Mike to gain 0")) "No log should be printed"))
       (testing "Regression test for #3828"
         (take-credits state :runner)
         (take-credits state :corp)


### PR DESCRIPTION
Fixes #5665 and also makes Psych Mike ability optional (as written on the card itself).