### PR TITLE
prevent multiple Mayfly prompts from spawning

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1693,14 +1693,13 @@
                    1 1 "All"
                    {:additional-ability
                     {:msg "will trash itself when this run ends"
-                     :effect (effect
+                     :effect (req
                                (register-events
-                                 card
+                                 state :runner (get-card state card)
                                  [{:event :run-ends
                                    :duration :end-of-run
                                    :unregister-once-resolved true
                                    :async true
-                                   :interactive (req true)
                                    :effect (effect (trash eid card {:cause :runner-ability}))}]))}})
                  (strength-pump 1 1)]}))
 

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -4041,6 +4041,7 @@
         (is (= 0 (count (remove :broken (:subroutines (get-ice state :hq 0))))) "Broken all subroutines")
         (core/continue state :corp nil)
         (run-jack-out state)
+        (is (no-prompt? state :runner) "Mayfly not prompting to resolve each of its events")
         (is (= 1 (count (:discard (get-runner)))) "Mayfly trashed when run ends"))))
 
 (deftest mayfly-trash-does-not-trigger-dummy-box


### PR DESCRIPTION
They become annoying after you've broken many pieces of ice.