### PR TITLE
ADT/Tranquility/Agenda fix

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -207,7 +207,7 @@
                        :async true
                        :effect (effect (corp-install eid target nil
                                                      {:ignore-all-cost true
-                                                      :install-state :rezzed-no-rez-cost}))
+                                                      :install-state :rezzed-no-cost}))
                        :cancel-effect (effect (system-msg "does not install any of the top 5 cards")
                                               (effect-completed eid))}
                       card nil))}})

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -170,7 +170,7 @@
                     :rezzed
                     (if-not (agenda? moved-card)
                       (rez state side eid moved-card {:no-msg no-msg})
-                      (checkpoint state nil (make-eid state eid)))
+                      (checkpoint state nil eid))
                     ;; "Face-up" cards
                     :face-up
                     (let [moved-card (-> (get-card state moved-card)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -161,7 +161,7 @@
                     (if-not (agenda? moved-card)
                       (rez state side eid moved-card {:ignore-cost :all-costs
                                                       :no-msg no-msg})
-                      (checkpoint state nil (make-eid state eid)))
+                      (checkpoint state nil eid))
                     ;; Ignore rez cost only
                     :rezzed-no-rez-cost
                     (rez state side eid moved-card {:ignore-cost :rez-costs

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -158,15 +158,19 @@
                   (case install-state
                     ;; Ignore all costs
                     :rezzed-no-cost
-                    (rez state side eid moved-card {:ignore-cost :all-costs
-                                                    :no-msg no-msg})
+                    (if-not (agenda? moved-card)
+                      (rez state side eid moved-card {:ignore-cost :all-costs
+                                                      :no-msg no-msg})
+                      (checkpoint state nil (make-eid state eid)))
                     ;; Ignore rez cost only
                     :rezzed-no-rez-cost
                     (rez state side eid moved-card {:ignore-cost :rez-costs
                                                     :no-msg no-msg})
                     ;; Pay costs
                     :rezzed
-                    (rez state side eid moved-card {:no-msg no-msg})
+                    (if-not (agenda? moved-card)
+                      (rez state side eid moved-card {:no-msg no-msg})
+                      (checkpoint state nil (make-eid state eid)))
                     ;; "Face-up" cards
                     :face-up
                     (let [moved-card (-> (get-card state moved-card)

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3875,7 +3875,7 @@
           "Runner gained 1 credit from PAD Tap"
           (click-prompt state :corp "Gain 2 [Credits]")))))
 
-(deftest tranquility-home-grid-interaction-with-adt-and-agendas-issue-#6588
+(deftest tranquility-home-grid-interaction-with-adt-and-agendas
   ;;check tranquility fires at the right time when installing an agenda and failing to rez it, issue #6588
   (do-game
     (new-game {:corp {:deck [(qty "PAD Campaign" 3) (qty "Project Atlas" 2)]

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3876,7 +3876,7 @@
           (click-prompt state :corp "Gain 2 [Credits]")))))
 
 (deftest tranquility-home-grid-interaction-with-adt-and-agendas-issue-#6588
-  ;;check tranquility fires at the right time when installing an agenda and failing to rez it
+  ;;check tranquility fires at the right time when installing an agenda and failing to rez it, issue #6588
   (do-game
     (new-game {:corp {:deck [(qty "PAD Campaign" 3) (qty "Project Atlas" 2)]
                       :hand ["Tranquility Home Grid" "Architect Deployment Test"]

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3875,6 +3875,24 @@
           "Runner gained 1 credit from PAD Tap"
           (click-prompt state :corp "Gain 2 [Credits]")))))
 
+(deftest tranquility-home-grid-interaction-with-adt-and-agendas-issue-#6588
+  ;;check tranquility fires at the right time when installing an agenda and failing to rez it
+  (do-game
+    (new-game {:corp {:deck [(qty "PAD Campaign" 3) (qty "Project Atlas" 2)]
+                      :hand ["Tranquility Home Grid" "Architect Deployment Test"]
+                      :credits 10}})
+    (play-from-hand state :corp "Tranquility Home Grid" "New remote")
+    (play-from-hand state :corp "Architect Deployment Test" "Server 1")
+    (rez state :corp (get-content state :remote1 0))
+    (let [adt (get-content state :remote1 1)]
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (score-agenda state :corp (refresh adt))
+      (click-prompt state :corp "OK")
+      (click-prompt state :corp "Project Atlas")
+      (click-prompt state :corp "Server 1")
+      (click-prompt state :corp "Gain 2 [Credits]"))))
+
 (deftest underway-grid
   ;; Underway Grid - prevent expose of cards in server
   (do-game


### PR DESCRIPTION
Installing with `:rez-no-rez-cost` or `:rez-no-cost` wouldn't trigger a checkpoint if you picked an agenda, because `rez` in `rezzing` just completes it's eid if you pick an agenda. 
I added a tiny bit of logic into `installing` that asks "is this an agenda? if so, just trigger the event instead of invoking rez".

Closes #6588