### PR TITLE
Hide "Yes" if unable to pay for yes side of optional

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1891,6 +1891,7 @@
             {:choices {:card #(and (hardware? %)
                                    (<= (:cost %) max-cost))}
              :msg (msg "trash " (:title target))
+             :async true
              :effect (effect (trash eid target {:cause-card card}))})
           card nil))}}}})
 
@@ -2875,10 +2876,11 @@
      {:label "Give the Runner X tags"
       :async true
       :effect (req (let [tags (max 1 (count-tags state))]
-                     (gain-tags state :corp eid tags)
-                     (system-msg
-                       state side
-                       (str "uses " (:title card) " to give the Runner " (quantify tags "tag")))))}}}})
+                     (wait-for (gain-tags state :corp (make-eid state eid) tags)
+                               (system-msg
+                                 state side
+                                 (str "uses " (:title card) " to give the Runner " (quantify tags "tag")))
+                               (effect-completed state nil eid))))}}}})
 
 (defcard "Too Big to Fail"
   {:on-play

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -619,6 +619,7 @@
                      :req (req (and this-server tagged))
                      :successful
                      {:msg "do 1 meat damage"
+                      :async true
                       :effect (effect (damage eid :meat 1 {:card card
                                                            :unpreventable true}))}}}]})
 

--- a/src/clj/game/core/optional.clj
+++ b/src/clj/game/core/optional.clj
@@ -31,14 +31,17 @@
                          (effect-completed state side eid))))]
      (let [autoresolve-fn (:autoresolve ability)
            autoresolve-answer (when autoresolve-fn
-                                (autoresolve-fn state side eid card targets))]
+                                (autoresolve-fn state side eid card targets))
+           choices [(when (can-pay? state side eid card (:title card) (:cost (:yes-ability ability)))
+                      "Yes")
+                    "No"]]
        (case autoresolve-answer
          "Yes" (prompt-fn {:value "Yes"})
          "No" (prompt-fn {:value "No"})
          (do (when autoresolve-fn
                (toast state side (str "This prompt can be skipped by clicking "
                                       (:title card) " and toggling autoresolve")))
-             (show-prompt state side eid card message ["Yes" "No"]
+             (show-prompt state side eid card message choices
                           prompt-fn (assoc ability :targets targets))))))))
 
 (defn- check-optional

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -4959,23 +4959,6 @@
       (is (= 1 (count-tags state)) "Runner has 1 tag")
       (is (zero? (count (:hand (get-runner)))) "Runner took 3 net damage")))
 
-(deftest snare-can-t-afford
-    ;; Can't afford
-    (do-game
-      (new-game {:corp {:deck ["Snare!"]}
-                 :runner {:deck [(qty "Sure Gamble" 3) (qty "Diesel" 3)]}})
-      (play-from-hand state :corp "Snare!" "New remote")
-      (take-credits state :corp)
-      (core/lose state :corp :credit 7)
-      (run-empty-server state "Server 1")
-      (is (= :waiting (prompt-type :runner))
-          "Runner has prompt to wait for Snare!")
-      (click-prompt state :corp "Yes")
-      (is (zero? (count-tags state)) "Runner has 0 tags")
-      (click-prompt state :runner "Pay 0 [Credits] to trash")
-      (is (no-prompt? state :runner) "Runner waiting prompt is cleared")
-      (is (zero? (count (:discard (get-runner)))) "Runner took no damage")))
-
 (deftest snare-with-dedicated-response-team
     ;; with Dedicated Response Team
     (do-game


### PR DESCRIPTION
Related to #7215.

I initially put the `can-pay?` check directly in `check-optional` but that's no good cuz players can always choose "No". Now it will just hide the `"Yes"` button if they can't pay.