### PR TITLE
Clarify cost to place advancement counter for Vasilisa on-encounter effect

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -3976,7 +3976,7 @@
 
 (defcard "Vasilisa"
   {:on-encounter
-   {:optional {:prompt "Place 1 advancement counter on a card that can be advanced?"
+   {:optional {:prompt "Pay 1 [Credits] to place 1 advancement counter on a card that can be advanced?"
                :waiting-prompt true
                :req (req (and (can-pay? state side eid card nil [:credit 1])
                               (some #(or (not (rezzed? %))


### PR DESCRIPTION
First PR here :)

On encounter, Vasilisa would prompt: 

> Place 1 advancement counter on a card that can be advanced?

I found this a bit misleading, as it's not clear from the prompt that it actually costs 1 credit. This PR changes the prompt to:

> Pay 1 [Credits] to place 1 advancement counter on a card that can be advanced?

which makes the cost clear to the user. 