### PR TITLE
Small fixes to messages

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1542,7 +1542,7 @@
                            (update-all-advancement-requirements state)
                            (update-all-agenda-points state)
                            (check-win-by-agenda state side))
-              :cancel-effect (effect (system-msg "declines to use Regensis to reveal an Agenda"))}})
+              :cancel-effect (effect (system-msg "declines to use Regenesis to reveal an agenda in Archives"))}})
 
 (defcard "Remastered Edition"
   {:on-score {:effect (effect (add-counter card :agenda 1))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1383,7 +1383,7 @@
                                         (moon-pool-place-advancements agenda-count)
                                         card nil)
                                       (effect-completed state side eid)))))
-           :cancel-effect (effect (system-msg "declines to use Moon Pool to reveal any cards from Archives")
+           :cancel-effect (effect (system-msg "declines to use Moon Pool to reveal any cards in Archives")
                                   (effect-completed eid))}]
       {:abilities [{:prompt "Trash up to 2 cards from HQ"
                     :label "Trash up to 2 cards from HQ"
@@ -1398,7 +1398,7 @@
                                              state side
                                              moon-pool-reveal-ability
                                              card nil)))
-                    :cancel-effect (effect (system-msg "declines to use Moon Pool to trash cards from HQ")
+                    :cancel-effect (effect (system-msg "declines to use Moon Pool to trash any cards from HQ")
                                            (continue-ability moon-pool-reveal-ability card nil))}]})))
 
 (defcard "Mr. Stone"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2192,6 +2192,7 @@
             {:req (req (not (in-discard? card)))
              :waiting-prompt "Corp to choose an option"
              :prompt "Pay 4 [Credits] to use Snare! ability?"
+             :no-ability {:effect (effect (system-msg "declines to use Snare!"))}
              :yes-ability {:async true
                            :cost [:credit 4]
                            :msg "do 3 net damage and give the Runner 1 tag"
@@ -2272,6 +2273,8 @@
                                           (installed? target)
                                           (not (same-card? target card))))}
                  :msg (msg "trash " (:title target) " and gain 3 [Credits]")
+                 :cancel-effect (req (system-msg state :corp "declines to use Svyatogor Excavator")
+                                     (effect-completed state side eid))
                  :effect (req (wait-for (trash state side target {:unpreventable true :cause-card card})
                                         (gain-credits state side eid 3)))}]
     {:flags {:corp-phase-12 (req (>= (count (all-installed state :corp)) 2))}

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -175,7 +175,7 @@
                               (continue-ability
                                 state side
                                 {:optional
-                                 {:waiting-prompt (str "Corp to decide if they will rez " cname)
+                                 {:waiting-prompt "Corp to make a decision"
                                   :prompt (msg (build-cost-string [:credit cost])
                                                ", plus " (str/lower-case (build-cost-string additional-costs))
                                                " as an additional cost to rez " cname "?")
@@ -1991,7 +1991,7 @@
               :yes-ability {:msg "gain 2 [Credits]"
                             :async true
                             :effect (effect (gain-credits eid 2))}
-              :no-ability {:effect (effect (system-msg "declines to use Supercorridor to gain 2 [Credits]"))}}}]
+              :no-ability {:effect (effect (system-msg "declines to use Supercorridor"))}}}]
    :abilities [(set-autoresolve :auto-fire "Supercorridor")]})
 
 (defcard "Swift"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1719,6 +1719,8 @@
                                      (rezzed? target)
                                      (not (same-card? card target))))}
             :waiting-prompt "Corp to choose an option"
