### PR TITLE
fix Friday Chip log

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -816,7 +816,7 @@
                                             :autoresolve (get-autoresolve :auto-fire)
                                             :yes-ability {:effect (effect (system-msg
                                                                             :runner
-                                                                            (msg "uses " (:title card) " to place 1 virus counter on itself"))
+                                                                            (str "uses " (:title card) " to place 1 virus counter on itself"))
                                                                           (add-counter :runner card :virus 1))}}}
                                   mult-ab {:prompt (msg "Place virus counters on " (:title card) "?")
                                            :choices {:number (req amt-trashed)


### PR DESCRIPTION
It was previously printing some kind of noise like this:
![image](https://user-images.githubusercontent.com/1105053/222225230-bdc44a85-d93c-41fa-93f7-8158435f46df.png)
