### PR TITLE
Remove Audacity on play message from Shipment from Vladisibirsk

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -2524,7 +2524,6 @@
     {:on-play
      {:async true
       :req (req (<= 2 (count-tags state)))
-      :msg "trash all cards in HQ"
       :effect (effect (continue-ability (ability 4) card nil))}}))
 
 (defcard "Shoot the Moon"


### PR DESCRIPTION
Was spectating a game and noticed this message popped up in the logs. Assumed it's just accidental copy and paste from Audacity implementation.