### PR TITLE
Unify autoresolve keywords

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1687,7 +1687,7 @@
     {:flags {:has-events-when-stolen true}
      :on-score {:effect add-credits
                 :interactive (req true)}
-     :abilities [(set-autoresolve :auto-fire "whether to take credits off SSL")]
+     :abilities [(set-autoresolve :auto-fire "SSL Endorsement")]
      :stolen {:effect add-credits}
      :events [{:event :corp-turn-begins
                :optional

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -240,7 +240,7 @@
                :interactive (req true)
                :async true
                :effect (effect (continue-ability (senai-ability (:card context)) card nil))}]
-     :abilities [(set-autoresolve :auto-fire "whether to fire Amani Senai")]}))
+     :abilities [(set-autoresolve :auto-fire "Amani Senai")]}))
 
 (defcard "Anson Rose"
   (let [ability {:label "Place 1 advancement token on Anson Rose (start of turn)"
@@ -1276,7 +1276,7 @@
     {:derezzed-events [corp-rez-toast]
      :events [(assoc ability :event :corp-turn-begins)]
      :on-rez {:effect (req (add-counter state side card :credit 8))}
-     :abilities [(set-autoresolve :auto-reshuffle "Marilyn reshuffle")]
+     :abilities [(set-autoresolve :auto-reshuffle "Marilyn Campaign's shuffling itself back into R&D")]
      :on-trash {:interactive (req true)
                 :optional
                 {:waiting-prompt "Corp to choose an option"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -802,8 +802,7 @@
                  :choices {:card virus-program?}
                  :effect (req (add-counter state :runner card :virus -1)
                               (add-counter state :runner target :virus 1))}]
-    {:abilities [(set-autoresolve :auto-accept "Friday Chip")]
-     :on-install {:effect (effect (toast "Tip: You can toggle automatically adding virus counters by clicking Friday Chip."))}
+    {:abilities [(set-autoresolve :auto-fire "Friday Chip")]
      :events [(assoc ability :event :runner-turn-begins)
               {:event :runner-trash
                :once-per-instance true
@@ -812,7 +811,7 @@
                :effect (req (let [amt-trashed (count (filter #(corp? (:card %)) targets))
                                   sing-ab {:optional
                                            {:prompt "Place a virus counter on Friday Chip?"
-                                            :autoresolve (get-autoresolve :auto-accept)
+                                            :autoresolve (get-autoresolve :auto-fire)
                                             :yes-ability {:effect (effect (system-msg
                                                                             :runner
                                                                             "places 1 virus counter on Friday Chip")
@@ -1065,14 +1064,14 @@
              :optional {:req (req (and (first-event? state :runner :successful-run)
                                        (pos? (count-virus-programs state))))
                         :prompt "Place a virus counter?"
-                        :autoresolve (get-autoresolve :auto-add)
+                        :autoresolve (get-autoresolve :auto-fire)
                         :yes-ability {:prompt "Choose an installed virus program to add a virus counter to"
                                       :choices {:card #(and (installed? %)
                                                             (has-subtype? % "Virus")
                                                             (program? %))}
                                       :msg (msg "place 1 virus counter on " (:title target))
                                       :effect (effect (add-counter target :virus 1))}}}]
-   :abilities [(set-autoresolve :auto-add "Knobkierie")]})
+   :abilities [(set-autoresolve :auto-fire "Knobkierie")]})
 
 (defcard "Lemuria Codecracker"
   {:abilities [{:cost [:click 1 :credit 1]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -802,7 +802,7 @@
                  :choices {:card virus-program?}
                  :effect (req (add-counter state :runner card :virus -1)
                               (add-counter state :runner target :virus 1))}]
-    {:abilities [(set-autoresolve :auto-fire "Friday Chip")]
+    {:abilities [(set-autoresolve :auto-fire "Friday Chip placing virus counters on itself")]
      :events [(assoc ability :event :runner-turn-begins)
               {:event :runner-trash
                :once-per-instance true

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1543,7 +1543,7 @@
      :interactive (req true)
      :optional
      {:prompt "Rez Formicary?"
-      :autoresolve (get-autoresolve :auto-formicary)
+      :autoresolve (get-autoresolve :auto-fire)
       :req (req (and (can-rez? state side card)
                      (can-pay? state side eid card nil (get-rez-cost state side card nil))))
       :yes-ability
@@ -1569,7 +1569,7 @@
                                  (do (system-msg state :runner "chooses to end the run")
                                      (end-run state :corp eid card))
                                  (damage state :runner eid :net 2 {:card card :unpreventable true})))}]
-   :abilities [(set-autoresolve :auto-formicary "Formicary")]})
+   :abilities [(set-autoresolve :auto-fire "Formicary")]})
 
 (defcard "Free Lunch"
   {:abilities [{:cost [:power 1]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1569,7 +1569,7 @@
                                  (do (system-msg state :runner "chooses to end the run")
                                      (end-run state :corp eid card))
                                  (damage state :runner eid :net 2 {:card card :unpreventable true})))}]
-   :abilities [(set-autoresolve :auto-fire "Formicary")]})
+   :abilities [(set-autoresolve :auto-fire "Formicary rezzing and moving itself on approach")]})
 
 (defcard "Free Lunch"
   {:abilities [{:cost [:power 1]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1529,7 +1529,7 @@
 (defcard "Pravdivost Consulting: Political Solutions"
   {:events [{:event :successful-run
              :optional {:req (req (first-event? state side :successful-run))
-                        :autoresolve (get-autoresolve :auto-fire)
+                        :autoresolve (get-autoresolve :auto-pravdivost)
                         :interactive (req true)
                         :prompt "Place 1 advancement counter on a card that can be advanced?"
                         :yes-ability {:waiting-prompt "Corp to make a decision"
@@ -1539,7 +1539,7 @@
                                       :cancel-effect (effect (system-msg "declines to use Pravdivost Consulting"))
                                       :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}
                         :no-ability {:effect (effect (system-msg "declines to use Pravdivost Consulting"))}}}]
-   :abilities [(set-autoresolve :auto-fire "Pravdivost Consulting: Political Solutions")]})
+   :abilities [(set-autoresolve :auto-pravdivost "Pravdivost Consulting: Political Solutions")]})
 
 (defcard "Quetzal: Free Spirit"
   {:abilities [(assoc (break-sub nil 1 "Barrier" {:repeatable false}) :once :per-turn)]})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -416,7 +416,7 @@
                           :effect (req (chosen-damage state :corp target))}
                          card nil))}
               :no-ability
-              {:effect (req (system-msg state :corp "declines to use Chronos Protocol"))}}}]})
+              {:effect (req (system-msg state :corp "declines to use Chronos Protocol: Selective Mind-mapping"))}}}]})
 
 (defcard "Cybernetics Division: Humanity Upgraded"
   {:constant-effects [(hand-size+ -1)]})
