### PR TITLE
Replay API uses path-params (but still breaks)

### DIFF
--- a/src/clj/web/stats.clj
+++ b/src/clj/web/stats.clj
@@ -359,7 +359,8 @@
 
 (defn replay-handler
   [{db :system/db
-    {:keys [gameid bugid n d b]}  :params
+    {:keys [gameid bugid]}  :path-params
+    {:keys [n d b]}               :query-params
     scheme                        :scheme
     headers                       :headers
     :as req}]


### PR DESCRIPTION
Fixed the 404 for loading replays, but when the replay loads we still get a rendering error