### PR TITLE
Upgrade sente and wrap handshake handler so it does not leak middleware stack on exceptions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                                com.cognitect/transit-java]]
                  [com.google.javascript/closure-compiler-unshaded "v20211006"]
                  [org.clojure/core.async "1.5.644"]
-                 [com.taoensso/sente "1.19.1" :exclusions [org.clojure/tools.reader]]
+                 [com.taoensso/sente "1.19.2" :exclusions [org.clojure/tools.reader]]
                  [com.taoensso/tempura "1.2.1"]
                  [ring/ring-core "1.9.4"]
                  [ring/ring-devel "1.9.4" :exclusions [org.clojure/java.classpath]]

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -24,7 +24,8 @@
                                        (:client-id ring-req)))})
       {:keys [ch-recv send-fn connected-uids
               ajax-post-fn ajax-get-or-ws-handshake-fn]} chsk-server]
-  (defonce handshake-handler ajax-get-or-ws-handshake-fn)
+  (defonce handshake-handler (fn [& args] (try (apply ajax-get-or-ws-handshake-fn args)
+                                               (catch Exception _ (println "Caught an error in the handshake handler")))))
   (defonce post-handler ajax-post-fn)
   (defonce connected-sockets connected-uids)
   (defonce ch-chsk ch-recv)


### PR DESCRIPTION
This updates to Sente to 1.19.2 which removes revealing sensitive information into the logs.  Additionally this updates the handshake handler to catch exceptions which also can leak sensitive information.

Here's what hitting `/chsk` without Ring/Cookie headers now reports:

```
2023-08-30T21:40:32.860Z Brians-MBP ERROR [taoensso.sente:752] - Client's Ring request doesn't have a client id. Does your server have the necessary keyword Ring middleware (`wrap-params` & `wrap-keyword-params`)?: u_[REDACTED]/c_/n_ce51d4
Caught an error in the handshake handler
```

