### PR TITLE
superdeep borehole fix and tests

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2340,7 +2340,7 @@
                           (gain-bad-publicity state :corp eid 1))}
             {:event :counter-added
              :req (req (and (same-card? card target)
-                            (not (pos? (get-counters card :power)))
+                            (not (pos? (get-counters (get-card state card) :power)))
                             (:borehole-valid (:special card))))
              :msg "win the game"
              :effect (req (win state :corp "Superdeep Borehole extinction event"))}]})

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -5042,6 +5042,28 @@
       (is (= 0 (get-counters (refresh bore) :bad-publicity)) "1 bp counters")
       (is (= "Superdeep Borehole extinction event" (:reason @state)) "Win condition reports borehole"))))
 
+(deftest superdeep-borehole-doesn't-instantly-win
+  (do-game
+    (new-game {:corp {:hand ["Superdeep Borehole"]
+                      :deck [(qty "Hedge Fund" 50)]}})
+    (play-from-hand state :corp "Superdeep Borehole" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (is (not (= :corp (:winner @state))) "Corp doesn't win")))
+
+(deftest superdeep-borehole-doesn't-instantly-win-when-disabled
+  (do-game
+    (new-game {:corp {:hand ["Superdeep Borehole"]
+                      :deck [(qty "Hedge Fund" 50)]}
+               :runner {:hand ["Light the Fire!" "Sure Gamble"]}})
+    (play-from-hand state :corp "Superdeep Borehole" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Light the Fire!")
+    (card-ability state :runner (get-resource state 0) 0)
+    (click-prompt state :runner "Server 1")
+    (rez state :corp (get-content state :remote1 0))
+    (run-jack-out state)
+    (is (not (= :corp (:winner @state))) "Corp doesn't win")))
+
 (deftest synth-dna-modification
   ;; Synth DNA Modification
   (do-game


### PR DESCRIPTION
Just need to say `(get-card state card)` instead of `card`, it was fetching the pre-rez version with 0 counters on it before.

I also added a test to make sure it doesn't happen, and another test to verify the Light the Fire!/other disabe-card interactions work right.

Closes #6778, Closes #6776