### PR TITLE
rename /take-brain to /take-core

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -481,7 +481,7 @@
                                 :effect (effect (swap-installed (first targets) (second targets)))}
                                 (map->Card {:title "/swap-installed command"}) nil))
         "/tag"        #(swap! %1 assoc-in [%2 :tag :base] (constrain-value value 0 1000))
-        "/take-brain" #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :brain (constrain-value value 0 1000)
+        "/take-core" #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :brain (constrain-value value 0 1000)
                                                     {:card (map->Card {:title "/damage command" :side %2})}))
         "/take-meat"  #(when (= %2 :runner) (damage %1 %2 (make-eid %1) :meat  (constrain-value value 0 1000)
                                                     {:card (map->Card {:title "/damage command" :side %2})}))

--- a/src/cljs/nr/help.cljs
+++ b/src/cljs/nr/help.cljs
@@ -151,9 +151,9 @@
     :has-args :required
     :usage "/tag n"
     :help "Set your tags to n"}
-   {:name "/take-brain"
+   {:name "/take-core"
     :has-args :required
-    :usage "/take-brain n"
+    :usage "/take-core n"
     :help "Take n core damage (Runner only)"}
    {:name "/take-meat"
     :has-args :required

--- a/test/clj/game/core/say_test.clj
+++ b/test/clj/game/core/say_test.clj
@@ -256,7 +256,7 @@
         (core/command-parser state :runner {:user user :text "/take-core 3"})
         (is (= 3 (:brain-damage (get-runner))) "Runner gains 3 core")
         (core/command-parser state :runner {:user user :text "/take-core -5"})
-        (is (= 3 (:brain-damage (get-runner))) "Runner gains 0 cire")
+        (is (= 3 (:brain-damage (get-runner))) "Runner gains 0 core")
         (core/command-parser state :runner {:user user :text "/take-core 99999999999999999999999999999999999999999999"})
         (is (= 1003 (:brain-damage (get-runner))) "Runner gains 1000 core"))))
 

--- a/test/clj/game/core/say_test.clj
+++ b/test/clj/game/core/say_test.clj
@@ -249,16 +249,16 @@
         (core/command-parser state :runner {:user user :text "/tag 99999999999999999999999999999999999999999999"})
         (is (= 1000 (:base (:tag (get-runner)))) "Runner has 1000 tags"))))
 
-  (testing "/take-brain"
+  (testing "/take-core"
     (let [user {:username "Runner"}]
       (do-game
         (new-game)
-        (core/command-parser state :runner {:user user :text "/take-brain 3"})
-        (is (= 3 (:brain-damage (get-runner))) "Runner gains 3 brain")
-        (core/command-parser state :runner {:user user :text "/take-brain -5"})
-        (is (= 3 (:brain-damage (get-runner))) "Runner gains 0 brain")
-        (core/command-parser state :runner {:user user :text "/take-brain 99999999999999999999999999999999999999999999"})
-        (is (= 1003 (:brain-damage (get-runner))) "Runner gains 1000 brain"))))
+        (core/command-parser state :runner {:user user :text "/take-core 3"})
+        (is (= 3 (:brain-damage (get-runner))) "Runner gains 3 core")
+        (core/command-parser state :runner {:user user :text "/take-core -5"})
+        (is (= 3 (:brain-damage (get-runner))) "Runner gains 0 cire")
+        (core/command-parser state :runner {:user user :text "/take-core 99999999999999999999999999999999999999999999"})
+        (is (= 1003 (:brain-damage (get-runner))) "Runner gains 1000 core"))))
 
   (testing "/trace"
     (let [user {:username "Corp"}]


### PR DESCRIPTION
renames `/take-brain` to `/take-core` and updates the usage in tests.

Just another small PR updating brain->core in places.

This PR still doesn't touch the functions like `do-brain-damage`, etc. But for the user front end, they should see `/take-core` as the command, and no references to `brain damage` on the front end (I think).