### PR TITLE
placeholder impl for hush

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2443,9 +2443,11 @@
 (defcard "Magnet"
   (letfn [(disable-hosted [state side c]
             (doseq [hc (:hosted (get-card state c))]
-              (unregister-events state side hc)
-              (unregister-constant-effects state side hc)
-              (update! state side (dissoc hc :abilities))))]
+              ;; TODO - remove this boilerplate when disabling cards is reworked
+              (when (not= (:title hc) "Hush")
+                (unregister-events state side hc)
+                (unregister-constant-effects state side hc)
+                (update! state side (dissoc hc :abilities)))))]
     {:on-rez {:async true
               :effect (req (let [magnet card]
                              (wait-for (resolve-ability

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1568,7 +1568,9 @@
                 :cost [:click 1]
                 :choices {:card #(and (ice? %)
                                       (installed? %)
-                                      (can-host? %))}}]})
+                                      (can-host? %))}
+                :msg (msg "host itself on " (card-str state target))
+                :effect (effect (host target card))}]})
 
 (defcard "Hyperbaric"
   (auto-icebreaker {:data {:counter {:power 1}}

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -1558,6 +1558,18 @@
   (auto-icebreaker {:abilities [(break-sub 1 1 "Code Gate")
                                 (strength-pump 2 4 :end-of-run {:label "add 4 strength (using at least 1 stealth [Credits])" :cost-req (min-stealth 1)})]}))
 
+(defcard "Hush"
+  ;; TODO - come back to this once disabling cards has been reworded. nbkelly, jan 2023
+  {:implementation "Unimplemented - corp must use /disable-card and /enable-card on ice to fix any issues (ie anansi, afshar, magnet)"
+   :hosting {:card #(and (ice? %)
+                         (can-host? %))}
+   :abilities [{:label "Host on a piece of ice"
+                :prompt "Choose a piece of ice"
+                :cost [:click 1]
+                :choices {:card #(and (ice? %)
+                                      (installed? %)
+                                      (can-host? %))}}]})
+
 (defcard "Hyperbaric"
   (auto-icebreaker {:data {:counter {:power 1}}
                     :abilities [(break-sub 1 1 "Code Gate")


### PR DESCRIPTION
This is a boilerplate "it's at least convenient" non-implementation. You can host it on ice, you can move it to other ice, and magnet doesn't (or shouldn't) silence it. 

There's also reminder text on it so players know how to resolve cards like anansi.

I've put TODOs in so we can remember to fix it later.