### PR TITLE
Make 'Attempt reconnect' based on connection status

### DIFF
--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -54,6 +54,7 @@
                            (:options (js->clj js/user :keywordize-keys true)))
 
            :cards-loaded false
+           :connected false
            :previous-cards {}
            :sets [] :mwl [] :cycles []
            :decks [] :decks-loaded false

--- a/src/cljs/nr/status_bar.cljs
+++ b/src/cljs/nr/status_bar.cljs
@@ -9,11 +9,11 @@
    [nr.ws :as ws]
    [reagent.core :as r]))
 
-(defn current-game-count [user games]
+(defn current-game-count [user games connected?]
   (r/with-let [c (r/track (fn [] (count (filter-games @user @games (:visible-formats @app-state)))))]
     [:div.float-right
      (tr [:nav/game-count] @c)
-     (when (zero? @c)
+     (when (not @connected?)
        [:a.reconnect-button {:on-click #(ws/chsk-reconnect!)} "Attempt reconnect"])]))
 
 (defn in-game-buttons [user current-game gameid]
@@ -67,9 +67,10 @@
   (r/with-let [user (r/cursor app-state [:user])
                games (r/cursor app-state [:games])
                gameid (r/cursor app-state [:gameid])
-               current-game (r/cursor app-state [:current-game])]
+               current-game (r/cursor app-state [:current-game])
+               connected? (r/cursor app-state [:connected])]
     [:div
-     [current-game-count user games]
+     [current-game-count user games connected?]
      [in-game-buttons user current-game gameid]
      [replay-and-spectator-buttons gameid]
      [spectator-list current-game]]))

--- a/src/cljs/nr/ws.cljs
+++ b/src/cljs/nr/ws.cljs
@@ -10,7 +10,7 @@
 
 (if-not ?csrf-token
   (println "CSRF token NOT detected in HTML, default Sente config will reject requests")
-  (let [{:keys [chsk ch-recv send-fn]}
+  (let [{:keys [chsk ch-recv send-fn state]}
         (sente/make-channel-socket-client!
           "/chsk"
           ?csrf-token
@@ -18,6 +18,9 @@
            :wrap-recv-evs? false})]
     (def chsk chsk)
     (def ch-chsk ch-recv)
+    (def ch-state state)
+    (add-watch ch-state :watch-connection (fn [_ _ _ state]
+                                            (swap! app-state assoc :connected (:open? state))))
     (defn ws-send!
       ([ev] (send-fn ev))
       ([ev ?timeout ?cb] (send-fn ev ?timeout ?cb)))))


### PR DESCRIPTION
Demo (had a temporary disconnect link for debugging):


https://github.com/mtgred/netrunner/assets/5345/78fff99b-bdff-4377-9ecc-c40a2588aa57


I noticed a bunch of ajax connections popping up last time there were server list errors - I assume this is because users were double clicking the "Attempt Reconnect" button.  I think the button makes sense but probably with a bit more precise heuristic for appearing.

I couldn't figure out a better way to bridge the watchable state out of sente into the reagent atom than the `add-watch` method I used.

