### PR TITLE
Fix issues with trojans losing mu cost when hosted ice moves

### DIFF
--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2379,6 +2379,22 @@
       (click-prompt state :runner "No action")
   )))
 
+(deftest formicary-with-trojan-doesnt-reset-mu-when-moving
+  ;; Rezzing and moving Formicary with trojan doesn't make the trojan mu-cost disappear
+  (do-game
+    (new-game {:corp {:deck ["Formicary"]}
+               :runner {:deck ["Saci"]}})
+    (play-from-hand state :corp "Formicary" "R&D")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Saci")
+    (click-card state :runner (get-ice state :rd 0))
+    (run-on state "HQ")
+    (is (zero? (get-in @state [:run :position])) "Now approaching server")
+    (run-continue state)
+    (changes-val-macro 0 (core/available-mu state)
+                       "Available MU should not change"
+                       (click-prompt state :corp "Yes"))))
+
 (deftest free-lunch-basic-behavior
   ;; Basic behavior
   (do-game

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -4751,6 +4751,27 @@
       (click-card state :runner (refresh rime)))
     (is (= 2 (core/get-strength (refresh (get-ice state :archives 0)))) "Ice Wall retains strength")))
 
+(deftest tao-salonga-swapping-ice-with-trojan-doesnt-reset-mu
+  ;;Tāo Salonga swapping ice with trojan doesn't make the trojan mu-cost disappear
+  (do-game
+    (new-game {:corp {:hand ["Palisade" "Ice Wall" "House of Knives"]}
+               :runner {:id "Tāo Salonga: Telepresence Magician"
+                        :hand ["Saci"]}})
+    (play-from-hand state :corp "Palisade" "Archives")
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (take-credits state :corp)
+    (let [palisade (get-ice state :archives 0)
+          iw (get-ice state :remote1 0)]
+      (play-from-hand state :runner "Saci")
+      (click-card state :runner iw)
+      (run-empty-server state "HQ")
+      (changes-val-macro 0 (core/available-mu state)
+                         "Available MU should not change"
+                         (click-prompt state :runner "Steal")
+                         (click-prompt state :runner "Yes")
+                         (click-card state :runner (refresh palisade))
+                         (click-card state :runner (refresh iw))))))
+
 (deftest the-foundry-refining-the-process-interaction-with-accelerated-beta-test
     ;; interaction with Accelerated Beta Test
     (do-game


### PR DESCRIPTION
Not the most elegant fix - there seems like there should be a refactor here somewhere.

I think it's currently safe to ignore the no-mu option in these two cases as 
- `swap-installed` is only used with ICE
- `get-moved-card` only refreshes hosted cards if the host stays in the same zone - and I'm not sure there's any way for this to happen on runner's side?

Perhaps the no-mu should be a property or something of the host card rather than the hosting/install actions - and then every program can just always reset its memory effect when moved or avoid if the host ignores mu cost?

Fixes #7151 