### PR TITLE
Don't trigger Ob Superheavy when trashed card has no cost

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1483,11 +1483,13 @@
                                   :effect (resolve-install)}
                                  card nil))}}})]
     {:events [{:event :corp-trash
-               :req (req (and
-                           (installed? (:card context))
-                           (rezzed? (:card context))
-                           (some? (trash-cause eid target))
-                           (not (used-this-turn? (:cid card) state))))
+               :req (req (let [trashed-card (:card context)]
+                           (and
+                             (installed? trashed-card)
+                             (rezzed? trashed-card)
+                             (not (nil? (:cost trashed-card)))
+                             (some? (trash-cause eid target))
+                             (not (used-this-turn? (:cid card) state)))))
                :async true
                :interactive (req true)
                :waiting "Corp to make a decision"

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3648,6 +3648,16 @@
    (is (= ["No install"] (prompt-buttons :corp)) "Sole option available is Done")
    (click-prompt state :corp "No install")))
 
+(deftest ob-logistics-no-trigger-when-trashed-card-has-no-cost
+  (do-game
+    (new-game {:corp {:id "Ob Superheavy Logistics: Extract. Export. Excel."
+                      :hand ["Extract", "Oaktown Renovation"]
+                      :deck ["Anoetic Void"]}})
+    (play-from-hand state :corp "Oaktown Renovation" "New remote")
+    (play-from-hand state :corp "Extract")
+    (click-card state :corp (get-content state :remote1 0))
+    (no-prompt? state :corp)))
+
 (deftest omar-keung-conspiracy-theorist-make-a-successful-run-on-the-chosen-server-once-per-turn
     ;; Make a successful run on the chosen server once per turn
     (do-game


### PR DESCRIPTION
Fixes #6488 

Maybe should also not fire when cost of trashed card is 0, since it will always have no legal targets?