### PR TITLE
Fix Hermes and Leela being able to bounce Public agendas

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1056,7 +1056,7 @@
 (defcard "Hermes"
   (let [leela {:interactive (req true)
                :prompt "Choose an unrezzed card to return to HQ"
-               :choices {:card #(and (not (rezzed? %))
+               :choices {:card #(and (not (faceup? %))
                                      (installed? %)
                                      (corp? %))}
                :msg (msg "add " (card-str state target) " to HQ")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1187,7 +1187,7 @@
 (defcard "Leela Patel: Trained Pragmatist"
   (let [leela {:interactive (req true)
                :prompt "Choose an unrezzed card to return to HQ"
-               :choices {:card #(and (not (rezzed? %))
+               :choices {:card #(and (not (faceup? %))
                                      (installed? %)
                                      (corp? %))}
                :msg (msg "add " (card-str state target) " to HQ")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -4,7 +4,7 @@
    [game.core.access :refer [access-bonus max-access]]
    [game.core.board :refer [all-active all-active-installed all-installed all-installed-runner-type
                             card->server server->zone]]
-   [game.core.card :refer [active? agenda? asset? card-index corp? facedown?
+   [game.core.card :refer [active? agenda? asset? card-index corp? facedown? faceup?
                            get-advancement-requirement get-card get-counters
                            get-nested-host get-title get-zone
                            hardware? has-subtype? in-hand? in-discard? ice? installed?
@@ -477,7 +477,7 @@
                   :ability
                   {:prompt "Choose a card to shuffle into R&D"
                    :choices {:card #(and (not (ice? %))
-                                         (not (rezzed? %))
+                                         (not (faceup? %))
                                          (zero? (get-counters % :advancement)))}
                    :msg (msg "shuffle " (card-str state target) " into R&D")
                    :effect (effect (move :corp target :deck)

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -2180,6 +2180,22 @@
       (is (= 4 (count (:discard (get-runner)))) "Prevented 1 of 3 net damage; used facedown card")
       (is (last-n-log-contains? state 2 "Runner trashes 1 installed card \\(a facedown card\\) to use Heartbeat to prevent 1 damage\\.")))))
 
+(deftest hermes-public-agenda
+  (do-game
+   (new-game {:runner {:hand ["Hermes"]}
+              :corp {:hand ["Ice Wall" "Oaktown Renovation" "Oaktown Renovation"]}})
+   (play-from-hand state :corp "Oaktown Renovation" "New remote")
+   (play-from-hand state :corp "Oaktown Renovation" "New remote")
+   (play-from-hand state :corp "Ice Wall" "Server 1")
+   (take-credits state :corp)
+   (play-from-hand state :runner "Hermes")
+   (run-empty-server state :remote2)
+   (click-prompt state :runner "Steal")
+   (click-card state :runner (get-content state :remote1 0))
+   (is (= 0 (count (:hand (get-corp)))) "Hermes can not bounce Public agenda")
+   (click-card state :runner (get-ice state :remote1 0))
+   (is (= 1 (count (:hand (get-corp)))) "Hermes can bounce facedown ice")))
+
 (deftest hijacked-router-run-on-archives
     ;; Run on Archives
     (do-game

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -2759,6 +2759,21 @@
       (click-card state :runner (get-content state :remote1 0))
       (is (not (:run @state)) "Run is over")))
 
+(deftest leela-patel-trained-pragmatist-public-agenda
+    ;; agendas with Public subtype are neither rezzed or unrezzed
+    (do-game
+      (new-game {
+                 :corp {:hand ["Ice Wall" "Oaktown Renovation" "Oaktown Renovation"]}
+                 :runner {:id "Leela Patel: Trained Pragmatist"}})
+      (play-from-hand state :corp "Oaktown Renovation" "New remote")
+      (play-from-hand state :corp "Oaktown Renovation" "New remote")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (take-credits state :corp)
+      (run-empty-server state :remote2)
+      (click-prompt state :runner "Steal")
+      (click-card state :runner (get-content state :remote1 0))
+      (is (= 0 (count (:hand (get-corp)))) "Leela can not bounce Public agenda")))
+
 (deftest leela-patel-trained-pragmatist-upgrades-returned-to-hand-in-the-middle-of-a-run-do-not-break-the-run-issue-2008
     ;; upgrades returned to hand in the middle of a run do not break the run. Issue #2008
     (do-game

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -390,11 +390,13 @@
   ;; Analog Dreamers
   (do-game
     (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
-                      :hand ["Hostile Takeover" "PAD Campaign"]}
+                      :hand ["Hostile Takeover" "PAD Campaign" "Oaktown Renovation"]}
                :runner {:hand ["Analog Dreamers"]}})
+    (core/gain state :corp :click 1)
     (play-from-hand state :corp "Hostile Takeover" "New remote")
     (play-from-hand state :corp "PAD Campaign" "New remote")
     (advance state (get-content state :remote1 0) 1)
+    (play-from-hand state :corp "Oaktown Renovation" "New remote")
     (take-credits state :corp)
     (play-from-hand state :runner "Analog Dreamers")
     (card-ability state :runner (get-program state 0) 0)
@@ -403,6 +405,9 @@
     (click-card state :runner "Hostile Takeover")
     (is (= "Choose a card to shuffle into R&D" (:msg (prompt-map :runner)))
         "Can't click on Hostile Takeover")
+    (click-card state :runner "Oaktown Renovation")
+    (is (= "Choose a card to shuffle into R&D" (:msg (prompt-map :runner)))
+        "Can't click on Oaktown Renovation because it's face up")
     (let [number-of-shuffles (count (core/turn-events state :corp :corp-shuffle-deck))
           pad (get-content state :remote2 0)]
       (click-card state :runner "PAD Campaign")


### PR DESCRIPTION
I ended up doing this in a game and realizing it was probably not allowed.  Looking into new printing of Oaktown Renovation and it's clear neither of these should be able to bounce it.

<img width="320" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/b27e013f-e8cd-449f-a779-de1e5caa13e8">

EDIT: Searched through and found one more that should follow this rule which is Analog Dreamers, very rotated but maybe it gets brought back in some System Update.