### PR TITLE
Update jnet image URL

### DIFF
--- a/src/clj/tasks/nrdb.clj
+++ b/src/clj/tasks/nrdb.clj
@@ -16,7 +16,7 @@
     [tasks.setup :refer [connect disconnect]]))
 
 (def ^:const edn-base-url "https://raw.githubusercontent.com/NoahTheDuke/netrunner-data/master/edn/raw_data.edn")
-(def ^:const jnet-image-url "https://static.nrdbassets.com/v1/large/")
+(def ^:const jnet-image-url "https://card-images.netrunnerdb.com/v1/large/")
 
 (defn download-edn-data
   [localpath]


### PR DESCRIPTION
The main NRDB image URL has changed and new cards are only available on this domain going forward.