### PR TITLE
Ensure Kimberlite Field uses printed rez/install cost

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1048,14 +1048,14 @@
     :choices {:card #(rezzed? %)}
     :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
                            (effect-completed eid))
-    :effect (req (let [target-cost (rez-cost state :corp target)]
+    :effect (req (let [target-cost (:cost target)]
                    (wait-for (trash state side target {:cause-card card})
                              (continue-ability
                                state side
                                {:prompt (str "Choose a runner card that costs " target-cost " or less to trash")
                                 :choices {:card #(and (installed? %)
                                                       (runner? %)
-                                                      (<= (install-cost state :runner %) target-cost))}
+                                                      (<= (:cost %) target-cost))}
                                 :msg (msg "trash " (:title target))
                                 :async true
                                 :effect (effect (trash eid target))}

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -2060,15 +2060,20 @@
     (is (no-prompt? state :corp))))
 
 (deftest kimberlite-standard-functionality
+  ;; Kimberlite Field trashes runner card based on printed costs of each card
   (do-game
-    (new-game {:corp {:hand ["Kimberlite Field" "Echo Chamber"]}
+    (new-game {:corp {:hand ["Kimberlite Field" "Echo Chamber" "Breaker Bay Grid" "TechnoCo"]}
                :runner {:hand ["Amina" "Paperclip"] :credits 15}})
     (play-from-hand state :corp "Echo Chamber" "New remote")
+    (play-from-hand state :corp "Breaker Bay Grid" "Server 1")
+    (play-from-hand state :corp "TechnoCo" "New remote")
     (take-credits state :corp)
     (play-from-hand state :runner "Amina")
     (play-from-hand state :runner "Paperclip")
     (take-credits state :runner)
+    (rez state :corp (get-content state :remote1 1)) ;; lowers Echo Chamber cost - KF should use printed
     (rez state :corp (get-content state :remote1 0))
+    (rez state :corp (get-content state :remote2 0)) ;; increases Amina + Paperclip cost - KF should use printed
     (play-and-score state "Kimberlite Field")
     (click-card state :corp "Echo Chamber")
     (click-card state :corp "Amina")


### PR DESCRIPTION
Fixes #7189 

> When you score this agenda, you may trash 1 of your rezzed cards. If you do, trash 1 installed Runner card with a printed install cost equal to or less than the printed rez cost of the Corp card you trashed.