### PR TITLE
Bulk bugfixes 1

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -38,9 +38,11 @@
                 :msg (msg "force the Corp to lose " (min 5 (:credit corp))
                           " [Credits], gain " (* 2 (min 5 (:credit corp)))
                           " [Credits] and take 2 tags")
-                :effect (req (wait-for (gain-tags state :runner 2)
-                                       (wait-for (gain-credits state :runner (* 2 (min 5 (:credit corp))))
-                                                 (lose-credits state :corp eid (min 5 (:credit corp))))))}})]})
+                :effect (req (let [creds-lost (min 5 (:credit corp))]
+                               (wait-for
+                                (lose-credits state :corp creds-lost)
+                                (wait-for (gain-tags state :runner 2)
+                                          (gain-credits state :runner eid (* 2 creds-lost))))))}})]})
 
 (defcard "Always Have a Backup Plan"
   {:makes-run true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -341,7 +341,7 @@
                                       (in-hand? %))}
                 :msg (msg "play " (:title target))
                 :effect (effect (update! (dissoc (get-card state card) :comet-event))
-                                (play-instant eid target nil))}]})
+                                (play-instant (assoc eid :source-type :play) target nil))}]})
 
 (defcard "Cortez Chip"
   {:abilities [{:prompt "Choose a piece of ice"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3199,7 +3199,8 @@
   (constellation-ice trash-hardware-sub))
 
 (defcard "Thimblerig"
-  (let [ability {:optional
+  (let [ability {:interactive (req run)
+                 :optional
                  {:req (req (and (<= 2 (count (filter ice? (all-installed state :corp))))
                                  (if run (same-card? (:ice context) card) true)))
                   :prompt "Swap Thimblerig with another ice?"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -680,7 +680,7 @@
 (defcard "Hyoubu Institute: Absolute Clarity"
   {:events [{:event :corp-reveal
              :once :per-turn
-             :req (req (first-event? state side :corp-reveal))
+             :req (req (first-event? state side :corp-reveal #(pos? (count %))))
              :msg "gain 1 [Credits]"
              :async true
              :effect (effect (gain-credits eid 1))}]

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -2051,7 +2051,7 @@
        (take-credits state :corp)
        (run-on state "R&D")
        (rez state :corp sm)
-       (is (changes-credits (get-corp) 1
+       (is (changes-credits (get-corp) 0
                             (run-continue state))) ;trigger slot machine
        (run-continue state :movement)
        (run-jack-out state)


### PR DESCRIPTION
I'm going through all of the old issues trying to pick up things that are easy/doable/no longer relevant. Here's a quick batch of fixes:

1) Account siphon order changed, so the interaction is correct with No One Home - Closes #5433
2) Thimblerig is interactive during a run, so it can interact with other cards (specifically Rover Algorithm) - Closes #5591 
3) Hyoubu requires a card to actually be revealed to trigger (and the test case was fixed - it was gaining 1 on revealing 0 cards from R&D before) - Closes #5492 
4) Comet can interact with credit counters (Closes #4952)