### PR TITLE
Ensure Kimberlite Field uses printed rez cost

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1048,7 +1048,7 @@
     :choices {:card #(rezzed? %)}
     :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
                            (effect-completed eid))
-    :effect (req (let [target-cost (rez-cost state :corp target)]
+    :effect (req (let [target-cost (:cost target)]
                    (wait-for (trash state side target {:cause-card card})
                              (continue-ability
                                state side

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -2060,14 +2060,17 @@
     (is (no-prompt? state :corp))))
 
 (deftest kimberlite-standard-functionality
+  ;; Kimberlite Field trashes runner card based on printed cost of corp card
   (do-game
-    (new-game {:corp {:hand ["Kimberlite Field" "Echo Chamber"]}
+    (new-game {:corp {:hand ["Kimberlite Field" "Echo Chamber" "Breaker Bay Grid"]}
                :runner {:hand ["Amina" "Paperclip"] :credits 15}})
     (play-from-hand state :corp "Echo Chamber" "New remote")
+    (play-from-hand state :corp "Breaker Bay Grid" "Server 1")
     (take-credits state :corp)
     (play-from-hand state :runner "Amina")
     (play-from-hand state :runner "Paperclip")
     (take-credits state :runner)
+    (rez state :corp (get-content state :remote1 1))
     (rez state :corp (get-content state :remote1 0))
     (play-and-score state "Kimberlite Field")
     (click-card state :corp "Echo Chamber")


### PR DESCRIPTION
Fixes #7189 

> When you score this agenda, you may trash 1 of your rezzed cards. If you do, trash 1 installed Runner card with a printed install cost equal to or less than the printed rez cost of the Corp card you trashed.