### PR TITLE
Fix Tranquilizer + Cookbook/Grimoire Interaction

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -893,7 +893,7 @@
 (defcard "Grimoire"
   {:constant-effects [(mu+ 2)]
    :events [{:event :runner-install
-             :silent (req true)
+             :interactive (req true)
              :req (req (has-subtype? (:card context) "Virus"))
              :effect (effect (add-counter (:card context) :virus 1))}]})
 

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2490,7 +2490,8 @@
                       (derez state side (get-card state (:host card)))))]
     {:hosting {:card #(and (ice? %)
                            (can-host? %))}
-     :on-install {:effect action}
+     :on-install {:interactive (req true)
+                  :effect action}
      :events [{:event :runner-turn-begins
                :effect action}]}))
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -579,7 +579,7 @@
 
 (defcard "Cookbook"
   {:events [{:event :runner-install
-             :silent (req true)
+             :interactive (req true)
              :optional {:prompt "Place a virus counter?"
                         :req (req (has-subtype? (:card context) "Virus"))
                         :autoresolve (get-autoresolve :auto-cookbook)


### PR DESCRIPTION
Solving #6150 set Cookbook and Grimoire to interactive, and Tranquilizer on install is set to interactive