### PR TITLE
When updating emails, change the emailhash too.

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -152,7 +152,8 @@
     (acknowledged?
       (mc/update db "users"
                  {:username username}
-                 {"$set" {:email email}}))
+                 {"$set" {:email email
+                          :emailhash (md5 email)}}))
     (response 200 {:message "Refresh your browser"})
 
     :else


### PR DESCRIPTION
The emailhash is used primarily for the avatar picture (taken from gravatar.com). By updating the emailhash, we make it easier for the user to change their avatar.

---

Note: this is my first pull request to this repo. I have little experience with Netrunner, Clojure, and everything else :) so feel free to disregard this PR if it isn't helpful.