### PR TITLE
Refactor storing lobby-updates as separate key in app-state

### DIFF
--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -9,8 +9,9 @@
 
 (defn register-user
   [app-state uid user]
-  (merge app-state {:users (assoc (:users app-state) uid (assoc user :uid uid))
-                    :lobby-updates (assoc (:lobby-updates app-state) uid true)}))
+  (-> app-state
+      (assoc-in [:users uid] (assoc user :uid uid))
+      (assoc-in [:lobby-updates uid] true)))
 
 (defn uid->lobby
   ([uid] (uid->lobby (:lobbies @app-state) uid))

--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -4,11 +4,13 @@
 
 (defonce app-state
   (atom {:lobbies {}
+         :lobby-updates {}
          :users {}}))
 
 (defn register-user
   [app-state uid user]
-  (assoc-in app-state [:users uid] (assoc user :uid uid :lobby-updates true)))
+  (merge app-state {:users (assoc (:users app-state) uid (assoc user :uid uid))
+                    :lobby-updates (assoc (:lobby-updates app-state) uid true)}))
 
 (defn uid->lobby
   ([uid] (uid->lobby (:lobbies @app-state) uid))
@@ -60,8 +62,12 @@
 
 (defn pause-lobby-updates
   [uid]
-  (swap! app-state assoc-in [:users uid :lobby-updates] false))
+  (swap! app-state assoc-in [:lobby-updates uid] false))
 
 (defn continue-lobby-updates
   [uid]
-  (swap! app-state assoc-in [:users uid :lobby-updates] true))
+  (swap! app-state assoc-in [:lobby-updates uid] true))
+
+(defn receive-lobby-updates?
+  [uid]
+  (get-in @app-state [:lobby-updates uid] false))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -188,9 +188,8 @@
   Filters the list per each users block list."
   ([]
    (let [user-cache (:users @app-state/app-state)
-         uids (ws/connected-uids)
-         users (map #(get user-cache %) uids)
-         users (filter #(:lobby-updates %) users)]
+         uids (filter #(app-state/receive-lobby-updates? %) (ws/connected-uids))
+         users (map #(get user-cache %) uids)]
      (broadcast-lobby-list users)))
   ([users]
    (assert (or (sequential? users) (nil? users)) (str "Users must be a sequence: " (pr-str users)))

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -65,6 +65,7 @@
 (defmethod ig/init-key :web/app-state [_ _]
   (reset! app-state/app-state
           {:lobbies {}
+           :lobby-updates {}
            :users {}})
   (reset! angel-arena/arena-queue []))
 


### PR DESCRIPTION
Refactored the lobby update tracking a bit so that it's managed under it's own key, don't think this will necessarily fix anything but might make it easier if we want to further extract it.

Would be good to have @lostgeek opinion on this change.