### PR TITLE
Tracking changes to the game state to make diffs quicker

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -322,7 +322,7 @@
                             (when (and
                                    (:access @state)
                                    (:run @state))
-                              (swap! state assoc-in [:run :shuffled-during-access :rd] true))
+                              (swap!* state assoc-in [:run :shuffled-during-access :rd] true))
                             (continue-ability state :corp (trash-step c '()) card nil)))}}}]
       {:on-score arrange-rd
        :stolen arrange-rd})))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -801,7 +801,7 @@
                             (not (get-in @state [:per-turn (:cid card)]))))
              :msg (msg "increase the install cost of " (:title (:card context))
                        " by " (get-counters card :power) " [Credits]")
-             :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}]})
+             :effect (req (swap!* state assoc-in [:per-turn (:cid card)] true))}]})
 
 (defcard "Dr. Vientiane Keeling"
   {:static-abilities [(runner-hand-size+ (req (- (get-counters card :power))))]
@@ -1140,7 +1140,7 @@
                            (prevent-draw state :runner)))}
    :events [{:event :runner-turn-begins
              :effect (effect (max-draw :runner 2))}]
-   :leave-play (req (swap! state update-in [:runner :register] dissoc :max-draw :cannot-draw))})
+   :leave-play (req (swap!* state update-in [:runner :register] dissoc :max-draw :cannot-draw))})
 
 (defcard "Ghost Branch"
   (advance-ambush 0 {:async true
@@ -2648,7 +2648,7 @@
   {:events [{:event :runner-turn-begins
              :effect (req (prevent-current state side))}]
    :on-rez {:effect (req (prevent-current state side))}
-   :leave-play (req (swap! state assoc-in [:runner :register :cannot-play-current] false))})
+   :leave-play (req (swap!* state assoc-in [:runner :register :cannot-play-current] false))})
 
 (defcard "The Root"
   {:recurring 3

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -32,7 +32,7 @@
                 :msg "gain 1 [Credits]"
                 :async true
                 :effect (req (wait-for (gain-credits state side 1 :corp-click-credit)
-                                       (swap! state update-in [:stats side :click :credit] (fnil inc 0))
+                                       (swap!* state update-in [:stats side :click :credit] (fnil inc 0))
                                        (trigger-event state side :corp-click-credit)
                                        (play-sfx state side "click-credit")
                                        (effect-completed state side eid)))}
@@ -42,7 +42,7 @@
                 :msg "draw 1 card"
                 :async true
                 :effect (req (trigger-event state side :corp-click-draw (-> @state side :deck (nth 0)))
-                             (swap! state update-in [:stats side :click :draw] (fnil inc 0))
+                             (swap!* state update-in [:stats side :click :draw] (fnil inc 0))
                              (play-sfx state side "click-card")
                              (draw state side eid 1))}
                {:label "Install 1 agenda, asset, upgrade, or piece of ice from HQ"
@@ -114,7 +114,7 @@
                 :msg "gain 1 [Credits]"
                 :async true
                 :effect (req (wait-for (gain-credits state side 1 :runner-click-credit)
-                                       (swap! state update-in [:stats side :click :credit] (fnil inc 0))
+                                       (swap!* state update-in [:stats side :click :credit] (fnil inc 0))
                                        (trigger-event state side :runner-click-credit)
                                        (play-sfx state side "click-credit")
                                        (effect-completed state side eid)))}
@@ -123,7 +123,7 @@
                 :cost [:click]
                 :msg "draw 1 card"
                 :effect (req (trigger-event state side :runner-click-draw (-> @state side :deck (nth 0)))
-                             (swap! state update-in [:stats side :click :draw] (fnil inc 0))
+                             (swap!* state update-in [:stats side :click :draw] (fnil inc 0))
                              (play-sfx state side "click-card")
                              (draw state side eid 1))}
                {:label "Install 1 program, resource, or piece of hardware from the grip"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -425,7 +425,7 @@
           :async true
           :msg (msg "trash " (:title target) " at no cost and suffer 1 meat damage")
           :effect (req (wait-for (trash state side (assoc target :seen true) {:cause-card card})
-                                 (swap! state assoc-in [:runner :register :trashed-card] true)
+                                 (swap!* state assoc-in [:runner :register :trashed-card] true)
                                  (damage state :runner eid :meat 1 {:unboostable true})))}]))}})
 
 (defcard "Calling in Favors"
@@ -698,8 +698,8 @@
 (defcard "Corporate Scandal"
   {:on-play {:msg "give the Corp 1 additional bad publicity"
              :implementation "No enforcement that this Bad Pub cannot be removed"
-             :effect (req (swap! state update-in [:corp :bad-publicity :additional] inc))}
-   :leave-play (req (swap! state update-in [:corp :bad-publicity :additional] dec))})
+             :effect (req (swap!* state update-in [:corp :bad-publicity :additional] inc))}
+   :leave-play (req (swap!* state update-in [:corp :bad-publicity :additional] dec))})
 
 (defcard "Creative Commission"
   {:on-play {:msg (msg "gain 5 [Credits]"
@@ -1238,7 +1238,7 @@
                    (some #{:archives} (:successful-run runner-reg))))
     :rfg-instead-of-trashing true
     :msg "take an additional turn after this one"
-    :effect (req (swap! state update-in [:runner :extra-turns] (fnil inc 0)))}})
+    :effect (req (swap!* state update-in [:runner :extra-turns] (fnil inc 0)))}})
 
 (defcard "Escher"
   (letfn [(es [] {:async true
@@ -2848,7 +2848,7 @@
                    ;; Move the selected ID to [:runner :identity] and set the zone
                    (let [new-id (-> target :title server-card make-card (assoc :zone [:identity]))
                          num-old-blanks (:num-disabled old-runner-identity)]
-                     (swap! state assoc-in [side :identity] new-id)
+                     (swap!* state assoc-in [side :identity] new-id)
                      (card-init state side new-id)
                      (when num-old-blanks
                        (dotimes [_ num-old-blanks]
@@ -3073,7 +3073,7 @@
                                                   (in-discard? %))}
                             :effect (req (doseq [c targets]
                                            (move state side c :hand))
-                                         (swap! state assoc-in [:run :prevent-hand-access] true)
+                                         (swap!* state assoc-in [:run :prevent-hand-access] true)
                                          (effect-completed state side eid))}
                            card nil)))}}}]
     {:makes-run true
@@ -3260,9 +3260,9 @@
                             this-card-run))
              :silent (req true)
              :msg "access cards from the bottom of R&D"
