### PR TITLE
Rename brain damage to core damage, Part I

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -472,6 +472,8 @@
         "/tag"        #(swap! %1 assoc-in [%2 :tag :base] (constrain-value value 0 1000))
         "/take-brain" #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :brain (constrain-value value 0 1000)
                                                     {:card (map->Card {:title "/damage command" :side %2})}))
+        "/take-core" #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :brain (constrain-value value 0 1000)
+                                                    {:card (map->Card {:title "/damage command" :side %2})}))
         "/take-meat"  #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :meat  (constrain-value value 0 1000)
                                                     {:card (map->Card {:title "/damage command" :side %2})}))
         "/take-net"   #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :net   (constrain-value value 0 1000)

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -776,7 +776,7 @@
 ;; BrainDamage
 (defmethod cost-name :brain [_] :brain)
 (defmethod value :brain [[_ cost-value]] cost-value)
-(defmethod label :brain [cost] (str "suffer " (value cost) " brain damage"))
+(defmethod label :brain [cost] (str "suffer " (value cost) " core damage"))
 (defmethod payable? :brain
   [cost state side eid card]
   (<= (value cost) (count (get-in @state [:runner :hand]))))
@@ -785,7 +785,7 @@
   (wait-for (damage state side :brain (value cost) {:unpreventable true})
             (complete-with-result
               state side eid
-              {:msg (str "suffers " (count async-result) " brain damage")
+              {:msg (str "suffers " (count async-result) " core damage")
                :type :brain
                :value (count async-result)
                :targets async-result})))

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -131,11 +131,11 @@
    :effect (effect (damage eid :meat dmg {:card card}))})
 
 (defn do-brain-damage
-  "Do specified amount of brain damage."
+  "Do specified amount of core damage."
   [dmg]
-  {:label (str "Do " dmg " brain damage")
+  {:label (str "Do " dmg " core damage")
    :async true
-   :msg (str "do " dmg " brain damage")
+   :msg (str "do " dmg " core damage")
    :effect (effect (damage eid :brain dmg {:card card}))})
 
 (defn trash-on-empty

--- a/src/cljs/nr/gameboard/player_stats.cljs
+++ b/src/cljs/nr/gameboard/player_stats.cljs
@@ -94,7 +94,7 @@
                        (when show-tagged [:div.warning "!"])]))
          (ctrl
           :brain-damage
-          [:div (str brain-damage " " (tr [:game.brain-damage "Brain Damage"]))])]))))
+          [:div (str brain-damage " " (tr [:game.brain-damage "Core Damage"]))])]))))
 
 (defmethod stats-area "Corp" [corp]
   (let [ctrl (stat-controls-for-side :corp)]

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -155,6 +155,10 @@
     :has-args :required
     :usage "/take-brain n"
     :help "Take n brain damage (Runner only)"}
+   {:name "/take-core"
+    :has-args :required
+    :usage "/take-core n"
+    :help "Take n core damage (Runner only)"}
    {:name "/take-meat"
     :has-args :required
     :usage "/take-meat n"

--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -357,7 +357,7 @@
    :scored-area "Scored Area"
    :archives "Archives"
    :max-hand "Max hand size"
-   :brain-damage "Brain Damage"
+   :brain-damage "Core Damage"
    :tag-count (fn [[base additional total]]
                 (str base (when (pos? additional) (str " + " additional)) " Tag" (if (not= total 1) "s" "")))
    :agenda-count (fn [[agenda-point]] (str agenda-point " Agenda Point" (when (not= agenda-point 1) "s")))

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -2428,23 +2428,23 @@
   ;; NEXT Wave 2
   (do-game
       (new-game {:corp {:deck [(qty "NEXT Wave 2" 2) "NEXT Bronze"]}})
-      (is (zero? (:brain-damage (get-runner))) "Runner should start with 0 brain damage")
+      (is (zero? (:brain-damage (get-runner))) "Runner should start with 0 core damage")
       (play-from-hand state :corp "NEXT Bronze" "HQ")
       (let [nxbr (get-ice state :hq 0)]
         (rez state :corp nxbr))
       (play-and-score state "NEXT Wave 2")
       (click-prompt state :corp "No")
-      (is (zero? (:brain-damage (get-runner))) "Runner should stay at 0 brain damage")
+      (is (zero? (:brain-damage (get-runner))) "Runner should stay at 0 core damage")
       (play-and-score state "NEXT Wave 2")
       (click-prompt state :corp "Yes")
-      (is (= 1 (:brain-damage (get-runner))) "Runner should gain 1 brain damage")))
+      (is (= 1 (:brain-damage (get-runner))) "Runner should gain 1 core damage")))
 
 (deftest next-wave-2-stealing-doesn-t-do-anything
     ;; Stealing doesn't do anything
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                         :hand ["NEXT Wave 2" "NEXT Bronze"]}})
-      (is (zero? (:brain-damage (get-runner))) "Runner should start with 0 brain damage")
+      (is (zero? (:brain-damage (get-runner))) "Runner should start with 0 core damage")
       (play-from-hand state :corp "NEXT Bronze" "HQ")
       (let [nxbr (get-ice state :hq 0)]
         (rez state :corp nxbr))
@@ -2454,7 +2454,7 @@
       (run-continue state)
       (run-continue state)
       (click-prompt state :runner "Steal")
