### PR TITLE
Adding settings for showing card labels for face-up and/or unrezzed cards

### DIFF
--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -161,8 +161,9 @@
 
 (defn profile-keys []
   [:background :pronouns :language :default-format :show-alt-art :blocked-users
-   :alt-arts :card-resolution :deckstats :gamestats :card-zoom
-   :pin-zoom :card-back :stacked-cards :sides-overlap :archives-sorted :heap-sorted])
+   :alt-arts :card-resolution :deckstats :gamestats :card-zoom :pin-zoom
+   :card-back :stacked-cards :sides-overlap :archives-sorted :heap-sorted
+   :labeled-cards :labeled-unrezzed-cards])
 
 (defn update-profile-handler
   [{db :system/db

--- a/src/cljs/nr/about.cljs
+++ b/src/cljs/nr/about.cljs
@@ -46,6 +46,8 @@
            [:li "bbbbbbbbba: Language translations."]
            [:li "Seojun Park: Language translations."]
            [:li "PopTartNZ: High-resolution card images."]
+           [:li "Rhahi: Labelling and other QoL functionality ported with permission from "
+            [:a {:href "https://addons.mozilla.org/en-US/firefox/addon/cyberfeeder/" :target "_blank"} "Cyberfeeder"] " Firefox plugin"]
            (make-artists)
            ]
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1953,7 +1953,9 @@
         active-player (r/cursor game-state [:active-player])
         zoom-card (r/cursor app-state [:zoom])
         background (r/cursor app-state [:options :background])
-        custom-bg-url (r/cursor app-state [:options :custom-bg-url])]
+        custom-bg-url (r/cursor app-state [:options :custom-bg-url])
+        labeled-unrezzed-cards (r/cursor app-state [:options :labeled-unrezzed-cards])
+        labeled-cards (r/cursor app-state [:options :labeled-cards])]
 
     (go (while true
           (let [zoom (<! zoom-channel)]
@@ -2037,7 +2039,9 @@
                  runner-rig (r/cursor game-state [:runner :rig])
                  sfx (r/cursor game-state [:sfx])]
              [:div.gameview
-              [:div.gameboard
+              [:div {:class [:gameboard
+                             (when @labeled-unrezzed-cards :show-unrezzed-card-labels)
+                             (when @labeled-cards :show-card-labels)]}
                (let [me-keep (r/cursor game-state [me-side :keep])
                      op-keep (r/cursor game-state [op-side :keep])
                      me-quote (r/cursor game-state [me-side :quote])

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -8,13 +8,25 @@
   (fn []
     [:div.settings
      [:section
-      [:h4 (tr [:ingame-settings.card-stacking "Card stacking"])]
+      [:h4 (tr [:ingame-settings.card-stacking "Card settings"])]
       [:div
        [:label [:input {:type "checkbox"
                         :value true
                         :checked (get-in @app-state [:options :stacked-cards])
                         :on-change #(swap! app-state assoc-in [:options :stacked-cards] (.. % -target -checked))}]
-        (tr [:ingame-settings.stack-cards "Stack cards"])]]]
+        (tr [:ingame-settings.stack-cards "Stack cards"])]]
+      [:div
+       [:label [:input {:type "checkbox"
+                        :value true
+                        :checked (get-in @app-state [:options :labeled-unrezzed-cards])
+                        :on-change #(swap! app-state assoc-in [:options :labeled-unrezzed-cards] (.. % -target -checked))}]
+        (tr [:ingame-settings.stack-cards "Label unrezzed cards"])]]
+      [:div
+       [:label [:input {:type "checkbox"
+                        :value true
+                        :checked (get-in @app-state [:options :labeled-cards])
+                        :on-change #(swap! app-state assoc-in [:options :labeled-cards] (.. % -target -checked))}]
+        (tr [:ingame-settings.stack-cards "Label face up cards"])]]]
 
      [:section
       [:h4 (tr [:ingame-settings.card-stacking "Sorting"])]

--- a/src/css/cardlabels.styl
+++ b/src/css/cardlabels.styl
@@ -1,0 +1,118 @@
+card-border-radius = 3.5px
+
+showLabel()
+  position: absolute
+  background: linear-gradient(180deg, rgba(20,20,20,0.85) 0%, rgba(20,20,20,0.7) 65%, rgba(20,20,20,0) 100%)
+  text-shadow: 0 0 3px black
+  white-space: nowrap
+  text-overflow: clip
+  overflow: hidden
+  padding: 0.1rem
+  width: 100%
+  z-index: 11
+
+  &:hover
+    white-space: unset
+    text-overflow: unset
+    overflow: unset
+    font-size: 0.7em
+    z-index: 15
+
+iceLabel()
+  background: linear-gradient(270deg, rgba(20,20,20,0.85) 0%, rgba(20,20,20,0.7) 65%, rgba(20,20,20,0) 100%)
+  border-top-right-radius: card-border-radius
+  border-bottom-right-radius: card-border-radius
+  writing-mode: vertical-rl
+  width: unset
+  z-index: unset // ensures the label doesn't sit above hosted cards
+
+iceLabelForCorp()
+  iceLabel()
+  right: 0
+  top: 0
+  bottom: 0
+
+iceLabelForRunner()
+  iceLabel()
+  top: 0
+  bottom: 0
+  transform: scale(-1, -1)
+
+.gameboard
+  &.show-unrezzed-card-labels
+    .me
+      .card
+        &:hover
+          .cardname
+            z-index: 12
+            background-color: rgb(50,50,50)
+        img + .cardname
+          showLabel()
+      .content
+        img + .cardname
+          border-top-right-radius: card-border-radius
+          border-top-left-radius: card-border-radius
+
+      .ices
+        img + .cardname
+          iceLabelForCorp()
+
+  &.show-card-labels
+    .card
+      &:hover
+        .cardname // ensure label visible when card is hovered
+          z-index: 15 !important
+          background-color: rgb(50,50,50) !important
+      div + .cardname
+        showLabel()
+        border-top-left-radius: card-border-radius
+        border-top-right-radius: card-border-radius
+
+    .discard, .prompt-card-preview
+      .card
+        div + .cardname
+          z-index: -1 // hide label for top of discard
+    .scored
+      .card-wrapper + .header
+        z-index: -1 // hide score area label once agenda pops in
+    .rfg
+      .header
+        top: auto
+        bottom: 0
+
+    .me
+      .hand-controls
+        .header
+          top: auto
+          bottom: 0
+      .ices
+        div + .cardname
+          iceLabelForCorp()
+        .additional-subtypes
+          right: 8px
+          top: 10px
+          white-space: nowrap
+    .opponent
+      .ices
+        div + .cardname
+          iceLabelForRunner()
+        .strength // move strength indicator out of label
+          z-index: 15
+          top: 0.4em
+          left: unset
+          right: 0.4em
+        .additional-subtypes // move subtypes out of moved strength
+          top: 30px
+    .ices
+      .hosted
+        div + .cardname
+          z-index: 13
+          right: auto
+          top: auto
+          bottom: auto
+          width: 100%
+          writing-mode: unset
+          transform: unset
+    .identity
+      .additional-subtypes
+        top: 15px

--- a/src/css/netrunner.styl
+++ b/src/css/netrunner.styl
@@ -20,6 +20,7 @@
 @require "deckbuilder"
 @require "lobby"
 @require "gameboard"
+@require "cardlabels"
 @require "account"
 @require "help"
 @require "about"


### PR DESCRIPTION
I've ported over the labelling from the Cyberfeeder Firefox plugin (with permission from Rhahi) as these seem like they'd be very generally useful, especially for people who are streaming and having to constantly hover over cards for viewers.

Below are some screenshots - I think I've accounted for most scenarios but I'm sure there's some odd edge-case missing:

**Runner with labels off**
![runner-no-labels](https://github.com/mtgred/netrunner/assets/5345/fef811bc-72cd-45c7-8d77-ca8ade8657c4)

**Runner with labels on**
![runner-with-labels](https://github.com/mtgred/netrunner/assets/5345/5bf0cf40-5a42-40fe-b7be-49b5db4149cf)

**Corp with labels off**
![corp-no-labels](https://github.com/mtgred/netrunner/assets/5345/8ab28a65-557e-4178-ac1f-91975a0443db)

**Corp with just unrezzed labels on**
![corp-unrezzed-labels](https://github.com/mtgred/netrunner/assets/5345/11e9b782-1c88-4317-b052-b8c45c5eea1f)

**Corp with all labels on**
![corp-all-labels](https://github.com/mtgred/netrunner/assets/5345/b55f0b4a-c7f7-4656-8117-cf2bd89bb6f0)


There are definitely issues with overlapping, currently hovering over a card will make sure it's label is brought to the forefront.  I think many of these issues already exist without labels and I don't think they labels really make anything worse when it gets cluttered (and it's pretty easy to just turn them off).