### PR TITLE
ixodidae, lamprey, tapwrm, etc are all trashed by the runner now

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2476,8 +2476,9 @@
    :events [{:event :purge
              :condition :hosted
              :async true
-             :effect (req (wait-for (trash state side card {:cause :purge
-                                                            :cause-card card})
+             :msg (msg "trash itself")
+             :effect (req (wait-for (trash state :runner card {:cause :purge
+                                                               :cause-card card})
                                     (update-all-agenda-points state side)
                                     (effect-completed state side eid)))}
             (successful-run-replace-breach

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2476,7 +2476,7 @@
    :events [{:event :purge
              :condition :hosted
              :async true
-             :msg (msg "trash itself")
+             :msg "trash itself"
              :effect (req (wait-for (trash state :runner card {:cause :purge
                                                                :cause-card card})
                                     (update-all-agenda-points state side)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -765,6 +765,7 @@
                    (swap! state assoc-in [:corp :register :cannot-score] agendas)))}
    :events [{:event :purge
              :async true
+             :msg (msg "trash itself")
              :effect (req (swap! state update-in [:corp :register] dissoc :cannot-score)
                           (trash state :runner eid card {:cause :purge
                                                          :cause-card card}))}
@@ -1146,8 +1147,9 @@
                        :value 1}]
    :events [{:event :purge
              :async true
-             :effect (effect (trash eid card {:cause :purge
-                                              :cause-card card}))}]})
+             :msg (msg "trash itself")
+             :effect (req (trash state :runner eid card {:cause :purge
+                                                         :cause-card card}))}]})
 
 (defcard "Djinn"
   {:abilities [{:label "Search the stack for a virus program and add it to your Grip"
@@ -1247,8 +1249,9 @@
   {:events [(breach-access-bonus :rd 1)
             {:event :purge
              :async true
-             :effect (effect (trash eid card {:cause :purge
-                                              :cause-card card}))}]})
+             :msg (msg "trash itself")
+             :effect (req (trash state :runner eid card {:cause :purge
+                                                         :cause-card card}))}]})
 
 (defcard "Expert Schedule Analyzer"
   (let [ability (successful-run-replace-breach
@@ -1602,7 +1605,8 @@
              :effect (effect (gain-credits :runner eid 1))}
             {:event :purge
              :async true
-             :effect (effect (trash eid card {:cause :purge :cause-card card}))}]})
+             :msg (msg "trash itself")
+             :effect (req (trash state :runner eid card {:cause :purge :cause-card card}))}]})
 
 (defcard "Keyhole"
   (let [ability (successful-run-replace-breach
@@ -1677,8 +1681,9 @@
              :effect (effect (lose-credits :corp eid 1))}
             {:event :purge
              :async true
-             :effect (effect (trash eid card {:cause :purge
-                                              :cause-card card}))}]})
+             :msg (msg "trash itself")
+             :effect (req (trash state :runner eid card {:cause :purge
+                                                         :cause-card card}))}]})
 
 (defcard "Leech"
   {:events [{:event :successful-run
@@ -2582,7 +2587,8 @@
      :events [(assoc ability :event :runner-turn-begins)
               {:event :purge
                :async true
-               :effect (effect (trash eid card {:cause :purge :cause-card card}))}]}))
+               :msg (msg "trash itself")
+               :effect (req (trash state :runner eid card {:cause :purge :cause-card card}))}]}))
 
 (defcard "Torch"
   (auto-icebreaker {:abilities [(break-sub 1 1 "Code Gate")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -765,7 +765,7 @@
                    (swap! state assoc-in [:corp :register :cannot-score] agendas)))}
    :events [{:event :purge
              :async true
-             :msg (msg "trash itself")
+             :msg "trash itself"
              :effect (req (swap! state update-in [:corp :register] dissoc :cannot-score)
                           (trash state :runner eid card {:cause :purge
                                                          :cause-card card}))}
@@ -1147,7 +1147,7 @@
                        :value 1}]
    :events [{:event :purge
              :async true
-             :msg (msg "trash itself")
+             :msg "trash itself"
              :effect (req (trash state :runner eid card {:cause :purge
                                                          :cause-card card}))}]})
 
@@ -1249,7 +1249,7 @@
   {:events [(breach-access-bonus :rd 1)
             {:event :purge
              :async true
-             :msg (msg "trash itself")
+             :msg "trash itself"
              :effect (req (trash state :runner eid card {:cause :purge
                                                          :cause-card card}))}]})
 
@@ -1605,7 +1605,7 @@
              :effect (effect (gain-credits :runner eid 1))}
             {:event :purge
              :async true
-             :msg (msg "trash itself")
+             :msg "trash itself"
              :effect (req (trash state :runner eid card {:cause :purge :cause-card card}))}]})
 
 (defcard "Keyhole"
@@ -1681,7 +1681,7 @@
              :effect (effect (lose-credits :corp eid 1))}
             {:event :purge
              :async true
-             :msg (msg "trash itself")
+             :msg "trash itself"
              :effect (req (trash state :runner eid card {:cause :purge
                                                          :cause-card card}))}]})
 
@@ -2587,7 +2587,7 @@
      :events [(assoc ability :event :runner-turn-begins)
               {:event :purge
                :async true
-               :msg (msg "trash itself")
+               :msg "trash itself"
                :effect (req (trash state :runner eid card {:cause :purge :cause-card card}))}]}))
 
 (defcard "Torch"


### PR DESCRIPTION
This means that "trash cards" triggers like wasteland will trigger like they're meant to (like they do with clot).

I think that side was injecting the corporation before, since they were the one triggering the event.

Closes #6582