### PR TITLE
Upgrade http-kit to 2.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                  [buddy/buddy-auth "3.0.1"]
                  [crypto-password "0.3.0"]
                  [digest "1.4.10"]
-                 [http-kit "2.6.0"]
+                 [http-kit "2.7.0"]
                  [com.draines/postal "2.0.5"]
                  [throttler "1.0.1"]
                  [clj-http "3.12.3"]


### PR DESCRIPTION
Kind of a long shot to see if this helps with websocket issues at all, seems like a few things have been fixed with dropping sticky dead connections.  Tried it all locally and it seems fine, I assume it should work fine with stuff like Sente since it's all the same developer.