### PR TITLE
New commands

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -20,7 +20,7 @@
    [game.core.prompts :refer [show-prompt]]
    [game.core.props :refer [set-prop]]
    [game.core.psi :refer [psi-game]]
-   [game.core.rezzing :refer [rez]]
+   [game.core.rezzing :refer [rez derez]]
    [game.core.runs :refer [end-run get-current-encounter jack-out]]
    [game.core.say :refer [system-msg system-say unsafe-say]]
    [game.core.set-up :refer [build-card]]
@@ -292,6 +292,16 @@
                    nil nil))}
       nil nil)))
 
+(defn command-derez
+  [state side]
+  (when (= :corp side)
+    (resolve-ability
+     state side
+     {:prompt "Choose a card to derez"
+      :choices {:card #(rezzed? %)}
+      :effect (effect (derez target))}
+     nil nil)))
+
 (defn command-trash
   [state side]
   (let [f (if (= :corp side) corp? runner?)]
@@ -328,6 +338,7 @@
         "/counter"    #(command-counter %1 %2 args)
         "/credit"     #(swap! %1 assoc-in [%2 :credit] (constrain-value value 0 1000))
         "/deck"       #(toast %1 %2 "/deck number takes the format #n")
+        "/derez"      command-derez
         "/discard"    #(toast %1 %2 "/discard number takes the format #n")
         "/discard-random" #(move %1 %2 (rand-nth (get-in @%1 [%2 :hand])) :discard)
         "/draw"       #(draw %1 %2 (make-eid %1) (constrain-value value 0 1000))

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -405,13 +405,6 @@
                                                       :not-equal {:msg "resolve unequal bets effect"}}))
         "/reload-id"  command-reload-id
         "/replace-id" #(command-replace-id %1 %2 args)
-        "/reveal-hand" #(resolve-ability %1 %2
-                                         {:effect (effect (system-msg (str
-                                                                       (if (= :corp %2)
-                                                                         "reveals cards from HQ: "
-                                                                         "reveals cards from the Grip: ")
-                                                                       (string/join ", " (sort (map :title (:hand (if (= side :corp) corp runner))))))))}
-                                         nil nil)
     :async true
         "/rez"        #(when (= %2 :corp)
                           (resolve-ability %1 %2
@@ -436,6 +429,13 @@
                                         (map->Card {:title "/rfg command"}) nil)
         "/roll"       #(command-roll %1 %2 value)
         "/save-replay" command-save-replay
+        "/show-hand" #(resolve-ability %1 %2
+                                         {:effect (effect (system-msg (str
+                                                                       (if (= :corp %2)
+                                                                         "shows cards from HQ: "
+                                                                         "shows cards from the Grip: ")
+                                                                       (string/join ", " (sort (map :title (:hand (if (= side :corp) corp runner))))))))}
+                                         nil nil)
         "/summon"     #(command-summon %1 %2 args)
         "/swap-ice"   #(when (= %2 :corp)
                           (resolve-ability

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -256,6 +256,22 @@
       (catch Exception ex
         (toast state side (str card-name " isn't a real card"))))))
 
+(defn command-reload-id
+  [state side]
+  (let [card-name (:title (get-in @state [side :identity]))]
+    (try
+      (let [s-card (server-card card-name)
+            card (when (and s-card (same-side? (:side s-card) side))
+                   (build-card s-card))]
+        (if card
+          (let [new-id (-> card :title server-card make-card (assoc :zone [:identity] :type "Identity"))]
+            (disable-identity state side)
+            (swap! state assoc-in [side :identity] new-id)
+            (card-init state side new-id {:resolve-effect true :init-data true}))
+          (toast state side (str card-name " isn't a valid card"))))
+      (catch Exception ex
+        (toast state side (str card-name " isn't a real card"))))))
+
 (defn command-replace-id
   [state side args]
   (let [card-name (string/join " " args)]
@@ -387,6 +403,7 @@
                                                     (map->Card {:title "/psi command" :side %2})
                                                     {:equal  {:msg "resolve equal bets effect"}
                                                       :not-equal {:msg "resolve unequal bets effect"}}))
+        "/reload-id"  command-reload-id
         "/replace-id" #(command-replace-id %1 %2 args)
         "/rez"        #(when (= %2 :corp)
                           (resolve-ability %1 %2

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -102,12 +102,18 @@
     :has-args :required
     :usage "/replace-id n"
     :help "Replace your ID with the card \"n\""}
+   {:name "/reveal-hand"
+    :usage "/reveal-hand"
+    :help "Reveals your hand in the chat log"}
    {:name "/rez"
     :usage "/rez"
     :help "Choose a card to rez, ignoring all costs (Corp only)"}
    {:name "/rez-all"
     :usage "/rez-all"
     :help "Rez all cards, ignoring all costs and flip cards in archives faceup (Corp only). For revealing your servers at the end of a game."}
+   {:name "/rez-free"
+    :usage "/rez-free"
+    :help "Choose a card to rez, ignoring all costs and on-rez abilities (Corp only)"}
    {:name "/rfg"
     :usage "/rfg"
     :help "Choose a card to remove from the game"}

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -95,6 +95,9 @@
    {:name "/psi"
     :usage "/psi"
     :help "Start a Psi game (Corp only)"}
+   {:name "/reload-id"
+    :usage "/reload-id"
+    :help "Reloads your ID (this can sometimes fix gamestates)"}
    {:name "/replace-id"
     :has-args :required
     :usage "/replace-id n"

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -41,6 +41,9 @@
     :has-args :required
     :usage "/deck #n"
     :help "Put card number n from your hand on top of your deck"}
+   {:name "/derez"
+    :usage "/derez"
+    :help "derez a rezzed card (corp only)"}
    {:name "/discard"
     :has-args :required
     :usage "/discard #n"

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -65,6 +65,9 @@
     :has-args :required
     :usage "/handsize n"
     :help "Set your handsize to n"}
+   {:name "/host"
+    :usage "/host"
+    :help "Manually host a card on another card"}
    {:name "/install-ice"
     :usage "/install-ice"
     :help "Install a piece of ice at any position in a server (Corp only)"}
@@ -102,9 +105,6 @@
     :has-args :required
     :usage "/replace-id n"
     :help "Replace your ID with the card \"n\""}
-   {:name "/reveal-hand"
-    :usage "/reveal-hand"
-    :help "Reveals your hand in the chat log"}
    {:name "/rez"
     :usage "/rez"
     :help "Choose a card to rez, ignoring all costs (Corp only)"}
@@ -124,6 +124,9 @@
    {:name "/save-replay"
     :usage "/save-replay"
     :help "Save a replay of the game"}
+   {:name "/show-hand"
+    :usage "/show-hand"
+    :help "Shows your hand in the chat log (does not proc reveal triggers)"}
    {:name "/summon"
     :has-args :required
     :usage "/summon n"


### PR DESCRIPTION
I implemented a few commands mentioned in issues. Specifically:
* `rez-free`: rezzes a card in a disabled state, then enables it. This lets you fix gamestate with cards that have on-rez effects, like spin doctor
* `reveal-hand`: reveals your hand in the game log. Does not trigger reveal effects in game.


![reveal-hand-01_000](https://user-images.githubusercontent.com/9095245/167528644-8effeb74-7640-4350-8347-19743da2862b.jpg)

* `reload-id`: reloads the currently active identity. This is primarily for dev/testing, but sometimes it can fix mirrormorph.
* `derez`: I'm surprised this didn't exist as a command to start with.


Worth discussion: should `rez-free` just replace the `rez` command?

Closes #6358, closes #6266.

Maybe closes #6256 - do we want to keep the derez button on cards?