### PR TITLE
implement Azef Protocol (beta version)

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -220,6 +220,23 @@
                                  :effect (effect (add-prop :corp target :advance-counter c {:placed true}))})
                               card nil))}})
 
+(defcard "Azef Protocol"
+  (let [ability {:async true
+                 :msg "do 2 meat damage"
+                 :effect (effect (damage eid :meat 2 {:card card}))}
+        pay-score-cost {:waiting-prompt "Corp to make a decision"
+                        :prompt "Choose another installed card to trash"
+                        :msg (msg "trash " (card-str state target))
+                        :choices {:card #(and (installed? %)
+                                              (corp? %))}
+                        :effect (req (trash state side eid target {:unpreventable true})
+                                     (continue-ability state side ability card nil))}]
+    {:on-score pay-score-cost
+     :flags {:can-score (req (let [result (<= 2 (count (all-installed state :corp)))]
+                               (when-not result
+                                 (toast state :corp "Cannot score Azef Protocol without trashing another installed card." "warning"))
+                               result))}}))
+
 (defcard "Bacterial Programming"
   (letfn [(hq-step [remaining to-trash to-hq]
             {:async true

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -384,6 +384,25 @@
       (click-prompt state :runner "Steal")
       (is (= 4 (get-counters (refresh iw) :advancement)) "Ice Wall should gain 2 advancement tokens"))))
 
+(deftest azef-protocol
+  ;; Azef Protocol
+  (do-game
+    (new-game {:corp {:hand ["Azef Protocol" "Ice Wall"]}
+               :runner {:hand [(qty "Sure Gamble" 5)]}})
+    (core/gain state :corp :click 2)
+    (play-from-hand state :corp "Azef Protocol" "New remote")
+    (let [azef (get-content state :remote1 0)]
+      (advance state azef 3)
+      (score state :corp (refresh azef))
+      (is (zero? (:agenda-point (get-corp))) "Corp should not be able to score Azef Protocol")
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (score state :corp (refresh azef))
+      (is (not (no-prompt? state :runner)) "Runner waiting for Corp to pay additional cost to score Azef Protocol")
+      (click-card state :corp (get-ice state :hq 0))
+      (is (= 1 (count (:discard (get-corp)))) "Ice Wall trashed to pay Azef Protocol's score cost")
+      (is (= 2 (:agenda-point (get-corp))) "Scored Azef Protocol for 2 points")
+      (is (= 2 (count (:discard (get-runner)))) "Runner should have discarded 2 cards"))))
+
 (deftest bacterial-programming-scoring-should-not-cause-a-run-to-exist-for-runner
     ;; Scoring should not cause a run to exist for runner.
     (do-game


### PR DESCRIPTION
I had to find a workaround to pay additional costs for scoring agendas since there is no support for it at the moment. 😅 

This is not ideal since one could score leveraging a cost reduction card (e.g. SanSan City Grid) and trash it later to pay the additional cost.