### PR TITLE
Fix for Odore's ability

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2086,9 +2086,7 @@
    :abilities [(set-autoresolve :auto-fire "Nyashia")]})
 
 (defcard "Odore"
-  (auto-icebreaker {:abilities [(break-sub 2 0 "Sentry"
-                                           {:req (req (> 3 (count (filter #(has-subtype? % "Virtual")
-                                                                          (all-active-installed state :runner)))))})
+  (auto-icebreaker {:abilities [(break-sub 2 0 "Sentry")
                                 (break-sub 0 1 "Sentry"
                                            {:label "Break 1 Sentry subroutine (Virtual restriction)"
                                             :req (req (<= 3 (count (filter #(has-subtype? % "Virtual")


### PR DESCRIPTION
Odore's first ability `2c: Break all subs` can be used while 3 Virtuals are installed. (Relevant interactions exist where a player wants to do this over the `0c: Break a sub` ability.)