### PR TITLE
Pause lobby updates when lobby view is closed or window is inactive

### DIFF
--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -8,7 +8,7 @@
 
 (defn register-user
   [app-state uid user]
-  (assoc-in app-state [:users uid] (assoc user :uid uid)))
+  (assoc-in app-state [:users uid] (assoc user :uid uid :lobby-updates true)))
 
 (defn uid->lobby
   ([uid] (uid->lobby (:lobbies @app-state) uid))
@@ -57,3 +57,11 @@
         new-users (dissoc users uid)
         _ (println "NEW USERS" new-users)]
     (swap! app-state #(assoc %1 :users new-users))))
+
+(defn pause-lobby-updates
+  [uid]
+  (swap! app-state assoc-in [:users uid :lobby-updates] false))
+
+(defn continue-lobby-updates
+  [uid]
+  (swap! app-state assoc-in [:users uid :lobby-updates] true))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -189,7 +189,8 @@
   ([]
    (let [user-cache (:users @app-state/app-state)
          uids (ws/connected-uids)
-         users (map #(get user-cache %) uids)]
+         users (map #(get user-cache %) uids)
+         users (filter #(:lobby-updates %) users)]
      (broadcast-lobby-list users)))
   ([users]
    (assert (or (sequential? users) (nil? users)) (str "Users must be a sequence: " (pr-str users)))
@@ -651,3 +652,14 @@
     (if (and lobby (in-lobby? uid lobby))
       (update-in lobbies [gameid :mute-spectators] not)
       lobbies)))
+
+(defmethod ws/-msg-handler :lobby/pause-updates
+  [{{user :user} :ring-req
+    uid :uid}]
+  (app-state/pause-lobby-updates uid))
+
+(defmethod ws/-msg-handler :lobby/continue-updates
+  [{{user :user} :ring-req
+    uid :uid}]
+  (app-state/continue-lobby-updates uid)
+  (send-lobby-list uid))

--- a/src/cljs/nr/lobby.cljs
+++ b/src/cljs/nr/lobby.cljs
@@ -223,10 +223,14 @@
 (defn games-list-panel [state games current-game user visible-formats]
   [:div.games
    [button-bar state games current-game user visible-formats]
-   (if (= "angel-arena" (:room @state))
-     [angel-arena/game-list state {:games games
-                                   :current-game current-game}]
-     [game-list state user games current-game])])
+   (if @ws/lobby-updates-state
+     (if (= "angel-arena" (:room @state))
+       [angel-arena/game-list state {:games games
+                                     :current-game current-game}]
+       [game-list state user games current-game])
+     [:div
+      "Lobby updates halted." ; this should never be visible
+      [:button {:on-click #(ws/lobby-updates-continue!)} "Reenable lobby updates"]])])
 
 (defn right-panel
   [state decks current-game user]

--- a/src/cljs/nr/lobby.cljs
+++ b/src/cljs/nr/lobby.cljs
@@ -21,6 +21,8 @@
    [taoensso.sente :as sente]))
 
 (defmethod ws/event-msg-handler :lobby/list [{data :?data}]
+  (when (get-in @app-state [:current-game :started] false) ; Pause lobby updates if in game
+    (ws/lobby-updates-pause!))
   (swap! app-state assoc :games data))
 
 (defmethod ws/event-msg-handler :lobby/state [{data :?data}]

--- a/src/cljs/nr/ws.cljs
+++ b/src/cljs/nr/ws.cljs
@@ -3,6 +3,7 @@
    [nr.ajax :refer [?csrf-token]]
    [nr.appstate :refer [app-state current-gameid]]
    [nr.utils :refer [non-game-toast]]
+   [reagent.core :as r]
    [taoensso.sente  :as sente :refer [start-client-chsk-router!]]))
 
 (defonce lock (atom false))
@@ -70,3 +71,14 @@
           (start-client-chsk-router!
             ch-chsk
             event-msg-handler-wrapper)))
+
+(def lobby-updates-state (r/atom true))
+(defn lobby-updates-pause! []
+  (ws-send! [:lobby/pause-updates])
+  (reset! lobby-updates-state false)
+  (print "lobby-updates-state:" @lobby-updates-state))
+
+(defn lobby-updates-continue! []
+  (ws-send! [:lobby/continue-updates])
+  (reset! lobby-updates-state true)
+  (print "lobby-updates-state:" @lobby-updates-state))

--- a/src/cljs/nr/ws.cljs
+++ b/src/cljs/nr/ws.cljs
@@ -75,10 +75,8 @@
 (def lobby-updates-state (r/atom true))
 (defn lobby-updates-pause! []
   (ws-send! [:lobby/pause-updates])
-  (reset! lobby-updates-state false)
-  (print "lobby-updates-state:" @lobby-updates-state))
+  (reset! lobby-updates-state false))
 
 (defn lobby-updates-continue! []
   (ws-send! [:lobby/continue-updates])
-  (reset! lobby-updates-state true)
-  (print "lobby-updates-state:" @lobby-updates-state))
+  (reset! lobby-updates-state true))


### PR DESCRIPTION
Pauses lobby updates while:
1. the window is minimized / a different tab is opened,
2. the lobby is not shown (i.e. while in another tab or while in a game).