### PR TITLE
Stop go loops in deckbuilder when leaving page

### DIFF
--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -363,7 +363,8 @@
       "All" (concat runner-factions corp-factions)
       "Any Side" (concat runner-factions corp-factions)
       "Runner" (conj runner-factions "Neutral")
-      "Corp" corp-factions)))
+      "Corp" corp-factions
+      (concat runner-factions corp-factions))))
 
 (defn- filter-alt-art-cards [cards]
   (let [lang (get-in @app-state [:options :language] "en")


### PR DESCRIPTION
Fixes problem requiring multiple clicks to select a deck after leaving the page and no longer displaying card zoom images