### PR TITLE
fix Deep Dive cost check for second access

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -801,12 +801,12 @@
                    (let [top-8 (sort-by :title (get-set-aside state :corp eid))]
                      (wait-for
                       (resolve-ability state side (deep-dive-access top-8) card nil)
-                      (if (and (pos? (count async-result))
-                               (pos? (:click runner)))
+                      (if (pos? (count async-result))
                         (wait-for (resolve-ability
                                    state side
                                    {:optional
                                     {:prompt "Pay [Click] to access another card?"
+                                     :req (req (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil [:lose-click 1]))
                                      :no-ability {:msg "decline to access another card"}
                                      :yes-ability
                                      {:async true

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1646,6 +1646,29 @@
     (is (= 0 (count (:deck (get-corp)))))
     (is (= 2 (count (:discard (get-corp)))))))
 
+(deftest deep-dive-ikawah-cost-for-second-card
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 3) "Ikawah Project" "Project Vitruvius"]}
+	       :runner {:hand ["Deep Dive"]}})
+    (draw state :corp)
+    (core/move state :corp (find-card "Hedge Fund" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Ikawah Project" (:hand (get-corp))) :deck)
+    (core/move state :corp (find-card "Project Vitruvius" (:hand (get-corp))) :deck)
+    ;;R&D is now: Hedge Fund, Ikawah Project, Project Vitruvius
+    (take-credits state :corp)
+    (core/gain state :runner :click 1)
+    ;;run the three centrals
+    (run-empty-server state "Archives")
+    (run-empty-server state "R&D")
+    (click-prompt state :runner "No action")
+    (run-empty-server state "HQ")
+    (click-prompt state :runner "No action")
+    (play-from-hand state :runner "Deep Dive")
+    (click-prompt state :runner "Ikawah Project")
+    (click-prompt state :runner "Pay to steal")
+    (is (no-prompt? state :runner) 
+        "Runner shouldn't be given the option to access the second card since he spent the last click to steal Ikawah")))
+
 (deftest deep-dive-basic-functionality
   (do-game
     (new-game {:corp {:hand ["Ansel 1.0" "Better Citizen Program" "Chiyashi" 


### PR DESCRIPTION
If the Runner loses their last click mid-access, e.g. to steal an Ikawah Project, they see the prompt for the second access anyway.
Added a test to demonstrate the scenario