-             :effect (req (swap! state assoc-in [:runner :rd-access-fn] reverse))}
+             :effect (req (swap!* state assoc-in [:runner :rd-access-fn] reverse))}
             {:event :run-ends
-             :effect (req (swap! state assoc-in [:runner :rd-access-fn] seq))}]})
+             :effect (req (swap!* state assoc-in [:runner :rd-access-fn] seq))}]})
 
 (defcard "Singularity"
   {:makes-run true
@@ -3512,7 +3512,7 @@
                :effect (req (when-not (get-in card [:special :ss-target])
                               (update! state side (assoc-in card [:special :ss-target] target)))
                             (let [new-pump (assoc (second targets) :duration :end-of-run)]
-                              (swap! state assoc :effects
+                              (swap!* state assoc :effects
                                      (->> (:effects @state)
                                           (remove #(= (:uuid %) (:uuid new-pump)))
                                           (#(conj % new-pump))

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -167,7 +167,7 @@
      :req (req (and (= target :archives)
                     (not= (:max-access run) 0)
                     (not-empty (:discard corp))))
-     :effect (req (swap! state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
+     :effect (req (swap!* state update-in [:corp :discard] #(map (fn [c] (assoc c :seen true)) %))
                   (continue-ability
                     state side
                     {:optional
@@ -702,7 +702,7 @@
   {:abilities [(break-sub 1 1 "All" {:req (req true)})]})
 
 (defcard "Ekomind"
-  (let [update-base-mu (fn [state n] (swap! state assoc-in [:runner :memory :base] n))]
+  (let [update-base-mu (fn [state n] (swap!* state assoc-in [:runner :memory :base] n))]
     {:effect (req (update-base-mu state (count (get-in @state [:runner :hand])))
                   (add-watch state :ekomind (fn [_k ref old new]
                                               (let [hand-size (count (get-in new [:runner :hand]))]
@@ -822,7 +822,7 @@
               :player :runner
               :yes-ability {:msg "reduce the base trace strength to 0"
                             :cost [:trash-can]
-                            :effect (req (swap! state assoc-in [:trace :force-base] 0))}}}]
+                            :effect (req (swap!* state assoc-in [:trace :force-base] 0))}}}]
    :abilities [{:label "Jack out"
                 :req (req (and (or run
                                    (get-current-encounter state))
@@ -970,7 +970,7 @@
                                       (has-subtype? % "Icebreaker")
                                       (not (has-subtype? % "AI")))}
                 :effect (req (when-let [host (get-card state (:host card))]
-                               (swap! state assoc :effects
+                               (swap!* state assoc :effects
                                       (reduce
                                         (fn [effects e]
                                           (conj effects
@@ -990,14 +990,14 @@
              :effect (req (let [last-pump (assoc (second targets)
                                                  :duration :end-of-turn
                                                  :original-duration (:duration (last (:effects @state))))]
-                            (swap! state assoc :effects
+                            (swap!* state assoc :effects
                                    (->> (:effects @state)
                                         (remove #(= (:uuid last-pump) (:uuid %)))
                                         (#(conj % last-pump))
                                         (into []))))
                           (update-breaker-strength state side target))}]
    :leave-play (req (when-let [host (get-card state (:host card))]
-                      (swap! state assoc :effects
+                      (swap!* state assoc :effects
                              (reduce
                                (fn [effects e]
                                  (conj effects
@@ -2209,7 +2209,7 @@
                 :msg "suffer 2 meat damage"
                 :effect (effect (enable-runner-damage-choice)
                                 (damage eid :meat 2 {:unboostable true :card card}))}
-   :leave-play (req (swap! state update :damage dissoc :damage-choose-runner))
+   :leave-play (req (swap!* state update :damage dissoc :damage-choose-runner))
    :events [{:event :pre-resolve-damage
              :async true
              :req (req (and (pos? (last targets))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1668,7 +1668,7 @@
                                 (move state side (get-card state card)
                                       [:servers (target-server run) :ices]
                                       {:front true})
-                                (swap! state assoc-in [:run :position] 1)
+                                (swap!* state assoc-in [:run :position] 1)
                                 (set-next-phase state :encounter-ice)
                                 (set-current-ice state)
                                 (update-all-ice state side)
@@ -2159,7 +2159,7 @@
                        :duration :end-of-encounter
                        :unregister-once-resolved true
                        :msg (msg "can jack out again after encountering " (:title encountered-ice))
-                       :effect (req (swap! state update :run dissoc :cannot-jack-out))
+                       :effect (req (swap!* state update :run dissoc :cannot-jack-out))
                        :req (req (same-card? encountered-ice (:ice context)))}])))}]))}]})
 
 (defcard "Information Overload"
@@ -3036,7 +3036,7 @@
              :msg (str "force the runner to lose a [Click], if able. "
                        "Corp gains an additional [Click] to spend during their next turn")
              :effect (req (lose-clicks state :runner 1)
-                          (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}]
+                          (swap!* state update-in [:corp :extra-click-temp] (fnil inc 0)))}]
     {:subroutines [sub
                    sub]}))
 
@@ -3593,7 +3593,7 @@
                                       [{:event :encounter-ice
                                         :duration :end-of-run
                                         :unregister-once-resolved true
-                                        :effect (req (swap! state update :run dissoc :cannot-jack-out))}])
+                                        :effect (req (swap!* state update :run dissoc :cannot-jack-out))}])
                                      (if (and (= 1 (count (:encounters @state)))
                                               (not= :success (:phase run)))
                                        (do (redirect-run state side "Archives" :approach-ice)
@@ -3891,7 +3891,7 @@
   {:subroutines [(do-brain-damage 2)
                  (combine-abilities trash-installed-sub (gain-credits-sub 3))
                  end-the-run]
-   :runner-abilities [(bioroid-break 1 1 {:additional-ability {:effect (req (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}})]})
+   :runner-abilities [(bioroid-break 1 1 {:additional-ability {:effect (req (swap!* state update-in [:corp :extra-click-temp] (fnil inc 0)))}})]})
 
 (defcard "Tyrant"
   (zero-to-hero end-the-run))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -66,8 +66,8 @@
 ;;; Helper functions for Draft cards
 (def draft-points-target
   "Set each side's agenda points target at 6, per draft format rules"
-  (req (swap! state assoc-in [:runner :agenda-point-req] 6)
-       (swap! state assoc-in [:corp :agenda-point-req] 6)))
+  (req (swap!* state assoc-in [:runner :agenda-point-req] 6)
+       (swap!* state assoc-in [:corp :agenda-point-req] 6)))
 
 (defn- has-most-faction?
   "Checks if the faction has a plurality of rezzed / installed cards"
@@ -203,7 +203,7 @@
                                                 (map #(assoc % :zone [:play-area]))
                                                 (into []))]
                             ;; Add directives to :play-area - assumed to be empty
-                            (swap! state assoc-in [:runner :play-area] directives)
+                            (swap!* state assoc-in [:runner :play-area] directives)
                             (continue-ability
                               state side
                               {:prompt (str "Choose 3 starting directives")
@@ -217,7 +217,7 @@
                                                 (make-eid state eid) c
                                                 {:ignore-all-cost true
                                                  :custom-message (fn [_] (str "starts with " (:title c) " in play"))}))
-                                            (swap! state assoc-in [:runner :play-area] []))}
+                                            (swap!* state assoc-in [:runner :play-area] []))}
                               card nil)))}]})
 
 (defcard "AgInfusion: New Miracles for a New World"
@@ -460,8 +460,8 @@
 
 (defcard "Cerebral Imaging: Infinite Frontiers"
   {:static-abilities [(corp-hand-size+ (req (:credit corp)))]
-   :effect (req (swap! state assoc-in [:corp :hand-size :base] 0))
-   :leave-play (req (swap! state assoc-in [:corp :hand-size :base] 5))})
+   :effect (req (swap!* state assoc-in [:corp :hand-size :base] 0))
+   :leave-play (req (swap!* state assoc-in [:corp :hand-size :base] 5))})
 
 (defcard "Chaos Theory: Wünderkind"
   {:static-abilities [(mu+ 1)]})
@@ -469,7 +469,7 @@
 (defcard "Chronos Protocol: Selective Mind-mapping"
   {:req (req (empty? (filter #(= :net (:damage-type (first %))) (turn-events state :runner :damage))))
    :effect (effect (enable-corp-damage-choice))
-   :leave-play (req (swap! state update-in [:damage] dissoc :damage-choose-corp))
+   :leave-play (req (swap!* state update-in [:damage] dissoc :damage-choose-corp))
    :events [{:event :corp-phase-12
              :effect (effect (enable-corp-damage-choice))}
             {:event :runner-phase-12
@@ -562,8 +562,8 @@
              :effect (req (if (in-discard? target)
                             (effect-completed state side eid)
                             (do (when run
-                                  (swap! state assoc-in [:run :did-trash] true))
-                                (swap! state assoc-in [:runner :register :trashed-card] true)
+                                  (swap!* state assoc-in [:run :did-trash] true))
+                                (swap!* state assoc-in [:runner :register :trashed-card] true)
                                 (system-msg state :runner
                                             (str "uses " (:title card) " to"
                                                  " trash " (:title target)
@@ -675,7 +675,7 @@
                                                        " at no cost, spending " msg))
                                       (trash state side eid (assoc accessed-card :seen true) {:accessed true}))
                                   ;; Player cancelled ability
-                                  (do (swap! state dissoc-in [:per-turn (:cid card)])
+                                  (do (swap!* state dissoc-in [:per-turn (:cid card)])
                                       (access-non-agenda state side eid accessed-card :skip-trigger-event true)))))))}}})
 
 (defcard "Fringe Applications: Tomorrow, Today"
@@ -959,7 +959,7 @@
                                  empty?)))
              :msg "put 1 charge counter on itself"
              :effect (req (add-counter state side card :power 1)
-                          (swap! state assoc-in [:corp :agenda-point-req]
+                          (swap!* state assoc-in [:corp :agenda-point-req]
                                  (dec (get-in @state [:corp :agenda-point-req])))
                           (check-win-by-agenda state))}]})
 
