### PR TITLE
Fix Accelerated Diagnostics not discarding unplayed cards

### DIFF
--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -140,6 +140,17 @@
       (click-card state :corp "Breaking News")
       (click-prompt state :corp "BOOM!")))
 
+(deftest accelerated-diagnostics-trashes-unplayed-cards
+    ;; No additional costs
+    (do-game
+      (new-game {:corp {:deck [(qty "Ice Wall" 4)]
+                        :hand ["Accelerated Diagnostics"]}})
+      (play-from-hand state :corp "Accelerated Diagnostics")
+      (click-prompt state :corp "OK")
+      (click-prompt state :corp "Cancel")
+      (is (= 4 (count (:discard (get-corp)))))
+      (is (= 3 (count (filter #(not (:seen %)) (:discard (get-corp))))) "3 face down cards in archives")))
+
 (deftest ad-blitz
   ;; Launch Campaign
   (do-game


### PR DESCRIPTION
![image](https://github.com/mtgred/netrunner/assets/5345/8249ef6a-5b3d-4a19-af2e-5b88df4cb488)

Blast from the past - had this come up in a Chimera game and it didn't actually trash any of the cards non-operation cards I saw.