### PR TITLE
Fix Yakov and other abilities that fire even when trashed

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1172,31 +1172,25 @@
                :effect (effect (lose-credits :runner eid 1))}})
 
 (defcard "Hostile Architecture"
-  (let [valid-trash (fn [target] (and (corp? (:card target)) (installed? (:card target))))
-        ability
-        {:event :runner-trash
-         :async true
-         :once :per-turn
-         :once-per-instance false
-         :req (req (and (valid-trash target)
-                        (first-event? state side :runner-trash #(valid-trash (first %)))))
-         :msg "do 2 meat damage"
-         :effect (effect (damage :corp eid :meat 2 {:card card}))}]
-    {:on-trash (assoc ability :req (req (and (= :runner side)
-                                             (no-event? state side :runner-trash #(valid-trash (first %))))))
-     :events [ability]}))
-
+  (letfn [(valid-trash [target]
+            (and (corp? (:card target))
+                 (installed? (:card target))))]
+    {:events [{:event :runner-trash
+               :async true
+               :once :per-turn
+               :once-per-instance false
+               :req (req (and (valid-trash target)
+                              (first-event? state side :runner-trash #(valid-trash (first %)))))
+               :msg "do 2 meat damage"
+               :effect (effect (damage :corp eid :meat 2 {:card card}))}]}))
 
 (defcard "Hostile Infrastructure"
-  (let [ability
-        {:event :runner-trash
-         :async true
-         :once-per-instance false
-         :req (req (corp? (:card target)))
-         :msg "do 1 net damage"
-         :effect (effect (damage :corp eid :net 1 {:card card}))}]
-    {:on-trash (assoc ability :req (req (= :runner side)))
-     :events [ability]}))
+  {:events [{:event :runner-trash
+             :async true
+             :once-per-instance false
+             :req (req (corp? (:card target)))
+             :msg "do 1 net damage"
+             :effect (effect (damage :corp eid :net 1 {:card card}))}]})
 
 (defcard "Hyoubu Research Facility"
   {:events [{:event :reveal-spent-credits

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -267,7 +267,7 @@
                     ;; everything is queued, then we perform the actual checkpoint.
                     (forfeit state side (make-eid state eid) agenda {:msg false
                                                                      :suppress-checkpoint true}))
-                  (wait-for (checkpoint state nil (make-eid state eid) nil)
+                  (wait-for (checkpoint state nil (make-eid state eid) {:durations [:game-trash]})
                             (complete-with-result
                               state side eid
                               {:msg (str "forfeits " (quantify (value cost) "agenda")

--- a/src/clj/game/core/damage.clj
+++ b/src/clj/game/core/damage.clj
@@ -4,7 +4,7 @@
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.engine :refer [checkpoint queue-event trigger-event trigger-event-simult]]
     [game.core.flags :refer [cards-can-prevent? get-prevent-list]]
-    [game.core.moving :refer [trash-cards]]
+    [game.core.moving :refer [trash-cards get-trash-event]]
     [game.core.prompt-state :refer [add-to-prompt-queue remove-from-prompt-queue]]
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
     [game.core.say :refer [system-msg]]
@@ -135,8 +135,10 @@
                                                           :card card
                                                           :damage-type dmg-type
                                                           :cards-trashed cards-trashed})
-                              (wait-for (checkpoint state nil (make-eid state eid) {:duration :damage})
-                                        (complete-with-result state side eid cards-trashed)))))))))
+                              (let [trash-event (get-trash-event side false)
+                                    args {:durations [:damage trash-event]}]
+                                (wait-for (checkpoint state nil (make-eid state eid) args)
+                                          (complete-with-result state side eid cards-trashed))))))))))
 
 (defn damage-count
   "Calculates the amount of damage to do, taking into account prevention and boosting effects."

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -638,8 +638,7 @@
   "Prepare the list of the given player's handlers for this event.
   Gather all registered handlers from the state, then append the card-abilities if appropriate,
   then filter to remove suppressed handlers and those whose req is false.
-  This is essentially Phase 9.3 and 9.6.7a of CR 1.1:
-  https://nullsignal.games/wp-content/uploads/2021/03/Comprehensive_Rules_1.1.pdf"
+  This is essentially 9.6.2, 9.6.5, and 9.6.15 of CR 1.8."
   ([state side event targets] (gather-events state side event targets nil))
   ([state side event targets card-abilities] (gather-events state side (make-eid state) event targets card-abilities))
   ([state side eid event targets card-abilities]

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -477,13 +477,13 @@
              (and (in-discard? card)
                   (faceup? card)))))))
 
