### PR TITLE
bump NodeJS to v18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 RUN chmod -R 777 /root/
 
 # Install npm+dependencies
-RUN curl -sL https://deb.nodesource.com/setup_17.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get install nodejs
 COPY package.json /usr/src/app/
 COPY package-lock.json /usr/src/app/


### PR DESCRIPTION
I couldn't build Docker image anymore because v17 is discontinued.