### PR TITLE
Don't allow Cybersand Harvester trash ability when no credits

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -703,6 +703,7 @@
              :effect (effect (add-counter :corp card :credit 2))}]
    :abilities [{:label "Take all hosted credits"
                 :cost [:trash-can]
+                :req (req (pos? (get-counters card :credit)))
                 :msg (msg "gain " (get-counters card :credit) " [Credits]")
                 :async true
                 :effect (effect (gain-credits eid (get-counters card :credit)))}

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -1209,6 +1209,14 @@
         (card-ability state :corp (refresh ch) 0))
       (is (= 1 (count (:discard (get-corp)))) "Cybersand Harvester got trashed"))))
 
+(deftest cybersand-harvester-cant-be-trashed-when-no-credits
+  (do-game
+    (new-game {:corp {:deck ["Cybersand Harvester"]}})
+    (play-from-hand state :corp "Cybersand Harvester" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (card-ability state :corp (get-content state :remote1 0) 0)
+    (is (= "Cybersand Harvester" (:title (get-content state :remote1 0))) "Cybersand Harveste was not trashed")))
+
 (deftest daily-business-show-full-test
     ;; Full test
     (do-game


### PR DESCRIPTION
<img width="795" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/d77934bf-2b1b-4190-9672-5d78b585eedc">
