### PR TITLE
fix Eli 2.0 and Tapestry draws to be optional

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1283,9 +1283,11 @@
    :runner-abilities [(bioroid-break 1 1)]})
 
 (defcard "Eli 2.0"
-  {:subroutines [{:async true
-                  :msg "draw 1 card"
-                  :effect (effect (draw eid 1))}
+  {:subroutines [{:optional
+                  {:prompt "Draw 1 card?"
+                   :msg "draw 1 card"
+                   :yes-ability {:async true
+                                 :effect (effect (draw eid 1))}}}
                  end-the-run
                  end-the-run]
    :runner-abilities [(bioroid-break 2 2)]})
@@ -3373,9 +3375,11 @@
 
 (defcard "Tapestry"
   {:subroutines [runner-loses-click
-                 {:async true
-                  :msg "draw 1 card"
-                  :effect (effect (draw eid 1))}
+                 {:optional
+                  {:prompt "Draw 1 card?"
+                   :msg "draw 1 card"
+                   :yes-ability {:async true
+                                 :effect (effect (draw eid 1))}}}
                  {:req (req (pos? (count (:hand corp))))
                   :prompt "Choose a card in HQ to move to the top of R&D"
                   :choices {:card #(and (in-hand? %)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1286,10 +1286,12 @@
   {:subroutines [{:optional
                   {:prompt "Draw 1 card?"
                    :msg "draw 1 card"
+                   :autoresolve (get-autoresolve :auto-fire)
                    :yes-ability {:async true
                                  :effect (effect (draw eid 1))}}}
                  end-the-run
                  end-the-run]
+   :abilities [(set-autoresolve :auto-fire "Eli 2.0 drawing cards")]
    :runner-abilities [(bioroid-break 2 2)]})
 
 (defcard "Endless EULA"
@@ -3378,6 +3380,7 @@
                  {:optional
                   {:prompt "Draw 1 card?"
                    :msg "draw 1 card"
+                   :autoresolve (get-autoresolve :auto-fire)
                    :yes-ability {:async true
                                  :effect (effect (draw eid 1))}}}
                  {:req (req (pos? (count (:hand corp))))
@@ -3385,7 +3388,8 @@
                   :choices {:card #(and (in-hand? %)
                                         (corp? %))}
                   :msg "add 1 card in HQ to the top of R&D"
-                  :effect (effect (move target :deck {:front true}))}]})
+                  :effect (effect (move target :deck {:front true}))}]
+  :abilities [(set-autoresolve :auto-fire "Tapestry drawing cards")]})
 
 (defcard "Taurus"
   (constellation-ice trash-hardware-sub))


### PR DESCRIPTION
[Eli 2.0](https://netrunnerdb.com/en/card/13034) and [Tapestry](https://netrunnerdb.com/en/card/13037) subroutines say indeed "may draw"