### PR TITLE
Another fix to unrezzed labels

### DIFF
--- a/src/css/cardlabels.styl
+++ b/src/css/cardlabels.styl
@@ -47,7 +47,7 @@ iceLabelForRunner()
       .me
         .card
           &:hover
-            .cardname
+            img + .cardname
               z-index: 12
               background-color: rgb(50,50,50)
           img + .cardname


### PR DESCRIPTION
One more fix to the unrezzed labels, this time on hover.  I've now played a few games with the startup decks locally and just this option on and think I've worked out the final issues 😅 