### PR TITLE
Fix issue where M.I.C. reported weird continue run errors

### DIFF
--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -4622,12 +4622,14 @@
       (is (nil? (:run @state)) "M.I.C. ended the run")
       (core/gain state :runner :click 1)
       (run-on state "HQ")
+      (run-continue state)
       (changes-val-macro
         -1 (:click (get-runner))
         "Runner spent 1 click to pay M.I.C. ability"
         (card-ability state :corp mic 0)
         (click-prompt state :runner "Spend [Click]"))
       (is (:run @state) "Run is still going")
+      (is (= :movement (:phase (:run @state))) "Encounter with M.I.C. is over")
       (is (= 1 (count (:discard (get-corp)))) "M.I.C. got trashed"))))
 
 (deftest mind-game-server-redirection


### PR DESCRIPTION
Saw quite a few errors that looked like this in the logs:

```
java.lang.Exception: Continue clicked at the wrong time
 at game.core.runs$fn__9468$fn__9469.invoke (runs.clj:482)
    game.core.runs$fn__9468.invokeStatic (runs.clj:481)
    game.core.runs/fn (runs.clj:479)
    clojure.lang.MultiFn.invoke (MultiFn.java:239)
    game.cards.ice$fn__37940$fn__37947$fn__37949.invoke (ice.clj:2520)
    game.core.eid$effect_completed.invokeStatic (eid.clj:50)
    game.core.eid$effect_completed.invoke (eid.clj:45)
    game.core.engine$trigger_pending_abilities.invokeStatic (engine.clj:993)
    game.core.engine$trigger_pending_abilities.invoke (engine.clj:979)
    game.core.engine$checkpoint$fn__6874$fn__6877$fn__6880.invoke (engine.clj:1120)
    game.core.eid$effect_completed.invokeStatic (eid.clj:50)
    game.core.eid$effect_completed.invoke (eid.clj:45)
    game.core.engine$check_restrictions$fn__6830.invoke (engine.clj:1091)
    game.core.eid$effect_completed.invokeStatic (eid.clj:50)
    game.core.eid$effect_completed.invoke (eid.clj:45)
    game.core.engine$resolve_ability_eid.invokeStatic (engine.clj:271)
    game.core.engine$resolve_ability_eid.invoke (engine.clj:266)
    game.core.engine$resolve_ability.invokeStatic (engine.clj:264)
    game.core.engine$resolve_ability.invoke (engine.clj:260)
    game.core.engine$check_restrictions.invokeStatic (engine.clj:1077)
    game.core.engine$check_restrictions.invoke (engine.clj:1071)
    game.core.engine$checkpoint$fn__6874$fn__6877.invoke (engine.clj:1111)
    game.core.eid$effect_completed.invokeStatic (eid.clj:50)
    game.core.eid$effect_completed.invoke (eid.clj:45)
    game.core.engine$check_unique_and_consoles.invokeStatic (engine.clj:1069)
    game.core.engine$check_unique_and_consoles.invoke (engine.clj:1044)
    game.core.engine$checkpoint$fn__6874.invoke (engine.clj:1108)
    game.core.eid$effect_completed.invokeStatic (eid.clj:50)
    game.core.eid$effect_completed.invoke (eid.clj:45)
    game.core.engine$unregister_expired_durations$fn__6794.invoke (engine.clj:1027)
    game.core.eid$effect_completed.invokeStatic (eid.clj:50)
    game.core.eid$effect_completed.invoke (eid.clj:45)
    game.core.engine$internal_trash_cards.invokeStatic (engine.clj:1009)
    game.core.engine$internal_trash_cards.invoke (engine.clj:1003)
    game.core.engine$trash_when_expired.invokeStatic (engine.clj:1016)
    game.core.engine$trash_when_expired.invoke (engine.clj:1011)
    game.core.engine$unregister_expired_durations.invokeStatic (engine.clj:1021)
    game.core.engine$unregister_expired_durations.invoke (engine.clj:1019)
    game.core.engine$checkpoint.invokeStatic (engine.clj:1103)
    game.core.engine$checkpoint.invoke (engine.clj:1093)
    game.core.engine$checkpoint.invokeStatic (engine.clj:1098)
    game.core.engine$checkpoint.invoke (engine.clj:1093)
    game.core.runs$register_unsuccessful_run$fn__9574.invoke (runs.clj:661)
    game.core.eid$effect_completed.invokeStatic (eid.clj:50)
    game.core.eid$effect_completed.invoke (eid.clj:45)
    game.core.runs$handle_end_run.invokeStatic (runs.clj:813)
    game.core.runs$handle_end_run.invoke (runs.clj:792)
    game.core.runs$register_unsuccessful_run.invokeStatic (runs.clj:659)
    game.core.runs$register_unsuccessful_run.invoke (runs.clj:654)
    game.core.runs$resolve_end_run.invokeStatic (runs.clj:669)
    game.core.runs$resolve_end_run.invoke (runs.clj:663)
    game.core.runs$end_run.invokeStatic (runs.clj:700)
    game.core.runs$end_run.invoke (runs.clj:675)
    game.core.runs$end_run.invokeStatic (runs.clj:677)
    game.core.runs$end_run.invoke (runs.clj:675)
    game.cards.ice$end_the_run_unless_runner_pays$fn__34079.invoke (ice.clj:183)
    game.core.engine$do_effect.invokeStatic (engine.clj:322)
    game.core.engine$do_effect.invoke (engine.clj:318)
    game.core.engine$do_paid_ability.invokeStatic (engine.clj:372)
    game.core.engine$do_paid_ability.invoke (engine.clj:364)
...
```

And believe this is due to M.I.C. trash ability trying to account for trying to move the run along if it's trashed during an encounter with it.  Hopefully this is a bit more clearer to what I think was the intent.