### PR TITLE
Implementation and tests for Deep Dive, Bailiff

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -648,24 +648,29 @@
                                                          {:duration :end-of-run})]))}]})
 
 (defcard "Deep Dive"
- (letfn [(deep-dive-access-singleton [cards]
- 	  ;; access exactly one card without showing a menu
+  (letfn [(deep-dive-access [cards]
+ 	   ;; Accesses a card from a set of given cards.
+	   ;; Returns the set of unchosen cards as async-result
 	   {:async true
-	    :msg (msg "access " (:title (first cards)))
-	    :effect (req (wait-for
-	     	     	    (access-card state side (first cards))			    
-			    (effect-completed state side eid)))})
-	 (deep-dive-select [cards]	 
-	   ;; access a card, then return the list of cards without the accessed card
-	   {:prompt "Select a card to access"
-	    :waiting-prompt "Runner to access a card"
-	    :not-distinct true
-	    :choices cards
-	    :async true
-	    :effect (req (wait-for
-	    	    	   (access-card state side target)
-			   (let [new-cards (remove #(same-card? % target) cards)]
-			     (effect-completed state side (make-result eid new-cards)))))})]
+	    :effect (req (wait-for (resolve-ability state side
+	       (if (= 1 (count cards))
+	             ;; Only show a menu if there's more than one card
+	     	     {:async true
+		      :msg (msg "access " (:title (first cards)))
+	              :effect (req (wait-for
+	     	                     (access-card state side (first cards))
+		                     (effect-completed state side eid)))}
+		     {:prompt "Select a card to access"
+	              :waiting-prompt "Runner to access a card"
+	              :not-distinct true
+	              :choices cards
+	              :async true
+	              :effect (req (wait-for
+	    	                     (access-card state side target)
+		                     (let [new-cards (remove #(same-card? % target) cards)]
+		                       (effect-completed state side (make-result eid new-cards)))))})
+	        card nil)
+	        (effect-completed state side (make-result eid async-result))))})]
   {:on-play
     {:req (req (and (some #{:hq} (:successful-run runner-reg))
                               (some #{:rd} (:successful-run runner-reg))
@@ -673,47 +678,38 @@
 			      (pos? (count (:deck corp)))))
      :async true
      :msg (req
-     	    ;going to have to trust this occurs before the cards are actually set aside
             (let [top-8-msg (seq (take 8 (:deck corp)))]
-              (str "set aside "     	         
+              (str "set aside "
 	        (if top-8-msg
-	  	  (str "(set-aside: ) " (string/join ", " (map :title top-8-msg))
-		    " from the top of R&D")
+	  	  (str (string/join ", " (map :title top-8-msg)) " from the top of R&D")
+		  ;; note - this should never happen
 		  "no cards"))))
      :effect
        (req
-         ; TODO - use set-aside zone once it is implemented
+         ;; TODO - use set-aside zone once it is implemented
          (let [top-8 (seq (take 8 (:deck corp)))]
-	   (if (= 1 (count top-8))
-	       (resolve-ability state side (deep-dive-access-singleton top-8) card nil)
-	       (wait-for
-	             (resolve-ability state side (deep-dive-select top-8) card nil)		     
-	   	     (if (and (pos? (count async-result))
-		     	      (pos? (:click runner)))
-		       ;; If there's at least one card remaining, prompt for the repeat access
-		       (wait-for
-		         (resolve-ability state side
-		           {:optional
-			    {:prompt "Pay [Click] to access another card?"
-			     :waiting-prompt "Runner to make a decision"
-			     :no-ability {:msg "decline to access another card"}
-			     :yes-ability
-			     {:cost [:lose-click 1]
-			      :msg "access another card"
-			      :effect (req
-			        (wait-for (resolve-ability state side
-			          (if (= 1 (count async-result))
-			            (resolve-ability state side (deep-dive-access-singleton async-result) card nil)
-				    (resolve-ability state side (deep-dive-select async-result) card nil))
-				    card nil)
-                                ((system-msg state side (str " shuffles R&D"))
-	                          (shuffle! state :corp :deck)
-			          (effect-completed state side eid))))}}} card nil)
-			 (effect-completed state side eid))
-		       ((system-msg state side (str " shuffles R&D"))
-		         (shuffle! state :corp :deck)
-	                 (effect-completed state side eid)))))))}}))
-
+	   (wait-for
+	     (resolve-ability state side (deep-dive-access top-8) card nil)
+	     (if (and (pos? (count async-result))
+	              (pos? (:click runner)))
+	       (wait-for (resolve-ability state side
+	         {:optional
+		   {:prompt "Pay [Click] to access another card?"
+		    :no-ability {:msg "decline to access another card"}
+		    :yes-ability
+		    {:async true
+		     :cost [:lose-click 1]
+		     :msg "access another card"
+		     :effect (req (wait-for
+		               (resolve-ability state side (deep-dive-access async-result) card nil)
+			       (effect-completed state side eid)))}}}
+		 card nil)
+		 (do (system-msg state :side (str "shuffles R&D"))
+		   (shuffle! state :corp :deck)
+		   (effect-completed state side eid)))
+	       (do (system-msg state :side (str "shuffles R&D"))
+		   (shuffle! state :corp :deck)
+		   (effect-completed state side eid))))))}}))
 
 (defcard "Déjà Vu"
   {:on-play

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -655,7 +655,7 @@
 	     (if shuffle
 	       (system-msg state side (str " shuffles R&D!"))
 	       (shuffle! state :corp :deck)
-	     )))
+	     )))	 	
 
 	 ;;access one card from a list of cards
 	 (deep-dive-select [cards]
@@ -717,18 +717,19 @@
                               (some #{:rd} (:successful-run runner-reg))
                               (some #{:archives} (:successful-run runner-reg))))
      :async true
-     :msg "select a card to access from the top 8 cards of R&D."     
+     :msg (req
+     	    ;going to have to trust this occurs before the cards are actually set aside
+            (let [top-8-msg (seq (take 8 (:deck corp)))]
+              (str "set aside the top 8 cards of R&D."     	         
+	        (if top-8-msg
+	  	  (str "(set-aside: ) " (string/join ", " (map :title top-8-msg))
+		    " from the top of R&D")
+		  "no cards"))))
      :effect
        (req
+         ;TODO - use set-aside zone
          (let [top-8 (seq (take 8 (:deck corp)))]
-	 ;;reveal the cards chosen
-	   (system-msg state side
- 	    (str " uses Deep Dive to reveal "
-	      (if top-8
-	  	(str "(top: ) " (string/join ", " (map :title top-8))
-				     		    " from the top of R&D")
-		"no cards")))
-	  ;;if there is only one card in that set, it must be accessed (and we can skip the menu)
+	  ;if there is only one card in that set, it must be accessed (and we can skip the menu)
 	  (if (= 1 (count top-8))
 	     (deep-dive-single top-8 state side eid false)
 	     ;;if there's more than one card to choose from
@@ -737,11 +738,9 @@
 		  (wait-for
 		    (resolve-ability state side
 		      (deep-dive-recursive top-8)
-		     card nil)
-		  )))
+		     card nil))))
 	    (effect-completed state side eid)	  
