### PR TITLE
General refactors

### DIFF
--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,0 +1,16 @@
+(ns taoensso.encore
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias [{:keys [node]}]
+  (let [[sym-raw src-raw] (rest (:children node))
+        src (if src-raw src-raw sym-raw)
+        sym (if src-raw
+              sym-raw
+              (symbol (name (hooks/sexpr src))))]
+    {:node (with-meta
+             (hooks/list-node
+               [(hooks/token-node 'def)
+                (hooks/token-node (hooks/sexpr sym))
+                (hooks/token-node (hooks/sexpr src))])
+             (meta src))}))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -2020,10 +2020,10 @@
               :msg (msg "prevent subroutines on " target " ice from being broken until next turn")}})
 
 (defcard "Utopia Fragment"
-  {:events [{:event :pre-steal-cost
-             :req (req (pos? (get-counters target :advancement)))
-             :effect (req (let [counter (get-counters target :advancement)]
-                            (steal-cost-bonus state side [:credit (* 2 counter)] {:source card :source-type :ability})))}]})
+  {:static-abilities [{:type :steal-additional-cost
+                       :req (req (pos? (get-counters target :advancement)))
+                       :value (req [[:credit (* 2 (get-counters target :advancement))]
+                                    {:source card :source-type :ability}])}]})
 
 (defcard "Vanity Project"
   ;; No special implementation

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -587,7 +587,8 @@
   {:on-score {:optional
               {:prompt "Purge virus counters?"
                :yes-ability {:msg "purge virus counters"
-                             :effect (effect (purge))}}}
+                             :async true
+                             :effect (effect (purge eid))}}}
    :events [{:event :purge
              :req (req (first-event? state :corp :purge))
              :once :per-turn

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -52,7 +52,6 @@
    [game.core.tags :refer [gain-tags]]
    [game.core.to-string :refer [card-str]]
    [game.core.toasts :refer [toast]]
-   [game.core.trace :refer [init-trace-bonus]]
    [game.core.update :refer [update!]]
    [game.core.winning :refer [check-win-by-agenda]]
    [game.macros :refer [continue-ability effect msg req wait-for]]
@@ -1022,10 +1021,10 @@
                      (update-all-ice state side)))
    :static-abilities [{:type :ice-strength
                        :req (req (has-subtype? target "Tracer"))
-                       :value 1}]
-   :events [{:event :pre-init-trace
-             :req (req (= :subroutine (:source-type (second targets))))
-             :effect (effect (init-trace-bonus 1))}]})
+                       :value 1}
+                      {:type :trace-base-strength
+                       :req (req (= :subroutine (:source-type (second targets))))
+                       :value 1}]})
 
 (defcard "Jumon"
   {:events
@@ -1202,12 +1201,10 @@
                              (do (system-msg state :corp (str "uses Net Quarantine to gain " extra " [Credits]"))
                                  (gain-credits state side eid extra))
                              (effect-completed state side eid))))}]
