### PR TITLE
Bulk bugfixes 2

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -313,7 +313,7 @@
         cards (vec (map #(first (second %)) breaks))
         subs (map #(:subroutines %) cards)
         broken-subs (map #(filter :broken %) subs)
-        breakers (flatten (map #(map :breaker %) broken-subs))
+        breakers (mapcat #(map :breaker %) broken-subs)
         ;; this is the list of every breaker the runner used to
         ;; break a subroutine this run. If we check that it has a
         ;; 'lose-click' break ability, we should be safe most of the

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -425,8 +425,8 @@
                                  :effect (effect (add-counter card :virus 1))}]
                     :strength-bonus (req (get-virus-counters state card))
                     :events [{:event :end-breach-server
-                              :req (req (and (not (or (:did-steal target)
-                                                      (:did-trash target)))))
+                              :req (req (not (or (:did-steal target)
+                                                 (:did-trash target))))
                               :effect (effect (add-counter card :virus 1))}
                              {:event :expose
                               :effect (effect (add-counter card :virus 1))}]}))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -424,10 +424,9 @@
                                  :msg "manually place a virus counter on itself"
                                  :effect (effect (add-counter card :virus 1))}]
                     :strength-bonus (req (get-virus-counters state card))
-                    :events [{:event :run-ends
-                              :req (req (and (not (or (:did-trash target)
-                                                      (:did-steal target)))
-                                             (:did-access target)))
+                    :events [{:event :end-breach-server
+                              :req (req (and (not (or (:did-steal target)
+                                                      (:did-trash target)))))
                               :effect (effect (add-counter card :virus 1))}
                              {:event :expose
                               :effect (effect (add-counter card :virus 1))}]}))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -417,8 +417,7 @@
              :msg "gain 1 [Credits]"}]})
 
 (defcard "Aumakua"
-  (auto-icebreaker {:implementation "Place counters manually for access outside of a run or cards that replace access like Ash"
-                    ; We would need a :once :per-access key to make this work for Gang Sign etc.
+  (auto-icebreaker {:implementation "Erratum: Whenever you finish breaching a server, if you did not steal or trash any accessed cards, place 1 virus counter on this program."
                     :abilities [(break-sub 1 1)
                                 {:label "Place a virus counter"
                                  :msg "manually place a virus counter on itself"

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -414,6 +414,10 @@
    (swap! state assoc :access card)
    ;; Reset counters for increasing costs of trash, steal, and access.
    (swap! state update :bonus dissoc :trash :steal-cost :access-cost)
+   (when (:breach @state)
+     (let [zone (or (#{:discard :deck :hand} (first (get-zone card)))
+                    (second (get-zone card)))]
+       (swap! state update-in [:breach :cards-accessed zone] (fnil inc 0))))
    (when (:run @state)
      (let [zone (or (#{:discard :deck :hand} (first (get-zone card)))
                     (second (get-zone card)))]

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -1285,14 +1285,13 @@
   ([state side eid server {:keys [no-root access-first] :as args}]
    (system-msg state side (str "breaches " (zone->name server)))
    (wait-for (trigger-event-sync state side :breach-server (first server))
-             (swap! state assoc :breach {:breach-server (first server) })
+             (swap! state assoc :breach {:breach-server (first server) :from-server (first server)})
              (let [args (clean-access-args args)
                    access-amount (num-cards-to-access state side (first server) nil)]
                (turn-archives-faceup state side server)
                (when (:run @state)
                  (swap! state assoc-in [:run :did-access] true))
                (wait-for (resolve-ability state side (choose-access access-amount server (assoc args :server server)) nil nil)
-                         (system-msg state side (str "breach: " (:breach @state)))
                          (wait-for (trigger-event-sync state side :end-breach-server (:breach @state))
                                    (swap! state assoc :breach nil)
                                    (unregister-floating-effects state side :end-of-access)

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -6577,3 +6577,56 @@
       (play-from-hand state :runner "Corroder")
       (is (zero? (get-strength (refresh wrap)))
           "Wraparound 0 strength after Corroder installed"))))
+
+(deftest zed-1.0
+  ;; zed 1.0 - only does brain damage if the runner spends a click to break a sub
+  (do-game
+   (new-game {:corp {:hand ["Zed 1.0"]}})
+   (play-from-hand state :corp "Zed 1.0" "HQ")
+   (let [zed (get-ice state :hq 0)]
+     (rez state :corp zed)
+     (take-credits state :corp)
+     (run-on state :hq)
+     (run-continue state)
+     (card-side-ability state :runner zed 0)
+     (click-prompt state :runner "Do 1 brain damage")
+     (fire-subs state zed)
+     (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")))
+  (do-game
+   (new-game {:corp {:hand ["Zed 1.0"]}})
+   (play-from-hand state :corp "Zed 1.0" "HQ")
+   (let [zed (get-ice state :hq 0)]
+     (rez state :corp zed)
+     (take-credits state :corp)
+     (run-on state :hq)
+     (run-continue state)
+     (fire-subs state zed)
+     (is (= 0 (:brain-damage (get-runner))) "Runner took 0 brain damage"))))
+
+(deftest zed-2.0
+  ;; zed 2.0 - only does brain damage if the runner spends a click to break a sub
+  (do-game
+   (new-game {:corp {:hand ["Zed 2.0"] :credits 10}})
+   (play-from-hand state :corp "Zed 2.0" "HQ")
+   (let [zed (get-ice state :hq 0)]
+     (rez state :corp zed)
+     (take-credits state :corp)
+     (run-on state :hq)
+     (run-continue state)
+     (card-side-ability state :runner zed 0)
+     (click-prompt state :runner "Trash a piece of hardware")
+     (click-prompt state :runner "Trash a piece of hardware")
+     (fire-subs state zed)
+     (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")))
+  (do-game
+   (new-game {:corp {:hand ["Zed 2.0"] :credits 10}})
+   (play-from-hand state :corp "Zed 2.0" "HQ")
+   (let [zed (get-ice state :hq 0)]
+     (rez state :corp zed)
+     (take-credits state :corp)
+     (run-on state :hq)
+     (run-continue state)
+     (fire-subs state zed)
+     (click-prompt state :corp "Done")
+     (click-prompt state :corp "Done")
+     (is (= 0 (:brain-damage (get-runner))) "Runner took 0 brain damage"))))

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -537,6 +537,39 @@
       (run-empty-server state "Server 1")
       (is (zero? (get-counters (get-program state 0) :virus)) "Aumakua does not gain virus counter from ABT-forced trash")))
 
+(deftest aumakua-gang-sign-interaction
+  ;; Gang sign should give turtle counters
+  (do-game
+   (new-game {:corp {:hand ["Hostile Takeover" "NGO Front"]}
+              :runner {:hand ["Aumakua" (qty "Gang Sign" 2)]}})
+   (take-credits state :corp)
+   (play-from-hand state :runner "Aumakua")
+   (play-from-hand state :runner "Gang Sign")
+   (play-from-hand state :runner "Gang Sign")
+   (take-credits state :runner)
+   (play-and-score state "Hostile Takeover")
+   (click-prompt state :runner "Gang Sign")
+   (click-prompt state :runner "No action")
+   (is (= 1 (get-counters (get-program state 0) :virus)) "Aumakua gained a virus counter from the first breach")
+   (click-prompt state :runner "Pay 1 [Credits] to trash")
+   (is (= 1 (get-counters (get-program state 0) :virus)) "Aumakua gained no virus counter from the second breach")))
+
+(deftest aumakua-divide-and-conquer
+  ;; divide and conquer should proc turtle for each access
+  (do-game
+   (new-game {:corp {:discard ["Hostile Takeover"] :deck ["Ice Wall"] :hand ["Ice Wall"]}
+              :runner {:hand ["Aumakua" "Sure Gamble" "Divide and Conquer"]}})
+   (take-credits state :corp)
+   (play-from-hand state :runner "Sure Gamble")
+   (play-from-hand state :runner "Aumakua")
+   (play-run-event state "Divide and Conquer" :archives)
+   (click-prompt state :runner "Steal")
+   (is (= 0 (get-counters (get-program state 0) :virus)) "Aumakua gained no virus counter")
+   (click-prompt state :runner "No action")
+   (is (= 1 (get-counters (get-program state 0) :virus)) "Aumakua gained a virus counter")
+   (click-prompt state :runner "No action")
+   (is (= 2 (get-counters (get-program state 0) :virus)) "Aumakua gained a virus counter")))
+
 (deftest baba-yaga
   ;; Baba Yaga
   (do-game

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3197,6 +3197,21 @@
     (click-prompt state :runner "Yes")
     (is (= 2 (count (:discard (get-runner)))) "Second Lewi trashed due to no credits")))
 
+(deftest lewi-guilherme-lovegood-interaction-#3345
+  ;; hand size does not persist while blanked by Dr. Lovegood
+  (do-game
+   (new-game {:runner {:hand ["Lewi Guilherme" "Dr. Lovegood"]}})
+   (take-credits state :corp)
+   (play-from-hand state :runner "Lewi Guilherme")
+   (is (= 4 (hand-size :corp)) "-1 hand size from lewi")
+   (play-from-hand state :runner "Dr. Lovegood")
+   (take-credits state :runner)
+   (take-credits state :corp)
+   (click-prompt state :runner "Dr. Lovegood")
+   (click-card state :runner "Lewi Guilherme")
+   (is (= 5 (hand-size :corp)) "-1 hand size from lewi")
+   (is (no-prompt? state :runner) "No more prompt to activate")))
+
 (deftest liberated-account
   ;; Liberated Account
   (do-game

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -2514,6 +2514,21 @@
       (click-prompt state :runner "No action")
       (is (not (:breach @state)) "Not currently breaching")))))
 
+(deftest mwanza-city-grid-salsette-slums
+  (do-game
+   (new-game {:corp {:hand ["Mwanza City Grid"]}
+              :runner {:hand ["Salsette Slums"] :credits 10}})
+   (play-from-hand state :corp "Mwanza City Grid" "HQ")
+   (rez state :corp (get-content state :hq 0))
+   (take-credits state :corp)
+   (play-from-hand state :runner "Salsette Slums")
+   (run-on state "HQ")
+   (run-continue state)
+   (changes-val-macro
+    +2 (:credit (get-corp))
+    "Corp gained +2, even after mwanza was RFG'd"
+    (click-prompt state :runner "[Salsette Slums] Remove card from game"))))
+
 (deftest mwanza-city-grid-interaction-with-kitsune
     ;; Regression test for #3469
     ;; interaction with Kitsune


### PR DESCRIPTION
Going through a few more old issues.
* Lewi/lovegood was fixed at some point, so I added a test.
* I added an implementation for Zed 1.0/2.0 that crawls through the run log, and finds out if any break abilities that cost :lose-click have been used. The implementation looks ugly, I would appreciate advice on how to make it nicer.
* I wanted to make aumakua better, so I tried using `:end-breach-server`, only to find that it tracked literally nothing except the server that was breached.  So I added some state tracking for each breach, and that information is returned with `:end-breach-server`. Right now, aumakua should work with divide and conquer, gang sign, kitsune, shiro, etc, properly now. I'm going to add some tests for this soon. Once that's done, this closes #6355 and closes #4455
* I expanded breach tracking enough that we can fix mwanza city grid (closes #5616, closes #6253, closes #3714)
