### PR TITLE
Fix interaction of Verbal Plasticity and The Class Act

### DIFF
--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -5,7 +5,7 @@
    [game.core.card :refer [agenda? asset? event? get-card hardware? ice?
                            in-hand? operation? program? resource? upgrade?]]
    [game.core.def-helpers :refer [defcard]]
-   [game.core.drawing :refer [draw]]
+   [game.core.drawing :refer [draw use-bonus-click-draws!]]
    [game.core.eid :refer [effect-completed]]
    [game.core.engine :refer [trigger-event]]
    [game.core.flags :refer [can-advance? untrashable-while-resources?]]
@@ -125,7 +125,7 @@
                 :effect (req (trigger-event state side :runner-click-draw (-> @state side :deck (nth 0)))
                              (swap! state update-in [:stats side :click :draw] (fnil inc 0))
                              (play-sfx state side "click-card")
-                             (draw state side eid 1))}
+                             (draw state side eid (+ 1 (use-bonus-click-draws! state))))}
                {:label "Install 1 program, resource, or piece of hardware from the grip"
                 :async true
                 :req (req (and (not-empty (:hand runner))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -21,7 +21,7 @@
    [game.core.damage :refer [damage damage-prevent]]
    [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out
                                   reorder-choice trash-on-empty do-net-damage]]
-   [game.core.drawing :refer [draw draw-bonus first-time-draw-bonus]]
+   [game.core.drawing :refer [draw click-draw-bonus]]
    [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events
@@ -1840,7 +1840,7 @@
 (defcard "Laguna Velasco District"
   {:events [{:event :runner-click-draw
              :msg "draw 1 additional card"
-             :effect (effect (draw-bonus 1))}]})
+             :effect (effect (click-draw-bonus 1))}]})
 
 (defcard "Levy Advanced Research Lab"
   (letfn [(lab-keep [cards]
@@ -3586,8 +3586,7 @@
   {:events [{:event :runner-click-draw
              :req (req (genetics-trigger? state side :runner-click-draw))
              :msg "draw 1 additional card"
-             :async true
-             :effect (effect (draw-bonus 1))}]})
+             :effect (effect (click-draw-bonus 1))}]})
 
 (defcard "Virus Breeding Ground"
   {:events [{:event :runner-turn-begins

--- a/src/clj/game/core/drawing.clj
+++ b/src/clj/game/core/drawing.clj
@@ -29,6 +29,18 @@
   [state _ n]
   (swap! state update-in [:bonus :draw] (fnil #(+ % n) 0)))
 
+(defn click-draw-bonus
+  "Registers a bonus of n draws to the next draw done by a click (Laguna Velasco District)"
+  [state _ n]
+  (swap! state update-in [:bonus :click-draw] (fnil #(+ % n) 0)))
+
+(defn use-bonus-click-draws!
+  "Returns value of click-draw bonus and reset it"
+  [state]
+  (let [bonus-click-draws (get-in @state [:bonus :click-draw] 0)]
+    (swap! state update :bonus dissoc :click-draw)
+    bonus-click-draws))
+
 (defn first-time-draw-bonus
   [side n]
   (let [event (keyword (str "pre-" (name side) "-draw"))]

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -6234,6 +6234,19 @@
     "Draw 1 card at the start of turn"
     (take-credits state :runner))))
 
+(deftest the-class-act-draw-bonus
+  ;; The Class Act - Issue #7182 - Not receiving bonus draw from Verbal Plasticity
+  (do-game
+    (new-game {:runner {:deck [(qty "Sure Gamble" 10)]
+                        :hand ["The Class Act" "Verbal Plasticity"]
+                        :credits 10}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Verbal Plasticity")
+    (play-from-hand state :runner "The Class Act")
+    (click-draw state :runner)
+    (is (not (no-prompt? state :runner)) "The Class Act is prompting the runner to choose")
+    (is (= 3 (count (:set-aside (get-runner)))) "The Class Act set aside 3 cards")))
+
 (deftest the-helpful-ai
   ;; The Helpful AI - +1 link; trash to give an icebreaker +2 str until end of turn
   (do-game


### PR DESCRIPTION
Created a new bonus key specifically for drawing via basic action - as the two runner cards that used `draw-bonus` are both scoped to just basic draw.  This bonus is then applied as part of the basic action rather than within the draw function.

Fixes #7182 