-;; CR 1.5
+;; CR 1.8
 ;; 10.1.3. Some abilities add a card to a player’s score area “as an agenda”. When this
 ;;    happens, the card loses all its previous properties and gains only those
 ;;    properties specified in the effect converting it. This conversion lasts until the
 ;;    card moves to a zone that is not a score area, at which point it returns to being
 ;;    its original printed card. If this happens in any way other than by agenda
-;;    forfeit, the card is immediately trashed. See rule 8.2.5.
+;;    forfeit, the card is immediately trashed.
 
 (defn convert-to-agenda
   [{:keys [cid code host hosted side title zone implementation]} n]
@@ -499,7 +499,7 @@
      :type "Agenda"
      :zone zone}))
 
-;; CR 1.5
+;; CR 1.8
 ;; 10.1.4. Some abilities can convert a card into a counter. When this happens, the card
 ;;    loses all its previous properties and gains only those properties specified in the
 ;;    effect converting it. This conversion lasts until the counter moves to another

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -2573,7 +2573,8 @@
 (deftest hostile-infrastructure-basic-behavior
     ;; Basic behavior
     (do-game
-      (new-game {:corp {:deck [(qty "Hostile Infrastructure" 3)]}})
+      (new-game {:corp {:deck [(qty "Hostile Infrastructure" 3)]}
+                 :runner {:hand [(qty "Sure Gamble" 5)]}})
       (core/gain state :runner :credit 50)
       (play-from-hand state :corp "Hostile Infrastructure" "New remote")
       (rez state :corp (get-content state :remote1 0))

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -76,7 +76,6 @@
         -6 (:credit (get-runner))
         "Spent 6 credits to break 3 barrier subs"
         (card-ability state :runner (refresh adept) 0)
-        (print-prompts)
         (click-prompt state :runner "End the run")
         (click-prompt state :runner "End the run")
         (click-prompt state :runner "End the run"))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -4632,26 +4632,29 @@
 
 (deftest yakov-multiple-trashed
   (do-game
-    (new-game {:corp {:hand ["Yakov Erikovich Avdakov" "NGO Front"
+    (new-game {:corp {:hand ["Yakov Erikovich Avdakov" (qty "NGO Front" 2)
                              "Prisec" "Mutually Assured Destruction"]
                       :credits 15}})
-    (core/gain state :corp :click 5)
+    (core/gain state :corp :click 6)
     (play-from-hand state :corp "Yakov Erikovich Avdakov" "New remote")
     (play-from-hand state :corp "NGO Front" "Server 1")
     (play-from-hand state :corp "Prisec" "Server 1")
+    (play-from-hand state :corp "NGO Front" "New remote")
     (rez state :corp (get-content state :remote1 0))
     (rez state :corp (get-content state :remote1 1))
     (rez state :corp (get-content state :remote1 2))
+    (rez state :corp (get-content state :remote2 0))
     (changes-val-macro
       -3 (:click (get-corp))
       "Spent 3 clicks to go MAD"
       (play-from-hand state :corp "Mutually Assured Destruction"))
     (changes-val-macro
       +6 (:credit (get-corp))
-      "trashed 3 cards"
+      "trashed 4 cards - 3 in Yakov server"
       (click-card state :corp (get-content state :remote1 0))
       (click-card state :corp (get-content state :remote1 1))
       (click-card state :corp (get-content state :remote1 2))
+      (click-card state :corp (get-content state :remote2 0))
       (click-prompt state :corp "Yakov Erikovich Avdakov")
       (click-prompt state :corp "Yakov Erikovich Avdakov"))
     (is (no-prompt? state :corp))))


### PR DESCRIPTION
The core of the fix is marking all `:X-trash` events as having `:X-trash` duration so they last past when the trashed card is moved to discard and then clearing them when calling `checkpoint`. Means we don't have to do shenanigans with `:on-trash` as well; that can stay purely for "whenever the X trashes this Y" effects.

Related to #7192