### PR TITLE
Highlight player name in logs to more easily determine side

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -50,6 +50,7 @@
   (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
   (swap! app-state assoc-in [:options :log-width] (:log-width @s))
   (swap! app-state assoc-in [:options :log-top] (:log-top @s))
+  (swap! app-state assoc-in [:options :log-player-highlight] (:log-player-highlight @s))
   (swap! app-state assoc-in [:options :blocked-users] (:blocked-users @s))
   (swap! app-state assoc-in [:options :alt-arts] (:alt-arts @s))
   (swap! app-state assoc-in [:options :gamestats] (:gamestats @s))
@@ -61,6 +62,7 @@
   (.setItem js/localStorage "sounds_volume" (:volume @s))
   (.setItem js/localStorage "log-width" (:log-width @s))
   (.setItem js/localStorage "log-top" (:log-top @s))
+  (.setItem js/localStorage "log-player-highlight" (:log-player-highlight @s))
   (.setItem js/localStorage "player-stats-icons" (:player-stats-icons @s))
   (.setItem js/localStorage "stacked-cards" (:stacked-cards @s))
   (.setItem js/localStorage "sides-overlap" (:sides-overlap @s))
@@ -373,7 +375,25 @@
            [:h4 (tr [:settings.log-size "Log size"])]
            [:div
             [log-width-option s]
-            [log-top-option s]]]
+            [log-top-option s]]
+           [:br]
+           [:h4 (tr [:settings.log-player-highlight "Log player highlight"])]
+           [:div
+            [:div.radio
+             [:label [:input {:name "log-player-highlight"
+                              :type "radio"
+                              :value "blue-red"
+                              :checked (= "blue-red" (:log-player-highlight @s))
+                              :on-change #(swap! s assoc :log-player-highlight (.. % -target -value))}]
+              (tr [:settings.log-player-highlight-red-blue "Corp: Blue / Runner: Red"])]]
+
+            [:div.radio
+             [:label [:input {:name "log-player-highlight"
+                              :type "radio"
+                              :value "none"
+                              :checked (= "none" (:log-player-highlight @s))
+                              :on-change #(swap! s assoc :log-player-highlight (.. % -target -value))}]
+              (tr [:settings.log-player-highlight-none "None"])]]]]
 
           (let [custom-bg-selected (= (:background @s) "custom-bg" )
                 custom-bg-url (r/atom (:custom-bg-url @s))]
@@ -555,6 +575,7 @@
                        :runner-board-order (get-in @app-state [:options :runner-board-order])
                        :log-width (get-in @app-state [:options :log-width])
                        :log-top (get-in @app-state [:options :log-top])
+                       :log-player-highlight (get-in @app-state [:options :log-player-highlight])
                        :gamestats (get-in @app-state [:options :gamestats])
                        :deckstats (get-in @app-state [:options :deckstats])
                        :blocked-users (sort (get-in @app-state [:options :blocked-users]))})]

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -48,6 +48,7 @@
                             :gamestats "always"
                             :log-width (str->int (get-local-value "log-width" "300"))
                             :log-top (str->int (get-local-value "log-top" "419"))
+                            :log-player-highlight (get-local-value "log-player-highlight" "blue-red")
                             :sounds (= (get-local-value "sounds" "true") "true")
                             :lobby-sounds (= (get-local-value "lobby_sounds" "true") "true")
                             :sounds-volume (str->int (get-local-value "sounds_volume" "100"))}

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -10,7 +10,7 @@
    [nr.gameboard.state :refer [game-state not-spectator?]]
    [nr.help :refer [command-info]]
    [nr.translations :refer [tr]]
-   [nr.utils :refer [influence-dot render-message]]
+   [nr.utils :refer [highlight-side influence-dot render-message]]
    [nr.ws :as ws]
    [reagent.core :as r]
    [reagent.dom :as rdom]))
@@ -175,9 +175,10 @@
          [indicate-action]
          [command-menu !input-ref state]]))))
 
