### PR TITLE
Overclock

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -75,7 +75,7 @@
                  [metosin/malli "0.7.0"]]
 
   :plugins [[lein-eftest "0.5.9"]
-            [cider/cider-nrepl "0.27.3"]]
+            [cider/cider-nrepl "0.26.0"]]
 
   :profiles {:dev {:dependencies [[binaryage/devtools "1.0.4"]
                                   [cider/piggieback "0.5.3"]

--- a/project.clj
+++ b/project.clj
@@ -75,7 +75,7 @@
                  [metosin/malli "0.7.0"]]
 
   :plugins [[lein-eftest "0.5.9"]
-            [cider/cider-nrepl "0.26.0"]]
+            [cider/cider-nrepl "0.27.3"]]
 
   :profiles {:dev {:dependencies [[binaryage/devtools "1.0.4"]
                                   [cider/piggieback "0.5.3"]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -422,7 +422,8 @@
              :prompt "Choose a server"
              :choices (req runnable-servers)
              :effect (effect (make-run eid target card))}
-   :interactions {:pay-credits {:type :credit}}
+   :interactions {:pay-credits {:req (req run)
+                                :type :credit}}
    :events [{:event :run-ends
              :player :runner
              :prompt "Choose a program that was used during the run"
@@ -2215,7 +2216,8 @@
 (defcard "Overclock"
   {:makes-run true
    :data {:counter {:credit 5}}
-   :interactions {:pay-credits {:type :credit}}
+   :interactions {:pay-credits {:req (req run)
+                                :type :credit}}
    :on-play {:prompt "Choose a server"
              :choices (req runnable-servers)
              :async true

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1044,6 +1044,22 @@
       (click-card state :runner (get-program state 0))
       (is (= 2 (count (:discard (get-runner)))) "Imp and Cold Read in discard")))
 
+(deftest cold-read-earth-station
+  ;;ensure that cold read can't pay for the earth station ability
+  (do-game
+    (new-game {:runner {:hand ["Cold Read" "Sure Gamble"]}
+               :corp {:id "Earth Station: SEA Headquarters" :hand ["PAD Campaign"]}})
+    (card-ability state :corp (get-in @state [:corp :identity]) 0)
+    (is (:flipped (get-in @state [:corp :identity])) "Earth station is on flip side")
+    (play-from-hand state :corp "PAD Campaign" "New Remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Sure Gamble")
+    (changes-val-macro -6 (:credit (get-runner))
+                       "Paid for earth station"
+                       (play-from-hand state :runner "Cold Read")
+                       (click-prompt state :runner "Server Remote"))
+    (is (no-prompt? state :runner) "waiting on earth station payment prompt")))
+
 (deftest cold-read-pay-credits-prompt
     ;; Pay-credits prompt
     (do-game
@@ -1060,7 +1076,7 @@
                            (click-card state :runner cr))
         (run-continue state)
         (click-card state :runner refr)
-        (is (= 2 (count (:discard (get-runner)))) "Cold Read and Refractor in discard"))))
+        (is (= 2 (count (:discard (get-runner)))) "Cold Read and Refractor in discard"))))    
 
 (deftest ^{:card-title "compile"}
   compile-test
@@ -4558,6 +4574,22 @@
              (= 1 (count (:discard (get-corp)))))
         "Corp hand empty and Eve in Archives")
     (is (= 4 (:credit (get-runner))))))
+
+(deftest overclock-earth-station
+  ;;ensure that overclock can't pay for the earth station ability
+  (do-game
+    (new-game {:runner {:hand ["Overclock" "Sure Gamble"]}
+               :corp {:id "Earth Station: SEA Headquarters" :hand ["PAD Campaign"]}})
+    (card-ability state :corp (get-in @state [:corp :identity]) 0)
+    (is (:flipped (get-in @state [:corp :identity])) "Earth station is on flip side")
+    (play-from-hand state :corp "PAD Campaign" "New Remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Sure Gamble")
+    (changes-val-macro -7 (:credit (get-runner))
+                       "Paid for earth station"
+                       (play-from-hand state :runner "Overclock")
+                       (click-prompt state :runner "Server Remote"))
+    (is (no-prompt? state :runner) "waiting on earth station payment prompt")))
 
 (deftest paper-tripping
   ;; Paper Tripping


### PR DESCRIPTION
fixes overclock and cold read credits being able to be spent after playing the event but before being in a run (ie to pay for earth station).

Closes #6216 , but also deals with:

* Cold read vs. earth station
* This same issue was happening with reduced service and cold site server too, and should be resolved