### PR TITLE
Meridian ends the encounter (rather than continuing to a nil state)

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2462,8 +2462,7 @@
                                  (do (system-msg state :runner "adds Meridian to their score area as an agenda worth -1 agenda points")
                                      (as-agenda state :runner card -1)
                                      (when current-ice
-                                       (continue state :corp nil)
-                                       (continue state :runner nil))
+                                       (encounter-ends state side eid))
                                      (effect-completed state side eid))))}]})
 
 (defcard "Merlin"

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -4076,6 +4076,7 @@
       (card-subroutine state :corp (refresh mer) 0)
       (click-prompt state :runner "Add Meridian to score area")
       (is (:run @state) "Run is still live")
+      (run-continue state)
       (is (= 1 (count (:scored (get-runner)))) "In runner score area")
       (is (= -1 (:agenda-point (get-runner))) "Worth -1 agenda points")
       (is (empty? (get-ice state :hq)) "ice uninstalled"))))


### PR DESCRIPTION
Slightly bizarre thing to see in the code. I assume it worked at some point, since I remember playing Meridian.

Closes #6651