### PR TITLE
fix Pravdivost ability not being optional

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1522,13 +1522,19 @@
 
 (defcard "Pravdivost Consulting: Political Solutions"
   {:events [{:event :successful-run
-             :req (req (first-event? state side :successful-run))
-             :interactive (req true)
-             :waiting-prompt "Corp to make a decision"
-             :prompt "Choose a card to place 1 advancement token on"
-             :choices {:card can-be-advanced?}
-             :msg (msg "place 1 advancement token on " (card-str state target))
-             :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}]})
+             :optional {:req (req (first-event? state side :successful-run))
+                        :autoresolve (get-autoresolve :auto-pravdivost)
+                        :prompt "Place 1 advancement counter on a card that can be advanced?"
+                        :yes-ability {:interactive (req true)
+                                      :waiting-prompt "Corp to make a decision"
+                                      :prompt "Choose a card to place 1 advancement token on"
+                                      :choices {:card can-be-advanced?}
+                                      :msg (msg "place 1 advancement token on " (card-str state target))
+                                      :cancel-effect (effect (system-msg "declines to use Pravdivost Consulting"))
+                                      :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}
+                        :no-ability {:effect (effect (system-msg "declines to use Pravdivost Consulting"))}
+                        }}]
+   :abilities [(set-autoresolve :auto-pravdivost "Pravdivost Consulting: Political Solutions")]})
 
 (defcard "Quetzal: Free Spirit"
   {:abilities [(assoc (break-sub nil 1 "Barrier" {:repeatable false}) :once :per-turn)]})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1524,16 +1524,15 @@
   {:events [{:event :successful-run
              :optional {:req (req (first-event? state side :successful-run))
                         :autoresolve (get-autoresolve :auto-pravdivost)
+                        :interactive (req true)
                         :prompt "Place 1 advancement counter on a card that can be advanced?"
-                        :yes-ability {:interactive (req true)
-                                      :waiting-prompt "Corp to make a decision"
+                        :yes-ability {:waiting-prompt "Corp to make a decision"
                                       :prompt "Choose a card to place 1 advancement token on"
                                       :choices {:card can-be-advanced?}
                                       :msg (msg "place 1 advancement token on " (card-str state target))
                                       :cancel-effect (effect (system-msg "declines to use Pravdivost Consulting"))
                                       :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}
-                        :no-ability {:effect (effect (system-msg "declines to use Pravdivost Consulting"))}
-                        }}]
+                        :no-ability {:effect (effect (system-msg "declines to use Pravdivost Consulting"))}}}]
    :abilities [(set-autoresolve :auto-pravdivost "Pravdivost Consulting: Political Solutions")]})
 
 (defcard "Quetzal: Free Spirit"

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3754,6 +3754,7 @@
     (take-credits state :corp)
     (run-on state :hq)
     (run-continue state)
+    (click-prompt state :corp "Yes")
     ;; fake prompt, doesn't give away that PAD cannot be advanced
     (click-prompt state :corp "Done")))
 
@@ -3765,6 +3766,7 @@
     (take-credits state :corp)
     (run-on state :hq)
     (run-continue state)
+    (click-prompt state :corp "Yes")
     (click-card state :corp "NGO Front")
     (is (= 1 (get-counters (get-content state :remote1 0) :advancement)) "NGO was advanced")))
 


### PR DESCRIPTION
Reworked to resemble other _may_ abilities.
Added `set-autoresolve` for convenience.