### PR TITLE
added aria live to in-game log, and added aria label to icon pattern …

### DIFF
--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -205,7 +205,8 @@
          (into [:div.messages {:class [(when (:replay @game-state)
                                          "panel-bottom")]
                                :on-mouse-over #(card-preview-mouse-over % zoom-channel)
-                               :on-mouse-out #(card-preview-mouse-out % zoom-channel)}]
+                               :on-mouse-out #(card-preview-mouse-out % zoom-channel)
+                               :aria-live "polite"}]
                (map
                  (fn [{:keys [user text timestamp]}]
                    ^{:key timestamp}

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -151,7 +151,7 @@
 (def icon-patterns
   "A sequence of icon pattern pairs consisting of an regex, used to match icon
   codes, and the span fragment that should replace it"
-  (letfn [(span-of [icon] [:span {:class (str "anr-icon " icon) :title (str " " icon) :aria-label (str icon) :role (str "img") }])
+  (letfn [(span-of [icon] [:span {:class (str "anr-icon " icon) :title (str " " icon) :aria-label (str icon) :role ("img") }])
           (regex-of [icon-code] (re-pattern (str "(?i)" (regex-escape icon-code))))]
     (->> {"[credit]" "credit"
           "[credits]" "credit"

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -151,7 +151,7 @@
 (def icon-patterns
   "A sequence of icon pattern pairs consisting of an regex, used to match icon
   codes, and the span fragment that should replace it"
-  (letfn [(span-of [icon] [:span {:class (str "anr-icon " icon) :title (str " " icon)}])
+  (letfn [(span-of [icon] [:span {:class (str "anr-icon " icon) :title (str " " icon) :aria-label (str icon) :role (str "img") }])
           (regex-of [icon-code] (re-pattern (str "(?i)" (regex-escape icon-code))))]
     (->> {"[credit]" "credit"
           "[credits]" "credit"


### PR DESCRIPTION
…pairs. This would make it so a screen reader would read out the events of a game/replay as it was happening.

https://www.youtube.com/watch?v=XxEfvgoZd3Y Here's a video showing it in action.

I'm not sure about the change for icons. I noticed there's a tooltip that appears when you hover over the icons, the code that creates that tooltip may be a better place to add the aria-label.

References:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions