### PR TITLE
Fix Tatu-Bola not registering derezzed events

### DIFF
--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -6764,6 +6764,20 @@
       "Corp gained no credits"
       (click-prompt state :corp "OK"))))
 
+(deftest tatu-bola-formicary
+  (do-game
+    (new-game {:corp {:hand ["Tatu-Bola" "Formicary"]}})
+    (play-from-hand state :corp "Tatu-Bola" "R&D")
+    (take-credits state :corp)
+    (run-on state "R&D")
+    (rez state :corp (get-ice state :rd 0))
+    (run-continue state)
+    (run-continue state :movement)
+    (click-prompt state :corp "Yes")
+    (click-prompt state :corp "Formicary")
+    (run-continue state)
+    (is (= "Rez and move Formicary protecting R&D at position 0 to protect the approched server?" (:msg (prompt-map :corp))))))
+
 (deftest thimblerig-thimblerig-does-not-open-a-prompt-if-it-s-the-only-piece-of-ice
   ;; Thimblerig does not open a prompt if it's the only piece of ice
   (do-game


### PR DESCRIPTION
The swap method used by Tatu-Bola wasn't registering derezzed effects (think only Formicary uses this right now). Sort of a bespoke engine fix for this problem but possibly covers other future derezzed ice effects.

Fixes #7168 