### PR TITLE
ob doesn't just blindly say yes anymore

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1486,7 +1486,7 @@
                :req (req (and
                            (installed? (:card context))
                            (rezzed? (:card context))
-                           (some? (trash-cause eid target))
+                           (trash-cause eid target)
                            (not (used-this-turn? (:cid card) state))))
                :async true
                :interactive (req true)


### PR DESCRIPTION
at some point we (probably me) switched away from returning a reason and went to just returning true/false, and (some? false) is true :joy:.

Closes  #6501, partially deals with #6537 (there should be a checklist there)