### PR TITLE
Small fixes to messages

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1883,8 +1883,7 @@
                                        (trash state side card {:cause-card card})
                                        (wait-for
                                          (gain-credits state side 3)
-                                         (wait-for (draw state side 3)
-                                                   (effect-completed state side eid)))))}}}
+                                         (draw state side eid 3))))}}}
                      card nil))}]
     {:derezzed-events [corp-rez-toast]
      :flags {:corp-phase-12 (req true)}

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1234,7 +1234,7 @@
   {:events [{:event :rez
              :req (req (ice? (:card context)))
              :async true
-             :msg "to give the Runner 1 tag"
+             :msg "give the Runner 1 tag"
              :effect (req (gain-tags state :runner eid 1))}]})
 
 (defcard "Malia Z0L0K4"
@@ -1876,7 +1876,7 @@
                    (continue-ability
                      {:optional
                       {:prompt "Trash Rashida Jaheem to gain 3 [Credits] and draw 3 cards?"
-                       :msg "to trash itself"
+                       :msg "gain 3 [Credits] and draw 3 cards"
                        :yes-ability
                        {:async true
                         :effect (req (wait-for
@@ -1884,7 +1884,6 @@
                                        (wait-for
                                          (gain-credits state side 3)
                                          (wait-for (draw state side 3)
-                                                   (system-msg state side (str "uses " (:title card) " to gain 3 [Credits] and draw 3 cards"))
                                                    (effect-completed state side eid)))))}}}
                      card nil))}]
     {:derezzed-events [corp-rez-toast]
@@ -1962,7 +1961,7 @@
 (defcard "Rex Campaign"
   (let [payout-ab {:prompt "Choose one"
                    :choices ["Remove 1 bad publicity" "Gain 5 [Credits]"]
-                   :msg (msg "to " (decapitalize target))
+                   :msg (msg (decapitalize target))
                    :async true
                    :effect (req (if (= target "Remove 1 bad publicity")
                                   (lose-bad-publicity state side eid 1)

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2319,7 +2319,7 @@
    {:play-cost-bonus (req (- (get-link state)))
     :prompt "Choose one"
     :choices ["Gain 4 [Credits]" "Draw 4 cards"]
-    :msg (msg "to " (decapitalize target))
+    :msg (msg (decapitalize target))
     :async true
     :effect (req (if (= target "Gain 4 [Credits]")
                    (gain-credits state :runner eid 4)

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1620,7 +1620,7 @@
              :async true
              :prompt "Choose one"
              :choices ["Draw 1 card" "Gain 1 [Credits]"]
-             :msg (msg (str/lower-case target))
+             :msg (msg (decapitalize target))
              :effect (req (if (= target "Draw 1 card")
                             (draw state side eid 1)
                             (gain-credits state side eid 1)))}]})
@@ -2571,7 +2571,7 @@
                               (lose-credits state :runner (make-eid state eid) spent)
                               (system-msg state :runner (str "spends " spent " [Credit]"))
                               (system-msg state :corp (str (if correct-guess " " " in")
-                                                           "correctly guesses " (str/lower-case target)))
+                                                           "correctly guesses " (decapitalize target)))
                               (wait-for
                                 (trigger-event-simult state side :reveal-spent-credits nil nil spent)
                                 (if correct-guess

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1388,7 +1388,7 @@
              :req (req (and
                          (= :hq (first (:server target)))
                          (first-event? state side :successful-run #(= :hq (first (:server (first %)))))))
-             :msg (msg "force the Corp to lose 1 [Credits]")
+             :msg "force the Corp to lose 1 [Credits]"
              :async true
              :effect (req (if (pos? (:credit corp))
                             (wait-for (lose-credits state :corp 1)

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -177,7 +177,7 @@
                                 {:optional
                                  {:waiting-prompt "Corp to make a decision"
                                   :prompt (msg (build-cost-string [:credit cost])
-                                               ", plus " (str/lower-case (build-cost-string additional-costs))
+                                               ", plus " (decapitalize (build-cost-string additional-costs))
                                                " as an additional cost to rez " cname "?")
                                   :player :corp
                                   :yes-ability {:async true

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2319,8 +2319,8 @@
   {:subroutines [trash-resource-sub
                  trash-resource-sub
                  (do-net-damage 1)
-                 {:label "Runner loses 1[click], if able. End the run."
-                  :msg "make the Runner lose 1[click] and end the run"
+                 {:label "Runner loses [click], if able. End the run."
+                  :msg "make the Runner lose [click] and end the run"
                   :async true
                   :effect (req (lose-clicks state :runner 1)
                                (end-run state :corp eid card))}]})

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2307,8 +2307,8 @@
   {:subroutines [trash-program-sub
                  trash-program-sub
                  trash-hardware-sub
-                 {:label "Runner loses 3 [credit], if able. End the run."
-                  :msg "make the Runner lose 3 [credit] and end the run"
+                 {:label "Runner loses 3 [Credits], if able. End the run."
+                  :msg "make the Runner lose 3 [Credits] and end the run"
                   :async true
                   :effect (req (if (>= (:credit runner) 3)
                                  (wait-for (lose-credits state (make-eid state eid) :runner 3)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1422,7 +1422,7 @@
                       state side
                       {:optional
                        {:prompt (str "Rez " (:title inst-target) ", paying additional costs?")
-                        :yes-ability {:msg (msg "to rez " (:title inst-target)
+                        :yes-ability {:msg (msg "rez " (:title inst-target)
                                                 ", paying additional costs")
                                       :async true
                                       :effect (req (corp-install state side eid inst-target nil
@@ -1473,7 +1473,7 @@
                         (str "Shuffle your deck (search for a " target-cost "-cost card from your deck?)"))
               :once :per-turn
               :yes-ability
-              {:msg (msg "to search R&D for a " (str target-cost) "-cost card")
+              {:msg (msg "search R&D for a " (str target-cost) "-cost card")
                :async true
                :effect (req (if (>= target-cost 0)
                               (continue-ability
@@ -1490,7 +1490,7 @@
                                 card nil)
                               (continue-ability
                                 state side
-                                {:msg "to shuffle R&D"
+                                {:msg "shuffle R&D"
                                  :effect (effect (shuffle! :corp :deck))}
                                 card nil)))}
               :no-ability
@@ -1675,7 +1675,7 @@
   (let [ab {:prompt "Choose one"
             :player :corp
             :choices ["Gain 2 [Credits]" "Draw 2 cards"]
-            :msg (msg "to " (decapitalize target))
+            :msg (msg (decapitalize target))
             :async true
             :interactive (req true)
             :effect (req (if (= target "Gain 2 [Credits]")

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -949,7 +949,7 @@
               {:async true
                :prompt (str "Choose one. Choice " current " of " total)
                :choices ["Gain 2 [Credits]" "Draw 2 cards"]
-               :msg (msg (str/lower-case target))
+               :msg (msg (decapitalize target))
                :effect (req (if (= target "Gain 2 [Credits]")
                               (wait-for (gain-credits state :corp 2)
                                         (continue-ability state side (repeat-choice (inc current) total)
@@ -1757,7 +1757,7 @@
                    "Draw 3 cards"
                    (when tagged
                      "Gain 3 [Credits] and draw 3 cards")])
-    :msg (msg (str/lower-case target))
+    :msg (msg (decapitalize target))
     :async true
     :effect (req (case target
                    "Gain 3 [Credits]"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -453,7 +453,7 @@
           :not-equal {:player :runner
                       :prompt "Choose one"
                       :choices ["Take 1 tag" "Suffer 1 brain damage"]
-                      :msg (msg "give the Runner " target)
+                      :msg (msg "force the Runner to " (decapitalize target))
                       :effect (req (if (= target "Take 1 tag")
                                      (gain-tags state :runner eid 1)
                                      (damage state side eid :brain 1 {:card card})))}}}})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2282,7 +2282,7 @@
                                   {:prompt "Choose one"
                                    :choices ["Gain 3 [Credits]" "Draw 2 cards"]
                                    :async true
-                                   :msg (msg "to " (decapitalize target))
+                                   :msg (msg (decapitalize target))
                                    :effect (req (if (= target "Draw 2 cards")
                                                   (draw state :runner eid 2)
                                                   (gain-credits state :runner eid 3)))}))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1195,9 +1195,9 @@
                       "Pay 1 [Credits]")
                     "Trash Fencer Fueno"])
      :player :runner
-     :msg (req (if (= target "Trash Fencer Fueno")
-                 "to trash itself"
-                (msg "to " (decapitalize target))))
+     :msg (msg (if (= target "Trash Fencer Fueno")
+                 "trash itself"
+                 (decapitalize target)))
      :async true
      :effect (req (if (= target "Trash Fencer Fueno")
                     (trash state :runner eid card {:cause-card card})
@@ -1364,9 +1364,9 @@
                             [{:event :pre-resolve-damage
                               :unregister-once-resolved true
                               :async true
-                              :msg (if (= target "Trash Guru Davinder")
-                                         "to trash itself"
-                                         (msg "to " (decapitalize target)))
+                              :msg (msg (if (= target "Trash Guru Davinder")
+                                          "trash itself"
+                                          (decapitalize target)))
                               :prompt "Choose one"
                               :choices (req [(when (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil :credit 4)
                                                "Pay 4 [Credits]")
@@ -1676,9 +1676,9 @@
                                   "Pay 1 [Credits]")
                                 "Trash Lewi Guilherme"])
                  :player :runner
-                 :msg (req (if (= target "Trash Lewi Guilherme")
-                            "to trash itself"
-                            (msg "to " (decapitalize target))))
+                 :msg (msg (if (= target "Trash Lewi Guilherme")
+                             "trash itself"
+                             (decapitalize target)))
                  :effect (req (if (= target "Trash Lewi Guilherme")
                                 (trash state :runner eid card {:cause-card card})
                                 (pay state :runner eid card :credit 1)))}]
@@ -1936,9 +1936,9 @@
                        "Trash a random card from the grip")
                      "Trash Mystic Maemi"])
      :player :runner
-     :msg (req (if (= target "Trash Mystic Maemi")
-                "to trash itself"
-                (msg "to " (decapitalize target))))
+     :msg (msg (if (= target "Trash Mystic Maemi")
+                 "trash itself"
+                 (decapitalize target)))
      :async true
      :effect (req (if (= target "Trash Mystic Maemi")
                     (trash state :runner eid card {:cause-card card})
@@ -2176,7 +2176,7 @@
                :card #(and (installed? %)
                            (runner? %))}
      :player :runner
-     :msg (msg "to trash " (:title target))
+     :msg (msg "trash " (:title target))
      :async true
      :effect (effect (trash eid target {:cause :runner-ability :cause-card card}))}
     ;; companion-builder: ability
@@ -2534,7 +2534,7 @@
                                               (filter #(not (has-subtype? % "Virtual"))
                                                       (get-in runner [:rig :resource]))
                                               (:hand runner))]
-                            (str "to prevent all damage, trash "
+                            (str "prevent all damage, trash "
                                  (quantify (count cards) "card")
                                  " (" (str/join ", " (map :title cards)) "),"
                                  " lose " (quantify (:credit (:runner @state)) "credit")
@@ -3264,9 +3264,9 @@
     {:prompt "Choose one"
      :choices ["Take 1 tag" "Trash Trickster Taka"]
      :player :runner
-     :msg (req (if (= target "Trash Trickster Taka")
-                "to trash itself"
-                (msg "to " (decapitalize target))))
+     :msg (msg (if (= target "Trash Trickster Taka")
+                 "trash itself"
+                 (decapitalize target)))
      :async true
      :effect (req (if (= target "Trash Trickster Taka")
                     (trash state :runner eid card {:cause-card card})

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -729,7 +729,7 @@
             :async true
             :waiting-prompt "Runner to choose an option"
             :msg (req (if (= target "The Corp removes 1 bad publicity")
-                       "to remove 1 bad publicity"
+                       "remove 1 bad publicity"
                        (msg "force the Runner to " (decapitalize target))))
             :prompt "Choose one"
             :choices ["Take 1 tag" "The Corp removes 1 bad publicity"]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -728,9 +728,9 @@
             :player :runner
             :async true
             :waiting-prompt "Runner to choose an option"
-            :msg (req (if (= target "The Corp removes 1 bad publicity")
+            :msg (msg (if (= target "The Corp removes 1 bad publicity")
                        "remove 1 bad publicity"
-                       (msg "force the Runner to " (decapitalize target))))
+                       (str "force the Runner to " (decapitalize target))))
             :prompt "Choose one"
             :choices ["Take 1 tag" "The Corp removes 1 bad publicity"]
             :effect (req (if (= target "Take 1 tag")

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -253,6 +253,7 @@
              :interactive (req true)
              :player :runner
              :req (req this-server)
+             :msg (msg "force the Runner to " (decapitalize target))
              :prompt "Choose one"
              :choices ["Take 1 brain damage" "Jack out"]
              :effect (req (if (= target "Take 1 brain damage")

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -3699,7 +3699,7 @@
     (card-ability state :corp (get-content state :remote1 0) 0)
     (click-prompt state :corp "Yes")
     (click-prompt state :corp "Yes")
-    (is (second-last-log-contains? state "shuffle") "Ob superheavy should shuffle R&D")))
+    (is (last-log-contains? state "shuffle") "Ob superheavy should shuffle R&D")))
 
 (deftest omar-keung-conspiracy-theorist-make-a-successful-run-on-the-chosen-server-once-per-turn
     ;; Make a successful run on the chosen server once per turn


### PR DESCRIPTION
Remove multiple redundant "to" from messages, prefer decapitalize over str/lower-case, fix Cerebral Cast message