### PR TITLE
remove additional confirmation prompt from Pravdivost Consulting's ability

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1528,18 +1528,16 @@
 
 (defcard "Pravdivost Consulting: Political Solutions"
   {:events [{:event :successful-run
-             :optional {:req (req (first-event? state side :successful-run))
-                        :autoresolve (get-autoresolve :auto-pravdivost)
-                        :interactive (req true)
-                        :prompt "Place 1 advancement counter on a card that can be advanced?"
-                        :yes-ability {:waiting-prompt "Corp to make a decision"
-                                      :prompt "Choose a card to place 1 advancement token on"
-                                      :choices {:card can-be-advanced?}
-                                      :msg (msg "place 1 advancement token on " (card-str state target))
-                                      :cancel-effect (effect (system-msg "declines to use Pravdivost Consulting"))
-                                      :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}
-                        :no-ability {:effect (effect (system-msg "declines to use Pravdivost Consulting"))}}}]
-   :abilities [(set-autoresolve :auto-pravdivost "Pravdivost Consulting: Political Solutions")]})
+             :req (req (first-event? state side :successful-run))
+             :interactive (req true)
+             :async true
+             :waiting-prompt "Corp to make a decision"
+             :prompt "Choose a card to place 1 advancement token on"
+             :choices {:card can-be-advanced?}
+             :msg (msg "place 1 advancement token on " (card-str state target))
+             :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))
+             :cancel-effect (effect (system-msg "declines to use Pravdivost Consulting")
+                                    (effect-completed eid))}]})
 
 (defcard "Quetzal: Free Spirit"
   {:abilities [(assoc (break-sub nil 1 "Barrier" {:repeatable false}) :once :per-turn)]})

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3780,8 +3780,7 @@
     (take-credits state :corp)
     (run-on state :hq)
     (run-continue state)
-    (click-prompt state :corp "Yes")
-    ;; fake prompt, doesn't give away that PAD cannot be advanced
+    (is (not (no-prompt? state :runner)) "Fake prompt is displayed to the Runner")
     (click-prompt state :corp "Done")))
 
 (deftest pravdivost-consulting-happy-path
@@ -3792,7 +3791,6 @@
     (take-credits state :corp)
     (run-on state :hq)
     (run-continue state)
-    (click-prompt state :corp "Yes")
     (click-card state :corp "NGO Front")
     (is (= 1 (get-counters (get-content state :remote1 0) :advancement)) "NGO was advanced")))
 


### PR DESCRIPTION
After playing with it for a while, I can see why Aesop's Pawnshop didn't ask you for confirmation every time.. 🙄 