### PR TITLE
fix Pulse making the Runner lose clicks instead of spend them

### DIFF
--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -5282,8 +5282,24 @@
         (fire-subs state (refresh p1)))
       (changes-val-macro
         -1 (:click (get-runner))
-        "paid 1 click"
-        (click-prompt state :runner "Lose [Click]")))))
+        "spent 1 click"
+        (click-prompt state :runner "Spend [Click]")))))
+
+(deftest pulse-run-last-click
+  ;; Pulse - cannot spend click when running last click
+  (do-game
+    (new-game {:corp {:hand ["Pulse"]}})
+    (play-from-hand state :corp "Pulse" "HQ")
+    (take-credits state :corp)
+    (dotimes [_ 3]
+      (click-credit state :runner))
+    (run-on state :hq)
+    (let [pulse (get-ice state :hq 0)]
+      (rez state :corp pulse)
+      (run-continue state)
+      (fire-subs state (refresh pulse))
+      (is (= ["End the run"] (prompt-buttons :runner))
+          "Runner has no click left to spend"))))
 
 (deftest red-tape
   ;; Red Tape

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3521,7 +3521,7 @@
         (rez state :corp (refresh tur))
         (run-continue state)
         (card-ability state :runner (refresh inv) 0)
-        (click-prompt state :runner "End the run unless the Runner spends [Click][Click][Click]")
+        (click-prompt state :runner "End the run unless the Runner pays [Click][Click][Click]")
         (run-continue state)
         (click-prompt state :runner "Yes")
         (click-card state :runner (get-ice state :hq 1))


### PR DESCRIPTION
Also refactor "etr-unless" functions, which allowed the Runner to ignore the cost associated to the non-etr choice and continue the run.

Turing and Wotan were affected by the same problem of Pulse.