### PR TITLE
tremolo doesn't allow for a negative break cost

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2786,7 +2786,7 @@
                                     -))]
     (auto-icebreaker {:abilities [(break-sub 3 2 "Barrier"
                                              {:label "Break up to 2 Barrier subroutine"
-                                              :break-cost-bonus (req [:credit (credit-discount state)])})
+                                              :break-cost-bonus (req [:credit (max -3 (credit-discount state))])})
                                   (strength-pump 2 2)]})))
 
 (defcard "Trope"


### PR DESCRIPTION
It was allowing for a negative cost before and breaking the math when 4+ cybernetics were installed