### PR TITLE
fixed ltf/reduced service interaction, added test

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1614,7 +1614,7 @@
                                        (when (and (some #{:content} (:zone second-card))
                                                   (some #{server} (:zone second-card)))
                                          (disable-card state :corp second-card))
-                                       ;; disable cards that have left the server
+                                       ;; enable cards that have left the server
                                        (when (and (some #{:content} (:zone first-card))
                                                   (not (some #{server} (:zone first-card)))
                                                   (some #{server} (:zone second-card)))
@@ -1624,12 +1624,12 @@
                                                   (some #{server} (:zone first-card)))
                                          (enable-card state :corp second-card))))}
           run-end-trigger {:event :run-ends
-                           :duration :end-of-run 
+                           :duration :end-of-run
                            :effect (effect (enable-server (first (:server target))))}]
       {:abilities [{:label "Run a remote server."
                     :cost [:trash-can :click 1 :brain 1]
                     :prompt "Choose a remote server to run with Light the Fire"
-                    :choices (req (filter #(can-run-server? state %) remotes))
+                    :choices (req (cancellable (filter #(can-run-server? state %) remotes)))
                     :msg (msg "make a run on " target " during which cards in the root of the attacked server lose all abilities")
                     :makes-run true
                     :async true
@@ -1639,8 +1639,8 @@
                                                            ;post-redirect-trigger
                                                            corp-install-trigger
                                                            swap-trigger])
-                                    (disable-server (second (server->zone state target)))
-                                    (make-run eid target card))}]})))
+                                    (make-run eid target card)
+                                    (disable-server (second (server->zone state target))))}]})))
 
 (defcard "Logic Bomb"
   {:abilities [{:label "Bypass the encountered ice"

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3345,6 +3345,25 @@
    (is (= 3 (count (:discard (get-corp)))) "Hokusai grid trashed from Server 2")
    (is (= 1 (count (:hand (get-runner)))) "Lost no card from Grip to Hokusai Grid")))
 
+(deftest light-the-fire-reduced-service-issue-#6340
+  ;; github issue #6340
+  (do-game
+    ;; can afford to pay 8 - pay 8 before the run initiates
+    (new-game {:corp {:hand ["Reduced Service"]} :credits 10
+               :runner {:hand ["Light the Fire!" "Sure Gamble"]
+                        :credits 12}})
+    (play-from-hand state :corp "Reduced Service" "New remote")
+    (let [rs (get-content state :remote1 0)]
+      (rez state :corp rs)
+      (click-prompt state :corp "4")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Light the Fire!")
+      (card-ability state :runner (get-resource state 0) 0)
+      (changes-val-macro
+       -8 (:credit (get-runner))
+       "Spent 8 credits to make a run on the server"
+       (click-prompt state :runner "Server 1")))))
+
 (deftest logic-bomb
   ;; Logic Bomb
   (do-game


### PR DESCRIPTION
Changed order of events in light the fire (make run, then disable cards). All tests seem to still pass.
Also added a test to see that the runner does pay before running.

Fixes #6340