-	 ))}}
-))
+	 ))}}))
 
 (defcard "Déjà Vu"
   {:on-play

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -593,9 +593,17 @@
                  end-the-run]})
 
 (defcard "Bailiff"
+  (letfn [(bailiff-gain-credits [state side eid n]
+  	    (if (pos? n)
+	      (wait-for (gain-credits state :corp (make-eid state eid) 1)
+	      		(bailiff-gain-credits state side eid (dec n)))
+	      (effect-completed state side eid)))]
   {:implementation "Gain credit is manual"
-   :abilities [(gain-credits-sub 1)]
-   :subroutines [end-the-run]})
+   :on-break-subs {:msg (msg (let [n-subs (count (second targets))]
+   		  	       (str "gain " n-subs " [Credits] from the runner breaking subs")))
+		   :async true
+		   :effect (effect (bailiff-gain-credits eid (count (second targets))))}
+   :subroutines [end-the-run]}))
 
 (defcard "Ballista"
   {:subroutines [{:label "Trash 1 program or end the run"

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1472,6 +1472,190 @@
       (click-prompt state :runner "No action"))
     (is (no-prompt? state :runner) "No more accesses after 3")))
 
+(deftest deep-dive-no-cards
+  ;;there are no cards in R&D (the event shouldn't be playable? 
+  ;; - at least make sure it doesn't break the game)
+  (do-game
+    (new-game {:corp {:hand [(qty "Hedge Fund" 5)]}
+    	       :runner {:hand["Deep Dive"]}})
+    (take-credits state :corp)
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (run-empty-server state "HQ")
+    (click-prompt state :runner "No action")
+    (play-from-hand state :runner "Deep Dive")
+    (is (no-prompt? state :runner) 
+        "Runner shouldn't be given the option to access from an empty R&D")
+    (is (no-prompt? state :corp)
+        "Corporation player shouldn't be waiting on prompts"))
+)
+
+(deftest deep-dive-single-card
+  ;;there is only a single card to access - the runner doesn't see a menu, 
+  ;; or get offered to spend a click. 
+  (do-game
+    (new-game {:corp {:deck ["Fire Wall" "Brainstorm" "Chiyashi" 
+    	      	     	     "DNA Tracker" "Excalibur" "PAD Campaign"]}
+	       :runner {:hand ["Deep Dive" "Deep Dive" "Deep Dive"]}})
+    (draw state :corp)
+    (core/move state :corp (find-card "PAD Campaign" (:hand (get-corp))) :deck)
+    (take-credits state :corp)
+    ;; R&D is now: Pad Campaign
+    (core/gain state :runner :click 1)
+    (core/gain state :runner :credit 100)    
+    ;;run the three centrals
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (click-prompt state :runner "No action")
+    (run-empty-server state "HQ")
+    (click-prompt state :runner "No action")    
+    (play-from-hand state :runner "Deep Dive")
+    (click-prompt state :runner "No action")
+    (is (no-prompt? state :runner) "Access not completed or offered second access")
+    (is (no-prompt? state :corp) "Corp stuck waiting for runner")
+    ;;now we check pad campaign still exists, and that we didn't spend a second click
+    (is (= 1 (count (:deck (get-corp)))))
+    (is (= 0 (count (:discard (get-corp)))))
+    (is (= 1 (:click (get-runner))) "Shouldn't lose a click from deep dive")
+))
+
+(deftest deep-dive-two-cards
+  (do-game
+    (new-game {:corp {:hand ["Fire Wall" "Brainstorm" "Chiyashi" 
+    	      	     	     "DNA Tracker" "Marilyn Campaign" "PAD Campaign"]}
+	       :runner {:hand ["Deep Dive" "Deep Dive" "Deep Dive"]}})
+    (draw state :corp)
+    (core/move state :corp (find-card "PAD Campaign" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Marilyn Campaign" (:hand (get-corp))) :deck)
+    
+    (is (= (:title (nth (-> @state :corp :deck) 0)) "PAD Campaign"))
+    (is (= (:title (nth (-> @state :corp :deck) 1)) "Marilyn Campaign"))
+    ;;R&D is now: PAD Campaign, Marilyn Campaign
+    (take-credits state :corp)
+    (core/gain state :runner :click 96)
+    (core/gain state :runner :credit 100)    
+    ;;run the three centrals
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (click-prompt state :runner "No action")
+    (run-empty-server state "HQ")
+    (click-prompt state :runner "No action")  
+    ;;access pad campaign, do not trash it, then refuse the second access  
+    (play-from-hand state :runner "Deep Dive")
+    (click-prompt state :runner "PAD Campaign")
+    (click-prompt state :runner "No action")
+    (click-prompt state :runner "No")
+    (is (no-prompt? state :runner) 
+        "Runner shouldn't be given the option to access from an empty R&D")
+    (is (no-prompt? state :corp)
+        "Corporation player shouldn't be waiting on prompts")
+    (is (= 96 (:click (get-runner))) "Shouldn't spend a click with Deep Dive")
+    ;;access marilyn campaign, trash it, then access pad campaign
+    (play-from-hand state :runner "Deep Dive")
+    (click-prompt state :runner "Marilyn Campaign")
+    (click-prompt state :runner "Pay 3 [Credits] to trash")
+    (click-prompt state :runner "Yes")
+    (click-prompt state :runner "Pay 4 [Credits] to trash")
+    (is (no-prompt? state :runner) 
+        "Runner should not be waiting on a prompt")
+    (is (no-prompt? state :corp)
+        "Corporation player shouldn't be waiting on prompts (again)")
+    (is (= 94 (:click (get-runner))) "Should have spend two clicks on Deep Dive")
+    (is (= 0 (count (:deck (get-corp)))))
+    (is (= 2 (count (:discard (get-corp)))))
+))
+
+(deftest deep-dive-basic-functionality
+  (do-game
+    (new-game {:corp {:hand ["Ansel 1.0" "Better Citizen Program" "Chiyashi" 
+    	      	     	     "Dedicated Technician Team"
+    	      	     	     "Efficiency Committee" "Friends in High Places" "Gyri Labyrinth"
+			     "Heimdall 1.0" "Ichi 1.0" "Janus 1.0"]}
+ 	       :runner {:hand ["Deep Dive" "Deep Dive" "Deep Dive"]}})
+    (draw state :corp)
+    (core/move state :corp (find-card "Ansel 1.0" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Better Citizen Program" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Chiyashi" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Dedicated Technician Team" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Efficiency Committee" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Friends in High Places" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Gyri Labyrinth" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Heimdall 1.0" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Ichi 1.0" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Janus 1.0" (:hand (get-corp))) :deck)    
+    (is (= (:title (nth (-> @state :corp :deck) 0)) "Ansel 1.0"))
+    (is (= (:title (nth (-> @state :corp :deck) 1)) "Better Citizen Program"))
+    (is (= (:title (nth (-> @state :corp :deck) 2)) "Chiyashi"))
+    (is (= (:title (nth (-> @state :corp :deck) 3)) "Dedicated Technician Team"))
+    (is (= (:title (nth (-> @state :corp :deck) 4)) "Efficiency Committee"))
+    (is (= (:title (nth (-> @state :corp :deck) 5)) "Friends in High Places"))
+    (is (= (:title (nth (-> @state :corp :deck) 6)) "Gyri Labyrinth"))
+    (is (= (:title (nth (-> @state :corp :deck) 7)) "Heimdall 1.0"))
+    (is (= (:title (nth (-> @state :corp :deck) 8)) "Ichi 1.0"))
+    (is (= (:title (nth (-> @state :corp :deck) 9)) "Janus 1.0"))
+    ;;R&D is now: A B C D E F G H I J
+    (take-credits state :corp)
+    (core/gain state :runner :click 96)
+    (core/gain state :runner :credit 100)    
+    ;;run the three centrals
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (click-prompt state :runner "No action")
+    (run-empty-server state "HQ")
+    ;;steal better citizen and effcom
+    (play-from-hand state :runner "Deep Dive")
+    (click-prompt state :runner "Better Citizen Program")
+    (click-prompt state :runner "Steal")
+    (click-prompt state :runner "Yes")    
+    (click-prompt state :runner "Efficiency Committee")
+    (click-prompt state :runner "Steal")    
+    (is (no-prompt? state :runner) 
+        "Runner should not be waiting on a prompt")
+    (is (no-prompt? state :corp)
+        "Corporation player shouldn't be waiting on prompts")
+    (is (= 95 (:click (get-runner))) "Should have spend two clicks on Deep Dive")
+    (is (= 8 (count (:deck (get-corp)))))
+    (is (= 0 (count (:discard (get-corp)))))
+    (is (= 4 (:agenda-point (get-runner))) "Runner scored two agendas")
+  )
+)
+
+(deftest deep-dive-strongbox-ikawah-bellona
+  (do-game 
+    (new-game {:corp {:hand ["Strongbox" "Ikawah Project" "Bellona" "Fire Wall"]}
+	       :runner {:hand ["Deep Dive" "Deep Dive" "Deep Dive"]}})
+    (draw state :corp)
+    (core/move state :corp (find-card "Fire Wall" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Ikawah Project" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Bellona" (:hand (get-corp))) :deck)
+    (play-from-hand state :corp "Strongbox" "R&D")
+    (rez state :corp (get-content state :rd 0))
+    (take-credits state :corp)
+    (core/gain state :runner :click 96)
+    (core/gain state :runner :credit 95)    
+    ;;run the three centrals
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (click-prompt state :runner "Card from deck")
+    (click-prompt state :runner "No action")
+    (click-prompt state :runner "No action")
+    (run-empty-server state "HQ")
+    ;;play from hand, and attempt to steal ikawah - this should cost us 2 clicks and 2 credits
+    (play-from-hand state :runner "Deep Dive")
+    (click-prompt state :runner "Bellona")
+    (click-prompt state :runner "Pay to steal")
+    ;;runner should now have 95 clicks and 93 credits
+    (is (= 95 (:click (get-runner))) "Should have spent +1 click to steal bellona")
+    (is (= 93 (:credit (get-runner))) "Should have spent +5 credits to steal bellona")
+    (click-prompt state :runner "Yes")
+    (click-prompt state :runner "Ikawah Project")
+    (click-prompt state :runner "Pay to steal")
+    ;;runner should now have 92 clicks and 91 credits
+    (is (= 92 (:click (get-runner))) "Should have spent +1 click to steal bellona")
+    (is (= 91 (:credit (get-runner))) "Should have spent +5 credits to steal bellona")
+  )
+)
+
 (deftest deja-vu
   ;; Deja Vu - recur one non-virus or two virus cards
   (do-game

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -496,6 +496,115 @@
       (rez state :corp (refresh ab))
       (is (= 5 (:credit (get-corp))) "Paid 3 credits to rez; 2 advancments on Asteroid Belt"))))
 
+(deftest bailiff-gain-credit-when-broken
+  (do-game
+    (new-game {:corp {:hand ["Bailiff"]}
+    	       :runner {:hand ["Corroder"]}})
+    (play-from-hand state :corp "Bailiff" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Corroder")
+    (let [blf (get-ice state :hq 0)
+    	  cor (get-program state 0)]
+
+      (run-on state "HQ")
+      (rez state :corp blf)
+      (run-continue state)
+      (changes-val-macro
+        +1 (:credit (get-corp))
+	"Gained 1c from subroutines being broken"
+	(card-ability state :runner cor 0)
+	(click-prompt state :runner "End the run")
+	(is (last-log-contains? state "Corp uses Bailiff to gain 1 \\[Credits\\]")
+	    "Correct message")))))
+
+(deftest bailiff-interaction-with-hippo
+  (do-game
+    (new-game {:corp {:hand ["Bailiff"]}
+    	       :runner {:hand ["Corroder" "Hippo"]}})
+    (play-from-hand state :corp "Bailiff" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Corroder")
+    (play-from-hand state :runner "Hippo")
+    (let [blf (get-ice state :hq 0)
+    	  cor (get-program state 0)]
+
+      (run-on state "HQ")
+      (rez state :corp blf)
+      (run-continue state)
+      (changes-val-macro
+        0 (:credit (get-corp))
+	"Never gained money from bailiff"
+	(core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh cor)})
+	(click-prompt state :runner "Yes")))))
+
+(deftest bailiff-interaction-with-hippo-sub-boost-with-cleaver
+  (do-game
+    (new-game {:corp {:hand ["Bailiff" "Sub Boost"]}
+    	       :runner {:hand ["Cleaver" "Hippo"]
+	       	        :credits 6}})
+    (play-from-hand state :corp "Bailiff" "HQ")
+    (rez state :corp (get-ice state :hq 0))
+    (play-from-hand state :corp "Sub Boost")
+    (click-card state :corp (refresh (get-ice state :hq 0)))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Cleaver")
+    (play-from-hand state :runner "Hippo")
+    (let [blf (get-ice state :hq 0)
+    	  cor (get-program state 0)]
+      (run-on state "HQ")
+      (run-continue state)
+      (changes-val-macro
+        +0 (:credit (get-corp))
+	"Gained 0 credits from bailiff + sub boost being broken with cleaver + hippo"
+	(core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh cor)})
+	(click-prompt state :runner "Yes")))))
+
+(deftest bailiff-interaction-with-hippo-sub-boost-with-corroder
+  (do-game
+    (new-game {:corp {:hand ["Bailiff" "Sub Boost"]}
+    	       :runner {:hand ["Corroder" "Hippo"]
+	       	        :credits 6}})
+    (play-from-hand state :corp "Bailiff" "HQ")
+    (rez state :corp (get-ice state :hq 0))
+    (play-from-hand state :corp "Sub Boost")
+    (click-card state :corp (refresh (get-ice state :hq 0)))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Corroder")
+    (play-from-hand state :runner "Hippo")
+    (let [blf (get-ice state :hq 0)
+    	  cor (get-program state 0)]
+      (run-on state "HQ")
+      (run-continue state)
+      (changes-val-macro
+        +1 (:credit (get-corp))
+	"Gained 1 credit from bailiff + sub boost being broken with corroder + hippo"
+	(core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh cor)})
+	(click-prompt state :runner "Yes")))))
+
+
+(deftest bailiff-sub-boost-auto-break
+  (do-game
+    (new-game {:corp {:hand["Bailiff" "Sub Boost"]}
+    	       :runner {:hand ["Corroder"]}})
+    (play-from-hand state :corp "Bailiff" "HQ")
+    (let [blf (get-ice state :hq 0)]
+      (rez state :corp blf)
+      (play-from-hand state :corp "Sub Boost")
+      (click-card state :corp (refresh blf))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Corroder")
+      (let [cor (get-program state 0)]
+        (run-on state "HQ")
+	(run-continue state)
+	(changes-val-macro
+	  +2 (:credit (get-corp))
+	  "Gained 2c from the runner breaking"
+	  (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh cor)})
+	  (is (and (last-n-log-contains? state 2 "Corp uses Bailiff to gain 1 \\[Credits\\]")
+	      	   (last-n-log-contains? state 3 "Corp uses Bailiff to gain 1 \\[Credits\\]"))
+	      "Correct messages"))))))
+
+
 (deftest ballista
   ;; Ballista
   (do-game


### PR DESCRIPTION
Deep Dive will skip the menu/asking for a second access when there is exactly one card, which seems correct.

There are exactly two flaws with this implementation that I know about:
* You shouldn't be able to play deep dive when there are 0 cards in R&D (it can't change the game state)
* Bacterial Programming is incorrect when used during resolution of Deep Dive

The first issue is easily fixable, I just don't know exactly how (I assume it's simple oneliner in the req function). The second one would require a 'set-aside' implementation, which is currently a bit out of my league.

I believe I have got all the edge cases in testing, specifically:
* Trashing and stealing work
* The happy path (accessing 8 cards)
* It works with additional costs (strongbox, ikawah, etc)

Though it is possible I have still overlooked something.