### PR TITLE
Log counts of connected uids every 30 seconds

### DIFF
--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -43,6 +43,13 @@
 
 (defn connected-uids [] (seq (:any @connected-sockets)))
 
+(defonce log-connected-uid-counts
+  (go (while true
+    (<! (timeout 30000))
+    (println (str "connected uids -"
+                  " :ajax " (count (:ajax @connected-sockets))
+                  " :ws " (count (:ws @connected-sockets)))))))
+
 (defonce ratelimiter
   (go (while true
         (<! (timeout (int buffer-clear-timer-ms)))


### PR DESCRIPTION
Adding some basic polling logs to see if the connect uid counts are increasing more than expected

Here's what these look like locally (I had it at 3000 ms during this test)

<img width="1430" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/e8090df8-e217-441f-9737-0633651adc15">
