### PR TITLE
Fix indexes on printed subs when ice loses all variables subs

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -78,6 +78,7 @@
          new-subs (->> (range total)
                        (reduce (fn [ice _] (add-sub ice sub (:cid ice) args)) new-card)
                        :subroutines
+                       (map-indexed (fn [idx sub] (assoc sub :index idx)))
                        (into []))
          new-card (assoc new-card :subroutines new-subs)]
      (update! state :corp new-card)
@@ -90,6 +91,7 @@
          new-subs (->> (range total)
                        (reduce (fn [ice _] (add-sub ice sub (:cid ice) args)) card)
                        :subroutines
+                       (map-indexed (fn [idx sub] (assoc sub :index idx)))
                        (into []))
          new-card (assoc card :subroutines new-subs)]
      (update! state :corp new-card)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -75,11 +75,12 @@
                                 (:variable %))
                           (:subroutines card))
          new-card (assoc card :subroutines old-subs)
-         new-subs (->> (range total)
-                       (reduce (fn [ice _] (add-sub ice sub (:cid ice) args)) new-card)
-                       :subroutines
-                       (map-indexed (fn [idx sub] (assoc sub :index idx)))
-                       (into []))
+         new-subs (if (pos? total)
+                    (->> (range total)
+                         (reduce (fn [ice _] (add-sub ice sub (:cid ice) args)) new-card)
+                         :subroutines
+                         (into []))
+                    (into [] (map-indexed (fn [idx sub] (assoc sub :index idx)) (:subroutines new-card))))
          new-card (assoc new-card :subroutines new-subs)]
      (update! state :corp new-card)
      (trigger-event state side :subroutines-changed (get-card state new-card)))))
@@ -91,7 +92,6 @@
          new-subs (->> (range total)
                        (reduce (fn [ice _] (add-sub ice sub (:cid ice) args)) card)
                        :subroutines
-                       (map-indexed (fn [idx sub] (assoc sub :index idx)))
                        (into []))
          new-card (assoc card :subroutines new-subs)]
      (update! state :corp new-card)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -520,7 +520,6 @@
    reset-all-subs
    reset-all-subs!
    reset-sub
-   reset-sub!
    resolve-subroutine
    resolve-subroutine!
    resolve-unbroken-subs!

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -519,7 +519,6 @@
    reset-all-ice
    reset-all-subs
    reset-all-subs!
-   reset-sub
    resolve-subroutine
    resolve-subroutine!
    resolve-unbroken-subs!

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -218,14 +218,11 @@
   [state ice]
   (update! state :corp (dont-resolve-all-subroutines ice)))
 
-(defn reset-sub
-  [sub]
-  (dissoc sub :broken :fired :resolve))
-
 (defn reset-all-subs
   "Mark all broken/fired subroutines as unbroken/unfired"
   [ice]
-  (update ice :subroutines #(into [] (map reset-sub %))))
+  (letfn [(reset-sub [sub] (dissoc sub :broken :fired :resolve))]
+    (update ice :subroutines #(into [] (map reset-sub %)))))
 
 (defn reset-all-subs!
   "Marks all broken subroutines as unbroken, update!s state"

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -219,17 +219,13 @@
   (update! state :corp (dont-resolve-all-subroutines ice)))
 
 (defn reset-sub
-  [ice sub]
-  (assoc ice :subroutines (assoc (:subroutines ice) (:index sub) (dissoc sub :broken :fired :resolve))))
-
-(defn reset-sub!
-  [state ice sub]
-  (update! state :corp (reset-sub ice sub)))
+  [sub]
+  (dissoc sub :broken :fired :resolve))
 
 (defn reset-all-subs
   "Mark all broken/fired subroutines as unbroken/unfired"
   [ice]
-  (reduce reset-sub ice (:subroutines ice)))
+  (update ice :subroutines #(into [] (map reset-sub %))))
 
 (defn reset-all-subs!
   "Marks all broken subroutines as unbroken, update!s state"

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -2052,6 +2052,19 @@
    (is (empty? (:discard (get-corp))))
    (is (not (:run @state)) "Run ended")))
 
+(deftest envelopment-sub-indexed-correctly-7201
+  ;; Envelopment should only have one trash subroutine at index 0 after running out of counters
+  (do-game
+    (new-game {:corp {:hand ["Envelopment"] :credits 10}})
+    (play-from-hand state :corp "Envelopment" "HQ")
+    (rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (dotimes [_ 4]
+      (take-credits state :runner)
+      (take-credits state :corp))
+    (is (= 1 (count (:subroutines (get-ice state :hq 0)))))
+    (is (= 0 (:index (first (:subroutines (get-ice state :hq 0))))))))
+
 (deftest excalibur
   ;; Excalibur - Prevent Runner from making another run this turn
   (do-game


### PR DESCRIPTION
Fixes #7201 
Fixes #6584 

The underlying issue for both these is that the subroutine indexes were only being updated via `add-sub` function, and so when there were 0 calls to `add-sub`, then the original subroutines stick around but never had their indexes reset.  This would cause an issue further in the game during ice encounter in `reset-sub` which relies on `:index` being correct to `assoc` the subroutines back into the list properly after removing broken/fired/resolved status - effectively cloning any subroutines whose indexes were previously greater than or equal to the current number of subs.

This would have caused issues I think only with ice that appends variable subs to the front, so this hopefully fixes issues with Blockchain, Envelopment, and Loki.