### PR TITLE
Adopt official terminology, part 1

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -19,7 +19,7 @@
    [game.core.def-helpers :refer [corp-recur defcard do-net-damage
                                   offer-jack-out reorder-choice get-x-fn]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [register-floating-effect]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed make-eid]]
    [game.core.engine :refer [pay register-events resolve-ability
                              unregister-events]]
@@ -235,12 +235,12 @@
                 :req (req run)
                 :label "increase cost to break subroutines or jack out"
                 :msg "make the Runner trash a card from the grip as an additional cost to jack out or break subroutines for the remainder of the run"
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                   card
                                   {:type :break-sub-additional-cost
                                    :duration :end-of-run
                                    :value (req (repeat (count (:broken-subs (second targets))) [:trash-from-hand 1]))})
-                                (register-floating-effect
+                                (register-lingering-effect
                                   card
                                   {:type :jack-out-additional-cost
                                    :duration :end-of-run
@@ -601,7 +601,7 @@
              :interactive (req true)
              :psi {:req (req (= :hq (target-server context)))
                    :once :per-turn
-                   :not-equal {:effect (effect (register-floating-effect
+                   :not-equal {:effect (effect (register-lingering-effect
                                                  card
                                                  {:type :corp-choose-hq-access
                                                   :duration :end-of-run
@@ -1184,7 +1184,7 @@
   {:on-score {:async true
               :msg "Draw 3 cards and skip their discard step this turn"
               :effect (effect
-                        (register-floating-effect
+                        (register-lingering-effect
                           card
                           {:type :skip-discard
                            :duration :end-of-turn
@@ -1993,7 +1993,7 @@
    :abilities [{:cost [:agenda 1]
                 :req (req run)
                 :msg "prevent this run from becoming successful"
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                   card
                                   {:type :block-successful-run
                                    :duration :end-of-run

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -78,7 +78,7 @@
                 :interactive (req true)
                 :async true
                 :effect (effect (gain-credits eid (count-ice corp)))}
-     :constant-effects [{:type :ice-strength
+     :static-abilities [{:type :ice-strength
                          :req (req (has-subtype? target subtype))
                          :value 1}]}))
 
@@ -410,7 +410,7 @@
 (defcard "Braintrust"
   {:on-score {:effect (effect (add-counter card :agenda (quot (- (get-counters (:card context) :advancement) 3) 2)))
               :silent (req true)}
-   :constant-effects [{:type :rez-cost
+   :static-abilities [{:type :rez-cost
                        :req (req (ice? target))
                        :value (req (- (get-counters card :agenda)))}]})
 
@@ -680,7 +680,7 @@
     :effect (effect (derez target))}})
 
 (defcard "Eden Fragment"
-  {:constant-effects [{:type :ignore-install-cost
+  {:static-abilities [{:type :ignore-install-cost
                        :req (req (and (ice? target)
                                       (->> (turn-events state side :corp-install)
                                            (map #(:card (first %)))
@@ -1020,7 +1020,7 @@
                      (system-msg state side "uses Improved Tracers to increase the strength of Tracer ice by 1")
                      (system-msg state side "uses Improved Tracers to increase the base strength of all trace subroutines by 1")
                      (update-all-ice state side)))
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (has-subtype? target "Tracer"))
                        :value 1}]
    :events [{:event :pre-init-trace
@@ -1147,7 +1147,7 @@
 
 (defcard "Medical Breakthrough"
   {:flags {:has-events-when-stolen true}
-   :constant-effects [{:type :advancement-requirement
+   :static-abilities [{:type :advancement-requirement
                        :req (req (= (:title target) "Medical Breakthrough"))
                        :value -1}]})
 
@@ -1562,7 +1562,7 @@
   {:move-zone (req (when (and (in-scored? card)
                               (= :corp (:scored-side card)))
                      (system-msg state side "uses Rebranding Team to make all assets gain Advertisement")))
-   :constant-effects [{:type :gain-subtype
+   :static-abilities [{:type :gain-subtype
                        :req (req (asset? target))
                        :value "Advertisement"}]})
 
@@ -1646,7 +1646,7 @@
   {:move-zone (req (when (and (in-scored? card)
                               (= :corp (:scored-side card)))
                      (system-msg state side "uses Remote Data Farm to increase their maximum hand size by 2")))
-   :constant-effects [(corp-hand-size+ 2)]})
+   :static-abilities [(corp-hand-size+ 2)]})
 
 (defcard "Remote Enforcement"
   {:on-score
@@ -1728,7 +1728,7 @@
   {:move-zone (req (when (and (in-scored? card)
                               (= :corp (:scored-side card)))
                      (system-msg state side "uses Self-Destruct Chips to decrease the Runner's maximum hand size by 1")))
-   :constant-effects [(runner-hand-size+ -1)]})
+   :static-abilities [(runner-hand-size+ -1)]})
 
 (defcard "Send a Message"
   (let [ability
@@ -1859,7 +1859,7 @@
                                 card nil)
                               (effect-completed state side eid))))}]
    :leave-play (effect (update-all-icebreakers))
-   :constant-effects [{:type :breaker-strength
+   :static-abilities [{:type :breaker-strength
                        :value -2
                        :req (req (and run
                                       (has-subtype? target "Icebreaker")
@@ -1894,7 +1894,7 @@
                                (continue-ability state side (sft 1 max-ops) card nil)))}}))
 
 (defcard "Superconducting Hub"
-  {:constant-effects [{:type :hand-size
+  {:static-abilities [{:type :hand-size
                        :req (req (= :corp side))
                        :value 2}]
    :on-score
@@ -2077,7 +2077,7 @@
                              result))}})
 
 (defcard "Water Monopoly"
-  {:constant-effects [{:type :install-cost
+  {:static-abilities [{:type :install-cost
                        :req (req (and (resource? target)
                                       (not (has-subtype? target "Virtual"))
                                       (not (:facedown (second targets)))))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -415,7 +415,7 @@
      :abilities [ability]}))
 
 (defcard "Brain-Taping Warehouse"
-  {:constant-effects [{:type :rez-cost
+  {:static-abilities [{:type :rez-cost
                        :req (req (and (ice? target)
                                       (has-subtype? target "Bioroid")))
                        :value (req (- (:click runner)))}]})
@@ -487,7 +487,7 @@
                      :effect (effect (damage eid :brain (get-counters (get-card state card) :advancement) {:card card}))}))
 
 (defcard "Chairman Hiro"
-  {:constant-effects [(runner-hand-size+ -2)]
+  {:static-abilities [(runner-hand-size+ -2)]
    :on-trash executive-trash-effect})
 
 (defcard "Chekist Scion"
@@ -694,7 +694,7 @@
      :abilities [ability (set-autoresolve :auto-fire "CSR Campaign")]}))
 
 (defcard "Cybernetics Court"
-  {:constant-effects [(corp-hand-size+ 4)]})
+  {:static-abilities [(corp-hand-size+ 4)]})
 
 (defcard "Cybersand Harvester"
   {:events [{:event :rez
@@ -789,7 +789,7 @@
                 :keep-menu-open :while-2-clicks-left
                 :msg "place 1 power counter"
                 :effect (effect (add-counter card :power 1))}]
-   :constant-effects [{:type :install-cost
+   :static-abilities [{:type :install-cost
                        :req (req (and (pos? (get-counters card :power))
                                       (not (get-in @state [:per-turn (:cid card)]))))
                        :value (req (get-counters card :power))}]
@@ -802,7 +802,7 @@
              :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}]})
 
 (defcard "Dr. Vientiane Keeling"
-  {:constant-effects [(runner-hand-size+ (req (- (get-counters card :power))))]
+  {:static-abilities [(runner-hand-size+ (req (- (get-counters card :power))))]
    :events [{:event :rez
              :req (req (same-card? card (:card context)))
              :msg "place 1 power counter on itself"
@@ -901,7 +901,7 @@
                                  card nil)))}]})
 
 (defcard "Encryption Protocol"
-  {:constant-effects [{:type :trash-cost
+  {:static-abilities [{:type :trash-cost
                        :req (req (installed? target))
                        :value 1}]})
 
@@ -1038,7 +1038,7 @@
              :effect (req (as-agenda state :corp card 1))}]})
 
 (defcard "Front Company"
-  {:constant-effects [{:type :cannot-run-on-server
+  {:static-abilities [{:type :cannot-run-on-server
                        :req (req (not (pos? (count (turn-events state side :run)))))
                        :value (req (map first (get-remotes state)))}]
    :rez-req (req (= (:active-player @state) :corp))
@@ -1558,7 +1558,7 @@
                  :once :per-turn
                  :async true
                  :effect (effect (gain-credits eid 1))}]
-    {:constant-effects [(runner-hand-size+ 1)]
+    {:static-abilities [(runner-hand-size+ 1)]
      :derezzed-events [corp-rez-toast]
      :events [(assoc ability :event :corp-turn-begins)]
      :abilities [ability]}))
@@ -2271,7 +2271,7 @@
 
 (defcard "Sandburg"
   {:on-rez {:effect (effect (update-all-ice))}
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (<= 10 (:credit corp)))
                        :value (req (quot (:credit corp) 5))}]
    :events [{:event :corp-gain
@@ -2484,7 +2484,7 @@
              :effect (effect (add-counter card :power 1))}]})
 
 (defcard "Student Loans"
-  {:constant-effects [{:type :play-additional-cost
+  {:static-abilities [{:type :play-additional-cost
                        :req (req (and (event? target)
                                       (seq (filter #(= (:title %) (:title target)) (:discard runner)))))
                        :value [:credit 2]}]})
@@ -2591,7 +2591,7 @@
                 (hardware? card)
                 (and (resource? card)
                      (has-subtype? card "Virtual"))))]
-    {:constant-effects [{:type :install-cost
+    {:static-abilities [{:type :install-cost
                          :req (req (and (is-techno-target target)
                                         (not (:facedown (second targets)))))
                          :value 1}]
@@ -2638,7 +2638,7 @@
 
 (defcard "The Board"
   {:on-trash executive-trash-effect
-   :constant-effects [{:type :agenda-value
+   :static-abilities [{:type :agenda-value
                        :req (req (= :runner (:scored-side target)))
                        :value -1}]})
 
@@ -2699,7 +2699,7 @@
             :effect (effect (add-icon card target "TMB" (faction-label card))
                             (update! (assoc-in (get-card state card) [:special :trieste-target] target)))}
    :leave-play (effect (remove-icon card))
-   :constant-effects [{:type :prevent-paid-ability
+   :static-abilities [{:type :prevent-paid-ability
                        :req (req
                               (let [[break-card break-ability] targets]
                                 (and
@@ -2906,7 +2906,7 @@
 (defcard "Watchdog"
   (letfn [(not-triggered? [state]
             (no-event? state :runner :rez #(ice? (:card (first %)))))]
-    {:constant-effects [{:type :rez-cost
+    {:static-abilities [{:type :rez-cost
                          :req (req (and (ice? target)
                                         (not-triggered? state)))
                          :value (req (- (count-tags state)))}]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -22,7 +22,7 @@
                                   reorder-choice trash-on-empty get-x-fn]]
    [game.core.drawing :refer [draw first-time-draw-bonus max-draw
                               remaining-draws]]
-   [game.core.effects :refer [register-floating-effect]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [complete-with-result effect-completed is-basic-advance-action? make-eid]]
    [game.core.engine :refer [pay register-events resolve-ability]]
    [game.core.events :refer [first-event? no-event? turn-events]]
@@ -1271,7 +1271,7 @@
                                       (rezzed? %))}
                 :req (req (pos? (get-counters card :power)))
                 :msg "add strength to a rezzed piece of ice"
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                   card
                                   (let [it-target target]
                                     {:type :ice-strength

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -17,7 +17,7 @@
    [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out
                                   reorder-choice]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [register-floating-effect]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [complete-with-result effect-completed make-eid
                           make-result]]
    [game.core.engine :refer [not-used-once? pay register-events
@@ -358,7 +358,7 @@
                                                                     (let [context (first targets)]
                                                                       (not (rezzed? (:ice context))))))))
                                  :effect (effect
-                                           (register-floating-effect
+                                           (register-lingering-effect
                                              card
                                              (let [approached-ice (:ice context)]
                                                {:type :rez-additional-cost
@@ -2300,7 +2300,7 @@
              :req (req this-card-run)
              :effect (req
                        (let [blocked-server (first (:server target))]
-                         (register-floating-effect
+                         (register-lingering-effect
                            state side card
                            {:type :cannot-run-on-server
                             :req (req true)
@@ -3144,7 +3144,7 @@
    :on-play {:prompt "Choose a server"
              :choices (req runnable-servers)
              :async true
-             :effect (effect (register-floating-effect
+             :effect (effect (register-lingering-effect
                                card
                                {:type :rez-additional-cost
                                 :duration :end-of-run
@@ -3235,7 +3235,7 @@
   {:events [{:event :encounter-ice
              :once :per-turn
              :effect (effect
-                       (register-floating-effect
+                       (register-lingering-effect
                          card
                          (let [target-ice (:ice context)]
                            {:type :ice-strength
@@ -3639,7 +3639,7 @@
     :choices {:card #(and (installed? %)
                           (ice? %))}
     :msg (msg "make " (card-str state target) " gain Sentry, Code Gate, and Barrier until the end of the turn")
-    :effect (req (register-floating-effect state side card
+    :effect (req (register-lingering-effect state side card
                  (let [ice target]
                    {:type :gain-subtype
                     :duration :end-of-turn
@@ -3686,7 +3686,7 @@
     :choices (req runnable-servers)
     :makes-run true
     :async true
-    :effect (effect (register-floating-effect
+    :effect (effect (register-lingering-effect
                       card
                       {:type :rez-additional-cost
                        :duration :end-of-run

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1585,7 +1585,7 @@
                            (gain-credits state :runner eid 10)))}})
 
 (defcard "Hacktivist Meeting"
-  {:constant-effects [{:type :rez-additional-cost
+  {:static-abilities [{:type :rez-additional-cost
                        :req (req (not (ice? target)))
                        :value [:randomly-trash-from-hand 1]}]})
 
@@ -1985,7 +1985,7 @@
 
 (defcard "Itinerant Protesters"
   {:on-play {:msg "reduce the Corp's maximum hand size by 1 for each bad publicity"}
-   :constant-effects [(corp-hand-size+ (req (- (count-bad-pub state))))]})
+   :static-abilities [(corp-hand-size+ (req (- (count-bad-pub state))))]})
 
 (defcard "Jailbreak"
   {:makes-run true
@@ -2619,7 +2619,7 @@
    :on-play {:req (req archives-runnable)
              :async true
              :effect (effect (make-run eid :archives card))}
-   :constant-effects [{:type :agenda-value
+   :static-abilities [{:type :agenda-value
                        :req (req (same-card? (:host card) target))
                        :value -1}]
    :events [{:event :purge
@@ -3675,7 +3675,7 @@
                                  card nil))))}}))
 
 (defcard "Traffic Jam"
-  {:constant-effects [{:type :advancement-requirement
+  {:static-abilities [{:type :advancement-requirement
                        :value (req (->> (:scored corp)
                                         (filter #(= (:title %) (:title target)))
                                         (count)))}]})

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -95,7 +95,7 @@
                                       (installed? %))}
                 :msg (msg "host itself on " (card-str state target))
                 :effect (effect (host (get-card state target) (get-card state card)))}
-   :constant-effects [{:type :gain-subtype
+   :static-abilities [{:type :gain-subtype
                        :req (req (same-card? target (:host card)))
                        :value "AI"}]
    :abilities [(break-sub [:lose-click 1] 1 "All" {:req (req true)})]})
@@ -147,7 +147,7 @@
                                            (contains? (card-def current-ice) :on-encounter)))))]}))
 
 (defcard "Akamatsu Mem Chip"
-  {:constant-effects [(mu+ 1)]})
+  {:static-abilities [(mu+ 1)]})
 
 (defcard "Aniccam"
   (let [ability {:async true
@@ -158,7 +158,7 @@
                                   (first-trash? state event-targets?))))
                  :msg "draw 1 card"
                  :effect (effect (draw :runner eid 1))}]
-    {:constant-effects [(mu+ 1)]
+    {:static-abilities [(mu+ 1)]
      :events [(assoc ability :event :corp-trash)
               (assoc ability :event :runner-trash)
               (assoc ability :event :game-trash)]}))
@@ -182,7 +182,7 @@
                                     :effect (effect (move :corp target :rfg))}}} card nil))}]})
 
 (defcard "Astrolabe"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :server-created
              :msg "draw 1 card"
              :async true
@@ -215,7 +215,7 @@
    :in-play [:click-per-turn 1]})
 
 (defcard "Blackguard"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :expose
              :msg (msg "attempt to force the rez of " (:title target))
              :async true
@@ -310,17 +310,17 @@
                           card nil))))]})
 
 (defcard "Box-E"
-  {:constant-effects [(mu+ 2)
+  {:static-abilities [(mu+ 2)
                       (runner-hand-size+ 2)]})
 
 (defcard "Brain Cage"
-  {:constant-effects [(runner-hand-size+ 3)]
+  {:static-abilities [(runner-hand-size+ 3)]
    :on-install {:async true
                 :effect (effect (damage eid :brain 1 {:card card}))}})
 
 (defcard "Brain Chip"
   {:x-fn (req (max (get-in @state [:runner :agenda-point] 0) 0))
-   :constant-effects [(mu+
+   :static-abilities [(mu+
                         (req (pos? ((get-x-fn) state side eid card targets)))
                         ;; [:regular N] is needed to make the mu system work
                         (req [:regular ((get-x-fn) state side eid card targets)]))
@@ -397,7 +397,7 @@
                                (effect-completed eid))}}}]})
 
 (defcard "Carnivore"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :interactions
    {:access-ability
     {:label "Trash card"
@@ -458,7 +458,7 @@
                 :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target nil))}]})
 
 (defcard "Comet"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :play-event
              :req (req (first-event? state side :play-event))
              :effect (req (system-msg state :runner
@@ -492,7 +492,7 @@
                                      :value [:credit 2]})))}]})
 
 (defcard "Cyberdelia"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :subroutines-broken
              :req (req (and (all-subs-broken? target)
                             (first-event? state side :subroutines-broken #(all-subs-broken? (first %)))))
@@ -510,7 +510,7 @@
                                 :type :recurring}}})
 
 (defcard "CyberSolutions Mem Chip"
-  {:constant-effects [(mu+ 2)]})
+  {:static-abilities [(mu+ 2)]})
 
 (defcard "Cybsoft MacroDrive"
   {:recurring 1
@@ -519,7 +519,7 @@
                                 :type :recurring}}})
 
 (defcard "Daredevil"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :run
              :once :per-turn
              :req (req (and (<= 2 (:position target))
@@ -541,7 +541,7 @@
                 :msg (msg "pump the strength of " (get-in card [:host :title]) " by 4")}]})
 
 (defcard "Deep Red"
-  {:constant-effects [(caissa-mu+ 3)]
+  {:static-abilities [(caissa-mu+ 3)]
    :events [{:event :runner-install
              :optional
              {:req (req (has-subtype? (:card context) "Caïssa"))
@@ -562,7 +562,7 @@
                            card nil))}}}]})
 
 (defcard "Demolisher"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       {:type :trash-cost
                        :value -1}]
    :events [{:event :runner-trash
@@ -576,7 +576,7 @@
              :effect (effect (gain-credits :runner eid 1))}]})
 
 (defcard "Desperado"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :successful-run
              :silent (req true)
              :async true
@@ -620,7 +620,7 @@
                 :effect (effect (host card target)
                                 (unregister-effects-for-card target #(= :used-mu (:type %)))
                                 (update-mu))}]
-   :constant-effects [{:type :breaker-strength
+   :static-abilities [{:type :breaker-strength
                        :req (req (same-card? target (first (:hosted card))))
                        :value 2}]})
 
@@ -632,7 +632,7 @@
               :msg "access 1 additional cards from HQ"})]})
 
 (defcard "Doppelgänger"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :runner-install
              :req (req (same-card? card (:card context)))
              :silent (req true)
@@ -687,11 +687,11 @@
                                 :type :recurring}}})
 
 (defcard "Dyson Mem Chip"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       (link+ 1)]})
 
 (defcard "DZMZ Optimizer"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       {:type :install-cost
                        :req (req (and (program? target)
                                       (no-event? state :runner :runner-install #(program? (:card (first %))))))
@@ -735,7 +735,7 @@
 
 (defcard "Endurance"
   {:data {:counter {:power 3}}
-   :constant-effects [(mu+ 2)]
+   :static-abilities [(mu+ 2)]
    :events [{:event :successful-run
              :req (req (first-event? state :runner :successful-run))
              :msg "place 1 power counter on itself"
@@ -846,7 +846,7 @@
 (defcard "Forger"
   {:interactions {:prevent [{:type #{:tag}
                              :req (req true)}]}
-   :constant-effects [(link+ 1)]
+   :static-abilities [(link+ 1)]
    :abilities [{:msg "avoid 1 tag"
                 :label "Avoid 1 tag"
                 :async true
@@ -1019,7 +1019,7 @@
 (defcard "Ghosttongue"
   {:on-install {:async true
                 :effect (effect (damage eid :brain 1 {:card card}))}
-   :constant-effects [{:type :play-cost
+   :static-abilities [{:type :play-cost
                        :req (req (event? target))
                        :value -1}]})
 
@@ -1034,14 +1034,14 @@
                                        (continue-ability state side (offer-jack-out) card nil)))}]})
 
 (defcard "Grimoire"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :runner-install
              :interactive (req true)
              :req (req (has-subtype? (:card context) "Virus"))
              :effect (effect (add-counter (:card context) :virus 1))}]})
 
 (defcard "Heartbeat"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :interactions {:prevent [{:type #{:net :brain :meat}
                              :req (req true)}]}
    :abilities [{:label "Prevent 1 damage"
@@ -1060,7 +1060,7 @@
                                   (corp? %))}
             :msg (msg "add " (card-str state target) " to HQ")
             :effect (effect (move :corp target :hand))}]
-    {:constant-effects [(mu+ 1)]
+    {:static-abilities [(mu+ 1)]
      :events [(assoc ab :event :agenda-scored)
               (assoc ab :event :agenda-stolen)]}))
 
@@ -1108,13 +1108,13 @@
                 :msg "suffer 1 meat damage"
                 :effect (effect (damage eid :meat 1 {:unboostable true :card card}))}
    :data {:counter {:power 2}}
-   :constant-effects [(runner-hand-size+ (req (get-counters card :power)))]})
+   :static-abilities [(runner-hand-size+ (req (get-counters card :power)))]})
 
 (defcard "HQ Interface"
   {:events [(breach-access-bonus :hq 1)]})
 
 (defcard "Keiko"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :spent-credits-from-card
              :req (req (and (not (facedown? target))
                             (has-subtype? target "Companion")
@@ -1141,7 +1141,7 @@
              :effect (effect (gain-credits :runner eid 1))}]})
 
 (defcard "Knobkierie"
-  {:constant-effects [(virus-mu+ 3)]
+  {:static-abilities [(virus-mu+ 3)]
    :events [{:event :successful-run
              :interactive (req true)
              :optional {:req (req (and (first-event? state :runner :successful-run)
@@ -1175,11 +1175,11 @@
                                       :async true
                                       :effect (req (draw state :runner eid 1))}
                         :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}}}]
-   :constant-effects [(mu+ 2)]
+   :static-abilities [(mu+ 2)]
    :abilities [(set-autoresolve :auto-fire "LilyPAD")]})
 
 (defcard "LLDS Memory Diamond"
-  {:constant-effects [(link+ 1)
+  {:static-abilities [(link+ 1)
                       (runner-hand-size+ 1)
                       (mu+ 1)]})
 
@@ -1197,7 +1197,7 @@
                                 :type :recurring}}})
 
 (defcard "Logos"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       (runner-hand-size+ 1)]
    :events [{:event :agenda-scored
              :player :runner
@@ -1238,7 +1238,7 @@
                                 (add-counter state side card :power cost))))}]}))
 
 (defcard "Marrow"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       (runner-hand-size+ 3)]
    :on-install {:async true
                 :effect (effect (damage eid :brain 1 {:card card}))}
@@ -1248,7 +1248,7 @@
              :effect (effect (continue-ability (sabotage-ability 1) card nil))}]})
 
 (defcard "Masterwork (v37)"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :run
              :interactive (req true)
              :optional
@@ -1276,13 +1276,13 @@
 
 (defcard "Māui"
   {:x-fn (req (count (get-in corp [:servers :hq :ices])))
-   :constant-effects [(mu+ 2)]
+   :static-abilities [(mu+ 2)]
    :recurring (get-x-fn)
    :interactions {:pay-credits {:req (req (= [:hq] (get-in @state [:run :server])))
                                 :type :recurring}}})
 
 (defcard "Maw"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :post-access-card
              :label "Trash a card from HQ"
              :async true
@@ -1300,7 +1300,7 @@
                             (trash state :corp eid card-to-trash {:cause-card card :cause :forced-to-trash})))}]})
 
 (defcard "Maya"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :post-access-card
              :optional
              {:req (req (in-deck? (second targets)))
@@ -1313,11 +1313,11 @@
                             (gain-tags state :runner eid 1))}}}]})
 
 (defcard "MemStrips"
-  {:constant-effects [(virus-mu+ 3)]})
+  {:static-abilities [(virus-mu+ 3)]})
 
 (defcard "Mind's Eye"
   {:implementation "Power counters added automatically"
-   :constant-effects [(mu+ 1)]
+   :static-abilities [(mu+ 1)]
    :events [{:event :successful-run
              :silent (req true)
              :req (req (= :rd (target-server context)))
@@ -1328,7 +1328,7 @@
                 :effect (req (breach-server state side eid [:rd] {:no-root true}))}]})
 
 (defcard "Mirror"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :successful-run
              :async true
              :req (req (= :rd (target-server context)))
@@ -1352,7 +1352,7 @@
                                   (continue-ability state side (when (< n 3) (mh (inc n))) card nil)))})]
     {:interactions {:prevent [{:type #{:net :brain}
                                :req (req true)}]}
-     :constant-effects [(mu+ 3)]
+     :static-abilities [(mu+ 3)]
      :on-install {:async true
                   :effect (effect (continue-ability (mhelper 1) card nil))}
      :abilities [{:msg "prevent 1 brain or net damage"
@@ -1442,7 +1442,7 @@
                             card nil))}]})
 
 (defcard "Obelus"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       (runner-hand-size+ (req (count-tags state)))]
    :events [{:event :run-ends
              :once :per-turn
@@ -1521,12 +1521,12 @@
          :msg "gain 1 [Credits]"
          :effect (req (wait-for (gain-credits state :runner 1)
                                 (continue-ability state side install-ability card nil)))}]
