### PR TITLE
Don't sort choices when deck is not shuffled

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -198,7 +198,7 @@
     :req (req (not-empty (:deck corp)))
     :effect (effect (continue-ability
                       {:prompt "Choose a card to install"
-                       :choices (cancellable (filter corp-installable-type? (take 5 (:deck corp))) :sorted)
+                       :choices (cancellable (filter corp-installable-type? (take 5 (:deck corp))))
                        :async true
                        :effect (effect (corp-install eid target nil
                                                      {:ignore-all-cost true

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -2034,7 +2034,7 @@
                   :choices
                   (cancellable (filter #(and (corp-installable-type? %)
                                              (some #{"New remote"} (installable-servers state %)))
-                                       top-five) :sorted)
+                                       top-five))
                   :msg "install a card from the top of the R&D in a remote server"
                   :effect (effect (continue-ability (install-card target) card nil))
                   :cancel-effect (effect (system-msg (str "declines to use " (get-title card) " to install a card from the top of R&D"))


### PR DESCRIPTION
Don't actually want to sort these when you are seeing the top X cards of the deck and the card name might be in the list multiple times.