### PR TITLE
Reduce sente logging from info to default (warn)

### DIFF
--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -16,7 +16,6 @@
                                           arg))]
     (assoc data :vargs (map filter-uid-from-log-arg (:vargs data )))))
 (timbre/merge-config! {:middleware [redact-uid-middleware]})
-(sente/set-min-log-level! :info)
 
 (let [chsk-server (sente/make-channel-socket-server!
                     (get-sch-adapter)
@@ -59,16 +58,16 @@
           ws-conn-total (reduce + ws-conn-counts)
           ws-conn-max (apply max (conj ws-conn-counts 0))
           ]
-      (println (str "connected -"
-                    " :ajax { "
-                    " uid: " ajax-uid-count
-                    " conn: " ajax-conn-total
-                    " conn-max: " ajax-conn-max
-                    " } :ws { "
-                    " uid: " ws-uid-count
-                    " conn: " ws-conn-total
-                    " conn-max: " ws-conn-max
-                    " }"))))))
+      (timbre/info (str "connected -"
+                        " :ajax { "
+                        " uid: " ajax-uid-count
+                        " conn: " ajax-conn-total
+                        " conn-max: " ajax-conn-max
+                        " } :ws { "
+                        " uid: " ws-uid-count
+                        " conn: " ws-conn-total
+                        " conn-max: " ws-conn-max
+                        " }"))))))
 
 (defonce ratelimiter
   (go (while true


### PR DESCRIPTION
Currently sente is logging at `info` level which provides some basic info when users connect and disconnect - this was useful to see the kinds of activity when we were debugging connection issues but it's quite chatty and mostly just noise now.  The default is `warn` which is one level down, I've therefore left in the timbre middleware that makes sure we don't accidentally log user IDs into the logs.

This also updates the current "connections aggregate" logging that happens every 5 minutes to use `timbre/info` instead of `println` as timbre will include stuff like timestamps which are useful (previously the sente logging used timbre so you could mostly derive the timestamp before between the sente log lines).

<img width="1201" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/3abafe31-aa40-49f9-bb9a-35711d13f2a5">
