### PR TITLE
Gamenet triggers a 'spend-credits' event when recurring sources are used

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -132,11 +132,16 @@
       (and (pos? (value cost))
            (pos? (count (provider-func))))
       (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid (value cost) (stealth-value cost)) card nil)
-                (swap! state update-in [:stats side :spent :credit] (fnil + 0) (value cost))
-                (complete-with-result state side eid {:msg (str "pays " (:msg async-result))
-                                                      :type :credit
-                                                      :value (:number async-result)
-                                                      :targets (:targets async-result)}))
+                (wait-for (trigger-event-sync
+                            state side (make-eid state eid)
+                            (if (= side :corp) :corp-spent-credits :runner-spent-credits)
+                            (value cost))
+                          (swap! state update-in [:stats side :spent :credit] (fnil + 0) (value cost))
+                          (complete-with-result state side eid
+                                                {:msg (str "pays " (:msg async-result))
+                                                 :type :credit
+                                                 :value (:number async-result)
+                                                 :targets (:targets async-result)})))
       (pos? (value cost))
       (do (lose state side :credit (value cost))
           (wait-for (trigger-event-sync


### PR DESCRIPTION
We weren't triggering any `:x-spend-credits` events at all if any recurring/disposable credits existed in the game (regardless of if they were used or not), so I added that in, and now gamenet works if you spend credits from other credit sources, or if you have other credit sources.

Closes #6314, Closes #6367