### PR TITLE
Heap breakers and mercur during the off turn

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1965,12 +1965,16 @@
                             (do (system-msg state :runner (str "places 1 [Credits] on Net Mercur"))
                                 (add-counter state :runner card :credit 1)
                                 (effect-completed state side eid))))}]
-   ; Normally this should be (req true), but having pay-credits prompts on
-   ; literally every interaction would get tiresome. Therefore Net Mercur will
-   ; only ask for payments during a run, traces, psi games, and prevention abilities
-   :interactions {:pay-credits {:req (req (or run
-                                              (#{:psi :trace} (:source-type eid))
-                                              (#{:net :meat :brain :tag} (get-in @state [:prevent :current]))))
+   ;; Normally this should be (req true), but having pay-credits prompts on
+   ;; literally every interaction would get tiresome. Therefore Net Mercur will
+   ;; only ask for payments during a run, traces, psi games, and prevention abilities
+   ;; with the release of twinning, net mercur should always ask when spending credits on
+   ;; the opponents turn
+   :interactions {:pay-credits {:req (req (or
+                                            run
+                                            (= :corp (:active-player @state))
+                                            (#{:psi :trace} (:source-type eid))
+                                            (#{:net :meat :brain :tag} (get-in @state [:prevent :current]))))
                                 :type :credit}}})
 
 (defcard "Network Exchange"

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -789,7 +789,7 @@
         (trash-from-hand state :runner "Black Orchestra")
         (run-empty-server state :hq)
         (click-prompt state :corp "Yes")
-        (is (= "Install Black Orchestra?" (:msg (prompt-map :runner))) "Prompted to install Black Orchestra")
+        (is (= "Install Black Orchestra from the heap?" (:msg (prompt-map :runner))) "Prompted to install Black Orchestra")
         (click-prompt state :runner "Yes")
         (let [bo (get-program state 0)]
           (is (installed? bo) "Black Orchestra is installed")
@@ -4688,7 +4688,7 @@
   ;; Paperclip - prompt to install on encounter, but not if another is installed
   (do-game
       (new-game {:corp {:deck ["Vanilla"]}
-                 :runner {:deck [(qty "Paperclip" 2)]
+                 :runner {:deck [(qty "Paperclip" 3)]
                           :credits 10}})
       (play-from-hand state :corp "Vanilla" "Archives")
       (take-credits state :corp)
@@ -4700,9 +4700,11 @@
       (run-continue-until state :success)
       (is (not (:run @state)) "Run ended")
       (trash-from-hand state :runner "Paperclip")
+      (trash-from-hand state :runner "Paperclip")
       (run-on state "Archives")
       (run-continue state)
-      (is (no-prompt? state :runner) "No prompt to install second Paperclip")))
+      (click-prompt state :runner "No")
+      (is (no-prompt? state :runner) "No prompt to install third Paperclip")))
 
 (deftest paperclip-firing-on-facedown-ice-shouldn-t-crash
     ;; firing on facedown ice shouldn't crash

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -6346,6 +6346,37 @@
         (click-prompt state :runner "0")
         (is (= 4 (count-tags state)) "Bouncing enables Hard-Hitting News"))))
 
+(deftest the-twinning-net-mercur-corp-turn
+  (do-game
+    (new-game {:runner {:hand ["The Twinning" "Net Mercur", "Mantle", "Corroder" "Spec Work"] :credits 15}
+               :corp {:hand [(qty "Hedge Fund" 4)] :deck [(qty "Hedge Fund" 4)]}})
+    (take-credits state :corp)
+    (core/gain state :runner :click 10)
+    (play-from-hand state :runner "Net Mercur")
+    (play-from-hand state :runner "Mantle")
+    (play-from-hand state :runner "Corroder")
+    (play-from-hand state :runner "The Twinning")
+    (let [corr (get-program state 1)
+          mantle (get-program state 0)]
+      (run-on state :hq)
+      (changes-val-macro 0 (:credit (get-runner))
+                         "Used 1 credit from mantle"
+                         (card-ability state :runner corr 1)
+                         (click-card state :runner mantle)
+                         (click-prompt state :runner "Place 1 [Credits]"))
+      (run-jack-out state)
+      (play-from-hand state :runner "Spec Work")
+      (click-card state :runner "Mantle")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Hedge Fund")
+      (let [twin (get-resource state 1)]
+        (changes-val-macro
+          1 (get-counters (refresh twin) :power)
+          "1 counter for spending on the corp turn"
+          (card-ability state :runner corr 1)
+          (click-card state :runner "Net Mercur"))))
+  ))
+
 (deftest the-twinning
   ;; First time each turn you spend credits from an installed card, place 1 power counter
   ;; on breach hq/r&d - spend up to 2 counters to access that many more cards


### PR DESCRIPTION
Allows net-mercur to automatically be used as a source during off-turns (and adds a test) to make twinning easier to use - closes #6535.

Additionally, I made it so the heap breakers 
1) allow for multiple copies to be installed 
2) specify that they are installing from the heap
3) allow you to ask to never see the prompt while the breaker is installed

Which closes #6512