### PR TITLE
Fixes #6507

### DIFF
--- a/src/clj/game/core/board.clj
+++ b/src/clj/game/core/board.clj
@@ -80,6 +80,13 @@
     (all-installed-runner state)
     (all-installed-corp state)))
 
+(defn all-installed-and-scored
+  "Returns a vector of all installed cards for the given side, including those hosted on other cards,
+   but not including 'inactive hosting' like Personal Workshop, and the cards in the given side's scored area."
+  [state side]
+  (concat (all-installed state side)
+          (-> @state side :scored)))
+
 (defn get-all-installed
   "Returns a list of all installed cards"
   [state]

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -1,7 +1,7 @@
 (ns game.core.turns
   (:require
     [game.core.agendas :refer [update-all-advancement-requirements]]
-    [game.core.board :refer [all-active all-active-installed all-installed]]
+    [game.core.board :refer [all-active all-active-installed all-installed all-installed-and-scored]]
     [game.core.card :refer [facedown? get-card has-subtype? in-hand? installed?]]
     [game.core.drawing :refer [draw]]
     [game.core.effects :refer [unregister-floating-effects any-effects]]
@@ -62,7 +62,7 @@
   (when (= side :corp)
     (swap! state update-in [:turn] inc))
 
-  (doseq [c (filter :new (all-installed state side))]
+  (doseq [c (filter :new (all-installed-and-scored state side))]
     (update! state side (dissoc c :new)))
 
   (swap! state assoc :active-player side :per-turn nil :end-turn false)


### PR DESCRIPTION
When removing the :new flag at the start of a turn, also remove if from cards in the scored area