### PR TITLE
Closes #6522: fix z-index

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -337,6 +337,7 @@
 
     .hand-container, .deck-container, .discard-container
         position: relative
+        z-index: 30
 
     .hand-controls
         display: inline-block


### PR DESCRIPTION
The *-container are position: relative, so they create a new stacking context. Setting .servers-menu's z-index to 30 therefore does not render it above .panel's z-index of 20; the positioned parent of .server-menu needs the z-index.