### PR TITLE
Bulk bugfixes 3

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3014,7 +3014,8 @@
                                       (when (pos? (count from))
                                         (reorder-choice :corp :runner from '() (count from) from)))
                                     card nil))}
-                 {:optional
+                 {:label "The runner breaches R&D unless the corp pays 1 [Credit]"
+                  :optional
                   {:prompt "Pay 1 [Credits] to keep the Runner from breaching R&D?"
                    :yes-ability {:cost [:credit 1]
                                  :msg "keep the Runner from breaching R&D"}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2005,7 +2005,7 @@
                                   card
                                   (let [ice current-ice]
                                     {:type :gain-subtype
-                                     :duration :end-of-run
+                                     :duration :end-of-encounter
                                      :req (req (same-card? target ice))
                                      :value target})))}]})
 


### PR DESCRIPTION
Another batch of fixes.
* Flame out only creates on trigger now/doesn't quash other triggers that are applied to flame out
* Pelangi last for the encounter instead of the whole run
* Bioroid break, f2p and negotiator now require the runner is encountering them for their abilities to be used (so you can't use any random bioroid ability to break whatever ice you're encountering)
* The second subroutine on shiro now has a label