### PR TITLE
Prevention checks for nil

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1671,7 +1671,9 @@
   (letfn [(eventmap [s]
             (into {} (reverse (get s :turn-events))))]
     {:interactions {:prevent [{:type #{:net :brain :meat}
-                               :req (req (:access @state))}]}
+                               :req (req (and (:access @state)
+                                              (= (:cid (second (:pre-damage (eventmap @state))))
+                                                 (:cid (first (:pre-access-card (eventmap @state)))))))}]}
      :abilities [{:cost [:x-credits :trash-can]
                   :label "prevent damage"
                   :req (req (and (:access @state)

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -373,7 +373,7 @@
   [state side card type target args]
   (->> (get-card-prevention card type)
        (map #(ab-can-prevent? state side card (:req %) target args))
-       (some #(-> % false? not))))
+       (some identity)))
 
 (defn cards-can-prevent?
   "Checks if any cards in a list can prevent this type"

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2486,6 +2486,28 @@
                            (card-ability state :runner refr 1)
                            (click-card state :runner lp)))))
 
+(deftest lucky-charm-requires-hq-run
+  (do-game
+    (new-game {:runner {:hand ["Lucky Charm"]}
+               :corp {:hand ["Vanilla"]}})
+    (play-from-hand state :corp "Vanilla" "R&D")
+    (take-credits state :corp)
+    (let [vanilla (get-ice state :rd 0)]
+      (rez state :corp (refresh vanilla))
+      (play-from-hand state :runner "Lucky Charm")
+      (run-on state "R&D")
+      (run-continue state)
+      (card-subroutine state :corp (refresh vanilla) 0)
+      (is (= nil (:run @state)) "no run")
+      (is (no-prompt? state :runner) "no charm prompt")
+      (run-empty-server state "HQ")
+      (is (no-prompt? state :runner))
+      (run-on state "R&D")
+      (run-continue state :encounter-ice)
+      (card-subroutine state :corp (refresh vanilla) 0)
+      (is (:run @state) "Run not ended yet")
+      (is (seq (:prompt (get-runner))) "Runner prompted to ETR"))))
+
 (deftest lucky-charm-no-interference-with-runs-ending-successfully-or-by-jacking-out-and-batty-normal-etr-border-control-interaction
     ;; No interference with runs ending successfully or by jacking out, and Batty/normal ETR/Border Control interaction
     (do-game

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -3838,7 +3838,6 @@
       ; Recon Drone ability won't fire as we are not accessing HOK
       (card-ability state :runner rd2 0)
       (is (nil? (:number (:choices (prompt-map :runner)))) "No choice to prevent damage from HOK")
-      (click-prompt state :runner "Done")
       (is (= 4 (count (:hand (get-runner)))) "Runner took 1 net damage from HOK")
       (click-prompt state :corp "No")
       (click-prompt state :runner "No action")


### PR DESCRIPTION
Previously, flags only checked if the prevention ability didn't return false, but a lot of reqs return `nil` instead.

Recon drone now passes it's tests (Closes #6403, Closes #5874).

Additionally, there's a test for lucky charm requiring an hq run (Closes #6406).

There may potentially be a historical issue or two open that this may close, I only checked the first couple of pages.