### PR TITLE
add msg to Mr. Hendrik to print ability's cost

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1037,6 +1037,8 @@
   (installed-access-trigger
     2
     {:async true
+     ;; Adding a msg to print the ability's cost
+     :msg "force the Runner to suffer a core damage or lose all remaining [Click]"
      :effect
      (effect (continue-ability {:player :runner
                                 :prompt "Choose one"


### PR DESCRIPTION
I noticed that Mr. Hendrik's ability cost never gets printed, probably because of the convoluted Runner prompt been spawn by the `continue-ability`, which is the one getting the cost associated to.