### PR TITLE
ob ignores warnings on its installs

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1427,6 +1427,7 @@
                                       :async true
                                       :effect (req (corp-install state side eid inst-target nil
                                                                  {:ignore-all-cost true
+                                                                  :no-warning true
                                                                   :install-state :rezzed-no-rez-cost}))}
                         :no-ability {:msg "install a card ignoring all credit costs"
                                      :async true
@@ -1434,19 +1435,21 @@
                                                                 {:ignore-all-cost true}))}}}
                       card nil)
                     ;; It might be worth having a fake prompt here - at the very least, this prevents
-                    ;; the corp from accidentally revealing the card they select
+                    ;; the corp from accidentally revealing that they can't pay for the card they select
                     (pos? (count add-costs))
                     (continue-ability
                       state side
                       {:msg "install a card without paying additional costs to rez"
                        :async true
                        :effect (req (corp-install state side eid inst-target nil
-                                                  {:ignore-all-cost true}))}
+                                                  {:ignore-all-cost true
+                                                   :no-warning true}))}
                       card nil)
                     :else
                     (wait-for (reveal state side inst-target)
                               (corp-install state side eid (get-card state inst-target) nil
                                             {:ignore-all-cost true
+                                             :no-warning true
                                              :install-state :rezzed-no-rez-cost})))))))
           ;; Identify that the card wasn't just dragged to the discard, and that it was trashed
           ;; by the corporation.


### PR DESCRIPTION
The linecount for ob grows by another three.

There is a potential argument for having `complete-rez`, which is what issues the warning, also just decline to issue it when a card is rezzed with `ignore-costs`, but I'm not sure enough cards will get minted for it to matter.

Closes #6477