### PR TITLE
fix Economic Warfare credits check

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -708,7 +708,7 @@
 (defcard "Economic Warfare"
   {:on-play
    {:req (req (and (last-turn? state :runner :successful-run)
-                   (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil :credit 4)))
+                   (>= (:credit runner) 4)))
     :msg "make the runner lose 4 [Credits]"
     :async true
     :effect (effect (lose-credits :runner eid 4))}})

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -1167,6 +1167,25 @@
     (play-from-hand state :corp "Economic Warfare")
     (is (= 3 (:credit (get-runner))) "Runner has 3 credits")))
 
+(deftest economic-warfare-ignoring-net-mercur-credits
+  ;; Economic Warfare should ignore Net Mercur credits
+  (do-game
+    (new-game {:corp {:hand ["Economic Warfare"]}
+               :runner {:hand ["Net Mercur" "Mantle" "Marjanah"]}})
+    (take-credits state :corp)
+    (core/gain state :runner :credit 2)
+    (play-from-hand state :runner "Marjanah")
+    (play-from-hand state :runner "Mantle")
+    (play-from-hand state :runner "Net Mercur")
+    (run-on state :archives)
+    (card-ability state :runner (get-program state 0) 1)
+    (click-card state :runner (get-program state 1))
+    (click-prompt state :runner "Place 1 [Credits]")
+    (run-continue state)
+    (take-credits state :runner)
+    (play-from-hand state :corp "Economic Warfare")
+    (is (= 3 (:credit (get-runner))) "Runner has still 3 credits")))
+
 (deftest election-day
   (do-game
     (new-game {:corp {:deck [(qty "Election Day" 7)]}})


### PR DESCRIPTION
While fixing Machicolation A sub, I noticed Econ Warfare was also using can-pay? but, since they are both worded as "if able", they should not consider hosted credits or similia.