### PR TITLE
Convert to explicit game.core.* requires

### DIFF
--- a/src/clj/dev/user.clj
+++ b/src/clj/dev/user.clj
@@ -1,10 +1,7 @@
 (ns dev.user
   (:require
    [integrant.repl :as ig-repl]
-   [time-literals.read-write :as read-write]
    [web.system :as system]))
-
-(read-write/print-time-literals-clj!)
 
 (ig-repl/set-prep! (fn [] (system/server-config)))
 

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -1,7 +1,28 @@
 (ns game.cards.basic
-  (:require [game.core :refer :all]
-            [game.utils :refer :all]
-            [jinteki.utils :refer :all]))
+  (:require
+   [game.core.agendas :refer [update-advancement-requirement]]
+   [game.core.board :refer [all-active-installed installable-servers]]
+   [game.core.card :refer [agenda? asset? event? get-card hardware? ice?
+                           in-hand? operation? program? resource? upgrade?]]
+   [game.core.def-helpers :refer [defcard]]
+   [game.core.drawing :refer [draw]]
+   [game.core.eid :refer [effect-completed]]
+   [game.core.engine :refer [trigger-event]]
+   [game.core.flags :refer [can-advance? untrashable-while-resources?]]
+   [game.core.gaining :refer [gain-credits]]
+   [game.core.installing :refer [corp-can-pay-and-install? corp-install
+                                 runner-can-pay-and-install? runner-install]]
+   [game.core.moving :refer [trash]]
+   [game.core.play-instants :refer [can-play-instant? play-instant]]
+   [game.core.props :refer [add-prop]]
+   [game.core.purging :refer [purge]]
+   [game.core.runs :refer [make-run]]
+   [game.core.say :refer [play-sfx]]
+   [game.core.tags :refer [lose-tags]]
+   [game.core.to-string :refer [card-str]]
+   [game.macros :refer [effect msg req wait-for]]
+   [game.utils :refer :all]
+   [jinteki.utils :refer :all]))
 
 ;; Card definitions
 

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1,10 +1,62 @@
 (ns game.cards.programs
-  (:require [game.core :refer :all]
-            [game.core.cost-fns :refer [all-stealth min-stealth]]
-            [game.core.runs :refer [active-encounter?]]
-            [game.utils :refer :all]
-            [jinteki.utils :refer :all]
-            [clojure.string :as string]))
+  (:require
+   [clojure.string :as str]
+   [game.core.access :refer [access-bonus max-access]]
+   [game.core.board :refer [all-active all-active-installed all-installed
+                            card->server server->zone]]
+   [game.core.card :refer [agenda? asset? card-index corp? facedown?
+                           get-advancement-requirement get-card get-counters
+                           get-nested-host get-zone hardware? has-subtype? ice? in-discard? in-hand? installed?
+                           program? resource? rezzed? runner?]]
+   [game.core.card-defs :refer [card-def]]
+   [game.core.cost-fns :refer [all-stealth install-cost min-stealth rez-cost]]
+   [game.core.costs :refer [total-available-credits]]
+   [game.core.damage :refer [damage-prevent]]
+   [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out]]
+   [game.core.drawing :refer [draw]]
+   [game.core.effects :refer [register-floating-effect
+                              unregister-effects-for-card]]
+   [game.core.eid :refer [effect-completed make-eid]]
+   [game.core.engine :refer [ability-as-handler dissoc-req not-used-once? pay
+                             prompt! register-events register-once
+                             trigger-event trigger-event-simult unregister-events print-msg]]
+   [game.core.events :refer [first-event? first-installed-trash?
+                             first-successful-run-on-server? turn-events]]
+   [game.core.expose :refer [expose]]
+   [game.core.finding :refer [find-cid]]
+   [game.core.flags :refer [can-host? card-flag? zone-locked?]]
+   [game.core.gaining :refer [gain-clicks gain-credits lose-credits]]
+   [game.core.hosting :refer [host]]
+   [game.core.ice :refer [all-subs-broken-by-card? all-subs-broken?
+                          any-subs-broken-by-card? auto-icebreaker break-sub
+                          break-subroutine! break-subroutines-msg dont-resolve-subroutine! get-strength ice-strength
+                          pump pump-ice set-current-ice strength-pump unbroken-subroutines-choice
+                          update-breaker-strength]]
+   [game.core.initializing :refer [ability-init card-init]]
+   [game.core.installing :refer [install-locked? runner-can-install?
+                                 runner-install]]
+   [game.core.link :refer [get-link]]
+   [game.core.memory :refer [available-mu update-mu]]
+   [game.core.moving :refer [flip-facedown mill move swap-cards swap-ice trash
+                             trash-prevent]]
+   [game.core.optional :refer [get-autoresolve set-autoresolve]]
+   [game.core.payment :refer [build-cost-label can-pay? cost-target cost-value]]
+   [game.core.prompts :refer [cancellable]]
+   [game.core.props :refer [add-counter add-icon remove-icon]]
+   [game.core.revealing :refer [reveal]]
+   [game.core.rezzing :refer [derez rez get-rez-cost]]
+   [game.core.runs :refer [active-encounter? bypass-ice continue get-current-encounter make-run
+                           successful-run-replace-breach]]
+   [game.core.say :refer [system-msg]]
+   [game.core.servers :refer [is-central? is-remote? target-server zone->name]]
+   [game.core.shuffling :refer [shuffle!]]
+   [game.core.tags :refer [gain-tags lose-tags]]
+   [game.core.to-string :refer [card-str]]
+   [game.core.update :refer [update!]]
+   [game.core.virus :refer [get-virus-counters]]
+   [game.macros :refer [continue-ability effect msg req wait-for]]
+   [game.utils :refer :all]
+   [jinteki.utils :refer :all]))
 
 (defn- power-counter-break
   "Only break ability uses power counters
@@ -583,7 +635,7 @@
                                     (reveal state side (make-eid state eid) cards)
                                     (system-msg state side (str payment-str
                                                                 " to use Bug to reveal "
-                                                                (string/join ", " (map :title cards))))
+                                                                (str/join ", " (map :title cards))))
                                     (effect-completed state side eid))))))}}}]})
 
 (defcard "Bukhgalter"
@@ -868,7 +920,7 @@
                                                     card nil))))}))]
     {:on-install {:async true
                   :interactive (req (some #(card-flag? % :runner-install-draw true) (all-active state :runner)))
-                  :msg (msg "reveal the top 5 cards of their Stack: " (string/join ", " (map :title (take 5 (:deck runner)))))
+                  :msg (msg "reveal the top 5 cards of their Stack: " (str/join ", " (map :title (take 5 (:deck runner)))))
                   :waiting-prompt "Runner to make a decision"
                   :effect (req (let [from (take 5 (:deck runner))]
                                  (wait-for (reveal state side from)
@@ -1171,7 +1223,7 @@
                   :duration :end-of-run
                   :ability
                   {:msg (msg "reveal all of the cards cards in HQ: "
-                             (string/join ", " (map :title (:hand corp))))
+                             (str/join ", " (map :title (:hand corp))))
                    :async true
                    :effect (effect (reveal eid (:hand corp)))}})]
     {:abilities [{:cost [:click 1]
@@ -2378,7 +2430,7 @@
                    :msg (msg "reveal " (->> (:deck corp)
                                             (take 3)
                                             (map :title)
-                                            (string/join ", ")))
+                                            (str/join ", ")))
                    :effect (req (wait-for
                                  (reveal state side (take 3 (:deck corp)))
                                  (continue-ability
@@ -2536,7 +2588,7 @@
                                :all true
                                :card #(and (runner? %)
                                            (in-discard? %))}
-                     :msg (msg "shuffle " (string/join ", " (map :title targets))
+                     :msg (msg "shuffle " (str/join ", " (map :title targets))
                                " into their Stack")
                      :effect (req (doseq [c targets] (move state side c :deck))
                                   (shuffle! state side :deck))}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1,9 +1,62 @@
 (ns game.cards.upgrades
-  (:require [game.core :refer :all]
-            [game.utils :refer :all]
-            [jinteki.utils :refer :all]
-            [clojure.string :as string]
-            [cond-plus.core :refer [cond+]]))
+  (:require
+   [clojure.string :as str]
+   [cond-plus.core :refer [cond+]]
+   [game.core.access :refer [access-bonus set-only-card-to-access
+                             steal-cost-bonus]]
+   [game.core.bad-publicity :refer [lose-bad-publicity]]
+   [game.core.board :refer [all-active-installed all-installed card->server
+                            get-remotes server->zone server-list]]
+   [game.core.card :refer [agenda? asset? can-be-advanced?
+                           corp-installable-type? corp? get-card get-counters get-zone
+                           has-subtype? ice? in-discard? in-hand? installed? operation? program? resource? rezzed?
+                           runner? upgrade?]]
+   [game.core.cost-fns :refer [install-cost rez-cost]]
+   [game.core.costs :refer [total-available-credits]]
+   [game.core.damage :refer [damage]]
+   [game.core.def-helpers :refer [corp-rez-toast defcard offer-jack-out
+                                  reorder-choice]]
+   [game.core.drawing :refer [draw]]
+   [game.core.effects :refer [register-floating-effect]]
+   [game.core.eid :refer [effect-completed make-eid]]
+   [game.core.engine :refer [dissoc-req pay register-default-events
+                             register-events resolve-ability unregister-events]]
+   [game.core.events :refer [first-event? first-run-event? turn-events]]
+   [game.core.expose :refer [expose-prevent]]
+   [game.core.finding :refer [find-cid find-latest]]
+   [game.core.flags :refer [clear-persistent-flag! enable-run-on-server
+                            is-scored? prevent-run-on-server
+                            register-persistent-flag! register-run-flag!]]
+   [game.core.gaining :refer [gain-credits lose-clicks lose-credits]]
+   [game.core.hand-size :refer [corp-hand-size+]]
+   [game.core.ice :refer [all-subs-broken? get-run-ices pump-ice
+                          unbroken-subroutines-choice update-all-ice update-all-icebreakers]]
+   [game.core.installing :refer [corp-install]]
+   [game.core.moving :refer [mill move remove-from-currently-drawing
+                             swap-cards swap-ice trash trash-cards]]
+   [game.core.optional :refer [get-autoresolve set-autoresolve]]
+   [game.core.payment :refer [can-pay? cost-value]]
+   [game.core.play-instants :refer [play-instant]]
+   [game.core.prompts :refer [cancellable clear-wait-prompt]]
+   [game.core.props :refer [add-counter add-prop set-prop]]
+   [game.core.purging :refer [purge]]
+   [game.core.revealing :refer [reveal]]
+   [game.core.rezzing :refer [rez]]
+   [game.core.runs :refer [end-run force-ice-encounter jack-out redirect-run
+                           set-next-phase start-next-phase]]
+   [game.core.say :refer [system-msg]]
+   [game.core.servers :refer [central->zone from-same-server? in-same-server?
+                              is-central? protecting-same-server? same-server?
+                              target-server unknown->kw zone->name]]
+   [game.core.shuffling :refer [shuffle!]]
+   [game.core.tags :refer [gain-tags]]
+   [game.core.to-string :refer [card-str]]
+   [game.core.toasts :refer [toast]]
+   [game.core.trace :refer [init-trace-bonus]]
+   [game.core.update :refer [update!]]
+   [game.macros :refer [continue-ability effect msg req wait-for]]
+   [game.utils :refer :all]
+   [jinteki.utils :refer :all]))
 
 ;; Card definitions
 
@@ -131,7 +184,7 @@
    :abilities [{:cost [:click 1]
                 :req (req (pos? (count (:deck corp))))
                 :async true
-                :msg (msg (str "reveal " (string/join ", " (map :title (take 3 (:deck corp)))) " from R&D"))
+                :msg (msg (str "reveal " (str/join ", " (map :title (take 3 (:deck corp)))) " from R&D"))
                 :label "Add 1 card from top 3 of R&D to HQ"
                 :waiting-prompt "Corp to make a decision"
                 :effect (req
@@ -524,7 +577,7 @@
                             (protecting-same-server? card target)))
              :msg (msg (let [deck (:deck runner)]
                          (if (pos? (count deck))
-                           (str "trash " (string/join ", " (map :title (take 2 deck))) " from the Stack")
+                           (str "trash " (str/join ", " (map :title (take 2 deck))) " from the Stack")
                            "trash the top 2 cards from their Stack - but the Stack is empty")))
              :async true
              :effect (effect (mill :corp eid :runner 2))}]})
@@ -1391,7 +1444,7 @@
                                          :choices ["Lose [Click][Click]" "Take 1 brain damage"]
                                          :async true
                                          :effect
-                                         (req (if (string/starts-with? target "Take")
+                                         (req (if (str/starts-with? target "Take")
                                                 (do
                                                   (system-msg state side (str "chooses to take 1 brain damage"))
                                                   (damage state side eid :brain 1 {:card tempus}))
@@ -1429,7 +1482,7 @@
                              (= :corp (second targets))
                              (pos? (last targets))
                              (first-run-event? state side :pre-resolve-damage
-                                               (fn [[t s n]]
+                                               (fn [[t s]]
                                                  (and (= :net t)
                                                       (= :corp s))))
                              (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil [:credit 2])))
@@ -1503,7 +1556,7 @@
 
 (defcard "Vladisibirsk City Grid"
   {:advanceable :always
-   :abilities [{:cost [:advancement 2]              
+   :abilities [{:cost [:advancement 2]
                 :once :per-turn
                 :prompt (msg "Choose an advanceable card in " (zone->name (second (get-zone card))))
                 :label "Place 2 advancement counters (once per turn)"
@@ -1525,7 +1578,7 @@
                        :max n
                        :card #(and (runner? %)
                                    (installed? %))}
-             :msg (msg "force the Runner to trash " (string/join ", " (map :title targets)))
+             :msg (msg "force the Runner to trash " (str/join ", " (map :title targets)))
              :effect (req (wait-for (trash-cards state :runner targets {:unpreventable true :cause-card card :cause :forced-to-trash})
                                     (effect-completed state side eid)))})
           (ability []

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -2,7 +2,6 @@
   (:require
     [game.core.access :refer [access-bonus]]
     [game.core.card :refer [corp? get-card get-counters has-subtype? in-discard? faceup?]]
-    [game.core.card-defs :refer [defcard-impl]]
     [game.core.damage :refer [damage]]
     [game.core.eid :refer [effect-completed]]
     [game.core.engine :refer [resolve-ability trigger-event-sync]]
@@ -230,7 +229,7 @@
 
 (defmacro defcard
   [title ability]
-  `(defmethod ~'defcard-impl ~title [~'_]
+  `(defmethod game.core.card-defs/defcard-impl ~title [~'_]
      (if-let [cached-ability# (get card-defs-cache ~title)]
        cached-ability#
        (let [ability# (add-default-abilities ~title ~ability)]

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -23,15 +23,17 @@
    [org.httpkit.server :refer [run-server server-stop!]]
    [taoensso.sente :as sente]
    [time-literals.data-readers]
-   [time-literals.read-write]
+   [time-literals.read-write :as read-write]
    [web.angel-arena :as angel-arena]
-   [web.versions :refer [frontend-version banned-msg]]
    [web.api :refer [make-app make-dev-app]]
    [web.app-state :as app-state]
    [web.game]
    [web.lobby :as lobby]
    [web.utils :refer [tick]]
+   [web.versions :refer [banned-msg frontend-version]]
    [web.ws :refer [ch-chsk event-msg-handler]]))
+
+(read-write/print-time-literals-clj!)
 
 (defmethod aero/reader 'ig/ref
   [_ _ value]


### PR DESCRIPTION
This is "small" in that there's no logic changes, just switching from `(:require [game.core :refer :all]` to `(:require [game.core.access :refer [a b c]] [game.core.bad-publicity :refer [x y z]] ...)` etc.