### PR TITLE
Surround calls to "import-vars" with an anonymous function

### DIFF
--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -63,7 +63,12 @@
     [game.macros]
     [potemkin :refer [import-vars]]))
 
-(import-vars
+(defmacro expose-vars
+  "Surrounds a import-vars call with an anonymous function to get arround the 64kb limit on the method size in the JVM" 
+  [symbols]
+  `((fn ~[] (import-vars ~symbols))))
+
+(expose-vars
   [game.core.access
    access-bonus
    access-bonus-count
@@ -98,7 +103,7 @@
    steal-cost-bonus
    turn-archives-faceup])
 
-(import-vars
+(expose-vars
   [game.core.actions
    advance
    click-advance
@@ -128,19 +133,19 @@
    trash-resource
    view-deck])
 
-(import-vars
+(expose-vars
   [game.core.agendas
    update-advancement-requirement
    update-all-advancement-requirements
    update-all-agenda-points])
 
-(import-vars
+(expose-vars
   [game.core.bad-publicity
    bad-publicity-prevent
    gain-bad-publicity
    lose-bad-publicity])
 
-(import-vars
+(expose-vars
   [game.core.board
    all-active
    all-active-installed
@@ -159,7 +164,7 @@
    server->zone
    server-list])
 
-(import-vars
+(expose-vars
   [game.core.card
    active?
    agenda?
@@ -214,20 +219,20 @@
    upgrade?
    virus-program?])
 
-(import-vars
+(expose-vars
   [game.core.card-defs
    card-def
    defcard-impl])
 
-(import-vars
+(expose-vars
   [game.core.change-vals
    change])
 
-(import-vars
+(expose-vars
   [game.core.checkpoint
    fake-checkpoint])
 
-(import-vars
+(expose-vars
   [game.core.commands
    command-adv-counter
    command-counter
@@ -235,7 +240,7 @@
    command-undo-turn
    parse-command])
 
-(import-vars
+(expose-vars
   [game.core.cost-fns
    break-sub-ability-cost
    card-ability-cost
@@ -253,11 +258,11 @@
    score-additional-cost-bonus
    trash-cost])
 
-(import-vars
+(expose-vars
   [game.core.costs
    total-available-credits])
 
-(import-vars
+(expose-vars
   [game.core.damage
    chosen-damage
    corp-can-choose-damage?
@@ -269,7 +274,7 @@
    enable-runner-damage-choice
    runner-can-choose-damage?])
 
-(import-vars
+(expose-vars
   [game.core.def-helpers
    breach-access-bonus
    combine-abilities
@@ -284,12 +289,12 @@
    trash-on-empty
    corp-recur])
 
-(import-vars
+(expose-vars
   [game.core.diffs
    public-states
    public-diffs])
 
-(import-vars
+(expose-vars
   [game.core.drawing
    draw
    draw-bonus
@@ -297,7 +302,7 @@
    max-draw
    remaining-draws])
 
-(import-vars
+(expose-vars
   [game.core.effects
    any-effects
    gather-effects
@@ -311,7 +316,7 @@
    unregister-effects-for-card
    unregister-floating-effects])
 
-(import-vars
+(expose-vars
   [game.core.eid
    complete-with-result
    effect-completed
@@ -320,7 +325,7 @@
    make-result
    register-effect-completed])
 
-(import-vars
+(expose-vars
   [game.core.engine
    ability-as-handler
    can-trigger?
@@ -352,7 +357,7 @@
    unregister-suppress
    unregister-suppress-by-uuid])
 
-(import-vars
+(expose-vars
   [game.core.events
    event-count
    first-event?
@@ -372,19 +377,19 @@
    second-event?
    turn-events])
 
-(import-vars
+(expose-vars
   [game.core.expose
    expose
    expose-prevent])
 
-(import-vars
+(expose-vars
   [game.core.finding
    find-card
    find-cid
    find-latest
    get-scoring-owner])
 
-(import-vars
+(expose-vars
   [game.core.flags
    ab-can-prevent?
    any-flag-fn?
@@ -434,7 +439,7 @@
    when-scored?
    zone-locked?])
 
-(import-vars
+(expose-vars
   [game.core.gaining
    base-mod-size
    deduct
@@ -447,7 +452,7 @@
    safe-inc-n
    sub->0])
 
-(import-vars
+(expose-vars
   [game.core.hand-size
    corp-hand-size+
    hand-size
@@ -456,12 +461,12 @@
    sum-hand-size-effects
    update-hand-size])
 
-(import-vars
+(expose-vars
   [game.core.hosting
    host
    remove-from-host])
 
-(import-vars
+(expose-vars
   [game.core.ice
    add-extra-sub!
    add-sub
@@ -515,14 +520,14 @@
    update-ice-in-server
    update-ice-strength])
 
-(import-vars
+(expose-vars
   [game.core.identities
    disable-card
    disable-identity
    enable-card
    enable-identity])
 
-(import-vars
+(expose-vars
   [game.core.initializing
    ability-init
    card-init
@@ -533,7 +538,7 @@
    update-ability-cost-str
    update-all-card-labels])
 
-(import-vars
+(expose-vars
   [game.core.installing
    corp-can-pay-and-install?
    corp-install
@@ -546,13 +551,13 @@
    runner-can-pay-and-install?
    runner-install])
 
-(import-vars
+(expose-vars
   [game.core.link
    get-link
    link+
    update-link])
 
-(import-vars
+(expose-vars
   [game.core.memory
    available-mu
    caissa-mu+
@@ -560,7 +565,7 @@
    update-mu
    virus-mu+])
 
-(import-vars
+(expose-vars
   [game.core.moving
    add-to-currently-drawing
    as-agenda
@@ -581,14 +586,14 @@
    trash-prevent
    uninstall])
 
-(import-vars
+(expose-vars
   [game.core.optional
    get-autoresolve
    never?
    optional-ability
    set-autoresolve])
 
-(import-vars
+(expose-vars
   [game.core.payment
    add-cost-label-to-ability
    build-cost-label
@@ -607,23 +612,23 @@
    payable?
    value])
 
-(import-vars
+(expose-vars
   [game.core.play-instants
    can-play-instant?
    play-instant
    play-instant-costs])
 
-(import-vars
+(expose-vars
   [game.core.pick-counters
    pick-credit-providing-cards
    pick-virus-counters-to-spend])
 
-(import-vars
+(expose-vars
   [game.core.process-actions
    command-parser
    process-action])
 
-(import-vars
+(expose-vars
   [game.core.props
    add-counter
    add-icon
@@ -631,19 +636,19 @@
    remove-icon
    set-prop])
 
-(import-vars
+(expose-vars
   [game.core.player
    map->Corp
    map->Runner
    new-corp
    new-runner])
 
-(import-vars
+(expose-vars
   [game.core.prompt-state
    add-to-prompt-queue
    remove-from-prompt-queue])
 
-(import-vars
+(expose-vars
   [game.core.prompts
    cancellable
    choice-parser
@@ -657,27 +662,27 @@
    show-trace-prompt
    show-wait-prompt])
 
-(import-vars
+(expose-vars
   [game.core.psi
    psi-game])
 
-(import-vars
+(expose-vars
   [game.core.purging
    purge])
 
-(import-vars
+(expose-vars
   [game.core.revealing
    conceal-hand
    reveal
    reveal-hand])
 
-(import-vars
+(expose-vars
   [game.core.rezzing
    derez
    get-rez-cost
    rez])
 
-(import-vars
+(expose-vars
   [game.core.runs
    add-run-effect
    bypass-ice
@@ -709,7 +714,7 @@
    total-cards-accessed
    total-run-cost])
 
-(import-vars
+(expose-vars
   [game.core.say
    enforce-msg
    indicate-action
@@ -721,7 +726,7 @@
    implementation-msg
    system-say])
 
-(import-vars
+(expose-vars
   [game.core.servers
    central->name
    central->zone
@@ -743,7 +748,7 @@
    zone->sort-key
    zones->sorted-names])
 
-(import-vars
+(expose-vars
   [game.core.set-up
    build-card
    create-deck
@@ -751,62 +756,62 @@
    keep-hand
    mulligan])
 
-(import-vars
+(expose-vars
   [game.core.shuffling
    shuffle!
    shuffle-deck
    shuffle-into-deck
    shuffle-into-rd-effect])
 
-(import-vars
+(expose-vars
   [game.core.state
    make-rid
    map->State
    new-state])
 
-(import-vars
+(expose-vars
   [game.core.subtypes
    update-all-subtypes])
 
-(import-vars
+(expose-vars
   [game.core.tags
    gain-tags
    lose-tags
    tag-prevent])
 
-(import-vars
+(expose-vars
   [game.core.to-string
    card-str])
 
-(import-vars
+(expose-vars
   [game.core.toasts
    show-error-toast
    toast])
 
-(import-vars
+(expose-vars
   [game.core.trace
    init-trace
    init-trace-bonus])
 
-(import-vars
+(expose-vars
   [game.core.turns
    end-phase-12
    end-turn
    start-turn])
 
-(import-vars
+(expose-vars
   [game.core.update
    update!
    update-hosted!])
 
-(import-vars
+(expose-vars
   [game.core.virus
    count-virus-programs
    get-virus-counters
    number-of-virus-counters
    number-of-runner-virus-counters])
 
-(import-vars
+(expose-vars
   [game.core.winning
    check-win-by-agenda
    clear-win
@@ -815,7 +820,7 @@
    win
    win-decked])
 
-(import-vars
+(expose-vars
   [game.macros
    continue-ability
    effect
@@ -823,3 +828,4 @@
    req
    wait-for
    when-let*])
+

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -66,7 +66,7 @@
 (defmacro expose-vars
   "Surrounds a import-vars call with an anonymous function to get arround the 64kb limit on the method size in the JVM" 
   [symbols]
-  `((fn ~[] (import-vars ~symbols))))
+  `((fn [] (import-vars ~symbols))))
 
 (expose-vars
   [game.core.access


### PR DESCRIPTION
This causes the compiler to put each call in a separate method. If it tried to put them all in one single method, it would grow beyond the JVM's maximum of 64kb. Fixes #6397. This should also get circle-ci working again.

This is my first time coding clojure, so if you don't feel this is a good solution or spot anything weird, please do point it out!

Steps to reproduce:

- Make a fresh clone of the repo
- Switch to this branch (`fix-build`)
- `$ lein repl`

Old behaviour: The compilation would fail (as seen in the issue)
New Behaviour: The compilation succeeds (and so do the tests that are supposed to succeed with `$ lein test`)