### PR TITLE
Show implementation messages in game log

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -718,6 +718,7 @@
    play-sfx
    say
    system-msg
+   implementation-msg
    system-say])
 
 (import-vars

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -20,7 +20,7 @@
     [game.core.prompts :refer [resolve-select]]
     [game.core.props :refer [add-counter add-prop set-prop]]
     [game.core.runs :refer [continue total-run-cost]]
-    [game.core.say :refer [play-sfx system-msg]]
+    [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.servers :refer [name-zone unknown->kw zones->sorted-names]]
     [game.core.to-string :refer [card-str]]
     [game.core.toasts :refer [toast]]
@@ -558,6 +558,7 @@
         points (get-agenda-points c)]
     (system-msg state :corp (str "scores " (:title c)
                                  " and gains " (quantify points "agenda point")))
+    (implementation-msg state card)
     (set-prop state :corp (get-card state c) :advance-counter 0)
     (swap! state update-in [:corp :register :scored-agenda] #(+ (or % 0) points))
     (play-sfx state side "agenda-score")

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -16,7 +16,7 @@
     [game.core.moving :refer [move trash]]
     [game.core.payment :refer [build-spend-msg can-pay? merge-costs]]
     [game.core.rezzing :refer [rez]]
-    [game.core.say :refer [play-sfx system-msg]]
+    [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.servers :refer [name-zone remote-num->name]]
     [game.core.state :refer [make-rid]]
     [game.core.to-string :refer [card-str]]
@@ -113,6 +113,9 @@
           server-name (if (= server "New remote")
                         (str (remote-num->name (dec (:rid @state))) " (new remote)")
                         server)]
+      (when (and (= :face-up install-state)
+                 (agenda? card))
+        (implementation-msg state card))
       (system-msg state side (str (build-spend-msg cost-str "install") card-name
                                   (if (ice? card) " protecting " " in ") server-name)))))
 
@@ -351,6 +354,8 @@
                                                   :no-mu no-mu}))]
     (when-not no-msg
       (runner-install-message state side (:title installed-card) payment-str args))
+    (when-not facedown
+      (implementation-msg state card))
     (play-sfx state side "install-runner")
     (when (and (not facedown)
                (resource? card))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -113,11 +113,11 @@
           server-name (if (= server "New remote")
                         (str (remote-num->name (dec (:rid @state))) " (new remote)")
                         server)]
+      (system-msg state side (str (build-spend-msg cost-str "install") card-name
+                                  (if (ice? card) " protecting " " in ") server-name))
       (when (and (= :face-up install-state)
                  (agenda? card))
-        (implementation-msg state card))
-      (system-msg state side (str (build-spend-msg cost-str "install") card-name
-                                  (if (ice? card) " protecting " " in ") server-name)))))
+        (implementation-msg state card)))))
 
 (defn corp-install-list
   "Returns a list of targets for where a given card can be installed."

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -36,6 +36,7 @@
                    "play "
                    (build-spend-msg payment-str "play"))]
     (system-msg state side (str play-msg title (when ignore-cost " at no cost")))
+    (implementation-msg state card)
     (play-sfx state side "play-instant")
     ;; Select the "on the table" version of the card
     (let [card (current-handler state side card)
@@ -48,8 +49,6 @@
                             card)
                           {:resolve-effect true :init-data true});;:resolve-effect is true as a temporary solution to allow Direct Access to blank IDs
           play-event (if (= side :corp) :play-operation :play-event)]
-      ;; print card errata/implementation if it has any
-      (implementation-msg state card)
       (queue-event state play-event {:card card :event play-event})
       (wait-for (checkpoint state nil (make-eid state eid) {:duration play-event})
                 (wait-for (resolve-ability state side (make-eid state eid) cdef card nil)

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -11,7 +11,7 @@
     [game.core.initializing :refer [card-init]]
     [game.core.moving :refer [move trash]]
     [game.core.payment :refer [build-spend-msg can-pay? merge-costs]]
-    [game.core.say :refer [play-sfx system-msg]]
+    [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.update :refer [update!]]
     [game.macros :refer [wait-for]]
     [game.utils :refer [same-card? to-keyword]]))
@@ -48,6 +48,8 @@
                             card)
                           {:resolve-effect true :init-data true});;:resolve-effect is true as a temporary solution to allow Direct Access to blank IDs
           play-event (if (= side :corp) :play-operation :play-event)]
