### PR TITLE
Case insensitive email check when handling forget password

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -93,7 +93,7 @@
 
 (defn find-non-banned-user
   [db query]
-  (active-user? (mc/find-one-as-map db "users" query)))
+  (active-user? (find-one-as-map-case-insensitive db "users" query)))
 
 (defn login-handler
   [{db :system/db


### PR DESCRIPTION
A user sent me an email because when trying to reset his password, his email was not recognised. When trying to create an account with the same email, he got an error message saying the email is already used.

It turns out the email linked to his account has a capital letter.

