### PR TITLE
Support for translated card data

### DIFF
--- a/src/clj/web/api.clj
+++ b/src/clj/web/api.clj
@@ -47,7 +47,8 @@
       ["/cards"
        ["" {:get data/cards-handler}]
        ["/version" {:get data/cards-version-handler}]
-       ["/altarts" {:get data/alt-arts-handler}]]
+       ["/altarts" {:get data/alt-arts-handler}]
+       ["/lang/:lang" {:get data/lang-handler}]]
       ["/news" {:get data/news-handler}]
       ["/sets" {:get data/sets-handler}]
       ["/mwl" {:get data/mwl-handler}]

--- a/src/clj/web/data.clj
+++ b/src/clj/web/data.clj
@@ -32,6 +32,15 @@
 (defn cards-handler [{db :system/db}]
   (response 200 (enriched-cards db)))
 
+(defn- validate-lang
+  [lang]
+  (contains? #{"de" "es" "fr" "it" "ja" "ko" "pl" "zh"} lang))
+
+(defn lang-handler [{db :system/db {lang :lang} :path-params}]
+  (if (validate-lang lang)
+      (response 200 (map #(dissoc % :_id) (mc/find-maps db (str "cards-" lang))))
+      (response 200 {})))
+
 (defn alt-arts-handler [{db :system/db}]
   (response 200 (map #(dissoc % :_id) (mc/find-maps db "altarts"))))
 

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -300,7 +300,7 @@
 (defn card-as-text
   "Generate text html representation a card"
   [card show-extra-info]
-  (let [title (:title card)
+  (let [title (tr-data :title card)
         icon (faction-icon (:faction card) title)
         uniq (when (:uniqueness card) "◇ ")]
     [:div
@@ -452,7 +452,7 @@
          [card-as-text card true]
          (when-let [url (base-image-url card)]
            [:img {:src url
-                  :alt (:title card)
+                  :alt (tr-data :title card)
                   :onError #(-> (swap! cv assoc :show-text true))
                   :onLoad #(-> % .-target js/$ .show)}]))])))
 

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -411,6 +411,7 @@
     cards
     (let [lcquery (s/lower-case query)]
       (filter #(or (s/includes? (s/lower-case (:title %)) lcquery)
+                   (s/includes? (s/lower-case (tr-data :title %)) lcquery)
                    (s/includes? (:normalizedtitle %) lcquery))
               cards))))
 

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -341,7 +341,7 @@
                    (let [status (get-in card [:format (keyword k)] "unknown")
                          c (text-class-for-status status)]
                      ^{:key k}
-                     [:div.format-item {:class c} name
+                     [:div.format-item {:class c} (tr-format name)
                       (cond (:banned status) banned-span
                             (:restricted status) restricted-span
                             (:rotated status) rotated-span

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -10,7 +10,7 @@
    [nr.account :refer [alt-art-name]]
    [nr.ajax :refer [GET]]
    [nr.appstate :refer [app-state]]
-   [nr.translations :refer [tr tr-faction tr-format tr-side tr-sort tr-type]]
+   [nr.translations :refer [tr tr-faction tr-format tr-side tr-sort tr-type tr-data]]
    [nr.utils :refer [banned-span deck-points-card-span faction-icon
                      format->slug get-image-path image-or-face influence-dots
                      non-game-toast render-icons restricted-span rotated-span set-scroll-top slug->format
@@ -332,7 +332,7 @@
      [:div.text.card-body
       [:p [:span.type (tr-type (:type card))]
        (if (empty? (:subtype card)) "" (str ": " (:subtype card)))]
-      [:pre (render-icons (:text (get @all-cards (:title card))))]
+      [:pre (render-icons (tr-data :text (get @all-cards (:title card))))]
 
       (when show-extra-info
         [:<>

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -32,8 +32,11 @@
                   {} (:cards format))))
 
 (go (let [server-version (get-in (<! (GET "/data/cards/version")) [:json :version])
+          lang (get-in @app-state [:options :language] "en")
           local-cards (js->clj (.parse js/JSON (.getItem js/localStorage "cards")) :keywordize-keys true)
-          need-update? (or (not local-cards) (not= server-version (:version local-cards)))
+          need-update? (or (not local-cards)
+                           (not= server-version (:version local-cards))
+                           (not= lang (:lang local-cards)))
           latest-cards (if need-update?
                            (:json (<! (GET "/data/cards")))
                            (:cards local-cards))
@@ -59,7 +62,7 @@
       (reset! cards/cycles cycles)
       (swap! app-state assoc :sets sets :cycles cycles)
       (when need-update?
-        (.setItem js/localStorage "cards" (.stringify js/JSON (clj->js {:cards cards :version server-version}))))
+        (.setItem js/localStorage "cards" (.stringify js/JSON (clj->js {:cards cards :version server-version :lang lang}))))
       (reset! all-cards (into {} (map (juxt :title identity) (sort-by :code cards))))
       (swap! app-state assoc
              :cards-loaded true

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -11,7 +11,7 @@
     [nr.auth :refer [authenticated] :as auth]
     [nr.cardbrowser :refer [cards-channel factions filter-title image-url] :as cb]
     [nr.deck-status :refer [deck-status-span]]
-    [nr.translations :refer [tr tr-faction tr-format tr-side tr-type]]
+    [nr.translations :refer [tr tr-faction tr-format tr-side tr-type tr-data]]
     [nr.utils :refer [alliance-dots banned-span cond-button
                       deck-points-card-span dots-html format->slug format-date-time
                       influence-dot influence-dots mdy-formatter non-game-toast num->percent
@@ -96,7 +96,7 @@
   (if (empty? title)
     {:display-name "Missing Identity"}
     (let [card (lookup side {:title title})]
-      (assoc card :display-name (build-identity-name title setname)))))
+      (assoc card :display-name (build-identity-name (tr-data :title card) setname)))))
 
 (defn add-params-to-card
   "Add art and id parameters to a card hash"
@@ -192,10 +192,12 @@
   [all-titles card]
   (let [card-title (:title card)
         indexes (keep-indexed #(if (= %2 card-title) %1 nil) all-titles)
-        dups (> (count indexes) 1)]
+        dups (> (count indexes) 1)
+        display-title (tr-data :title card)
+        setname (:setname card)]
     (if dups
-      (assoc card :display-name (str (:title card) " (" (:setname card) ")"))
-      (assoc card :display-name (:title card)))))
+      (assoc card :display-name (str display-title " (" setname ")"))
+      (assoc card :display-name display-title))))
 
 (defn- insert-params
   "Add card parameters into the string representation"
@@ -532,8 +534,8 @@
                                            (swap! card-state assoc :query (.. e -target -textContent))
                                            (swap! card-state assoc :selected i)
                                            nil)
-                               :key (:title (nth matches i))}
-                         (:title (nth matches i))]))])))]])))
+                               :key (tr-data :title (nth matches i))}
+                         (tr-data :title (nth matches i))]))])))]])))
 
 (defn deck-name
   ([deck] (deck-name deck 40))
@@ -572,7 +574,7 @@
       [deck-status-span deck]
       [:p (deck-date deck)]]
      [:h4 (deck-name deck)]
