### PR TITLE
Simplify ambushes

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -3,7 +3,7 @@
    [clojure.pprint :as pprint]
    [clojure.set :as set]
    [clojure.string :as str]
-   [game.core.access :refer [access-card]]
+   [game.core.access :refer [access-card installed-access-trigger]]
    [game.core.actions :refer [score]]
    [game.core.agendas :refer [update-all-advancement-requirements
                               update-all-agenda-points]]
@@ -63,23 +63,7 @@
    [jinteki.utils :refer :all]))
 
 ;;; Asset-specific helpers
-(defn installed-access-trigger
-  "Effect for triggering ambush on access.
-  Ability is what happends upon access. If cost is specified Corp needs to pay that to trigger."
-  ([cost ability]
-   (let [ab (if (pos? cost) (assoc ability :cost [:credit cost]) ability)
-         prompt (if (pos? cost)
-                  (req (str "Pay " cost " [Credits] to use " (:title card) " ability?"))
-                  (req (str "Use " (:title card) " ability?")))]
-     (installed-access-trigger cost ab prompt)))
-  ([cost ability prompt]
-   {:access {:optional
-             {:req (req (and installed (>= (:credit corp) cost)))
-              :waiting-prompt (:waiting-prompt ability)
-              :prompt prompt
-              :yes-ability (dissoc ability :waiting-prompt)}}}))
-
-(defn advance-ambush
+(defn- advance-ambush
   "Creates advanceable ambush structure with specified ability for specified cost"
   ([cost ability] (assoc (installed-access-trigger cost ability) :advanceable :always))
   ([cost ability prompt] (assoc (installed-access-trigger cost ability prompt) :advanceable :always)))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [cond-plus.core :refer [cond+]]
    [game.core.access :refer [access-bonus set-only-card-to-access
+                             installed-access-trigger
                              steal-cost-bonus]]
    [game.core.bad-publicity :refer [lose-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed card->server
@@ -1263,16 +1264,13 @@
              :msg "prevent the Runner from jacking out unless they trash an installed program"}]})
 
 (defcard "Prisec"
-  {:access {:optional
-            {:req (req (installed? card))
-             :waiting-prompt "Corp to choose an option"
-             :prompt "Pay 2 [Credits] to use Prisec ability?"
-             :yes-ability
-             {:cost [:credit 2]
-              :msg "do 1 meat damage and give the Runner 1 tag"
-              :async true
-              :effect (req (wait-for (damage state side :meat 1 {:card card})
-                                     (gain-tags state :corp eid 1)))}}}})
+  (installed-access-trigger
+    2
+    {:waiting-prompt "Corp to choose an option"
+     :msg "do 1 meat damage and give the Runner 1 tag"
+     :async true
+     :effect (req (wait-for (damage state side :meat 1 {:card card})
+                            (gain-tags state :corp eid 1)))}))
 
 (defcard "Product Placement"
   {:flags {:rd-reveal (req true)}

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -94,6 +94,7 @@
    get-all-content
    get-all-hosted
    get-only-card-to-access
+   installed-access-trigger
    interactions
    max-access
    msg-handle-access

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -4,6 +4,7 @@
     [game.core.board :refer [all-active]]
     [game.core.card :refer [agenda? condition-counter? corp? get-agenda-points get-card get-zone in-discard? in-hand? in-scored? operation? rezzed?]]
     [game.core.card-defs :refer [card-def]]
+    [game.core.costs :refer [total-available-credits]]
     [game.core.cost-fns :refer [card-ability-cost trash-cost]]
     [game.core.effects :refer [any-effects register-constant-effects register-floating-effect sum-effects unregister-floating-effects]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
@@ -339,7 +340,7 @@
      (installed-access-trigger cost ab prompt)))
   ([cost ability prompt]
    {:access {:optional
-             {:req (req (and installed (>= (:credit corp) cost)))
+             {:req (req (and installed (>= (total-available-credits state :corp eid card) cost)))
               :waiting-prompt (:waiting-prompt ability)
               :prompt prompt
               :yes-ability (dissoc ability :waiting-prompt)}}}))

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -328,6 +328,22 @@
     (assoc (ability-as-handler card acc)
            :condition :accessed)))
 
+(defn installed-access-trigger
+  "Effect for triggering ambush on access.
+  Ability is what happends upon access. If cost is specified Corp needs to pay that to trigger."
+  ([cost ability]
+   (let [ab (if (pos? cost) (assoc ability :cost [:credit cost]) ability)
+         prompt (if (pos? cost)
+                  (req (str "Pay " cost " [Credits] to use " (:title card) " ability?"))
+                  (req (str "Use " (:title card) " ability?")))]
+     (installed-access-trigger cost ab prompt)))
+  ([cost ability prompt]
+   {:access {:optional
+             {:req (req (and installed (>= (:credit corp) cost)))
+              :waiting-prompt (:waiting-prompt ability)
+              :prompt prompt
+              :yes-ability (dissoc ability :waiting-prompt)}}}))
+
 (defn- access-trigger-events
   "Trigger access effects, then move into trash/steal choice."
   [state side eid c title args]


### PR DESCRIPTION
Some upgrades are de facto ambushes, so they might as well be implemented the same way as their asset counterparts.