-      (is (zero? (:brain-damage (get-runner))) "Runner should still have 0 brain damage")))
+      (is (zero? (:brain-damage (get-runner))) "Runner should still have 0 core damage")))
 
 (deftest nisei-mk-ii
   ;; Nisei MK II - Remove hosted counter to ETR, check this works in 4.3
@@ -3627,7 +3627,7 @@
       (is (not (rezzed? (refresh ash))) "Ash should be derezzed"))))
 
 (deftest sentinel-defense-program
-  ;; Sentinel Defense Program - Doesn't fire if brain damage is prevented
+  ;; Sentinel Defense Program - Doesn't fire if core damage is prevented
   (do-game
     (new-game {:corp {:deck ["Sentinel Defense Program" "Viktor 1.0"]}
                :runner {:deck ["Feedback Filter" (qty "Sure Gamble" 3)]}})
@@ -3641,13 +3641,13 @@
       (rez state :corp viktor)
       (run-continue state)
       (card-subroutine state :corp viktor 0)
-      (click-prompt state :runner "Done")  ;; Don't prevent the brain damage
+      (click-prompt state :runner "Done")  ;; Don't prevent the core damage
       (is (= 1 (count (:discard (get-runner)))))
       (is (= 1 (:brain-damage (get-runner))))
       (click-prompt state :runner "Done")  ;; So we take the net, but don't prevent it either
       (is (= 2 (count (:discard (get-runner)))))
       (card-subroutine state :corp viktor 0)
-      (card-ability state :runner ff 1)  ;; Prevent the brain damage this time
+      (card-ability state :runner ff 1)  ;; Prevent the core damage this time
       (is (= 3 (count (:discard (get-runner)))) "Feedback filter trashed, didn't take another net damage")
       (is (= 1 (:brain-damage (get-runner)))))))
 

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -629,7 +629,7 @@
       (take-credits state :corp)
       (run-empty-server state "Server 1")
       (click-prompt state :corp "Yes") ; choose to do the optional ability
