### PR TITLE
Sneakdoor Prime A & B

### DIFF
--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -53,8 +53,8 @@
                            update-current-encounter]]
    [game.core.sabotage :refer [sabotage-ability]]
    [game.core.say :refer [system-msg]]
-   [game.core.servers :refer [is-central? is-remote? protecting-same-server?
-                              target-server zone->name]]
+   [game.core.servers :refer [central->name is-central? is-remote? protecting-same-server?
+                              target-server unknown->kw zone->name]]
    [game.core.shuffling :refer [shuffle!]]
    [game.core.tags :refer [gain-tags lose-tags]]
    [game.core.to-string :refer [card-str]]
@@ -2784,6 +2784,29 @@
                                     :effect (req (swap! state assoc-in [:run :server] [:hq])
                                                  (trigger-event state :corp :no-action))}])
                                 (make-run eid :archives (get-card state card)))}]})
+
+(defcard "Sneakdoor Prime B"
+  {:abilities [{:cost [:click 2]
+                :prompt "Choose a server"
+                :choices (req (cancellable
+                                (->> runnable-servers
+                                     (map unknown->kw)
+                                     (filter is-central?)
+                                     (map central->name))))
+                :msg "make a run on central server"
+                :makes-run true
+                :async true
+                :effect (effect (register-events
+                                  card
+                                  [{:event :pre-successful-run
+                                    :duration :end-of-run
+                                    :unregister-once-resolved true
+                                    :prompt "Choose a server"
+                                    :choices (req (cancellable remotes))
+                                    :msg (msg "change the attacked server to " target)
+                                    :effect (req (swap! state assoc-in [:run :server] [(unknown->kw target)])
+                                                 (trigger-event state :corp :no-action))}])
+                          (make-run eid target card))}]})
 
 (defcard "Snitch"
   {:events [{:event :approach-ice

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -54,7 +54,7 @@
    [game.core.sabotage :refer [sabotage-ability]]
    [game.core.say :refer [system-msg]]
    [game.core.servers :refer [central->name is-central? is-remote? protecting-same-server?
-                              target-server unknown->kw zone->name]]
+                              remote->name target-server unknown->kw zone->name]]
    [game.core.shuffling :refer [shuffle!]]
    [game.core.tags :refer [gain-tags lose-tags]]
    [game.core.to-string :refer [card-str]]
@@ -2784,6 +2784,32 @@
                                     :effect (req (swap! state assoc-in [:run :server] [:hq])
                                                  (trigger-event state :corp :no-action))}])
                                 (make-run eid :archives (get-card state card)))}]})
+
+(defcard "Sneakdoor Prime A"
+         {:abilities [{:cost [:click 2]
+                       :prompt "Choose a server"
+                       :choices (req (cancellable
+                                       (->> runnable-servers
+                                            (map unknown->kw)
+                                            (filter is-remote?)
+                                            (map remote->name))))
+                       :msg "make a run on a remote server"
+                       :makes-run true
+                       :async true
+                       :effect (effect (register-events
+                                         card
+                                         [{:event :pre-successful-run
+                                           :duration :end-of-run
+                                           :unregister-once-resolved true
+                                           :prompt "Choose a server"
+                                           :choices (req (->> servers
+                                                              (map unknown->kw)
+                                                              (filter is-central?)
+                                                              (map central->name)))
+                                           :msg (msg "change the attacked server to " target)
+                                           :effect (req (swap! state assoc-in [:run :server] [(unknown->kw target)])
+                                                        (trigger-event state :corp :no-action))}])
+                                       (make-run eid target card))}]})
 
 (defcard "Sneakdoor Prime B"
   {:abilities [{:cost [:click 2]

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -6633,6 +6633,25 @@
           (run-continue state :success)
           (is (= :archives (get-in @state [:run :server 0])) "Run continues on Archives")))))
 
+(deftest sneakdoor-prime-b
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "PAD Campaign" 2)]}
+               :runner {:hand ["Sneakdoor Prime B"]
+                        :credits 10}})
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Sneakdoor Prime B")
+    (card-ability state :runner (get-program state 0) 0)
+    (is (= ["Archives" "R&D" "HQ" "Cancel"] (prompt-buttons :runner)) "Only centrals available")
+    (click-prompt state :runner "HQ")
+    (run-continue state)
+    (is (= ["Server 1" "Server 2" "Cancel"] (prompt-buttons :runner)) "Only remotes available")
+    (click-prompt state :runner "Server 1")
+    (is (= :remote1 (get-in @state [:run :server 0])) "Run continues on Server 1")
+    (is (= ["Pay 4 [Credits] to trash" "No action"] (prompt-buttons :runner)) "Runner accessing card in Server 1")))
+
 (deftest snitch-only-works-on-rezzed-ice
     ;; Only works on rezzed ice
     (do-game

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -6633,6 +6633,25 @@
           (run-continue state :success)
           (is (= :archives (get-in @state [:run :server 0])) "Run continues on Archives")))))
 
+(deftest sneakdoor-prime-a
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand [(qty "PAD Campaign" 3)]}
+               :runner {:hand ["Sneakdoor Prime A"]
+                        :credits 10}})
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Sneakdoor Prime A")
+    (card-ability state :runner (get-program state 0) 0)
+    (is (= ["Server 1" "Server 2" "Cancel"] (prompt-buttons :runner)) "Only remotes available")
+    (click-prompt state :runner "Server 1")
+    (run-continue state)
+    (is (= ["Archives" "R&D" "HQ"] (prompt-buttons :runner)) "Only centrals available")
+    (click-prompt state :runner "HQ")
+    (is (= :hq (get-in @state [:run :server 0])) "Run continues on HQ")
+    (is (= ["Pay 4 [Credits] to trash" "No action"] (prompt-buttons :runner)) "Runner accessing card in HQ")))
+
 (deftest sneakdoor-prime-b
   (do-game
     (new-game {:corp {:deck [(qty "Hedge Fund" 5)]


### PR DESCRIPTION
Quite a late addition to implement some campaign cards from 2016 but the new Chimera format that builds random singleton eternal decks is sourcing cards from the entire pool, so thought I'd implement some of the missing ones so they can more easily be used in that format.