### PR TITLE
Vanilla docker compose fails with nr.dev required namespace not available.

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -4,6 +4,6 @@
         :output-dir "resources/public/js"
         :devtools {:watch-dir "resources/public/css"
                    :watch-path "/css"
-                   :repl-init-ns nr.dev}
-        :dev {:modules {:main {:entries [nr.dev]}}}
+                   :repl-init-ns dev.nr}
+        :dev {:modules {:main {:entries [dev.nr]}}}
         :release {:modules {:main {:entries [prod.nr]}}}}}}

--- a/src/cljs/dev/nr.cljs
+++ b/src/cljs/dev/nr.cljs
@@ -1,4 +1,4 @@
-(ns nr.dev
+(ns dev.nr
   (:require
     [nr.main :as main]
     [devtools.core :as devtools]))


### PR DESCRIPTION
to mirror namespace prod, move dev to src/cljs/nr

fixes issue #6883 