@@ -655,7 +655,7 @@
              :optional {:prompt "Add card from Archives to HQ?"
                         :autoresolve (get-autoresolve :auto-fire)
                         :yes-ability (corp-recur)}}]
-   :abilities [(set-autoresolve :auto-fire "add card from Archives to HQ")]})
+   :abilities [(set-autoresolve :auto-fire "Haas-Bioroid: Precision Design")]})
 
 (defcard "Haas-Bioroid: Stronger Together"
   {:constant-effects [{:type :ice-strength
@@ -1036,7 +1036,7 @@
                             :async true
                             :effect (effect (draw :corp eid 1))}
               :no-ability {:effect (effect (system-msg "declines to use Laramy Fisk: Savvy Investor"))}}}]
-   :abilities [(set-autoresolve :auto-fire "force Corp draw")]})
+   :abilities [(set-autoresolve :auto-fire "Laramy Fisk: Savvy Investor")]})
 
 (defcard "Lat: Ethical Freelancer"
   {:events [{:event :runner-turn-ends
@@ -1252,7 +1252,7 @@
                        {:msg "give the Runner 1 tag"
                         :async true
                         :effect (effect (gain-tags :corp eid 1 {:unpreventable true}))}}}}}]
-   :abilities [(set-autoresolve :auto-fire "CtM")]})
+   :abilities [(set-autoresolve :auto-fire "NBN: Controlling the Message")]})
 
 (defcard "NBN: Making News"
   {:recurring 2
@@ -1710,7 +1710,7 @@
                                              " on " (card-str state target))
                                    :effect (effect (add-prop target :advance-counter agenda-points {:placed true}))}
                                   card nil)))}}}]
