### PR TITLE
Force sente to use ajax while ws is debugged

### DIFF
--- a/src/cljs/nr/ws.cljs
+++ b/src/cljs/nr/ws.cljs
@@ -14,7 +14,7 @@
         (sente/make-channel-socket-client!
           "/chsk"
           ?csrf-token
-          {:type :auto
+          {:type :ajax
            :wrap-recv-evs? false})]
     (def chsk chsk)
     (def ch-chsk ch-recv)


### PR DESCRIPTION
Currently the server does not seem to be establishing any new websocket connections. 

Players have actually discovered a bug with double clicking the "Attempt Reconnect" link which ends up tricking sente into switching into AJAX.  As far as I can tell this is the only way people are able to play games right now.

This change would just make that step unnecessary while the websocket issue is sorted out.