### PR TITLE
Allow deckbuilder to retain cards that are surrounded by square brackets

### DIFF
--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -137,7 +137,7 @@
   "Parse a single line of a deck string"
   [line]
   (let [clean (s/trim line)
-        [_ qty-str card-name _ card-params] (re-matches #"(\d+)[^\s]*\s+([^\[]+)(\[(.*)\])?" clean)]
+        [_ qty-str card-name card-params] (re-matches #"(\d+)[^\s]*\s+(([^\[]+)|(\[(.*)\]))" clean)]
     (if (and qty-str
              (not (js/isNaN (str->int qty-str)))
              card-name)


### PR DESCRIPTION
Some deployments have cards with names that are surrounded with square brackets, the deckbuilder will find these cards when searched for but when editing later the square bracket card will get filtered out.  The current regex seems to sort of be aware of this case but doesn't handle it properly.

This update will make it so it will consider it valid for cards to either:
* have no `[` character in the card name (this is the old behavior)
* have the card name start with `[` and end with `]`

<img width="651" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/a82fe28b-f98b-4352-8b36-3fd8b76d6f76">