-     :abilities [(set-autoresolve :auto-fire "SSO")]}))
+     :abilities [(set-autoresolve :auto-fire "SSO Industries: Fueling Innovation")]}))
 
 (defcard "Steve Cambridge: Master Grifter"
   {:events [{:event :successful-run

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -102,7 +102,7 @@
                  {:optional
                   {:prompt "Expose installed card unless Corp pays 1 [Credits]?"
                    :player :runner
-                   :autoresolve (get-autoresolve :auto-419)
+                   :autoresolve (get-autoresolve :auto-fire)
                    :no-ability {:effect (req (clear-wait-prompt state :corp))}
                    :yes-ability
                    {:async true
@@ -131,7 +131,7 @@
                                                (effect-completed state side eid)))}}}
                                      card targets)))}}}
                  card targets))}]
-   :abilities [(set-autoresolve :auto-419 "419")]})
+   :abilities [(set-autoresolve :auto-fire "419")]})
 
 (defcard "Acme Consulting: The Truth You Need"
   (letfn [(outermost? [state ice]
@@ -653,9 +653,9 @@
    :events [{:event :agenda-scored
              :interactive (req true)
              :optional {:prompt "Add card from Archives to HQ?"
-                        :autoresolve (get-autoresolve :auto-precision-design)
+                        :autoresolve (get-autoresolve :auto-fire)
                         :yes-ability (corp-recur)}}]
-   :abilities [(set-autoresolve :auto-precision-design "add card from Archives to HQ")]})
+   :abilities [(set-autoresolve :auto-fire "add card from Archives to HQ")]})
 
 (defcard "Haas-Bioroid: Stronger Together"
   {:constant-effects [{:type :ice-strength
@@ -1022,32 +1022,32 @@
 (defcard "Laramy Fisk: Savvy Investor"
   {:events [{:event :successful-run
              :async true
-             :interactive (get-autoresolve :auto-fisk (complement never?))
-             :silent (get-autoresolve :auto-fisk never?)
+             :interactive (get-autoresolve :auto-fire (complement never?))
+             :silent (get-autoresolve :auto-fire never?)
              :optional
              {:req (req (and (is-central? (:server context))
                              (first-event? state side :successful-run
                                            (fn [targets]
                                              (let [context (first targets)]
                                                (is-central? (:server context)))))))
-              :autoresolve (get-autoresolve :auto-fisk)
+              :autoresolve (get-autoresolve :auto-fire)
               :prompt "Force the Corp to draw a card?"
               :yes-ability {:msg "force the Corp to draw 1 card"
                             :async true
                             :effect (effect (draw :corp eid 1))}
               :no-ability {:effect (effect (system-msg "declines to use Laramy Fisk: Savvy Investor"))}}}]
-   :abilities [(set-autoresolve :auto-fisk "force Corp draw")]})
+   :abilities [(set-autoresolve :auto-fire "force Corp draw")]})
 
 (defcard "Lat: Ethical Freelancer"
   {:events [{:event :runner-turn-ends
              :optional {:req (req (= (count (:hand runner)) (count (:hand corp))))
-                        :autoresolve (get-autoresolve :auto-lat)
+                        :autoresolve (get-autoresolve :auto-fire)
                         :prompt "Draw 1 card?"
                         :yes-ability {:async true
                                       :msg "draw 1 card"
                                       :effect (effect (draw :runner eid 1))}
                         :no-ability {:effect (effect (system-msg "declines to use Lat: Ethical Freelancer"))}}}]
-   :abilities [(set-autoresolve :auto-lat "Lat: Ethical Freelancer")]})
+   :abilities [(set-autoresolve :auto-fire "Lat: Ethical Freelancer")]})
 
 (defcard "Leela Patel: Trained Pragmatist"
   (let [leela {:interactive (req true)
@@ -1245,14 +1245,14 @@
                                                    targets)))))
               :waiting-prompt "Corp to make a decision"
               :prompt "Trace the Runner with NBN: Controlling the Message?"
