### PR TITLE
Fix wrong username validation check

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -68,11 +68,8 @@
   [{db :system/db
     {:keys [username password confirm-password email]} :params}]
   (cond
-    (within-char-limit-username? username)
-    (response 401 {:message "Usernames are limited to 20 characters"})
-
-    (= (valid-username? username) false)
-    (response 401 {:message "Username contain invalid characters."})
+    (not (valid-username? username))
+    (response 401 {:message "Username is not valid"})
 
     (not= password confirm-password)
     (response 401 {:message "Passwords must match"})


### PR DESCRIPTION
It was mistyped as a username having to be, at the same time, greater than AND smaller than 20 characters.

Since `valid-username?` checks for both size and invalid characters, I've changed the message to a more generic one.