-      (is (= 2 (:brain-damage (get-runner))) "Runner takes 2 brain damage"))))
+      (is (= 2 (:brain-damage (get-runner))) "Runner takes 2 core damage"))))
 
 (deftest chairman-hiro
   ;; Chairman Hiro - Reduce Runner max hand size; add as 2 agenda points if Runner trashes him
@@ -1587,11 +1587,11 @@
     (run-continue-until state :success)
     (click-prompt state :corp "Yes")
     (click-prompt state :runner "Pay 0 [Credits] to trash")
-    (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")
+    (is (= 2 (:brain-damage (get-runner))) "Runner took 2 core damage")
     (run-empty-server state "Server 2")
     (click-prompt state :corp "Yes")
     (click-prompt state :runner "Pay 0 [Credits] to trash")
-    (is (= 2 (:brain-damage (get-runner))) "Runner did not take brain damage when no piece of ice protected Edge of World")))
+    (is (= 2 (:brain-damage (get-runner))) "Runner did not take core damage when no piece of ice protected Edge of World")))
 
 (deftest eliza-s-toybox
   ;; Eliza's Toybox - Rez a card ignoring all costs
@@ -2665,7 +2665,7 @@
       (is (= 2 (:base (prompt-map :corp))) "Base Trace should be up to 2")
       (click-prompt state :corp "1")
       (click-prompt state :runner "0")
-      (is (= 1 (:brain-damage (get-runner))) "Trace succeeded so runner should take 1 brain damage")
+      (is (= 1 (:brain-damage (get-runner))) "Trace succeeded so runner should take 1 core damage")
       (is (= 1 (-> (get-runner) :discard count)) "Trace succeeded so runner should discard card from damage")
       (is (= 1 (-> (get-corp) :discard count)) "Kuwinda should be in Archives")
       (is (= "Kuwinda K4H1U3" (-> (get-corp) :discard first :title)) "Kuwinda should be in Archives")

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -208,7 +208,7 @@
      (is (no-prompt? state :runner) "Not prompted to run again"))))
 
 (deftest amped-up
-  ;; Amped Up - Gain 3 clicks and take 1 unpreventable brain damage
+  ;; Amped Up - Gain 3 clicks and take 1 unpreventable core damage
   (do-game
     (new-game {:runner {:deck ["Amped Up"
                                "Feedback Filter"
@@ -217,11 +217,11 @@
     (play-from-hand state :runner "Feedback Filter")
     (play-from-hand state :runner "Amped Up")
     (is (no-prompt? state :runner)
-        "Feedback Filter brain damage prevention opportunity not given")
+        "Feedback Filter core damage prevention opportunity not given")
     (is (= 5 (:click (get-runner))) "Runner gained 2 clicks from Amped Up")
     (is (= 2 (count (:discard (get-runner)))) "Runner discarded 1 card from damage")
     (is (= 4 (hand-size :runner)) "Runner handsize decreased by 1")
-    (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")))
+    (is (= 1 (:brain-damage (get-runner))) "Took 1 core damage")))
 
 (deftest another-day-another-paycheck
   ;; Another Day, Another Paycheck
@@ -3265,9 +3265,9 @@
      (take-credits state :corp)
      (play-from-hand state :runner "In the Groove")
      (play-from-hand state :runner "Brain Cage")
-     (is (= 0 (:brain-damage (get-runner))) "No brain damage taken yet")
+     (is (= 0 (:brain-damage (get-runner))) "No core damage taken yet")
      (click-prompt state :runner "Brain Cage")
-     (is (= 1 (:brain-damage (get-runner))) "Brain damage taken")
+     (is (= 1 (:brain-damage (get-runner))) "core damage taken")
      (is (changes-credits (get-runner) 1
                              (click-prompt state :runner "Gain 1 [Credits]")))))
 
@@ -5699,7 +5699,7 @@
     (is (= "Enigma" (-> (get-corp) :discard first :title)) "Enigma should be trashed")))
 
 (deftest running-hot
-  ;; Amped Up - Gain 3 clicks and take 1 unpreventable brain damage
+  ;; Amped Up - Gain 3 clicks and take 1 unpreventable core damage
   (do-game
     (new-game {:runner {:deck ["Running Hot"
                                "Feedback Filter"
@@ -5708,11 +5708,11 @@
     (play-from-hand state :runner "Feedback Filter")
     (play-from-hand state :runner "Running Hot")
     (is (no-prompt? state :runner)
-        "Feedback Filter brain damage prevention opportunity not given")
+        "Feedback Filter core damage prevention opportunity not given")
     (is (= 5 (:click (get-runner))) "Runner gained 2 clicks from Running Hot")
     (is (= 2 (count (:discard (get-runner)))) "Runner discarded 1 card from damage")
     (is (= 4 (hand-size :runner)) "Runner handsize decreased by 1")
-    (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")))
+    (is (= 1 (:brain-damage (get-runner))) "Took 1 core damage")))
 
 (deftest running-interference
   ;; Running Interference
@@ -5983,7 +5983,7 @@
       (play-from-hand state :runner "Steelskin Scarring"))))
 
 (deftest stimhack
-  ;; Stimhack - Gain 9 temporary credits and take 1 brain damage after the run
+  ;; Stimhack - Gain 9 temporary credits and take 1 core damage after the run
   (do-game
     (new-game {:corp {:deck ["Eve Campaign"]}
                :runner {:deck ["Stimhack" "Sure Gamble"]}})
@@ -5999,7 +5999,7 @@
              (= 1 (count (:discard (get-corp)))))
         "Corp hand empty and Eve in Archives")
     (is (= 5 (:credit (get-runner))))
-    (is (zero? (count (:hand (get-runner)))) "Lost card from Grip to brain damage")
+    (is (zero? (count (:hand (get-runner)))) "Lost card from Grip to core damage")
     (is (= 4 (hand-size :runner)))
     (is (= 1 (:brain-damage (get-runner))))))
 

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -204,7 +204,7 @@
       (is (find-card "Corroder" (:hand (get-runner))) "The runner has drawn a card")))
 
 (deftest aniccam-the-effect-triggers-on-brain-damage
-    ;; The effect triggers on brain damage
+    ;; The effect triggers on core damage
     (do-game
       (new-game {:runner {:hand ["Aniccam" "Sure Gamble"]
                           :deck ["Corroder"]}})
@@ -940,7 +940,7 @@
       (is (not (no-prompt? state :runner)))))
 
 (deftest buffer-drive-the-effect-triggers-on-brain-damage
-    ;; The effect triggers on brain damage
+    ;; The effect triggers on core damage
     (do-game
       (new-game {:runner {:hand [(qty "Buffer Drive" 3)]}})
       (take-credits state :corp)
@@ -1611,7 +1611,7 @@
       (is (= 2 (get-counters (refresh end) :power)) "gained 1 counter from a successful run"))))
 
 (deftest feedback-filter
-  ;; Feedback Filter - Prevent net and brain damage
+  ;; Feedback Filter - Prevent net and core damage
   (do-game
     (new-game {:corp {:deck ["Data Mine"
                              "Cerebral Overwriter"
@@ -1641,7 +1641,7 @@
         (card-ability state :runner ff 1)
         (click-prompt state :runner "Done")
         (click-prompt state :runner "Pay 0 [Credits] to trash") ; trash Overwriter for 0
-        (is (= 1 (:brain-damage (get-runner))) "2 of the 3 brain damage prevented")
+        (is (= 1 (:brain-damage (get-runner))) "2 of the 3 core damage prevented")
         (is (= 2 (count (:hand (get-runner)))))
         (is (empty? (get-hardware state)) "Feedback Filter trashed")))))
 
@@ -3738,7 +3738,7 @@
     (is (= 3 (:credit (get-runner))) "Paid 2c for each of 3 copies")))
 
 (deftest ramujan-reliant-550-bmi
-  ;; Prevent up to X net or brain damage.
+  ;; Prevent up to X net or core damage.
   (do-game
       (new-game {:corp {:deck ["Data Mine" "Snare!"]}
                  :runner {:deck [(qty "Sure Gamble" 5)]
@@ -3777,7 +3777,7 @@
           (is (= 1 (count (:hand (get-runner)))) "3 net damage prevented")))))
 
 (deftest ramujan-reliant-550-bmi-prevent-up-to-x-net-or-brain-damage-empty-stack
-    ;; Prevent up to X net or brain damage. Empty stack
+    ;; Prevent up to X net or core damage. Empty stack
     (do-game
       (new-game {:corp {:deck ["Data Mine"]}
                  :runner {:deck ["Ramujan-reliant 550 BMI" "Sure Gamble"]}})
@@ -3870,7 +3870,7 @@
       (click-prompt state :corp "Yes")
       (card-ability state :runner rd4 0)
       (click-prompt state :runner "1")
-      (is (= 2 (count (:hand (get-runner)))) "Runner took no brain damage"))))
+      (is (= 2 (count (:hand (get-runner)))) "Runner took no core damage"))))
 
 (deftest record-reconstructor
   ;; Record Reconstructor
@@ -4285,7 +4285,7 @@
           "Runner has ability target prompt")))
 
 (deftest spinal-modem
-  ;; Spinal Modem - +1 MU, 2 recurring credits, take 1 brain damage on successful trace during run
+  ;; Spinal Modem - +1 MU, 2 recurring credits, take 1 core damage on successful trace during run
   (do-game
       (new-game {:corp {:deck ["Caduceus"]}
                  :runner {:deck ["Spinal Modem" "Sure Gamble"]}})
@@ -4302,7 +4302,7 @@
         (card-subroutine state :corp cad 0)
         (click-prompt state :corp "0")
         (click-prompt state :runner "0")
-        (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")
+        (is (= 1 (:brain-damage (get-runner))) "Took 1 core damage")
         (is (= 1 (count (:discard (get-runner)))))
         (is (= 4 (hand-size :runner)) "Reduced hand size"))))
 

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1992,7 +1992,7 @@
       (click-card state :runner "Clone Chip")
       (is (empty? (get-hardware state)) "Sac Con trashed")
       (card-subroutine state :corp fairchild 2)