+      ;; print card errata/implementation if it has any
+      (implementation-msg state card)
       (queue-event state play-event {:card card :event play-event})
       (wait-for (checkpoint state nil (make-eid state eid) {:duration play-event})
                 (wait-for (resolve-ability state side (make-eid state eid) cdef card nil)

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -13,7 +13,7 @@
     [game.core.moving :refer [trash-cards]]
     [game.core.payment :refer [build-spend-msg can-pay? merge-costs]]
     [game.core.runs :refer [continue]]
-    [game.core.say :refer [play-sfx system-msg]]
+    [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.toasts :refer [toast]]
     [game.core.to-string :refer [card-str]]
     [game.core.update :refer [update!]]
@@ -65,12 +65,13 @@
                                               (update-in [:zone] #(map to-keyword %))
                                               (update-in [:host :zone] #(map to-keyword %)))))
                     (when-not no-msg
-                      (system-msg state side
-                                  (str (build-spend-msg msg "rez" "rezzes")
-                                       (:title card)
-                                       (cond
-                                         alternative-cost " by paying its alternative cost"
-                                         ignore-cost " at no cost"))))
+                      (do (system-msg state side
+                                      (str (build-spend-msg msg "rez" "rezzes")
+                                           (:title card)
+                                           (cond
+                                             alternative-cost " by paying its alternative cost"
+                                             ignore-cost " at no cost")))
+                          (implementation-msg state card)))
                     (when (and (not no-warning) (:corp-phase-12 @state))
                       (toast state :corp "You are not allowed to rez cards between Start of Turn and Mandatory Draw.
                                          Please rez prior to clicking Start Turn in the future." "warning"

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -65,13 +65,13 @@
                                               (update-in [:zone] #(map to-keyword %))
                                               (update-in [:host :zone] #(map to-keyword %)))))
                     (when-not no-msg
-                      (do (system-msg state side
-                                      (str (build-spend-msg msg "rez" "rezzes")
-                                           (:title card)
-                                           (cond
-                                             alternative-cost " by paying its alternative cost"
-                                             ignore-cost " at no cost")))
-                          (implementation-msg state card)))
+                      (system-msg state side
+                                  (str (build-spend-msg msg "rez" "rezzes")
+                                       (:title card)
+                                       (cond
+                                         alternative-cost " by paying its alternative cost"
+                                         ignore-cost " at no cost")))
+                      (implementation-msg state card))
                     (when (and (not no-warning) (:corp-phase-12 @state))
                       (toast state :corp "You are not allowed to rez cards between Start of Turn and Mandatory Draw.
                                          Please rez prior to clicking Start Turn in the future." "warning"

--- a/src/clj/game/core/say.clj
+++ b/src/clj/game/core/say.clj
@@ -50,6 +50,11 @@
   [state card text]
   (system-say state nil (str (:title card) " " text ".")))
 
+(defn implementation-msg
+  [state card]
+  (when (not= :full (:implementation card))
+    (enforce-msg state card (str "implementation: " (:implementation card)))))
+
 (defn indicate-action
   [state side _]
   (system-say state side

--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -11,7 +11,7 @@
    [game.core.initializing :refer [card-init make-card]]
    [game.core.player :refer [new-corp new-runner]]
    [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
-   [game.core.say :refer [system-msg system-say]]
+   [game.core.say :refer [system-msg system-say implementation-msg]]
    [game.core.shuffling :refer [shuffle-into-deck]]
    [game.core.state :refer [new-state]]
    [game.macros :refer [wait-for]]
@@ -134,7 +134,9 @@
       (swap! state assoc :log (into [] messages))
       (system-say state nil "[hr]"))
     (card-init state :corp corp-identity)
+    (implementation-msg state corp-identity)
     (card-init state :runner runner-identity)
+    (implementation-msg state runner-identity)
     (create-basic-action-cards state)
     (fake-checkpoint state)
     (wait-for (trigger-event-sync state :corp :pre-start-game nil)


### PR DESCRIPTION
This allows for implementation messages to be shown for relevant cards when they're rezzed, installed face-up (runner, or corp agendas), scored (by the corp), or played from hand (operation/events).

There is a single `implementation-msg` command in `say` which takes `state` and `card`, and if the card has implementation information, prints it.

![impl_04](https://user-images.githubusercontent.com/9095245/167372592-327844c5-af5f-4154-9789-170849351dc5.jpg)

![impl_03](https://user-images.githubusercontent.com/9095245/167372600-365819b4-2971-4c80-848c-d094020e3bb5.jpg)

![impl_02](https://user-images.githubusercontent.com/9095245/167372602-2f84ce81-bffe-45df-adb1-7e9dba55c111.jpg)

![impl_01](https://user-images.githubusercontent.com/9095245/167372606-87eba0e1-abe0-4ebe-a5aa-30276bc73b54.jpg)

I'm not 100% sold on the format I'm using, but it seems alright for now. I can't use a capital I on implementation, because that matches Imp.

I think there should be implementation notes on Identities, but I have no clue how (where) to sanely implement that.

Closes #5210, #5959