-              :autoresolve (get-autoresolve :auto-ctm)
+              :autoresolve (get-autoresolve :auto-fire)
               :yes-ability
               {:trace {:base 4
                        :successful
                        {:msg "give the Runner 1 tag"
                         :async true
                         :effect (effect (gain-tags :corp eid 1 {:unpreventable true}))}}}}}]
-   :abilities [(set-autoresolve :auto-ctm "CtM")]})
+   :abilities [(set-autoresolve :auto-fire "CtM")]})
 
 (defcard "NBN: Making News"
   {:recurring 2
@@ -1529,7 +1529,7 @@
 (defcard "Pravdivost Consulting: Political Solutions"
   {:events [{:event :successful-run
              :optional {:req (req (first-event? state side :successful-run))
-                        :autoresolve (get-autoresolve :auto-pravdivost)
+                        :autoresolve (get-autoresolve :auto-fire)
                         :interactive (req true)
                         :prompt "Place 1 advancement counter on a card that can be advanced?"
                         :yes-ability {:waiting-prompt "Corp to make a decision"
@@ -1539,7 +1539,7 @@
                                       :cancel-effect (effect (system-msg "declines to use Pravdivost Consulting"))
                                       :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}
                         :no-ability {:effect (effect (system-msg "declines to use Pravdivost Consulting"))}}}]
-   :abilities [(set-autoresolve :auto-pravdivost "Pravdivost Consulting: Political Solutions")]})
+   :abilities [(set-autoresolve :auto-fire "Pravdivost Consulting: Political Solutions")]})
 
 (defcard "Quetzal: Free Spirit"
   {:abilities [(assoc (break-sub nil 1 "Barrier" {:repeatable false}) :once :per-turn)]})
@@ -1694,7 +1694,7 @@
                                (not-empty (ice-with-no-advancement-tokens state))))
                 :waiting-prompt "Corp to make a decision"
                 :prompt "Place advancement tokens?"
-                :autoresolve (get-autoresolve :auto-sso)
+                :autoresolve (get-autoresolve :auto-fire)
                 :yes-ability
                 {:async true
                  :effect (req (let [agendas (installed-faceup-agendas state)
@@ -1710,7 +1710,7 @@
                                              " on " (card-str state target))
                                    :effect (effect (add-prop target :advance-counter agenda-points {:placed true}))}
                                   card nil)))}}}]
