### PR TITLE
Explicit no-op handler for sente pong from client -> server

### DIFF
--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -64,6 +64,7 @@
     (?reply-fn {:msg "Unhandled event"})))
 
 (defmethod -msg-handler :chsk/ws-ping [_])
+(defmethod -msg-handler :chsk/ws-pong [_])
 ;; NOTE - :chsk/uidport-close is handled in game.clj
 (defmethod -msg-handler :chsk/uidport-open
   [{uid :uid


### PR DESCRIPTION
It looks like sente now sends pong acks on ping.  The server is currently logging these pongs as unknown message so I've just copied to same way we "handle" the pings.