+            :cancel-effect (effect (system-msg "declines to use Hákarl 1.0 to derez another card")
+                                   (effect-completed eid))
             :effect (effect (derez target)
                             (system-msg (str "prevents the runner from using printed abilities on bioroid ice for the rest of the turn"))
                             (register-floating-effect

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2251,7 +2251,7 @@
                                                    (system-msg state :runner "shuffles their Grip into their Stack"))}
                                      :no-ability
                                      {:async true
-                                      :effect (effect (system-msg :runner "declines to shuffle their Grip into their Stack. Loki ends the run")
+                                      :effect (effect (system-msg :runner "declines to shuffle their Grip into their Stack")
                                                       (end-run eid card))}}}
                                    card nil)))}]})
 

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1291,7 +1291,8 @@
                                (update! state side (assoc-in c [:seen] false)))
                              (shuffle! state :corp :discard)
                              (continue-ability state side install-abi card nil)))
-      :cancel-effect (req (doseq [c (:discard (:corp @state))]
+      :cancel-effect (req (system-msg state :corp "declines to use Kakurenbo to trash any cards from HQ")
+                          (doseq [c (:discard (:corp @state))]
                             (update! state side (assoc-in c [:seen] false)))
                           (shuffle! state :corp :discard)
                           (continue-ability state side install-abi card nil))}}))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -214,6 +214,8 @@
                                           (installed? target)
                                           (not (same-card? target card))))}
                  :msg (msg "trash " (:title target) " and gain 3 [Credits]")
+                 :cancel-effect (req (system-msg state :runner "declines to use Aesop's Pawnshop")
+                                     (effect-completed state side eid))
                  :effect (req (wait-for (trash state side target {:unpreventable true :cause-card card})
                                         (gain-credits state side eid 3)))}]
     {:flags {:runner-phase-12 (req (>= (count (all-installed state :runner)) 2))}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -3374,7 +3374,7 @@
                                      :effect (effect (system-msg (str "draws " (:title (first (:deck corp)))))
                                                      (draw eid 1))}
                                     :no-ability
-                                    {:effect (effect (system-msg "declines to draw with Woman in the Red Dress"))}}}
+                                    {:effect (effect (system-msg "declines to use Woman in the Red Dress"))}}}
                                   card nil)))}]
     {:events [(assoc ability :event :runner-turn-begins)]
      :abilities [ability]}))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -601,7 +601,7 @@
       :msg (msg "force the Runner to encounter " (card-str state target))
       :effect (req (wait-for (trash state :corp (assoc card :seen true) {:unpreventable true :cause-card card})
                              (force-ice-encounter state side eid target)))}
-     :no-ability {:effect (effect (system-msg :corp (str "declines to use Ganked!")))}}}})
+     :no-ability {:effect (effect (system-msg "declines to use Ganked!"))}}}})
 
 (defcard "Georgia Emelyov"
   {:events [{:event :unsuccessful-run
@@ -979,9 +979,9 @@
                                             (system-msg state side "uses Mavirus to do 1 net damage")
                                             (damage state side eid :net 1 {:card card}))
                                           (effect-completed state side eid)))}
-             :no-ability {:msg (msg "decline to purge virus counters")
-                          :async true
-                          :effect (req (if (rezzed? card)
+             :no-ability {:async true
+                          :effect (req (system-msg state side "declines to use Mavirus to purge virus counters")
+                                       (if (rezzed? card)
                                          (do
                                            (system-msg state side "uses Mavirus to do 1 net damage")
                                            (damage state side eid :net 1 {:card card}))

--- a/test/clj/game/core/sabotage_test.clj
+++ b/test/clj/game/core/sabotage_test.clj
@@ -42,8 +42,6 @@
       (let [prev-cards-in-rd (-> (get-corp) :deck count)
             prev-cards-in-hq (-> (get-corp) :hand count)]
         (click-prompt state :corp "Done")
-        (println (prompt-fmt :corp))
-        (println (clojure.string/join "\n" (map :text (:log @state))))
         (is (= (- prev-cards-in-rd 3)
                (-> (get-corp) :deck count))
             "3 cards from R&D trashed")


### PR DESCRIPTION
Add "decline" messages to improve clarity, fix Regenesis typo, remove leftover `println` from test