### PR TITLE
WIP/proof of concept - Cannot use ability

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -232,11 +232,29 @@
   (Central suite: Alias, Breach, Passport)"
   [break pump]
   (auto-icebreaker
-    {:abilities [(break-sub (:break-cost break) (:break break) (:breaks break)
-                            {:req (req (and (#{:hq :rd :archives} (target-server run))
-                                            (<= (get-strength current-ice) (get-strength card))
-                                            (has-subtype? current-ice (:breaks break))))})
-                 pump]}))
+   {:cannot-use-ability (req
+                         ;(system-msg state side (str "cannot-use check"))
+                         (let [encountered-ice-zone (:zone (get-current-ice state))]
+                           ;; passport requires the ice is NOT protecting a remote server
+                           ;; this means we can't just check which server we're on (because of
+                           ;; cards like konjin, awakening center, etc), so we have to check
+                           ;; where the ice is.
+                           ;;(system-msg state side (pr-str encountered))
+                           (and (some #{:ices} encountered-ice-zone)
+                                (some #{:server} encountered-ice-zone)
+                                (not (some #{:hq :rd :archives} encountered-ice-zone)))))
+                           ;(system-msg state side (:zone encountered-ice))))
+                           ;;(not (#{:hq :rd :archives} (target-server run)))))
+    :abilities [(break-sub (:break-cost break) (:break break) (:breaks break)
+                           {:req (req (let [cannot-fn (:cannot-use-ability card)
+                                            ;; state side eid card ???
+                                             cannot-use-abi (cannot-fn state side nil card nil)]
+                                        (and
+                                         (not cannot-use-abi)
+                                         (<= (get-strength current-ice) (get-strength card))
+                                         (has-subtype? current-ice (:breaks break)))))})
+                pump]}))
+    
 
 (defn- return-and-derez
   "Return to grip to derez current ice

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -194,6 +194,7 @@
                 :implementation (card-implemented card)
                 :subroutines (subroutines-init (assoc card :cid cid) cdef)
                 :abilities (ability-init cdef)
+                :cannot-use-ability (:cannot-use-ability cdef)
                 :printed-title (:title card))
          (dissoc :setname :text :_id :influence :number :influencelimit
                  :image_url :factioncost :format :quantity)

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -11,6 +11,7 @@
    agendapoints
    art
    baselink
+   cannot-use-ability
    card-target
    cid
    code

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -269,7 +269,7 @@
     (let [alias (get-program state 0)
           zed1 (get-ice state :hq 0)
           zed2 (get-ice state :remote1 0)]
-      (is (= 1 (get-strength (refresh alias))) "Starts with 2 strength")
+      (is (= 1 (get-strength (refresh alias))) "Starts with 1 strength")
       (card-ability state :runner (refresh alias) 1)
       (is (= 4 (get-strength (refresh alias))) "Can gain strength outside of a run")
       (run-on state :hq)
@@ -285,6 +285,7 @@
       (run-on state :remote1)
       (rez state :corp (refresh zed2))
       (run-continue state)
+      (is (no-prompt? state :runner) "Just checking")
       (card-ability state :runner (refresh alias) 0)
       (is (no-prompt? state :runner) "No break prompt because we're running a remote"))))
 


### PR DESCRIPTION
See #6237 - A flat 'cannot-use-ability' applying to the whole card didn't seem reasonable, because you should be able to use abilities on the cards that aren't interfacing (ie you can boost strength while running remotes if you needed to tank your credits, or spend credits for net mercur). We can't put the `cannot-use-ability` fn in the ability itself either, because then it gets copied by baba yaga (or maybe yaga should strip that?).

I found a sort of compromise was placing the :cannot-use-ability key in the card, and referring to it in the :req function of the ability, like:
`
:req (req (not (:cannot-use-ability ...)))
`
This means that cards which copy the abilities will end up getting nil when trying to call that, which should always be true. 

Maybe a better option would be actually putting a specific key in with the card, like:

`
:cannot-use-ability {:central-breaker (req ...)}
`