@@ -1332,7 +1332,7 @@
                                 :effect (req (wait-for (corp-install state side target (zone->name (target-server run))
                                                                      {:ignore-all-cost true
                                                                       :front true})
-                                                       (swap! state assoc-in [:run :position] 1)
+                                                       (swap!* state assoc-in [:run :position] 1)
                                                        (set-next-phase state :approach-ice)
                                                        (update-all-ice state side)
                                                        (update-all-icebreakers state side)
@@ -1500,7 +1500,7 @@
                   :async true
                   :effect (req (wait-for (draw state side (- 5 (count (:hand corp))) {:suppress-event true})
                                          (update! state side (dissoc card :fill-hq))
-                                         (swap! state assoc :turn-events nil)
+                                         (swap!* state assoc :turn-events nil)
                                          (effect-completed state side eid)))}]}))
 
 (defcard "Nisei Division: The Next Generation"
@@ -1681,7 +1681,7 @@
              :choices ["HQ" "R&D"]
              :msg (msg "change the attacked server to " target)
              :effect (req (let [target-server (if (= target "HQ") :hq :rd)]
-                            (swap! state assoc-in [:run :server] [target-server])
+                            (swap!* state assoc-in [:run :server] [target-server])
                             (trigger-event state :corp :no-action)))}
             {:event :run-ends
              :effect (effect (update! (dissoc-in card [:special :omar-run])))}]})

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -604,7 +604,7 @@
                 "shuffle R&D"
                 (str "reveal " (:title target) " from R&D and add it to HQ")))
     :effect (let [end-effect (req (system-msg state side "can not score agendas for the remainder of the turn")
-                                  (swap! state assoc-in [:corp :register :cannot-score]
+                                  (swap!* state assoc-in [:corp :register :cannot-score]
                                          (filter agenda? (all-installed state :corp)))
                                   (register-events
                                     state side card
@@ -1297,7 +1297,7 @@
              :rfg-instead-of-trashing true
              :async true
              :effect (req (wait-for (damage state :runner :brain 1 {:card card})
-                                    (swap! state update-in [:runner :extra-click-temp] (fnil dec 0))
+                                    (swap!* state update-in [:runner :extra-click-temp] (fnil dec 0))
                                     (effect-completed state side eid)))}})
 
 (defcard "Interns"
@@ -2319,7 +2319,7 @@
     :choices ["Suffer 1 core damage" "Get 3 fewer [Click] on the next turn"]
     :effect (req (if (= target "Suffer 1 core damage")
                    (pay state :runner eid card [:brain 1])
-                   (do (swap! state update-in [:runner :extra-click-temp] (fnil #(- % 3) 0))
+                   (do (swap!* state update-in [:runner :extra-click-temp] (fnil #(- % 3) 0))
                        (effect-completed state side eid))))}})
 
 (defcard "Rolling Brownout"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -130,7 +130,7 @@
                                                           :effect (effect (runner-install :runner (assoc eid :source card :source-type :runner-install) card nil))}
                                         ;; Add a register to note that the player was already asked about installing,
                                         ;; to prevent multiple copies from prompting multiple times.
-                                        (= target "No") {:effect (req (swap! state assoc-in [:run :register (keyword (str "conspiracy-" title)) (:cid current-ice)] true))}
+                                        (= target "No") {:effect (req (swap!* state assoc-in [:run :register (keyword (str "conspiracy-" title)) (:cid current-ice)] true))}
                                         ;; mark that we never want to install this heap breaker while another copy is installed
                                         :else {:effect (req
                                                          (let [heap-breakers (filter #(= title (:title %)) (all-active-installed state :runner))]
@@ -839,17 +839,17 @@
    {:effect (req (let [agendas (->> (turn-events state :corp :corp-install)
                                     (filter #(agenda? (:card (first %))))
                                     (map first))]
-                   (swap! state assoc-in [:corp :register :cannot-score] agendas)))}
+                   (swap!* state assoc-in [:corp :register :cannot-score] agendas)))}
    :events [{:event :purge
              :async true
              :msg "trash itself"
-             :effect (req (swap! state update-in [:corp :register] dissoc :cannot-score)
+             :effect (req (swap!* state update-in [:corp :register] dissoc :cannot-score)
                           (trash state :runner eid card {:cause :purge
                                                          :cause-card card}))}
             {:event :corp-install
              :req (req (agenda? (:card context)))
-             :effect (req (swap! state update-in [:corp :register :cannot-score] #(cons (:card context) %)))}]
-   :leave-play (req (swap! state update-in [:corp :register] dissoc :cannot-score))})
+             :effect (req (swap!* state update-in [:corp :register :cannot-score] #(cons (:card context) %)))}]
+   :leave-play (req (swap!* state update-in [:corp :register] dissoc :cannot-score))})
 
 (defcard "Collective Consciousness"
   {:events [{:event :rez
@@ -927,7 +927,7 @@
                 :msg "redirect the run"
                 :effect (req (let [dest (second (get-zone target))
                                    tgtndx (card-index state target)]
-                               (swap! state update-in [:run]
+                               (swap!* state update-in [:run]
                                       #(assoc % :position tgtndx :server [dest]))
                                (set-current-ice state)
                                (trash state side eid card {:unpreventable true
@@ -2781,7 +2781,7 @@
                                     :interactive (req true)
                                     :msg "change the attacked server to HQ"
                                     :req (req (= :archives (-> run :server first)))
-                                    :effect (req (swap! state assoc-in [:run :server] [:hq])
+                                    :effect (req (swap!* state assoc-in [:run :server] [:hq])
                                                  (trigger-event state :corp :no-action))}])
                                 (make-run eid :archives (get-card state card)))}]})
 
@@ -2871,7 +2871,7 @@
              :msg (msg "swap " (card-str state cice)
                        " and " (card-str state target))
              :effect (req (let [tgtndx (card-index state target)]
-                            (when run (swap! state assoc-in [:run :position] (inc tgtndx)))
+                            (when run (swap!* state assoc-in [:run :position] (inc tgtndx)))
                             (swap-ice state side cice target)))})]
     {:abilities [{:cost [:credit 2]
                   :msg "swap a piece of Barrier ice"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -878,7 +878,7 @@
                                            :effect (effect (runner-install :runner eid card {:ignore-all-cost true}))}
                              ;; Add a register to note that the player was already asked about installing,
                              ;; to prevent multiple copies from prompting multiple times.
-                             :no-ability {:effect (req (swap! state assoc-in [:runner :register :crowdfunding-prompt] true))}}}
+                             :no-ability {:effect (req (swap!* state assoc-in [:runner :register :crowdfunding-prompt] true))}}}
                            card nil))}]}))
 
 (defcard "Crypt"
@@ -1357,7 +1357,7 @@
           (host-agenda? [agenda]
             {:optional {:prompt (str "Host " (:title agenda) " on Film Critic?")
                         :yes-ability {:effect (req (host state side card agenda)
-                                                   (swap! state dissoc :access))
+                                                   (swap!* state dissoc :access))
                                       :msg (msg "host " (:title agenda) " instead of accessing it")}}})]
     {:events [{:event :access
                :req (req (and (empty? (filter agenda? (:hosted card)))
@@ -2196,7 +2196,7 @@
             {:event :breach-server
              :req (req (and (= target :archives)
                             (seq (filter :trash (:discard corp)))))
-             :effect (req (swap! state assoc-in [:per-turn (:cid card)] true))}
+             :effect (req (swap!* state assoc-in [:per-turn (:cid card)] true))}
             {:event :pre-trash
              :req (req (let [cards (map first (rest (turn-events state side :pre-trash)))]
                          (and (empty? (filter :trash cards))
@@ -2204,11 +2204,11 @@
              :once :per-turn
              :msg (msg "reveal " (card-str state target {:visible true}))
              :async true
-             :effect (req (swap! state assoc-in [:runner :register :must-trash-with-credits] true)
+             :effect (req (swap!* state assoc-in [:runner :register :must-trash-with-credits] true)
                           (reveal state side eid target))}
             {:event :post-access-card
              :req (req (get-in @state [:runner :register :must-trash-with-credits]))
-             :effect (req (swap! state assoc-in [:runner :register :must-trash-with-credits] false))}]})
+             :effect (req (swap!* state assoc-in [:runner :register :must-trash-with-credits] false))}]})
 
 (defcard "New Angeles City Hall"
   {:interactions {:prevent [{:type #{:tag}
@@ -2463,7 +2463,7 @@
                                  target
                                  {:cost-bonus (discount state card)
                                   :custom-message #(str (build-spend-msg % "install") (:title target) " using " (:title card))})
-                            (swap! state assoc-in [:per-turn (:cid card)] true))})]})
+                            (swap!* state assoc-in [:per-turn (:cid card)] true))})]})
 
 (defcard "Penumbral Toolkit"
   {:data {:counter {:credit 4}}
@@ -2901,7 +2901,7 @@
                       :msg (msg "approach " (card-str state target))
                       :effect (req (wait-for (trash state side card {:unpreventable true :cause-card card})
                                              (let [dest (second (get-zone target))]
-                                               (swap! state update-in [:run]
+                                               (swap!* state update-in [:run]
                                                       #(assoc % :position (inc run-position) :server [dest]))
                                                (set-next-phase state :approach-ice)
                                                (update-all-ice state side)
@@ -2918,12 +2918,12 @@
 
 (defcard "Starlight Crusade Funding"
   {:on-install {:msg "ignore additional costs on Double events"
-                :effect (req (swap! state assoc-in [:runner :register :double-ignore-additional] true))}
+                :effect (req (swap!* state assoc-in [:runner :register :double-ignore-additional] true))}
    :events [{:event :runner-turn-begins
              :msg "lose [Click] and ignore additional costs on Double events"
              :effect (req (lose-clicks state :runner 1)
-                          (swap! state assoc-in [:runner :register :double-ignore-additional] true))}]
-   :leave-play (req (swap! state update-in [:runner :register] dissoc :double-ignore-additional))})
+                          (swap!* state assoc-in [:runner :register :double-ignore-additional] true))}]
+   :leave-play (req (swap!* state update-in [:runner :register] dissoc :double-ignore-additional))})
 
 (defcard "Stim Dealer"
   {:events [{:event :runner-turn-begins
@@ -3373,9 +3373,9 @@
              :keep-menu-open :while-clicks-left
              :msg (msg "bounce off of " name " for a token (shortcut)")
              :effect (req (add-counter state :runner card :power 1)
-                          (swap! state assoc-in [:runner :register :made-click-run] true)
-                          (swap! state update-in [:runner :register :unsuccessful-run] conj server)
-                          (swap! state update-in [:runner :register :made-run] conj server))})]
+                          (swap!* state assoc-in [:runner :register :made-click-run] true)
+                          (swap!* state update-in [:runner :register :unsuccessful-run] conj server)
+                          (swap!* state update-in [:runner :register :made-run] conj server))})]
     {:events [{:event :agenda-stolen
                :effect (effect (update! (assoc card :agenda-stolen true)))
                :silent (req true)}
@@ -3424,9 +3424,9 @@
 (defcard "Theophilius Bagbiter"
   {:static-abilities [(runner-hand-size+ (req (:credit runner)))]
    :on-install {:async true
-                :effect (req (swap! state assoc-in [:runner :hand-size :base] 0)
+                :effect (req (swap!* state assoc-in [:runner :hand-size :base] 0)
                              (lose-credits state :runner eid :all))}
-   :leave-play (req (swap! state assoc-in [:runner :hand-size :base] 5))})
+   :leave-play (req (swap!* state assoc-in [:runner :hand-size :base] 5))})
 
 (defcard "Thunder Art Gallery"
   (let [first-event-check (fn [state fn1 fn2]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -425,7 +425,7 @@
                 :async true
                 :effect (req (wait-for
                                (trash state :corp (make-eid state eid) card {:cause-card card})
-                               (swap! state update-in [:run :position] inc)
+                               (swap!* state update-in [:run :position] inc)
                                (set-next-phase state :approach-ice)
                                (update-all-ice state side)
                                (update-all-icebreakers state side)
@@ -921,7 +921,7 @@
                                  :prompt-type :bogus}
                                 card nil)))}
               {:event :post-corp-draw
-               :effect (req (swap! state dissoc-in [:per-turn :jinja-city-grid-draw]))}]}))
+               :effect (req (swap!* state dissoc-in [:per-turn :jinja-city-grid-draw]))}]}))
 
 (defcard "K. P. Lynn"
   {:events [{:event :pass-all-ice
@@ -1042,7 +1042,7 @@
              :req (req (and (:successful target)
                             (= (target-server target) (second (get-zone card)))
                             (or (< (:credit runner) 6) (zero? (:click runner)))))
-             :effect (req (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}]})
+             :effect (req (swap!* state update-in [:corp :extra-click-temp] (fnil inc 0)))}]})
 
 (defcard "Marcus Batty"
   {:abilities [{:label "Start a Psi game to resolve a subroutine"
@@ -1658,14 +1658,14 @@
               :yes-ability
               {:async true
                :msg "do 1 core damage instead of net damage"
-               :effect (req (swap! state update :damage dissoc :damage-replace :defer-damage)
+               :effect (req (swap!* state update :damage dissoc :damage-replace :defer-damage)
                             (wait-for (pay state :corp (make-eid state eid) card :credit 2)
                                       (system-msg state side (:msg async-result))
                                       (wait-for (damage state side :brain 1 {:card card})
-                                                (swap! state assoc-in [:damage :damage-replace] true)
+                                                (swap!* state assoc-in [:damage :damage-replace] true)
                                                 (effect-completed state side eid))))}
               :no-ability
-              {:effect (req (swap! state update :damage dissoc :damage-replace))}}}]})
+              {:effect (req (swap!* state update :damage dissoc :damage-replace))}}}]})
 
 (defcard "Traffic Analyzer"
   {:events [{:event :rez

--- a/src/clj/game/core/agendas.clj
+++ b/src/clj/game/core/agendas.clj
@@ -5,7 +5,8 @@
     [game.core.card-defs :refer [card-def]]
     [game.core.effects :refer [sum-effects]]
     [game.core.eid :refer [make-eid]]
-    [game.core.update :refer [update!]]))
+    [game.core.update :refer [update!]]
+    [game.utils :refer [swap!*]]))
 
 (defn- advancement-requirement
   [state {:keys [advancementcost] :as card}]
@@ -72,7 +73,7 @@
         total-points (+ user-adjusted-points scored-points)
         changed? (not= current-points total-points)]
     (when changed?
-      (swap! state assoc-in [side :agenda-point] total-points))
+      (swap!* state assoc-in [side :agenda-point] total-points))
     changed?))
 
 (defn- update-side-agenda-points

--- a/src/clj/game/core/bad_publicity.clj
+++ b/src/clj/game/core/bad_publicity.clj
@@ -7,11 +7,12 @@
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg]]
     [game.core.toasts :refer [toast]]
