### PR TITLE
Fix user `lastConnection` key in the db

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -105,7 +105,7 @@
       (and user (password/check password (:password user)))
       (do (mc/update db "users"
                      {:username username}
-                     {"$set" {:last-connection (inst/now)}})
+                     {"$set" {:lastConnection (inst/now)}})
           (assoc (response 200 {:message "ok"})
                  :cookies {"session" (merge {:value (create-token auth user)}
                                             (:cookie auth))}))


### PR DESCRIPTION
The logic in `user.clj` and `db.clj` uses the `lastConnection` key in the `users` MongoDB collection.
