### PR TITLE
Add :implementation to condition-counters

### DIFF
--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -495,10 +495,11 @@
 ;;    characteristics, and is trashed.
 
 (defn convert-to-condition-counter
-  [{:keys [cid code side title zone]}]
+  [{:keys [cid code side title zone implementation]}]
   (map->Card
     {:cid cid
      :code code
+     :implementation implementation
      :printed-title title
      :side side
      :type "Counter"


### PR DESCRIPTION
This fixes at least two things:

a) When installing such a card (like 'On the Lam'), since :implementation is not :full and :title is empty, the message 'implementation: .' will be logged.

b) When hovering over an installed card, it shows the warning 'not implemented' (even if the card is implemented)