-     :abilities [(set-autoresolve :auto-sso "SSO")]}))
+     :abilities [(set-autoresolve :auto-fire "SSO")]}))
 
 (defcard "Steve Cambridge: Master Grifter"
   {:events [{:event :successful-run

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -787,7 +787,7 @@
                              (= :rd (target-server context))))
               :player :runner
               :waiting-prompt "Runner to choose an option"
-              :autoresolve (get-autoresolve :auto-conduit)
+              :autoresolve (get-autoresolve :auto-place-counter)
               :prompt "Use Conduit?"
               :yes-ability {:msg "place 1 virus counter on itself"
                             :effect (effect (add-counter card :virus 1))}
@@ -802,7 +802,7 @@
                 :makes-run true
                 :async true
                 :effect (req (make-run state side eid :rd card))}
-               (set-autoresolve :auto-conduit "Conduit")]})
+               (set-autoresolve :auto-place-counter "Conduit")]})
 
 (defcard "Consume"
   {:events [{:event :runner-trash
@@ -811,7 +811,7 @@
              :req (req (some #(corp? (:card %)) targets))
              :effect (req (let [amt-trashed (count (filter #(corp? (:card %)) targets))
                                 sing-ab {:optional {:prompt "Place a virus counter on Consume?"
-                                                    :autoresolve (get-autoresolve :auto-accept)
+                                                    :autoresolve (get-autoresolve :auto-place-counter)
                                                     :yes-ability {:effect (effect (add-counter :runner card :virus 1))
                                                                   :msg "place 1 virus counter on Consume"}}}
                                 mult-ab {:prompt "Place virus counters on Consume?"
@@ -836,7 +836,7 @@
                             (str "gain " (* 2 global-virus) " [Credits], removing " (quantify local-virus "virus counter") " from Consume"
                                  (when (pos? hivemind-virus)
                                    (str " (and " hivemind-virus " from Hivemind)")))))}
-               (set-autoresolve :auto-accept "adding virus counters")]})
+               (set-autoresolve :auto-place-counter "adding virus counters")]})
 
 (defcard "Copycat"
   {:abilities [{:async true
@@ -2652,11 +2652,11 @@
                            (can-host? %))}
      :on-install {:async true
                   :effect trash-if-5}
-     :abilities [(set-autoresolve :auto-accept "place virus counter on Trypano")]
+     :abilities [(set-autoresolve :auto-place-counter "place virus counter on Trypano")]
      :events [{:event :runner-turn-begins
                :optional
                {:prompt "Place a virus counter on Trypano?"
-                :autoresolve (get-autoresolve :auto-accept)
+                :autoresolve (get-autoresolve :auto-place-counter)
                 :yes-ability {:msg "place a virus counter on itself"
                               :effect (req (add-counter state side card :virus 1))}}}
               {:event :counter-added

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1914,11 +1914,11 @@
                              (= target :rd)))
               :waiting-prompt "Runner to choose an option"
               :prompt "Spend a power counter on Nyashia to access 1 additional card?"
-              :autoresolve (get-autoresolve :auto-nyashia)
+              :autoresolve (get-autoresolve :auto-fire)
               :yes-ability {:msg "access 1 additional card from R&D"
                             :effect (effect (access-bonus :rd 1)
                                             (add-counter card :power -1))}}}]
-   :abilities [(set-autoresolve :auto-nyashia "Nyashia")]})
+   :abilities [(set-autoresolve :auto-fire "Nyashia")]})
 
 (defcard "Odore"
   (auto-icebreaker {:abilities [(break-sub 2 0 "Sentry"
@@ -2553,7 +2553,7 @@
   {:events [{:event :subroutines-broken
              :optional {:req (req (all-subs-broken? target))
                         :prompt "Place 1 power counter on Takobi?"
-                        :autoresolve (get-autoresolve :auto-takobi)
+                        :autoresolve (get-autoresolve :auto-fire)
                         :yes-ability
                         {:msg "place 1 power counter on itself"
                          :effect (effect (add-counter card :power 1))}}}]
@@ -2566,7 +2566,7 @@
                                       (installed? %))}
                 :msg (msg "give +3 strength to " (:title target))
                 :effect (effect (pump target 3))}
-               (set-autoresolve :auto-takobi "Takobi")]})
+               (set-autoresolve :auto-fire "Takobi")]})
 
 (defcard "Tapwrm"
   (let [ability {:label "Gain [Credits] (start of turn)"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -802,7 +802,7 @@
                 :makes-run true
                 :async true
                 :effect (req (make-run state side eid :rd card))}
-               (set-autoresolve :auto-place-counter "Conduit")]})
+               (set-autoresolve :auto-place-counter "Conduit placing virus counters on itself")]})
 
 (defcard "Consume"
   {:events [{:event :runner-trash
@@ -836,7 +836,7 @@
                             (str "gain " (* 2 global-virus) " [Credits], removing " (quantify local-virus "virus counter") " from Consume"
                                  (when (pos? hivemind-virus)
                                    (str " (and " hivemind-virus " from Hivemind)")))))}
-               (set-autoresolve :auto-place-counter "adding virus counters")]})
+               (set-autoresolve :auto-place-counter "Consume placing virus counters on itself")]})
 
 (defcard "Copycat"
   {:abilities [{:async true
@@ -2553,7 +2553,7 @@
   {:events [{:event :subroutines-broken
              :optional {:req (req (all-subs-broken? target))
                         :prompt "Place 1 power counter on Takobi?"
-                        :autoresolve (get-autoresolve :auto-fire)
+                        :autoresolve (get-autoresolve :auto-place-counter)
                         :yes-ability
                         {:msg "place 1 power counter on itself"
                          :effect (effect (add-counter card :power 1))}}}]
@@ -2566,7 +2566,7 @@
                                       (installed? %))}
                 :msg (msg "give +3 strength to " (:title target))
                 :effect (effect (pump target 3))}
-               (set-autoresolve :auto-fire "Takobi")]})
+               (set-autoresolve :auto-place-counter "Takobi placing power counters on itself")]})
 
 (defcard "Tapwrm"
   (let [ability {:label "Gain [Credits] (start of turn)"
@@ -2652,7 +2652,7 @@
                            (can-host? %))}
      :on-install {:async true
                   :effect trash-if-5}
-     :abilities [(set-autoresolve :auto-place-counter "place virus counter on Trypano")]
+     :abilities [(set-autoresolve :auto-place-counter "Trypano placing virus counters on itself")]
      :events [{:event :runner-turn-begins
                :optional
                {:prompt "Place a virus counter on Trypano?"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -690,7 +690,7 @@
                         :autoresolve (get-autoresolve :auto-fire)
                         :yes-ability {:msg (msg "place 1 virus counter on " (card-str state (:card context)))
                                       :effect (effect (add-counter (:card context) :virus 1))}}}]
-   :abilities [(set-autoresolve :auto-fire "Cookbook's 'Place virus counter' ability")]})
+   :abilities [(set-autoresolve :auto-fire "Cookbook")]})
 
 (defcard "Corporate Defector"
   {:events [{:event :corp-click-draw
@@ -840,7 +840,7 @@
                 :effect (effect (trigger-event :searched-stack nil)
                                 (shuffle! :deck)
                                 (runner-install (assoc eid :source card :source-type :runner-install) target nil))}
-               (set-autoresolve :auto-place-counter "placing virus counters on Crypt")]})
+               (set-autoresolve :auto-place-counter "Crypt placing virus counters on itself")]})
 
 (defcard "Cybertrooper Talut"
   {:constant-effects [(link+ 1)]
@@ -1276,7 +1276,7 @@
                         :yes-ability {:prompt (req (->> corp :deck first :title (str "The top card of R&D is ")))
                                       :msg "look at the top card of R&D"
                                       :choices ["OK"]}}}]