-    {:events [{:event :pre-init-trace
-               :once :per-turn
-               :silent (req true)
-               :msg "reduce Runner's base link to zero"
-               :effect (req (swap! state assoc-in [:trace :force-link] 0))}
-              (assoc nq :event :successful-trace)
+    {:static-abilities [{:type :trace-force-link
+                         :req (req (= 1 (count (turn-events state side :pre-init-trace))))
+                         :value 0}]
+     :events [(assoc nq :event :successful-trace)
               (assoc nq :event :unsuccessful-trace)]}))
 
 (defcard "New Construction"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1203,7 +1203,7 @@
                                  (gain-credits state side eid extra))
                              (effect-completed state side eid))))}]
     {:static-abilities [{:type :trace-force-link
-                         :req (req (= 1 (count (turn-events state side :pre-init-trace))))
+                         :req (req (= 1 (count (turn-events state side :initialize-trace))))
                          :value 0}]
      :events [(assoc nq :event :successful-trace)
               (assoc nq :event :unsuccessful-trace)]}))

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -104,8 +104,9 @@
                {:label "Purge virus counters"
                 :cost [:click 3]
                 :msg "purge all virus counters"
-                :effect (effect (purge)
-                                (play-sfx "virus-purge"))}]})
+                :async true
+                :effect (req (play-sfx state side "virus-purge")
+                             (purge state side eid))}]})
 
 (defcard "Runner Basic Action Card"
   {:abilities [{:label "Gain 1 [Credits]"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2659,9 +2659,10 @@
                                                           (:discard runner))))))}})
 
 (defcard "Power to the People"
-  {:events [{:event :pre-steal-cost
+  {:events [{:event :access
              :duration :end-of-turn
              :once :per-turn
+             :unregister-once-resolved true
              :msg "gain 7 [Credits]"
              :async true
              :effect (effect (gain-credits eid 7))}]})

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -818,7 +818,7 @@
                                   :type :custom}}}))
 
 (defcard "Flip Switch"
-  {:events [{:event :pre-init-trace
+  {:events [{:event :initialize-trace
              :optional
              {:req (req (= :runner (:active-player @state)))
               :waiting-prompt true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -70,18 +70,14 @@
 ;; Card definitions
 
 (defcard "Acacia"
-  {:events [{:event :pre-purge
-             :effect (req (let [counters (number-of-virus-counters state)]
-                            (update! state side (assoc-in (get-card state card) [:special :numpurged] counters))))}
-            {:event :purge
+  {:events [{:event :purge
              :optional
              {:player :runner
               :waiting-prompt true
-              :prompt "Trash Acacia to gain 1 [Credits] for each virus counter been removed?"
+              :prompt "Trash Acacia to gain 1 [Credits] for each purged virus counter?"
               :yes-ability
               {:async true
-               :effect (req (let [counters (- (get-in (get-card state card) [:special :numpurged])
-                                              (number-of-virus-counters state))]
+               :effect (req (let [counters (:total-purged-counters context)]
                               (wait-for (trash state side card {:cause-card card})
                                         (system-msg state side (str "trashes Acacia and gains " counters " [Credit]"))
                                         (gain-credits state side eid counters))))}}}]})

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2547,7 +2547,8 @@
 (defcard "Macrophage"
   {:subroutines [(trace-ability 4 {:label  "Purge virus counters"
                                    :msg    "purge virus counters"
-                                   :effect (effect (purge))})
+                                   :async true
+                                   :effect (effect (purge eid))})
                  (trace-ability 3 {:label   "Trash a virus"
                                    :prompt  "Choose a virus to trash"
                                    :choices {:card #(and (installed? %)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1692,9 +1692,10 @@
 
 (defcard "NAPD Cordon"
   (lockdown
-   {:events [{:event :pre-steal-cost
-              :effect (req (let [counter (get-counters target :advancement)]
-                             (steal-cost-bonus state side [:credit (+ 4 (* 2 counter))] {:source card :source-type :ability})))}]}))
+    {:static-abilities
+     [{:type :steal-additional-cost
+       :value (req [[:credit (+ 4 (* 2 (get-counters target :advancement)))]
+                    {:source card :source-type :ability}])}]}))
 
 (defcard "Neural EMP"
   {:on-play
@@ -1925,8 +1926,8 @@
                       card nil))}})
 
 (defcard "Predictive Algorithm"
-  {:events [{:event :pre-steal-cost
-             :effect (effect (steal-cost-bonus [:credit 2] {:source card :source-type :ability}))}]})
+  {:static-abilities [{:type :steal-additional-cost
+                       :value (req [[:credit 2] {:source card :source-type :ability}])}]})
 
 (defcard "Predictive Planogram"
   {:on-play

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -2765,9 +2765,10 @@
                      (continue-ability state side (sun serv) card nil)))}}))
 
 (defcard "Surveillance Sweep"
-  {:events [{:event :pre-init-trace
-             :req (req run)
-             :effect (req (swap! state assoc-in [:trace :player] :runner))}]})
+  {:static-abilities
+   [{:type :trace-runner-spends-first
+     :req (req run)
+     :value true}]})
 
 (defcard "Sweeps Week"
   {:on-play

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -553,7 +553,8 @@
 (defcard "Cyberdex Trial"
   {:on-play
    {:msg "purge virus counters"
-    :effect (effect (purge))}})
+    :async true
+    :effect (effect (purge eid))}})
 
 (defcard "Death and Taxes"
   {:implementation "Credit gain mandatory to save on wait-prompts, adjust credits manually if credit not wanted."
@@ -2279,18 +2280,19 @@
                              (system-msg state side "uses Reverse Infection to gain 2 [Credits]")
                              (effect-completed state side eid))
                    (let [pre-purge-virus (number-of-virus-counters state)]
-                     (purge state side)
-                     (let [post-purge-virus (number-of-virus-counters state)
-                           num-virus-purged (- pre-purge-virus post-purge-virus)
-                           num-to-trash (quot num-virus-purged 3)]
-                       (wait-for (mill state :corp :runner num-to-trash)
-                                 (system-msg state side
-                                             (str "uses Reverse Infection to purge "
-                                                  (quantify num-virus-purged "virus counter")
-                                                  " and trash "
-                                                  (quantify num-to-trash "card")
-                                                  " from the top of the stack"))
-                                 (effect-completed state side eid))))))}})
+                     (wait-for
+                       (purge state side)
+                       (let [post-purge-virus (number-of-virus-counters state)
+                             num-virus-purged (- pre-purge-virus post-purge-virus)
+                             num-to-trash (quot num-virus-purged 3)]
+                         (wait-for (mill state :corp :runner num-to-trash)
+                                   (system-msg state side
+                                               (str "uses Reverse Infection to purge "
+                                                    (quantify num-virus-purged "virus counter")
+                                                    " and trash "
+                                                    (quantify num-to-trash "card")
+                                                    " from the top of the stack"))
+                                   (effect-completed state side eid)))))))}})
 
 (defcard "Rework"
   {:on-play

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -53,13 +53,13 @@
                            update-current-encounter]]
    [game.core.sabotage :refer [sabotage-ability]]
    [game.core.say :refer [system-msg]]
