### PR TITLE
Add /bug-report route back to fix bug reports

### DIFF
--- a/src/cljs/nr/routes.cljs
+++ b/src/cljs/nr/routes.cljs
@@ -42,6 +42,8 @@
                :view lobby-or-game}]
      ["/replay/:rid" {:name :nav/replay-lobby
                :view lobby-or-game}]
+     ["/bug-report/:rid" {:name :nav/bug-report
+                      :view lobby-or-game}]
      ["/help" {:name :nav/help
                :view help}]
      ["/account" {:name :nav/account


### PR DESCRIPTION
Spent a bit of time trying to work out what was wrong and I think eventually found the issue to be a missing front-end route? I was able to get this to work locally, though note it just seems like the normal replay flow, I wasn't sure if there was meant to be anything more intricate for bug reports @lostgeek 