### PR TITLE
Use effects for unrunnable servers

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [game.core.access :refer [access-card breach-server get-only-card-to-access
                              num-cards-to-access]]
-   [game.core.actions :refer [can-run-server? get-runnable-zones]]
    [game.core.agendas :refer [update-all-agenda-points]]
    [game.core.bad-publicity :refer [gain-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed server->zone]]
@@ -53,8 +52,8 @@
    [game.core.props :refer [add-counter add-icon add-prop remove-icon]]
    [game.core.revealing :refer [reveal]]
    [game.core.rezzing :refer [derez get-rez-cost rez]]
-   [game.core.runs :refer [bypass-ice gain-next-run-credits make-run
-                           prevent-access successful-run-replace-breach
+   [game.core.runs :refer [bypass-ice can-run-server? gain-next-run-credits get-runnable-zones
+                           make-run prevent-access successful-run-replace-breach
                            total-cards-accessed]]
    [game.core.sabotage :refer [sabotage-ability]]
    [game.core.say :refer [system-msg]]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [game.core.access :refer [access-card breach-server get-only-card-to-access
                              num-cards-to-access]]
-   [game.core.actions :refer [get-runnable-zones]]
+   [game.core.actions :refer [can-run-server? get-runnable-zones]]
    [game.core.agendas :refer [update-all-agenda-points]]
    [game.core.bad-publicity :refer [gain-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed server->zone]]
@@ -28,7 +28,7 @@
                              turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-cid find-latest]]