-      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage"))))
+      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 core damage"))))
 
 (deftest fairchild-3-0
   ;; Fairchild 3.0
@@ -2033,7 +2033,7 @@
       (run-continue state)
       (is (= 1 (count-bad-pub state)) "Gained 1 bad pub")
       (card-subroutine state :corp fen 0)
-      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")
+      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 core damage")
       (is (= 1 (count (:discard (get-runner)))))
       (is (= 4 (hand-size :runner))))))
 
@@ -2714,7 +2714,7 @@
       (is (no-prompt? state :runner) "No prompt to break hakarl")
       (fire-subs state (refresh hakarl))
       (is (nil? (:run @state)))
-      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")
+      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 core damage")
       (run-on state "Server 1")
       ;; effect lasts all turn
       (rez state :corp eli)
@@ -2729,12 +2729,12 @@
       (run-continue state)
       (card-side-ability state :runner hakarl 0)
       (is (not (no-prompt? state :runner)) "Runner prompted to break hakarl")
-      (click-prompt state :runner "Do 1 brain damage")
+      (click-prompt state :runner "Do 1 core damage")
       (click-prompt state :runner "End the run")
       (is (= 1 (:click (get-runner))) "Runner spent clicks breaking hakarl")
       (is (not (nil? (:run @state))))
       (fire-subs state (refresh hakarl))
-      (is (= 1 (:brain-damage (get-runner))) "Runner did not take any extra brain damage")
+      (is (= 1 (:brain-damage (get-runner))) "Runner did not take any extra core damage")
       (is (not (nil? (:run @state)))))))
 
 (deftest hakarl-1-0-wrong-server
@@ -3388,9 +3388,9 @@
       (rez state :corp kamali)
       (run-continue state)
       (card-subroutine state :corp kamali 0)
-      (is (zero? (:brain-damage (get-runner))) "Runner starts with 0 brain damage")
-      (click-prompt state :runner "Take 1 brain damage")
-      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")
+      (is (zero? (:brain-damage (get-runner))) "Runner starts with 0 core damage")
+      (click-prompt state :runner "Take 1 core damage")
+      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 core damage")
       (card-subroutine state :corp kamali 1)
       (is (empty? (:discard (get-runner))) "Runner starts with no discarded cards")
       (click-prompt state :runner "Trash an installed piece of hardware")
@@ -6535,7 +6535,7 @@
       (run-continue state)
       (is (= 3 (:click (get-runner))) "Runner starts with 3 clicks")
       (card-side-ability state :runner tyr 0)
-      (click-prompt state :runner "Do 2 brain damage")
+      (click-prompt state :runner "Do 2 core damage")
       (click-prompt state :runner "Trash an installed Runner card. Gain 3 [Credits]")
       (click-prompt state :runner "End the run")
       (is (= 0 (:click (get-runner))) "Runner has no clicks left")
@@ -6895,7 +6895,7 @@
           "Wraparound 0 strength after Corroder installed"))))
 
 (deftest zed-1.0
-  ;; zed 1.0 - only does brain damage if the runner spends a click to break a sub
+  ;; zed 1.0 - only does core damage if the runner spends a click to break a sub
   (do-game
     (new-game {:corp {:hand ["Zed 1.0"]}})
     (play-from-hand state :corp "Zed 1.0" "HQ")
@@ -6905,9 +6905,9 @@
       (run-on state :hq)
       (run-continue state)
       (card-side-ability state :runner zed 0)
-      (click-prompt state :runner "Do 1 brain damage")
+      (click-prompt state :runner "Do 1 core damage")
       (fire-subs state zed)
-      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")))
+      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 core damage")))
   (do-game
     (new-game {:corp {:hand ["Zed 1.0"]}})
     (play-from-hand state :corp "Zed 1.0" "HQ")
@@ -6917,10 +6917,10 @@
       (run-on state :hq)
       (run-continue state)
       (fire-subs state zed)
-      (is (= 0 (:brain-damage (get-runner))) "Runner took 0 brain damage"))))
+      (is (= 0 (:brain-damage (get-runner))) "Runner took 0 core damage"))))
 
 (deftest zed-2.0
-  ;; zed 2.0 - only does brain damage if the runner spends a click to break a sub
+  ;; zed 2.0 - only does core damage if the runner spends a click to break a sub
   (do-game
     (new-game {:corp {:hand ["Zed 2.0"] :credits 10}})
     (play-from-hand state :corp "Zed 2.0" "HQ")
@@ -6933,7 +6933,7 @@
       (click-prompt state :runner "Trash a piece of hardware")
       (click-prompt state :runner "Trash a piece of hardware")
       (fire-subs state zed)
-      (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")))
+      (is (= 2 (:brain-damage (get-runner))) "Runner took 2 core damage")))
   (do-game
     (new-game {:corp {:hand ["Zed 2.0"] :credits 10}})
     (play-from-hand state :corp "Zed 2.0" "HQ")
@@ -6945,4 +6945,4 @@
       (fire-subs state zed)
       (click-prompt state :corp "Done")
       (click-prompt state :corp "Done")
-      (is (= 0 (:brain-damage (get-runner))) "Runner took 0 brain damage"))))
+      (is (= 0 (:brain-damage (get-runner))) "Runner took 0 core damage"))))

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -422,7 +422,7 @@
       (run-empty-server state :remote1)
       (click-prompt state :corp "Yes")
       (click-prompt state :runner "Pay 0 [Credits] to trash")
