### PR TITLE
Fix Starlit Knight interaction with ACME Consulting

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -57,7 +57,7 @@
                               target-server zone->name]]
    [game.core.shuffling :refer [shuffle!]]
    [game.core.subtypes :refer [update-all-subtypes]]
-   [game.core.tags :refer [gain-tags lose-tags]]
+   [game.core.tags :refer [gain-tags lose-tags sum-tag-effects]]
    [game.core.threat :refer [threat threat-level]]
    [game.core.to-string :refer [card-str]]
    [game.core.toasts :refer [toast]]
@@ -3539,7 +3539,7 @@
 
 (defcard "Starlit Knight"
   (let [sub-count (fn [state]
-                    (count-tags state))
+                    (sum-tag-effects state))
         sub end-the-run]
     {:on-encounter {:req (req (threat-level 4 state))
                     :effect (effect (gain-variable-subs card (sub-count state) sub {:variable true :front false :end true}))}

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -6461,6 +6461,23 @@
         (fire-subs state (refresh sk)))
       (is (not (:run @state)) "Run ended"))))
 
+(deftest starlit-knight-acme
+  (do-game
+    (new-game {:corp {:id "Acme Consulting: The Truth You Need"
+                      :hand ["Starlit Knight" "Vanity Project"]
+                      :credits 20}})
+    (play-from-hand state :corp "Starlit Knight" "HQ")
+    (let [sk (get-ice state :hq 0)]
+      (rez state :corp sk)
+      (play-and-score state "Vanity Project")
+      (take-credits state :corp)
+      (run-on state :hq)
+      (run-continue state)
+      (is (= ["Give the Runner 1 tag"
+              "Give the Runner 1 tag"
+              "End the run"]
+             (map :label (:subroutines (refresh sk))))))))
+
 (deftest stavka
   (do-game
    (new-game {:corp {:hand ["Stavka" "Prisec"] :credits 10}


### PR DESCRIPTION
Spent a bit of time trawling through backtraces to understand a bit why the issue reported here: #6996 happens.

From what I can tell from the `continue` action will process `on-encounter` (including any ice on-encounter effects) and then do a fake-checkpoint to sort of realign all the different values from what's been processed. Since the fake-checkpoint is the earliest that the tags effects are being reevaluated this leads to the total tags not yet set by the time Starlit Knight's on-encounter happens.  I guess this is generally just a problem with on-encounter effects is that they've run before some constant effects have been reevaluated (maybe this is just limited to tag total?).

I've updated Starlit Knight to just calculate the tag effects directly rather than relying on the stored total, but I wasn't sure if this was risky or too much breaking of encapsulation (since this function isn't used anywhere else currently).