### PR TITLE
Fix Yakov firing on all trashed cards when included in trash

### DIFF
--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -47,7 +47,7 @@
    [game.core.say :refer [system-msg]]
    [game.core.servers :refer [central->zone from-same-server? in-same-server?
                               is-central? protecting-same-server? same-server?
-                              target-server unknown->kw zone->name]]
+                              same-zone? target-server unknown->kw zone->name]]
    [game.core.shuffling :refer [shuffle!]]
    [game.core.tags :refer [gain-tags]]
    [game.core.threat :refer [threat-level]]
@@ -1838,10 +1838,14 @@
                  (corp? (:card target))
                  (installed? (:card target))))]
     {:on-trash {:async true
-                :once-per-instance false
                 :interactive (req true)
-                :msg "gain 2 [Credits]"
-                :effect (effect (gain-credits eid 2))}
+                :effect (req (doseq [t targets]
+                               (let [trashing (:card t)]
+                                 (when (and (same-zone? (:zone trashing) (:previous-zone card))
+                                            (corp? trashing)
+                                            (installed? trashing))
+                                   (gain-credits state side eid 2)
+                                   (system-msg state :corp (str "uses " (:title card) " to gain 2 [Credits]"))))))}
      :events [{:event :runner-trash
                :async true
                :once-per-instance false

--- a/src/clj/game/core/servers.clj
+++ b/src/clj/game/core/servers.clj
@@ -100,14 +100,19 @@
   [zone]
   (or (#{:hq :rd :archives} zone) :remote))
 
+(defn same-zone?
+  "True if the two zones are IN or PROTECTING the same server."
+  [zone1 zone2]
+  (and zone1
+       zone2
+       (= (second zone1) (second zone2))))
+
 (defn same-server?
   "True if the two cards are IN or PROTECTING the same server."
   [card1 card2]
   (and card1
        card2
-       (let [zone1 (get-zone card1)
-             zone2 (get-zone card2)]
-         (= (second zone1) (second zone2)))))
+       (same-zone? (get-zone card1) (get-zone card2))))
 
 (defn protecting-same-server?
   "True if an ice is protecting the server that the card is in or protecting."

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -4625,33 +4625,32 @@
     (changes-val-macro
       +6 (:credit (get-corp))
       "+6 from 3 trashes"
-      (play-from-hand state :runner "Apocalypse")
-      (click-prompt state :corp "Yakov Erikovich Avdakov")
-      (click-prompt state :corp "Yakov Erikovich Avdakov"))
+      (play-from-hand state :runner "Apocalypse"))
     (is (no-prompt? state :corp))))
 
 (deftest yakov-multiple-trashed
   (do-game
-    (new-game {:corp {:hand ["Yakov Erikovich Avdakov" "NGO Front"
+    (new-game {:corp {:hand ["Yakov Erikovich Avdakov" (qty "NGO Front" 2)
                              "Prisec" "Mutually Assured Destruction"]
                       :credits 15}})
-    (core/gain state :corp :click 5)
+    (core/gain state :corp :click 6)
     (play-from-hand state :corp "Yakov Erikovich Avdakov" "New remote")
     (play-from-hand state :corp "NGO Front" "Server 1")
     (play-from-hand state :corp "Prisec" "Server 1")
+    (play-from-hand state :corp "NGO Front" "New remote")
     (rez state :corp (get-content state :remote1 0))
     (rez state :corp (get-content state :remote1 1))
     (rez state :corp (get-content state :remote1 2))
+    (rez state :corp (get-content state :remote2 0))
     (changes-val-macro
       -3 (:click (get-corp))
       "Spent 3 clicks to go MAD"
       (play-from-hand state :corp "Mutually Assured Destruction"))
     (changes-val-macro
       +6 (:credit (get-corp))
-      "trashed 3 cards"
+      "trashed 4 cards - 3 in Yakov server"
       (click-card state :corp (get-content state :remote1 0))
       (click-card state :corp (get-content state :remote1 1))
       (click-card state :corp (get-content state :remote1 2))
-      (click-prompt state :corp "Yakov Erikovich Avdakov")
-      (click-prompt state :corp "Yakov Erikovich Avdakov"))
+      (click-card state :corp (get-content state :remote2 0)))
     (is (no-prompt? state :corp))))


### PR DESCRIPTION
This fixes this issue mentioned on GLC.

![image](https://github.com/mtgred/netrunner/assets/5345/91d089b5-66d7-4874-9ede-bc5b05104655)

The existing issue is because `:once-per-instance false` makes it way to the actual `on-trash` effect resolving, and therefore it resolves for ever single card being trashed at the same time by MAD (or whatever else) regardless of any criteria.  This means any `:req` added is really just to check if the event should fire at all (only in the context of Yakov) and then the effect fires for every instance of card being trashed at the same time.  I don't think this is the correct keyword for this situation.

In an ideal engine scenario: when everything is trashed by MAD, Yakov would fire the `:on-trash` event on itself being trashed and still be able to trigger events off its `:corp-trash` event to catch the other cards being trashed and determine if they should gain credits or not.  Unfortunately it's not able to do that when it itself is part of the list of cards being trashed as I believe it's already gone by the time the actual `:corp-trash` event comes around to resolve.

The implementation for this to actually work is a total hack and I'm not even sure there's precedent for it.  I noticed through all this debugging that the `:on-trash` event actually receives the entire list of cards being trashed in `targets`.  So using that list of trashing cards check to see if this any of them meet the Yakov criteria (including Yakov itself - which of course succeeds since it was in the same server as itself) against the card triggering the `:on-trash` event whose reference has actually been moved so need to check its `:previous-zone` (again it checks itself as well).

I'm not sure how to really untangle a better solution out of the engine, I feel like there's maybe an exception to be made for certain kinds of events that should also be able to trigger on cards in the middle of being trashed but it will be quite complicated least of all because the engine will still need to trash not firing that event for a card against itself (it should prefer `:on-trash` instead of `:xxx-trash` in that scenario I think).