### PR TITLE
ob allows you to shuffle when trashing a 0 cost card (and a test)

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1874,8 +1874,9 @@
                                        (trash state side card {:cause-card card})
                                        (wait-for
                                          (gain-credits state side 3)
-                                         (draw state side eid 3)
-                                         (system-msg state side (str "uses " (:title card) " to gain 3 [Credits] and draw 3 cards")))))}}}
+                                         (wait-for (draw state side 3)
+                                                   (system-msg state side (str "uses " (:title card) " to gain 3 [Credits] and draw 3 cards"))
+                                                   (effect-completed state side eid)))))}}}
                      card nil))}]
     {:derezzed-events [corp-rez-toast]
      :flags {:corp-phase-12 (req true)}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1869,9 +1869,10 @@
                       {:prompt "Trash Rashida Jaheem to gain 3 [Credits] and draw 3 cards?"
                        :yes-ability
                        {:async true
-                        :msg "gain 3 [Credits] and draw 3 cards"
+                        ;:msg "gain 3 [Credits] and draw 3 cards"
                         :effect (req (wait-for
                                        (trash state side card {:cause-card card})
+                                       (system-msg state side (str "uses " (:title card) " to gain 3 [Credits] and draw 3 cards"))
                                        (wait-for
                                          (gain-credits state side 3)
                                          (draw state side eid 3))))}}}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1872,10 +1872,10 @@
                        {:async true
                         :effect (req (wait-for
                                        (trash state side card {:cause-card card})
-                                       (system-msg state side (str "uses " (:title card) " to gain 3 [Credits] and draw 3 cards"))
                                        (wait-for
                                          (gain-credits state side 3)
-                                         (draw state side eid 3))))}}}
+                                         (draw state side eid 3)
+                                         (system-msg state side (str "uses " (:title card) " to gain 3 [Credits] and draw 3 cards")))))}}}
                      card nil))}]
     {:derezzed-events [corp-rez-toast]
      :flags {:corp-phase-12 (req true)}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1867,9 +1867,9 @@
                    (continue-ability
                      {:optional
                       {:prompt "Trash Rashida Jaheem to gain 3 [Credits] and draw 3 cards?"
+                       :msg "to trash itself"
                        :yes-ability
                        {:async true
-                        ;:msg "gain 3 [Credits] and draw 3 cards"
                         :effect (req (wait-for
                                        (trash state side card {:cause-card card})
                                        (system-msg state side (str "uses " (:title card) " to gain 3 [Credits] and draw 3 cards"))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1465,23 +1465,31 @@
           ;; prompts to install an x-cost card (handles validation)
           (ob-ability [target-cost]
             {:optional
-             {:prompt (str "Install a " target-cost "-cost card from your deck?")
+             {:prompt (if (>= target-cost 0)
+                        (str "Install a " target-cost "-cost card from your deck?")
+                        (str "Shuffle your deck (search for a " target-cost "-cost card from your deck?)"))
               :once :per-turn
-              :req (req (>= target-cost 0))
               :yes-ability
               {:msg (msg "to search R&D for a " (str target-cost) "-cost card")
                :async true
-               :effect (effect (continue-ability
-                                 {:prompt "Choose a card to install and rez"
-                                  :choices (req (conj (filter #(and (= target-cost (:cost %))
-                                                                    (or (asset? %)
-                                                                        (upgrade? %)
-                                                                        (ice? %)))
-                                                              (vec (sort-by :title (:deck corp))))
-                                                      "No install"))
-                                  :async true
-                                  :effect (resolve-install)}
-                                 card nil))}}})]
+               :effect (req (if (>= target-cost 0)
+                              (continue-ability
+                                state side
+                                {:prompt "Choose a card to install and rez"
+                                 :choices (req (conj (filter #(and (= target-cost (:cost %))
+                                                                   (or (asset? %)
+                                                                       (upgrade? %)
+                                                                       (ice? %)))
+                                                             (vec (sort-by :title (:deck corp))))
+                                                     "No install"))
+                                 :async true
+                                 :effect (resolve-install)}
+                                card nil)
+                              (continue-ability
+                                state side
+                                {:msg "to shuffle R&D"
+                                 :effect (effect (shuffle! :corp :deck))}
+                                card nil)))}}})]
     {:events [{:event :corp-trash
                :req (req (and
                            (installed? (:card context))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1491,8 +1491,7 @@
                                  :effect (effect (shuffle! :corp :deck))}
                                 card nil)))}
               :no-ability
-              {:effect (effect (system-msg "declines to use Ob Superheavy Logistics: Extract. Export. Excel."))}
-              }})]
+              {:effect (effect (system-msg "declines to use Ob Superheavy Logistics: Extract. Export. Excel."))}}})]
     {:events [{:event :corp-trash
                :req (req (and
                            (installed? (:card context))

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3684,8 +3684,7 @@
     (card-ability state :corp (get-content state :remote1 0) 0)
     (click-prompt state :corp "Yes")
     (click-prompt state :corp "Yes")
-    ;; if rashida gets changed, this will be 'second-last'
-    (is (last-log-contains? state "shuffle") "Ob superheavy should shuffle R&D")))
+    (is (second-last-log-contains? state "shuffle") "Ob superheavy should shuffle R&D")))
 
 (deftest omar-keung-conspiracy-theorist-make-a-successful-run-on-the-chosen-server-once-per-turn
     ;; Make a successful run on the chosen server once per turn

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3670,6 +3670,23 @@
    (is (empty? (:prompt (get-corp))) "No Ob prompt")
    (is (find-card "Oaktown Renovation" (:discard (get-corp))) "Oaktown is trashed")))
 
+(deftest ob-superheavy-logistics-shuffle-with-rashida
+  ;; you can search for -1 cost cards as an excuse to shuffle your deck
+  (do-game
+    (new-game {:corp {:id "Ob Superheavy Logistics: Extract. Export. Excel."
+                      :hand ["Rashida Jaheem"]
+                      :deck [(qty "Hedge Fund" 15)]}})
+    (play-from-hand state :corp "Rashida Jaheem" "New remote")
+    (take-credits state :corp)
+    (rez state :corp (get-content state :remote1 0))
+    (take-credits state :runner)
+    (is (:corp-phase-12 @state) "Corp has opportunity to use Rashida")
+    (card-ability state :corp (get-content state :remote1 0) 0)
+    (click-prompt state :corp "Yes")
+    (click-prompt state :corp "Yes")
+    ;; if rashida gets changed, this will be 'second-last'
+    (is (last-log-contains? state "shuffle") "Ob superheavy should shuffle R&D")))
+
 (deftest omar-keung-conspiracy-theorist-make-a-successful-run-on-the-chosen-server-once-per-turn
     ;; Make a successful run on the chosen server once per turn
     (do-game


### PR DESCRIPTION
You're allowed to search for a card with a -1 printed cost (even though none have been printed).

To avoid wasting time, searching with a cost of -1 or less will just instantly shuffle the deck. If they make a card with a printed cost of less than 0, they've earned the five minutes it takes to fix it :joy:.

Also I noticed the ordering when using rashida (the test case) will say what it does when it trashes rashida, rather than when it actually draws 3/gains 3. I've moved the rashida log message a tiny bit (this also means it orders nicely with ob and other things that trigger from trashing a card).

Closes #6595