-     [:span (get-in deck [:identity :title])]
+     [:span (tr-data :title (:identity deck))]
      [deck-stats-line deck]]))
 
 (def all-sides-filter "Any Side")
@@ -642,7 +644,7 @@
   "Make the view of a single line in the deck - returns a span"
   [{:keys [identity cards format] :as deck} {:keys [qty card] :as line}]
   [:span qty "  "
-   (if-let [title (:title card)]
+   (if-let [title (tr-data :title card)]
      (let [infaction (no-inf-cost? identity card)
            card-status (format-status format card)
            banned (:banned card-status)
@@ -670,7 +672,7 @@
 (defn line-name-span
   "Make the view of a single line in the deck - returns a span"
   [{:keys [identity cards format] :as deck} {:keys [qty card] :as line}]
-  [:span (if-let [name (:title card)]
+  [:span (if-let [name (tr-data :title card)]
            (let [infaction (no-inf-cost? identity card)
                  card-status (format-status format card)
                  banned (:banned card-status)
@@ -721,7 +723,7 @@
   (let [id (:identity deck)]
     [:div.header
      [:img {:src (image-url id)
-            :alt (:title id)}]
+            :alt (tr-data :title id)}]
      [:div.header-text
       [:h4 {:class (str "fake-link"
                         (let [status (format-status (:format deck) id)]
@@ -731,7 +733,7 @@
                                                  :art (:art id)
                                                  :id (:id id)})
             :on-mouse-leave #(put! zoom-channel false) }
-       (:title id)
+       (tr-data :title id)
        (let [status (format-status (:format deck) id)]
          (cond (:banned status) banned-span
                (:restricted status) restricted-span
@@ -884,7 +886,7 @@
 
 (defn- identity-option-string
   [card]
-  (.stringify js/JSON (clj->js {:title (:title card)
+  (.stringify js/JSON (clj->js {:title (tr-data :title card)
                                 :id (:code card)})))
 
 (defn- create-identity
@@ -1002,7 +1004,7 @@
   (when-let [url (image-url card)]
     [:div.card-preview.blue-shade
      [:img {:src url
-            :alt (:title card)}]]))
+            :alt (tr-data :title card)}]]))
 
 (defn list-panel
   [s user decks decks-loaded scroll-top]

--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -2941,3 +2941,6 @@
 (def tr-lobby (partial tr-string "lobby"))
 (def tr-pronouns (partial tr-string "pronouns"))
 (def tr-watch-join (partial tr-string "lobby"))
+
+(defn tr-data [key data]
+  (or (get-in data [:localized key]) (key data)))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -10,6 +10,7 @@
    [goog.string :as gstring]
    [goog.string.format]
    [nr.appstate :refer [app-state]]
+   [nr.translations :refer [tr-data]]
    [reagent.dom :as rd]))
 
 ;; Dot definitions
@@ -194,12 +195,18 @@
   "A sequence of card pattern pairs consisting of a regex, used to match a card
   name in text, and the span fragment that should replace it"
   []
-  (letfn [(span-of [title] [:span {:class "fake-link" :data-card-title title} title])]
-    (->> (:all-cards-and-flips @app-state)
-         (vals)
-         (remove :replaced_by)
-         (map (fn [c] [(:title c) (span-of (:title c))]))
-         (sort-by (comp count str first) >))))
+  (letfn [(span-of [title tr-title] [:span {:class "fake-link" :data-card-title title} tr-title])]
+    (distinct (concat
+     (->> (:all-cards-and-flips @app-state)
+          (vals)
+          (remove :replaced_by)
+          (map (fn [c] [(:title c) (span-of (:title c) (:title c))]))
+          (sort-by (comp count str first) >))
+     (->> (:all-cards-and-flips @app-state)
+          (vals)
+          (remove :replaced_by)
+          (map (fn [c] [(tr-data :title c) (span-of (:title c) (tr-data :title c))]))
+          (sort-by (comp count str first) >))))))
 
 (def card-patterns (memoize card-patterns-impl))
 
@@ -211,7 +218,7 @@
     (->> (:all-cards-and-flips @app-state)
          (vals)
          (filter #(not (:replaced_by %)))
-         (map (fn [k] (regex-escape (:title k))))
+         (map (fn [k] (join "|" (map regex-escape (distinct [(:title k) (tr-data :title k)])))))
          (join "|"))))
 
 (def contains-card-pattern (memoize contains-card-pattern-impl))


### PR DESCRIPTION
This adds support for displaying translated card data, namely:
- The card browser will display the translated title, data, and formats if available.
- The deck builder will display transalted card names if available. (The text listing will always be in English.)
- The search functionality (in the card browser and deck builder) will consider both English and the user selected language. For example, with a Japanese language setting, searching for Overclock or オーバークロック will return the same card, always displayed as オーバークロック. There is no behavior change if the selected language is English.
- The card pattern search text search for chat will consider English and the selected language. For example, with a Japanese language setting, typing in Overclock or オーバークロック will parse the text, using the original language of the text while displaying the same card image pop-up. There is no behavior change if the selected language is English.

Localized card data is pulled from raw_data.edn under `:cards-<lc>` (changes there will be going to the other repo) and is exposed via `/cards/lang/<lc>`. The client will fetch localized data for the user-selected language and will merge it into card data under `:localized`, along with language checks in order to re-generate the data on a language change.

~~Note that translated data does not currently exist in the raw data. I'm looking for a contact to follow up with to discuss the best way to get the translated data in netrunner-cards-json to the data used by jnet. In the meantime, I've tested these changes by manually editing the raw data.~~

![jnet-jp](https://github.com/mtgred/netrunner/assets/31943434/6106fe25-44bd-4b8e-839e-128021191f1d)
![jnet-ko](https://github.com/mtgred/netrunner/assets/31943434/f135e951-02fb-403d-8f94-c1eb55349285)