### PR TITLE
Fix issue with card preview links disappearing

### DIFF
--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -208,7 +208,8 @@
           (map (fn [c] [(tr-data :title c) (span-of (:title c) (tr-data :title c))]))
           (sort-by (comp count str first) >))))))
 
-(def card-patterns (memoize card-patterns-impl))
+(def card-patterns-memo (memoize card-patterns-impl))
+(defn card-patterns [] (card-patterns-memo (:cards-loaded @app-state)))
 
 (defn contains-card-pattern-impl
   "A card pattern regex, used to match a card name in text to check if the rest
@@ -221,7 +222,8 @@
          (map (fn [k] (join "|" (map regex-escape (distinct [(:title k) (tr-data :title k)])))))
          (join "|"))))
 
-(def contains-card-pattern (memoize contains-card-pattern-impl))
+(def contains-card-pattern-memo (memoize contains-card-pattern-impl))
+(defn contains-card-pattern [] (contains-card-pattern-memo (:cards-loaded @app-state)))
 
 (def special-patterns
   (letfn [(regex-of [icon-code] (re-pattern (str "(?i)" (regex-escape icon-code))))]
@@ -291,8 +293,8 @@
   "Render all cards in a given text or HTML fragment input"
   [input]
   (cond
-    (re-find (contains-card-pattern (:cards-loaded @app-state)) (or input ""))
-    (render-input input (card-patterns (:cards-loaded @app-state)))
+    (re-find (contains-card-pattern) (or input ""))
+    (render-input input (card-patterns))
     (string? input) [:<> input]
     (vector? input) input
     :else [:<>]))

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -291,8 +291,8 @@
   "Render all cards in a given text or HTML fragment input"
   [input]
   (cond
-    (re-find (contains-card-pattern) (or input ""))
-    (render-input input (card-patterns))
+    (re-find (contains-card-pattern (:cards-loaded @app-state)) (or input ""))
+    (render-input input (card-patterns (:cards-loaded @app-state)))
     (string? input) [:<> input]
     (vector? input) input
     :else [:<>]))


### PR DESCRIPTION
This happens very frequently to me where the preview links just stop working after a refresh or accidental horizontal scroll turns into a browser back.  This is especially difficult for new players who as runners are only able to see an installed unrezzed card via the preview link when trashing.

I think I've narrowed the issue down to a race condition where the card data isn't loaded yet when the checking functions are memoized and so further invocations don't contain the card data - I was able to reproduce this very consistently by deleting the cards from local storage and throttling the browser requests.

The attached video shows the very simple fix of passing the card loaded state to the memoized function to ensure memoization remains but allows for refresh when cards are loaded.

https://github.com/mtgred/netrunner/assets/5345/a6f7de76-af22-4289-b58e-5f8c1709d7e7

