### PR TITLE
Support www.netrunnerdb.com decklist URLs when importing decks

### DIFF
--- a/src/clj/web/nrdb.clj
+++ b/src/clj/web/nrdb.clj
@@ -3,7 +3,6 @@
             [monger.collection :as mc]
             [monger.operators :refer :all]
             [org.httpkit.client :as http]
-            [clj-uuid :as uuid]
             [clojure.string :as str]))
 
 (def nrdb-decklist-url "https://netrunnerdb.com/api/2.0/public/decklist/")
@@ -12,7 +11,8 @@
 (defn- parse-input
   "Want to handle an NRDB URL or just a deck id number"
   [input]
-  (let [input (if (str/starts-with? input nrdb-readable-url)
+  (let [input (str/replace input "www.netrunnerdb.com" "netrunnerdb.com")
+        input (if (str/starts-with? input nrdb-readable-url)
                 (subs input (count nrdb-readable-url))
                 input)
         [id] (str/split input #"/")]


### PR DESCRIPTION
Determined this was an issue from people mentioning import problems on GLC.  Discovered it's because they are importing via www URLs.

Maybe there's a more clever way with regexs here but this does work.