-    {:constant-effects [(mu+ 1)]
+    {:static-abilities [(mu+ 1)]
      :events [(assoc gain-credit-ability :event :agenda-scored)
               (assoc gain-credit-ability :event :agenda-stolen)]}))
 
 (defcard "Paragon"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :successful-run
              :interactive (get-autoresolve :auto-fire (complement never?))
              :silent (get-autoresolve :auto-fire never?)
@@ -1559,7 +1559,7 @@
 (defcard "Patchwork"
   (let [patchwork-ability {:once :per-turn
                            :effect (effect (update! (assoc-in card [:special :patchwork] true)))}]
-    {:constant-effects [(mu+ 1)]
+    {:static-abilities [(mu+ 1)]
      :interactions
      {:pay-credits
       {:req (req (and (or (= :play (:source-type eid))
@@ -1597,7 +1597,7 @@
        :cost-reduction true}}}))
 
 (defcard "Pennyshaver"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :successful-run
              :silent (req true)
              :async true
@@ -1634,7 +1634,7 @@
                                                    (draw state :corp eid 1)))}
               :no-ability {:effect (effect (system-msg (str "declines to use " (:title card)))
                                            (effect-completed eid))}}}]
-    {:constant-effects [(mu+ 1)
+    {:static-abilities [(mu+ 1)
                         (link+ 1)]
      :events [{:event :pass-ice
                :req (req (and (= (:server run) [:hq])
@@ -1704,7 +1704,7 @@
                                 :type :recurring}}})
 
 (defcard "Q-Coherence Chip"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events (let [e {:async true
                     :interactive (req true)
                     :req (req (and (installed? (:card target))
@@ -1738,7 +1738,7 @@
   {:events [(breach-access-bonus :rd 1)]})
 
 (defcard "Rabbit Hole"
-  {:constant-effects [(link+ 1)]
+  {:static-abilities [(link+ 1)]
    :on-install
    {:optional
     {:req (req (some #(when (= (:title %) (:title card)) %) (:deck runner)))
@@ -1799,7 +1799,7 @@
                 :effect (effect (move :corp target :deck {:front true}))}})]})
 
 (defcard "Reflection"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       (link+ 1)]
    :events [{:event :jack-out
              :async true
@@ -1915,7 +1915,7 @@
                                (update-breaker-strength state side t)))}]})
 
 (defcard "Security Nexus"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       (link+ 1)]
    :events [{:event :encounter-ice
              :interactive (req true)
@@ -1981,7 +1981,7 @@
                             ((:value %) state side eid (get-card state (:card %)) (cons target targets))))
                    (reduce +)
                    (abs))))]
-    {:constant-effects [(mu+ 2)]
+    {:static-abilities [(mu+ 2)]
      :events [{:event :encounter-ice
                :interactive (req true)
                :optional
@@ -2013,7 +2013,7 @@
                                 :type :recurring}}})
 
 (defcard "Simulchip"
-  {:constant-effects [{:type :card-ability-additional-cost
+  {:static-abilities [{:type :card-ability-additional-cost
                        :req (req (and (same-card? card target)
                                       (let [pred (fn [targets]
                                                    (some #(and (runner? (:card %))
@@ -2048,7 +2048,7 @@
 (defcard "Skulljack"
   {:on-install {:async true
                 :effect (effect (damage eid :brain 1 {:card card}))}
-   :constant-effects [{:type :trash-cost
+   :static-abilities [{:type :trash-cost
                        :value -1}]})
 
 (defcard "Solidarity Badge"
@@ -2086,7 +2086,7 @@
                              (effect-completed eid))}]})
 
 (defcard "Spinal Modem"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :recurring 2
    :events [{:event :successful-trace
              :req (req run)
@@ -2097,7 +2097,7 @@
                                 :type :recurring}}})
 
 (defcard "Sports Hopper"
-  {:constant-effects [(link+ 1)]
+  {:static-abilities [(link+ 1)]
    :abilities [{:label "Draw 3 cards"
                 :msg "draw 3 cards"
                 :async true
@@ -2127,7 +2127,7 @@
                                   card nil))}]})
 
 (defcard "Supercorridor"
-  {:constant-effects [(mu+ 2)
+  {:static-abilities [(mu+ 2)
                       (runner-hand-size+ 1)]
    :events [{:event :runner-turn-ends
              :interactive (get-autoresolve :auto-fire (complement never?))
@@ -2145,7 +2145,7 @@
    :abilities [(set-autoresolve :auto-fire "Supercorridor")]})
 
 (defcard "Swift"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :play-event
              :req (req (and (has-subtype? (:card context) "Run")
                             (first-event? state side :play-event #(has-subtype? (:card (first %)) "Run"))))
@@ -2153,13 +2153,13 @@
              :effect (effect (gain-clicks 1))}]})
 
 (defcard "T400 Memory Diamond"
-  {:constant-effects [(mu+ 1)
+  {:static-abilities [(mu+ 1)
                       {:type :hand-size
                        :req (req (= :runner side))
                        :value 1}]})
 
 (defcard "The Gauntlet"
-  {:constant-effects [(mu+ 2)]
+  {:static-abilities [(mu+ 2)]
    :events [{:event :breach-server
              :req (req (= :hq target))
              :effect (req (let [broken-ice
@@ -2180,12 +2180,12 @@
   {:hosting {:card #(and (has-subtype? % "Icebreaker")
                          (installed? %))}
    :on-install {:effect (effect (update-breaker-strength (:host card)))}
-   :constant-effects [{:type :breaker-strength
+   :static-abilities [{:type :breaker-strength
                        :req (req (same-card? target (:host card)))
                        :value 1}]})
 
 (defcard "The Toolbox"
-  {:constant-effects [(mu+ 2)
+  {:static-abilities [(mu+ 2)
                       (link+ 2)]
    :recurring 2
    :interactions {:pay-credits {:req (req (and (= :ability (:source-type eid))
@@ -2249,7 +2249,7 @@
                                         (access-card state side eid (nth (:deck corp) (dec (str->int target))) "an unseen card")))}})]})
 
 (defcard "Turntable"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [{:event :agenda-stolen
              :interactive (req true)
              :req (req (seq (:scored corp)))
@@ -2273,7 +2273,7 @@
                  :once :per-turn
                  :async true
                  :effect (effect (draw eid 1))}]
-    {:constant-effects [(mu+ 1)]
+    {:static-abilities [(mu+ 1)]
      :flags {:runner-turn-draw true
              :runner-phase-12 (req (< 1 (count (filter #(card-flag? % :runner-turn-draw true)
                                                        (cons (get-in @state [:runner :identity])
@@ -2313,12 +2313,12 @@
                  :once :per-turn
                  :async true
                  :effect (effect (draw eid 1))}]
-    {:constant-effects [(mu+ 1)]
+    {:static-abilities [(mu+ 1)]
      :events [(assoc ability :event :runner-turn-begins)]
      :abilities [ability]}))
 
 (defcard "Virtuoso"
-  {:constant-effects [(mu+ 1)]
+  {:static-abilities [(mu+ 1)]
    :events [(assoc identify-mark-ability :event :runner-turn-begins)
             {:event :successful-run
              :req (req (and (:marked-server target)
@@ -2378,7 +2378,7 @@
 
 (defcard "Zamba"
   {:implementation "Credit gain is automatic"
-   :constant-effects [(mu+ 2)]
+   :static-abilities [(mu+ 2)]
    :events [{:event :expose
              :async true
              :effect (effect (gain-credits :runner eid 1))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -18,8 +18,8 @@
    [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out
                                   reorder-choice trash-on-empty get-x-fn]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [register-floating-effect
-                              unregister-effects-for-card unregister-floating-effects]]
+   [game.core.effects :refer [register-lingering-effect
+                              unregister-effects-for-card unregister-lingering-effects]]
    [game.core.eid :refer [effect-completed make-eid make-result]]
    [game.core.engine :refer [can-trigger? not-used-once? register-events
                              register-once register-suppress resolve-ability trigger-event
@@ -483,7 +483,7 @@
                 :msg (msg "increase the rez cost of " (card-str state target)
                           " by 2 [Credits] until the end of the turn")
                 :cost [:trash-can]
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                   card
                                   (let [ice target]
                                     {:type :rez-additional-cost
@@ -591,7 +591,7 @@
               :yes-ability
               {:msg (msg "give -6 strength to " (card-str state (:ice context)) " for the remainder of the run")
                :cost [:remove-from-game]
-               :effect (effect (register-floating-effect
+               :effect (effect (register-lingering-effect
                                  card
                                  (let [ice (:ice context)]
                                    {:type :ice-strength
@@ -652,7 +652,7 @@
                             :msg (msg "make a run on " target)
                             :makes-run true
                             :effect (effect (update! (dissoc card :dopp-active))
-                                            (unregister-floating-effects :end-of-run)
+                                            (unregister-lingering-effects :end-of-run)
                                             (unregister-floating-events :end-of-run)
                                             (update-all-icebreakers)
                                             (update-all-ice)
@@ -1990,13 +1990,13 @@
                 :yes-ability
                 {:msg (msg "lower their maximum hand size by 1 and reduce the strength of " (:title current-ice) " to 0")
                  :effect (effect
-                           (register-floating-effect
+                           (register-lingering-effect
                              card
                              {:type :hand-size
                               :duration :until-runner-turn-begins
                               :req (req (= :runner side))
                               :value -1})
-                           (register-floating-effect
+                           (register-lingering-effect
                              :runner card
                              (let [ice current-ice]
                                {:type :ice-strength

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -19,7 +19,7 @@
                                   do-brain-damage do-net-damage offer-jack-out
                                   reorder-choice get-x-fn]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [get-effects register-floating-effect unregister-constant-effects]]
+   [game.core.effects :refer [get-effects register-floating-effect unregister-static-abilities]]
    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
    [game.core.engine :refer [gather-events pay register-events resolve-ability
                              trigger-event trigger-event-simult unregister-events]]
@@ -385,7 +385,7 @@
   [subroutines]
   {:advanceable :always
    :subroutines subroutines
-   :constant-effects [(ice-strength-bonus (req (get-counters card :advancement)))]})
+   :static-abilities [(ice-strength-bonus (req (get-counters card :advancement)))]})
 
 (defn space-ice
   "Creates data for Space ice with specified abilities."
@@ -474,7 +474,7 @@
   "Creates the data for morph ice with specified types and ability."
   [base other ability]
   {:advanceable :always
-   :constant-effects [{:type :lose-subtype
+   :static-abilities [{:type :lose-subtype
                        :req (req (and (same-card? card target)
                                       (odd? (get-counters (get-card state card) :advancement))))
                        :value base}
@@ -666,7 +666,7 @@
                     :effect (effect (add-prop target :advance-counter 1 {:placed true})
                                     (gain-credits eid 1))}
                    (assoc end-the-run :breakable breakable-fn)]
-     :constant-effects [(ice-strength-bonus
+     :static-abilities [(ice-strength-bonus
                           (req (<= 3 (get-counters card :advancement)))
                           3)]}))
 
@@ -856,7 +856,7 @@
 
 (defcard "Bathynomus"
   {:subroutines [(do-net-damage 3)]
-   :constant-effects [(ice-strength-bonus (req (protecting-archives? card)) 3)]})
+   :static-abilities [(ice-strength-bonus (req (protecting-archives? card)) 3)]})
 
 (defcard "Battlement"
   {:subroutines [end-the-run
@@ -1070,7 +1070,7 @@
             :choices ["Barrier" "Code Gate" "Sentry"]
             :msg (msg "make itself gain " target)
             :effect (effect (update! (assoc card :subtype-target target)))}
-   :constant-effects [{:type :gain-subtype
+   :static-abilities [{:type :gain-subtype
                        :req (req (and (same-card? card target) (:subtype-target card)))
                        :value (req (:subtype-target card))}]
    :events [{:event :runner-turn-ends
@@ -1187,7 +1187,7 @@
                         :label "The Runner trashes 1 program")
                  runner-loses-click
                  end-the-run]
-   :constant-effects [(ice-strength-bonus
+   :static-abilities [(ice-strength-bonus
                         (req (some #(has-subtype? % "AI") (all-active-installed state :runner)))
                         3)]})
 
@@ -1205,13 +1205,13 @@
                                         (in-discard? %))}
                   :msg (msg (corp-install-msg target))
                   :effect (effect (corp-install eid target nil nil))}]
-   :constant-effects [(ice-strength-bonus (req (protecting-archives? card)) 3)]})
+   :static-abilities [(ice-strength-bonus (req (protecting-archives? card)) 3)]})
 
 (defcard "Curtain Wall"
   {:subroutines [end-the-run
                  end-the-run
                  end-the-run]
-   :constant-effects [(ice-strength-bonus
+   :static-abilities [(ice-strength-bonus
                         (req (let [ices (:ices (card->server state card))]
                                (same-card? card (last ices))))
                         4)]
@@ -1356,7 +1356,7 @@
             :msg (msg "place " (quantify target "power counter"))
             :effect (effect (add-counter card :power target)
                             (update-ice-strength card))}
-   :constant-effects [(ice-strength-bonus (req (get-counters card :power)))]
+   :static-abilities [(ice-strength-bonus (req (get-counters card :power)))]
    :subroutines [(trace-ability 2 {:label "Give the Runner 1 tag and end the run"
                                    :msg "give the Runner 1 tag and end the run"
                                    :async true
@@ -1766,7 +1766,7 @@
                              :label "Draw cards, reveal and shuffle agendas"
                              :effect (req (wait-for (resolve-ability state side draw-ab card nil)
                                                     (continue-ability state side reveal-and-shuffle card nil)))}]
-    {:constant-effects [(ice-strength-bonus (req (= :this-turn (:rezzed card))) 6)]
+    {:static-abilities [(ice-strength-bonus (req (= :this-turn (:rezzed card))) 6)]
      :subroutines [draw-reveal-shuffle
                    end-the-run]}))
 
@@ -1795,14 +1795,14 @@
    :subroutines [trash-program-sub]})
 
 (defcard "Guard"
-  {:constant-effects [{:type :bypass-ice
+  {:static-abilities [{:type :bypass-ice
                        :req (req (same-card? card target))
                        :value false}]
    :subroutines [end-the-run]})
 
 (defcard "Gutenberg"
   {:subroutines [(tag-trace 7)]
-   :constant-effects [(ice-strength-bonus (req (protecting-rd? card)) 3)]})
+   :static-abilities [(ice-strength-bonus (req (protecting-rd? card)) 3)]})
 
 (defcard "Gyri Labyrinth"
   {:subroutines [{:req (req run)
@@ -1895,7 +1895,7 @@
                   :effect (effect (clear-wait-prompt :runner)
                                   (trash eid target {:cause :subroutine}))}
                  end-the-run]
-   :constant-effects [(ice-strength-bonus (req (- (count (filter #(has-subtype? % "Icebreaker")
+   :static-abilities [(ice-strength-bonus (req (- (count (filter #(has-subtype? % "Icebreaker")
                                                                  (all-active-installed state :runner))))))]})
 
 (defcard "Hailstorm"
@@ -2193,7 +2193,7 @@
 
 (defcard "IQ"
   {:subroutines [end-the-run]
-   :constant-effects [(ice-strength-bonus (req (count (:hand corp))))]
+   :static-abilities [(ice-strength-bonus (req (count (:hand corp))))]
    :rez-cost-bonus (req (count (:hand corp)))
    :leave-play (req (remove-watch state (keyword (str "iq" (:cid card)))))})
 
@@ -2497,7 +2497,7 @@
                                   card nil)))}]}))
 
 (defcard "Lotus Field"
-  {:constant-effects [{:type :cannot-lower-strength
+  {:static-abilities [{:type :cannot-lower-strength
                        :req (req (same-card? card (:ice context)))
                        :value true}]
    :subroutines [end-the-run]})
@@ -2570,7 +2570,7 @@
               ;; TODO - remove this boilerplate when disabling cards is reworked
               (when (not= (:title hc) "Hush")
                 (unregister-events state side hc)
-                (unregister-constant-effects state side hc)
+                (unregister-static-abilities state side hc)
                 (update! state side (dissoc hc :abilities)))))]
     {:on-rez {:async true
               :effect (req (let [magnet card]
@@ -2691,7 +2691,7 @@
 
 (defcard "Meru Mati"
   {:subroutines [end-the-run]
-   :constant-effects [(ice-strength-bonus (req (protecting-hq? card)) 3)]})
+   :static-abilities [(ice-strength-bonus (req (protecting-hq? card)) 3)]})
 
 (defcard "Metamorph"
   {:subroutines [{:label "Swap two pieces of ice or swap two installed non-ice"
@@ -2853,7 +2853,7 @@
 (defcard "Mother Goddess"
   (let [mg {:req (req (ice? target))
             :effect (effect (update-all-subtypes))}]
-    {:constant-effects [{:type :gain-subtype
+    {:static-abilities [{:type :gain-subtype
                          :req (req (same-card? card target))
                          :value (req (->> (vals (:servers corp))
                                           (mapcat :ices)
@@ -2931,7 +2931,7 @@
 
 (defcard "NEXT Bronze"
   {:subroutines [end-the-run]
-   :constant-effects [(ice-strength-bonus (req (next-ice-count corp)))]})
+   :static-abilities [(ice-strength-bonus (req (next-ice-count corp)))]})
 
 (defcard "NEXT Diamond"
   {:rez-cost-bonus (req (- (next-ice-count corp)))
@@ -3106,7 +3106,7 @@
                  end-the-run-if-tagged]})
 
 (defcard "Palisade"
-  {:constant-effects [(ice-strength-bonus (req (not (protecting-a-central? card))) 2)]
+  {:static-abilities [(ice-strength-bonus (req (not (protecting-a-central? card))) 2)]
    :subroutines [end-the-run]})
 
 (defcard "Paper Wall"
@@ -3142,7 +3142,7 @@
    :subroutines [(give-tags 1)
                  end-the-run
                  end-the-run]
-   :constant-effects [(ice-strength-bonus (req (wonder-sub card 3)) 5)]})
+   :static-abilities [(ice-strength-bonus (req (wonder-sub card 3)) 5)]})
 
 (defcard "Phoneutria"
   {:subroutines [(do-net-damage 1)
@@ -3199,7 +3199,7 @@
                   :effect (effect (add-counter card :power 1)
                                   (update-all-ice))}
    :subroutines [end-the-run]
-   :constant-effects [(ice-strength-bonus (req (get-counters card :power)))]})
+   :static-abilities [(ice-strength-bonus (req (get-counters card :power)))]})
 
 (defcard "Rainbow"
   {:subroutines [end-the-run]})
@@ -3223,7 +3223,7 @@
                                   (update-all-ice))}]})
 
 (defcard "Resistor"
-  {:constant-effects [(ice-strength-bonus (req (count-tags state)))]
+  {:static-abilities [(ice-strength-bonus (req (count-tags state)))]
    :subroutines [(trace-ability 4 end-the-run)]})
 
 (defcard "Rime"
@@ -3233,7 +3233,7 @@
                   :msg "force the Runner to lose 1 [Credit]"
                   :async true
                   :effect (effect (lose-credits :runner eid 1))}]
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (protecting-same-server? card target))
                        :value 1}]})
 
@@ -3343,7 +3343,7 @@
 
 (defcard "Sandstone"
   {:subroutines [end-the-run]
-   :constant-effects [(ice-strength-bonus (req (- (get-counters card :virus))))]
+   :static-abilities [(ice-strength-bonus (req (- (get-counters card :virus))))]
    :on-encounter {:msg "place 1 virus counter on itself"
                   :effect (effect (add-counter card :virus 1)
                                   (update-ice-strength (get-card state card)))}})
@@ -3367,11 +3367,11 @@
                    sub]}))
 
 (defcard "Seidr Adaptive Barrier"
-  {:constant-effects [(ice-strength-bonus (req (count (:ices (card->server state card)))))]
+  {:static-abilities [(ice-strength-bonus (req (count (:ices (card->server state card)))))]
    :subroutines [end-the-run]})
 
 (defcard "Self-Adapting Code Wall"
-  {:constant-effects [{:type :cannot-lower-strength
+  {:static-abilities [{:type :cannot-lower-strength
                        :req (req (same-card? card (:ice context)))
                        :value true}]
    :subroutines [end-the-run]})
@@ -3570,7 +3570,7 @@
                  trash-program-sub]})
 
 (defcard "Surveyor"
-  {:constant-effects [(ice-strength-bonus (get-x-fn))]
+  {:static-abilities [(ice-strength-bonus (get-x-fn))]
    :x-fn (req (* 2 (count (:ices (card->server state card)))))
    :subroutines [{:label "Trace X - Give the Runner 2 tags"
                   :trace {:base (get-x-fn)
@@ -3625,7 +3625,7 @@
                :effect (effect (reset-variable-subs card (get-counters card :advancement) sub))}]}))
 
 (defcard "Swordsman"
-  {:constant-effects [{:type :cannot-break-subs-on-ice
+  {:static-abilities [{:type :cannot-break-subs-on-ice
                        :req (req (and (same-card? card (:ice context))
                                       (has-subtype? (:icebreaker context) "AI")))
                        :value true}]
@@ -3829,7 +3829,7 @@
                  (trace-ability 6 cannot-steal-or-trash-sub)]})
 
 (defcard "Tree Line"
-  {:constant-effects [(ice-strength-bonus (req (get-counters card :advancement)))]
+  {:static-abilities [(ice-strength-bonus (req (get-counters card :advancement)))]
    :subroutines [{:msg "gain 1 [Credits] and end the run"
                   :async true
                   :effect (req (wait-for (gain-credits state side 1)
@@ -3873,7 +3873,7 @@
                  (do-net-damage 1)]})
 
 (defcard "Turing"
-  {:constant-effects [{:type :cannot-break-subs-on-ice
+  {:static-abilities [{:type :cannot-break-subs-on-ice
                        :req (req (and (same-card? card (:ice context))
                                       (has-subtype? (:icebreaker context) "AI")))
                        :value true}
@@ -4149,7 +4149,7 @@
 
 (defcard "Wraparound"
   {:subroutines [end-the-run]
-   :constant-effects [(ice-strength-bonus
+   :static-abilities [(ice-strength-bonus
                         (req (not-any? #(has-subtype? % "Fracter") (all-active-installed state :runner)))
                         7)]})
 

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -19,7 +19,7 @@
                                   do-brain-damage do-net-damage offer-jack-out
                                   reorder-choice get-x-fn]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [get-effects register-floating-effect unregister-static-abilities]]
+   [game.core.effects :refer [get-effects register-lingering-effect unregister-static-abilities]]
    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
    [game.core.engine :refer [gather-events pay register-events resolve-ability
                              trigger-event trigger-event-simult unregister-events]]
@@ -610,7 +610,7 @@
                         :yes-ability {:prompt "Select another installed card to trash"
                                       :cost [:trash-other-installed 1]
                                       :msg "prevent its printed subroutines being broken this encounter"
-                                      :effect (effect (register-floating-effect
+                                      :effect (effect (register-lingering-effect
                                                         card {:type :cannot-break-subs-on-ice
                                                               :req (req (same-card? card (:ice context)))
                                                               :value true
@@ -1118,7 +1118,7 @@
                  :unregister-once-resolved true
                  :effect
                  (req (let [target-ice (:ice context)]
-                        (register-floating-effect
+                        (register-lingering-effect
                           state side card
                           {:type :ice-strength
                            :duration :end-of-encounter
@@ -1808,7 +1808,7 @@
   {:subroutines [{:req (req run)
                   :label "Reduce Runner's hand size by 2"
                   :msg "reduce the Runner's maximum hand size by 2 until the start of the next Corp turn"
-                  :effect (effect (register-floating-effect
+                  :effect (effect (register-lingering-effect
                                     card
                                     {:type :hand-size
                                      :duration :until-corp-turn-begins
@@ -1854,7 +1854,7 @@
                                             [{:event :run-ends
                                               :duration :end-of-run
                                               :effect (effect (remove-icon card t))}])
-                                          (register-floating-effect state side card (prevent-sub-break-by t))
+                                          (register-lingering-effect state side card (prevent-sub-break-by t))
                                           (effect-completed state side eid)))}
                           card nil))}
                :no-ability {:effect (effect (system-msg :corp (str "declines to use " (:title card))))}}}}))
@@ -1874,7 +1874,7 @@
                                    (effect-completed eid))
             :effect (effect (derez target)
                             (system-msg (str "prevents the runner from using printed abilities on bioroid ice for the rest of the turn"))
-                            (register-floating-effect
+                            (register-lingering-effect
                              card
                              {:type :prevent-paid-ability
                               :duration :end-of-turn
@@ -2136,7 +2136,7 @@
                 :duration :end-of-run
                 :unregister-once-resolved true
                 :msg (msg "prevent the runner from breaking subroutines on " (:title (:ice context)))
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                  card
                                  (let [encountered-ice (:ice context)]
                                    {:type :cannot-break-subs-on-ice
@@ -2171,7 +2171,7 @@
 (defcard "Interrupt 0"
   (let [sub {:label "Make the Runner pay 1 [Credits] to use icebreaker"
              :msg "make the Runner pay 1 [Credits] to use icebreakers to break subroutines during this run"
-             :effect (effect (register-floating-effect
+             :effect (effect (register-lingering-effect
                                card
                                {:type :break-sub-additional-cost
                                 :duration :end-of-run
@@ -2436,7 +2436,7 @@
                           (active? %))
               :not-self true}
     :effect (req (let [target-subtypes (:subtype target)]
-                   (register-floating-effect
+                   (register-lingering-effect
                      state :corp card
                      {:type :gain-subtype
                       :duration :end-of-run
@@ -2773,7 +2773,7 @@
                                                                 (not= :success (:phase (:run @state))))]
                                          (when can-redirect?
                                            (redirect-run state side target :approach-ice))
-                                         (register-floating-effect
+                                         (register-lingering-effect
                                            state side card
                                            {:type :jack-out-additional-cost
                                             :duration :end-of-run
@@ -3215,7 +3215,7 @@
 (defcard "Red Tape"
   {:subroutines [{:label "Give +3 strength to all ice for the remainder of the run"
                   :msg "give +3 strength to all ice for the remainder of the run"
-                  :effect (effect (register-floating-effect
+                  :effect (effect (register-lingering-effect
                                   card
                                   {:type :ice-strength
                                    :duration :end-of-run
@@ -3461,7 +3461,7 @@
              :effect (req (move state :runner (first (:deck runner)) :deck)
                           (let [t3 (top-3 state)
                                 effect-type (effect-type card)]
-                            (register-floating-effect
+                            (register-lingering-effect
                               state side card
                               {:type effect-type
                                :duration :end-of-encounter
@@ -3559,7 +3559,7 @@
                        :yes-ability {:prompt "Choose another installed card to trash"
                                      :cost [:trash-other-installed 1]
                                      :msg "give itself +5 strength for the remainder of the run"
-                                     :effect (effect (register-floating-effect
+                                     :effect (effect (register-lingering-effect
                                                       card
                                                       {:type :ice-strength
                                                        :duration :end-of-run
@@ -3912,7 +3912,7 @@
                                   " on this ice per encounter for the remainder of this run")
                         :effect
                         (req (wait-for (gain-credits state :runner 2)
-                                       (register-floating-effect
+                                       (register-lingering-effect
                                          state side card
                                          {:type :cannot-break-subs-on-ice
                                           :duration :end-of-run

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -18,7 +18,7 @@
                              enable-corp-damage-choice]]
    [game.core.def-helpers :refer [corp-recur defcard offer-jack-out]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [register-floating-effect]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed is-basic-advance-action? make-eid]]
    [game.core.eid :refer [effect-completed make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events register-once resolve-ability trigger-event]]
@@ -1531,7 +1531,7 @@
                          " and lower the strength of " (:title current-ice)
                          " by 2 for the remainder of the run")
                :async true
-               :effect (effect (register-floating-effect
+               :effect (effect (register-lingering-effect
                                  card
                                  (let [ice current-ice]
                                    {:type :ice-strength
@@ -1747,7 +1747,7 @@
              :once :per-turn
              :msg (msg "make " (:title (:ice context))
                        " gain Code Gate until the end of the run")
-             :effect (effect (register-floating-effect
+             :effect (effect (register-lingering-effect
                                card
                                (let [ice (:ice context)]
                                  {:type :gain-subtype

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -186,7 +186,7 @@
   (letfn [(outermost? [state ice]
             (let [server-ice (:ices (card->server state ice))]
               (same-card? ice (last server-ice))))]
-    {:constant-effects [{:type :tags
+    {:static-abilities [{:type :tags
                          :req (req (and (get-current-encounter state)
                                         (rezzed? current-ice)
                                         (outermost? state current-ice)))
@@ -398,7 +398,7 @@
                                     (or (has-subtype? card "Job")
                                         (has-subtype? card "Connection")))))
           (not-triggered? [state] (no-event? state :runner :runner-install #(az-type? (:card (first %)))))]
-    {:constant-effects [{:type :install-cost
+    {:static-abilities [{:type :install-cost
                          :req (req (and (az-type? target)
                                         (not-triggered? state)))
                          :value -1}]
@@ -459,12 +459,12 @@
              :effect (effect (continue-ability (charge-ability state side eid card) card nil))}]})
 
 (defcard "Cerebral Imaging: Infinite Frontiers"
-  {:constant-effects [(corp-hand-size+ (req (:credit corp)))]
+  {:static-abilities [(corp-hand-size+ (req (:credit corp)))]
    :effect (req (swap! state assoc-in [:corp :hand-size :base] 0))
    :leave-play (req (swap! state assoc-in [:corp :hand-size :base] 5))})
 
 (defcard "Chaos Theory: Wünderkind"
-  {:constant-effects [(mu+ 1)]})
+  {:static-abilities [(mu+ 1)]})
 
 (defcard "Chronos Protocol: Selective Mind-mapping"
   {:req (req (empty? (filter #(= :net (:damage-type (first %))) (turn-events state :runner :damage))))
@@ -501,7 +501,7 @@
               {:effect (req (system-msg state :corp (str "declines to use " (:title card))))}}}]})
 
 (defcard "Cybernetics Division: Humanity Upgraded"
-  {:constant-effects [(hand-size+ -1)]})
+  {:static-abilities [(hand-size+ -1)]})
 
 (defcard "Earth Station: SEA Headquarters"
   (let [flip-effect (effect (update! (if (:flipped card)
@@ -521,7 +521,7 @@
                :req (req (and (= :hq (target-server context))
                               (:flipped card)))
                :effect flip-effect}]
-     :constant-effects [{:type :run-additional-cost
+     :static-abilities [{:type :run-additional-cost
                          :req (req (or
                                      (and (not (:flipped card))
                                           (= :hq (:server (second targets))))
@@ -731,7 +731,7 @@
                                       (effect-completed state side eid))))}]})
 
 (defcard "Haarpsichord Studios: Entertainment Unleashed"
-  {:constant-effects [{:type :cannot-steal
+  {:static-abilities [{:type :cannot-steal
                        :value (req (pos? (event-count state side :agenda-stolen)))}]
    :events [{:event :access
              :req (req (and (agenda? target)
@@ -769,7 +769,7 @@
              :effect (effect (gain-credits eid 1))}]})
 
 (defcard "Haas-Bioroid: Precision Design"
-  {:constant-effects [(corp-hand-size+ 1)]
+  {:static-abilities [(corp-hand-size+ 1)]
    :events [{:event :agenda-scored
              :interactive (req true)
              :optional {:prompt "Add 1 card from Archives to HQ?"
@@ -778,7 +778,7 @@
    :abilities [(set-autoresolve :auto-fire "Haas-Bioroid: Precision Design")]})
 
 (defcard "Haas-Bioroid: Stronger Together"
-  {:constant-effects [{:type :ice-strength
+  {:static-abilities [{:type :ice-strength
                        :req (req (has-subtype? target "Bioroid"))
                        :value 1}]
    :leave-play (effect (update-all-ice))
@@ -857,7 +857,7 @@
                                                       :code (str (subs (:code card) 0 5) "flip")
                                                       :subtype "Digital")))
                          (update-link state))]
-    {:constant-effects [(link+ (req (:flipped card)) 1)
+    {:static-abilities [(link+ (req (:flipped card)) 1)
                         {:type :gain-subtype
                          :req (req (and (same-card? card target) (:flipped card)))
                          :value "Digital"}
@@ -930,7 +930,7 @@
      :abilities [ability]}))
 
 (defcard "Industrial Genomics: Growing Solutions"
-  {:constant-effects [{:type :trash-cost
+  {:static-abilities [{:type :trash-cost
                        :value (req (count (remove :seen (:discard corp))))}]})
 
 (defcard "Information Dynamics: All You Need To Know"
@@ -1066,7 +1066,7 @@
                             (mill state :corp eid :runner 1)))}]})
 
 (defcard "Jinteki: Replicating Perfection"
-  {:constant-effects [{:type :cannot-run-on-server
+  {:static-abilities [{:type :cannot-run-on-server
                        :req (req (no-event? state side :run #(is-central? (:server (first %)))))
                        :value (req (map first (get-remotes state)))}]})
 
@@ -1109,7 +1109,7 @@
   (letfn [(kate-type? [card] (or (hardware? card)
                                  (program? card)))
           (not-triggered? [state] (no-event? state :runner :runner-install #(kate-type? (:card (first %)))))]
-    {:constant-effects [{:type :install-cost
+    {:static-abilities [{:type :install-cost
                          :req (req (and (kate-type? target)
                                         (not-triggered? state)))
                          :value -1}]
@@ -1299,7 +1299,7 @@
                :effect (effect
                         (update! (assoc-in card [:special :mm-actions] []))
                         (update! (assoc-in (get-card state card) [:special :mm-click] false)))}]
-     :constant-effects [{:type :prevent-paid-ability
+     :static-abilities [{:type :prevent-paid-ability
                          :req (req (and (get-in card [:special :mm-click])
                                         (let [cid (:cid target)
                                               ability-idx (nth targets 2 nil)
@@ -1429,7 +1429,7 @@
                             (draw state :corp eid 2)))}]})
 
 (defcard "NBN: The World is Yours*"
-  {:constant-effects [(corp-hand-size+ 1)]})
+  {:static-abilities [(corp-hand-size+ 1)]})
 
 (defcard "Near-Earth Hub: Broadcast Center"
   {:events [{:event :server-created
@@ -1721,7 +1721,7 @@
 (defcard "Reina Roja: Freedom Fighter"
   (letfn [(not-triggered? [state]
             (no-event? state :runner :rez #(ice? (:card (first %)))))]
-    {:constant-effects [{:type :rez-cost
+    {:static-abilities [{:type :rez-cost
                          :req (req (and (ice? target)
                                         (not (rezzed? target))
                                         (not-triggered? state)))
@@ -1946,7 +1946,7 @@
   {})
 
 (defcard "SYNC: Everything, Everywhere"
-  {:constant-effects [{:type :card-ability-additional-cost
+  {:static-abilities [{:type :card-ability-additional-cost
                        :req (req (let [targetcard (first targets)
                                        target (second targets)]
                                    (and (not (:sync-flipped card))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -20,7 +20,7 @@
    [game.core.def-helpers :refer [corp-recur defcard do-brain-damage
                                   reorder-choice get-x-fn]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [register-floating-effect]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed make-eid make-result]]
    [game.core.engine :refer [pay register-events resolve-ability]]
    [game.core.events :refer [first-event? last-turn? no-event? not-last-turn?
@@ -294,7 +294,7 @@
 (defcard "Bad Times"
   {:on-play {:req (req tagged)
              :msg "force the Runner to lose 2[mu] until the end of the turn"
-             :effect (req (register-floating-effect
+             :effect (req (register-lingering-effect
                             state :corp card
                             (assoc (mu+ -2) :duration :end-of-turn))
                           (update-mu state))}})

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -761,7 +761,7 @@
 
 (defcard "Enforced Curfew"
   {:on-play {:msg "reduce the Runner's maximum hand size by 1"}
-   :constant-effects [(runner-hand-size+ -1)]})
+   :static-abilities [(runner-hand-size+ -1)]})
 
 (defcard "Enforcing Loyalty"
   {:on-play
@@ -780,7 +780,7 @@
 (defcard "Enhanced Login Protocol"
   {:on-play {:msg (str "add an additional cost of [Click]"
                        " to make the first run not through a card ability this turn")}
-   :constant-effects [{:type :run-additional-cost
+   :static-abilities [{:type :run-additional-cost
                        :req (req (and (no-event? state side :run #(:click-run (:cost-args (first %))))
                                       (:click-run (second targets))))
                        :value [:click 1]}]})
@@ -1401,7 +1401,7 @@
 
 (defcard "Lag Time"
   {:on-play {:effect (effect (update-all-ice))}
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :value 1}]
    :leave-play (effect (update-all-ice))})
 
@@ -1502,7 +1502,7 @@
                                    (installed? %))}
              :msg (msg "host itself on " (card-str state target) ". The Runner has an additional tag")
              :effect (effect (install-as-condition-counter eid card target))}
-   :constant-effects [{:type :tags
+   :static-abilities [{:type :tags
                        :value 1}]
    :leave-play (req (system-msg state :corp "trashes MCA Informant"))
    :runner-abilities [{:label "Trash MCA Informant host"
@@ -1711,7 +1711,7 @@
 
 (defcard "NEXT Activation Command"
   (lockdown
-   {:constant-effects [{:type :ice-strength
+   {:static-abilities [{:type :ice-strength
                         :value 2}
                        {:type :prevent-paid-ability
                         :req (req (let [target-card (first targets)
@@ -1808,7 +1808,7 @@
              :msg (msg "give +2 strength to " (card-str state target))
              :async true
              :effect (effect (install-as-condition-counter eid card target))}
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (same-card? target (:host card)))
                        :value 2}]})
 
@@ -2317,7 +2317,7 @@
 
 (defcard "Rolling Brownout"
   {:on-play {:msg "increase the play cost of operations and events by 1 [Credits]"}
-   :constant-effects [{:type :play-cost
+   :static-abilities [{:type :play-cost
                        :value 1}]
    :events [{:event :play-event
              :once :per-turn
@@ -2331,7 +2331,7 @@
              :msg (msg "host itself as a condition counter on " (card-str state target))
              :async true
              :effect (effect (install-as-condition-counter eid card target))}
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (same-card? target (:host card)))
                        :value (req (get-counters card :power))}]
    :events [{:event :pass-ice
@@ -2387,7 +2387,7 @@
 
 (defcard "Scarcity of Resources"
   {:on-play {:msg "increase the install cost of resources by 2"}
-   :constant-effects [{:type :install-cost
+   :static-abilities [{:type :install-cost
                        :req (req (resource? target))
                        :value 2}]})
 
@@ -2464,7 +2464,7 @@
 
 (defcard "Service Outage"
   {:on-play {:msg "add a cost of 1 [Credit] for the Runner to make the first run each turn"}
-   :constant-effects [{:type :run-additional-cost
+   :static-abilities [{:type :run-additional-cost
                        :req (req (no-event? state side :run))
                        :value [:credit 1]}]})
 
@@ -2665,7 +2665,7 @@
                :async true
                :effect (req (add-extra-sub! state :corp (get-card state target) new-sub (:cid card))
                             (install-as-condition-counter state side eid card (get-card state target)))}
-     :constant-effects [{:type :gain-subtype
+     :static-abilities [{:type :gain-subtype
                          :req (req (and (same-card? target (:host card))
                                         (rezzed? target)))
                          :value "Barrier"}]
@@ -2878,7 +2878,7 @@
     :effect (effect (damage eid :meat 2 {:card card}))}})
 
 (defcard "Transparency Initiative"
-  {:constant-effects [{:type :gain-subtype
+  {:static-abilities [{:type :gain-subtype
                        :req (req (and (same-card? target (:host card))
                                       (rezzed? target)))
                        :value "Public"}]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -235,7 +235,7 @@
   (Greek/Philosopher suite: Adept, Sage, Savant)"
   [abilities]
   (auto-icebreaker {:abilities abilities
-                    :constant-effects [(breaker-strength-bonus (req (available-mu state)))]}))
+                    :static-abilities [(breaker-strength-bonus (req (available-mu state)))]}))
 
 (defn- break-multiple-types
   "Single ability to break multiple types of ice
@@ -347,7 +347,7 @@
   "Reduce MU cost to 0 with 2+ link
   (Cloud subtype: Creeper, ZU.13 Key Master, B&E, GlobalSec)"
   [cdef]
-  (update cdef :constant-effects conj {:type :used-mu
+  (update cdef :static-abilities conj {:type :used-mu
                                        :req (req (<= 2 (get-link state)))
                                        :value (req (- (:memoryunits card)))}))
 
@@ -358,7 +358,7 @@
   (auto-icebreaker
     (cloud-icebreaker
       {:abilities [(break-sub [:trash-can] 3 ice-type)]
-       :constant-effects [(breaker-strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
+       :static-abilities [(breaker-strength-bonus (req (count (filter #(has-subtype? % "Icebreaker")
                                                                       (all-active-installed state :runner)))))]})))
 
 (defn- global-sec-breaker
@@ -505,7 +505,7 @@
                 :msg (msg "place " (quantify (cost-value eid :x-credits) "power counter") " on itself")
                 :effect (effect (add-counter card :power (cost-value eid :x-credits)))}
    :abilities [(break-sub 1 1 "All" {:req (req (= (get-strength current-ice) (get-strength card)))})]
-   :constant-effects [(breaker-strength-bonus (req (get-counters card :power)))]})
+   :static-abilities [(breaker-strength-bonus (req (get-counters card :power)))]})
 
 (defcard "Au Revoir"
   {:events [{:event :jack-out
@@ -528,7 +528,7 @@
                                 {:label "Place 1 virus counter"
                                  :msg "manually place 1 virus counter on itself"
                                  :effect (effect (add-counter card :virus 1))}]
-                    :constant-effects [(breaker-strength-bonus (req (get-virus-counters state card)))]
+                    :static-abilities [(breaker-strength-bonus (req (get-virus-counters state card)))]
                     :events [{:event :end-breach-server
                               :req (req (not (or (:did-steal target)
                                                  (:did-trash target))))
@@ -617,7 +617,7 @@
   (auto-icebreaker {:on-install {:async true
                                  :effect (effect (damage eid :brain 1 {:card card}))}
                     :abilities [(break-sub 1 0 "Barrier")]
-                    :constant-effects [(breaker-strength-bonus (req (:brain-damage runner)))]}))
+                    :static-abilities [(breaker-strength-bonus (req (:brain-damage runner)))]}))
 
 (defcard "Berserker"
   (auto-icebreaker {:events [{:event :encounter-ice
@@ -654,7 +654,7 @@
                                   :msg (msg "host itself on " (card-str state target))
                                   :effect (effect (host target card))}
                                  card nil)))}]
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (and (= (:cid target)
                                          (:cid (:host card)))
                                       (:rezzed target)))
@@ -777,7 +777,7 @@
                                 :type :recurring}}})
 
 (defcard "Chakana"
-  {:constant-effects [{:type :advancement-requirement
+  {:static-abilities [{:type :advancement-requirement
                        :req (req (<= 3 (get-virus-counters state card)))
                        :value 1}]
    :events [{:event :successful-run
@@ -802,7 +802,7 @@
   {:implementation "[Erratum] Program: Virus - Trojan"
    :hosting {:card #(and (ice? %)
                          (can-host? %))}
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (same-card? target (:host card)))
                        :value (req (- (get-virus-counters state card)))}]
    :events [{:event :encounter-ice
@@ -817,7 +817,7 @@
 
 (defcard "Cat's Cradle"
   (auto-icebreaker
-    {:constant-effects [{:type :rez-cost
+    {:static-abilities [{:type :rez-cost
                          :req (req (and (ice? target) (has-subtype? target "Code Gate")))
                          :value 1}]
      :abilities [(break-sub 1 1 "Code Gate")
@@ -971,7 +971,7 @@
 
 (defcard "Cradle"
   (auto-icebreaker {:abilities [(break-sub 2 0 "Code Gate")]
-                    :constant-effects [(breaker-strength-bonus (req (- (count (:hand runner)))))]}))
+                    :static-abilities [(breaker-strength-bonus (req (- (count (:hand runner)))))]}))
 
 (defcard "Creeper"
   (cloud-icebreaker
@@ -1101,7 +1101,7 @@
                                  :msg "place 1 virus counter on itself"
                                  :req (req (:runner-phase-12 @state))
                                  :effect (effect (add-counter card :virus 1))}]
-                    :constant-effects [(breaker-strength-bonus (get-x-fn))]}))
+                    :static-abilities [(breaker-strength-bonus (get-x-fn))]}))
 
 (defcard "Datasucker"
   {:events [{:event :successful-run
@@ -1239,7 +1239,7 @@
   {:on-install {:prompt "Choose a server"
                 :choices (req servers)
                 :effect (effect (update! (assoc card :card-target target)))}
-   :constant-effects [{:type :install-cost
+   :static-abilities [{:type :install-cost
                        :req (req (let [serv (:server (second targets))]
                                    (= serv (:card-target card))))
                        :value 1}]
@@ -1288,7 +1288,7 @@
                                 (strength-pump 1 1)]}))
 
 (defcard "Echelon"
-  (auto-icebreaker {:constant-effects [(breaker-strength-bonus (req (count (filter #(and (program? %)
+  (auto-icebreaker {:static-abilities [(breaker-strength-bonus (req (count (filter #(and (program? %)
                                                                                          (has-subtype? % "Icebreaker"))
                                                                                    (all-active-installed state :runner)))))]
                     :abilities [(break-sub 1 1 "Sentry")
@@ -1301,7 +1301,7 @@
                          (rezzed? %))}
    :on-install {:msg (msg "make " (card-str state (:host card))
                           " gain Barrier, Code Gate and Sentry subtypes")}
-   :constant-effects [{:type :gain-subtype
+   :static-abilities [{:type :gain-subtype
                        :req (req (same-card? target (:host card)))
                        :value ["Barrier" "Code Gate" "Sentry"]}]})
 
@@ -1489,7 +1489,7 @@
                                 (strength-pump 1 1)]}))
 
 (defcard "Gauss"
-  (auto-icebreaker {:constant-effects [(breaker-strength-bonus (req (= :this-turn (installed? card))) 3)]
+  (auto-icebreaker {:static-abilities [(breaker-strength-bonus (req (= :this-turn (installed? card))) 3)]
                     :abilities [(break-sub 1 1 "Barrier")
                                 (strength-pump 2 2)]}))
 
@@ -1650,7 +1650,7 @@
                                  :msg "place 1 power counter"
                                  :async true
                                  :effect (effect (add-counter eid card :power 1 nil))}]
-                    :constant-effects [(breaker-strength-bonus (req (get-counters card :power)))]}))
+                    :static-abilities [(breaker-strength-bonus (req (get-counters card :power)))]}))
 
 (defcard "Hyperdriver"
   {:flags {:runner-phase-12 (req true)}
@@ -1737,7 +1737,7 @@
              :effect (req (trash state :runner eid card {:cause :purge :cause-card card}))}]})
 
 (defcard "K2CP Turbine"
-  {:constant-effects [{:type :breaker-strength
+  {:static-abilities [{:type :breaker-strength
                        :req (req (and (has-subtype? target "Icebreaker")
                                       (not (has-subtype? target "AI"))))
                        :value 2}]
@@ -2014,7 +2014,7 @@
 
 (defcard "Maven"
   (auto-icebreaker {:abilities [(break-sub 2 1)]
-                    :constant-effects [(breaker-strength-bonus (req (count (filter program? (all-active-installed state :runner)))))]}))
+                    :static-abilities [(breaker-strength-bonus (req (count (filter program? (all-active-installed state :runner)))))]}))
 
 (defcard "Mayfly"
   (auto-icebreaker
@@ -2089,7 +2089,7 @@
 (defcard "Monkeywrench"
   {:hosting {:card #(and (ice? %)
                          (can-host? %))}
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (and (ice? target)
                                       (= (get-zone (:host card)) (get-zone target))))
                        :value (req (if (same-card? target (:host card)) -2 -1))}]})
@@ -2107,7 +2107,7 @@
   (virus-breaker "Sentry"))
 
 (defcard "Na'Not'K"
-  (auto-icebreaker {:constant-effects [(breaker-strength-bonus (req (count run-ices)))]
+  (auto-icebreaker {:static-abilities [(breaker-strength-bonus (req (count run-ices)))]
                     :abilities [(break-sub 1 1 "Sentry")
                                 (strength-pump 3 2)]}))
 
@@ -2148,7 +2148,7 @@
 
 (defcard "Nfr"
   (auto-icebreaker {:abilities [(break-sub 1 1 "Barrier")]
-                    :constant-effects [(breaker-strength-bonus (req (get-counters card :power)))]
+                    :static-abilities [(breaker-strength-bonus (req (get-counters card :power)))]
                     :events [{:event :end-of-encounter
                               :req (req (all-subs-broken-by-card? (:ice context) card))
                               :msg "place 1 power counter on itself"
@@ -2225,7 +2225,7 @@
                               :effect (effect (continue-ability (charge-ability state side eid card) card nil))}]}))
 
 (defcard "Origami"
-  {:constant-effects [{:type :hand-size
+  {:static-abilities [{:type :hand-size
                        :req (req (= :runner side))
                        :value (req (count (filter #(= (:title %) "Origami")
                                                   (all-active-installed state :runner))))}]})
@@ -2315,7 +2315,7 @@
                    (update! state side (assoc-in card [:special :installing] true))
                    (when-let [card (get-card state card)]
                      (update! state side (update-in card [:special] dissoc :installing)))))}
-   :constant-effects [{:type :ice-strength
+   :static-abilities [{:type :ice-strength
                        :req (req (same-card? target (:host card)))
                        :value (req (- (get-virus-counters state card)))}]
    :events [{:event :runner-turn-begins
@@ -2538,7 +2538,7 @@
                                  :msg "remove 1 power counter"
                                  :label "Remove 1 power counter"
                                  :effect (effect (add-counter card :power -1))}]
-                    :constant-effects [(breaker-strength-bonus (req (get-counters card :power)))
+                    :static-abilities [(breaker-strength-bonus (req (get-counters card :power)))
                                        {:type :used-mu
                                         :duration :constant
                                         :value (req (get-counters card :power))}]}))
@@ -2648,7 +2648,7 @@
                                   :msg (msg "host itself on " (card-str state target))
                                   :effect (effect (host target card))}
                                  card nil)))}]
-   :constant-effects [{:type :rez-cost
+   :static-abilities [{:type :rez-cost
                        :req (req (and (ice? target)
                                       (= (get-zone (:host card)) (get-zone target))))
                        :value 2}]})
@@ -2759,7 +2759,7 @@
   (auto-icebreaker {:x-fn (req (if (threat-level 4 state) -2 0))
                     :abilities [(break-sub 1 1 "Code Gate")
                                 (strength-pump 2 2)]
-                    :constant-effects [(breaker-strength-bonus (get-x-fn))]}))
+                    :static-abilities [(breaker-strength-bonus (get-x-fn))]}))
 
 (defcard "Shiv"
   (break-and-enter "Sentry"))
@@ -2852,11 +2852,11 @@
                                 {:cost [:credit 2]
                                  :msg "place 1 power counter"
                                  :effect (effect (add-counter card :power 1))}]
-                    :constant-effects [(breaker-strength-bonus (req (get-counters card :power)))]}))
+                    :static-abilities [(breaker-strength-bonus (req (get-counters card :power)))]}))
 
 (defcard "Sūnya"
   (auto-icebreaker {:abilities [(break-sub 2 1 "Sentry")]
-                    :constant-effects [(breaker-strength-bonus (req (get-counters card :power)))]
+                    :static-abilities [(breaker-strength-bonus (req (get-counters card :power)))]
                     :events [{:event :end-of-encounter
                               :req (req (all-subs-broken-by-card? (:ice context) card))
                               :msg "place 1 power counter on itself"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2540,7 +2540,7 @@
                                  :effect (effect (add-counter card :power -1))}]
                     :static-abilities [(breaker-strength-bonus (req (get-counters card :power)))
                                        {:type :used-mu
-                                        :duration :constant
+                                        :duration :while-active
                                         :value (req (get-counters card :power))}]}))
 
 (defcard "Reaver"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -16,7 +16,7 @@
    [game.core.damage :refer [damage damage-prevent]]
    [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out trash-on-empty get-x-fn]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [any-effects register-floating-effect
+   [game.core.effects :refer [any-effects register-lingering-effect
                               unregister-effects-for-card]]
    [game.core.eid :refer [effect-completed make-eid]]
    [game.core.engine :refer [ability-as-handler dissoc-req not-used-once? pay
@@ -278,7 +278,7 @@
                      {:cost [:credit cost]
                       :msg (msg "make " (:title current-ice) " gain " ice-type)
                       :effect (effect (register-once {:once :per-turn} card)
-                                      (register-floating-effect
+                                      (register-lingering-effect
                                         card
                                         (let [ice current-ice]
                                           {:type :gain-subtype
@@ -584,7 +584,7 @@
                                  :msg (msg "prevent " (card-str state current-ice) " from ending the run this encounter")
                                  :effect (req
                                            (let [target-ice (:ice (get-current-encounter state))]
-                                             (register-floating-effect
+                                             (register-lingering-effect
                                                state side
                                                card
                                                {:type :auto-prevent-run-end
@@ -2074,7 +2074,7 @@
                               :req (req (and (any-subs-broken-by-card? target card)
                                              run))
                               :effect (req (let [broken-ice target]
-                                             (register-floating-effect
+                                             (register-lingering-effect
                                                state side
                                                card
                                                {:type :prevent-paid-ability
@@ -2250,7 +2250,7 @@
                                :msg (msg "spend [Click] and make " (card-str state ice)
                                          " gain " target
                                          " until the end of the next run this turn")
-                               :effect (effect (register-floating-effect
+                               :effect (effect (register-lingering-effect
                                                  card
                                                  {:type :gain-subtype
                                                   :duration :end-of-next-run
@@ -2275,7 +2275,7 @@
                                   sort))
                :msg (msg "make " (card-str state current-ice) " gain " target)
                :effect (effect (register-once {:once :per-turn} card)
-                               (register-floating-effect
+                               (register-lingering-effect
                                  card
                                  (let [ice current-ice]
                                    {:type :gain-subtype
@@ -2400,7 +2400,7 @@
                 :msg (msg "make " (card-str state current-ice)
                           " gain " target
                           " until end of the encounter")
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                   card
                                   (let [ice current-ice]
                                     {:type :gain-subtype

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -166,7 +166,7 @@
               (assoc am :event :agenda-stolen)]}))
 
 (defcard "Access to Globalsec"
-  {:constant-effects [(link+ 1)]})
+  {:static-abilities [(link+ 1)]})
 
 (defcard "Activist Support"
   {:events [{:event :corp-turn-begins
@@ -453,7 +453,7 @@
                                  card nil))}]}))
 
 (defcard "Beach Party"
-  {:constant-effects [(runner-hand-size+ 5)]
+  {:static-abilities [(runner-hand-size+ 5)]
    :events [{:event :runner-turn-begins
              :msg "lose [Click]"
              :effect (effect (lose-clicks 1))}]})
@@ -564,7 +564,7 @@
    :abilities [ability]}))
 
 (defcard "Borrowed Satellite"
-  {:constant-effects [(link+ 1)
+  {:static-abilities [(link+ 1)
                       (runner-hand-size+ 1)]})
 
 (defcard "Bug Out Bag"
@@ -901,7 +901,7 @@
                (set-autoresolve :auto-place-counter "Crypt placing virus counters on itself")]})
 
 (defcard "Cybertrooper Talut"
-  {:constant-effects [(link+ 1)]
+  {:static-abilities [(link+ 1)]
    :events [{:event :runner-install
              :silent (req true)
              :req (req (and (has-subtype? (:card context) "Icebreaker")
@@ -1119,7 +1119,7 @@
                                  (enable-card state side hosted)))}}))
 
 (defcard "Donut Taganes"
-  {:constant-effects [{:type :play-cost
+  {:static-abilities [{:type :play-cost
                        :value 1}]})
 
 (defcard "Dr. Lovegood"
@@ -1561,7 +1561,7 @@
      :abilities [ability]}))
 
 (defcard "Hernando Cortez"
-  {:constant-effects [{:type :rez-additional-cost
+  {:static-abilities [{:type :rez-additional-cost
                        :req (req (and (<= 10 (:credit corp))
                                       (ice? target)))
                        :value (req [:credit (count (:subroutines target))])}]})
@@ -1640,7 +1640,7 @@
                                 :type :credit}}})
 
 (defcard "Ice Carver"
-  {:constant-effects [{:type :ice-strength
+  {:static-abilities [{:type :ice-strength
                        :req (req (and (get-current-encounter state)
                                       (same-card? current-ice target)))
                        :value -1}]})
@@ -1883,7 +1883,7 @@
                                 (trash state :runner eid card {:cause-card card})
                                 (pay state :runner eid card :credit 1)))}]
     {:flags {:drip-economy true}
-     :constant-effects [(corp-hand-size+ -1)]
+     :static-abilities [(corp-hand-size+ -1)]
      :events [(assoc ability :event :runner-turn-begins)]}))
 
 (defcard "Liberated Account"
@@ -2029,7 +2029,7 @@
              :effect (effect (trash-cards eid (filter program? (:hosted card)) {:cause-card card}))}]})
 
 (defcard "Maxwell James"
-  {:constant-effects [(link+ 1)]
+  {:static-abilities [(link+ 1)]
    :abilities [{:req (req (some #{:hq} (:successful-run runner-reg)))
                 :prompt "Choose a piece of ice protecting a remote server"
                 :choices {:card #(and (ice? %)
@@ -2185,7 +2185,7 @@
 
 (defcard "Network Exchange"
   {:on-install {:msg "increase the install cost of non-innermost ice by 1"}
-   :constant-effects [{:type :install-cost
+   :static-abilities [{:type :install-cost
                        :req (req (ice? target))
                        :value (req (when (pos? (count (:dest-zone (second targets)))) 1))}]})
 
@@ -2387,7 +2387,7 @@
                      (gain-credits eid 1))}))
 
 (defcard "Paparazzi"
-  {:constant-effects [{:type :is-tagged
+  {:static-abilities [{:type :is-tagged
                        :val true}]
    :events [{:event :pre-damage
              :req (req (= target :meat)) :msg "prevent all meat damage"
@@ -2581,7 +2581,7 @@
    :abilities [(set-autoresolve :auto-fire "Psych Mike")]})
 
 (defcard "Public Sympathy"
-  {:constant-effects [(runner-hand-size+ 2)]})
+  {:static-abilities [(runner-hand-size+ 2)]})
 
 (defcard "Rachel Beckman"
   (trash-when-tagged-contructor "Rachel Beckman" {:in-play [:click-per-turn 1]}))
@@ -2764,7 +2764,7 @@
                                 (trash-prevent :hardware 1))}]})
 
 (defcard "Safety First"
-  {:constant-effects [(runner-hand-size+ -2)]
+  {:static-abilities [(runner-hand-size+ -2)]
    :events [{:event :runner-turn-ends
              :async true
              :effect (req (if (< (count (:hand runner)) (hand-size state :runner))
@@ -3094,7 +3094,7 @@
                             (gain-credits state side eid credits)))}]})
 
 (defcard "The Archivist"
-  {:constant-effects [(link+ 1)]
+  {:static-abilities [(link+ 1)]
    :events [{:event :agenda-scored
              :interactive (req true)
              :trace {:base 1
@@ -3165,7 +3165,7 @@
 
 (defcard "The Black File"
   {:on-install {:msg "prevent the Corp from winning the game unless they are flatlined"}
-   :constant-effects [{:type :cannot-win-on-points
+   :static-abilities [{:type :cannot-win-on-points
                        :req (req (and (= :corp side)
                                       (< (get-counters card :power) 3)))
                        :value true}]
@@ -3214,7 +3214,7 @@
                         card nil)))}]}))
 
 (defcard "The Helpful AI"
-  {:constant-effects [(link+ 1)]
+  {:static-abilities [(link+ 1)]
    :abilities [{:msg (msg "give +2 strength to " (:title target))
                 :label "pump icebreaker"
                 :choices {:card #(and (has-subtype? % "Icebreaker")
@@ -3298,7 +3298,7 @@
                   :effect (effect (play-instant eid target {:ignore-cost true}))}]}))
 
 (defcard "The Source"
-  {:constant-effects [{:type :advancement-requirement
+  {:static-abilities [{:type :advancement-requirement
                        :value 1}]
    :events [{:event :agenda-scored
              :async true
@@ -3418,7 +3418,7 @@
                            card nil)))}]})
 
 (defcard "Theophilius Bagbiter"
-  {:constant-effects [(runner-hand-size+ (req (:credit runner)))]
+  {:static-abilities [(runner-hand-size+ (req (:credit runner)))]
    :on-install {:async true
                 :effect (req (swap! state assoc-in [:runner :hand-size :base] 0)
                              (lose-credits state :runner eid :all))}
@@ -3639,7 +3639,7 @@
    :abilities [(set-autoresolve :auto-fire "Whistleblower")]})
 
 (defcard "Wireless Net Pavilion"
-  {:constant-effects [{:type :card-ability-additional-cost
+  {:static-abilities [{:type :card-ability-additional-cost
                        :req (req (let [targetcard (first targets)
                                        target (second targets)]
                                    (and (same-card? targetcard (:basic-action-card corp))
@@ -3689,7 +3689,7 @@
                 :effect (effect (draw eid 2))}]})
 
 (defcard "Xanadu"
-  {:constant-effects [{:type :rez-cost
+  {:static-abilities [{:type :rez-cost
                        :req (req (ice? target))
                        :value 1}]})
 

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -22,7 +22,7 @@
    [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out
                                   reorder-choice trash-on-empty do-net-damage]]
    [game.core.drawing :refer [draw draw-bonus first-time-draw-bonus]]
-   [game.core.effects :refer [register-floating-effect]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events
                              register-once register-suppress resolve-ability
@@ -1004,7 +1004,7 @@
                 :choices {:card #(and (installed? %)
                                       (has-subtype? % "Icebreaker"))}
                 :cost [:trash-can]
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                   card
                                   (let [breaker target]
                                     {:type :breaker-strength

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -94,7 +94,7 @@
                                            (effect-completed eid))}}}]})
 
 (defcard "Akitaro Watanabe"
-  {:constant-effects [{:type :rez-cost
+  {:static-abilities [{:type :rez-cost
                        :req (req (and (ice? target)
                                       (= (card->server state card) (card->server state target))))
                        :value -2}]})
@@ -318,7 +318,7 @@
                                   (trash state :corp eid card {:cause-card card}))))))}]})
 
 (defcard "Breaker Bay Grid"
-  {:constant-effects [{:type :rez-cost
+  {:static-abilities [{:type :rez-cost
                        :req (req (in-same-server? card target))
                        :value -5}]})
 
@@ -439,7 +439,7 @@
                                            (effect-completed state side eid)))))}]})
 
 (defcard "Cold Site Server"
-  {:constant-effects [{:type :run-additional-cost
+  {:static-abilities [{:type :run-additional-cost
                        :req (req (= (:server (second targets)) (unknown->kw (get-zone card))))
                        :value (req (repeat (get-counters card :power) [:credit 1 :click 1]))}]
    :events [{:event :corp-turn-begins
@@ -464,7 +464,7 @@
                 :effect (effect (pump-ice target (cost-value eid :x-credits) :end-of-turn))}]})
 
 (defcard "Crisium Grid"
-  {:constant-effects [{:type :block-successful-run
+  {:static-abilities [{:type :block-successful-run
                        :req (req this-server)
                        :value true}]})
 
@@ -631,7 +631,7 @@
                  etr]}))
 
 (defcard "Experiential Data"
-  {:constant-effects [{:type :ice-strength
+  {:static-abilities [{:type :ice-strength
                        :req (req (protecting-same-server? card target))
                        :value 1}]})
 
@@ -1098,7 +1098,7 @@
                             (continue-ability state :runner (offer-jack-out) card nil))}}}]})
 
 (defcard "Midway Station Grid"
-  {:constant-effects [{:type :break-sub-additional-cost
+  {:static-abilities [{:type :break-sub-additional-cost
                        :req (req (and ; The card is an icebreaker
                                       (has-subtype? target "Icebreaker")
                                       ; and is using a break ability
@@ -1238,7 +1238,7 @@
                               card nil)))}]})
 
 (defcard "Navi Mumbai City Grid"
-  {:constant-effects [{:type :prevent-paid-ability
+  {:static-abilities [{:type :prevent-paid-ability
                        :req (req (let [target-card (first targets)]
                                    (and run
                                         (= (:side target-card) "Runner")
@@ -1288,7 +1288,7 @@
                    card nil))}}}]})
 
 (defcard "Oaktown Grid"
-  {:constant-effects [{:type :trash-cost
+  {:static-abilities [{:type :trash-cost
                        :req (req (in-same-server? card target))
                        :value 3}]})
 
@@ -1303,7 +1303,7 @@
 
 (defcard "Off the Grid"
   {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
-   :constant-effects [{:type :cannot-run-on-server
+   :static-abilities [{:type :cannot-run-on-server
                        :req (req (rezzed? card))
                        :value (req (second (get-zone card)))}]
    :events [{:event :successful-run
@@ -1392,7 +1392,7 @@
 
 (defcard "Port Anson Grid"
   {:on-rez {:msg "prevent the Runner from jacking out unless they trash an installed program"}
-   :constant-effects [{:type :jack-out-additional-cost
+   :static-abilities [{:type :jack-out-additional-cost
                        :duration :end-of-run
                        :req (req this-server)
                        :value [:program 1]}]
@@ -1434,7 +1434,7 @@
              :effect (effect (steal-cost-bonus [:credit 5] {:source card :source-type :ability}))}]})
 
 (defcard "Reduced Service"
-  {:constant-effects [{:type :run-additional-cost
+  {:static-abilities [{:type :run-additional-cost
                        :req (req (= (:server (second targets)) (unknown->kw (get-zone card))))
                        :value (req (repeat (get-counters card :power) [:credit 2]))}]
    :events [{:event :successful-run
@@ -1455,10 +1455,10 @@
 
 (defcard "Research Station"
   {:install-req (req (filter #{"HQ"} targets))
-   :constant-effects [(corp-hand-size+ 2)]})
+   :static-abilities [(corp-hand-size+ 2)]})
 
 (defcard "Ruhr Valley"
-  {:constant-effects [{:type :run-additional-cost
+  {:static-abilities [{:type :run-additional-cost
                        :req (req (= (:server (second targets)) (unknown->kw (get-zone card))))
                        :value [:click 1]}]})
 
@@ -1476,7 +1476,7 @@
                 :effect (effect (damage eid :brain 1 {:card card}))}]})
 
 (defcard "SanSan City Grid"
-  {:constant-effects [{:type :advancement-requirement
+  {:static-abilities [{:type :advancement-requirement
                        :req (req (in-same-server? card target))
                        :value -1}]})
 
@@ -1719,7 +1719,7 @@
              :req (req (same-server? card target))
              :msg "prevent 1 card from being exposed"
              :effect (effect (expose-prevent 1))}]
-   :constant-effects [{:type :bypass-ice
+   :static-abilities [{:type :bypass-ice
                        :req (req (same-server? card target))
                        :value false}]})
 
@@ -1748,7 +1748,7 @@
                 :effect (effect (add-prop target :advance-counter 2 {:placed true}))}]})
 
 (defcard "Vovô Ozetti"
-   {:constant-effects [{:type :rez-cost
+   {:static-abilities [{:type :rez-cost
                        :req (req (and (or (ice? target)
                                           (threat-level 4 state))
                                       (= (card->server state card) (card->server state target))))
@@ -1851,7 +1851,7 @@
 
 (defcard "ZATO City Grid"
   {:install-req (req (remove #{"HQ" "R&D" "Archives"} targets))
-   :constant-effects [{:type :gain-encounter-ability
+   :static-abilities [{:type :gain-encounter-ability
                        :req (req (and (protecting-same-server? card target)
                                       (some #(:printed %) (:subroutines target))
                                       (not (:disabled target))))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -18,7 +18,7 @@
    [game.core.def-helpers :refer [corp-rez-toast defcard offer-jack-out
                                   reorder-choice get-x-fn]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [register-floating-effect]]
+   [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed get-ability-targets is-basic-advance-action? make-eid]]
    [game.core.engine :refer [dissoc-req pay register-default-events
                              register-events resolve-ability unregister-events]]
@@ -750,7 +750,7 @@
                                (pos? (count (:hand corp)))))
                 :async true
                 :cost [:trash-from-hand 1]
-                :effect (effect (register-floating-effect
+                :effect (effect (register-lingering-effect
                                   card
                                   {:type :ice-strength
                                    :duration :end-of-run
@@ -1727,7 +1727,7 @@
   {:events [{:event :subroutines-broken
              :req (req (and this-server (all-subs-broken? target)))
              :msg "reduce the Runner's maximum hand size by 1 until the start of the next Corp turn"
-             :effect (effect (register-floating-effect
+             :effect (effect (register-lingering-effect
                                card
                                {:type :hand-size
                                 :duration :until-corp-turn-begins

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -324,10 +324,10 @@
    get-effects
    get-effect-maps
    get-effect-value
-   register-constant-effects
+   register-static-abilities
    register-floating-effect
    sum-effects
-   unregister-constant-effects
+   unregister-static-abilities
    unregister-effects-for-card
    unregister-floating-effects])
 

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -325,11 +325,11 @@
    get-effect-maps
    get-effect-value
    register-static-abilities
-   register-floating-effect
+   register-lingering-effect
    sum-effects
    unregister-static-abilities
    unregister-effects-for-card
-   unregister-floating-effects])
+   unregister-lingering-effects])
 
 (expose-vars
   [game.core.eid

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -5,7 +5,7 @@
     [game.core.card :refer [agenda? condition-counter? corp? get-agenda-points get-card get-zone in-discard? in-hand? in-scored? operation? rezzed?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [card-ability-cost trash-cost]]
-    [game.core.effects :refer [any-effects register-constant-effects register-floating-effect sum-effects unregister-floating-effects]]
+    [game.core.effects :refer [any-effects register-static-abilities register-floating-effect sum-effects unregister-floating-effects]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.engine :refer [ability-as-handler can-trigger? checkpoint register-pending-event pay queue-event register-default-events resolve-ability should-trigger? trigger-event trigger-event-simult trigger-event-sync unregister-floating-events]]
     [game.core.finding :refer [find-cid]]
@@ -180,7 +180,7 @@
   (let [c (move state :runner (dissoc card :advance-counter :new) :scored {:force true})
         _ (when (card-flag? c :has-events-when-stolen true)
             (register-default-events state side c)
-            (register-constant-effects state side c))
+            (register-static-abilities state side c))
         _ (update-all-advancement-requirements state)
         _ (update-all-agenda-points state)
         c (get-card state c)

--- a/src/clj/game/core/access.clj
+++ b/src/clj/game/core/access.clj
@@ -5,7 +5,7 @@
     [game.core.card :refer [agenda? condition-counter? corp? get-agenda-points get-card get-zone in-discard? in-hand? in-scored? operation? rezzed?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [card-ability-cost trash-cost]]
-    [game.core.effects :refer [any-effects register-static-abilities register-floating-effect sum-effects unregister-floating-effects]]
+    [game.core.effects :refer [any-effects register-static-abilities register-lingering-effect sum-effects unregister-lingering-effects]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.engine :refer [ability-as-handler can-trigger? checkpoint register-pending-event pay queue-event register-default-events resolve-ability should-trigger? trigger-event trigger-event-simult trigger-event-sync unregister-floating-events]]
     [game.core.finding :refer [find-cid]]
@@ -1227,7 +1227,7 @@
   ([state side server bonus] (access-bonus state side server bonus (if (:run @state) :end-of-run :end-of-access)))
   ([state side server bonus duration]
    (let [floating-effect
-         (register-floating-effect
+         (register-lingering-effect
            state side nil
            {:type :access-bonus
             :duration duration
@@ -1301,7 +1301,7 @@
       (swap! state assoc-in [:run :did-access] true)
       (max-access state n))
     (wait-for (resolve-ability state side (choose-access access-amount server {:server server}) nil nil)
-              (unregister-floating-effects state side :end-of-access)
+              (unregister-lingering-effects state side :end-of-access)
               (unregister-floating-events state side :end-of-access)
               (effect-completed state side eid))))
 
@@ -1320,6 +1320,6 @@
                (wait-for (resolve-ability state side (choose-access access-amount server (assoc args :server server)) nil nil)
                          (wait-for (trigger-event-sync state side :end-breach-server (:breach @state))
                                    (swap! state assoc :breach nil)
-                                   (unregister-floating-effects state side :end-of-access)
+                                   (unregister-lingering-effects state side :end-of-access)
                                    (unregister-floating-events state side :end-of-access)
                                    (effect-completed state side eid)))))))

--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -1,7 +1,7 @@
 (ns game.core.change-vals
   (:require
     [game.core.agendas :refer [update-all-agenda-points]]
-    [game.core.effects :refer [register-floating-effect]]
+    [game.core.effects :refer [register-lingering-effect]]
     [game.core.engine :refer [trigger-event]]
     [game.core.gaining :refer [base-mod-size deduct gain]]
     [game.core.hand-size :refer [hand-size update-hand-size]]
@@ -28,7 +28,7 @@
 (defn- change-mu
   "Send a system message indicating how mu was changed"
   [state side delta]
-  (register-floating-effect
+  (register-lingering-effect
     state side nil
     {:type :user-available-mu
      :value [:regular delta]})
@@ -59,7 +59,7 @@
 (defn- change-agenda-points
   "Change a player's total agenda points, using floating effects."
   [state side delta]
-  (register-floating-effect
+  (register-lingering-effect
     state side nil
     ;; This is needed as `req` creates/shadows the existing `side` already in scope.
     (let [user-side side]
@@ -75,7 +75,7 @@
 (defn- change-link
   "Change the runner's link, using floating effects."
   [state side delta]
-  (register-floating-effect
+  (register-lingering-effect
     state side nil
     {:type :user-link
      :value delta})
@@ -87,7 +87,7 @@
 (defn- change-hand-size
   "Change the player's hand-size, using floating effects."
   [state side delta]
-  (register-floating-effect
+  (register-lingering-effect
     state side nil
     (let [user-side side]
       {:type :user-hand-size

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -205,18 +205,18 @@
   (let [card (server-card title)]
     (if (has-subtype? card "Current")
       (let [event-keyword (if (corp? card) :agenda-stolen :agenda-scored)
-            constant-ab {:type :trash-when-expired
-                         :req (req (some #(let [event (:event %)
-                                                context-card (:card %)]
-                                            (or (= event event-keyword)
-                                                (and (or (= :play-event event)
-                                                         (= :play-operation event))
-                                                     (and (not (same-card? card context-card))
-                                                          (has-subtype? context-card "Current")
-                                                          true))))
-                                         targets))
-                         :value trash-or-rfg}]
-        (update ability :constant-effects #(conj (into [] %) constant-ab)))
+            static-ab {:type :trash-when-expired
+                       :req (req (some #(let [event (:event %)
+                                              context-card (:card %)]
+                                          (or (= event event-keyword)
+                                              (and (or (= :play-event event)
+                                                       (= :play-operation event))
+                                                   (and (not (same-card? card context-card))
+                                                        (has-subtype? context-card "Current")
+                                                        true))))
+                                       targets))
+                       :value trash-or-rfg}]
+        (update ability :static-abilities #(conj (into [] %) static-ab)))
       ability)))
 
 (defn add-default-abilities

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -27,7 +27,7 @@
                             (= :while-active (:duration %))))
               (into []))))
 
-(defn register-floating-effect
+(defn register-lingering-effect
   [state _ card ability]
   (let [ability (assoc
                   (select-keys ability [:type :duration :req :value])
@@ -36,7 +36,7 @@
     (swap! state update :effects conj ability)
     ability))
 
-(defn unregister-floating-effects
+(defn unregister-lingering-effects
   [state _ duration]
   (swap! state assoc :effects
          (->> (:effects @state)

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -12,7 +12,7 @@
           abilities (for [ability static-abilities]
                       (assoc
                         (select-keys ability [:type :req :value])
-                        :duration :constant
+                        :duration :while-active
                         :card card
                         :uuid (uuid/v1)))]
       (swap! state update :effects
@@ -24,7 +24,7 @@
   (swap! state assoc :effects
          (->> (:effects @state)
               (remove #(and (same-card? card (:card %))
-                            (= :constant (:duration %))))
+                            (= :while-active (:duration %))))
               (into []))))
 
 (defn register-floating-effect

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -5,11 +5,11 @@
             [game.core.eid :refer [make-eid]]
             [game.utils :refer [same-card? to-keyword]]))
 
-(defn register-constant-effects
+(defn register-static-abilities
   [state _ card]
-  (when (:constant-effects (card-def card))
-    (let [constant-effects (:constant-effects (card-def card))
-          abilities (for [ability constant-effects]
+  (when (:static-abilities (card-def card))
+    (let [static-abilities (:static-abilities (card-def card))
+          abilities (for [ability static-abilities]
                       (assoc
                         (select-keys ability [:type :req :value])
                         :duration :constant
@@ -19,7 +19,7 @@
              #(apply conj (into [] %) abilities))
       abilities)))
 
-(defn unregister-constant-effects
+(defn unregister-static-abilities
   [state _ card]
   (swap! state assoc :effects
          (->> (:effects @state)

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -7,7 +7,7 @@
     [game.core.board :refer [clear-empty-remotes all-installed-runner-type all-active-installed]]
     [game.core.card :refer [active? facedown? faceup? get-card get-cid get-title in-discard? in-hand? installed? rezzed? program? console? unique?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [get-effect-maps unregister-floating-effects]]
+    [game.core.effects :refer [get-effect-maps unregister-lingering-effects]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.payment :refer [build-spend-msg can-pay? handler merge-costs]]
     [game.core.prompt-state :refer [add-to-prompt-queue]]
@@ -1024,7 +1024,7 @@
             (unregister-floating-events state nil :pending)
             (doseq [duration durations
                     :when duration]
-              (unregister-floating-effects state nil duration)
+              (unregister-lingering-effects state nil duration)
               (unregister-floating-events state nil duration))
             (effect-completed state nil eid)))
 

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -65,7 +65,7 @@
                  (register-floating-effect
                    state side target
                    {:type :used-mu
-                    :duration :constant
+                    :duration :while-active
                     :value (:memoryunits target)})
                  (update-mu state)))))
        (when-let [hosted-gained (:hosted-gained cdef)]

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.card :refer [assoc-host-zones corp? get-card program? rezzed? runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [register-constant-effects register-floating-effect unregister-constant-effects]]
+    [game.core.effects :refer [register-static-abilities register-floating-effect unregister-static-abilities]]
     [game.core.eid :refer [make-eid]]
     [game.core.engine :refer [register-default-events unregister-events]]
     [game.core.initializing :refer [card-init]]
@@ -24,7 +24,7 @@
   ([state side card {:keys [zone cid host installed] :as target} {:keys [facedown no-mu]}]
    (when (not= cid (:cid card))
      (unregister-events state side target)
-     (unregister-constant-effects state side target)
+     (unregister-static-abilities state side target)
      (doseq [s [:runner :corp]]
        (if host
          (when-let [host-card (get-card state host)]
@@ -57,9 +57,9 @@
            (card-init state side target {:resolve-effect false
                                          :init-data true
                                          :no-mu no-mu})
-           ;; Otherwise just register events and constant effects
+           ;; Otherwise just register events and static abilities
            (do (register-default-events state side target)
-               (register-constant-effects state side target)
+               (register-static-abilities state side target)
                (when (and (program? target)
                           (not no-mu))
                  (register-floating-effect
@@ -70,7 +70,7 @@
                  (update-mu state)))))
        (when-let [hosted-gained (:hosted-gained cdef)]
          (hosted-gained state side (make-eid state) (get-card state card) [target]))
-       ;; Update all constant and floating effects
+       ;; Update all static abilities and floating effects
        (let [new-effects (reduce
                            (fn [all-effects current-effect]
                              (if (= cid (:cid (:card current-effect)))

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.card :refer [assoc-host-zones corp? get-card program? rezzed? runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [register-static-abilities register-floating-effect unregister-static-abilities]]
+    [game.core.effects :refer [register-static-abilities register-lingering-effect unregister-static-abilities]]
     [game.core.eid :refer [make-eid]]
     [game.core.engine :refer [register-default-events unregister-events]]
     [game.core.initializing :refer [card-init]]
@@ -62,7 +62,7 @@
                (register-static-abilities state side target)
                (when (and (program? target)
                           (not no-mu))
-                 (register-floating-effect
+                 (register-lingering-effect
                    state side target
                    {:type :used-mu
                     :duration :while-active

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -5,7 +5,7 @@
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [break-sub-ability-cost]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid make-result]]
-    [game.core.effects :refer [any-effects get-effects register-floating-effect sum-effects]]
+    [game.core.effects :refer [any-effects get-effects register-lingering-effect sum-effects]]
     [game.core.engine :refer [ability-as-handler pay resolve-ability trigger-event trigger-event-simult queue-event checkpoint]]
     [game.core.flags :refer [card-flag?]]
     [game.core.payment :refer [build-cost-label can-pay? merge-costs]]
@@ -403,7 +403,7 @@
   "Change a piece of ice's strength by n for the given duration of :end-of-encounter, :end-of-run or :end-of-turn"
   ([state side card n] (pump-ice state side card n :end-of-encounter))
   ([state side card n duration]
-   (register-floating-effect
+   (register-lingering-effect
      state side card
      {:type :ice-strength
       :duration duration
@@ -464,7 +464,7 @@
   "Change a breaker's strength by n for the given duration of :end-of-encounter, :end-of-run or :end-of-turn"
   ([state side card n] (pump state side card n :end-of-encounter))
   ([state side card n duration]
-   (let [floating-effect (register-floating-effect
+   (let [floating-effect (register-lingering-effect
                            state side (get-card state card)
                            {:type :breaker-strength
                             :duration duration

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -340,7 +340,7 @@
       (pump-fn state side (make-eid state) card targets)))))
 
 (defn ice-strength-bonus
-  "Use in :constant-effect vectors to give the current ice or program a conditional strength bonus"
+  "Use in :static-abilities vectors to give the current ice or program a conditional strength bonus"
   ([bonus]
    {:type :ice-strength
     :req (req (same-card? card target))
@@ -429,7 +429,7 @@
          (reduce (fnil + 0 0)))))
 
 (defn breaker-strength-bonus
-  "Use in :constant-effect vectors to give the current ice or program a conditional strength bonus"
+  "Use in :static-abilities vectors to give the current ice or program a conditional strength bonus"
   ([bonus]
    {:type :breaker-strength
     :req (req (same-card? card target))

--- a/src/clj/game/core/identities.clj
+++ b/src/clj/game/core/identities.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.card :refer [active?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [register-constant-effects unregister-constant-effects]]
+    [game.core.effects :refer [register-static-abilities unregister-static-abilities]]
     [game.core.eid :refer [make-eid]]
     [game.core.engine :refer [register-default-events resolve-ability unregister-events]]
     [game.core.initializing :refer [card-init deactivate]]
@@ -13,7 +13,7 @@
   [state side]
   (let [id (update! state side (assoc (get-in @state [side :identity]) :disabled true))]
     (unregister-events state side id)
-    (unregister-constant-effects state side id)
+    (unregister-static-abilities state side id)
     (when-let [leave-play (:leave-play (card-def id))]
       (leave-play state side (make-eid state) id nil))))
 
@@ -43,7 +43,7 @@
     (when effect
       (effect state side (make-eid state) id nil))
     (register-default-events state side id)
-    (register-constant-effects state side id)))
+    (register-static-abilities state side id)))
 
 (defn enable-identity
   "Enables the side's identity"

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -134,7 +134,7 @@
        (register-floating-effect
          state side c
          {:type :used-mu
-          :duration :constant
+          :duration :while-active
           :value (:memoryunits c)})
        (update-mu state))
      (if (and resolve-effect (is-ability? cdef))

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -4,7 +4,7 @@
     [game.core.card :refer [get-card map->Card program? runner?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost]]
-    [game.core.effects :refer [register-static-abilities register-floating-effect unregister-static-abilities]]
+    [game.core.effects :refer [register-static-abilities register-lingering-effect unregister-static-abilities]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [is-ability? register-default-events register-events resolve-ability unregister-events]]
     [game.core.finding :refer [find-cid]]
@@ -131,7 +131,7 @@
      ;; Facedown cards can't be initialized
      (when (and (program? card)
                 (not no-mu))
-       (register-floating-effect
+       (register-lingering-effect
          state side c
          {:type :used-mu
           :duration :while-active

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -4,7 +4,7 @@
     [game.core.card :refer [get-card map->Card program? runner?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost]]
-    [game.core.effects :refer [register-constant-effects register-floating-effect unregister-constant-effects]]
+    [game.core.effects :refer [register-static-abilities register-floating-effect unregister-static-abilities]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [is-ability? register-default-events register-events resolve-ability unregister-events]]
     [game.core.finding :refer [find-cid]]
@@ -65,7 +65,7 @@
   ([state side card] (deactivate state side card nil))
   ([state side {:keys [cid disabled installed rezzed] :as card} keep-counter]
    (unregister-events state side card)
-   (unregister-constant-effects state side card)
+   (unregister-static-abilities state side card)
    (trigger-leave-effect state side card)
    (when (and (find-cid cid (all-active-installed state side))
               (not disabled)
@@ -127,7 +127,7 @@
              :req (req (not (:disabled card)))
              :effect r}])))
      (register-default-events state side c)
-     (register-constant-effects state side c)
+     (register-static-abilities state side c)
      ;; Facedown cards can't be initialized
      (when (and (program? card)
                 (not no-mu))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -8,7 +8,7 @@
     [game.core.cost-fns :refer [ignore-install-cost? install-additional-cost-bonus install-cost]]
     [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
     [game.core.engine :refer [checkpoint register-pending-event pay queue-event register-events trigger-event-simult unregister-events]]
-    [game.core.effects :refer [register-constant-effects unregister-constant-effects]]
+    [game.core.effects :refer [register-static-abilities unregister-static-abilities]]
     [game.core.flags :refer [turn-flag? zone-locked?]]
     [game.core.hosting :refer [host]]
     [game.core.ice :refer [update-breaker-strength]]
@@ -476,9 +476,9 @@
                                                       :abilities abilities
                                                       :runner-abilities runner-abilities))]
                   (unregister-events state side card)
-                  (unregister-constant-effects state side card)
+                  (unregister-static-abilities state side card)
                   (register-events state side card events)
-                  (register-constant-effects state side card)
+                  (register-static-abilities state side card)
                   (complete-with-result state side eid card)))
       (wait-for (runner-install state side (make-eid state eid)
                                 card {:host-card target
@@ -487,7 +487,7 @@
                                                       :abilities abilities
                                                       :corp-abilities corp-abilities))]
                   (unregister-events state side card)
-                  (unregister-constant-effects state side card)
+                  (unregister-static-abilities state side card)
                   (register-events state side card events)
-                  (register-constant-effects state side card)
+                  (register-static-abilities state side card)
                   (complete-with-result state side eid card))))))

--- a/src/clj/game/core/memory.clj
+++ b/src/clj/game/core/memory.clj
@@ -146,7 +146,7 @@
           available-mu (merge-available-memory mu-list)
           used-mu-effects (conj (get-effect-maps state :runner :used-mu)
                                 {:type :used-mu
-                                 :duration :constant
+                                 :duration :while-active
                                  :card card
                                  :value mu-cost})
           used-mu (merge-used-memory state used-mu-effects)

--- a/src/clj/game/core/memory.clj
+++ b/src/clj/game/core/memory.clj
@@ -6,7 +6,7 @@
    [game.core.toasts :refer [toast]]))
 
 (defn mu+
-  "For use in :static-abilities and register-floating-effect.
+  "For use in :static-abilities and register-lingering-effect.
   Returns an effect map for :available-mu.
   Takes either the mu value or a :req 5-fn and the value.
   If :value is a function, it must return [:regular N] where N is a number."
@@ -20,7 +20,7 @@
              [:else (throw (Exception. (str "mu+ needs a vector, number, or function: " value)))])}))
 
 (defn virus-mu+
-  "For use in :static-abilities and register-floating-effect.
+  "For use in :static-abilities and register-lingering-effect.
   Returns an effect map for :available-mu
   Takes either the mu value or a :req 5-fn and the value.
   If :value is a function, it must return [:virus N] where N is a number."
@@ -31,7 +31,7 @@
                           [:else (throw (Exception. (str "virus-mu+ needs a vector, number, or function: " value)))]))))
 
 (defn caissa-mu+
-  "For use in :static-abilities and register-floating-effect.
+  "For use in :static-abilities and register-lingering-effect.
   Returns an effect map for :available-mu.
   Takes either the mu value or a :req 5-fn and the value.
   If :value is a function, it must return [:caissa N] where N is a number."

--- a/src/clj/game/core/memory.clj
+++ b/src/clj/game/core/memory.clj
@@ -6,7 +6,7 @@
    [game.core.toasts :refer [toast]]))
 
 (defn mu+
-  "For use in :constant-effects and register-floating-effect.
+  "For use in :static-abilities and register-floating-effect.
   Returns an effect map for :available-mu.
   Takes either the mu value or a :req 5-fn and the value.
   If :value is a function, it must return [:regular N] where N is a number."
@@ -20,7 +20,7 @@
              [:else (throw (Exception. (str "mu+ needs a vector, number, or function: " value)))])}))
 
 (defn virus-mu+
-  "For use in :constant-effects and register-floating-effect.
+  "For use in :static-abilities and register-floating-effect.
   Returns an effect map for :available-mu
   Takes either the mu value or a :req 5-fn and the value.
   If :value is a function, it must return [:virus N] where N is a number."
@@ -31,7 +31,7 @@
                           [:else (throw (Exception. (str "virus-mu+ needs a vector, number, or function: " value)))]))))
 
 (defn caissa-mu+
-  "For use in :constant-effects and register-floating-effect.
+  "For use in :static-abilities and register-floating-effect.
   Returns an effect map for :available-mu.
   Takes either the mu value or a :req 5-fn and the value.
   If :value is a function, it must return [:caissa N] where N is a number."

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -5,7 +5,7 @@
     [game.core.board :refer [all-active-installed]]
     [game.core.card :refer [active? card-index condition-counter? convert-to-agenda corp? facedown? fake-identity? get-card get-title get-zone has-subtype? ice? in-hand? in-play-area? installed? resource? rezzed? runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [register-constant-effects unregister-constant-effects]]
+    [game.core.effects :refer [register-static-abilities unregister-static-abilities]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid make-result]]
     [game.core.engine :as engine :refer [checkpoint dissoc-req register-pending-event queue-event register-default-events register-events should-trigger? trigger-event trigger-event-sync unregister-events]]
     [game.core.finding :refer [get-scoring-owner]]
@@ -68,8 +68,8 @@
                           (when (active? newh)
                             (unregister-events state side h)
                             (register-default-events state side newh)
-                            (unregister-constant-effects state side h)
-                            (register-constant-effects state side newh))
+                            (unregister-static-abilities state side h)
+                            (register-static-abilities state side newh))
                           [newh]))
         hosted (seq (mapcat (if same-zone? update-hosted trash-hosted) (:hosted card)))
         ;; Set :seen correctly
@@ -447,10 +447,10 @@
         (update-installed-card-indices state :corp (:zone b))
         (doseq [new-card [a-new b-new]]
           (unregister-events state side new-card)
-          (unregister-constant-effects state side new-card)
+          (unregister-static-abilities state side new-card)
           (when (rezzed? new-card)
             (do (register-default-events state side new-card)
-                (register-constant-effects state side new-card)))
+                (register-static-abilities state side new-card)))
           (doseq [h (:hosted new-card)]
             (let [newh (-> h
                            (assoc-in [:zone] '(:onhost))
@@ -458,8 +458,8 @@
               (update! state side newh)
               (unregister-events state side h)
               (register-default-events state side newh)
-              (unregister-constant-effects state side h)
-              (register-constant-effects state side newh))))
+              (unregister-static-abilities state side h)
+              (register-static-abilities state side newh))))
         (trigger-event state side :swap a-new b-new)))))
 
 (defn swap-ice
@@ -539,9 +539,9 @@
   (let [new-stolen (move state :runner scored :scored)
         new-scored (move state :corp stolen :scored)]
     (unregister-events state side stolen)
-    (unregister-constant-effects state side stolen)
+    (unregister-static-abilities state side stolen)
     (register-default-events state side new-scored)
-    (register-constant-effects state side new-scored)
+    (register-static-abilities state side new-scored)
     (when-not (card-flag? scored :has-events-when-stolen true)
       (deactivate state :corp new-stolen))
     (trigger-event state side :swap new-stolen new-scored)

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -143,7 +143,7 @@
     (swap! state assoc :effects
            (->> (:effects @state)
                 (remove #(and (same-card? card (:card %))
-                              (= :constant (:duration %))))
+                              (= :while-active (:duration %))))
                 (into [])))))
 
 (defn update-installed-card-indices

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -3,7 +3,7 @@
     [game.core.card :refer [get-zone has-subtype?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [play-additional-cost-bonus play-cost]]
-    [game.core.effects :refer [unregister-constant-effects]]
+    [game.core.effects :refer [unregister-static-abilities]]
     [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
     [game.core.engine :refer [checkpoint dissoc-req merge-costs-paid pay queue-event resolve-ability should-trigger? unregister-events]]
     [game.core.flags :refer [can-run? zone-locked?]]
@@ -59,7 +59,7 @@
                               (let [trash-or-move (if (= zone :rfg) async-rfg trash)]
                                 (wait-for (trash-or-move state side c {:unpreventable true})
                                           (unregister-events state side card)
-                                          (unregister-constant-effects state side card)
+                                          (unregister-static-abilities state side card)
                                           (when (= zone :rfg)
                                             (system-msg state side
                                                         (str "removes " (:title c) " from the game instead of trashing it")))

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -4,7 +4,7 @@
     [game.core.card :refer [asset? condition-counter? get-card ice? upgrade?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [rez-additional-cost-bonus rez-cost]]
-    [game.core.effects :refer [unregister-constant-effects]]
+    [game.core.effects :refer [unregister-static-abilities]]
     [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
     [game.core.engine :refer [register-pending-event queue-event checkpoint pay register-events resolve-ability trigger-event unregister-events]]
     [game.core.flags :refer [can-host? can-rez?]]
@@ -141,5 +141,5 @@
         (resolve-ability state side derez-effect (get-card state card) nil))
       (when-let [derezzed-events (:derezzed-events cdef)]
         (register-events state side card (map #(assoc % :condition :derezzed) derezzed-events))))
-    (unregister-constant-effects state side card)
+    (unregister-static-abilities state side card)
     (trigger-event state side :derez card side)))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -4,7 +4,7 @@
     [game.core.board :refer [all-active all-active-installed all-installed all-installed-and-scored]]
     [game.core.card :refer [facedown? get-card has-subtype? in-hand? installed?]]
     [game.core.drawing :refer [draw]]
-    [game.core.effects :refer [unregister-floating-effects any-effects]]
+    [game.core.effects :refer [unregister-lingering-effects any-effects]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [trigger-event trigger-event-simult unregister-floating-events]]
     [game.core.flags :refer [card-flag-fn? clear-turn-register!]]
@@ -36,9 +36,9 @@
   ([state side eid _]
    (turn-message state side true)
    (wait-for (trigger-event-simult state side (if (= side :corp) :corp-turn-begins :runner-turn-begins) nil nil)
-             (unregister-floating-effects state side :start-of-turn)
+             (unregister-lingering-effects state side :start-of-turn)
              (unregister-floating-events state side :start-of-turn)
-             (unregister-floating-effects state side (if (= side :corp) :until-corp-turn-begins :until-runner-turn-begins))
+             (unregister-lingering-effects state side (if (= side :corp) :until-corp-turn-begins :until-runner-turn-begins))
              (unregister-floating-events state side (if (= side :corp) :until-corp-turn-begins :until-runner-turn-begins))
              (when (= side :corp)
                (system-msg state side "makes mandatory start of turn draw")
@@ -131,11 +131,11 @@
      (wait-for (trigger-event-simult state side (if (= side :runner) :runner-turn-ends :corp-turn-ends) nil nil)
                (trigger-event state side (if (= side :runner) :post-runner-turn-ends :post-corp-turn-ends))
                (swap! state assoc-in [side :register-last-turn] (-> @state side :register))
-               (unregister-floating-effects state side :end-of-turn)
+               (unregister-lingering-effects state side :end-of-turn)
                (unregister-floating-events state side :end-of-turn)
-               (unregister-floating-effects state side :end-of-next-run)
+               (unregister-lingering-effects state side :end-of-next-run)
                (unregister-floating-events state side :end-of-next-run)
-               (unregister-floating-effects state side (if (= side :runner) :until-runner-turn-ends :until-corp-turn-ends))
+               (unregister-lingering-effects state side (if (= side :runner) :until-runner-turn-ends :until-corp-turn-ends))
                (unregister-floating-events state side (if (= side :runner) :until-runner-turn-ends :until-corp-turn-ends))
                (doseq [card (all-active-installed state :runner)]
                  ;; Clear :installed :this-turn as turn has ended

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2963,8 +2963,8 @@
         (is (= 2 (count (:scored (get-corp)))) "Two cards in score area")
         (is (= 4 (:agenda-point (get-corp))) "Gained 3 agenda points"))))
 
-(deftest lady-liberty-agenda-constant-effects
-    ;; Agenda constant effects
+(deftest lady-liberty-agenda-static-abilities
+    ;; Agenda static abilities
     (do-game
       (new-game {:corp {:deck ["Lady Liberty" "Self-Destruct Chips"]}})
       (play-from-hand state :corp "Lady Liberty" "New remote")

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3723,7 +3723,7 @@
       (play-from-hand state :runner "Inversificator")
       (run-on state "HQ")
       (rez state :corp (get-ice state :hq 1))
-      (core/register-floating-effect
+      (core/register-lingering-effect
         state :corp nil
         (let [ice (get-ice state :hq 1)]
           {:type :gain-subtype

--- a/test/clj/game/core/agendas_test.clj
+++ b/test/clj/game/core/agendas_test.clj
@@ -18,11 +18,11 @@
       (is (= 1 (agenda-points state nil test-card)))
       (is (= 5 (agenda-points state nil (assoc test-card :agendapoints 5)))))
     (testing "agenda-value"
-      (core/register-floating-effect state nil test-card {:type :agenda-value :value 1})
+      (core/register-lingering-effect state nil test-card {:type :agenda-value :value 1})
       (is (= 2 (agenda-points state nil test-card))))
     (testing "all together"
       (let [test-card (assoc test-card :agendapoints 5)]
-        (core/register-floating-effect state nil test-card {:type :agenda-value :value 1})
+        (core/register-lingering-effect state nil test-card {:type :agenda-value :value 1})
         (is (= 6 (agenda-points state nil test-card))) "5 + 1"))
     (testing "points-fn"
       (defmethod core/defcard-impl "Test Card" [_]
@@ -30,7 +30,7 @@
          :agendapoints-runner (req 10)})
       (is (= 5 (agenda-points state :corp test-card)))
       (is (= 10 (agenda-points state :runner test-card)))
-      (core/register-floating-effect state nil test-card {:type :agenda-value :value 1})
+      (core/register-lingering-effect state nil test-card {:type :agenda-value :value 1})
       (is (= 6 (agenda-points state :corp test-card)))
       (is (= 11 (agenda-points state :runner test-card)))))
   (remove-method core/defcard-impl "Test Card"))

--- a/test/clj/game/core/effects_test.clj
+++ b/test/clj/game/core/effects_test.clj
@@ -19,10 +19,10 @@
                      :side :runner
                      :title "Test Card 2"}
         type-1 {:type :test-type
-                :duration :constant
+                :duration :while-active
                 :value 1}
         type-2 {:type :test-type-2
-                :duration :constant
+                :duration :while-active
                 :value (constantly 2)}]
 
     (testing "Effect type filtering"
@@ -58,10 +58,10 @@
             :side :corp
             :title "Test Card 2"}
         f1 {:type :test-type
-            :duration :constant
+            :duration :while-active
             :value 1}
         f2 {:type :test-type
-            :duration :constant
+            :duration :while-active
             :value (constantly 2)}]
 
     ;; This is testing if the :req is not present, so no need to retest
@@ -116,7 +116,7 @@
               :title "Test Card"}
         f (fn [n]
             {:type :test-type
-             :duration :constant
+             :duration :while-active
              :value n})]
 
     (testing "Handles non-numbers"

--- a/test/clj/game/core/effects_test.clj
+++ b/test/clj/game/core/effects_test.clj
@@ -27,20 +27,20 @@
 
     (testing "Effect type filtering"
       (reset! state start)
-      (e/register-floating-effect state side corp-card type-1)
-      (e/register-floating-effect state side corp-card type-2)
-      (e/register-floating-effect state side corp-card type-1)
-      (e/register-floating-effect state side corp-card type-2)
+      (e/register-lingering-effect state side corp-card type-1)
+      (e/register-lingering-effect state side corp-card type-2)
+      (e/register-lingering-effect state side corp-card type-1)
+      (e/register-lingering-effect state side corp-card type-2)
       (let [effects (e/gather-effects state :corp :test-type)]
         (is (= 2 (count effects)) "Only 2 effects are returned")))
 
     (testing "Effect sorting"
       (reset! state start)
       (is (= :corp (:active-player @state)) "Corp is active player")
-      (e/register-floating-effect state side corp-card type-1)
-      (e/register-floating-effect state side runner-card type-1)
-      (e/register-floating-effect state side corp-card type-1)
-      (e/register-floating-effect state side runner-card type-1)
+      (e/register-lingering-effect state side corp-card type-1)
+      (e/register-lingering-effect state side runner-card type-1)
+      (e/register-lingering-effect state side corp-card type-1)
+      (e/register-lingering-effect state side runner-card type-1)
       (let [effects (e/gather-effects state :corp :test-type)]
         (is (= [:corp :corp :runner :runner] (map #(get-in % [:card :side]) effects))
             "Effects are sorted by active player first")))))
@@ -67,20 +67,20 @@
     ;; This is testing if the :req is not present, so no need to retest
     (testing ":value static values"
       (reset! state start)
-      (e/register-floating-effect state side c1 f1)
+      (e/register-lingering-effect state side c1 f1)
       (let [effects (e/get-effects state :corp c2 :test-type)]
         (is (= [1] effects) "Should return the static value")))
 
     (testing ":value function values"
       (reset! state start)
-      (e/register-floating-effect state side c1 f2)
+      (e/register-lingering-effect state side c1 f2)
       (let [effects (e/get-effects state :corp c2 :test-type)]
         (is (= [2] effects) "Should return the value returned by the function")))
 
     (testing ":req is present"
       (testing "and is called"
         (reset! state start)
-        (e/register-floating-effect
+        (e/register-lingering-effect
           state side c1
           (assoc f1 :req (fn [& _] (swap! state update :req-called inc))))
         (is (zero? (:req-called @state)) "The req hasn't been called")
@@ -91,7 +91,7 @@
 
       (testing "and returns a truthy value"
         (reset! state start)
-        (e/register-floating-effect
+        (e/register-lingering-effect
           state side c1
           (assoc f1 :req (constantly :true)))
         (let [effects (e/get-effects state :corp c2 :test-type)]
@@ -99,7 +99,7 @@
 
       (testing "and returns a falsey value"
         (reset! state start)
-        (e/register-floating-effect
+        (e/register-lingering-effect
           state side c1
           (assoc f1 :req (constantly nil)))
         (let [effects (e/get-effects state :corp c2 :test-type)]
@@ -121,9 +121,9 @@
 
     (testing "Handles non-numbers"
       (reset! state start)
-      (e/register-floating-effect state side card (f 1))
-      (e/register-floating-effect state side card (f 2))
-      (e/register-floating-effect state side card (f nil))
-      (e/register-floating-effect state side card (f 3))
-      (e/register-floating-effect state side card (f 4))
+      (e/register-lingering-effect state side card (f 1))
+      (e/register-lingering-effect state side card (f 2))
+      (e/register-lingering-effect state side card (f nil))
+      (e/register-lingering-effect state side card (f 3))
+      (e/register-lingering-effect state side card (f 4))
       (is (= 10 (e/sum-effects state side card :test-type)) "Doesn't fail on nils"))))

--- a/test/clj/game/core/memory_test.clj
+++ b/test/clj/game/core/memory_test.clj
@@ -88,7 +88,7 @@
 (deftest build-new-mu-using-mu-test
   (do-game
     (new-game {:runner {:hand ["Corroder" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Corroder" (:hand (get-runner)))
       {:type :used-mu
        :value 1})
@@ -104,7 +104,7 @@
 (deftest build-new-mu-greater-than-available-test
   (do-game
     (new-game {:runner {:hand ["Corroder" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Corroder" (:hand (get-runner)))
       {:type :used-mu
        :value 5})
@@ -120,7 +120,7 @@
 (deftest build-new-mu-increasing-available-mu-test
   (do-game
     (new-game {:runner {:hand ["Corroder" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Sure Gamble" (:hand (get-runner)))
       (memory/mu+ 2))
     (is (= {:only-for {:caissa {:available 0
@@ -135,7 +135,7 @@
 (deftest build-new-mu-virus-increasing-available-virus-mu-test
   (do-game
     (new-game {:runner {:hand ["Cache" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Sure Gamble" (:hand (get-runner)))
       (memory/virus-mu+ 2))
     (is (= {:only-for {:caissa {:available 0
@@ -150,10 +150,10 @@
 (deftest build-new-mu-virus-increasing-available-non-virus-mu-test
   (do-game
     (new-game {:runner {:hand ["Cache" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Sure Gamble" (:hand (get-runner)))
       (memory/mu+ 2))
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Sure Gamble" (:hand (get-runner)))
       (memory/virus-mu+ 2))
     (is (= {:only-for {:caissa {:available 0
@@ -168,7 +168,7 @@
 (deftest build-new-mu-virus-no-available-virus-mu-test
   (do-game
     (new-game {:runner {:hand ["Cache" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Cache" (:hand (get-runner)))
       {:type :used-mu
        :value 2})
@@ -184,10 +184,10 @@
 (deftest build-new-mu-virus-using-virus-mu-test
   (do-game
     (new-game {:runner {:hand ["Cache" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Sure Gamble" (:hand (get-runner)))
       (memory/virus-mu+ 2))
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Cache" (:hand (get-runner)))
       {:type :used-mu
        :value 2})
@@ -203,10 +203,10 @@
 (deftest build-new-mu-virus-using-more-than-available-test
   (do-game
     (new-game {:runner {:hand ["Cache" "Sure Gamble"]}})
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Sure Gamble" (:hand (get-runner)))
       (memory/virus-mu+ 2))
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Cache" (:hand (get-runner)))
       {:type :used-mu
        :value 3})
@@ -223,14 +223,14 @@
   (do-game
     (new-game)
     (is (false? (memory/update-mu state)) "Returns false when no change occurs")
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner nil
       {:type :used-mu
        :value 1})
     (is (true? (memory/update-mu state)) "Returns true when a change has occured"))
   (do-game
     (new-game)
-    (core/register-floating-effect
+    (core/register-lingering-effect
       state :runner (find-card "Sure Gamble" (:hand (get-runner)))
       (memory/virus-mu+ 2))
     (is (true? (memory/update-mu state)) "Returns true when a change has occured")))


### PR DESCRIPTION
When I wrote #4434, I didn't use the right terminology. I first called them `constant abilities`, and then `persistent effects`, and then landed on `constant effects`. Additionally, I used the phrase `floating effect`. Neither of these are right! It's bothered me for years that they aren't right and that I got them wrong. So here I am to fix my mistakes. Let's use the proper terminology.

I also took the opportunity to switch `:duration :constant` (the default) to `:duration :while-active`, which is more accurate.

Not everything created by `register-lingering-effect` is actually a Lingering Effect, so I'm still thinking about this one. And behind the scenes, static abilities and lingering effects use the same mechanisms, while `register-events` creates lingering effects of conditional abilities.

I plan to do a follow-up to this to switch `:events` to something like `:conditional-abilities`, but that's long and messy and will require changes to indentation and reflow.