### PR TITLE
translations: Use standardized codes

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -292,7 +292,7 @@
                             {:name "Français" :ref "fr"}
                             {:name "Deutsch" :ref "de"}
                             {:name "Italiano" :ref "it"}
-                            {:name "日本語" :ref "jp"}
+                            {:name "日本語" :ref "ja"}
                             {:name "한국어" :ref "ko"}
                             {:name "Polski" :ref "pl"}
                             {:name "Igpay Atinlay" :ref "la-pig"}]]

--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -1663,7 +1663,7 @@
 
 
   :ko
-  {:missing ":kr 텍스트를 찾을 수 없음"
+  {:missing ":ko 텍스트를 찾을 수 없음"
    :side
    {:corp "기업"
     :runner "러너"
@@ -2490,8 +2490,8 @@
    :win-points (fn [[turn]] (str "wygrywa przez zdobycie punktów zwycięstwa w " turn " turze."))}
    } 
 
-   :jp
-   {:missing ":jp missing text"
+   :ja
+   {:missing ":ja missing text"
     :side
     {:corp "コーポ"
      :runner "ランナー"
@@ -2577,9 +2577,9 @@
      :features "Features"
      :game-count (fn [[cnt]] (str "ルーム数 " cnt))}
     :menu
-    {:settings :jp.nav/settings
+    {:settings :ja.nav/settings
      :logout "ジャックアウト"
-     :admin :jp.nav/admin
+     :admin :ja.nav/admin
      :moderator "Moderator"
      :donor "Donor"}
     :card-browser


### PR DESCRIPTION
jp has been switched to ja to conform to the ISO 639-1 naming.

Also, a stray string reference to kr has been changed to ko.

This is relatively harmless right now (and I'll be informing Japanese Jinteki users since this will reset the language back to English), but it'll be important for localized data import as we'll otherwise have to add mappings (i.e. jp->ja, kr->ko, ...).