-   :abilities [(set-autoresolve :auto-peek "Find the Truth's peek at R&D ability")]
+   :abilities [(set-autoresolve :auto-peek "Find the Truth looking at the top card of R&D")]
    :corp-abilities [{:label (str "Explicitly reveal cards")
                      :prompt (str "Explicitly reveal runner draws due to Find the Truth?")
                      :choices ["Yes" "No"]
@@ -1607,7 +1607,7 @@
              :req (req (<= 4 (get-counters (get-card state card) :power)))
              :msg "add itself to their score area as an agenda worth 1 agenda point"
              :effect (req (as-agenda state :runner card 1))}]
-   :abilities [(set-autoresolve :auto-place-counter "Kasi String")]})
+   :abilities [(set-autoresolve :auto-place-counter "Kasi String placing power counters on itself")]})
 
 (defcard "Kati Jones"
   {:abilities [{:cost [:click 1]
@@ -3355,7 +3355,7 @@
                                      :req (req (= (:title target) named-agenda))
                                      :effect (effect (steal eid target))}]))
                                (trash eid card {:unpreventable true :cause-card card}))}}}]
-   :abilities [(set-autoresolve :auto-fire "Whistleblower's ability")]})
+   :abilities [(set-autoresolve :auto-fire "Whistleblower")]})
 
 (defcard "Wireless Net Pavilion"
   {:constant-effects [{:type :card-ability-additional-cost

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -826,7 +826,7 @@
              :silent (req true)
              :optional {:prompt "Place a virus counter on Crypt?"
                         :req (req (= :archives (target-server context)))
-                        :autoresolve (get-autoresolve :auto-add)
+                        :autoresolve (get-autoresolve :auto-place-counter)
                         :yes-ability {:msg "place a virus counter on itself"
                                       :effect (effect (add-counter card :virus 1))}}}]
    :abilities [{:async true
@@ -840,7 +840,7 @@
                 :effect (effect (trigger-event :searched-stack nil)
                                 (shuffle! :deck)
                                 (runner-install (assoc eid :source card :source-type :runner-install) target nil))}
-               (set-autoresolve :auto-add "placing virus counters on Crypt")]})
+               (set-autoresolve :auto-place-counter "placing virus counters on Crypt")]})
 
 (defcard "Cybertrooper Talut"
   {:constant-effects [(link+ 1)]
@@ -1596,7 +1596,7 @@
                              (not (:did-steal target))
                              (:did-access target)
                              (is-remote? (:server target))))
