### PR TITLE
Put cards back from play area after undoing a click

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -179,6 +179,8 @@
   (when-let [click-state (:click-state @state)]
     (when (= (:active-player @state) side)
       (reset! state (assoc click-state :log (:log @state) :click-state click-state :run nil :history (:history @state)))
+      (doseq [c (filter #(not (has-subtype? % "Lockdown")) (:play-area (side @state)))]
+        (move state side c (:previous-zone c) {:suppress-event true}))
       (system-say state side (str "[!] " (if (= side :corp) "Corp" "Runner") " uses the undo-click command"))
       (doseq [s [:runner :corp]]
         (toast state s "Game reset to start of click")))))

--- a/test/clj/game/core/actions_test.clj
+++ b/test/clj/game/core/actions_test.clj
@@ -46,6 +46,30 @@
     (is (= 4 (:click (get-runner))) "Runner back to 4 clicks")
     (is (= 5 (:credit (get-runner))) "Runner back to 5 credits")))
 
+(deftest undo-click-return-card-from-play-area
+  (do-game
+   (new-game {:corp {:deck ["Predictive Planogram"]}
+              :runner {:deck ["Dirty Laundry"]}})
+   (play-from-hand state :corp "Predictive Planogram")
+   (core/command-undo-click state :corp)
+   (is (= 0 (count (:play-area (get-corp)))) "Corp play area is empty")
+   (is (= 1 (count (:hand (get-corp)))) "Corp has 1 card in HQ")
+   (take-credits state :corp)
+   (play-from-hand state :runner "Dirty Laundry")
+   (core/command-undo-click state :runner)
+   (is (= 0 (count (:play-area (get-runner)))) "Runner play area is empty")
+   (is (= 1 (count (:hand (get-runner)))) "Player has 1 card in grip")))
+
+(deftest undo-click-does-not-return-lockdown-from-play-area
+  (do-game
+   (new-game {:corp {:deck ["NAPD Cordon" "Predictive Planogram"]}
+              :runner {:deck ["Dirty Laundry"]}})
+   (play-from-hand state :corp "NAPD Cordon")
+   (play-from-hand state :corp "Predictive Planogram")
+   (core/command-undo-click state :corp)
+   (is (= 1 (count (:play-area (get-corp)))) "Corp play area still has NAPD Cordon")
+   (is (= 1 (count (:hand (get-corp)))) "Corp has 1 card in HQ")))
+
 (deftest undo-click-with-bioroid-cost
   (do-game
     (new-game {:corp {:deck [(qty "Hedge Fund" 5)]


### PR DESCRIPTION
This is something I get bit by quite a bit - probably every other game or so - and I see it very frequently when spectating games.

Looking briefly into why this issue happens, I believe that the state of the previous click is saved when the cost of the click is being paid.  Since this happens after the card being played has been moved into the play area, the resulting state is just between the card being played and the cost being activated, and it ends up stuck in the play area.

My thought was to see if at this point it would also be fine to just put any cards in the play area back to where their previous zone was.  I wasn't sure if this was safe to do or could potentially affect randomness or shuffle if cards were brought into the play area from the Stack or R&D - happy to write a few more tests for these cases, I don't know the full card pool enough to know off the top of my head.  I think because the state returns to the time of cost then there shouldn't be much else to reset besides card being in the play area.

I specifically ignored doing anything with Lockdowns as they also live in the play area while active.  I figured if someone wanted to undo a click of playing the lockdown then it's just as annoying as it is now to drag it manually into HQ - but this fix hopefully touches the vast majority of cases of forgetting to drag it back.

A potential alternative is to have some kind of warning message if there's still a card in the play area after undoing a click so that it's easy to realize that it's happened.