### PR TITLE
Fix messages

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -318,7 +318,7 @@
           {:interactive (req true)
            :optional
            {:waiting-prompt true
-            :prompt "Arrange top 7 cards of R&D?"
+            :prompt "Arrange the top 7 cards of R&D?"
             :yes-ability
             {:async true
              :effect (req (let [c (take 7 (:deck corp))]
@@ -1448,7 +1448,7 @@
                                     (effect-completed eid))})
           (choose-card [run-server]
             {:async true
-             :prompt "Choose a card in or protecting the attacked server."
+             :prompt "Choose a card in or protecting the attacked server"
              :choices {:card #(= (first run-server) (second (get-zone %)))}
              :effect (effect (continue-ability (choose-swap target) card nil))
              :cancel-effect (effect (put-back-counter card)
@@ -1495,7 +1495,7 @@
 
 (defcard "Reeducation"
   (letfn [(corp-final [chosen original]
-            {:prompt (str "The bottom cards of R&D will be " (str/join  ", " (map :title chosen)) ".")
+            {:prompt (str "The bottom cards of R&D will be " (str/join  ", " (map :title chosen)))
              :choices ["Done" "Start over"]
              :async true
              :msg (req (let [n (count chosen)]
@@ -1539,7 +1539,7 @@
                                                                      (corp? (second %))))))
               ;; we want a prompt even if there are no valid targets,
               ;; to make sure we don't give away hidden info
-              :prompt "Select a face-down agenda in Archives?"
+              :prompt "Choose a face-down agenda in Archives"
               :choices {:card #(and (agenda? %)
                                     (in-discard? %)
                                     (not (faceup? %)))}
@@ -1885,7 +1885,7 @@
   {:implementation "Prevention of subroutine breaking is not enforced"
    :on-score {:prompt "Choose an ice type"
               :choices ["Barrier" "Code Gate" "Sentry"]
-              :msg (msg "prevent subroutines on " target " ice from being broken until next turn.")}})
+              :msg (msg "prevent subroutines on " target " ice from being broken until next turn")}})
 
 (defcard "Utopia Fragment"
   {:events [{:event :pre-steal-cost

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1610,7 +1610,7 @@
                                  :async true
                                  :req (req (seq (filter #(= (:title %) "Research Grant") (all-installed state :corp))))
                                  :effect (effect (score eid (get-card state target) {:no-req true}))
-                                 :msg "score another installed copy of Research Grant"}
+                                 :msg "score another installed copy of itself"}
                                 card nil))}})
 
 (defcard "Restructured Datapool"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -541,7 +541,7 @@
                 :effect (effect
                           (continue-ability
                             (let [from-ice target]
-                              {:prompt "Move to where?"
+                              {:prompt "Choose a piece of ice that can be advanced"
                                :choices {:card #(and (ice? %)
                                                      (not (same-card? from-ice %))
                                                      (can-be-advanced? %))}
@@ -1138,7 +1138,7 @@
                                         (= counters (:agendapoints %)))
                                   (:hand corp))))
                 :waiting-prompt true
-                :prompt "Choose an Agenda in HQ to move to score area"
+                :prompt "Choose an Agenda in HQ to add to score area"
                 :choices {:req (req (and (agenda? target)
                                          (= (:agendapoints target) (get-counters (get-card state card) :power))
                                          (in-hand? target)))}
@@ -2488,7 +2488,7 @@
                 (continue-ability
                   (let [card-to-install target]
                     {:async true
-                     :prompt (str "Where to install " (:title card-to-install))
+                     :prompt "Choose a server"
                      :choices (req (remove (set (zone->name (get-zone card)))
                                            (installable-servers state card-to-install)))
                      :effect (effect (corp-install eid card-to-install target {:ignore-all-cost true}))})

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -76,7 +76,7 @@
   [subtype]
   {:makes-run true
    :on-play {:async true
-             :prompt "Choose a server:"
+             :prompt "Choose a server"
              :choices (req runnable-servers)
              :effect (effect (make-run eid target card))}
    :events [{:event :subroutines-broken
@@ -439,7 +439,7 @@
 (defcard "CBI Raid"
   (letfn [(cbi-final [chosen original]
             {:player :corp
-             :prompt (str "The top cards of R&D will be " (str/join  ", " (map :title chosen)) ".")
+             :prompt (str "The top cards of R&D will be " (str/join  ", " (map :title chosen)))
              :choices ["Done" "Start over"]
              :async true
              :effect (req (if (= target "Done")
@@ -558,7 +558,7 @@
                 :once :per-run
                 :yes-ability
                 {:async true
-                 :prompt "Install from where?"
+                 :prompt "Choose where to install the program from"
                  :choices (req (if (not (zone-locked? state :runner :discard)) ["Stack" "Heap"] ["Stack"]))
                  :msg (msg "install a program from their " target)
                  :effect (effect (continue-ability
@@ -774,7 +774,7 @@
                                :effect (req (wait-for
                                              (access-card state side (first cards))
                                              (effect-completed state side eid)))}
-                              {:prompt "Select a card to access"
+                              {:prompt "Choose a card to access"
                                :waiting-prompt true
                                :not-distinct true
                                :choices cards
@@ -1255,7 +1255,7 @@
 
 (defcard "Falsified Credentials"
   {:on-play
-   {:prompt "Choose a type"
+   {:prompt "Choose one"
     :choices ["Agenda" "Asset" "Upgrade"]
     :msg (msg "guess " target)
     :async true
@@ -1377,7 +1377,7 @@
     (effect
       (continue-ability
         (let [top-ten (take 10 (:deck runner))]
-          {:prompt (str "The top cards of the stack are " (str/join ", " (map :title top-ten)) ".")
+          {:prompt (str "The top cards of the stack are " (str/join ", " (map :title top-ten)))
            :choices ["OK"]
            :async true
            :effect
@@ -1679,7 +1679,7 @@
 
 (defcard "Information Sifting"
   (letfn [(access-pile [cards pile pile-size]
-            {:prompt "Choose a card to access. You must access all cards."
+            {:prompt "Choose a card to access. You must access all cards"
              :choices [(str "Card from pile " pile)]
              :async true
              :req (req (if (:max-access run)
@@ -1896,7 +1896,7 @@
 (defcard "Khusyuk"
   (let [access-revealed (fn [revealed]
                           {:async true
-                           :prompt "Select a card to access"
+                           :prompt "Choose a card to access"
                            :waiting-prompt true
                            :not-distinct true
                            :choices revealed
@@ -2428,7 +2428,7 @@
               {:mandatory true
                :this-card-run true
                :ability
-               {:prompt "Select a card to access in the root of another server"
+               {:prompt "Choose a card in the root of another server to access"
                 :choices {:req (req (and (not= (first (:server (:run @state)))
                                                (second (get-zone (get-nested-host target))))
                                          (= (last (get-zone (get-nested-host target)))
@@ -2523,7 +2523,7 @@
 
 (defcard "Prey"
   {:makes-run true
-   :on-play {:prompt "Choose a server:"
+   :on-play {:prompt "Choose a server"
              :choices (req runnable-servers)
              :async true
              :effect (effect (make-run eid target card))}
@@ -2566,7 +2566,7 @@
   (letfn [(corp-choice [spent]
             {:player :corp
              :waiting-prompt true
-             :prompt "Even or odd?"
+             :prompt "Choose one"
              :choices ["Even" "Odd"]
              :async true
              :effect (req (let [correct-guess ((if (= target "Even") even? odd?) spent)]
@@ -2650,7 +2650,7 @@
 
 (defcard "Rebirth"
   {:on-play
-   {:prompt "Choose an identity to become"
+   {:prompt "Choose an identity"
     :rfg-instead-of-trashing true
     :choices (req (let [is-draft-id? #(.startsWith (:code %) "00")
                         runner-identity (:identity runner)
@@ -3171,7 +3171,7 @@
                      "Discard 2 cards from HQ")
                    "Draw 4 cards"])
     :async true
-    :msg (msg "force the corp to " (decapitalize target))
+    :msg (msg "force the Corp to " (decapitalize target))
     :effect (req (if (= target "Draw 4 cards")
                    (wait-for (draw state :corp 4)
                              (effect-completed state side eid))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -86,7 +86,7 @@
                                         (gain-credits state side eid counters))))}}}]})
 
 (defcard "Adjusted Matrix"
-  {:implementation "Click Adjusted Matrix to use ability."
+  {:implementation "Click Adjusted Matrix to use the ability"
    :on-install {:req (req (not-empty (filter #(has-subtype? % "Icebreaker") (all-active-installed state :runner))))
                 :prompt "Choose Icebreaker on which to install Adjusted Matrix"
                 :choices {:card #(and (runner? %)
@@ -1477,7 +1477,7 @@
                       (continue-ability
                         state side
                         {:prompt (str "Trash a card to lower the " cost-type
-                                      " cost of " (:title targetcard) " by 2 [Credits].")
+                                      " cost of " (:title targetcard) " by 2 [Credits]")
                          :async true
                          :choices {:card #(and (in-hand? %)
                                                (runner? %)
@@ -1567,8 +1567,7 @@
                         {:msg "look at the top 2 cards of the stack"
                          :choices ["OK"]
                          :prompt (msg "The top 2 cards of the stack are "
-                                      (str/join ", " (map :title (take 2 (:deck runner))))
-                                      ".")}}}]
+                                      (str/join ", " (map :title (take 2 (:deck runner)))))}}}]
    :abilities [(set-autoresolve :auto-fire "Prognostic Q-Loop")
                {:label "Reveal and install top card of the stack"
                 :once :per-turn
@@ -1845,7 +1844,7 @@
                                         [(breach-access-bonus kw bonus {:duration :end-of-run})])
                                       (make-run state side eid srv card))))})]
     {:abilities [{:req (req (<= 2 (count (:hand runner))))
-                  :label "run a server"
+                  :label "Run HQ or R&D"
                   :prompt "Choose one"
                   :waiting-prompt true
                   :choices ["HQ" "R&D"]
@@ -2086,7 +2085,7 @@
               {:target-server :rd
                :ability {:req (req (and (not= (:max-access run) 0)
                                         (pos? (count (:deck corp)))))
-                         :prompt "Which card from the top of R&D would you like to access? (Card 1 is on top.)"
+                         :prompt "Which card from the top of R&D would you like to access? (Card 1 is on top)"
                          :choices (req (map str (take (count (:deck corp)) (range 1 6))))
                          :msg (msg "only access the card at position " target " of R&D")
                          :async true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -129,7 +129,7 @@
                     state side
                     {:optional
                      {:prompt "Remove a card from the game instead of accessing it?"
-                      :yes-ability {:prompt "Choose a card in Archives to remove from the game instead of accessing"
+                      :yes-ability {:prompt "Choose a card in Archives"
                                     :choices (req (:discard corp))
                                     :msg (msg "remove " (:title target) " from the game")
                                     :effect (effect (move :corp target :rfg))}}} card nil))}]})
@@ -1637,7 +1637,7 @@
    {:optional
     {:req (req (some #(when (= (:title %) "Rabbit Hole") %) (:deck runner)))
      :prompt "Install another Rabbit Hole?"
-     :msg "install another Rabbit Hole"
+     :msg "install another copy of itself"
      :yes-ability {:async true
                    :effect (req (trigger-event state side :searched-stack nil)
                                 (shuffle! state :runner :deck)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1410,9 +1410,7 @@
              :prompt "Choose one"
              :waiting-prompt true
              :choices ["Gain 1 [Credits]" "Draw 1 card"]
-             :msg (req (if (= target "Gain 1 [Credits]")
-                         "gain 1 [Credits]"
-                         "draw 1 card"))
+             :msg (msg (decapitalize target))
              :effect (req (if (= target "Gain 1 [Credits]")
                             (gain-credits state :corp eid 1)
                             (draw state :corp eid 1)))}]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -590,7 +590,7 @@
                             (empty? (filter #(and (:broken %) (:printed %)) (:subroutines card)))
                             :unrestricted))]
     {:advanceable :always
-     :subroutines [{:label "Gain 1 [Credit]. Place 1 advancement token."
+     :subroutines [{:label "Gain 1 [Credit]. Place 1 advancement token"
                     :breakable breakable-fn
                     :msg (msg "gain 1 [Credit] and place 1 advancement token on " (card-str state target))
                     :prompt "Choose an installed card"
@@ -710,7 +710,7 @@
                   {:req (req (and (not (:bypass run))
                                   (not (forced-to-avoid-tags? state side))))
                    :player :runner
-                   :prompt "Take 1 tag to bypass?"
+                   :prompt "Take 1 tag to bypass Authenticator?"
                    :yes-ability
                    {:async true
                     :effect (req (system-msg state :runner "takes 1 tag on encountering Authenticator to bypass it")
@@ -1645,7 +1645,7 @@
                            :default (req 1)}
                  :msg (msg "draw " (quantify target "card"))
                  :effect (effect (draw eid target))}
-        reveal-and-shuffle {:prompt "Reveal and shuffle up to 3 agendas"
+        reveal-and-shuffle {:prompt "Reveal and shuffle up to 3 agendas into R&D"
                             :show-discard true
                             :choices {:card #(and (corp? %)
                                                   (or (in-hand? %)
@@ -1778,7 +1778,7 @@
 (defcard "Hailstorm"
   {:subroutines [{:label  "Remove a card in the Heap from the game"
                   :req     (req (not (zone-locked? state :runner :discard)))
-                  :prompt  "Choose a card in the Runner's Heap"
+                  :prompt  "Choose a card in the Heap"
                   :choices (req (cancellable (:discard runner) :sorted))
                   :msg     (msg "remove " (:title target) " from the game")
                   :effect  (effect (move :runner target :rfg))}
@@ -2110,7 +2110,7 @@
 (defcard "Jua"
   {:on-encounter {:msg "prevent the Runner from installing cards for the rest of the turn"
                   :effect (effect (register-turn-flag! card :runner-lock-install (constantly true)))}
-   :subroutines [{:label "Choose 2 installed Runner cards, if able. The Runner must add 1 of those to the top of the Stack."
+   :subroutines [{:label "Choose 2 installed Runner cards, if able. The Runner must add 1 of those to the top of the Stack"
                   :req (req (>= (count (all-installed state :runner)) 2))
                   :async true
                   :prompt "Choose 2 installed Runner cards"
@@ -2120,15 +2120,15 @@
                             :all true}
                   :msg (msg "add either " (card-str state (first targets))
                             " or " (card-str state (second targets))
-                            " to the Stack")
+                            " to the top of the Stack")
                   :effect (effect (continue-ability
                                     (when (= 2 (count targets))
                                       {:player :runner
                                        :waiting-prompt true
-                                       :prompt "Choose a card to move to the Stack"
+                                       :prompt "Choose a card to move to the top of the Stack"
                                        :choices {:card #(some (partial same-card? %) targets)}
                                        :effect (req (move state :runner target :deck {:front true})
-                                                    (system-msg state :runner (str "selected " (card-str state target) " to move to the Stack")))})
+                                                    (system-msg state :runner (str "selected " (card-str state target) " to move to the top of the Stack")))})
                                     card nil))}]})
 
 (defcard "Kakugo"
@@ -2174,7 +2174,7 @@
      :runner-abilities [(bioroid-break 1 1)]}))
 
 (defcard "Karunā"
-  {:subroutines [{:label "Do 2 net damage. The Runner may jack out."
+  {:subroutines [{:label "Do 2 net damage. The Runner may jack out"
                   :async true
                   :effect (req (wait-for (resolve-ability state side
                                                           (do-net-damage 2)
@@ -2188,7 +2188,7 @@
                    :prompt "Force the Runner to access a card in HQ?"
                    :yes-ability
                    {:async true
-                    :prompt "Choose a card in HQ to force access"
+                    :prompt "Choose a card in HQ"
                     :choices {:card (every-pred in-hand? corp?)
                               :all true}
                     :label "Force the Runner to breach HQ and access a card"
@@ -2321,7 +2321,7 @@
   {:subroutines [trash-program-sub
                  trash-program-sub
                  trash-hardware-sub
-                 {:label "Runner loses 3 [Credits], if able. End the run."
+                 {:label "Runner loses 3 [Credits], if able. End the run"
                   :msg "make the Runner lose 3 [Credits] and end the run"
                   :async true
                   :effect (req (if (>= (:credit runner) 3)
@@ -2333,7 +2333,7 @@
   {:subroutines [trash-resource-sub
                  trash-resource-sub
                  (do-net-damage 1)
-                 {:label "Runner loses [click], if able. End the run."
+                 {:label "Runner loses [click], if able. End the run"
                   :msg "make the Runner lose [click] and end the run"
                   :async true
                   :effect (req (lose-clicks state :runner 1)
@@ -2822,7 +2822,7 @@
 
 (defcard "Nightdancer"
   (let [sub {:label (str "The Runner loses [Click], if able. "
-                         "You have an additional [Click] to spend during your next turn.")
+                         "You have an additional [Click] to spend during your next turn")
              :msg (str "force the runner to lose a [Click], if able. "
                        "Corp gains an additional [Click] to spend during their next turn")
              :effect (req (lose-clicks state :runner 1)
@@ -3315,7 +3315,7 @@
                        :req (req (can-pay? state side (assoc eid :source card :source-type :ability)
                                            card nil
                                            [:trash-other-installed 1]))
-                       :yes-ability {:prompt "Select another installed card to trash"
+                       :yes-ability {:prompt "Choose another installed card to trash"
                                      :cost [:trash-other-installed 1]
                                      :msg "give itself +5 strength for the remainder of the run"
                                      :effect (effect (register-floating-effect
@@ -3645,7 +3645,7 @@
 
 (defcard "Vasilisa"
   {:on-encounter
-   {:optional {:prompt "Place 1 advancement counter?"
+   {:optional {:prompt "Place 1 advancement counter on a card that can be advanced?"
                :waiting-prompt true
                :req (req (and (can-pay? state side eid card nil [:credit 1])
                               (some #(or (not (rezzed? %))
@@ -3653,7 +3653,7 @@
                                     (all-installed state :corp))))
                :yes-ability {:cost [:credit 1]
                              :choices {:card can-be-advanced?}
-                             :prompt "Choose a card that can be advanced to place 1 advancement counter on"
+                             :prompt "Choose a card that can be advanced"
                              :msg (msg "place 1 advancement counter on " (card-str state target))
                              :effect (effect (add-prop target :advance-counter 1 {:placed true}))
                              :cancel-effect (effect (system-msg "declines to use Vasilisa")
@@ -3730,7 +3730,7 @@
   {:on-rez
    {:optional {:prompt "Search R&D for a piece of ice?"
                :req (req (and run this-server))
-               :yes-ability {:prompt "Choose a card"
+               :yes-ability {:prompt "Choose a piece of ice"
                              :async true
                              :msg (msg "reveal they added " (:title target) " to HQ from R&D")
                              :choices (req (cancellable (filter #(ice? %) (:deck corp)) :sorted))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1103,7 +1103,7 @@
                   :effect (effect
                            (update! (assoc-in card [:special :mm-actions] []))
                            (update! (assoc-in (get-card state card) [:special :mm-click] false)))}
-        mm-ability {:prompt "Gain [Click] or gain 1 [Credits]"
+        mm-ability {:prompt "Choose one"
                     :choices ["Gain [Click]" "Gain 1 [Credits]"]
                     :msg (msg (decapitalize target))
                     :once :per-turn
@@ -1858,7 +1858,7 @@
 (defcard "The Foundry: Refining the Process"
   {:events [{:event :rez
              :optional
-             {:prompt "Add another copy to HQ?"
+             {:prompt (msg "Add another copy of " (:title (:card context)) " to HQ?")
               :req (req (and (ice? (:card context))
                              (first-event? state :runner :rez #(ice? (:card (first %))))))
               :yes-ability

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -327,7 +327,7 @@
 
 (defcard "Azmari EdTech: Shaping the Future"
   {:events [{:event :corp-turn-ends
-             :prompt "Name a card type"
+             :prompt "Name a Runner card type"
              :choices ["Event" "Resource" "Program" "Hardware" "None"]
              :effect (effect (update! (assoc card :card-target (if (= "None" target) nil target)))
                              (system-msg (str "uses Azmari EdTech: Shaping the Future to name " target)))}
@@ -1656,7 +1656,7 @@
   {:implementation "Manually triggered, no restriction on which cards in Heap can be targeted. Cannot use on in progress run event"
    :abilities [{:label "Remove a card in the Heap that was just trashed from the game"
                 :waiting-prompt true
-                :prompt "Choose a card in the Runner's Heap that was just trashed"
+                :prompt "Choose a card in the Heap that was just trashed"
                 :once :per-turn
                 :choices (req (cancellable (:discard runner)))
                 :msg (msg "remove " (:title target) " from the game")
@@ -1702,7 +1702,7 @@
                {:req (req (and (not-empty (installed-faceup-agendas state))
                                (not-empty (ice-with-no-advancement-tokens state))))
                 :waiting-prompt true
-                :prompt "Place advancement tokens?"
+                :prompt "Place advancement tokens on an installed piece of ice?"
                 :autoresolve (get-autoresolve :auto-fire)
                 :yes-ability
                 {:async true
@@ -1865,9 +1865,9 @@
               {:effect (req (if-let [found-card (some #(when (= (:title %) (:title (:card context))) %) (concat (:deck corp) (:play-area corp)))]
                               (do (move state side found-card :hand)
                                   (system-msg state side (str "uses The Foundry to add a copy of "
-                                                              (:title found-card) " to HQ, and shuffles their deck"))
+                                                              (:title found-card) " to HQ, and shuffle R&D"))
                                   (shuffle! state side :deck))
-                              (do (system-msg state side (str "fails to find a target for The Foundry, and shuffles their deck"))
+                              (do (system-msg state side (str "shuffles R&D"))
                                   (shuffle! state side :deck))))}}}]})
 
 (defcard "The Masque: Cyber General"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -105,7 +105,7 @@
                                       (let [cards (filterv #(not (same-card? % target)) cards)]
                                         (continue-ability state side (ad state side eid card cards) card nil))))}))]
     {:on-play
-     {:prompt (msg "The top cards of R&D are " (str/join ", " (map :title (take 3 (:deck corp)))) ".")
+     {:prompt (msg "The top cards of R&D are " (str/join ", " (map :title (take 3 (:deck corp)))))
       :choices ["OK"]
       :async true
       :effect (effect (continue-ability (ad state side eid card (take 3 (:deck corp))) card nil))}}))
@@ -302,7 +302,7 @@
             (count (filter #(is-type? % t) (all-active-installed state :runner))))]
     {:on-play
      {:req (req (not-empty (all-active-installed state :runner)))
-      :prompt "Choose a card type"
+      :prompt "Choose one"
       :choices ["Hardware" "Program" "Resource"]
       :async true
       :msg (msg "choose " target)
@@ -613,15 +613,15 @@
                      (shuffle! state side :deck)
                      (continue-ability
                        state side
-                       {:prompt "You may install a card in HQ"
+                       {:prompt "Choose a card in HQ to install"
                         :choices {:card #(and (in-hand? %)
                                               (corp? %)
                                               (not (operation? %)))}
                         :effect (req (wait-for (resolve-ability
                                                  state side
                                                  (let [card-to-install target]
-                                                   {:prompt (str "Choose a location to install " (:title target))
-                                                    :choices (remove #{"HQ" "R&D" "Archives"} (corp-install-list state target))
+                                                   {:prompt "Choose a server"
+                                                    :choices (remove #{"HQ" "R&D" "Archives"} (corp-install-list state card-to-install))
                                                     :async true
                                                     :effect (effect (corp-install eid card-to-install target nil))})
                                                  target nil)
@@ -756,7 +756,7 @@
    {:req (req (and tagged
                    (seq (:scored runner))
                    (seq (:scored corp))))
-    :prompt "Choose a stolen agenda in the Runner's score area to swap"
+    :prompt "Choose an agenda in the Runner's score area to swap"
     :choices {:req (req (in-runner-scored? state side target))}
     :async true
     :effect (effect
@@ -817,7 +817,7 @@
                                                    (continue-ability state side (install-cards server (inc n)) card nil)
                                                    (effect-completed state side eid)))))})
                select-server {:async true
-                              :prompt "Install cards in which server?"
+                              :prompt "Choose a server"
                               :choices (req (conj (vec (get-remote-names state)) "New remote"))
                               :effect (effect (continue-ability (install-cards target 1) card nil))}]
            (wait-for (gain-credits state :corp X)
@@ -863,7 +863,7 @@
 (defcard "Focus Group"
   {:on-play
    {:req (req (last-turn? state :runner :successful-run))
-    :prompt "Choose a card type"
+    :prompt "Choose one"
     :choices ["Event" "Hardware" "Program" "Resource"]
     :async true
     :effect (req (let [type target
@@ -971,7 +971,7 @@
 (defcard "Game Over"
   {:on-play
    {:req (req (last-turn? state :runner :stole-agenda))
-    :prompt "Choose a card type"
+    :prompt "Choose one"
     :choices ["Hardware" "Program" "Resource"]
     :async true
     :effect (req (let [card-type target
@@ -987,7 +987,7 @@
                                {:async true
                                 :req (req (<= 3 (:credit runner)))
                                 :waiting-prompt true
-                                :prompt (msg "Prevent any " typemsg " from being trashed? Pay 3 [Credits] per card.")
+                                :prompt (msg "Prevent any " typemsg " from being trashed? Pay 3 [Credits] per card")
                                 :choices {:max (req (min numtargets (quot (total-available-credits state :runner eid card) 3)))
                                           :card #(and (installed? %)
                                                       (is-type? % card-type)
@@ -1050,7 +1050,7 @@
                {:player :runner
                 :async true
                 :waiting-prompt true
-                :prompt "Access card?"
+                :prompt "Access the installed card?"
                 :yes-ability
                 {:async true
                  :effect (req (wait-for (access-card state side target)
@@ -1092,7 +1092,7 @@
 
 (defcard "Hasty Relocation"
   (letfn [(hr-final [chosen original]
-            {:prompt (str "The top cards of R&D will be " (str/join  ", " (map :title chosen)) ".")
+            {:prompt (str "The top cards of R&D will be " (str/join  ", " (map :title chosen)))
              :choices ["Done" "Start over"]
              :async true
              :effect (req (if (= target "Done")
@@ -1493,7 +1493,7 @@
                           (mitosis-ability state side card eid (rest target-cards))
                           (effect-completed state side eid)))))]
     {:on-play
-     {:prompt "Select cards to install in new remotes"
+     {:prompt "Choose 2 cards to install in new remote servers"
       :choices {:card #(and (not (operation? %))
                             (corp? %)
                             (in-hand? %))
@@ -1995,7 +1995,7 @@
 
 (defcard "Replanting"
   (letfn [(replant [n]
-            {:prompt "Choose a card to install with Replanting"
+            {:prompt "Choose a card to install"
              :async true
              :choices {:card #(and (corp? %)
                                    (not (operation? %))
@@ -2232,7 +2232,7 @@
 
 (defcard "Seamless Launch"
   {:on-play
-   {:prompt "Choose target"
+   {:prompt "Choose an installed card"
     :req (req (some #(and (corp? %)
                           (installed? %)
                           (not (= :this-turn (installed? %))))
@@ -2260,7 +2260,7 @@
                         (continue-ability
                           (let [chosen-ice target]
                             {:async true
-                             :prompt (str "Choose where to install " (:title chosen-ice))
+                             :prompt "Choose a server"
                              :choices ["Archives" "R&D" "HQ"]
                              :msg (msg "reveal " (:title chosen-ice) " and install it, paying 3 [Credit] less")
                              :effect (req (wait-for
@@ -2415,7 +2415,7 @@
 (defcard "Standard Procedure"
   {:on-play
    {:req (req (last-turn? state :runner :successful-run))
-    :prompt "Choose a card type"
+    :prompt "Choose one"
     :choices ["Event" "Hardware" "Program" "Resource"]
     :msg (msg "name " target
               ", revealing " (str/join ", " (map :title (:hand runner)))

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -383,7 +383,7 @@
                                               (some #(has-subtype? % "Stealth")
                                                     (all-active state :runner))))
                                :once :per-turn
-                               :prompt (msg "Pay 2 [Credits] to bypass " (:title (:ice context)))
+                               :prompt (msg "Pay 2 [Credits] to bypass " (:title (:ice context)) "?")
                                :yes-ability
                                {:cost [:credit 2]
                                 :cost-req all-stealth
@@ -626,7 +626,7 @@
                     :events [{:event :end-of-encounter
                               :req (req (any-subs-broken-by-card? (:ice context) card))
                               :player :runner ; Needed for when the run is ended by the Corp
-                              :prompt "Choose a non-virus program to add to the top of your stack."
+                              :prompt "Choose a non-virus program to add to the top of your stack"
                               :choices {:card #(and (installed? %)
                                                     (program? %)
                                                     (not (facedown? %))
@@ -715,7 +715,7 @@
              :effect (effect (add-counter card :virus 1))}]})
 
 (defcard "Chameleon"
-  (auto-icebreaker {:on-install {:prompt "Choose one subtype"
+  (auto-icebreaker {:on-install {:prompt "Choose one"
                                  :choices ["Barrier" "Code Gate" "Sentry"]
                                  :msg (msg "choose " target)
                                  :effect (effect (update! (assoc card :subtype-target target)))}
@@ -828,7 +828,7 @@
                             (continue-ability state side ab card targets)))}]
    :abilities [{:req (req (pos? (get-virus-counters state card)))
                 :cost [:click 1]
-                :label "Gain 2 [Credits] for each hosted virus counter, then remove all virus counters."
+                :label "Gain 2 [Credits] for each hosted virus counter, then remove all virus counters"
                 :async true
                 :effect (req (wait-for (gain-credits state side (* 2 (get-virus-counters state card)))
                                        (update! state side (assoc-in card [:counter :virus] 0))
@@ -872,7 +872,7 @@
               :once :per-turn
               :prompt "Swap 2 pieces of ice?"
               :yes-ability
-              {:prompt "Choose ice protecting this server"
+              {:prompt "Choose a piece of ice protecting this server"
                :choices {:req (req (and (installed? target)
                                         (ice? target)
                                         (= (target-server (:run @state)) (second (get-zone target)))))}
@@ -880,7 +880,7 @@
                :effect (effect
                          (continue-ability
                            (let [first-ice target]
-                             {:prompt "Choose ice to swap with"
+                             {:prompt "Choose a piece of ice to swap with"
                               :choices {:req (req (and (installed? target)
                                                        (ice? target)
                                                        (not= first-ice target)))}
@@ -1973,7 +1973,7 @@
                 :effect (effect
                           (continue-ability
                             (let [ice target]
-                              {:prompt "Choose a subtype"
+                              {:prompt "Choose one"
                                :choices ["Sentry" "Code Gate" "Barrier"]
                                :msg (msg "spend [Click] and make " (card-str state ice)
                                          " gain " target
@@ -1989,7 +1989,7 @@
 (defcard "Panchatantra"
   {:events [{:event :encounter-ice
              :optional
-             {:prompt "Give ice a subtype?"
+             {:prompt "Give encountered piece ice a subtype?"
               :req (req (not (get-in @state [:per-turn (:cid card)])))
               :yes-ability
               {:prompt "Choose an ice subtype"
@@ -2461,10 +2461,10 @@
   {:events [{:event :approach-ice
              :optional
              {:req (req (not (rezzed? (:ice context))))
-              :prompt "Expose approached ice?"
+              :prompt "Expose approached piece of ice?"
               :yes-ability
               {:async true
-               :msg "expose the approached ice"
+               :msg "expose the approached piece of ice"
                :effect (req (wait-for
                               (expose state side (:ice context))
                               (continue-ability state side (offer-jack-out) card nil)))}}}]})
@@ -2603,7 +2603,7 @@
                                 (strength-pump 1 1)]}))
 
 (defcard "Tracker"
-  (let [ability {:prompt "Choose a server for Tracker"
+  (let [ability {:prompt "Choose a server"
                  :choices (req servers)
                  :msg (msg "target " target)
                  :req (req (not (:card-target card)))
@@ -2740,7 +2740,7 @@
 
 (defcard "Wari"
   (letfn [(prompt-for-subtype []
-            {:prompt "Choose a subtype"
+            {:prompt "Choose one"
              :choices ["Barrier" "Code Gate" "Sentry"]
              :async true
              :effect (req (wait-for (trash state side card {:unpreventable true

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -860,7 +860,7 @@
 
 (defcard "La Costa Grid"
   (let [ability {:prompt (msg "Choose a card in " (zone->name (second (get-zone card))))
-                 :label "place 1 advancement counter (start of turn)"
+                 :label "Place 1 advancement counter (start of turn)"
                  :msg (msg "place 1 advancement counter on " (card-str state target))
                  :choices {:req (req (and (installed? target)
                                           (in-same-server? card target)))}
@@ -895,7 +895,7 @@
              {:prompt "Search R&D for non-agenda card?"
               :req (req (= (:previous-zone (:card context)) (get-zone card)))
               :yes-ability
-              {:prompt "Choose card"
+              {:prompt "Choose a card"
                :choices (req (cancellable (filter #(not (agenda? %)) (:deck corp))
                                           :sorted))
                :msg (msg "reveal " (:title target) " and add it to HQ")
@@ -950,7 +950,7 @@
                 :cost [:trash-can]
                 :psi {:req (req this-server)
                       :not-equal
-                      {:prompt "Choose the ice"
+                      {:prompt "Choose a piece of ice"
                        :choices {:card #(and (ice? %)
                                              (rezzed? %))
                                  :all true}
@@ -1440,7 +1440,7 @@
                                            (can-pay? state side (assoc eid :source card :source-type :rez) % nil
                                                      [:credit (install-cost state side % {:cost-bonus -2})]))
                                      (all-installed state :corp)))))
-              :prompt "Rez another card paying 2 [Credits] less?"
+              :prompt "Rez another card paying 2 [Credits] less?"
               :yes-ability {:prompt "Choose a card to rez"
                             :choices {:req (req (and (not (rezzed? target))
                                                      (not (agenda? target))

--- a/src/clj/game/core/charge.clj
+++ b/src/clj/game/core/charge.clj
@@ -31,7 +31,7 @@
   ([state side eid card n]
    (if (can-charge state side)
      {:waiting-prompt true
-      :prompt (str "Select a card to charge")
+      :prompt "Choose an installed card"
       :choices {:card #(can-charge state side %)}
       :async true
       :msg (msg "charge " (:title target) (when (> n 1) (str n " times")))

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -352,7 +352,7 @@
                                           :choices {:card (fn [t] (same-side? (:side t) %2))}}
                                         (map->Card {:title "/card-info command"}) nil)
         "/charge"     #(resolve-ability %1 %2
-                                        {:prompt "Choose an installed card to charge"
+                                        {:prompt "Choose an installed card"
                                          :async true
                                          :effect (req (charge-card %1 %2 eid target))
                                          :choices {:card (fn [t] (same-side? (:side t) %2))}}
@@ -432,7 +432,7 @@
                                                            (enable-card (get-card state target)))}
                                           (map->Card {:title "/rez command"}) nil))
         "/rfg"        #(resolve-ability %1 %2
-                                        {:prompt "Choose a card to remove from the game"
+                                        {:prompt "Choose a card"
                                          :effect (req (let [c (deactivate %1 %2 target)]
                                                         (move %1 %2 c :rfg)))
                                          :choices {:card (fn [t] (same-side? (:side t) %2))}}

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -1275,7 +1275,7 @@
       (rez state :corp (get-ice state :archives 0))
       (run-continue state)
       (click-prompt state :runner "Yes")
-      (is (= "Install from where?" (:msg (prompt-map :runner))) "Stack is only option")
+      (is (= "Choose where to install the program from" (:msg (prompt-map :runner))) "Stack is only option")
       (is (= 1 (-> (prompt-map :runner) :choices count)) "Runner has 1 choice")
       (is (= ["Stack"] (prompt-buttons :runner)) "Runner's only choice is Stack")))
 

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -3507,7 +3507,7 @@
       (play-from-hand state :runner "Prognostic Q-Loop")
       (run-on state :hq)
       (click-prompt state :runner "Yes")
-      (is (= "The top 2 cards of the stack are Au Revoir, Bankroll." (:msg (prompt-map :runner))))
+      (is (= "The top 2 cards of the stack are Au Revoir, Bankroll" (:msg (prompt-map :runner))))
       (click-prompt state :runner "OK")
       (card-ability state :runner (get-hardware state 0) 1)
       (click-prompt state :runner "Yes")
@@ -3608,7 +3608,7 @@
       (is (= "Choose a trigger to resolve" (:msg (prompt-map :runner))))
       (click-prompt state :runner "Prognostic Q-Loop")
       (click-prompt state :runner "Yes")
-      (is (= "The top 2 cards of the stack are Au Revoir, Bankroll." (:msg (prompt-map :runner))))))
+      (is (= "The top 2 cards of the stack are Au Revoir, Bankroll" (:msg (prompt-map :runner))))))
 
 (deftest prognostic-q-loop-are-the-correct-cards-shown-if-another-start-of-run-trigger-draws-a-card-issue-4973
     ;; Are the correct cards shown if another start of run trigger draws a card. Issue #4973
@@ -3633,7 +3633,7 @@
       (is (= "Look at top 2 cards of the stack?" (:msg (prompt-map :runner))))
       (click-prompt state :runner "Yes")
       ; Au Revoir drawn by Masterwork off it's own install, Q Loop prompt shows accurate info
-      (is (= "The top 2 cards of the stack are Bankroll, Clone Chip." (:msg (prompt-map :runner))))))
+      (is (= "The top 2 cards of the stack are Bankroll, Clone Chip" (:msg (prompt-map :runner))))))
 
 (deftest prognostic-q-loop-works-with-paladin-poemu-5304
     ;; Works with Paladin Poemu #5304

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -160,7 +160,7 @@
         (card-ability state :runner cor 0)
         (click-prompt state :runner "End the run")
         (is (not (no-prompt? state :runner)) "Prompt to break second sub open")
-        (click-prompt state :runner "Gain 1 [Credit]. Place 1 advancement token.")
+        (click-prompt state :runner "Gain 1 [Credit]. Place 1 advancement token")
         (is (no-prompt? state :runner) "Prompt now closed")
         (is (empty? (remove :broken (:subroutines (refresh akhet)))) "All subroutines broken")
         (run-continue state :movement)
@@ -3617,7 +3617,7 @@
     (click-card state :corp "Karunā")
     (is (last-log-contains? state "Corp uses Loki to choose Karunā protecting HQ at position 0")
         "The message correctly prints")
-    (is (= ["Do 2 net damage. The Runner may jack out."
+    (is (= ["Do 2 net damage. The Runner may jack out"
             "Do 2 net damage"
             "End the run unless the Runner shuffles the grip into the stack"]
            (map :label (:subroutines (get-ice state :rd 0))))

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -1736,7 +1736,7 @@
       (run-continue-until state :success)
       (is (not (no-prompt? state :runner)) "Cordyceps prompt")
       (click-prompt state :runner "Yes")
-      (is (= "Choose ice protecting this server" (:msg (prompt-map :runner))))
+      (is (= "Choose a piece of ice protecting this server" (:msg (prompt-map :runner))))
       (is (= :select (prompt-type :runner)))
       (click-card state :runner "Ice Wall")
       (click-card state :runner "Enigma")
@@ -6024,7 +6024,7 @@
       (let [snitch (get-program state 0)]
         (run-on state "R&D")
         (is (prompt-is-card? state :runner snitch) "Option to expose")
-        (is (= "Expose approached ice?" (:msg (prompt-map :runner))))
+        (is (= "Expose approached piece of ice?" (:msg (prompt-map :runner))))
         (click-prompt state :runner "Yes")
         (is (= "Jack out?" (:msg (prompt-map :runner))))
         (click-prompt state :runner "Yes"))))


### PR DESCRIPTION
Clean up typos, trailing dots and colons, terminology (e.g. select vs choose, move vs add), Paige Piper allegedly "trashing" from the stack.