-      (is (= 2 (:brain-damage (get-runner))) "Runner took 2 brain damage")
+      (is (= 2 (:brain-damage (get-runner))) "Runner took 2 core damage")
       (is (= 1 (count (:discard (get-corp)))) "1 card in archives")))
 
 (deftest aginfusion-new-miracles-for-a-new-world-ability-works-5056

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -613,9 +613,9 @@
       (play-from-hand state :corp "Cerebral Cast")
       (click-prompt state :corp "0 [Credits]")
       (click-prompt state :runner "1 [Credits]")
-      (click-prompt state :runner "Suffer 1 brain damage")
-      (is (= 1 (count (:discard (get-runner)))) "Runner took a brain damage")
-      (is (zero? (count-tags state)) "Runner took no tags from brain damage choice")
+      (click-prompt state :runner "Suffer 1 core damage")
+      (is (= 1 (count (:discard (get-runner)))) "Runner took a core damage")
+      (is (zero? (count-tags state)) "Runner took no tags from core damage choice")
       (play-from-hand state :corp "Cerebral Cast")
       (click-prompt state :corp "0 [Credits]")
       (click-prompt state :runner "1 [Credits]")
@@ -883,7 +883,7 @@
       (is (= "Underway Renovation" (:title (get-scored state :corp 1)))))))
 
 (deftest defective-brainchips
-  ;; Defective Brainchips - Do 1 add'l brain damage the first time Runner takes some each turn
+  ;; Defective Brainchips - Do 1 add'l core damage the first time Runner takes some each turn
   (do-game
     (new-game {:corp {:deck ["Defective Brainchips" "Viktor 1.0"]}
                :runner {:deck [(qty "Sure Gamble" 2) (qty "Shiv" 2)]}})
@@ -895,10 +895,10 @@
       (rez state :corp vik)
       (run-continue state)
       (card-subroutine state :corp vik 0)
-      (is (= 2 (count (:discard (get-runner)))) "2 cards lost to brain damage")
+      (is (= 2 (count (:discard (get-runner)))) "2 cards lost to core damage")
       (is (= 2 (:brain-damage (get-runner))) "Brainchips dealt 1 additional brain dmg")
       (card-subroutine state :corp vik 0)
-      (is (= 3 (count (:discard (get-runner)))) "2 cards lost to brain damage")
+      (is (= 3 (count (:discard (get-runner)))) "2 cards lost to core damage")
       (is (= 3 (:brain-damage (get-runner))) "Brainchips didn't do additional brain dmg"))))
 
 (deftest ^:kaocha/pending digital-rights-management
@@ -2280,17 +2280,17 @@
     (new-game {:corp {:deck ["Kill Switch" (qty "Hostile Takeover" 2)]}})
     (play-from-hand state :corp "Kill Switch")
     (play-from-hand state :corp "Hostile Takeover" "New remote")
-    (is (zero? (:brain-damage (get-runner))) "Runner should start with 0 brain damage")
+    (is (zero? (:brain-damage (get-runner))) "Runner should start with 0 core damage")
     (play-and-score state "Hostile Takeover")
     (click-prompt state :corp "Hostile Takeover")
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 1 (:brain-damage (get-runner))) "Runner should get 1 brain damage from Kill Switch after Corp scores an agenda")
+    (is (= 1 (:brain-damage (get-runner))) "Runner should get 1 core damage from Kill Switch after Corp scores an agenda")
     (take-credits state :corp)
     (run-empty-server state :remote1)
     (click-prompt state :corp "0")
     (click-prompt state :runner "0")