-   [game.core.flags :refer [any-flag-fn? can-rez? can-run-server?
+   [game.core.flags :refer [any-flag-fn? can-rez?
                             clear-all-flags-for-card! clear-run-flag! clear-turn-flag!
                             in-corp-scored? register-run-flag! register-turn-flag! zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-clicks
@@ -246,7 +246,7 @@
   {:makes-run true
    :on-play {:async true
              :prompt "Choose a server"
-             :choices (req (filter #(can-run-server? state %) remotes))
+             :choices (req (cancellable (filter #(can-run-server? state %) remotes)))
              :effect (effect (make-run eid target card))}
    :events [(successful-run-replace-breach
               {:target-server :remote

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -26,7 +26,6 @@
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-latest]]
    [game.core.flags :refer [card-flag? clear-persistent-flag!
-                            enable-run-on-server prevent-run-on-server
                             register-persistent-flag! register-turn-flag! zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-credits]]
    [game.core.hand-size :refer [corp-hand-size+ hand-size+]]
@@ -1057,18 +1056,9 @@
                             (mill state :corp eid :runner 1)))}]})
 
 (defcard "Jinteki: Replicating Perfection"
-  {:events [{:event :runner-phase-12
-             :effect (req (apply prevent-run-on-server
-                                 state card (map first (get-remotes state))))}
-            {:event :run
-             :once :per-turn
-             :req (req (is-central? (:server target)))
-             :effect (req (apply enable-run-on-server
-                                 state card (map first (get-remotes state))))}]
-   :req (req (empty? (let [successes (turn-events state side :successful-run)]
-                       (filter is-central? (map :server successes)))))
-   :effect (req (apply prevent-run-on-server state card (map first (get-remotes state))))
-   :leave-play (req (apply enable-run-on-server state card (map first (get-remotes state))))})
+  {:constant-effects [{:type :cannot-run-on-server
+                       :req (req (no-event? state side :run #(is-central? (:server (first %)))))
+                       :value (req (map first (get-remotes state)))}]})
 
 (defcard "Jinteki: Restoring Humanity"
   {:events [{:event :corp-turn-ends

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [game.core.access :refer [access-bonus access-n-cards breach-server steal
                              steal-cost-bonus]]
-   [game.core.actions :refer [get-runnable-zones]]
+   [game.core.actions :refer [can-run-server? get-runnable-zones]]
    [game.core.agendas :refer [update-all-advancement-requirements
                               update-all-agenda-points]]
    [game.core.bad-publicity :refer [gain-bad-publicity]]
@@ -32,7 +32,7 @@
                              first-installed-trash-own? first-run-event?
                              first-successful-run-on-server? get-turn-damage no-event? second-event? turn-events]]
    [game.core.expose :refer [expose]]
-   [game.core.flags :refer [can-run-server? card-flag? clear-persistent-flag!
+   [game.core.flags :refer [card-flag? clear-persistent-flag!
                             has-flag? in-corp-scored?
                             register-persistent-flag! register-turn-flag! zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-clicks

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [game.core.access :refer [access-bonus access-n-cards breach-server steal
                              steal-cost-bonus]]
-   [game.core.actions :refer [can-run-server? get-runnable-zones]]
    [game.core.agendas :refer [update-all-advancement-requirements
                               update-all-agenda-points]]
    [game.core.bad-publicity :refer [gain-bad-publicity]]
@@ -60,7 +59,8 @@
    [game.core.props :refer [add-counter add-icon remove-icon]]
    [game.core.revealing :refer [reveal]]
    [game.core.rezzing :refer [derez rez]]
-   [game.core.runs :refer [bypass-ice gain-run-credits get-current-encounter
+   [game.core.runs :refer [bypass-ice can-run-server? get-runnable-zones
+                           gain-run-credits get-current-encounter
                            update-current-encounter
                            make-run set-next-phase
                            successful-run-replace-breach total-cards-accessed]]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -25,9 +25,8 @@
    [game.core.events :refer [first-event? first-run-event? turn-events]]
    [game.core.expose :refer [expose-prevent]]
    [game.core.finding :refer [find-cid find-latest]]
-   [game.core.flags :refer [clear-persistent-flag! enable-run-on-server
-                            is-scored? prevent-run-on-server
-                            register-persistent-flag! register-run-flag!]]
+   [game.core.flags :refer [clear-persistent-flag! is-scored? register-persistent-flag!
+                            register-run-flag!]]
    [game.core.gaining :refer [gain-credits lose-clicks lose-credits]]
    [game.core.hand-size :refer [corp-hand-size+]]
    [game.core.ice :refer [all-subs-broken? get-run-ices pump-ice resolve-subroutine!
@@ -1302,16 +1301,14 @@
 
 (defcard "Off the Grid"
   {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
-   :on-rez {:effect (req (prevent-run-on-server state card (second (get-zone card))))}
-   :events [{:event :runner-turn-begins
-             :effect (req (prevent-run-on-server state card (second (get-zone card))))}
-            {:event :successful-run
+   :constant-effects [{:type :cannot-run-on-server
+                       :req (req (rezzed? card))
+                       :value (req (second (get-zone card)))}]
+   :events [{:event :successful-run
              :req (req (= :hq (target-server context)))
              :async true
              :msg "trash itself"
-             :effect (req (enable-run-on-server state card (second (get-zone card)))
-                          (trash state :corp eid card {:cause-card card}))}]
-   :leave-play (req (enable-run-on-server state card (second (get-zone card))))})
+             :effect (req (trash state :corp eid card {:cause-card card}))}]})
 
 (defcard "Old Hollywood Grid"
   (let [ohg {:effect (effect

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -432,7 +432,6 @@
    clear-run-register!
    clear-turn-flag!
    clear-turn-register!
-   ;enable-run-on-server
    get-card-prevention
    get-prevent-list
    get-preventing-cards
@@ -445,7 +444,6 @@
    prevent-current
    prevent-draw
    prevent-jack-out
-   ;prevent-run-on-server
    register-persistent-flag!
    register-run-flag!
    register-turn-flag!

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -113,6 +113,7 @@
 (expose-vars
   [game.core.actions
    advance
+   can-run-server?
    click-advance
    click-credit
    click-draw
@@ -416,7 +417,6 @@
    can-advance?
    can-host?
    can-rez?
-   can-run-server?
    can-run?
    can-score?
    can-steal?
@@ -432,7 +432,7 @@
    clear-run-register!
    clear-turn-flag!
    clear-turn-register!
-   enable-run-on-server
+   ;enable-run-on-server
    get-card-prevention
    get-prevent-list
    get-preventing-cards
@@ -445,7 +445,7 @@
    prevent-current
    prevent-draw
    prevent-jack-out
-   prevent-run-on-server
+   ;prevent-run-on-server
    register-persistent-flag!
    register-run-flag!
    register-turn-flag!

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -113,7 +113,6 @@
 (expose-vars
   [game.core.actions
    advance
-   can-run-server?
    click-advance
    click-credit
    click-draw
@@ -122,7 +121,6 @@
    do-purge
    generate-install-list
    generate-runnable-zones
-   get-runnable-zones
    move-card
    play
    play-ability
@@ -714,6 +712,7 @@
    add-run-effect
    bypass-ice
    can-bypass-ice
+   can-run-server?
    check-auto-no-action
    check-for-empty-server
    complete-run
@@ -725,6 +724,7 @@
    gain-next-run-credits
    gain-run-credits
    get-current-encounter
+   get-runnable-zones
    handle-end-run
    jack-out
    jack-out-prevent

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -20,7 +20,7 @@
     [game.core.prompt-state :refer [remove-from-prompt-queue]]
     [game.core.prompts :refer [resolve-select]]
     [game.core.props :refer [add-counter add-prop set-prop]]
-    [game.core.runs :refer [continue total-run-cost]]
+    [game.core.runs :refer [can-run-server? continue get-runnable-zones total-run-cost]]
     [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.servers :refer [name-zone unknown->kw zones->sorted-names]]
     [game.core.to-string :refer [card-str]]
@@ -523,26 +523,9 @@
         (swap! state assoc-in [:corp :install-list] (installable-servers state card)))
       (swap! state dissoc-in [:corp :install-list]))))
 
-(defn get-runnable-zones
-  ([state] (get-runnable-zones state :runner (make-eid state) nil nil))
-  ([state side] (get-runnable-zones state side (make-eid state) nil nil))
-  ([state side card] (get-runnable-zones state side (make-eid state) card nil))
-  ([state side card args] (get-runnable-zones state side (make-eid state) card args))
-  ([state side eid card {:keys [zones ignore-costs]}]
-   (let [restricted-zones (distinct (flatten (get-effects state side nil :cannot-run-on-server)))
-         permitted-zones (remove (set restricted-zones) (or zones (get-zones state)))]
-     (if ignore-costs
-       permitted-zones
-       (filter #(can-pay? state :runner eid card nil (total-run-cost state side card {:server (unknown->kw %)}))
-               permitted-zones)))))
-
 (defn generate-runnable-zones
   [state _ _]
   (swap! state assoc-in [:runner :runnable-list] (zones->sorted-names (get-runnable-zones state))))
-
-(defn can-run-server?
-  [state server]
-  (some #{(unknown->kw server)} (seq (get-runnable-zones state))))
 
 (defn advance
   "Advance a corp card that can be advanced.

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -154,35 +154,6 @@
   [state side card flag]
   (clear-flag-for-card! state side card :persistent flag))
 
-;;; Functions related to servers that can be run
-;(defn prevent-run-on-server
-;  "Adds specified server to list of servers that cannot be run on.
-;  The causing card is also specified"
-;  [state card & servers]
-;  (doseq [server servers]
-;    (swap! state assoc-in [:runner :register :cannot-run-on-server server (:cid card)] true)))
-
-;(defn enable-run-on-server
-;  "Removes specified server from list of server for the associated card.
-;  If other cards are associated with the same server that server will still be unable to be run
-;  on."
-;  [state card & servers]
-;  (doseq [server servers]
-;    (let [card-map (get-in @state [:runner :register :cannot-run-on-server server])
-;          reduced-card-map (dissoc card-map (:cid card))]
-;      (if (empty? reduced-card-map)
-;        ;; removes server if no cards block it, otherwise updates the map
-;        (swap! state update-in [:runner :register :cannot-run-on-server] dissoc server)
-;        (swap! state assoc-in [:runner :register :cannot-run-on-server server]
-;               reduced-card-map)))))
-
-;(defn can-run-server?
-;  "Returns true if the specified server can be run on. Specified server must be string form."
-;  [state server]
-;  (not-any? #{server}
-;            (map zone->name (keys (get-in @state [:runner :register :cannot-run-on-server])))))
-
-
 ;;; Functions for preventing specific game actions.
 ;;; TODO: look into migrating these to turn-flags and run-flags.
 (defn prevent-draw [state _]
@@ -200,6 +171,7 @@
 (defn release-zone [state _ cid tside tzone]
   (swap! state update-in [tside :locked tzone] #(remove #{cid} %)))
 
+;; TODO: this can probably be made into costant/floating effects too
 (defn zone-locked?
   [state side zone]
   (seq (get-in @state [side :locked zone])))

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -155,32 +155,32 @@
   (clear-flag-for-card! state side card :persistent flag))
 
 ;;; Functions related to servers that can be run
-(defn prevent-run-on-server
-  "Adds specified server to list of servers that cannot be run on.
-  The causing card is also specified"
-  [state card & servers]
-  (doseq [server servers]
-    (swap! state assoc-in [:runner :register :cannot-run-on-server server (:cid card)] true)))
+;(defn prevent-run-on-server
+;  "Adds specified server to list of servers that cannot be run on.
+;  The causing card is also specified"
+;  [state card & servers]
+;  (doseq [server servers]
+;    (swap! state assoc-in [:runner :register :cannot-run-on-server server (:cid card)] true)))
 
-(defn enable-run-on-server
-  "Removes specified server from list of server for the associated card.
-  If other cards are associated with the same server that server will still be unable to be run
-  on."
-  [state card & servers]
-  (doseq [server servers]
-    (let [card-map (get-in @state [:runner :register :cannot-run-on-server server])
-          reduced-card-map (dissoc card-map (:cid card))]
-      (if (empty? reduced-card-map)
-        ;; removes server if no cards block it, otherwise updates the map
-        (swap! state update-in [:runner :register :cannot-run-on-server] dissoc server)
-        (swap! state assoc-in [:runner :register :cannot-run-on-server server]
-               reduced-card-map)))))
+;(defn enable-run-on-server
+;  "Removes specified server from list of server for the associated card.
+;  If other cards are associated with the same server that server will still be unable to be run
+;  on."
+;  [state card & servers]
+;  (doseq [server servers]
+;    (let [card-map (get-in @state [:runner :register :cannot-run-on-server server])
+;          reduced-card-map (dissoc card-map (:cid card))]
+;      (if (empty? reduced-card-map)
+;        ;; removes server if no cards block it, otherwise updates the map
+;        (swap! state update-in [:runner :register :cannot-run-on-server] dissoc server)
+;        (swap! state assoc-in [:runner :register :cannot-run-on-server server]
+;               reduced-card-map)))))
 
-(defn can-run-server?
-  "Returns true if the specified server can be run on. Specified server must be string form."
-  [state server]
-  (not-any? #{server}
-            (map zone->name (keys (get-in @state [:runner :register :cannot-run-on-server])))))
+;(defn can-run-server?
+;  "Returns true if the specified server can be run on. Specified server must be string form."
+;  [state server]
+;  (not-any? #{server}
+;            (map zone->name (keys (get-in @state [:runner :register :cannot-run-on-server])))))
 
 
 ;;; Functions for preventing specific game actions.

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -47,7 +47,7 @@
       (make-eid state (:eid (:run @state)))))
 
 ;; dependency loop - duplicate of actions/can-run-server?
-(defn- get-runnable-zones
+(defn get-runnable-zones
   ([state] (get-runnable-zones state :runner (make-eid state) nil nil))
   ([state side] (get-runnable-zones state side (make-eid state) nil nil))
   ([state side card] (get-runnable-zones state side (make-eid state) card nil))
@@ -60,7 +60,7 @@
        (filter #(can-pay? state :runner eid card nil (total-run-cost state side card {:server (unknown->kw %)}))
                permitted-zones)))))
 
-(defn- can-run-server?
+(defn can-run-server?
   [state server]
   (some #{(unknown->kw server)} (seq (get-runnable-zones state))))
 ;; end of boilerplate - nbkelly

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -46,7 +46,6 @@
   (or eid
       (make-eid state (:eid (:run @state)))))
 
-;; dependency loop - duplicate of actions/can-run-server?
 (defn get-runnable-zones
   ([state] (get-runnable-zones state :runner (make-eid state) nil nil))
   ([state side] (get-runnable-zones state side (make-eid state) nil nil))
@@ -63,7 +62,6 @@
 (defn can-run-server?
   [state server]
   (some #{(unknown->kw server)} (seq (get-runnable-zones state))))
-;; end of boilerplate - nbkelly
 
 (defn get-current-encounter
   [state]

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -1,14 +1,14 @@
 (ns game.core.runs
   (:require
     [game.core.access :refer [breach-server]]
-    [game.core.board :refer [server->zone]]
+    [game.core.board :refer [get-zones server->zone]]
     [game.core.card :refer [get-card get-zone rezzed?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [jack-out-cost run-cost run-additional-cost-bonus]]
     [game.core.effects :refer [any-effects get-effects]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid make-result]]
     [game.core.engine :refer [checkpoint end-of-phase-checkpoint register-pending-event pay queue-event resolve-ability trigger-event trigger-event-simult]]
-    [game.core.flags :refer [can-run? can-run-server? cards-can-prevent? clear-run-register! get-prevent-list prevent-jack-out]]
+    [game.core.flags :refer [can-run? cards-can-prevent? clear-run-register! get-prevent-list prevent-jack-out]]
     [game.core.gaining :refer [gain-credits]]
     [game.core.ice :refer [active-ice? get-current-ice get-run-ices update-ice-strength reset-all-ice reset-all-subs! set-current-ice]]
     [game.core.mark :refer [is-mark?]]
@@ -45,6 +45,25 @@
   [state eid]
   (or eid
       (make-eid state (:eid (:run @state)))))
+
+;; dependency loop - duplicate of actions/can-run-server?
+(defn- get-runnable-zones
+  ([state] (get-runnable-zones state :runner (make-eid state) nil nil))
+  ([state side] (get-runnable-zones state side (make-eid state) nil nil))
+  ([state side card] (get-runnable-zones state side (make-eid state) card nil))
+  ([state side card args] (get-runnable-zones state side (make-eid state) card args))
+  ([state side eid card {:keys [zones ignore-costs]}]
+   (let [restricted-zones (distinct (flatten (get-effects state side nil :cannot-run-on-server)))
+         permitted-zones (remove (set restricted-zones) (or zones (get-zones state)))]
+     (if ignore-costs
+       permitted-zones
+       (filter #(can-pay? state :runner eid card nil (total-run-cost state side card {:server (unknown->kw %)}))
+               permitted-zones)))))
+
+(defn- can-run-server?
+  [state server]
+  (some #{(unknown->kw server)} (seq (get-runnable-zones state))))
+;; end of boilerplate - nbkelly
 
 (defn get-current-encounter
   [state]

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -34,10 +34,10 @@
       unprotected (let [server (second (game.core.card/get-zone card))]
                     (empty? (get-in @state [:corp :servers server :ices])))
       runnable-servers (game.core.servers/zones->sorted-names
-                         (game.core.actions/get-runnable-zones state side eid card nil))
-      hq-runnable (some #{:hq} (game.core.actions/get-runnable-zones state))
-      rd-runnable (some #{:rd} (game.core.actions/get-runnable-zones state))
-      archives-runnable (some #{:archives} (game.core.actions/get-runnable-zones state))
+                         (game.core.runs/get-runnable-zones state side eid card nil))
+      hq-runnable (some #{:hq} (game.core.runs/get-runnable-zones state))
+      rd-runnable (some #{:rd} (game.core.runs/get-runnable-zones state))
+      archives-runnable (some #{:archives} (game.core.runs/get-runnable-zones state))
       tagged (jinteki.utils/is-tagged? state)
       ;; only intended for use in event listeners on (pre-/post-, un-)successful-run or run-ends
       ;; true if the run was initiated by this card

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -35,9 +35,9 @@
                     (empty? (get-in @state [:corp :servers server :ices])))
       runnable-servers (game.core.servers/zones->sorted-names
                          (game.core.actions/get-runnable-zones state side eid card nil))
-      hq-runnable (some #{:hq} (game.core.actions/get-runnable-zones state));not (:hq (get-in (:runner @state) [:register :cannot-run-on-server])))
-      rd-runnable (some #{:rd} (game.core.actions/get-runnable-zones state));(not (:rd (get-in (:runner @state) [:register :cannot-run-on-server])))
-      archives-runnable (some #{:archives} (game.core.actions/get-runnable-zones state));(not (:archives (get-in (:runner @state) [:register :cannot-run-on-server])))
+      hq-runnable (some #{:hq} (game.core.actions/get-runnable-zones state))
+      rd-runnable (some #{:rd} (game.core.actions/get-runnable-zones state))
+      archives-runnable (some #{:archives} (game.core.actions/get-runnable-zones state))
       tagged (jinteki.utils/is-tagged? state)
       ;; only intended for use in event listeners on (pre-/post-, un-)successful-run or run-ends
       ;; true if the run was initiated by this card

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -35,9 +35,9 @@
                     (empty? (get-in @state [:corp :servers server :ices])))
       runnable-servers (game.core.servers/zones->sorted-names
                          (game.core.actions/get-runnable-zones state side eid card nil))
-      hq-runnable (not (:hq (get-in (:runner @state) [:register :cannot-run-on-server])))
-      rd-runnable (not (:rd (get-in (:runner @state) [:register :cannot-run-on-server])))
-      archives-runnable (not (:archives (get-in (:runner @state) [:register :cannot-run-on-server])))
+      hq-runnable (some #{:hq} (game.core.actions/get-runnable-zones state));not (:hq (get-in (:runner @state) [:register :cannot-run-on-server])))
+      rd-runnable (some #{:rd} (game.core.actions/get-runnable-zones state));(not (:rd (get-in (:runner @state) [:register :cannot-run-on-server])))
+      archives-runnable (some #{:archives} (game.core.actions/get-runnable-zones state));(not (:archives (get-in (:runner @state) [:register :cannot-run-on-server])))
       tagged (jinteki.utils/is-tagged? state)
       ;; only intended for use in event listeners on (pre-/post-, un-)successful-run or run-ends
       ;; true if the run was initiated by this card


### PR DESCRIPTION
Another step in moving away from the flags system entirely.

There's a little bit of cleanup that can be done - notably, `can-run-server` is duplicated in `actions` and `runs` due to dependency issues - I can probably move it entirely to runs.

This means that RP and front company and off the grid and marathon can all work together in the same game (This is still a nightmare scenario, but only for the player now).

Though I can hardly believe it, it all just works.