### PR TITLE
modified mirrormorph as per #5200

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1000,7 +1000,12 @@
      :abilities [ability]}))
 
 (defcard "MirrorMorph: Endless Iteration"
-  (let [mm-ability {:prompt "Gain [Click] or gain 1 [Credits]"
+  (let [mm-clear {:prompt "Manually fix Mirrormorph"
+                  :msg (msg "manually clear Mirrormorph flags")
+                  :effect (effect
+                           (update! (assoc-in card [:special :mm-actions] []))
+                           (update! (assoc-in (get-card state card) [:special :mm-click] false)))}
+        mm-ability {:prompt "Gain [Click] or gain 1 [Credits]"
                     :choices ["Gain [Click]" "Gain 1 [Credits]"]
                     :msg (msg (decapitalize target))
                     :once :per-turn
@@ -1012,7 +1017,7 @@
                                        (effect-completed state side eid))
                                    (gain-credits state side eid 1)))}]
     {:implementation "Does not work with terminal Operations"
-     :abilities [mm-ability]
+     :abilities [mm-ability mm-clear]
      :events [{:event :corp-spent-click
                :async true
                :effect (req (let [cid (first target)
@@ -1032,8 +1037,14 @@
                                        (= 3 (count (distinct actions))))
                                 (continue-ability state side mm-ability (get-card state card) nil)
                                 (effect-completed state side eid))))}
+              {:event :runner-turn-begins
+               :effect (effect
+                        (update! (assoc-in card [:special :mm-actions] []))
+                        (update! (assoc-in (get-card state card) [:special :mm-click] false)))}
               {:event :corp-turn-ends
-               :effect (effect (update! (assoc-in card [:special :mm-actions] [])))}]
+               :effect (effect
+                        (update! (assoc-in card [:special :mm-actions] []))
+                        (update! (assoc-in (get-card state card) [:special :mm-click] false)))}]
      :constant-effects [{:type :prevent-paid-ability
                          :req (req (and (get-in card [:special :mm-click])
                                         (let [cid (:cid target)


### PR DESCRIPTION
I implemented the comment from @lostgeek in issue #5200, which is:
* When the runner turn begins, clear the content of `mm-actions` and `mm-click`.

Additionally, when the corp turn ends, we now also clear `mm-click' in addition to 'mm-actions'.

Those two changes should fix the most egregious/common instances of this bug. 

Sometimes (through fixing the gamestate) mirrormorph might be triggered on the runner turn, so neither corp-turn-ends or runner-turn-begins triggers will help. 

I've added a '**manually fix mirrormorph**' ability to the identity. I figure it can't be more egregious than 'manually trigger identity', and it's worth it if it stops at least one game getting scuttled. It may be worth adding this under implementation notes when you hover the card?

Closes #5200, Closes #5881, Closes #5163, Closes #6264.