-    (is (= 2 (:brain-damage (get-runner))) "Runner should get 1 brain damage from Kill Switch after accecssing an agenda")))
+    (is (= 2 (:brain-damage (get-runner))) "Runner should get 1 core damage from Kill Switch after accecssing an agenda")))
 
 (deftest lag-time
   (do-game
@@ -3353,7 +3353,7 @@
       (is (last-log-contains? state "Corp uses Reverse Infection to purge 9 virus counters and trash 3 cards from the top of the stack.") "Should write correct log")))
 
 (deftest riot-suppression-take-1-brain-damage
-    ;; Take 1 brain damage
+    ;; Take 1 core damage
     (do-game
       (new-game {:corp {:deck ["Riot Suppression" "Adonis Campaign"]}})
       (play-from-hand state :corp "Adonis Campaign" "New remote")
@@ -3363,10 +3363,10 @@
       (take-credits state :runner)
       (play-from-hand state :corp "Riot Suppression")
       (is (empty? (:discard (get-runner))) "Runner discard is empty")
-      (is (zero? (:brain-damage (get-runner))) "Runner starts with no brain damage")
+      (is (zero? (:brain-damage (get-runner))) "Runner starts with no core damage")
       (click-prompt state :runner "Yes")
-      (is (= 1 (count (:discard (get-runner)))) "1 card lost to brain damage")
-      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")
+      (is (= 1 (count (:discard (get-runner)))) "1 card lost to core damage")
+      (is (= 1 (:brain-damage (get-runner))) "Runner took 1 core damage")
       (is (= 1 (count (:discard (get-corp)))) "No corp cards trashed")
       (is (= 1 (count (:rfg (get-corp)))) "Riot Suppestion removed from game")
       (take-credits state :corp)
@@ -3383,10 +3383,10 @@
       (take-credits state :runner)
       (play-from-hand state :corp "Riot Suppression")
       (is (empty? (:discard (get-runner))) "Runner discard is empty")
-      (is (zero? (:brain-damage (get-runner))) "Runner starts with no brain damage")
+      (is (zero? (:brain-damage (get-runner))) "Runner starts with no core damage")
       (click-prompt state :runner "No")
       (is (empty? (:discard (get-runner))) "Runner discard statys empty")
-      (is (zero? (:brain-damage (get-runner))) "Runner takes no brain damage")
+      (is (zero? (:brain-damage (get-runner))) "Runner takes no core damage")
       (is (= 1 (count (:discard (get-corp)))) "No corp cards trashed")
       (is (= 1 (count (:rfg (get-corp)))) "Riot Suppestion removed from game")
       (take-credits state :corp)
@@ -4875,8 +4875,8 @@
           "Wetwork Refit is hosted on Eli 1.0")
       (is (= 3 (count (:subroutines (refresh eli))))
           "Eli 1.0 has 2 different subroutines")
-      (is (= "[Wetwork Refit] Do 1 brain damage" (:label (first (:subroutines (refresh eli)))))
-          "Eli 1.0 has a brain damage subroutine as his first subroutine")
+      (is (= "[Wetwork Refit] Do 1 core damage" (:label (first (:subroutines (refresh eli)))))
+          "Eli 1.0 has a core damage subroutine as his first subroutine")
       (core/move state :corp (first (:hosted (refresh eli))) :hand)
       (is (empty? (:hosted (refresh eli))) "No cards are hosted on Eli 1.0")
       (is (= 2 (count (:subroutines (refresh eli))))

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -276,7 +276,7 @@
       (rez state :corp (refresh zed1))
       (run-continue state)
       (card-ability state :runner (refresh alias) 0)
-      (click-prompt state :runner "Do 1 brain damage")
+      (click-prompt state :runner "Do 1 core damage")
       (click-prompt state :runner "Done")
       (is (= 1 (count (filter :broken (:subroutines (refresh zed1))))) "The subroutine is broken")
       (run-continue state :movement)
@@ -636,15 +636,15 @@
       (is (= 3 (get-strength (refresh vege))))
       (changes-val-macro
         1 (get-strength (refresh vege))
-        "Gained 1str from brain damage"
+        "Gained 1str from core damage"
         (damage state :runner :brain 1))
       (changes-val-macro
         1 (get-strength (refresh vege))
-        "Gained 1str from brain damage"
+        "Gained 1str from core damage"
         (damage state :runner :brain 1))
       (changes-val-macro
         1 (get-strength (refresh vege))
-        "Gained 1str from brain damage"
+        "Gained 1str from core damage"
         (damage state :runner :brain 1))
       (is (= 6 (get-strength (refresh vege)))))))
 
@@ -3045,9 +3045,9 @@
       (run-on state "HQ")
       (run-continue state)
       (card-ability state :runner (get-program state 0) 0)
-      (click-prompt state :runner "Do 1 brain damage or end the run")
+      (click-prompt state :runner "Do 1 core damage or end the run")
       (is (= 1 (count (remove :broken (:subroutines (get-ice state :hq 0))))) "Broke all but one subroutine")
-      (is (= "Do 1 brain damage or end the run" (:label (first (remove :broken (:subroutines (get-ice state :hq 0)))))) "Broke all but selected sub")
+      (is (= "Do 1 core damage or end the run" (:label (first (remove :broken (:subroutines (get-ice state :hq 0)))))) "Broke all but selected sub")
       (is (nil? (refresh (get-program state 0))) "Grappling Hook is now trashed")))
 
 (deftest grappling-hook-interaction-with-news-hound-4988
@@ -3435,7 +3435,7 @@
       (let [inv (get-program state 0)]
         (card-ability state :runner (refresh inv) 1)
         (card-ability state :runner (refresh inv) 0)
-        (click-prompt state :runner "Do 1 brain damage")
+        (click-prompt state :runner "Do 1 core damage")
         (click-prompt state :runner "End the run")
         (run-continue state)
         (click-prompt state :runner "Yes")
@@ -3469,7 +3469,7 @@
             inv (get-program state 2)]
         (card-ability state :runner (refresh inv) 1)
         (card-ability state :runner (refresh inv) 0)
-        (click-prompt state :runner "Do 1 brain damage")
+        (click-prompt state :runner "Do 1 core damage")
         (click-prompt state :runner "End the run")
         (run-continue state)
         (click-prompt state :runner "No")
@@ -3478,7 +3478,7 @@
         (run-on state "HQ")
         (run-continue state)
         (card-ability state :runner (refresh maven) 0)
-        (click-prompt state :runner "Do 1 brain damage")
+        (click-prompt state :runner "Do 1 core damage")
         (click-prompt state :runner "End the run")
         (run-continue state)
         (is (not (prompt-is-card? state :runner inv)) "Prompt shouldn't be Inversificator")
@@ -3503,7 +3503,7 @@
       (let [inv (get-program state 0)]
         (card-ability state :runner (refresh inv) 1)
         (card-ability state :runner (refresh inv) 0)
-        (click-prompt state :runner "Do 1 brain damage")
+        (click-prompt state :runner "Do 1 core damage")
         (click-prompt state :runner "End the run")
         (run-continue state)
         (click-prompt state :runner "No")
@@ -5666,7 +5666,7 @@
       (run-continue state)
       (card-ability state :runner (get-program state 0) 0)
       (is (seq (:prompt (get-runner))) "Have a break prompt")
-      (click-prompt state :runner "Trace 4 - Do 1 brain damage")
+      (click-prompt state :runner "Trace 4 - Do 1 core damage")
       (is (:broken (first (:subroutines (get-ice state :rd 0))))
           "The break ability worked")))
 

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -3374,7 +3374,7 @@
    (play-from-hand state :runner "Light the Fire!")
    (card-ability state :runner (get-resource state 0) 0)
    (click-prompt state :runner "Server 1")
