### PR TITLE
show subtype-target in the UI

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -133,6 +133,7 @@
    :side
    :strength
    :subroutines
+   :subtype-target
    :subtypes
    :title
    :type

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -56,6 +56,7 @@
    strength
    subroutines
    subtype
+   subtype-target
    subtypes
    title
    trash

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -621,7 +621,7 @@
   [{:keys [zone code type abilities counter
            subtypes strength current-strength selected hosted
            side facedown card-target icon new runner-abilities subroutines
-           corp-abilities]
+           subtype-target corp-abilities]
     :as card} flipped disable-click]
   (let [title (get-title card)]
     [:div.card-frame.menu-container
@@ -680,6 +680,7 @@
         [:div.darkbg.strength (or current-strength strength)])
       (when-let [{:keys [char color]} icon] [:div.darkbg.icon {:class color} char])
       (when card-target [:div.darkbg.card-target card-target])
+      (when subtype-target [:div.darkbg.subtype-target subtype-target])
       (when (active? card)
         (let [server-card (get @all-cards title)]
           [:div.darkbg.additional-subtypes

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -205,7 +205,7 @@
         &.green
             background-color: green-core
 
-    .card-target, .additional-subtypes
+    .card-target, .additional-subtypes, .subtype-target
         position: absolute
         z-index: 10
         padding: 0


### PR DESCRIPTION
I replicated the same UI feature of Azmari, Security Testing, mark mechanic, etc.

This really helps when multiple Chameleons (or rezzed Chimeras 😆 ) are installed.