### PR TITLE
Fix deckbuilder's "Import deck"

### DIFF
--- a/src/clj/web/nrdb.clj
+++ b/src/clj/web/nrdb.clj
@@ -16,8 +16,7 @@
                 (subs input (count nrdb-readable-url))
                 input)
         [id] (str/split input #"/")]
-    (when (uuid/uuidable? id)
-      id)))
+      id))
 
 (defn- lookup-card [db id]
   (or (mc/find-one-as-map db "cards" {:code id})

--- a/src/clj/web/nrdb.clj
+++ b/src/clj/web/nrdb.clj
@@ -27,7 +27,7 @@
   (fn [m k v]
     (let [card (lookup-card db (name k))]
       (if card
-        (if (= "identity" (:type card))
+        (if (= "Identity" (:type card))
           (assoc m :identity {:title (:title card) :side (:side card)})
           (update m :cards #(conj % {:card (:title card) :qty v})))
         m))))


### PR DESCRIPTION
I found a typo where the card type was written "identity" instead of "Identity", and I also added back support for legacy URLs. I think we should keep it at least until nrdb gets rid of the "Copy Legacy URL for Jinteki.net" button.

Closes https://github.com/mtgred/netrunner/issues/6492.