-   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to brain damage")
+   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to core damage")
    (is (= 1 (:brain-damage (get-runner))))
    (rez state :corp (refresh (get-content state :remote1 0)))
    (changes-val-macro 0 (:credit (get-runner))
@@ -3394,7 +3394,7 @@
    (play-from-hand state :runner "Light the Fire!")
    (card-ability state :runner (get-resource state 0) 0)
    (click-prompt state :runner "Server 1")
-   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to brain damage")
+   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to core damage")
    (is (= 1 (:brain-damage (get-runner))))
    (rez state :corp (refresh (get-content state :remote1 0)))
    (run-jack-out state)
@@ -3413,7 +3413,7 @@
    (play-from-hand state :runner "Light the Fire!")
    (card-ability state :runner (get-resource state 0) 0)
    (click-prompt state :runner "Server 1")
-   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to brain damage")
+   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to core damage")
    (let [crick (get-ice state :remote1 0)]
      (rez state :corp crick)
      (run-continue state)
@@ -3443,7 +3443,7 @@
    (play-from-hand state :runner "Light the Fire!")
    (card-ability state :runner (get-resource state 0) 0)
    (click-prompt state :runner "Server 1")
-   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to brain damage")
+   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to core damage")
    (rez state :corp (refresh (get-content state :remote1 0)))
    (rez state :corp (refresh (get-content state :remote2 0)))
    (let [meta (get-ice state :remote1 0)]
@@ -3479,7 +3479,7 @@
    (play-from-hand state :runner "Light the Fire!")
    (card-ability state :runner (get-resource state 0) 0)
    (click-prompt state :runner "Server 1")
-   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to brain damage")
+   (is (= 1 (count (:hand (get-runner)))) "Lost card from Grip to core damage")
    (let [sand (get-ice state :remote1 0)
          ngo (get-content state :remote1 0)
          hoku (get-content state :remote2 0)]
@@ -4078,7 +4078,7 @@
     (card-ability state :runner (get-resource state 0) 0)
     (is (zero? (count (:discard (get-corp)))) "Nothing discarded from HQ")
     (play-from-hand state :runner "Skulljack")
-    (is (= 3 (count (:hand (get-runner)))) "Took 1 brain damage")
+    (is (= 3 (count (:hand (get-runner)))) "Took 1 core damage")
     (card-ability state :runner (get-resource state 0) 0)
     (is (zero? (count (:discard (get-corp)))) "Nothing discarded from HQ")
     (let [sm (get-ice state :archives 0)]
@@ -5231,7 +5231,7 @@
         (is (no-prompt? state :runner) "Runner has no Friday Chip prompt"))))
 
 (deftest stim-dealer
-  ;; Stim Dealer - Take 1 brain damage when it accumulates 2 power counters
+  ;; Stim Dealer - Take 1 core damage when it accumulates 2 power counters
   (do-game
     (new-game {:runner {:deck ["Stim Dealer" "Sure Gamble" "Feedback Filter"]}})
     (take-credits state :corp)
@@ -5251,7 +5251,7 @@
       (take-credits state :corp)
       (is (zero? (get-counters (refresh sd) :power)) "Lost all counters")
       (is (no-prompt? state :runner) "No Feedback Filter brain dmg prevention possible")
-      (is (= 1 (:brain-damage (get-runner))) "Took 1 brain damage")
+      (is (= 1 (:brain-damage (get-runner))) "Took 1 core damage")
       (is (= 4 (:click (get-runner))) "Didn't gain extra click"))))
 
 (deftest stoneship-chart-room

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -472,7 +472,7 @@
       (is (= 1 (count (:discard (get-corp)))) "Bio Vault trashed"))))
 
 (deftest black-level-clearance-taking-brain-damage
-    ;; taking brain damage
+    ;; taking core damage
     (do-game
       (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
                         :hand ["Black Level Clearance"]}})
@@ -483,7 +483,7 @@
       (changes-val-macro
         0 (:credit (get-corp))
         "Corp gains 0 credits"
-        (click-prompt state :runner "Take 1 brain damage"))
+        (click-prompt state :runner "Take 1 core damage"))
       (is (get-run) "Run has ended")
       (is (get-content state :remote1) "Black Level Clearance has not been trashed")))
 
