### PR TITLE
fix The Class Act triggering when one card is drawn

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2713,7 +2713,8 @@
               (assoc draw-ability :event :runner-turn-ends)
               (first-time-draw-bonus :runner 1)
               {:event :runner-draw
-               :req (req (first-event? state :runner :runner-draw))
+               :req (req (and (first-event? state :runner :runner-draw)
+                              (< 1 (count runner-currently-drawing))))
                :once :per-turn
                :once-key :the-class-act-put-bottom
                :async true

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -5548,6 +5548,16 @@
    (is (no-prompt? state :runner) "No prompt from The Class Act")
    (is (empty? (find-card "Sure Gamble" (:hand (:runner @state)))) "Sure Gamble has not been drawn")))
 
+(deftest the-class-act-no-trigger-when-drawing-one-card
+  ;; no trigger when drawing one card
+  (do-game
+   (new-game {:runner {:deck ["Sure Gamble"]
+                       :hand ["The Class Act"]}})
+   (take-credits state :corp)
+   (play-from-hand state :runner "The Class Act")
+   (click-draw state :runner)
+   (is (no-prompt? state :runner) "No prompt from The Class Act")))
+
 (deftest the-class-act-no-lingering-bonus-draw-effect-if-no-cards-in-deck
   ;; The Class Act - Issue #6132 - No lingering bonus draw effect if no cards in deck
   (do-game


### PR DESCRIPTION
Fixes #6066 and #6107 (hopefully).