### PR TITLE
Fix issue with multiple upgrades on R&D and Archives being unclickable

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -366,6 +366,8 @@
 
     .hand-container, .deck-container, .discard-container
         position: relative
+
+    .hand-container
         z-index: 30
 
     .hand-controls


### PR DESCRIPTION
The original change for this came in for this issue: https://github.com/mtgred/netrunner/issues/6522

I'm not really sure why this approach was taken and not sure why it was applied to `.deck-container` and `.discard-container` as these aren't the same as `.hand-container` which is for the cards in your hand not for HQ/Identity.  

I removed the z-index entirely and it doesn't recreate the above issue, but I've left the z-index 30 on `.hand-container` just in case as I don't think it's harming anything (whereas the other two are blocking the first upgrade when a second upgrade is added).

<img width="760" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/811f6a98-9c46-4c97-a7ef-ad6b5bae40b9">
