### PR TITLE
Makes Endurance non-silent on runs with Into the Depths.

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -674,7 +674,8 @@
    :constant-effects [(mu+ 2)]
    :events [{:event :successful-run
              :req (req (first-event? state :runner :successful-run))
-             :silent (req true)
+             ;; Specifically non-silent on ItD runs because then order of Endurance trigger and ItD charge matters
+             :silent (req (not= "Into the Depths" (-> @state :run :source-event :title)))
              :msg "place 1 power counter on itself"
              :async true
              :effect (effect (add-counter eid card :power 1 nil))}]

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -674,8 +674,6 @@
    :constant-effects [(mu+ 2)]
    :events [{:event :successful-run
              :req (req (first-event? state :runner :successful-run))
-             ;; Specifically non-silent on ItD runs because then order of Endurance trigger and ItD charge matters
-             :silent (req (not= "Into the Depths" (-> @state :run :source-event :title)))
              :msg "place 1 power counter on itself"
              :async true
              :effect (effect (add-counter eid card :power 1 nil))}]


### PR DESCRIPTION
Fixes #6556 by making Endurance non-silent when ItD is the current run event.

Have tested manually with DL and ItD.