### PR TITLE
Only send toast to the side the toast is for

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -199,6 +199,10 @@
     (not-empty (select-non-nil-keys prompt prompt-keys))
     nil))
 
+(defn toast-summary
+  [toast same-side?]
+  (if same-side? toast nil))
+
 (def player-keys
   [:aid
    :user
@@ -234,6 +238,7 @@
       (update :scored cards-summary state side)
       (update :set-aside cards-summary state side)
       (update :prompt-state prompt-summary same-side?)
+      (update :toast toast-summary same-side?)
       (select-non-nil-keys (into player-keys additional-keys))))
 
 (def corp-keys


### PR DESCRIPTION
High ranking for best commit message of the year so far.

Here's a screenshot of what the toast diffs look on each side with this change:

![image](https://github.com/mtgred/netrunner/assets/5345/e3cdf6cf-de5f-4723-b0ee-1759eaf65679)
