### PR TITLE
Fix: Pay moon pool RFG cost even if no cards are discarded

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1390,6 +1390,7 @@
              :choices {:card #(and (corp? %)
                                    (in-hand? %))
                        :max 2}
+             :async true
              :msg (msg "trash " (count targets) " cards from HQ ")
              :effect (req (wait-for (trash-cards state :corp targets {:cause-card card})
                                     (continue-ability

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1371,7 +1371,7 @@
                                  (in-discard? %)
                                  (not (faceup? %)))
                      :max 2}
-           :msg (msg "to reveal " (str/join " and " (map :title targets)) " from Archives and shuffle them into R&D")
+           :msg (msg "reveal " (str/join " and " (map :title targets)) " from Archives and shuffle them into R&D")
            :effect (req (wait-for (reveal state side targets)
                                   (doseq [c targets]
                                     (move state side c :deck))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1385,21 +1385,26 @@
                                       (effect-completed state side eid)))))
            :cancel-effect (effect (system-msg "declines to use Moon Pool to reveal any cards in Archives")
                                   (effect-completed eid))}]
-      {:abilities [{:prompt "Trash up to 2 cards from HQ"
-                    :label "Trash up to 2 cards from HQ"
-                    :cost [:remove-from-game]
-                    :async true
-                    :choices {:card #(and (corp? %)
-                                          (in-hand? %))
-                              :max 2}
-                    :msg (msg "trash " (count targets) " cards from HQ ")
-                    :effect (req (wait-for (trash-cards state :corp targets {:cause-card card})
-                                           (continue-ability
-                                             state side
-                                             moon-pool-reveal-ability
-                                             card nil)))
-                    :cancel-effect (effect (system-msg "declines to use Moon Pool to trash any cards from HQ")
-                                           (continue-ability moon-pool-reveal-ability card nil))}]})))
+      (let [moon-pool-discard-ability
+            {:prompt "Trash up to 2 cards from HQ"
+             :choices {:card #(and (corp? %)
+                                   (in-hand? %))
+                       :max 2}
+             :msg (msg "trash " (count targets) " cards from HQ ")
+             :effect (req (wait-for (trash-cards state :corp targets {:cause-card card})
+                                    (continue-ability
+                                      state side
+                                      moon-pool-reveal-ability
+                                      card nil)))
+             :cancel-effect (effect (system-msg "declines to use Moon Pool to trash any cards from HQ")
+                                    (continue-ability moon-pool-reveal-ability card nil))}]
+        {:abilities [{:label "Trash up to 2 cards from HQ. Shuffle up to 2 cards from Archives into R&D"
+                      :cost [:remove-from-game]
+                      :async true
+                      :effect (effect (continue-ability
+                                        moon-pool-discard-ability
+                                        card nil))}]}))))
+
 
 (defcard "Mr. Stone"
   {:events [{:event :runner-gain-tag

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1384,8 +1384,8 @@
                                         card nil)
                                       (effect-completed state side eid)))))
            :cancel-effect (effect (system-msg "declines to use Moon Pool to reveal any cards in Archives")
-                                  (effect-completed eid))}]
-      (let [moon-pool-discard-ability
+                                  (effect-completed eid))}
+          moon-pool-discard-ability
             {:prompt "Trash up to 2 cards from HQ"
              :choices {:card #(and (corp? %)
                                    (in-hand? %))
@@ -1399,13 +1399,12 @@
                                       card nil)))
              :cancel-effect (effect (system-msg "declines to use Moon Pool to trash any cards from HQ")
                                     (continue-ability moon-pool-reveal-ability card nil))}]
-        {:abilities [{:label "Trash up to 2 cards from HQ. Shuffle up to 2 cards from Archives into R&D"
-                      :cost [:remove-from-game]
-                      :async true
-                      :effect (effect (continue-ability
-                                        moon-pool-discard-ability
-                                        card nil))}]}))))
-
+      {:abilities [{:label "Trash up to 2 cards from HQ. Shuffle up to 2 cards from Archives into R&D"
+                    :cost [:remove-from-game]
+                    :async true
+                    :effect (effect (continue-ability
+                                      moon-pool-discard-ability
+                                      card nil))}]})))
 
 (defcard "Mr. Stone"
   {:events [{:event :runner-gain-tag

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -3135,6 +3135,21 @@
     (score state :corp (get-content state :remote3 0))
     (is (= 1 (count (:scored (get-corp)))) "Hostile was scored")))
 
+(deftest moon-pool-rfg-when-no-cards-trashed-from-hq
+  (do-game
+    (new-game {:corp {:hand ["Moon Pool", (qty "Hedge Fund" 3)]
+                      :discard ["Longevity Serum"]}})
+    (play-from-hand state :corp "Moon Pool" "New remote")
+    (let [moon-pool (get-content state :remote1 0)]
+      (rez state :corp moon-pool)
+      (card-ability state :corp moon-pool 0)
+      (prompt-is-card? state :corp :moon-pool)
+      (click-prompt state :corp "Done")
+      (click-card state :corp "Longevity Serum")
+      (click-prompt state :corp "Done")
+      (no-prompt? state :corp)
+      (is (in-rfg? moon-pool)))))
+
 (deftest mr-stone
   ;; Mr Stone
   (do-game

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -3133,7 +3133,9 @@
     (click-card state :corp "Hostile Takeover")
     (click-card state :corp "Hostile Takeover")
     (score state :corp (get-content state :remote3 0))
-    (is (= 1 (count (:scored (get-corp)))) "Hostile was scored")))
+    (is (= 1 (count (:scored (get-corp)))) "Hostile was scored")
+    (is (find-card "Moon Pool" (:rfg (get-corp))) "Moon Pool is rfg'd")
+    (is (nil? (get-content state :remote1 0)))))
 
 (deftest moon-pool-rfg-when-no-cards-trashed-from-hq
   (do-game
@@ -3148,7 +3150,8 @@
       (click-card state :corp "Longevity Serum")
       (click-prompt state :corp "Done")
       (no-prompt? state :corp)
-      (is (in-rfg? moon-pool)))))
+      (is (find-card "Moon Pool" (:rfg (get-corp))) "Moon Pool is rfg'd")
+      (is (nil? (get-content state :remote1 0))))))
 
 (deftest mr-stone
   ;; Mr Stone


### PR DESCRIPTION
Fixes #6483 

now the child ability has the :cancel-effect, so cost can still be paid
