### PR TITLE
fix Rebranding Team being active in the Runner's score area

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1447,8 +1447,9 @@
                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]})
 
 (defcard "Remote Data Farm"
-  {:on-score {:silent (req true)
-              :msg "increase their maximum hand size by 2"}
+  {:move-zone (req (when (and (in-scored? card)
+                              (= :corp (:scored-side card)))
+                     (system-msg state side "uses Remote Data Farm to increase their maximum hand size by 2")))
    :constant-effects [(corp-hand-size+ 2)]})
 
 (defcard "Remote Enforcement"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1389,7 +1389,9 @@
                             (check-win-by-agenda))}})
 
 (defcard "Rebranding Team"
-  {:on-score {:msg "make all assets gain Advertisement"}
+  {:move-zone (req (when (and (in-scored? card)
+                              (= :corp (:scored-side card)))
+                     (system-msg state side "uses Rebranding Team to make all assets gain Advertisement")))
    :constant-effects [{:type :gain-subtype
                        :req (req (asset? target))
                        :value "Advertisement"}]})

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1518,8 +1518,9 @@
               :effect (effect (trash eid target))}})
 
 (defcard "Self-Destruct Chips"
-  {:on-score {:silent (req true)
-              :msg "decrease the Runner's maximum hand size by 1"}
+  {:move-zone (req (when (and (in-scored? card)
+                              (= :corp (:scored-side card)))
+                     (system-msg state side "uses Self-Destruct Chips to decrease the Runner's maximum hand size by 1")))
    :constant-effects [(runner-hand-size+ -1)]})
 
 (defcard "Send a Message"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1389,10 +1389,7 @@
                             (check-win-by-agenda))}})
 
 (defcard "Rebranding Team"
-  {:flags {:has-events-when-stolen true}
-   :move-zone (req (when (and (in-scored? card)
-                              (= :corp (:scored-side card)))
-                     (system-msg state side "uses Rebranding Team to make all assets gain Advertisement")))
+  {:on-score {:msg "make all assets gain Advertisement"}
    :constant-effects [{:type :gain-subtype
                        :req (req (asset? target))
                        :value "Advertisement"}]})

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -3083,14 +3083,28 @@
     (is (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Alliance"))
     (is (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Ritzy"))))
 
-(deftest rebranding-team-not-active-if-stolen
+(deftest rebranding-team-not-active-while-in-runner-score-area
   ;; Rebranding Team - not active while in the Runner's score area
   (do-game
-    (new-game {:corp {:deck ["Rebranding Team" "Museum of History"]}})
+    (new-game {:corp {:deck ["Rebranding Team" "Project Beale" "Museum of History" "Exchange of Information" "Exchange of Information"]}})
     (play-from-hand state :corp "Rebranding Team" "New remote")
     (take-credits state :corp)
     (run-empty-server state "Remote 1")
     (click-prompt state :runner "Steal")
+    (is (not (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Advertisement")))
+    (take-credits state :runner)
+    (core/gain state :corp :click 3)
+    (play-and-score state "Project Beale")
+    (gain-tags state :runner 1)
+    (play-from-hand state :corp "Exchange of Information")
+    (click-card state :corp (find-card "Rebranding Team" (:scored (get-runner))))
+    (click-card state :corp (find-card "Project Beale" (:scored (get-corp))))
+    (is (last-log-contains? state "make all assets gain Advertisement")
+          "Rebranding Team prints its log")
+    (is (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Advertisement"))
+    (play-from-hand state :corp "Exchange of Information")
+    (click-card state :corp (find-card "Project Beale" (:scored (get-runner))))
+    (click-card state :corp (find-card "Rebranding Team" (:scored (get-corp))))
     (is (not (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Advertisement")))))
 
 (deftest reeducation-simple-test

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -3399,6 +3399,30 @@
     (play-and-score state "Self-Destruct Chips")
     (is (= 4 (hand-size :runner)) "By scoring Self-Destruct Chips, Runner's hand size is reduced by 1")))
 
+(deftest self-destruct-chips-logging-when-entering-the-corp-score-area
+  ;; Self-Destruct Chips - logging when entering the Corp's score area
+  (do-game
+    (new-game {:corp {:deck ["Self-Destruct Chips" "Project Vitruvius" "Exchange of Information" "Exchange of Information"]}})
+    (play-from-hand state :corp "Self-Destruct Chips" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state "Remote 1")
+    (click-prompt state :runner "Steal")
+    (is (= 5 (hand-size :runner)))
+    (take-credits state :runner)
+    (core/gain state :corp :click 3)
+    (play-and-score state "Project Vitruvius")
+    (gain-tags state :runner 1)
+    (play-from-hand state :corp "Exchange of Information")
+    (click-card state :corp (find-card "Self-Destruct Chips" (:scored (get-runner))))
+    (click-card state :corp (find-card "Project Vitruvius" (:scored (get-corp))))
+    (is (last-log-contains? state "decrease the Runner's maximum hand size by 1")
+          "Self-Destruct Chips prints its log")
+    (is (= 4 (hand-size :runner)))
+    (play-from-hand state :corp "Exchange of Information")
+    (click-card state :corp (find-card "Project Vitruvius" (:scored (get-runner))))
+    (click-card state :corp (find-card "Self-Destruct Chips" (:scored (get-corp))))
+    (is (= 5 (hand-size :runner)))))
+
 (deftest send-a-message
   ;; Send a Message
   (do-game

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -3187,6 +3187,30 @@
       (play-and-score state "Remote Data Farm")
       (is (= 7 (hand-size :corp)))))
 
+(deftest remote-data-farm-logging-when-entering-the-corp-score-area
+  ;; Remote Data Farm - logging when entering the Corp's score area
+  (do-game
+    (new-game {:corp {:deck ["Remote Data Farm" "Project Beale" "Exchange of Information" "Exchange of Information"]}})
+    (play-from-hand state :corp "Remote Data Farm" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state "Remote 1")
+    (click-prompt state :runner "Steal")
+    (is (= 5 (hand-size :corp)))
+    (take-credits state :runner)
+    (core/gain state :corp :click 3)
+    (play-and-score state "Project Beale")
+    (gain-tags state :runner 1)
+    (play-from-hand state :corp "Exchange of Information")
+    (click-card state :corp (find-card "Remote Data Farm" (:scored (get-runner))))
+    (click-card state :corp (find-card "Project Beale" (:scored (get-corp))))
+    (is (last-log-contains? state "increase their maximum hand size by 2")
+          "Remote Data Farm prints its log")
+    (is (= 7 (hand-size :corp)))
+    (play-from-hand state :corp "Exchange of Information")
+    (click-card state :corp (find-card "Project Beale" (:scored (get-runner))))
+    (click-card state :corp (find-card "Remote Data Farm" (:scored (get-corp))))
+    (is (= 5 (hand-size :corp)))))
+
 (deftest remote-data-farm-removed-from-runner-score-area-issue-5109
     ;; removed from runner score area. Issue #5109
     (do-game

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -3083,6 +3083,16 @@
     (is (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Alliance"))
     (is (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Ritzy"))))
 
+(deftest rebranding-team-not-active-if-stolen
+  ;; Rebranding Team - not active while in the Runner's score area
+  (do-game
+    (new-game {:corp {:deck ["Rebranding Team" "Museum of History"]}})
+    (play-from-hand state :corp "Rebranding Team" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state "Remote 1")
+    (click-prompt state :runner "Steal")
+    (is (not (has-subtype? (find-card "Museum of History" (:hand (get-corp))) "Advertisement")))))
+
 (deftest reeducation-simple-test
     ;; Simple test
     (do-game


### PR DESCRIPTION
Fixes #6219.

Also fixes Remote Data Farm and Self-Destruct Chips not logging when swapped or added to the Corp's score area.