### PR TITLE
Ensure Saci doesn't fire off Magnet rez

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2659,12 +2659,12 @@
                             (not= (:title (:card context)) "Magnet")))
              :msg "gain 3 [Credits]"
              :async true
-             :effect (effect (gain-credits eid 3))}
+             :effect (effect (gain-credits :runner eid 3))}
             {:event :derez
              :req (req (same-card? target (:host card)))
              :msg "gain 3 [Credits]"
              :async true
-             :effect (effect (gain-credits eid 3))}]})
+             :effect (effect (gain-credits :runner eid 3))}]})
 
 (defcard "Sadyojata"
   (swap-with-in-hand "Sadyojata"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2655,7 +2655,8 @@
   {:hosting {:card #(and (ice? %)
                          (can-host? %))}
    :events [{:event :rez
-             :req (req (same-card? (:card context) (:host card)))
+             :req (req (and (same-card? (:card context) (:host card))
+                            (not= (:title (:card context)) "Magnet")))
              :msg "gain 3 [Credits]"
              :async true
              :effect (effect (gain-credits eid 3))}

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -6163,6 +6163,30 @@
           "Gained 3 credits on derez"
           (card-ability state :runner (get-resource state 0) 0)))))
 
+(deftest saci-magnet
+    ;; Saci should not trigger on Magent rez but should on Magnet derez
+    (do-game
+      (new-game {:corp {:hand ["Magnet"]}
+                 :runner {:hand ["Saci" "Emergency Shutdown"]}})
+      (play-from-hand state :corp "Magnet" "R&D")
+      (take-credits state :corp)
+      (let [magnet (get-ice state :rd 0)]
+        (play-from-hand state :runner "Saci")
+        (click-card state :runner magnet)
+        (run-on state "R&D")
+        (changes-val-macro
+          0 (:credit (get-runner))
+          "Should not gain 3 credits on rez"
+          (rez state :corp magnet))
+        (run-continue state)
+        (card-subroutine state :corp (refresh magnet) 0)
+        (run-empty-server state :hq)
+        (play-from-hand state :runner "Emergency Shutdown")
+        (changes-val-macro
+          3 (:credit (get-runner))
+          "Gained 3 credits on derez"
+          (click-card state :runner (refresh magnet))))))
+
 (deftest sadyojata-swap-ability
     ;; Swap ability
     (testing "Doesnt work if no Deva in hand"

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -6166,9 +6166,10 @@
 (deftest saci-magnet
     ;; Saci should not trigger on Magent rez but should on Magnet derez
     (do-game
-      (new-game {:corp {:hand ["Magnet"]}
-                 :runner {:hand ["Saci" "Emergency Shutdown"]}})
+      (new-game {:corp {:hand ["Magnet" "Ice Wall" "Divert Power"]}
+                 :runner {:hand ["Saci"]}})
       (play-from-hand state :corp "Magnet" "R&D")
+      (play-from-hand state :corp "Ice Wall" "Archives")
       (take-credits state :corp)
       (let [magnet (get-ice state :rd 0)]
         (play-from-hand state :runner "Saci")
@@ -6180,12 +6181,12 @@
           (rez state :corp magnet))
         (run-continue state)
         (card-subroutine state :corp (refresh magnet) 0)
-        (run-empty-server state :hq)
-        (play-from-hand state :runner "Emergency Shutdown")
+        (take-credits state :runner)
+        (play-from-hand state :corp "Divert Power")
         (changes-val-macro
           3 (:credit (get-runner))
           "Gained 3 credits on derez"
-          (click-card state :runner (refresh magnet))))))
+          (click-card state :corp (refresh magnet))))))
 
 (deftest sadyojata-swap-ability
     ;; Swap ability


### PR DESCRIPTION
Looked into a more elegant way than this to fix this at the engine but I think Saci's rez pending events trigger before Magnet's pending events due to it being runner turn and so Saci hasn't been disabled yet.  Mostly just wanted to codify the ruling into a test so happy if someone can provide a better implementation.

Fixes #7139.

UPDATE: While testing also found that Saci was giving credits to Corp from Corp triggered derez - fix this too.