@@ -3398,7 +3398,7 @@
       (is (= 5 (:strength (get-prompt state :runner))) "3 base, +2 of upgrade"))))
 
 (deftest ryon-knight
-  ;; Ryon Knight - Trash during run to do 1 brain damage if Runner has no clicks remaining
+  ;; Ryon Knight - Trash during run to do 1 core damage if Runner has no clicks remaining
   (do-game
     (new-game {:corp {:deck ["Ryon Knight"]}})
     (play-from-hand state :corp "Ryon Knight" "HQ")
@@ -3415,7 +3415,7 @@
       (run-on state :hq)
       (card-ability state :corp ryon 0)
       (is (zero? (:click (get-runner))))
-      (is (= 1 (:brain-damage (get-runner))) "Did 1 brain damage")
+      (is (= 1 (:brain-damage (get-runner))) "Did 1 core damage")
       (is (= 1 (count (:discard (get-corp)))) "Ryon trashed"))))
 
 (deftest sansan-city-grid
@@ -3616,7 +3616,7 @@
         (is (= (:cid scg2) (-> (prompt-map :corp) :card :cid)) "SCG did trigger for ice protecting HQ")))))
 
 (deftest tempus
-  ;; Tempus - Trace^3, the runner chooses to lose 2 clicks or take 1 brain damage
+  ;; Tempus - Trace^3, the runner chooses to lose 2 clicks or take 1 core damage
   (do-game
     (new-game {:corp {:deck [(qty "Tempus" 3)]}
                :runner {:deck [(qty "Sure Gamble" 3)]}})
@@ -3634,23 +3634,23 @@
     (run-on state "Server 1")
     (run-continue state)
     (click-prompt state :corp "0") ; trace
-    (is (zero? (:brain-damage (get-runner))) "Runner starts with 0 brain damage")
+    (is (zero? (:brain-damage (get-runner))) "Runner starts with 0 core damage")
     (click-prompt state :runner "0")
-    (is (= 1 (:brain-damage (get-runner))) "Runner took 1 brain damage")
+    (is (= 1 (:brain-damage (get-runner))) "Runner took 1 core damage")
     (click-prompt state :runner "Pay 0 [Credits] to trash") ; trash
     (take-credits state :runner)
     (take-credits state :corp)
     (run-on state "Archives")
     (run-continue state)
-    (is (= 1 (:brain-damage (get-runner))) "Runner takes no brain damage")
+    (is (= 1 (:brain-damage (get-runner))) "Runner takes no core damage")
     (is (= 3 (:click (get-runner))) "Runner loses no clicks")
     (run-on state "HQ")
     (run-continue state)
     (click-prompt state :corp "0") ; trace
     (click-prompt state :runner "0")
-    (is (= 1 (:brain-damage (get-runner))) "Runner starts with 1 brain damage")
-    (click-prompt state :runner "Suffer 1 brain damage")
-    (is (= 2 (:brain-damage (get-runner))) "Runner took 1 brain damage")
+    (is (= 1 (:brain-damage (get-runner))) "Runner starts with 1 core damage")
+    (click-prompt state :runner "Suffer 1 core damage")
+    (is (= 2 (:brain-damage (get-runner))) "Runner took 1 core damage")
     (click-prompt state :runner "No action") ; don't trash
     (run-on state "HQ")
     (run-continue state)
@@ -3690,7 +3690,7 @@
       (is (= 1 (count (:discard (get-corp)))) "The copy of Quicksand was trashed"))))
 
 (deftest tori-hanzo
-  ;; Tori Hanzō - Pay to do 1 brain damage instead of net damage
+  ;; Tori Hanzō - Pay to do 1 core damage instead of net damage
   (do-game
       (new-game {:corp {:deck ["Pup" "Tori Hanzō"]}
                  :runner {:deck [(qty "Sure Gamble" 3) "Net Shield"]}})
@@ -3722,7 +3722,7 @@
         (click-prompt state :runner "Suffer 1 net damage")
         (click-prompt state :runner "Done")
         (click-prompt state :corp "Yes")
-        (is (= 2 (count (:discard (get-runner)))) "1 brain damage suffered")
+        (is (= 2 (count (:discard (get-runner)))) "1 core damage suffered")
         (is (= 1 (:brain-damage (get-runner)))))))
 
 (deftest tori-hanzo-with-hokusai-grid-issue-2702
@@ -3748,7 +3748,7 @@
         (run-empty-server state "Archives")
         (click-prompt state :corp "Yes") ; Tori prompt to pay 2c to replace 1 net with 1 brain
         (is (= 2 (count (:discard (get-runner)))))
-        (is (= 1 (:brain-damage (get-runner))) "1 brain damage suffered")
+        (is (= 1 (:brain-damage (get-runner))) "1 core damage suffered")
         (click-prompt state :runner "Hokusai Grid")
         (click-prompt state :runner "No action")
         (click-prompt state :runner "No action")
@@ -3771,7 +3771,7 @@
         (card-subroutine state :corp pup 0)
         (click-prompt state :runner "Suffer 1 net damage")
         (click-prompt state :corp "Yes") ; pay 2c to replace 1 net with 1 brain
-        (is (= 1 (count (:discard (get-runner)))) "1 brain damage suffered")
+        (is (= 1 (count (:discard (get-runner)))) "1 core damage suffered")
         (is (= 1 (:brain-damage (get-runner))))
         (run-continue state :movement)
         (run-jack-out state)

--- a/test/clj/game/core/costs_test.clj
+++ b/test/clj/game/core/costs_test.clj
@@ -40,7 +40,7 @@
       (is (= [[:credit 1] [:net 1]] (core/merge-costs [[:net 1 :credit 1]]))))
     (testing "Damage is combined"
       (is (= [[:net 2]] (core/merge-costs [[:net 1 :net 1]]))))
-    (testing "Net, meat, and brain damage are recognized"
+    (testing "Net, meat, and core damage are recognized"
       (is (= [[:net 1] [:meat 1] [:brain 1]]
              (core/merge-costs [[:net 1] [:meat 1] [:brain 1]]))))))
 

--- a/test/clj/game/core/say_test.clj
+++ b/test/clj/game/core/say_test.clj
@@ -260,6 +260,17 @@
         (core/command-parser state :runner {:user user :text "/take-brain 99999999999999999999999999999999999999999999"})
         (is (= 1003 (:brain-damage (get-runner))) "Runner gains 1000 brain"))))
 
+  (testing "/take-core"
+    (let [user {:username "Runner"}]
+      (do-game
+        (new-game)
+        (core/command-parser state :runner {:user user :text "/take-core 3"})
+        (is (= 3 (:brain-damage (get-runner))) "Runner gains 3 brain")
+        (core/command-parser state :runner {:user user :text "/take-core -5"})
+        (is (= 3 (:brain-damage (get-runner))) "Runner gains 0 brain")
+        (core/command-parser state :runner {:user user :text "/take-core 99999999999999999999999999999999999999999999"})
+        (is (= 1003 (:brain-damage (get-runner))) "Runner gains 1000 brain"))))
+
   (testing "/trace"
     (let [user {:username "Corp"}]
       (do-game


### PR DESCRIPTION
This starts the process to rename "brain damage" to "core damage" by changing strings visible to the  user, and adding a `take-core` command.

## Tasks
- [x] Rename strings visible to end  user
- [x] Add `take-core` command 