### PR TITLE
formicary is silent when it's set to not resolve

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1573,7 +1573,8 @@
 (defcard "Formicary"
   {:derezzed-events
    [{:event :approach-server
-     :interactive (req true)
+     :interactive (req (not= ((get-autoresolve :auto-fire) state side eid card nil) "No"))
+     :silent (req (= ((get-autoresolve :auto-fire) state side eid card nil) "No"))
      :optional
      {:prompt (msg "Rez and move " (card-str state card {:visible true}) " to protect the approched server?")
       :autoresolve (get-autoresolve :auto-fire)

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2234,6 +2234,36 @@
       (is (= 1 (get-in @state [:run :position])) "Now approaching Formicary")
       (is (get-run) "The run is still in progress"))))
 
+(deftest formicary-autoresolve-qol-test
+  ;; checks that if autoresolve is set to never, the prompt will be silent
+  ;; this means you can prevent the runner from inferring formicary exists even with 2-3 of them
+  ;; on the field
+  (do-game
+    (new-game {:corp {:deck [(qty "Formicary" 2) "Manegarm Skunkworks"]}})
+    (play-from-hand state :corp "Formicary" "HQ")
+    (play-from-hand state :corp "Formicary" "Archives")
+    (play-from-hand state :corp "Manegarm Skunkworks" "HQ")
+    (take-credits state :corp)
+    (let [f1 (get-ice state :hq 0)
+          f2 (get-ice state :archives 0)
+          skunk (get-content state :hq 0)]
+      ;; Never resolve
+      (card-ability state :corp f1 0)
+      (click-prompt state :corp "Never")
+      (card-ability state :corp f2 0)
+      (click-prompt state :corp "Never")
+      (run-on state "R&D")
+      (run-continue state)
+      (is (= "Formicary" (:title (get-ice state :hq 0))) "Formicary is on HQ")
+      (is (not (get-run)) "The run has ended without prompting for Formicary")
+      (run-on state "HQ")
+      (rez state :corp skunk)
+      (run-continue state)
+      (run-continue state)
+      (click-prompt state :runner "Spend [Click][Click]")
+      (click-prompt state :runner "No action")
+  )))
+
 (deftest free-lunch-basic-behavior
   ;; Basic behavior
   (do-game


### PR DESCRIPTION
Formicary is only interactive if you haven't set it to `:never`, and it's silent when it is set to `:never`.

This means you can actually hide the existence of your two or three formicaries on board now. Consider this a minor buff to the prison experience.

Closes #6865