-   [game.core.sabotage :refer [sabotage-ability]]
    [game.core.servers :refer [is-central? is-remote? protecting-same-server?
                               target-server zone->name]]
    [game.core.shuffling :refer [shuffle!]]
    [game.core.tags :refer [gain-tags lose-tags]]
    [game.core.to-string :refer [card-str]]
    [game.core.threat :refer [threat threat-level]]
+   [game.core.trace :refer [force-base]]
    [game.core.update :refer [update!]]
    [game.core.virus :refer [get-virus-counters]]
    [game.macros :refer [continue-ability effect msg req wait-for]]
@@ -1225,7 +1225,7 @@
 
 (defcard "Disrupter"
   {:events
-   [{:event :pre-init-trace
+   [{:event :initialize-trace
      :trash-icon true
      :optional
      {:player :runner
@@ -1233,7 +1233,7 @@
       :prompt "Trash Disrupter to reduce the base trace strength to 0?"
       :yes-ability
       {:cost [:trash-can]
-       :effect (req (swap! state assoc-in [:trace :force-base] 0))}}}]})
+       :effect (req (force-base state 0))}}}]})
 
 (defcard "Diwan"
   {:on-install {:prompt "Choose a server"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2514,13 +2514,11 @@
                 :effect (effect (host card target)
                                 (unregister-effects-for-card target #(= :used-mu (:type %)))
                                 (update-mu))}]
-   :events [{:event :pre-purge
-             :effect (req (when-let [c (first (:hosted card))]
-                            (update! state side (assoc-in card [:special :numpurged] (get-counters c :virus)))))}
-            {:event :purge
-             :req (req (pos? (get-in card [:special :numpurged] 0)))
-             :effect (req (when-let [c (first (:hosted card))]
-                            (add-counter state side c :virus 1)))}]})
+   :static-abilities
+   [{:type :prevent-purge-virus-counters
+     :req (req (pos? (get-counters (first (:hosted card)) :virus)))
+     :value (req {:card (first (:hosted card))
+                  :quantity 1})}]})
 
 (defcard "Propeller"
   (auto-icebreaker {:data {:counter {:power 4}}

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -3299,15 +3299,16 @@
 
 (defcard "The Source"
   {:static-abilities [{:type :advancement-requirement
-                       :value 1}]
+                       :value 1}
+                      {:type :steal-additional-cost
+                       :value (req [[:credit 3]
+                                    {:source card :source-type :ability}])}]
    :events [{:event :agenda-scored
              :async true
              :effect (effect (trash eid card {:cause :runner-ability :cause-card card}))}
             {:event :agenda-stolen
              :async true
-             :effect (effect (trash eid card {:cause :runner-ability :cause-card card}))}
-            {:event :pre-steal-cost
-             :effect (effect (steal-cost-bonus [:credit 3] {:source card :source-type :ability}))}]})
+             :effect (effect (trash eid card {:cause :runner-ability :cause-card card}))}]})
 
 (defcard "The Supplier"
   (let [ability {:label "Install a hosted card (start of turn)"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2554,7 +2554,7 @@
                     card nil))}]})
 
 (defcard "Power Tap"
-  {:events [{:event :pre-init-trace
+  {:events [{:event :initialize-trace
              :msg "gain 1 [Credits]"
              :async true
              :effect (effect (gain-credits :runner eid 1))}]})

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -473,11 +473,13 @@
                {:waiting-prompt true
                 :prompt "Purge virus counters?"
                 :yes-ability {:msg "purge virus counters"
-                              :effect (effect (purge))}}}
+                              :async true
+                              :effect (effect (purge eid))}}}
    :abilities [{:label "Purge virus counters"
                 :msg "purge virus counters"
                 :cost [:trash-can]
-                :effect (effect (purge))}]})
+                :async true
+                :effect (effect (purge eid))}]})
 
 (defcard "Daniela Jorge Inácio"
   (let [steal-cost {:type :steal-additional-cost
@@ -1075,14 +1077,16 @@
    :on-access {:optional
                {:waiting-prompt true
                 :prompt "Purge virus counters?"
-                :yes-ability {:msg (msg "purge virus counters")
-                              :async true
-                              :effect (req (purge state side)
-                                           (if (rezzed? card)
-                                             (do
-                                               (system-msg state side (str "uses " (:title card) " to do 1 net damage"))
-                                               (damage state side eid :net 1 {:card card}))
-                                             (effect-completed state side eid)))}
+                :yes-ability
+                {:msg (msg "purge virus counters")
+                 :async true
+                 :effect (req (wait-for
+                                (purge state side)
+                                (if (rezzed? card)
+                                  (do
+                                    (system-msg state side (str "uses " (:title card) " to do 1 net damage"))
+                                    (damage state side eid :net 1 {:card card}))
+                                  (effect-completed state side eid))))}
                 :no-ability {:async true
                              :effect (req (system-msg state :corp (str "declines to use " (:title card)))
                                           (if (rezzed? card)
@@ -1093,7 +1097,8 @@
    :abilities [{:label "Purge virus counters"
                 :msg "purge virus counters"
                 :cost [:trash-can]
-                :effect (effect (purge))}]})
+                :async true
+                :effect (effect (purge eid))}]})
 
 (defcard "Midori"
   {:events [{:event :approach-ice

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -258,18 +258,18 @@
   {:on-trash
    {:req (req (and (= :runner side)
                    (:run @state)))
-    :effect (effect (register-events
+    :effect (effect (register-lingering-effect
                       card
-                      [{:event :pre-steal-cost
-                        :duration :end-of-run
-                        :req (req (or (= (get-zone target) (:previous-zone card))
-                                      (= (central->zone (get-zone target))
-                                         (butlast (:previous-zone card)))))
-                        :effect (effect (steal-cost-bonus [:net 2] {:source card :source-type :ability}))}]))}
-   :events [{:event :pre-steal-cost
-             :req (req (or (in-same-server? card target)
-                           (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:net 2] {:source card :source-type :ability}))}]})
+                      {:type :steal-additional-cost
+                       :duration :end-of-run
+                       :req (req (or (= (get-zone target) (:previous-zone card))
+                                                   (= (central->zone (get-zone target))
+                                                      (butlast (:previous-zone card)))))
+                       :value (req [[:net 2] {:source card :source-type :ability}])}))}
+   :static-abilities [{:type :steal-additional-cost
+                       :req (req (or (in-same-server? card target)
+                                     (from-same-server? card target)))
+                       :value (req [[:net 2] {:source card :source-type :ability}])}]})
 
 (defcard "Bernice Mai"
   {:events [{:event :successful-run
@@ -481,12 +481,14 @@
                 :effect (effect (purge))}]})
 
 (defcard "Daniela Jorge Inácio"
-  (let [pre-steal {:event :pre-steal-cost
-                   :req (req (or (in-same-server? card target)
-                                 (from-same-server? card target)))
-                   :effect
-                   (effect (steal-cost-bonus [:add-random-from-hand-to-bottom-of-deck 2] {:source card :source-type :ability}))}]
-    {:events [{:event :pre-access-card
+  (let [steal-cost {:type :steal-additional-cost
+                    :req (req (or (in-same-server? card target)
+                                  (from-same-server? card target)))
+                    :value (req [[:add-random-from-hand-to-bottom-of-deck 2]
+                                 {:source card :source-type :ability}])}]
+    {:implementation "trash cost not displayed on dialogue"
+     :static-abilities [steal-cost]
+     :events [{:event :pre-access-card
                :req (req (and (rezzed? card)
                               (same-card? target card)))
                ;; It would be lovely to instead use :trash-cost-bonus [:add-random-from-hand-to-bottom-of-deck 2]
@@ -494,15 +496,14 @@
                (req (register-run-flag!
                       state side
                       card :can-trash
-                      (fn [state side card]
+                      (fn [state _ card]
                         (or (not (same-card? target card))
-                                  (can-pay?
-                                    state :runner
-                                    (assoc eid :source card :source-type :ability)
-                                    card nil
-                                    [:add-random-from-hand-to-bottom-of-deck 2])))))}
-              pre-steal]
-     :implementation "trash cost not displayed on dialogue"
+                            (can-pay?
+                              state :runner
+                              (assoc eid :source card :source-type :ability)
+                              card nil
+                              [:add-random-from-hand-to-bottom-of-deck 2])))))}
+              steal-cost]
      :on-trash {:async true
                 :interactive (req true)
                 :req (req (and run (= :runner side)))
@@ -510,14 +511,16 @@
                 :effect
                 (req (wait-for (pay state :runner (make-eid state eid) card :add-random-from-hand-to-bottom-of-deck 2)
                                (system-msg state :runner (:msg async-result))
-                               (register-events state side card [(assoc pre-steal
-                                                                        :req
-                                                                        (req (or (= (:previous-zone card)
-                                                                                    (:zone target))
-                                                                                 ;; special central-servers case
-                                                                                 (= (central->zone (:zone target))
-                                                                                    (butlast (:previous-zone card)))))
-                                                                        :duration :end-of-run)])
+                               (register-lingering-effect
+                                 state side card
+                                 (assoc steal-cost
+                                        :req
+                                        (req (or (= (:previous-zone card)
+                                                    (:zone target))
+                                                 ;; special central-servers case
+                                                 (= (central->zone (:zone target))
+                                                    (butlast (:previous-zone card)))))
+                                        :duration :end-of-run))
                                (effect-completed state side eid)))}}))
 
 (defcard "Daruma"
@@ -1325,35 +1328,27 @@
              :effect (req (trash state :corp eid card {:cause-card card}))}]})
 
 (defcard "Old Hollywood Grid"
-  (let [ohg {:effect (effect
-                       (register-persistent-flag!
-                         card :can-steal
-                         (fn [state _ card]
-                           (if-not (some #(= (:title %) (:title card)) (:scored runner))
-                             ((constantly false)
-                              (toast state :runner "Cannot steal due to Old Hollywood Grid." "warning"))
-                             true))))}]
-    {:on-trash
-     {:req (req (and (= :runner side)
-                     (:run @state)))
-      :effect (effect (register-events
-                        card
-                        [(assoc ohg
-                                :event :pre-steal-cost
-                                :duration :end-of-run
-                                :req (req (or (= (get-zone target)
-                                                 (:previous-zone card))
-                                              (= (central->zone (get-zone target))
-                                                 (butlast (:previous-zone card))))))
-                         {:event :run-ends
-                          :duration :end-of-run
-                          :effect (req (clear-persistent-flag! state side card :can-steal))}]))}
-     :events [(assoc ohg
-                     :event :pre-steal-cost
-                     :req (req (or (in-same-server? card target)
-                                   (from-same-server? card target))))
-              {:event :access
-               :effect (req (clear-persistent-flag! state side card :can-steal))}]}))
+  {:on-trash
+   {:req (req (and (= :runner side)
+                   (:run @state)))
+    :effect (effect (register-lingering-effect
+                      card
+                      {:type :cannot-steal
+                       :duration :end-of-run
+                       :req (req (and (not-any? #(= (:title target) (:title %))
+                                                (:scored runner))
+                                      (or (= (get-zone target)
+                                             (:previous-zone card))
+                                          (= (central->zone (get-zone target))
+                                             (butlast (:previous-zone card))))))
+                       :value true}))}
+   :static-abilities [{:type :cannot-steal
+                       :duration :end-of-run
+                       :req (req (and (not-any? #(= (:title target) (:title %))
+                                                (:scored runner))
+                                      (or (in-same-server? card target)
+                                          (from-same-server? card target))))
+                       :value true}]})
 
 (defcard "Overseer Matrix"
   (let [ability {:event :runner-trash
@@ -1432,18 +1427,20 @@
   {:on-trash
    {:req (req (and (= :runner side)
                    (:run @state)))
-    :effect (effect (register-events
+    :effect (effect (register-lingering-effect
                       card
-                      [{:event :pre-steal-cost
-                        :duration :end-of-run
-                        :req (req (or (= (get-zone target) (:previous-zone card))
-                                      (= (central->zone (get-zone target))
-                                         (butlast (:previous-zone card)))))
-                        :effect (effect (steal-cost-bonus [:credit 5] {:source card :source-type :ability}))}]))}
-   :events [{:event :pre-steal-cost
-             :req (req (or (in-same-server? card target)
-                           (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:credit 5] {:source card :source-type :ability}))}]})
+                      {:type :steal-additional-cost
+                       :duration :end-of-run
+                       :req (req (or (= (get-zone target) (:previous-zone card))
+                                     (= (central->zone (get-zone target))
+                                        (butlast (:previous-zone card)))))
+                       :value (req [[:credit 5]
+                                    {:source card :source-type :ability}])}))}
+   :static-abilities [{:type :steal-additional-cost
+                       :req (req (or (in-same-server? card target)
+                                     (from-same-server? card target)))
+                       :value (req [[:credit 5]
+                                    {:source card :source-type :ability}])}]})
 
 (defcard "Reduced Service"
   {:static-abilities [{:type :run-additional-cost
@@ -1559,18 +1556,20 @@
   {:on-trash
    {:req (req (and (= :runner side)
                    (:run @state)))
-    :effect (effect (register-events
+    :effect (effect (register-lingering-effect
                       card
-                      [{:event :pre-steal-cost
-                        :duration :end-of-run
-                        :req (req (or (= (get-zone target) (:previous-zone card))
-                                      (= (central->zone (get-zone target))
-                                         (butlast (:previous-zone card)))))
-                        :effect (effect (steal-cost-bonus [:click 1] {:source card :source-type :ability}))}]))}
-   :events [{:event :pre-steal-cost
-             :req (req (or (in-same-server? card target)
-                           (from-same-server? card target)))
-             :effect (effect (steal-cost-bonus [:click 1] {:source card :source-type :ability}))}]})
+                      {:type :steal-additional-cost
+                       :duration :end-of-run
+                       :req (req (or (= (get-zone target) (:previous-zone card))
+                                     (= (central->zone (get-zone target))
+                                        (butlast (:previous-zone card)))))
+                       :value (req [[:click 1]
+                                    {:source card :source-type :ability}])}))}
+   :static-abilities [{:type :steal-additional-cost
+                       :req (req (or (in-same-server? card target)
+                                     (from-same-server? card target)))
+                       :value (req [[:click 1]
+                                    {:source card :source-type :ability}])}]})
 
 (defcard "Surat City Grid"
   {:events [{:event :rez

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -53,7 +53,6 @@
    [game.core.threat :refer [threat-level]]
    [game.core.to-string :refer [card-str]]
    [game.core.toasts :refer [toast]]
-   [game.core.trace :refer [init-trace-bonus]]
    [game.core.update :refer [update!]]
    [game.macros :refer [continue-ability effect msg req wait-for]]
    [game.utils :refer :all]
@@ -1472,9 +1471,9 @@
                        :value [:click 1]}]})
 
 (defcard "Rutherford Grid"
-  {:events [{:event :pre-init-trace
-             :req (req this-server)
-             :effect (effect (init-trace-bonus 2))}]})
+  {:static-abilities [{:type :trace-base-strength
+                       :req (req this-server)
+                       :value 2}]})
 
 (defcard "Ryon Knight"
   {:abilities [{:label "Do 1 core damage"

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -106,7 +106,6 @@
    num-cards-to-access
    set-only-card-to-access
    steal
-   steal-cost
    steal-cost-bonus
    turn-archives-faceup])
 
@@ -271,6 +270,7 @@
    run-additional-cost-bonus
    run-cost
    score-additional-cost-bonus
+   steal-cost
    trash-cost])
 
 (expose-vars

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -835,8 +835,8 @@
 
 (expose-vars
   [game.core.trace
-   init-trace
-   init-trace-bonus])
+   force-base
+   init-trace])
 
 (expose-vars
   [game.core.turns

--- a/src/clj/game/core/bad_publicity.clj
+++ b/src/clj/game/core/bad_publicity.clj
@@ -16,7 +16,6 @@
 
 (defn- resolve-bad-publicity
   [state side eid n]
-  (trigger-event state side :pre-resolve-bad-publicity n)
   (if (pos? n)
     (do (gain state :corp :bad-publicity n)
         (toast state :corp (str "Took " n " bad publicity!") "info")

--- a/src/clj/game/core/board.clj
+++ b/src/clj/game/core/board.clj
@@ -91,13 +91,10 @@
   "Returns a list of all installed cards"
   [state]
   (let [installed-runner-cards (runner-rig-cards state)
-        installed-corp-cards (corp-servers-cards state)
-        hosted-cards (into (mapcat :hosted installed-runner-cards)
-                           (mapcat :hosted installed-corp-cards))]
+        installed-corp-cards (corp-servers-cards state)]
     (loop [installed (transient [])
            unchecked (concat installed-runner-cards
-                             installed-corp-cards
-                             hosted-cards)]
+                             installed-corp-cards)]
       (if (empty? unchecked)
         (persistent! installed)
         (let [[card & remaining] unchecked]

--- a/src/clj/game/core/board.clj
+++ b/src/clj/game/core/board.clj
@@ -99,13 +99,13 @@
                              installed-corp-cards
                              hosted-cards)]
       (if (empty? unchecked)
-        (reverse (persistent! installed))
+        (persistent! installed)
         (let [[card & remaining] unchecked]
           (recur
             (if (installed? card)
               (conj! installed card)
               installed)
-            (into remaining (:hosted card))))))))
+            (into (vec remaining) (:hosted card))))))))
 
 (defn all-installed-runner-type
   "Returns a list of all installed, non-facedown runner cards of the requested type."

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -152,3 +152,11 @@
     (if (some #(= (cost-name %) :credit) costs)
       (map #(if (= (cost-name %) :credit) [:credit (value %) stealth-requirement] %) costs)
       (map #(if (= (cost-name %) :x-credits) [:x-credits nil stealth-requirement] %) costs))))
+
+(defn steal-cost
+  "Gets a vector of costs and their sources for stealing the given agenda."
+  [state side eid card]
+  (-> (when-let [costfun (:steal-cost-bonus (card-def card))]
+        [[(costfun state side eid card nil) {:source card :source-type :ability}]])
+      (concat (get-effects state side :steal-additional-cost card))
+      vec))

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -242,9 +242,9 @@
 
 (defmacro defcard
   [title ability]
-  `(defmethod card-defs/defcard-impl ~title [~'_]
-     (if-let [cached-ability# (get card-defs-cache ~title)]
-       cached-ability#
-       (let [ability# (add-default-abilities ~title ~ability)]
-         (swap! card-defs-cache assoc ~title ability#)
-         ability#))))
+  `(do (swap! card-defs-cache dissoc ~title)
+       (defmethod card-defs/defcard-impl ~title [~'_]
+         (or (get @card-defs-cache ~title)
+             (let [ability# (add-default-abilities ~title ~ability)]
+               (swap! card-defs-cache assoc ~title ability#)
+               ability#)))))

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -115,7 +115,7 @@
   ([state side effect-type target targets]
    (->> (get-effects state side effect-type target targets)
         (filter number?)
-        (reduce +))))
+        (reduce + 0))))
 
 (defn any-effects
   "Check if any effects return true for pred"

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -233,10 +233,10 @@
 
 (defn can-steal?
   "Checks if the runner can steal agendas"
-  [state side card]
-  (and (not (any-effects state side :cannot-steal true? card))
-       (check-flag-types? state side card :can-steal [:current-turn :current-run])
-       (check-flag-types? state side card :can-steal [:current-turn :persistent])))
+  [state side agenda]
+  (and (not (any-effects state side :cannot-steal true? agenda))
+       (check-flag-types? state side agenda :can-steal [:current-turn :current-run])
+       (check-flag-types? state side agenda :can-steal [:current-turn :persistent])))
 
 (defn can-trash?
   "Checks if the runner can trash cards"

--- a/src/clj/game/core/purging.clj
+++ b/src/clj/game/core/purging.clj
@@ -1,20 +1,38 @@
 (ns game.core.purging
   (:require
-    [game.core.board :refer [all-installed]]
-    [game.core.card :refer [get-counters has-subtype?]]
-    [game.core.engine :refer [trigger-event]]
+    [game.core.board :refer [get-all-installed]]
+    [game.core.card :refer [get-counters]]
+    [game.core.effects :refer [get-effects]]
+    [game.core.engine :refer [trigger-event trigger-event-sync]]
     [game.core.ice :refer [update-all-ice]]
     [game.core.props :refer [add-counter]]))
 
 (defn purge
   "Purges viruses."
-  [state side]
+  [state side eid]
   (trigger-event state side :pre-purge)
-  (let [installed-cards (concat (all-installed state :runner)
-                                (all-installed state :corp))]
-    (doseq [card installed-cards]
-      (when (or (has-subtype? card "Virus")
-                (contains? (:counter card) :virus))
-        (add-counter state :runner card :virus (- (get-counters card :virus)))))
-    (update-all-ice state side))
-  (trigger-event state side :purge))
+  (let [purge-preventions
+        (->> (get-effects state side :prevent-purge-virus-counters)
+             (reduce
+               (fn [acc cur]
+                 (assoc acc (-> cur :card :cid) cur))
+               {}))
+        cards-to-purge
+        (->> (get-all-installed state)
+             (keep (fn [card]
+                     (let [qty (get-counters card :virus)
+                           pp (get purge-preventions (:cid card))
+                           qty (if pp
+                                 (- qty (:quantity pp 0))
+                                 qty)]
+                       (when (pos? qty)
+                         {:card card :quantity qty}))))
+             (vec))]
+    (doseq [{:keys [card quantity]} cards-to-purge]
+      (add-counter state :runner card :virus (- quantity)))
+    (update-all-ice state side)
+    (let [total-purged-counters (reduce + 0 (mapv :quantity cards-to-purge))]
+      (trigger-event-sync
+        state side eid :purge
+        {:total-purged-counters total-purged-counters
+         :purges cards-to-purge}))))

--- a/src/clj/game/core/trace.clj
+++ b/src/clj/game/core/trace.clj
@@ -1,6 +1,7 @@
 (ns game.core.trace
   (:require
     [game.core.costs :refer [total-available-credits]]
+    [game.core.effects :refer [any-effects]]
     [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [can-trigger? pay register-ability-type resolve-ability trigger-event-simult trigger-event-sync]]
     [game.core.link :refer [get-link]]
@@ -16,9 +17,9 @@
 
 (defn- determine-initiator
   [state {:keys [player]}]
-  (let [constant-effect (get-in @state [:trace :player])]
+  (let [runner? (any-effects state nil :trace-runner-spends-first)]
     (cond
-      (some? constant-effect) constant-effect
+      runner? :runner
       (some? player) player
       :else :corp)))
 

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -848,7 +848,7 @@
       (is (changes-credits (get-corp) 4
                            (click-prompt state :corp "Yes")))
       (is (changes-credits (get-corp) 0
-                           (core/purge state :corp)))
+                           (purge state :corp)))
       (take-credits state :corp)
       (take-credits state :runner)
       (is (changes-credits (get-corp) 4
@@ -866,7 +866,7 @@
     (do-game
       (new-game {:corp {:deck ["Cyberdex Virus Suite" "Cyberdex Sandbox" "Cyberdex Trial"]}})
       (core/gain state :corp :click 10)
-      (core/purge state :corp)
+      (purge state :corp)
       (play-and-score state "Cyberdex Sandbox")
       (is (changes-credits
             (get-corp) 0

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -5115,7 +5115,7 @@
       (is (= 1 (:agenda-point (get-corp))))
       (is (zero? (:agenda-point (get-runner))))
       (take-credits state :runner)
-      (core/purge state :corp)
+      (purge state :corp)
       (is (= 1 (:agenda-point (get-corp))))
       (is (= 1 (:agenda-point (get-runner))))))
 

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -18,7 +18,7 @@
       (core/add-counter state :runner (get-program state 0) :virus 3)
       (take-credits state :runner)
       (is (= 2 (:credit (get-runner))) "Runner initial credits")
-      (core/purge state :corp)
+      (purge state :corp)
       (click-prompt state :runner "Yes")
       (is (= 9 (:credit (get-runner))) "Runner gained 9 credits")
       (is (= 1 (count (:discard (get-runner)))) "Acacia has trashed")))
@@ -36,7 +36,7 @@
       (let [llds (get-program state 1)]
         (changes-val-macro 0 (:credit (get-runner))
                            "Runner didn't get credits before deciding on LLDS"
-                           (core/purge state :corp)
+                           (purge state :corp)
                            (click-prompt state :runner "Yes"))
         (changes-val-macro -3 (:credit (get-runner))
                            "Runner pays 3 for LLDS"
@@ -60,7 +60,7 @@
         (core/add-counter state :corp sandstone :virus 1)
         (is (= 1 (get-counters (refresh sandstone) :virus)) "Sandstone has 1 virus counter")
         (is (= 7 (:credit (get-runner))) "Runner credits should be 7")
-        (core/purge state :corp)
+        (purge state :corp)
         (click-prompt state :runner "Yes")
         (is (= 8 (:credit (get-runner))) "Runner gained 1 credit from Sandstone's virus counter"))))
 

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -1597,7 +1597,7 @@
     (play-from-hand state :runner "Reaver")
     (take-credits state :runner)
     (is (= 0 (count (:hand (get-runner)))) "No cards in hand")
-    (core/purge state :corp)
+    (purge state :corp)
     (is (= "Clot" (-> (get-runner) :discard first :title)) "Clot was trashed on purge")
     (is (= 1 (count (:hand (get-runner)))) "Reaver triggered when Clot was trashed")
     ))
@@ -2460,7 +2460,7 @@
     (play-from-hand state :corp "Ice Wall" "HQ")
     (is (= 4 (:credit (get-corp))) "Diwan charged 1cr + 1cr to install a second ice protecting the named server")
     (core/gain state :corp :click 1)
-    (core/purge state :corp)
+    (purge state :corp)
     (starting-hand state :corp ["Fire Wall"])
     (play-from-hand state :corp "Fire Wall" "HQ") ; 2cr cost from normal install cost
     (is (= "Diwan" (-> (get-runner) :discard first :title)) "Diwan was trashed from purge")
@@ -4013,7 +4013,7 @@
     (is (= 5 (:credit (get-corp))) "Corp lost 1 credit")
     (click-prompt state :runner "No action")
     (take-credits state :runner)
-    (core/purge state :corp)
+    (purge state :corp)
     (is (empty? (get-program state)) "Lamprey trashed by purge")))
 
 (deftest laser-pointer

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -2008,7 +2008,7 @@
       (play-from-hand state :runner "Dummy Box")
       (play-from-hand state :runner "Clot")
       (take-credits state :runner)
-      (core/purge state :corp)
+      (purge state :corp)
       (is (no-prompt? state :runner) "Dummy Box not prompting to prevent purge trash")))
 
 (deftest dummy-box-don-t-prevent-trashing-from-hand
@@ -2327,9 +2327,9 @@
     (core/lose state :corp :credit 5)
     (core/gain state :corp :click 3)
     (is (= 3 (:credit (get-corp))))
-    (core/purge state :corp)
+    (purge state :corp)
     (is (= 1 (:credit (get-corp))) "Lost 2c when purging")
-    (core/purge state :corp)
+    (purge state :corp)
     (is (= 1 (:credit (get-corp))) "Lost no credits when purging, only had 1c")))
 
 (deftest film-critic-prevent-corp-trashed-execs-going-to-runner-scored-issues-1181-1042
@@ -6275,7 +6275,7 @@
        (is (no-prompt? state :runner) "Runner done waiting for Corp to pick their Nihilist poison")
        (is (no-prompt? state :corp) "Corp has no more prompts")
        (take-credits state :runner)
-       (core/purge state :corp)
+       (purge state :corp)
        (take-credits state :corp)
        (is (not (no-prompt? state :runner)) "Runner gets a prompt cuz we don't know what they have"))))
 
@@ -6317,7 +6317,7 @@
       (let [sandstone (get-ice state :hq 0)
             nihilist (get-resource state 0)]
         (rez state :corp sandstone)
-        (core/purge state :corp)
+        (purge state :corp)
         (core/add-counter state :corp sandstone :virus 2)
         (is (= 0 (get-counters (refresh nihilist) :virus)) "The Nihilist has 0 virus counters")
         (is (= 2 (get-counters (refresh sandstone) :virus)) "Sandstone has 2 virus counters")

--- a/test/clj/game/core/effects_test.clj
+++ b/test/clj/game/core/effects_test.clj
@@ -6,7 +6,7 @@
             [game.macros-test :refer :all]
             [clojure.test :refer :all]))
 
-(deftest gather-effects
+(deftest gather-effects-test
   (let [start {:active-player :corp
                :eid 0
                :req-called 0}
@@ -45,7 +45,7 @@
         (is (= [:corp :corp :runner :runner] (map #(get-in % [:card :side]) effects))
             "Effects are sorted by active player first")))))
 
-(deftest get-effects
+(deftest get-effects-test
   (let [start {:active-player :corp
                :eid 0
                :req-called 0}
@@ -105,7 +105,7 @@
         (let [effects (e/get-effects state :corp :test-type c2)]
           (is (= [] effects) "Should not return the effect value"))))))
 
-(deftest sum-effects
+(deftest sum-effects-test
   (let [start {:active-player :corp
                :eid 0
                :req-called 0}

--- a/test/clj/game/core_test.clj
+++ b/test/clj/game/core_test.clj
@@ -700,6 +700,10 @@
   ([state side n args]
    (core/draw state side (core/make-eid state) n args)))
 
+(defn purge
+  [state side]
+  (core/purge state side (core/make-eid state)))
+
 (defn print-log [state]
   (->> (:log @state)
        (map :text)


### PR DESCRIPTION
Switch `:pre-steal-cost` to a static ability, `:steal-additional-cost`.

Switch Surveillance Sweep to a static ability.

Change `:pre-init-trace` to `:initialize-trace`, and make `:trace-force-link` a static ability.

Make purges async, clean up Progenitor and Acacia.