### PR TITLE
fix Oppo Research prompt showing when the Corp has fewer than 5 credits

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1777,18 +1777,18 @@
                            (last-turn? state :runner :stole-agenda)))
              :effect (req
                        (wait-for (gain-tags state :corp (make-eid state eid) 2)
-                                 (if (threat-level 3 state)
-                                   (continue-ability
+                                 (continue-ability
                                      state side
                                      {:optional
                                       {:prompt "Pay 5 [Credit] to give the Runner 2 tags?"
+                                       :req (req (and (threat-level 3 state)
+                                                      (can-pay? state :corp eid card nil [:credit 5])))
                                        :waiting-prompt true
                                        :yes-ability {:async true
                                                      :cost [:credit 5]
                                                      :msg "give the Runner 2 tags"
                                                      :effect (req (gain-tags state :corp eid 2))}}}
-                                     card nil)
-                                   (effect-completed state side eid))))}})
+                                     card nil)))}})
 
 (defcard "Oversight AI"
   {:on-play {:choices {:card #(and (ice? %)

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1781,8 +1781,7 @@
                                      state side
                                      {:optional
                                       {:prompt "Pay 5 [Credit] to give the Runner 2 tags?"
-                                       :req (req (and (threat-level 3 state)
-                                                      (can-pay? state :corp eid card nil [:credit 5])))
+                                       :req (req (threat-level 3 state))
                                        :waiting-prompt true
                                        :yes-ability {:async true
                                                      :cost [:credit 5]

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2998,6 +2998,18 @@
       (click-prompt state :corp "Yes"))
     (is (= 5 (:credit (get-corp))) "Corp spent 5 additional credits")))
 
+(deftest oppo-research-threat-ability-cannot-pay
+  (do-game
+    (new-game {:corp {:hand ["Oppo Research" "Salvo Testing"]
+                      :credits 2}})
+    (play-from-hand state :corp "Salvo Testing" "New remote")
+    (take-credits state :corp)
+    (run-empty-server state "Server 1")
+    (click-prompt state :runner "Steal")
+    (take-credits state :runner)
+    (play-from-hand state :corp "Oppo Research")
+    (is (no-prompt? state :corp) "Corp cannot pay the additional 5 credits")))
+
 (deftest oppo-research-threat-ability-tag-prevention
   (do-game
     (new-game {:corp {:hand ["Oppo Research" "Salvo Testing"]

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -3008,7 +3008,8 @@
     (click-prompt state :runner "Steal")
     (take-credits state :runner)
     (play-from-hand state :corp "Oppo Research")
-    (is (no-prompt? state :corp) "Corp cannot pay the additional 5 credits")))
+    (is (= 1 (count (:choices (prompt-map :corp)))) "Corp cannot pay the additional 5 credits")
+    (click-prompt state :corp "No")))
 
 (deftest oppo-research-threat-ability-tag-prevention
   (do-game


### PR DESCRIPTION
Also moved Threat check to continue-ability's `:req`