### PR TITLE
chiyashi automatically trashes cards

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -873,15 +873,20 @@
    :subroutines [end-the-run]})
 
 (defcard "Chiyashi"
-  {:implementation "Trash effect when using an AI to break is activated manually"
-   :abilities [{:async true
-                :label "Trash the top 2 cards of the Runner's Stack"
-                :req (req (some #(has-subtype? % "AI") (all-active-installed state :runner)))
-                :msg (msg (str "trash " (string/join ", " (map :title (take 2 (:deck runner)))) " from the Runner's Stack"))
-                :effect (effect (mill :corp eid :runner 2))}]
-   :subroutines [(do-net-damage 2)
-                 (do-net-damage 2)
-                 end-the-run]})
+  (letfn [(chiyashi-auto-trash [state side eid n]
+            (if (pos? n)
+              (wait-for (mill state :corp :runner 2)
+                        (system-msg state side "uses Chiyashi to trash the top 2 cards of the Stack")
+                        (chiyashi-auto-trash state side eid (- n 1)))
+              (effect-completed state side eid)))]
+    {:events [{:event :subroutines-broken
+               :req (req (and (same-card? card (first targets))
+                              (seq (filter #(has-subtype? % "AI") (all-active-installed state :runner)))))
+               :async true
+               :effect (effect (chiyashi-auto-trash :corp eid (count (second targets))))}]
+     :subroutines [(do-net-damage 2)
+                   (do-net-damage 2)
+                   end-the-run]}))
 
 (defcard "Chrysalis"
   {:flags {:rd-reveal (req true)}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -877,7 +877,7 @@
             (if (pos? n)
               (wait-for (mill state :corp :runner 2)
                         (system-msg state side "uses Chiyashi to trash the top 2 cards of the Stack")
-                        (chiyashi-auto-trash state side eid (- n 1)))
+                        (chiyashi-auto-trash state side eid (dec n)))
               (effect-completed state side eid)))]
     {:events [{:event :subroutines-broken
                :req (req (and (same-card? card (first targets))

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1168,6 +1168,49 @@
         (take-credits state :runner)
         (is (not (rezzed? (refresh ch))))))))
 
+(deftest chiyashi-auto-trash
+  (do-game
+    (new-game {:corp {:hand [(qty "Chiyashi" 2)] :credits 30}
+               :runner {:hand ["Crypsis" "Corroder" "Hippo"] :deck [(qty "Sure Gamble" 50)] :credits 50}})
+    (play-from-hand state :corp "Chiyashi" "HQ")
+    (play-from-hand state :corp "Chiyashi" "R&D")
+    (rez state :corp (get-ice state :hq 0))
+    (rez state :corp (get-ice state :rd 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Crypsis")
+    (play-from-hand state :runner "Corroder")
+    (play-from-hand state :runner "Hippo")
+    (core/gain state :runner :click 100)
+    (let [corroder (get-program state 1)
+          crypsis (get-program state 0)]
+      ;; the ice is trashed before the 'trash 2' text on chiyashi
+      ;; is active, so it does not fire for the last subroutine
+      (run-on state "HQ")
+      (run-continue state)
+      (changes-val-macro
+        +4 (count (:discard (get-runner)))
+        "milled 4 with Chiyashi (2 + 2, ice trashed before third mill)"
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh corroder)})
+        (core/continue state :corp nil)
+        (click-prompt state :runner "Yes")
+        (run-jack-out state))
+      (run-on state "R&D")
+      (run-continue state)
+      (changes-val-macro
+        +7 (count (:discard (get-runner)))
+        "milled 6 with Chiyashi, and trashed crypsis"
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh crypsis)})
+        (core/continue state :corp nil)
+        (run-jack-out state))
+      (run-on state "R&D")
+      (run-continue state)
+      (changes-val-macro
+        0 (count (:discard (get-runner)))
+        "milled 0 with Chiyashi, no AI is installed"
+        (core/play-dynamic-ability state :runner {:dynamic "auto-pump-and-break" :card (refresh corroder)})
+        (core/continue state :corp nil)
+        (run-jack-out state)))))
+
 (deftest chrysalis
   ;; Chrysalis
   (do-game


### PR DESCRIPTION
Chiyashi automatically mills cards if there is an installed AI. 

The mills happen 2 at a time (so the interaction with buffer drive will always be correct), even when 2+ subroutines are broken at once.

This seems to work as expected when hippo is used (mills twice, then ice is trashed before the third mill) - not sure if there are any other cases I need to catch.

Closes #6404