### PR TITLE
Explicit reveals for jinja city grid

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -894,6 +894,10 @@
         .corp-board.opponent .server
             transform(initial)
 
+            .abilities, .runner-abilities
+                transform(translateY(115%))
+                bottom: 0%
+
             .content
                 transform(initial)
 


### PR DESCRIPTION
Right now I've solved the "runner abilities don't appear to work" issue by having the dropdowns drop "down" when the ability belongs to a card in the 'corp-top-opponent' area. 

The exact offset number (115%) can probably be tweaked for best aesthetics, I don't really have a good eye for that. 

For now, Closes #6663.

![example](https://user-images.githubusercontent.com/9095245/193801877-bbd1e63b-3e2c-4b6f-8403-8a18766b9b29.jpg) ![example3](https://user-images.githubusercontent.com/9095245/193801870-9e23735c-d1c6-4226-95f1-b7488332d1bb.jpg) ![example2](https://user-images.githubusercontent.com/9095245/193801873-f4d33962-d25d-460a-90b2-bd7d6e9ffcbf.jpg)

Next up will be
1) implementing the ability for jinja
2) maybe implementing it for corporate defector as well
