### PR TITLE
Fix/asa group installing asset on central servers

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -221,6 +221,7 @@
                                :choices {:card #(and (in-hand? %)
                                                      (corp? %)
                                                      (corp-installable-type? %)
+                                                     (or (is-remote? z) (not (asset? %)))
                                                      (not (agenda? %)))}
                                :async true
                                :effect (effect (corp-install eid target (zone->name z) nil))}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -213,11 +213,7 @@
                                 z (butlast (get-zone installed-card))]
                             (continue-ability
                               state side
-                              {:prompt (str "Choose a "
-                                            (if (is-remote? z)
-                                              "non-agenda"
-                                              "piece of ice")
-                                            " in HQ to install")
+                              {:prompt "Choose a non-agenda card in HQ to install"
                                :choices {:card #(and (in-hand? %)
                                                      (corp? %)
                                                      (corp-installable-type? %)

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -688,6 +688,17 @@
       (click-card state :corp (find-card "Urban Renewal" (:hand (get-corp))))
       (is (= "Urban Renewal" (:title (get-content state :remote1 0))) "Asa Group can install an asset in a remote")))
 
+(deftest asa-group-security-through-vigilance-asa-group-should-not-allow-installing-assets-on-central-servers
+    ;; Asa Group should not allow installing assets on central servers
+    (do-game
+      (new-game {:corp {:id "Asa Group: Security Through Vigilance"
+                        :deck ["Pup" "PAD Campaign" "Ben Musashi"]}})
+      (play-from-hand state :corp "Pup" "HQ")
+      (click-card state :corp (find-card "PAD Campaign" (:hand (get-corp))))
+      (is (empty? (get-content state :hq)) "Asa Group did not install asset on central server with its ability")
+      (click-card state :corp (find-card "Ben Musashi" (:hand (get-corp))))
+      (is (= "Ben Musashi" (:title (get-content state :hq 0))) "Asa Group can install an upgrade in a central server")))
+
 (deftest asa-group-security-through-vigilance-asa-group-ordering-correct-when-playing-mirrormorph
     ;; Asa Group ordering correct when playing Mirrormorph
     (do-game


### PR DESCRIPTION
Fixes #6384

I also simplified the prompt message since you are allowed to install upgrades on central servers, not only pieces of ice.