### PR TITLE
Add settings to allow sorting archives and heap popups

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -162,7 +162,7 @@
 (defn profile-keys []
   [:background :pronouns :language :default-format :show-alt-art :blocked-users
    :alt-arts :card-resolution :deckstats :gamestats :card-zoom
-   :pin-zoom :card-back :stacked-cards :sides-overlap])
+   :pin-zoom :card-back :stacked-cards :sides-overlap :archives-sorted :heap-sorted])
 
 (defn update-profile-handler
   [{db :system/db

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -289,6 +289,18 @@
      [tag {:src (str "/img/" card-back "-" s ".png")
            :alt alt}])))
 
+(defn sort-archives
+  [cards] (->> cards (sort-by get-title) (sort-by #(not (faceup? %)))))
+
+(defn sort-heap
+  [cards] (sort-by get-title cards))
+
+(defn sort-archives?
+  [] (get-in @app-state [:options :archives-sorted] false))
+
+(defn sort-heap?
+  [] (get-in @app-state [:options :heap-sorted] false))
+
 (defn card-img
   "Build an image of the card (is always face-up). Only shows the zoomed card image, does not do any interaction."
   [{:keys [code] :as card}]
@@ -889,7 +901,7 @@
         [:div
          [:a {:on-click #(close-popup % (:popup @s) nil false false)} (tr [:game.close "Close"])]]
         (doall
-          (for [card @discard]
+          (for [card (if (sort-heap?) (sort-heap @discard) @discard)]
             ^{:key (:cid card)}
             [card-view card]))]])))
 
@@ -920,7 +932,7 @@
                          face-up (count (filter faceup? @discard))]
                      (tr [:game.face-down-count] total face-up))]]
           (doall
-            (for [[idx c] (map-indexed vector @discard)]
+            (for [[idx c] (map-indexed vector (if (sort-archives?) (sort-archives @discard) @discard))]
               ^{:key idx}
               [:div (draw-card c false)]))]]))))
 

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -17,6 +17,21 @@
         (tr [:ingame-settings.stack-cards "Stack cards"])]]]
 
      [:section
+      [:h4 (tr [:ingame-settings.card-stacking "Sorting"])]
+      [:div
+       [:label [:input {:type "checkbox"
+                        :value true
+                        :checked (get-in @app-state [:options :archives-sorted])
+                        :on-change #(swap! app-state assoc-in [:options :archives-sorted] (.. % -target -checked))}]
+        (tr [:ingame-settings.stack-cards "Sort Archives"])]]
+      [:div
+       [:label [:input {:type "checkbox"
+                        :value true
+                        :checked (get-in @app-state [:options :heap-sorted])
+                        :on-change #(swap! app-state assoc-in [:options :heap-sorted] (.. % -target -checked))}]
+        (tr [:ingame-settings.stack-cards "Sort Heap"])]]]
+
+     [:section
       [:h4 (tr [:ingame-settings.runner-board-order "Runner board order"])]
       (doall (for [option [{:name (tr [:ingame-settings.runner-classic "classic"]) :ref "jnet"}
                            {:name (tr [:ingame-settings.runner-reverse "reversed"]) :ref "irl"}]]


### PR DESCRIPTION
<img width="226" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/97d5fe1f-9b67-47e0-9f1e-08fc4f3424a7">

<img width="626" alt="Screen Shot 2023-11-18 at 13 15 32" src="https://github.com/mtgred/netrunner/assets/5345/1cc2352f-c2ed-4c97-8d76-1a389a18d6a2">

<img width="670" alt="Screen Shot 2023-11-18 at 13 15 43" src="https://github.com/mtgred/netrunner/assets/5345/3a10375e-7a72-47f1-b003-d4affe8a025d">

Intentionally didn't apply this to the card that shows at the top of the archives/heap so you can always know what the last card you played was.