### PR TITLE
Ensure current 'Format' setting loads on settings form

### DIFF
--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -543,6 +543,7 @@
                        :pronouns (get-in @app-state [:options :pronouns])
                        :language (get-in @app-state [:options :language])
                        :sounds (get-in @app-state [:options :sounds])
+                       :default-format (get-in @app-state [:options :default-format])
                        :lobby-sounds (get-in @app-state [:options :lobby-sounds])
                        :volume (get-in @app-state [:options :sounds-volume])
                        :show-alt-art (get-in @app-state [:options :show-alt-art])


### PR DESCRIPTION
The current `/account` page doesn't populate the Format select with whatever value is set, this fixes that so you don't accidentally reset back to `Standard`.