-              :autoresolve (get-autoresolve :auto-kasistring)
+              :autoresolve (get-autoresolve :auto-place-counter)
               :waiting-prompt "Runner to choose an option"
               :prompt "Place 1 power counter on Kasi String?"
               :yes-ability {:msg "place a power counter on itself"
@@ -1607,7 +1607,7 @@
              :req (req (<= 4 (get-counters (get-card state card) :power)))
              :msg "add itself to their score area as an agenda worth 1 agenda point"
              :effect (req (as-agenda state :runner card 1))}]
-   :abilities [(set-autoresolve :auto-kasistring "Kasi String")]})
+   :abilities [(set-autoresolve :auto-place-counter "Kasi String")]})
 
 (defcard "Kati Jones"
   {:abilities [{:cost [:click 1]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -194,7 +194,7 @@
 (defcard "Aeneas Informant"
   {:events [{:event :post-access-card
              :optional
-             {:autoresolve (get-autoresolve :auto-reveal-and-gain)
+             {:autoresolve (get-autoresolve :auto-fire)
               :req (req (and (:trash (second targets))
                              (not (in-discard? target))))
               :prompt "Use Aeneas Informant?"
@@ -203,7 +203,7 @@
                                              (str " and reveal " (:title target)))))
                             :async true
                             :effect (effect (gain-credits eid 1))}}}]
-   :abilities [(set-autoresolve :auto-reveal-and-gain "Aeneas Informant")]})
+   :abilities [(set-autoresolve :auto-fire "Aeneas Informant")]})
 
 (defcard "Aesop's Pawnshop"
   (let [ability {:async true
@@ -687,10 +687,10 @@
              :interactive (req true)
              :optional {:prompt "Place a virus counter?"
                         :req (req (has-subtype? (:card context) "Virus"))
-                        :autoresolve (get-autoresolve :auto-cookbook)
+                        :autoresolve (get-autoresolve :auto-fire)
                         :yes-ability {:msg (msg "place 1 virus counter on " (card-str state (:card context)))
                                       :effect (effect (add-counter (:card context) :virus 1))}}}]
-   :abilities [(set-autoresolve :auto-cookbook "Cookbook's 'Place virus counter' ability")]})
+   :abilities [(set-autoresolve :auto-fire "Cookbook's 'Place virus counter' ability")]})
 
 (defcard "Corporate Defector"
   {:events [{:event :corp-click-draw
@@ -3335,7 +3335,7 @@
 (defcard "Whistleblower"
   {:events [{:event :successful-run
              :optional
-             {:autoresolve (get-autoresolve :auto-name-agenda)
+             {:autoresolve (get-autoresolve :auto-fire)
               :prompt "Trash Whistleblower to name an agenda?"
               :yes-ability
               {:async true
@@ -3355,7 +3355,7 @@
                                      :req (req (= (:title target) named-agenda))
                                      :effect (effect (steal eid target))}]))
                                (trash eid card {:unpreventable true :cause-card card}))}}}]
-   :abilities [(set-autoresolve :auto-name-agenda "Whistleblower's ability")]})
+   :abilities [(set-autoresolve :auto-fire "Whistleblower's ability")]})
 
 (defcard "Wireless Net Pavilion"
   {:constant-effects [{:type :card-ability-additional-cost

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -882,7 +882,7 @@
                       :effect (req (wait-for (trash state side (make-eid state eid) card {:unpreventable true :cause-card card})
                                              (redirect-run state side (zone->name (second (get-zone card))) :approach-ice)
                                              (continue-ability state :runner (offer-jack-out) card nil)))}}}}}]
-   :abilities [(set-autoresolve :auto-fire "Fire Letheia Nisei?")]})
+   :abilities [(set-autoresolve :auto-fire "Letheia Nisei")]})
 
 (defcard "Malapert Data Vault"
   {:events [{:event :agenda-scored


### PR DESCRIPTION
No sense in having `:auto-<cardname>` all over the place