-    [game.macros :refer [wait-for]]))
+    [game.macros :refer [wait-for]]
+    [game.utils :refer [swap!*]]))
 
 (defn bad-publicity-prevent
   [state side n]
-  (swap! state update-in [:bad-publicity :bad-publicity-prevent] (fnil #(+ % n) 0))
+  (swap!* state update-in [:bad-publicity :bad-publicity-prevent] (fnil #(+ % n) 0))
   (trigger-event state side (if (= side :corp) :corp-prevent :runner-prevent) `(:bad-publicity ~n)))
 
 (defn- resolve-bad-publicity
@@ -35,7 +36,7 @@
   ([state side n] (gain-bad-publicity state side (make-eid state) n nil))
   ([state side eid n] (gain-bad-publicity state side eid n nil))
   ([state side eid n {:keys [unpreventable card] :as args}]
-   (swap! state update-in [:bad-publicity] dissoc :bad-publicity-bonus :bad-publicity-prevent)
+   (swap!* state update-in [:bad-publicity] dissoc :bad-publicity-bonus :bad-publicity-prevent)
    (wait-for (trigger-event-sync state side :pre-bad-publicity card)
              (let [n (bad-publicity-count state side n args)
                    prevent (get-prevent-list state :corp :bad-publicity)]
@@ -44,7 +45,7 @@
                         (cards-can-prevent? state :corp prevent :bad-publicity))
                  (do (system-msg state :corp "has the option to avoid bad publicity")
                      (show-wait-prompt state :runner "Corp to prevent bad publicity")
-                     (swap! state assoc-in [:prevent :current] :bad-publicity)
+                     (swap!* state assoc-in [:prevent :current] :bad-publicity)
                      (show-prompt
                        state :corp nil
                        (str "Avoid " (when (< 1 n) "any of the ") n " bad publicity?") ["Done"]

--- a/src/clj/game/core/board.clj
+++ b/src/clj/game/core/board.clj
@@ -6,7 +6,7 @@
    [game.core.card-defs :refer [card-def]]
    [game.core.eid :refer [make-eid]]
    [game.core.servers :refer [is-remote? zones->sorted-names]]
-   [game.utils :refer [dissoc-in to-keyword]]))
+   [game.utils :refer [dissoc-in to-keyword swap!*]]))
 
 (defn corp-servers-cards [state]
   (for [server (vals (:servers (:corp @state)))
@@ -194,4 +194,4 @@
     (let [zone [:corp :servers (first remote)]]
       (when (and (empty? (get-in @state (conj zone :content)))
                  (empty? (get-in @state (conj zone :ices))))
-        (swap! state dissoc-in zone)))))
+        (swap!* state dissoc-in zone)))))

--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -9,7 +9,8 @@
     [game.core.memory :refer [available-mu update-mu]]
     [game.core.say :refer [system-msg]]
     [game.core.tags :refer [update-tag-status]]
-    [game.macros :refer [req]]))
+    [game.macros :refer [req]]
+    [game.utils :refer [swap!*]]))
 
 (defn- change-msg
   "Send a system message indicating the property change"
@@ -103,7 +104,7 @@
   [state side key delta]
   (if (neg? delta)
     (deduct state side [key (- delta)])
-    (swap! state update-in [side key] (partial + delta)))
+    (swap!* state update-in [side key] (partial + delta)))
   (change-msg state side key (get-in @state [side key]) delta))
 
 (defn change

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -20,7 +20,7 @@
    [game.core.update :refer [update!]]
    [game.core.virus :refer [number-of-virus-counters]]
    [game.macros :refer [continue-ability req wait-for]]
-   [game.utils :refer [enumerate-str quantify same-card?]]))
+   [game.utils :refer [enumerate-str quantify same-card? swap!*]]))
 
 ;; Click
 (defmethod cost-name :click [_] :click)
@@ -36,8 +36,8 @@
   [cost state side eid card actions]
   (let [a (keep :action actions)]
     (when (not (some #{:steal-cost} a))
-      (swap! state assoc :click-state (dissoc @state :log)))
-    (swap! state update-in [:stats side :lose :click] (fnil + 0) (value cost))
+      (swap!* state assoc :click-state (dissoc @state :log)))
+    (swap!* state update-in [:stats side :lose :click] (fnil + 0) (value cost))
     (deduct state side [:click (value cost)])
     (wait-for (trigger-event-sync state side (make-eid state eid)
                                   (if (= side :corp) :corp-spent-click :runner-spent-click)
@@ -45,7 +45,7 @@
               ;; sending the idx is mandatory to make wage workers functional
               ;; and so we can look through the events and figure out WHICH abilities were used
               ;; I don't think it will break anything
-              (swap! state assoc-in [side :register :spent-click] true)
+              (swap!* state assoc-in [side :register :spent-click] true)
               (complete-with-result state side eid {:msg (str "spends " (label cost))
                                                     :type :click
                                                     :value (value cost)}))))
@@ -65,12 +65,12 @@
   (<= 0 (- (get-in @state [side :click]) (value cost))))
 (defmethod handler :lose-click
   [cost state side eid card actions]
-  (swap! state update-in [:stats side :lose :click] (fnil + 0) (value cost))
+  (swap!* state update-in [:stats side :lose :click] (fnil + 0) (value cost))
   (deduct state side [:click (value cost)])
   (wait-for (trigger-event-sync state side (make-eid state eid)
                                 (if (= side :corp) :corp-spent-click :runner-spent-click)
                                 nil (value cost))
-            (swap! state assoc-in [side :register :spent-click] true)
+            (swap!* state assoc-in [side :register :spent-click] true)
             (complete-with-result state side eid {:msg (str "loses " (lose-click-label cost))
                                                   :type :lose-click
                                                   :value (value cost)})))
@@ -142,7 +142,7 @@
                               state side (make-eid state eid)
                               (if (= side :corp) :corp-spent-credits :runner-spent-credits)
                               (value cost))
-                            (swap! state update-in [:stats side :spent :credit] (fnil + 0) (value cost))
+                            (swap!* state update-in [:stats side :spent :credit] (fnil + 0) (value cost))
                             (complete-with-result state side eid
                                                   {:msg (str "pays " (:msg pay-async-result))
                                                    :type :credit
@@ -154,7 +154,7 @@
                       state side (make-eid state eid)
                       (if (= side :corp) :corp-spent-credits :runner-spent-credits)
                       (value cost))
-                    (swap! state update-in [:stats side :spent :credit] (fnil + 0) (value cost))
+                    (swap!* state update-in [:stats side :spent :credit] (fnil + 0) (value cost))
                     (complete-with-result state side eid {:msg (str "pays " (value cost) " [Credits]")
                                                           :type :credit
                                                           :value (value cost)})))
@@ -189,7 +189,7 @@
            (and (pos? cost)
                 (pos? (count (provider-func))))
            (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func eid cost stealth-value) card nil)
-                     (swap! state update-in [:stats side :spent :credit] (fnil + 0) cost)
+                     (swap!* state update-in [:stats side :spent :credit] (fnil + 0) cost)
                      (complete-with-result state side eid {:msg (str "pays " (:msg async-result))
                                                            :type :x-credits
                                                            :value (:number async-result)
@@ -200,7 +200,7 @@
                            state side (make-eid state eid)
                            (if (= side :corp) :corp-spent-credits :runner-spent-credits)
                            cost)
-                         (swap! state update-in [:stats side :spent :credit] (fnil + 0) cost)
+                         (swap!* state update-in [:stats side :spent :credit] (fnil + 0) cost)
                          (complete-with-result state side eid {:msg (str "pays " cost " [Credits]")
                                                                :type :x-credits
                                                                :value cost})))

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -17,7 +17,7 @@
     [game.core.to-string :refer [card-str]]
     [game.core.toasts :refer [toast]]
     [game.macros :refer [continue-ability effect msg req wait-for]]
-    [game.utils :refer [enumerate-str remove-once same-card? server-card to-keyword]]
+    [game.utils :refer [enumerate-str remove-once same-card? server-card to-keyword swap!*]]
     [jinteki.utils :refer [other-side]]))
 
 (defn combine-abilities
@@ -83,22 +83,22 @@
    :effect (req
              (cond
                (and (= dest "bottom") (= target "Done"))
-               (do (swap! state update-in [reorder-side :deck]
+               (do (swap!* state update-in [reorder-side :deck]
                           #(vec (concat (drop (count chosen) %) (reverse chosen))))
                    (when (and (= :corp reorder-side)
                               (:run @state)
                               (:access @state))
-                     (swap! state assoc-in [:run :shuffled-during-access :rd] true))
+                     (swap!* state assoc-in [:run :shuffled-during-access :rd] true))
                    (clear-wait-prompt state wait-side)
                    (effect-completed state side eid))
 
                (= target "Done")
-               (do (swap! state update-in [reorder-side :deck]
+               (do (swap!* state update-in [reorder-side :deck]
                           #(vec (concat chosen (drop (count chosen) %))))
                    (when (and (= :corp reorder-side)
                               (:run @state)
                               (:access @state))
-                     (swap! state assoc-in [:run :shuffled-during-access :rd] true))
+                     (swap!* state assoc-in [:run :shuffled-during-access :rd] true))
                    (clear-wait-prompt state wait-side)
                    (effect-completed state side eid))
 
@@ -242,9 +242,9 @@
 
 (defmacro defcard
   [title ability]
-  `(do (swap! card-defs-cache dissoc ~title)
+  `(do (swap!* card-defs-cache dissoc ~title)
        (defmethod card-defs/defcard-impl ~title [~'_]
          (or (get @card-defs-cache ~title)
              (let [ability# (add-default-abilities ~title ~ability)]
-               (swap! card-defs-cache assoc ~title ability#)
+               (swap!* card-defs-cache assoc ~title ability#)
                ability#)))))

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -3,7 +3,7 @@
             [game.core.card :refer [get-card]]
             [game.core.card-defs :refer [card-def]]
             [game.core.eid :refer [make-eid]]
-            [game.utils :refer [same-card? to-keyword]]))
+            [game.utils :refer [same-card? to-keyword swap!*]]))
 
 (defn register-static-abilities
   [state _ card]
@@ -15,13 +15,13 @@
                         :duration :while-active
                         :card card
                         :uuid (uuid/v1)))]
-      (swap! state update :effects
+      (swap!* state update :effects
              #(apply conj (into [] %) abilities))
       abilities)))
 
 (defn unregister-static-abilities
   [state _ card]
-  (swap! state assoc :effects
+  (swap!* state assoc :effects
          (->> (:effects @state)
               (remove #(and (same-card? card (:card %))
                             (= :while-active (:duration %))))
@@ -33,12 +33,12 @@
                   (select-keys ability [:type :duration :req :value])
                   :card card
                   :uuid (uuid/v1))]
-    (swap! state update :effects conj ability)
+    (swap!* state update :effects conj ability)
     ability))
 
 (defn unregister-lingering-effects
   [state _ duration]
-  (swap! state assoc :effects
+  (swap!* state assoc :effects
          (->> (:effects @state)
               (remove #(= duration (:duration %)))
               (into []))))
@@ -46,7 +46,7 @@
 (defn unregister-effects-for-card
   ([state _ card] (unregister-effects-for-card state nil card identity))
   ([state _ card pred]
-   (swap! state assoc :effects
+   (swap!* state assoc :effects
           (->> (:effects @state)
                (remove #(and (same-card? card (:card %))
                              (pred %)))

--- a/src/clj/game/core/eid.clj
+++ b/src/clj/game/core/eid.clj
@@ -2,12 +2,13 @@
   (:require
     [medley.core :refer [find-first]]
     [game.core.card :refer [basic-action?]]
-    [game.core.prompt-state :refer [remove-from-prompt-queue]]))
+    [game.core.prompt-state :refer [remove-from-prompt-queue]]
+    [game.utils :refer [swap!*]]))
 
 (defn make-eid
   ([state] (make-eid state nil))
   ([state existing-eid]
-   (assoc existing-eid :eid (:eid (swap! state update :eid inc)))))
+   (assoc existing-eid :eid (:eid (swap!* state update :eid inc)))))
 
 (defn eid-set-defaults
   "Set default values for fields in the `eid` if they are not already set."
@@ -33,7 +34,7 @@
   [state eid effect]
   (if (get-in @state [:effect-completed (:eid eid)])
     (throw (Exception. (str "Eid has already been registered")))
-    (swap! state assoc-in [:effect-completed (:eid eid)] effect)))
+    (swap!* state assoc-in [:effect-completed (:eid eid)] effect)))
 
 (defn clear-eid-wait-prompt
   [state side eid]
@@ -48,7 +49,7 @@
     (clear-eid-wait-prompt state side eid))
   (when-let [handler (get-in @state [:effect-completed (:eid eid)])]
     (let [results (handler eid)]
-      (swap! state update :effect-completed dissoc (:eid eid))
+      (swap!* state update :effect-completed dissoc (:eid eid))
       results)))
 
 (defn make-result

--- a/src/clj/game/core/expose.clj
+++ b/src/clj/game/core/expose.clj
@@ -8,11 +8,12 @@
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg]]
     [game.core.to-string :refer [card-str]]
-    [game.macros :refer [wait-for]]))
+    [game.macros :refer [wait-for]]
+    [game.utils :refer [swap!*]]))
 
 (defn expose-prevent
   [state _ n]
-  (swap! state update-in [:expose :expose-prevent] #(+ (or % 0) n)))
+  (swap!* state update-in [:expose :expose-prevent] #(+ (or % 0) n)))
 
 (defn- resolve-expose
   [state side eid target]
@@ -27,7 +28,7 @@
   ([state side target] (expose state side (make-eid state) target))
   ([state side eid target] (expose state side eid target nil))
   ([state side eid target {:keys [unpreventable]}]
-    (swap! state update :expose dissoc :expose-prevent)
+    (swap!* state update :expose dissoc :expose-prevent)
     (if (or (rezzed? target)
             (nil? target))
       (effect-completed state side eid) ; cannot expose faceup cards

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -8,7 +8,7 @@
     [game.core.servers :refer [zone->name]]
     [game.core.to-string :refer [card-str]]
     [game.core.toasts :refer [toast]]
-    [game.utils :refer [enumerate-str same-card? same-side?]]))
+    [game.utils :refer [enumerate-str same-card? same-side? swap!*]]))
 
 (defn card-flag?
   "Checks the card to see if it has a :flags entry of the given flag-key, and with the given value if provided"
@@ -44,7 +44,7 @@
 (defn- register-flag!
   "Register a flag of the specific type."
   [state _ card flag-type flag condition]
-  (swap! state update-in [:stack flag-type flag] #(conj % {:card card :condition condition})))
+  (swap!* state update-in [:stack flag-type flag] #(conj % {:card card :condition condition})))
 
 (defn- check-flag?
   "Flag condition will ask for permission to do something, e.g. :can-rez, :can-advance
@@ -75,12 +75,12 @@
 (defn- clear-all-flags!
   "Clears all flags of specified type"
   [state flag-type]
-  (swap! state assoc-in [:stack flag-type] nil))
+  (swap!* state assoc-in [:stack flag-type] nil))
 
 (defn- clear-flag-for-card!
   "Remove all entries for specified card for flag-type and flag"
   [state _ card flag-type flag]
-  (swap! state update-in [:stack flag-type flag]
+  (swap!* state update-in [:stack flag-type flag]
          (fn [flag-map] (remove #(= (get-cid %) (:cid card)) flag-map))))
 
 ;; Currently unused
@@ -156,19 +156,19 @@
 ;;; Functions for preventing specific game actions.
 ;;; TODO: look into migrating these to turn-flags and run-flags.
 (defn prevent-draw [state _]
-  (swap! state assoc-in [:runner :register :cannot-draw] true))
+  (swap!* state assoc-in [:runner :register :cannot-draw] true))
 
 (defn prevent-jack-out [state _]
-  (swap! state assoc-in [:run :cannot-jack-out] true))
+  (swap!* state assoc-in [:run :cannot-jack-out] true))
 
 (defn prevent-current [state _]
-  (swap! state assoc-in [:runner :register :cannot-play-current] true))
+  (swap!* state assoc-in [:runner :register :cannot-play-current] true))
 
 (defn lock-zone [state _ cid tside tzone]
-  (swap! state update-in [tside :locked tzone] #(conj % cid)))
+  (swap!* state update-in [tside :locked tzone] #(conj % cid)))
 
 (defn release-zone [state _ cid tside tzone]
-  (swap! state update-in [tside :locked tzone] #(remove #{cid} %)))
+  (swap!* state update-in [tside :locked tzone] #(remove #{cid} %)))
 
 ;; TODO: this can probably be made into costant/floating effects too
 (defn zone-locked?

--- a/src/clj/game/core/hand_size.clj
+++ b/src/clj/game/core/hand_size.clj
@@ -1,6 +1,7 @@
 (ns game.core.hand-size
   (:require
-    [game.core.effects :refer [sum-effects]]))
+    [game.core.effects :refer [sum-effects]]
+    [game.utils :refer [swap!*]]))
 
 (defn hand-size
   [state side]
@@ -20,7 +21,7 @@
         new-total (sum-hand-size-effects state side)
         changed? (not= old-total new-total)]
     (when changed?
-      (swap! state assoc-in [side :hand-size :total] new-total))
+      (swap!* state assoc-in [side :hand-size :total] new-total))
     changed?))
 
 (defn hand-size+

--- a/src/clj/game/core/hosting.clj
+++ b/src/clj/game/core/hosting.clj
@@ -8,7 +8,7 @@
     [game.core.initializing :refer [card-init]]
     [game.core.memory :refer [update-mu]]
     [game.core.update :refer [update! update-hosted!]]
-    [game.utils :refer [remove-once]]))
+    [game.utils :refer [remove-once swap!*]]))
 
 (defn remove-from-host
   "Removes a card from its host."
@@ -30,9 +30,9 @@
          (when-let [host-card (get-card state host)]
            (update! state side (update host-card :hosted
                                        (fn [coll] (remove-once #(= (:cid %) cid) coll)))))
-         (swap! state update-in (cons s (vec zone))
+         (swap!* state update-in (cons s (vec zone))
                 (fn [coll] (remove-once #(= (:cid %) cid) coll)))))
-     (swap! state update-in (cons side (vec zone)) (fn [coll] (remove-once #(= (:cid %) cid) coll)))
+     (swap!* state update-in (cons side (vec zone)) (fn [coll] (remove-once #(= (:cid %) cid) coll)))
      (let [card (get-card state card)
            card (assoc-host-zones card)
            target (assoc target
@@ -78,5 +78,5 @@
                                (conj all-effects current-effect)))
                            []
                            (:effects @state))]
-         (swap! state assoc :effects (into [] new-effects)))
+         (swap!* state assoc :effects (into [] new-effects)))
        (get-card state target)))))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -12,7 +12,7 @@
     [game.core.say :refer [system-msg]]
     [game.core.update :refer [update!]]
     [game.macros :refer [req effect msg continue-ability wait-for]]
-    [game.utils :refer [same-card? pluralize quantify remove-once]]
+    [game.utils :refer [same-card? pluralize quantify remove-once swap!*]]
     [jinteki.utils :refer [make-label]]
     [clojure.string :as string]))
 
@@ -38,7 +38,7 @@
   [state key value]
   (when-let [encounter (get-current-encounter state)]
     (let [updated-encounter (assoc encounter key value)]
-      (swap! state update :encounters #(conj (pop %) updated-encounter)))))
+      (swap!* state update :encounters #(conj (pop %) updated-encounter)))))
 
 (defn set-current-ice
   ([state]
@@ -51,7 +51,7 @@
          (set-current-ice state (nth run-ice (dec pos)))))))
   ([state card]
    (when (:run @state)
-     (swap! state assoc-in [:run :current-ice] (get-card state card)))))
+     (swap!* state assoc-in [:run :current-ice] (get-card state card)))))
 
 (defn active-ice?
   "Ice is active when installed and rezzed or is the current encounter"

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -15,7 +15,7 @@
     [game.core.props :refer [add-counter]]
     [game.core.update :refer [update!]]
     [game.macros :refer [req]]
-    [game.utils :refer [make-cid server-card to-keyword]]
+    [game.utils :refer [make-cid server-card to-keyword swap!*]]
     [jinteki.utils :refer [make-label]]))
 
 (defn subroutines-init
@@ -204,7 +204,7 @@
 (defn reset-card
   "Resets a card back to its original state - retaining any data in the :persistent key"
   ([state side {:keys [cid persistent previous-zone printed-title seen title zone]}]
-   (swap! state update :per-turn dissoc cid)
+   (swap!* state update :per-turn dissoc cid)
    (let [s-card (server-card (or printed-title title))
          new-card (make-card s-card cid)]
      (update! state side (assoc new-card

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -24,7 +24,7 @@
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability effect req wait-for]]
-    [game.utils :refer [dissoc-in in-coll? to-keyword]]))
+    [game.utils :refer [dissoc-in in-coll? to-keyword swap!*]]))
 
 (defn install-locked?
   "Checks if installing is locked"
@@ -285,7 +285,7 @@
        (corp-install state side eid card server (assoc args :host-card server))
        ;; A server was selected
        :else
-       (do (swap! state dissoc-in [:corp :install-list])
+       (do (swap!* state dissoc-in [:corp :install-list])
            (corp-install-pay state side eid card server args))))))
 
 ;; Unused in the corp install system, necessary for card definitions
@@ -368,7 +368,7 @@
     (play-sfx state side "install-runner")
     (when (and (not facedown)
                (resource? card))
-      (swap! state assoc-in [:runner :register :installed-resource] true))
+      (swap!* state assoc-in [:runner :register :installed-resource] true))
     (when (and (not facedown)
                (has-subtype? installed-card "Icebreaker"))
       (update-breaker-strength state side installed-card))

--- a/src/clj/game/core/link.clj
+++ b/src/clj/game/core/link.clj
@@ -1,6 +1,7 @@
 (ns game.core.link
   (:require
-    [game.core.effects :refer [sum-effects]]))
+    [game.core.effects :refer [sum-effects]]
+    [game.utils :refer [swap!*]]))
 
 (defn get-link
   ([state] (get-link state nil))
@@ -24,7 +25,7 @@
          new-link (sum-link-effects state id)
          changed? (not= old-link new-link)]
      (when changed?
-       (swap! state assoc-in [:runner :link] new-link))
+       (swap!* state assoc-in [:runner :link] new-link))
      changed?)))
 
 (defn link+

--- a/src/clj/game/core/mark.clj
+++ b/src/clj/game/core/mark.clj
@@ -3,11 +3,12 @@
     [game.core.say :refer [system-msg]]
     [game.core.servers :refer [central->name]]
     [game.core.update :refer [update!]]
-    [game.macros :refer [req]]))
+    [game.macros :refer [req]]
+    [game.utils :refer [swap!*]]))
 
 (defn set-mark
   [state new-mark]
-  (swap! state assoc :mark new-mark))
+  (swap!* state assoc :mark new-mark))
 
 (defn is-mark?
   [state s]

--- a/src/clj/game/core/memory.clj
+++ b/src/clj/game/core/memory.clj
@@ -3,7 +3,8 @@
    [cond-plus.core :refer [cond+]]
    [game.core.card :refer [has-subtype? virus-program? program?]]
    [game.core.effects :refer [get-effect-maps get-effect-value get-effects]]
-   [game.core.toasts :refer [toast]]))
+   [game.core.toasts :refer [toast]]
+   [game.utils :refer [swap!*]]))
 
 (defn mu+
   "For use in :static-abilities and register-lingering-effect.
@@ -134,7 +135,7 @@
      (when changed?
        (when (neg? (- (:available new-mu) (:used new-mu)))
          (toast state :runner "You have exceeded your memory units!"))
-       (swap! state update-in [:runner :memory] merge new-mu))
+       (swap!* state update-in [:runner :memory] merge new-mu))
      changed?)))
 
 (defn sufficient-mu?

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -14,7 +14,7 @@
     [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.update :refer [update!]]
     [game.macros :refer [wait-for]]
-    [game.utils :refer [same-card? to-keyword]]))
+    [game.utils :refer [same-card? to-keyword swap!*]]))
 
 (defn async-rfg
   ([state side eid card] (async-rfg state side eid card nil))
@@ -65,11 +65,11 @@
                                                         (str "removes " (:title c) " from the game instead of trashing it")))
                                           (when (has-subtype? card "Terminal")
                                             (lose state side :click (-> @state side :click))
-                                            (swap! state assoc-in [:corp :register :terminal] true))
+                                            (swap!* state assoc-in [:corp :register :terminal] true))
                                           (effect-completed state side eid)))
                               (do (when (has-subtype? card "Terminal")
                                     (lose state side :click (-> @state side :click))
-                                    (swap! state assoc-in [:corp :register :terminal] true))
+                                    (swap!* state assoc-in [:corp :register :terminal] true))
                                   (effect-completed state side eid)))))))))
 
 (defn play-instant-costs
@@ -128,7 +128,7 @@
              moved-card (move state side (assoc card :seen true) :play-area)]
          ;; Only mark the register once costs have been paid and card has been moved
          (when (has-subtype? card "Run")
-           (swap! state assoc-in [:runner :register :click-type] :run))
+           (swap!* state assoc-in [:runner :register :click-type] :run))
          (wait-for (pay state side (make-eid state eid) moved-card costs {:action :play-instant})
                    (let [payment-str (:msg async-result)
                          cost-paid (merge-costs-paid (:cost-paid eid) (:cost-paid async-result))]

--- a/src/clj/game/core/prompt_state.clj
+++ b/src/clj/game/core/prompt_state.clj
@@ -1,19 +1,21 @@
-(ns game.core.prompt-state)
+(ns game.core.prompt-state
+  (:require
+    [game.utils :refer [swap!*]]))
 
 (defn set-prompt-state
   ([state side]
    (let [current-prompt (first (get-in @state [side :prompt]))]
      (set-prompt-state state side current-prompt)))
   ([state side prompt]
-   (swap! state assoc-in [side :prompt-state] prompt)))
+   (swap!* state assoc-in [side :prompt-state] prompt)))
 
 (defn remove-from-prompt-queue
   [state side prompt]
-  (swap! state update-in [side :prompt] (fn [pr] (remove #(= % prompt) pr)))
+  (swap!* state update-in [side :prompt] (fn [pr] (remove #(= % prompt) pr)))
   (set-prompt-state state side))
 
 (defn add-to-prompt-queue
   "Adds a newly created prompt to the current prompt queue"
   [state side prompt]
-  (swap! state update-in [side :prompt] #(cons prompt %))
+  (swap!* state update-in [side :prompt] #(cons prompt %))
   (set-prompt-state state side))

--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -5,7 +5,7 @@
     [game.core.prompt-state :refer [add-to-prompt-queue remove-from-prompt-queue]]
     [game.core.toasts :refer [toast]]
     [game.macros :refer [when-let*]]
-    [game.utils :refer [pluralize side-str]]
+    [game.utils :refer [pluralize side-str swap!*]]
     [jinteki.utils :refer [other-side]]
     [medley.core :refer [find-first]]))
 
@@ -104,7 +104,7 @@
   (let [selected (get-in @state [side :selected 0])
         cards (map #(dissoc % :selected) (:cards selected))
         prompt (first (filter #(= :select (:prompt-type %)) (get-in @state [side :prompt])))]
-    (swap! state update-in [side :selected] #(vec (rest %)))
+    (swap!* state update-in [side :selected] #(vec (rest %)))
     (when prompt
       (remove-from-prompt-queue state side prompt))
     (if (seq cards)
@@ -130,7 +130,7 @@
            ability (if all (update-in ability [:choices] dissoc :min) ability) ; ignore :min if :all is set
            min-choices (get-in ability [:choices :min])
            max-choices (get-in ability [:choices :max])]
-       (swap! state update-in [side :selected]
+       (swap!* state update-in [side :selected]
               #(conj (vec %) {:ability (-> ability
                                            (dissoc :choices :waiting-prompt)
                                            (assoc :card card))

--- a/src/clj/game/core/psi.clj
+++ b/src/clj/game/core/psi.clj
@@ -8,6 +8,7 @@
     [game.core.prompts :refer [clear-wait-prompt show-prompt-with-dice show-wait-prompt]]
     [game.core.say :refer [system-msg]]
     [game.macros :refer [continue-ability effect wait-for]]
+    [game.utils :refer [swap!*]]
     [jinteki.utils :refer [str->int]]
     [clojure.string :as string]))
 
@@ -15,7 +16,7 @@
   "Resolves a psi game by charging credits to both sides and invoking the appropriate
   resolution ability."
   [state side eid card psi bet targets]
-  (swap! state assoc-in [:psi side] bet)
+  (swap!* state assoc-in [:psi side] bet)
   (let [opponent (if (= side :corp) :runner :corp)]
     (if-let [opponent-bet (get-in @state [:psi opponent])]
       (wait-for
@@ -38,7 +39,7 @@
   :equal and :not-equal abilities which will be triggered in resolve-psi accordingly."
   ([state side card psi] (psi-game state side (make-eid state {:source-type :psi}) card psi nil))
   ([state side eid card psi targets]
-   (swap! state assoc :psi {})
+   (swap!* state assoc :psi {})
    (register-once state side psi card)
    (let [eid (assoc eid :source-type :psi)]
      (doseq [s [:corp :runner]]

--- a/src/clj/game/core/revealing.clj
+++ b/src/clj/game/core/revealing.clj
@@ -1,16 +1,17 @@
 (ns game.core.revealing
   (:require
-    [game.core.engine :refer [trigger-event-sync]]))
+    [game.core.engine :refer [trigger-event-sync]]
+    [game.utils :refer [swap!*]]))
 
 (defn reveal-hand
   "Reveals a side's hand to opponent and spectators."
   [state side]
-  (swap! state assoc-in [side :openhand] true))
+  (swap!* state assoc-in [side :openhand] true))
 
 (defn conceal-hand
   "Conceals a side's revealed hand from opponent and spectators."
   [state side]
-  (swap! state update side dissoc :openhand))
+  (swap!* state update side dissoc :openhand))
 
 (defn reveal
   "Trigger the event for revealing one or more cards."

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -17,7 +17,7 @@
     [game.core.to-string :refer [card-str]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability effect wait-for]]
-    [game.utils :refer [enumerate-str to-keyword]]))
+    [game.utils :refer [enumerate-str to-keyword swap!*]]))
 
 (defn get-rez-cost
   [state side card {:keys [ignore-cost alternative-cost cost-bonus]}]
@@ -80,7 +80,7 @@
                       (do (update-ice-strength state side card)
                           (play-sfx state side "rez-ice"))
                       (play-sfx state side "rez-other"))
-                    (swap! state update-in [:stats :corp :cards :rezzed] (fnil inc 0))
+                    (swap!* state update-in [:stats :corp :cards :rezzed] (fnil inc 0))
                     (when-let [card-ability (:on-rez cdef)]
                       (register-pending-event state :rez card card-ability))
                     (queue-event state :rez {:card (get-card state card)

--- a/src/clj/game/core/say.clj
+++ b/src/clj/game/core/say.clj
@@ -2,7 +2,8 @@
   (:require
    [cljc.java-time.instant :as inst]
    [clojure.string :as str]
-   [game.core.toasts :refer [toast]]))
+   [game.core.toasts :refer [toast]]
+   [game.utils :refer [swap!*]]))
 
 (defn make-message
   "Create a message map, along with timestamp if none is provided."
@@ -22,8 +23,8 @@
   [state side {:keys [user text]}]
   (let [author (or user (get-in @state [side :user]))
         message (make-message {:user author :text text})]
-    (swap! state update :log conj message)
-    (swap! state assoc :typing false)))
+    (swap!* state update :log conj message)
+    (swap!* state assoc :typing false)))
 
 (defn system-say
   "Prints a system message to log (`say` from user __system__)"
@@ -35,7 +36,7 @@
   "Prints a reagent hiccup directly to the log. Do not use for any user-generated content!"
   [state text]
   (let [message (make-system-message text)]
-    (swap! state update :log conj message)))
+    (swap!* state update :log conj message)))
 
 (defn system-msg
   "Prints a message to the log without a username."
@@ -73,7 +74,7 @@
   Each SFX comes with a unique ID, so each client can track for themselves which sounds have already been played.
   The sfx queue has size limited to 3 to limit the sound torrent tabbed out or lagged players will experience."
   [state _ sfx]
-  (swap! state (fn [state]
+  (swap!* state (fn [state]
                  (if-let [current-id (:sfx-current-id state)]
                    (-> state
                        (update :sfx conj {:id (inc current-id) :name sfx})

--- a/src/clj/game/core/set_aside.clj
+++ b/src/clj/game/core/set_aside.clj
@@ -3,16 +3,17 @@
     [game.core.card :refer [in-set-aside?]]
     [game.core.eid :refer [effect-completed]]
     [game.core.moving :refer [move swap-cards]]
+    [game.utils :refer [swap!*]]
     [clojure.string :as string]))
 
 (defn set-aside
   "move a group of cards to the set-aside zone. Does not call effect-completed on the eid"
   ([state side eid cards] (set-aside state side eid cards true true))
-   ;(swap! state assoc-in [side :set-aside-tracking (:eid eid)] (map :cid cards))
+   ;(swap!* state assoc-in [side :set-aside-tracking (:eid eid)] (map :cid cards))
    ;(doseq [c cards] (move state side c :set-aside))
    ;(effect-completed state side eid))
   ([state side eid cards corp-vis runner-vis]
-   (swap! state assoc-in [side :set-aside-tracking (:eid eid)] (map :cid cards))
+   (swap!* state assoc-in [side :set-aside-tracking (:eid eid)] (map :cid cards))
    (doseq [c cards]
      (move state side (assoc c
                              :set-aside-visibility {:corp-can-see corp-vis :runner-can-see runner-vis}

--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -16,7 +16,7 @@
    [game.core.state :refer [new-state]]
    [game.macros :refer [wait-for]]
    [game.quotes :as quotes]
-   [game.utils :refer [server-card]]))
+   [game.utils :refer [server-card swap!*]]))
 
 (defn build-card
   [card]
@@ -40,7 +40,7 @@
     (when-let [cdef (card-def card)]
       (when-let [mul (:mulligan cdef)]
         (mul state side (make-eid state) card nil))))
-  (swap! state assoc-in [side :keep] :mulligan)
+  (swap!* state assoc-in [side :keep] :mulligan)
   (system-msg state side "takes a mulligan")
   (trigger-event state side :pre-first-turn)
   (when (and (= side :corp) (-> @state :runner :identity :title))
@@ -52,7 +52,7 @@
 (defn keep-hand
   "Choose not to mulligan."
   [state side _]
-  (swap! state assoc-in [side :keep] :keep)
+  (swap!* state assoc-in [side :keep] :keep)
   (system-msg state side "keeps their hand")
   (trigger-event state side :pre-first-turn)
   (when (and (= side :corp) (-> @state :runner :identity :title))
@@ -113,12 +113,12 @@
 
 (defn- create-basic-action-cards
   [state]
-  (swap! state
+  (swap!* state
          assoc-in [:corp :basic-action-card]
          (make-card {:side "Corp"
                      :type "Basic Action"
                      :title "Corp Basic Action Card"}))
-  (swap! state
+  (swap!* state
          assoc-in [:runner :basic-action-card]
          (make-card {:side "Runner"
                      :type "Basic Action"
@@ -131,7 +131,7 @@
         corp-identity (get-in @state [:corp :identity])
         runner-identity (get-in @state [:runner :identity])]
     (when-let [messages (seq (:messages game))]
-      (swap! state assoc :log (into [] messages))
+      (swap!* state assoc :log (into [] messages))
       (system-say state nil "[hr]"))
     (card-init state :corp corp-identity)
     (implementation-msg state corp-identity)
@@ -143,5 +143,5 @@
               (wait-for (trigger-event-sync state :runner :pre-start-game nil)
                         (init-hands state)
                         (fake-checkpoint state)))
-    (swap! state assoc :history [(:hist-state (public-states state))])
+    (swap!* state assoc :history [(:hist-state (public-states state))])
     state))

--- a/src/clj/game/core/shuffling.clj
+++ b/src/clj/game/core/shuffling.clj
@@ -5,7 +5,7 @@
     [game.core.moving :refer [move move-zone]]
     [game.core.say :refer [system-msg]]
     [game.macros :refer [continue-ability msg req]]
-    [game.utils :refer [enumerate-str quantify]]))
+    [game.utils :refer [enumerate-str quantify swap!*]]))
 
 (defn shuffle!
   "Shuffles the vector in @state [side kw]."
@@ -16,8 +16,8 @@
                (:run @state)
                (= :corp side)
                (= :deck kw))
-      (swap! state assoc-in [:run :shuffled-during-access :rd] true))
-    (swap! state update-in [side kw] shuffle)))
+      (swap!* state assoc-in [:run :shuffled-during-access :rd] true))
+    (swap!* state update-in [side kw] shuffle)))
 
 (defn shuffle-into-deck
   [state side & args]
@@ -52,9 +52,9 @@
 (defn shuffle-deck
   "Shuffle R&D/Stack."
   [state side {:keys [close]}]
-  (swap! state update-in [side :deck] shuffle)
+  (swap!* state update-in [side :deck] shuffle)
   (if close
     (do
-      (swap! state update-in [side] dissoc :view-deck)
+      (swap!* state update-in [side] dissoc :view-deck)
       (system-msg state side "stops looking at their deck and shuffles it"))
     (system-msg state side "shuffles their deck")))

--- a/src/clj/game/core/state.clj
+++ b/src/clj/game/core/state.clj
@@ -45,6 +45,8 @@
    turn-events
    turn-state
    typing
+   unsent-changes
+   unsent-changes-send-all
    winner
    winning-deck-id
    winning-user])
@@ -53,13 +55,14 @@
   "Returns a progressively-increasing integer to identify a new remote server."
   [state]
   (let [current-rid (:rid @state)]
-    (swap! state update :rid inc)
+    (swap! state update :rid inc) ;;TODO: Fix cyclic dependency when this is swap!*
     current-rid))
 
 (defn new-state
   [gameid room fmt now options corp runner]
   (map->State
     {:gameid gameid
+     :unsent-changes (hash-set :rid)
      :log []
      :active-player :runner
      :end-turn true

--- a/src/clj/game/core/toasts.clj
+++ b/src/clj/game/core/toasts.clj
@@ -1,4 +1,6 @@
-(ns game.core.toasts)
+(ns game.core.toasts
+  (:require
+    [game.utils :refer [swap!*]]))
 
 (defn toast
   "Adds a message to toast with specified severity (default as a warning) to the toast message list.
@@ -15,9 +17,9 @@
    ;; Allows passing just the toast msg-type as the options parameter
    (if message
      ;; normal toast - add to list
-     (swap! state update-in [side :toast] #(conj % {:msg message :type msg-type :options options}))
+     (swap!* state update-in [side :toast] #(conj % {:msg message :type msg-type :options options}))
      ;; no message - remove top toast from list
-     (swap! state update-in [side :toast] rest))))
+     (swap!* state update-in [side :toast] rest))))
 
 (defn show-error-toast
   [state side]

--- a/src/clj/game/core/trace.clj
+++ b/src/clj/game/core/trace.clj
@@ -7,7 +7,8 @@
     [game.core.link :refer [get-link]]
     [game.core.prompts :refer [clear-wait-prompt show-trace-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg system-say]]
-    [game.macros :refer [continue-ability effect wait-for]]))
+    [game.macros :refer [continue-ability effect wait-for]]
+    [game.utils :refer [swap!*]]))
 
 (defn- determine-initiator
   [state {:keys [player]}]
@@ -107,11 +108,11 @@
 
 (defn- reset-trace-modifications
   [state]
-  (swap! state assoc :trace nil))
+  (swap!* state assoc :trace nil))
 
 (defn force-base
   [state value]
-  (swap! state assoc-in [:trace :force-base] value))
+  (swap!* state assoc-in [:trace :force-base] value))
 
 (defn init-trace
   ([state side card] (init-trace state side (make-eid state {:source-type :trace}) card {:base 0}))

--- a/src/clj/game/core/update.clj
+++ b/src/clj/game/core/update.clj
@@ -1,7 +1,7 @@
 (ns game.core.update
   (:require [game.core.card :refer [get-card ice?]]
             [game.core.finding :refer [get-scoring-owner]]
-            [game.utils :refer [to-keyword same-card?]]))
+            [game.utils :refer [to-keyword same-card? swap!*]]))
 
 (declare update-hosted!)
 
@@ -11,7 +11,7 @@
   (cond
     (= type "Identity")
     (when (= side (to-keyword (:side card)))
-      (swap! state assoc-in [side :identity] card)
+      (swap!* state assoc-in [side :identity] card)
       card)
 
     host
@@ -22,7 +22,7 @@
     (let [z (cons (to-keyword (or (get-scoring-owner state card) (:side card))) zone)
               [head tail] (split-with #(not= (:cid %) cid) (get-in @state z))]
           (when (not-empty tail)
-            (swap! state assoc-in z (vec (concat head [card] (rest tail))))
+            (swap!* state assoc-in z (vec (concat head [card] (rest tail))))
             card))))
 
 (defn update-hosted!

--- a/src/clj/game/core/winning.clj
+++ b/src/clj/game/core/winning.clj
@@ -5,7 +5,7 @@
    [cond-plus.core :refer [cond+]]
    [game.core.effects :refer [any-effects]]
    [game.core.say :refer [play-sfx system-msg system-say]]
-   [game.utils :refer [dissoc-in]]
+   [game.utils :refer [dissoc-in swap!*]]
    [jinteki.utils :refer [other-side]]))
 
 (defn win
@@ -17,7 +17,7 @@
           duration (duration/to-minutes (duration/between started now))]
       (system-msg state side "wins the game")
       (play-sfx state side "game-end")
-      (swap! state (fn [state]
+      (swap!* state (fn [state]
                      (-> state
                          (assoc-in [:stats :time :ended] now)
                          (assoc-in [:stats :time :elapsed] duration)
@@ -41,7 +41,7 @@
           duration (duration/to-minutes (duration/between started now))]
       (system-say state nil "The game is a tie!")
       (play-sfx state nil "game-end")
-      (swap! state (fn [state]
+      (swap!* state (fn [state]
                      (-> state
                          (assoc-in [:stats :time :ended] now)
                          (assoc-in [:stats :time :elapsed] duration)
@@ -72,12 +72,12 @@
 (defn clear-win
   "Clears the current win condition. Requires both sides to have issued the command"
   [state side]
-  (swap! state assoc-in [side :clear-win] true)
+  (swap!* state assoc-in [side :clear-win] true)
   (when (and (-> @state :runner :clear-win) (-> @state :corp :clear-win))
     (system-msg state side "cleared the win condition")
-    (swap! state dissoc-in [:runner :clear-win])
-    (swap! state dissoc-in [:corp :clear-win])
-    (swap! state dissoc :winner :loser :winning-user :losing-user :reason :winning-deck-id :losing-deck-id :end-time)))
+    (swap!* state dissoc-in [:runner :clear-win])
+    (swap!* state dissoc-in [:corp :clear-win])
+    (swap!* state dissoc :winner :loser :winning-user :losing-user :reason :winning-deck-id :losing-deck-id :end-time)))
 
 (defn side-win
   [state side]

--- a/src/clj/game/main.clj
+++ b/src/clj/game/main.clj
@@ -1,14 +1,15 @@
 (ns game.main
   (:require [cheshire.generate :refer [add-encoder encode-str]]
             [game.core :as core]
-            [game.core.toasts :refer [toast]]))
+            [game.core.toasts :refer [toast]]
+            [game.utils :refer [swap!*]]))
 
 (add-encoder java.lang.Object encode-str)
 
 (defn set-action-id
   "Creates a unique action id for each server response - used in client lock"
   [state side]
-  (swap! state update-in [side :aid] (fnil inc 0)))
+  (swap!* state update-in [side :aid] (fnil inc 0)))
 
 (defn handle-action
   "Ensures the user is allowed to do command they are trying to do"
@@ -46,5 +47,5 @@
                     (= _id (get-in @state [:corp :user :_id])) :corp
                     (= _id (get-in @state [:runner :user :_id])) :runner
                     :else nil)]
-    (swap! state assoc-in [side :user] user)
+    (swap!* state assoc-in [side :user] user)
     (handle-notification state (str username " rejoined the game."))))

--- a/src/clj/web/angel_arena.clj
+++ b/src/clj/web/angel_arena.clj
@@ -6,7 +6,7 @@
    [game.core.diffs :as diffs]
    [game.core.say :refer [make-system-message system-msg]]
    [game.core.winning :refer [win]]
-   [game.utils :refer [in-coll?]]
+   [game.utils :refer [in-coll? swap!*]]
    [jinteki.utils :refer [other-side]]
    [monger.operators :refer :all]
    [monger.query :as mq]
@@ -247,14 +247,14 @@
   (select-keys user [:username :emailhash]))
 
 (defn set-inactive-left [state user side now]
-  (swap! state assoc-in [:angel-arena-info :inactivity-warning]
+  (swap!* state assoc-in [:angel-arena-info :inactivity-warning]
          {:stage :inactive-left
           :inactive-user (strip-user user)
           :inactive-side side
           :warning-time now}))
 
 (defn set-inactive-pre-start [state now]
-  (swap! state assoc-in [:angel-arena-info :inactivity-warning]
+  (swap!* state assoc-in [:angel-arena-info :inactivity-warning]
          {:stage :inactive-pre-start
           :inactive-side nil
           :inactive-user nil
@@ -262,7 +262,7 @@
           :period-to-react -1}))
 
 (defn set-inactive-start [state user side now]
-  (swap! state assoc-in [:angel-arena-info :inactivity-warning]
+  (swap!* state assoc-in [:angel-arena-info :inactivity-warning]
          {:stage :inactive-warning
           :inactive-user (strip-user user)
           :inactive-side side
@@ -270,10 +270,10 @@
           :period-to-react inactive-period-countdown}))
 
 (defn set-inactive-countdown [state]
-  (swap! state assoc-in [:angel-arena-info :inactivity-warning :stage] :inactive-countdown))
+  (swap!* state assoc-in [:angel-arena-info :inactivity-warning :stage] :inactive-countdown))
 
 (defn reset-inactive [state]
-  (swap! state update :angel-arena-info dissoc :inactivity-warning))
+  (swap!* state update :angel-arena-info dissoc :inactivity-warning))
 
 (defn player-left-lobby [lobby]
   (let [{:keys [original-players players]} lobby

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -5,7 +5,7 @@
    [clojure.string :as str]
    [crypto.password.bcrypt :as bcrypt]
    [game.core :as core]
-   [game.utils :refer [server-card]]
+   [game.utils :refer [server-card swap!*]]
    [jinteki.utils :refer [select-non-nil-keys side-from-str superuser?]]
    [jinteki.validator :as validator]
    [medley.core :refer [find-first random-uuid]]
@@ -317,7 +317,7 @@
       (if lobby?
         (when-let [state (:state lobby?)]
           (let [side (side-from-str (:side (player? uid lobby) ""))]
-            (swap! state update side dissoc :user)))
+            (swap!* state update side dissoc :user)))
         (close-lobby! db lobby))
       (send-lobby-state lobby?)
       (broadcast-lobby-list)
@@ -478,7 +478,7 @@
       (do (when-let [player (player? uid lobby?)]
             (let [side (side-from-str (:side player))]
               (when-let [state (:state lobby?)]
-                (swap! state assoc-in [side :user] user))))
+                (swap!* state assoc-in [side :user] user))))
           (send-lobby-state lobby?)
           (send-lobby-ting lobby?)
           (broadcast-lobby-list)


### PR DESCRIPTION
WIP for tracking changes to the game state.

All instances of `swap!` were changed to `swap!*`, which is defined in `utils.clj`. This function checks if the function for `swap!` was assoc(-in), dissoc(-in) or update(-in) and if so, tracks the keys that were changed in a hash-set `(:unsent-changes @state)`.

If all calls to `swap!*` between two calls of `diffs/public-states` were only such trackable changes, the differ is only fed the subset of the state-map that could've been changed (using a `utils/deep-select-keys`)

If there is a call to `swap!*` with some other function, the flag `(:unsent-changes-send-all @state)` is set to true and the next diff will act on the entire state as usual.