### PR TITLE
Guard against lobby player being set to nil and causing lobby list to fail

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -147,6 +147,7 @@
       (fn [lobby]
         (let [player-usernames (->> (:players lobby)
                                     (map #(get-in % [:user :username]))
+                                    (filter some?)
                                     (map str/lower-case)
                                     (set))
               user-blocked-players?

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -146,8 +146,7 @@
     (filter
       (fn [lobby]
         (let [player-usernames (->> (:players lobby)
-                                    (map #(get-in % [:user :username]))
-                                    (filter some?)
+                                    (keep #(get-in % [:user :username]))
                                     (map str/lower-case)
                                     (set))
               user-blocked-players?


### PR DESCRIPTION
Not really sure how lobbies end up in this state - either due to having a nil `:username` or what I suspect is actually just calling `get-in nil [:user :username]` which also return `nil`.  But I think it's probably worth guarding against this as when it happens it completely breaks all lobby fetching.

Here's a trace of what this usually looks like when it fails:
```
java.lang.NullPointerException
	at clojure.string$lower_case.invokeStatic(string.clj:217)
	at clojure.string$lower_case.invoke(string.clj:213)
	at clojure.core$map$fn__5884.invoke(core.clj:2757)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.RT.seq(RT.java:535)
	at clojure.core$seq__5419.invokeStatic(core.clj:139)
	at clojure.core$reduce1.invokeStatic(core.clj:932)
	at clojure.core$set.invokeStatic(core.clj:4101)
	at clojure.core$set.invoke(core.clj:4093)
	at web.lobby$filter_lobby_list$fn__81480.invoke(lobby.clj:151)
	at clojure.core$filter$fn__5911.invoke(core.clj:2825)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.RT.seq(RT.java:535)
	at clojure.core$seq__5419.invokeStatic(core.clj:139)
	at clojure.core$map$fn__5884.invoke(core.clj:2750)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.Cons.next(Cons.java:39)
	at clojure.lang.RT.length(RT.java:1785)
	at clojure.lang.RT.seqToArray(RT.java:1726)
	at clojure.lang.LazySeq.toArray(LazySeq.java:132)
	at clojure.lang.RT.toArray(RT.java:1699)
	at clojure.core$to_array.invokeStatic(core.clj:346)
	at clojure.core$sort.invokeStatic(core.clj:3101)
	at clojure.core$sort_by.invokeStatic(core.clj:3107)
	at clojure.core$sort_by.invokeStatic(core.clj:3107)
	at clojure.core$sort_by.invoke(core.clj:3107)
	at web.lobby$summaries_for_lobbies.invokeStatic(lobby.clj:166)
	at web.lobby$summaries_for_lobbies.invoke(lobby.clj:163)
	at web.lobby$prepare_lobby_list$iter__81487__81491$fn__81492.invoke(lobby.clj:183)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.RT.seq(RT.java:535)
	at clojure.core$seq__5419.invokeStatic(core.clj:139)
	at clojure.core$seq__5419.invoke(core.clj:139)
	at web.lobby$broadcast_lobby_list.invokeStatic(lobby.clj:197)
	at web.lobby$broadcast_lobby_list.invoke(lobby.clj:186)
	at web.lobby$broadcast_lobby_list.invokeStatic(lobby.clj:193)
	at web.lobby$broadcast_lobby_list.invoke(lobby.clj:186)
	at web.lobby$fn__81553.invokeStatic(lobby.clj:235)
	at web.lobby$fn__81553.invoke(lobby.clj:223)
	at clojure.lang.MultiFn.invoke(MultiFn.java:229)
	at web.ws$event_msg_handler.invokeStatic(ws.clj:117)
	at web.ws$event_msg_handler.invoke(ws.clj:113)
	at taoensso.sente$_start_chsk_router_BANG_$fn__76644$state_machine__67839__auto____76665$fn__76667$inst_76635__76685.invoke(sente.cljc:2092)
	at taoensso.sente$_start_chsk_router_BANG_$fn__76562.invoke(sente.cljc:2078)
	at taoensso.sente$_start_chsk_router_BANG_$fn__76644$state_machine__67839__auto____76665$fn__76667.invoke(sente.cljc:2080)
	at taoensso.sente$_start_chsk_router_BANG_$fn__76644$state_machine__67839__auto____76665.invoke(sente.cljc:2080)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:978)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:977)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:982)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:980)
	at clojure.core.async$ioc_alts_BANG_$fn__68068.invoke(async.clj:421)
	at clojure.core.async$do_alts$fn__68007$fn__68010.invoke(async.clj:288)
	at clojure.core.async.impl.channels.ManyToManyChannel$fn__66132$fn__66133.invoke(channels.clj:99)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at clojure.core.async.impl.concurrent$counted_thread_factory$reify__66035$fn__66036.invoke(concurrent.clj:29)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.lang.Thread.run(Thread.java:829)
```