### PR TITLE
WIP re-implement disabling cards

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -13,6 +13,7 @@
                            get-nested-host get-title get-zone hardware? has-subtype? ice? in-discard? in-hand?
                            installed? is-type? operation? program? resource? rezzed? runner? upgrade?]]
    [game.core.charge :refer [can-charge charge-ability charge-card]]
+   [game.core.checkpoint :refer [fake-checkpoint]]
    [game.core.cost-fns :refer [install-cost play-cost rez-cost]]
    [game.core.damage :refer [damage damage-prevent]]
    [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out
@@ -2896,13 +2897,14 @@
                                                    (get-in @state [:corp :hand])
                                                    (get-in @state [:corp :deck])
                                                    (get-in @state [:corp :discard]))))]
-    {:leave-play (req (doseq [c (rumor state)]
-                        (enable-card state :corp c)))
-     :on-play {:effect (req (doseq [c (rumor state)]
-                              (disable-card state :corp c)))}
-     :events [{:event :corp-install
-               :req (req (eligible? (:card context)))
-               :effect (effect (disable-card :corp (:card context)))}]}))
+    {:constant-effects [{:type :disable-card
+                         :req (req (eligible? target))
+                         :value (req true)}]
+     ;; this might not even be needed
+     :leave-play (req (fake-checkpoint state))}))
+
+     ;;doseq [c (rumor state)]
+     ;;(enable-card state :corp c)))
 
 (defcard "Run Amok"
   (letfn [(get-rezzed-cids [ice]

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -42,7 +42,7 @@
   (let [card (get-card state card)
         abilities (:abilities card)
         ab (nth abilities ability)
-        cannot-play (or (:disabled card)
+        cannot-play (or (any-effects state side :disable-card true? card)
                         (any-effects state side :prevent-paid-ability true? card [ab ability]))]
     (when-not cannot-play
       (do-play-ability state side card ab ability targets))))
@@ -434,7 +434,7 @@
   (let [card (get-card state card)
         cdef (card-def card)
         ab (get-in cdef [:corp-abilities ability])
-        cannot-play (or (:disabled card)
+        cannot-play (or (any-effects state side :disable-card true? card)
                         (any-effects state side :prevent-paid-ability true? card [ab ability]))]
     (when-not cannot-play
       (do-play-ability state side card ab ability targets))))
@@ -445,7 +445,7 @@
   (let [card (get-card state card)
         cdef (card-def card)
         ab (get-in cdef [:runner-abilities ability])
-        cannot-play (or (:disabled card)
+        cannot-play (or (any-effects state side :disable-card true? card)
                         (any-effects state side :prevent-paid-ability true? card [ab ability]))]
     (when-not cannot-play
       (do-play-ability state side card ab ability targets))))

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -4,7 +4,7 @@
     [game.core.card :refer [get-card map->Card program? runner?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost]]
-    [game.core.effects :refer [register-constant-effects register-floating-effect unregister-constant-effects]]
+    [game.core.effects :refer [register-constant-effects register-floating-effect unregister-constant-effects any-effects]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [is-ability? register-default-events register-events resolve-ability unregister-events]]
     [game.core.finding :refer [find-cid]]
@@ -124,7 +124,7 @@
          (register-events
            state side c
            [{:event (if (= side :corp) :corp-phase-12 :runner-phase-12)
-             :req (req (not (:disabled card)))
+             :req (req (not (any-effects state side :disable-card true? card)))
              :effect r}])))
      (register-default-events state side c)
      (register-constant-effects state side c)

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -115,17 +115,6 @@
          _ (doseq [[c-type c-num] data]
              (add-counter state side (get-card state c) c-type c-num {:placed true}))
          c (get-card state c)]
-     (when recurring
-       (let [recurring-fn (req (if (number? recurring) recurring (recurring state side eid card targets)))
-             r (req (let [card (update! state side (assoc-in card [:counter :recurring] 0))]
-                      (add-counter state side card
-                                   :recurring (recurring-fn state side eid card targets)
-                                   {:placed true})))]
-         (register-events
-           state side c
-           [{:event (if (= side :corp) :corp-phase-12 :runner-phase-12)
-             :req (req (not (any-effects state side :disable-card true? card)))
-             :effect r}])))
      (register-default-events state side c)
      (register-constant-effects state side c)
      ;; Facedown cards can't be initialized

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -4,7 +4,7 @@
     [game.core.card :refer [asset? condition-counter? get-card ice? upgrade?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [rez-additional-cost-bonus rez-cost]]
-    [game.core.effects :refer [unregister-constant-effects]]
+    [game.core.effects :refer [unregister-constant-effects any-effects]]
     [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
     [game.core.engine :refer [register-pending-event queue-event checkpoint pay register-events resolve-ability trigger-event unregister-events]]
     [game.core.flags :refer [can-host? can-rez?]]
@@ -81,7 +81,8 @@
                           (play-sfx state side "rez-ice"))
                       (play-sfx state side "rez-other"))
                     (swap! state update-in [:stats :corp :cards :rezzed] (fnil inc 0))
-                    (when-let [card-ability (:on-rez cdef)]
+                    (when-let [card-ability (and (not (any-effects state side :disable-card true? card))
+                                                 (:on-rez cdef))]
                       (register-pending-event state :rez card card-ability))
                     (queue-event state :rez {:card (get-card state card)
                                              :cost cost-paid})

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -31,7 +31,7 @@
               (concat
                 (when-not ignore-cost
                   [:credit cost])
-                (when (not (:disabled card))
+                (when-not (any-effects state side :disable-card true? card)
                   additional-costs))))))
 
 (defn trash-hosted-cards
@@ -46,8 +46,7 @@
                 (effect-completed state side eid)))))
 
 (defn- complete-rez
-  [state side eid
-   {:keys [disabled] :as card}
+  [state side eid card
    {:keys [alternative-cost ignore-cost no-warning no-msg press-continue] :as args}]
   (let [cdef (card-def card)
         costs (get-rez-cost state side card args)]
@@ -57,7 +56,7 @@
                   (effect-completed state side eid)
                   (let [_ (when (:derezzed-events cdef)
                             (unregister-events state side card))
-                        card (if disabled
+                        card (if (any-effects state side :disable-card true? card)
                                (update! state side (assoc card :rezzed :this-turn))
                                (card-init state side (assoc card :rezzed :this-turn) {:resolve-effect false :init-data true}))]
                     (doseq [h (:hosted card)]


### PR DESCRIPTION
Doing this in a less eclectic fashion this time.

I'm picking one card (this time, rumor mill), changing it to a constant/floating effect, then working backwards to get things functional.

So far, the following changes have been made:
* `:on-rez` effects require the card to not be disabled
* Most of the effects that looked for a `:disabled` key now check `:any-effect`. The outliers at the moment are card-init, disable-card, and diffs
* I still need to add a "gather all disabled cards and do changes" helper that goes in each checkpoint and fake-checkpoint

So far, the following cards have been changed:
* Rumor Mill (the fake checkpoint can maybe go away, since it trashes anyway)