### PR TITLE
Fix patchwork ability counting for "spending credits from installed cards" effects

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1493,7 +1493,8 @@
                          ; provide 0 credits
                          :cancel-effect (effect (effect-completed (make-result eid 0)))}
                         card nil)))
-       :type :custom}}}))
+       :type :custom
+       :cost-reduction true}}}))
 
 (defcard "Pennyshaver"
   {:constant-effects [(mu+ 1)]

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -81,6 +81,11 @@
   (req (update! state side (assoc-in card [:counter counter-type] (dec (get-counters card counter-type))))
        (complete-with-result state side eid 1)))
 
+(defn- not-cost-reduction-payment-cards
+  "Returns cards which do not have the :cost-reduction tag"
+  [cards]
+  (filter #(not (-> (card-def %) :interactions :pay-credits :cost-reduction)) cards))
+
 (defn pick-credit-providing-cards
   "Similar to pick-virus-counters-to-spend. Works on :recurring and normal credits."
   ([provider-func outereid] (pick-credit-providing-cards provider-func outereid nil 0 (hash-map)))
@@ -111,7 +116,7 @@
                                            (when (and card-strs remainder-str)
                                              " from their credit pool"))]
                           (lose state side :credit remainder)
-                          (let [cards (map :card (vals selected-cards))]
+                          (let [cards (not-cost-reduction-payment-cards (map :card (vals selected-cards)))]
                             (wait-for (trigger-spend-credits-from-cards state side cards)
                                       ; Now we trigger all of the :counter-added events we'd neglected previously
                                       (pick-counter-triggers state side eid selected-cards selected-cards target-count message))))

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -81,11 +81,6 @@
   (req (update! state side (assoc-in card [:counter counter-type] (dec (get-counters card counter-type))))
        (complete-with-result state side eid 1)))
 
-(defn- not-cost-reduction-payment-cards
-  "Returns cards which do not have the :cost-reduction tag"
-  [cards]
-  (filter #(not (-> (card-def %) :interactions :pay-credits :cost-reduction)) cards))
-
 (defn pick-credit-providing-cards
   "Similar to pick-virus-counters-to-spend. Works on :recurring and normal credits."
   ([provider-func outereid] (pick-credit-providing-cards provider-func outereid nil 0 (hash-map)))
@@ -116,7 +111,9 @@
                                            (when (and card-strs remainder-str)
                                              " from their credit pool"))]
                           (lose state side :credit remainder)
-                          (let [cards (not-cost-reduction-payment-cards (map :card (vals selected-cards)))]
+                          (let [cards (->> (vals selected-cards)
+                                          (map :card)
+                                          (remove #(-> (card-def %) :interactions :pay-credits :cost-reduction)))]
                             (wait-for (trigger-spend-credits-from-cards state side cards)
                                       ; Now we trigger all of the :counter-added events we'd neglected previously
                                       (pick-counter-triggers state side eid selected-cards selected-cards target-count message))))

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -3375,12 +3375,26 @@
       (new-game {:runner {:deck ["Patchwork" "Sure Gamble" "Film Critic"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Patchwork")
-      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
       (play-from-hand state :runner "Film Critic")
       (click-card state :runner (get-hardware state 0))
       (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))
       (is (= 1 (:credit (get-runner))) "Runner should still have 1c")
       (is (get-resource state 0) "Installed Film Critic")))
+
+(deftest patchwork-shouldn-t-trigger-credits-spent-from-cards-effects-issue-6462
+  ;; Patchwork shouldn't count for "spend credits from an installed card" type effects
+  (do-game
+    (new-game {:runner {:deck ["Patchwork" "Paperclip" "Sure Gamble" "The Twinning"] :credits 10 }})
+    (take-credits state :corp)
+    (play-from-hand state :runner "The Twinning")
+    (play-from-hand state :runner "Patchwork")
+    (let [patchwork (get-hardware state 0)
+          twinning (get-resource state 0)
+          paperclip (find-card "Paperclip" (:hand (get-runner)))]
+      (play-from-hand state :runner "Sure Gamble")
+      (click-card state :runner patchwork)
+      (click-card state :runner paperclip)
+      (is (= 0 (get-counters (refresh twinning) :power) "Twinning should not have gained a counter")))))
 
 (deftest pennyshaver
   ;; Pennyshaver - Prevent meat damage

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -3382,7 +3382,7 @@
       (is (get-resource state 0) "Installed Film Critic")))
 
 (deftest patchwork-shouldn-t-trigger-credits-spent-from-cards-effects-issue-6462
-  ;; Patchwork shouldn't count for "spend credits from an installed card" type effects
+  ;; Patchwork's ability shouldn't count for "spend credits from an installed card" type effects
   (do-game
     (new-game {:runner {:deck ["Patchwork" "Paperclip" "Sure Gamble" "The Twinning"] :credits 10 }})
     (take-credits state :corp)
@@ -3394,7 +3394,7 @@
       (play-from-hand state :runner "Sure Gamble")
       (click-card state :runner patchwork)
       (click-card state :runner paperclip)
-      (is (= 0 (get-counters (refresh twinning) :power) "Twinning should not have gained a counter")))))
+      (is (= 0 (get-counters (refresh twinning) :power)) "Twinning should not have gained a counter"))))
 
 (deftest pennyshaver
   ;; Pennyshaver - Prevent meat damage

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -3375,6 +3375,7 @@
       (new-game {:runner {:deck ["Patchwork" "Sure Gamble" "Film Critic"]}})
       (take-credits state :corp)
       (play-from-hand state :runner "Patchwork")
+      (is (= 1 (:credit (get-runner))) "Runner has 1 credit")
       (play-from-hand state :runner "Film Critic")
       (click-card state :runner (get-hardware state 0))
       (click-card state :runner (find-card "Sure Gamble" (:hand (get-runner))))

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -3398,7 +3398,7 @@
       (is (= 0 (get-counters (refresh twinning) :power)) "Twinning should not have gained a counter"))))
 
 (deftest pennyshaver
-  ;; Pennyshaver - Prevent meat damage
+  ;; Pennyshaver - Place credits on successful run and take credits from Pennyshaver
   (do-game
       (new-game {:corp {:deck ["Hedge Fund"]}
                  :runner {:deck ["Pennyshaver"]}})


### PR DESCRIPTION
Fixes #6462 

Since patchwork is the only card that works this way, I felt that this solution is a little easier than implementing a whole :reduce-cost interaction. Please let me know if I need to make any changes.