### PR TITLE
Fix :can-trash flag interaction

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -27,7 +27,7 @@
                              turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-cid find-latest]]
-   [game.core.flags :refer [any-flag-fn? can-rez?
+   [game.core.flags :refer [any-flag-fn? can-rez? can-trash?
                             clear-all-flags-for-card! clear-run-flag! clear-turn-flag!
                             in-corp-scored? register-run-flag! register-turn-flag! zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-clicks
@@ -424,7 +424,8 @@
         card
         [{:event :access
           :duration :end-of-turn
-          :req (req (not (in-discard? target)))
+          :req (req (and (can-trash? state :runner target)
+                         (not (in-discard? target))))
           :interactive (req true)
           :async true
           :msg (msg "trash " (:title target) " at no cost and suffer 1 meat damage")
@@ -953,6 +954,7 @@
              :effect (effect (make-run eid target card))}
    :interactions {:access-ability
                   {:label "Trash card"
+                   :req (req (can-trash? state :runner target))
                    :msg (msg "trash " (:title target) " at no cost")
                    :async true
                    :effect (effect (trash eid (assoc target :seen true) {:cause-card card}))}}})

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -28,7 +28,7 @@
                              run-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-card]]
-   [game.core.flags :refer [card-flag? in-corp-scored? register-run-flag!
+   [game.core.flags :refer [can-trash? card-flag? in-corp-scored? register-run-flag!
                             zone-locked?]]
    [game.core.gaining :refer [gain-clicks gain-credits lose-clicks
                               lose-credits]]
@@ -396,7 +396,8 @@
    :interactions
    {:access-ability
     {:label "Trash card"
-     :req (req (and (not (get-in @state [:per-turn (:cid card)]))
+     :req (req (and (can-trash? state :runner target)
+                    (not (get-in @state [:per-turn (:cid card)]))
                     (<= 2 (count (:hand runner)))))
      :cost [:trash-from-hand 2]
      :msg (msg "trash " (:title target) " at no cost")

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -26,7 +26,7 @@
                              first-successful-run-on-server? turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-cid]]
-   [game.core.flags :refer [can-host? card-flag? lock-zone release-zone zone-locked?]]
+   [game.core.flags :refer [can-host? can-trash? card-flag? lock-zone release-zone zone-locked?]]
    [game.core.gaining :refer [gain-clicks gain-credits lose-credits]]
    [game.core.hosting :refer [host]]
    [game.core.ice :refer [all-subs-broken-by-card? all-subs-broken?
@@ -1671,7 +1671,8 @@
 (defcard "Imp"
   {:data {:counter {:virus 2}}
    :interactions {:access-ability {:label "Trash card"
-                                   :req (req (not (get-in @state [:per-turn (:cid card)])))
+                                   :req (req (and (can-trash? state :runner target)
+                                                  (not (get-in @state [:per-turn (:cid card)]))))
                                    :cost [:virus 1]
                                    :msg (msg "trash " (:title target) " at no cost")
                                    :once :per-turn

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -5085,12 +5085,7 @@
     (click-prompt state :runner "Server 1")
     (run-continue state)
     (click-card state :runner "Project Beale")
-    ;; note: Imp does not check to see if the card can be trashed
-    ;;       the ability should fizzle though -nbkelly
-    (is (= ["[Imp] Hosted virus counter: Trash card" "No action"]
-           (mapv :value (:choices (prompt-map :runner)))))
-    (click-prompt state :runner "[Imp] Hosted virus counter: Trash card")
-    (is (= 0 (count (:discard (get-corp)))) "Beale was not trashed")))
+    (is (= ["No action"] (mapv :value (:choices (prompt-map :runner)))))))
 
 (deftest planned-assault
   ;; Planned Assault

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3518,6 +3518,21 @@
                    "Ice Wall"
                    "Oberth Protocol"]))))
 
+(deftest imp-cannot-trash-flag-interaction
+  ;; Interaction with :can-trash flag
+  (do-game
+    (new-game {:corp {:hand ["Project Atlas"]}
+               :runner {:hand ["Imp" "Pinhole Threading"]}})
+    (play-from-hand state :corp "Project Atlas" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Imp")
+    (play-from-hand state :runner "Pinhole Threading")
+    (click-prompt state :runner "Archives")
+    (run-continue state)
+    (click-card state :runner "Project Atlas")
+    (is (= ["No action"] (prompt-buttons :runner)))
+    (click-prompt state :runner "No action")))
+
 (deftest imp-vs-an-ambush
     ;; vs an ambush
     (do-game


### PR DESCRIPTION
Noticed while watching Metropole Grid stream that agendas could be trashed using Imp during Pinhole Threading access.