### PR TITLE
Fix Hostile Infrastructure always dealing 2 damage when trashed

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1182,7 +1182,8 @@
                         (first-event? state side :runner-trash #(valid-trash (first %)))))
          :msg "do 2 meat damage"
          :effect (effect (damage :corp eid :meat 2 {:card card}))}]
-    {:on-trash (assoc ability :req (req (= :runner side)))
+    {:on-trash (assoc ability :req (req (and (= :runner side)
+                                             (no-event? state side :runner-trash #(valid-trash (first %))))))
      :events [ability]}))
 
 

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2551,6 +2551,24 @@
     (click-prompt state :runner "Pay 4 [Credits] to trash")
     (is (= 2 (count (:discard (get-runner)))) "Took 0 more meat damage")))
 
+(deftest hostile-architecture-trash-other
+  (do-game
+    (new-game {:corp {:hand ["Hostile Architecture" "Bladderwort"]}
+               :runner {:hand [(qty "Sure Gamble" 5)]}})
+    (core/gain state :corp :credit 1)
+    (core/gain state :runner :credit 50)
+    (play-from-hand state :corp "Bladderwort" "New remote")
+    (play-from-hand state :corp "Hostile Architecture" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (rez state :corp (get-content state :remote2 0))
+    (take-credits state :corp)
+    (run-empty-server state "Server 1")
+    (click-prompt state :runner "Pay 3 [Credits] to trash")
+    (is (= 2 (count (:discard (get-runner)))) "Took 2 meat damage")
+    (run-empty-server state "Server 2")
+    (click-prompt state :runner "Pay 4 [Credits] to trash")
+    (is (= 2 (count (:discard (get-runner)))) "Took 0 more meat damage")))
+
 (deftest hostile-infrastructure-basic-behavior
     ;; Basic behavior
     (do-game


### PR DESCRIPTION
Noticed this while playing a game

<img width="383" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/dd0703e9-a952-4a6f-9b47-a52544351ce7">
