### PR TITLE
Fix Persistent issue with Tucana

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1681,8 +1681,10 @@
 (defcard "Tucana"
   (let [ability {:async true
                  :prompt "Choose a piece of ice to install and rez"
-                 :choices (req (cancellable (filter ice? (:deck corp))))
-                 :effect (req (corp-install state side eid target nil {:install-state :rezzed :combined-credit-discount 3}))
+                 :choices (req (cancellable (filter ice? (:deck corp)) true))
+                 :effect (req (do (corp-install state side eid target nil {:install-state :rezzed :combined-credit-discount 3})
+                                  (shuffle! state :corp :deck)
+                                  (system-msg state side (str "shuffles R&D"))))
                  :cancel-effect (effect (system-msg  "declines to use Tucana to install a card")
                                         (effect-completed eid))}]
     {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
@@ -1698,7 +1700,7 @@
                         card
                         [(assoc ability
                                 :event :agenda-stolen
-                                :req (req (= (second (:previous-zone card)) (first (:server context))))
+                                :req (req (= (:previous-zone card) (:previous-zone (:card context))))
                                 :duration :end-of-run)]))}}))
 
 (defcard "Tyr's Hand"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1682,9 +1682,10 @@
   (let [ability {:async true
                  :prompt "Choose a piece of ice to install and rez"
                  :choices (req (cancellable (filter ice? (:deck corp)) true))
-                 :effect (req (do (corp-install state side eid target nil {:install-state :rezzed :combined-credit-discount 3})
-                                  (shuffle! state :corp :deck)
-                                  (system-msg state side (str "shuffles R&D"))))
+                 :effect (req (wait-for (corp-install state side (make-eid state eid) target nil {:install-state :rezzed :combined-credit-discount 3})
+                                        (shuffle! state :corp :deck)
+                                        (system-msg state side (str "shuffles R&D"))
+                                        (effect-completed state side eid)))
                  :cancel-effect (effect (system-msg  "declines to use Tucana to install a card")
                                         (effect-completed eid))}]
     {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -3996,6 +3996,44 @@
       (click-prompt state :corp "Server 1")
       (click-prompt state :corp "Gain 2 [Credits]"))))
 
+(deftest tucana-corp-scores
+  (do-game
+    (new-game {:corp {:deck ["Ice Wall" "Fire Wall"]
+                      :hand ["Tucana" "Project Atlas"]}})
+    (play-from-hand state :corp "Tucana" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (play-from-hand state :corp "Project Atlas" "Server 1")
+    (score-agenda state :corp (get-content state :remote1 1))
+    (changes-val-macro
+      -2 (:credit (get-corp))
+      "Corp spends 5 - 3 credits to rez Fire Wall"
+      (is (= ["Fire Wall" "Ice Wall" nil] (prompt-titles :corp)))
+      (click-prompt state :corp "Fire Wall")
+      (is (= ["Archives" "R&D" "HQ" "Server 1" "New remote"] (prompt-buttons :corp)))
+      (click-prompt state :corp "HQ")
+      (is (= "Fire Wall" (:title (first (get-in @state [:corp :servers :hq :ices])))) "Fire Wall on HQ"))))
+
+(deftest tucana-runner-steals
+  (do-game
+    (new-game {:corp {:deck ["Ice Wall" "Fire Wall"]
+                     :hand ["Tucana" "Project Atlas"]}})
+    (play-from-hand state :corp "Tucana" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (play-from-hand state :corp "Project Atlas" "Server 1")
+    (take-credits state :corp)
+    (run-empty-server state "Server 1")
+    (click-card state :runner (get-content state :remote1 0))
+    (click-prompt state :runner "Pay 1 [Credits] to trash")
+    (changes-val-macro
+      -2 (:credit (get-corp))
+      "Corp spends 5 - 3 credits to rez Fire Wall"
+       (click-prompt state :runner "Steal")
+       (is (= ["Fire Wall" "Ice Wall" nil] (prompt-titles :corp)) "Tucana persistent, effect fires")
+       (click-prompt state :corp "Fire Wall")
+       (is (= ["Archives" "R&D" "HQ" "New remote"] (prompt-buttons :corp)) "Corp choices should not include original server as it's gone")
+       (click-prompt state :corp "HQ")
+       (is (= "Fire Wall" (:title (first (get-in @state [:corp :servers :hq :ices])))) "Fire Wall on HQ"))))
+
 (deftest underway-grid
   ;; Underway Grid - prevent expose of cards in server
   (do-game


### PR DESCRIPTION
Fixes issue where Tucana would not trigger after being trashed - I think its previous implementation expected a context from a run-end event (i.e. AMAZE) instead of agenda-stolen.

Also make sure Tucana shuffles R&D after firing.