-
 (defn log-messages []
-  (let [log (r/cursor game-state [:log])]
+  (let [log (r/cursor game-state [:log])
+        corp (r/cursor game-state [:corp :user :username])
+        runner (r/cursor game-state [:runner :user :username])]
     (r/create-class
       {:display-name "log-messages"
 
@@ -211,7 +212,7 @@
                  (fn [{:keys [user text timestamp]}]
                    ^{:key timestamp}
                    (if (= user "__system__")
-                     [:div.system (render-message text)]
+                     [:div.system (render-message (highlight-side text @corp @runner))]
                      [:div.message
                       [avatar user {:opts {:size 38}}]
                       [:div.content

--- a/src/cljs/nr/gameboard/log.cljs
+++ b/src/cljs/nr/gameboard/log.cljs
@@ -10,7 +10,8 @@
    [nr.gameboard.state :refer [game-state not-spectator?]]
    [nr.help :refer [command-info]]
    [nr.translations :refer [tr]]
-   [nr.utils :refer [highlight-side influence-dot render-message]]
+   [nr.utils :refer [influence-dot player-highlight-option-class
+                     render-message render-player-highlight]]
    [nr.ws :as ws]
    [reagent.core :as r]
    [reagent.dom :as rdom]))
@@ -204,7 +205,8 @@
        :reagent-render
        (fn []
          (into [:div.messages {:class [(when (:replay @game-state)
-                                         "panel-bottom")]
+                                         "panel-bottom")
+                                       (player-highlight-option-class)]
                                :on-mouse-over #(card-preview-mouse-over % zoom-channel)
                                :on-mouse-out #(card-preview-mouse-out % zoom-channel)
                                :aria-live "polite"}]
@@ -212,7 +214,7 @@
                  (fn [{:keys [user text timestamp]}]
                    ^{:key timestamp}
                    (if (= user "__system__")
-                     [:div.system (render-message (highlight-side text @corp @runner))]
+                     [:div.system (render-message (render-player-highlight text @corp @runner))]
                      [:div.message
                       [avatar user {:opts {:size 38}}]
                       [:div.content

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -10,8 +10,8 @@
    [nr.avatar :refer [avatar]]
    [nr.end-of-game-stats :refer [build-game-stats]]
    [nr.translations :refer [tr tr-format tr-lobby tr-side]]
-   [nr.utils :refer [day-word-with-time-formatter faction-icon
-                     format-date-time notnum->zero num->percent render-message
+   [nr.utils :refer [day-word-with-time-formatter faction-icon format-date-time
+                     highlight-side notnum->zero num->percent render-message
                      set-scroll-top store-scroll-top]]
    [nr.ws :as ws]
    [reagent.core :as r]))
@@ -129,7 +129,9 @@
      :component-will-unmount #(store-scroll-top % log-scroll-top)
      :reagent-render
      (fn [state _log-scroll-top]
-       (let [game (:view-game @state)]
+       (let [game (:view-game @state)
+             corp (get-in game [:corp :player :username])
+             runner (get-in game [:runner :player :username])]
          [:div {:style {:overflow "auto"}}
           [:div.panel.messages
            (if (seq (:log game))
@@ -137,7 +139,7 @@
                       (fn [i msg]
                         (when-not (and (= (:user msg) "__system__") (= (:text msg) "typing"))
                           (if (= (:user msg) "__system__")
-                            [:div.system {:key i} (render-message (:text msg))]
+                            [:div.system {:key i} (render-message (highlight-side (:text msg) corp runner))]
                             [:div.message {:key i}
                              [avatar (:user msg) {:opts {:size 38}}]
                              [:div.content

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -11,8 +11,8 @@
    [nr.end-of-game-stats :refer [build-game-stats]]
    [nr.translations :refer [tr tr-format tr-lobby tr-side]]
    [nr.utils :refer [day-word-with-time-formatter faction-icon format-date-time
-                     highlight-side notnum->zero num->percent render-message
-                     set-scroll-top store-scroll-top]]
+                     notnum->zero num->percent player-highlight-option-class
+                     render-message render-player-highlight set-scroll-top store-scroll-top]]
    [nr.ws :as ws]
    [reagent.core :as r]))
 
@@ -133,13 +133,13 @@
              corp (get-in game [:corp :player :username])
              runner (get-in game [:runner :player :username])]
          [:div {:style {:overflow "auto"}}
-          [:div.panel.messages
+          [:div.panel.messages {:class (player-highlight-option-class)}
            (if (seq (:log game))
              (doall (map-indexed
                       (fn [i msg]
                         (when-not (and (= (:user msg) "__system__") (= (:text msg) "typing"))
                           (if (= (:user msg) "__system__")
-                            [:div.system {:key i} (render-message (highlight-side (:text msg) corp runner))]
+                            [:div.system {:key i} (render-message (render-player-highlight (:text msg) corp runner))]
                             [:div.message {:key i}
                              [avatar (:user msg) {:opts {:size 38}}]
                              [:div.content

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -304,17 +304,22 @@
   [input]
   (render-specials (render-icons (render-cards input))))
 
-(defn highlight-patterns-impl [corp runner]
+(defn- player-highlight-patterns-impl [corp runner]
   (letfn [(regex-of [player-name] (re-pattern (str "(?i)" (regex-escape player-name))))]
     (->> {corp [:span.corp-username corp]
           runner [:span.runner-username runner]}
          (filter (fn [[k _]] (not-empty k)))
          (map (fn [[k v]] [(regex-of k) v]))
          (sort-by (comp count str first) >))))
-(def highlight-patterns (memoize highlight-patterns-impl))
+(def player-highlight-patterns (memoize player-highlight-patterns-impl))
 
-(defn highlight-side [message corp runner]
-  (render-input message (highlight-patterns corp runner)))
+(defn render-player-highlight [message corp runner]
+  (render-input message (player-highlight-patterns corp runner)))
+
+(defn player-highlight-option-class []
+  (case (get-in @app-state [:options :log-player-highlight])
+    "blue-red" "log-player-highlight-red-blue"
+               nil))
 
 (defn cond-button
   [text cond f]

--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -292,12 +292,7 @@
 (defn render-cards
   "Render all cards in a given text or HTML fragment input"
   [input]
-  (cond
-    (re-find (contains-card-pattern) (or input ""))
-    (render-input input (card-patterns))
-    (string? input) [:<> input]
-    (vector? input) input
-    :else [:<>]))
+  (render-input input (card-patterns)))
 
 (defn render-specials
   "Render all special codes in a given text or HTML fragment input"
@@ -307,9 +302,19 @@
 (defn render-message
   "Render icons, cards and special codes in a message"
   [input]
-  (if (string? input)
-    (render-specials (render-icons (render-cards input)))
-    input))
+  (render-specials (render-icons (render-cards input))))
+
+(defn highlight-patterns-impl [corp runner]
+  (letfn [(regex-of [player-name] (re-pattern (str "(?i)" (regex-escape player-name))))]
+    (->> {corp [:span.corp-username corp]
+          runner [:span.runner-username runner]}
+         (filter (fn [[k _]] (not-empty k)))
+         (map (fn [[k v]] [(regex-of k) v]))
+         (sort-by (comp count str first) >))))
+(def highlight-patterns (memoize highlight-patterns-impl))
+
+(defn highlight-side [message corp runner]
+  (render-input message (highlight-patterns corp runner)))
 
 (defn cond-button
   [text cond f]

--- a/src/css/chat.styl
+++ b/src/css/chat.styl
@@ -104,13 +104,15 @@
     button
         margin-right: 0
 
-.corp-username
-    font-weight: bold
-    color: blue-light
+.log-player-highlight-red-blue
+    .corp-username
+        font-weight: bold
+        color: blue-light
 
-.runner-username
-    font-weight: bold
-    color: red-core
+    .runner-username
+        font-weight: bold
+        color: red-core
+
 
 .typing
     position: absolute

--- a/src/css/chat.styl
+++ b/src/css/chat.styl
@@ -104,6 +104,14 @@
     button
         margin-right: 0
 
+.corp-username
+    font-weight: bold
+    color: blue-light
+
+.runner-username
+    font-weight: bold
+    color: red-core
+
 .typing
     position: absolute
     margin: 0


### PR DESCRIPTION
![image](https://github.com/mtgred/netrunner/assets/5345/607e6d09-cdb5-4544-af55-0348c938043a)

Adds an additional message render helper to put the player names in different spans when they are found in the message.  This makes it possible to add styles to these spans to make it more obvious if the player is Corp or Runner.  This should also make it much easier to do tricks like redacting the player names in replays, etc.

Additionally I made sure this processing runs before the `render-cards` helper which means that player names will no longer get turned into cards (example is "Imposter" above which normally would get a card link for "Imp").