### PR TITLE
Fix first sound effect not firing

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1293,14 +1293,6 @@
            [:br]
            [:button.win-right {:on-click #(swap! app-state assoc :start-shown true) :type "button"} "✘"]])))))
 
-(defn audio-component [_input]
-  (r/with-let [sfx-state (r/track #(select-keys @game-state [:sfx :sfx-current-id]))]
-    (r/create-class
-      {:display-name "audio-component"
-       :component-did-update (fn [] (update-audio @sfx-state))
-       ;; make this component rebuild when sfx changes.
-       :reagent-render (fn [sfx] @sfx nil)})))
-
 (defn get-run-ices []
   (let [server (-> (:run @game-state)
                    :server
@@ -2077,8 +2069,6 @@
                  [hand-view op-side op-hand op-hand-size op-hand-count (atom nil) (= @side :spectator)]]
 
                 [:div.inner-leftpane
-                 [audio-component sfx]
-
                  [:div.left-inner-leftpane
                   [:div
                    [stats-view opponent]
@@ -2118,3 +2108,6 @@
               (when (:replay @game-state)
                 [:div.bottompane
                  [replay-panel]])])))})))
+
+(defonce sfx (r/track #(select-keys @game-state [:sfx :sfx-current-id])))
+(defonce trigger-sfx (r/track! #(update-audio @sfx)))

--- a/src/cljs/nr/sounds.cljs
+++ b/src/cljs/nr/sounds.cljs
@@ -52,16 +52,15 @@
 
 (def sfx-last-played (atom nil))
 
-(defn update-audio [{:keys [gameid sfx sfx-current-id]}]
+(defn update-audio [{:keys [sfx sfx-current-id]}]
   ;; When it's the first game played with this state or when the sound history comes from different game,
   ;; we skip the cacophony
   (let [sfx-last-played @sfx-last-played]
     (when (and (get-in @app-state [:options :sounds])
-               (some? sfx-last-played)
-               (= gameid (:gameid sfx-last-played)))
+               (some? sfx-last-played))
       ;; Skip the SFX from queue with id smaller than the one last played, queue the rest
       (let [sfx-to-play (reduce (fn [sfx-list {:keys [id name]}]
-                                  (if (> id (:id sfx-last-played))
+                                  (if (> id sfx-last-played)
                                     (conj sfx-list name)
                                     sfx-list))
                                 []
@@ -69,5 +68,5 @@
         (play-sfx sfx-to-play))))
   ;; Remember the most recent sfx id as last played so we don't repeat it later
   (when sfx-current-id
-    (reset! sfx-last-played {:gameid gameid :id sfx-current-id})))
+    (reset! sfx-last-played sfx-current-id)))
 


### PR DESCRIPTION
The current pathway to firing sound effects is a bit awkward and lead to the issue of the first sound effect in a game not triggering - this would happen any time you reloaded the page as the atom for tracking the last sound effect would not automatically get set on things like `resync`.

This refactors out the whole component and react component rendering side effect mechanism around triggering the sound to just using the reagant reaction and track methods to trigger the sound functions directly.  This is way more consistent and works on the first sound effect.  I've checked with other clients spectating and such to ensure there's not some weirdness where you end up with all the sound effects playing at once.

I removed gameid from the "last sound" tracking atom as it wasn't actually being passed through and was always nil so the guard in the code was just always checking `(= nil nil)`.