### PR TITLE
Upgrade sente log level from :warn to :info (to provide more info on connection issues)

### DIFF
--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -35,8 +35,6 @@
 
 (read-write/print-time-literals-clj!)
 
-(sente/set-min-log-level! :info)
-
 (defmethod aero/reader 'ig/ref
   [_ _ value]
   (ig/ref value))

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -35,6 +35,8 @@
 
 (read-write/print-time-literals-clj!)
 
+(sente/set-min-log-level! :info)
+
 (defmethod aero/reader 'ig/ref
   [_ _ value]
   (ig/ref value))

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -4,7 +4,14 @@
    [web.app-state :refer [register-user! deregister-user!]]
    [web.user :refer [active-user?]]
    [taoensso.sente :as sente]
-   [taoensso.sente.server-adapters.http-kit :refer [get-sch-adapter]]))
+   [taoensso.sente.server-adapters.http-kit :refer [get-sch-adapter]]
+   [taoensso.timbre :as timbre]))
+
+(defn filter-uid-from-log-arg [arg] (if (string? arg)
+                                      (clojure.string/replace arg #"u_.*/c_" "u_[REDACTED]/c_")
+                                      arg))
+(timbre/merge-config! {:middleware [(fn [data] (assoc data :vargs (map filter-uid-from-log-arg (:vargs data ))))]})
+(sente/set-min-log-level! :info)
 
 (let [chsk-server (sente/make-channel-socket-server!
                     (get-sch-adapter)


### PR DESCRIPTION
This changes the log level (ideally temporarily) for sente on the server to INFO (default is WARN).  This will hopefully log a bit more information about websocket channels being initialised and what's going on with a frequent lack of handshaking.

--

Here's a full log that I generated locally that covers the following:
* two users logging in
* one user starting a game
* one use joining a game
* starting the game
* playing a full round on each side with actions
* conceding the game
* both players leaving

Effectively it looks like the only thing being logged is the start and stopping of websocket channels - so we shouldn't have to worry about game state information accidentally making its way into the logs.

```
2023-08-19T18:48:09.677Z Brians-MBP INFO [taoensso.sente:882] - [ws/on-open] New server WebSocket sch for u_test12/c_0154df/n_904459
2023-08-19T18:48:09.762Z Brians-MBP INFO [taoensso.sente:772] - Server will send :ws handshake to u_test12/c_0154df/n_904459
2023-08-19T18:48:09.771Z Brians-MBP INFO [taoensso.sente:942] - [ws/on-open] uid port open for u_test12/c_0154df/n_904459
2023-08-19T18:48:19.256Z Brians-MBP INFO [taoensso.sente:882] - [ws/on-open] New server WebSocket sch for u_test12/c_0a7c58/n_cd21d1
2023-08-19T18:48:19.257Z Brians-MBP INFO [taoensso.sente:772] - Server will send :ws handshake to u_test12/c_0a7c58/n_cd21d1
2023-08-19T18:48:21.680Z Brians-MBP INFO [taoensso.sente:857] - [ws/on-close] Server sch on-close timeout for u_test12/c_0154df/n_904459: {:disconnected? true}
2023-08-19T18:48:25.178Z Brians-MBP INFO [taoensso.sente:882] - [ws/on-open] New server WebSocket sch for u_test12/c_5ecb02/n_e74487
2023-08-19T18:48:25.178Z Brians-MBP INFO [taoensso.sente:772] - Server will send :ws handshake to u_test12/c_5ecb02/n_e74487
2023-08-19T18:48:27.626Z Brians-MBP INFO [taoensso.sente:857] - [ws/on-close] Server sch on-close timeout for u_test12/c_0a7c58/n_cd21d1: {:disconnected? true}
2023-08-19T18:48:34.762Z Brians-MBP INFO [taoensso.sente:882] - [ws/on-open] New server WebSocket sch for u_31d4e3/c_31d4e3/n_0d6132
2023-08-19T18:48:34.762Z Brians-MBP INFO [taoensso.sente:772] - Server will send :ws handshake to u_31d4e3/c_31d4e3/n_0d6132
2023-08-19T18:48:34.763Z Brians-MBP INFO [taoensso.sente:942] - [ws/on-open] uid port open for u_31d4e3/c_31d4e3/n_0d6132
2023-08-19T18:48:41.228Z Brians-MBP INFO [taoensso.sente:882] - [ws/on-open] New server WebSocket sch for u_test23/c_2733a9/n_cb8a9f
2023-08-19T18:48:41.229Z Brians-MBP INFO [taoensso.sente:772] - Server will send :ws handshake to u_test23/c_2733a9/n_cb8a9f
2023-08-19T18:48:41.229Z Brians-MBP INFO [taoensso.sente:942] - [ws/on-open] uid port open for u_test23/c_2733a9/n_cb8a9f
2023-08-19T18:48:43.553Z Brians-MBP INFO [taoensso.sente:857] - [ws/on-close] Server sch on-close timeout for u_31d4e3/c_31d4e3/n_0d6132: {:disconnected? true}
2023-08-19T18:48:43.555Z Brians-MBP INFO [taoensso.sente:873] - [ws/on-close] uid port close for u_31d4e3/c_31d4e3/n_0d6132
```