### PR TITLE
Fix AirbladeX prompting to prevent outside of a run

### DIFF
--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -115,7 +115,7 @@
                                     :effect (effect (unregister-suppress-by-uuid (:uuid suppress)))}])))}]
     {:data {:counter {:power 3}}
      :interactions {:prevent [{:type #{:net}
-                               :req (req true)}]}
+                               :req (req run)}]}
      :events [(trash-on-empty :power)
               {:event :encounter-ice
                :req (req (contains? (card-def current-ice) :on-encounter))

--- a/src/clj/game/core/damage.clj
+++ b/src/clj/game/core/damage.clj
@@ -152,9 +152,10 @@
   "for a preventable damage instance, handles all damage prevention effects that a player can use for it"
   ([state side eid type n player]
    (let [interrupts (get-prevent-list state player type)
+         cards-can-prevent (cards-can-prevent? state player interrupts type nil {:side side})
          other-player (if (= player :corp) :runner :corp)
          already-prevented (or (get-in @state [:damage :damage-prevent type]) 0)]
-     (if (and (cards-can-prevent? state player interrupts type nil {:side side})
+     (if (and cards-can-prevent
               (> n already-prevented))
        ;; player can prevent damage
        (do (system-msg state player "has the option to prevent damage")

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -330,7 +330,7 @@
    (ab-can-prevent? state side (make-eid state) card req-fn target args))
   ([state side eid card req-fn target args]
    (cond
-     req-fn (req-fn state side eid card (list (assoc args :prevent-target target)))
+     req-fn (if (req-fn state side eid card (list (assoc args :prevent-target target))) true false)
      :else false)))
 
 (defn get-card-prevention

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -126,6 +126,19 @@
         (card-ability state :runner airbladex 0))
       (is (= 1 (get-counters (refresh airbladex) :power)) "Spent 1 hosted power counter"))))
 
+(deftest airbladex-jsrd-ed-no-prevent-prompt-outside-run
+  (do-game
+    (new-game {:runner {:hand ["AirbladeX (JSRF Ed.)" (qty "Sure Gamble" 3)]}
+               :corp {:hand ["Reaper Function"]}})
+    (play-from-hand state :corp "Reaper Function" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "AirbladeX (JSRF Ed.)")
+    (take-credits state :runner)
+    (end-phase-12 state :corp)
+    (click-prompt state :corp "Yes")
+    (is (no-prompt? state :runner) "No damage prevention prompt outside of run")))
+
 (deftest akamatsu-mem-chip
   ;; Akamatsu Mem Chip - Gain 1 memory
   (do-game


### PR DESCRIPTION
Also updates `ab-can-prevent?` to check truthiness so that any `:req` on prevent map can do truthy returns rather than having to be exactly true.