### PR TITLE
Show run phase in continue multimethod default error throwing

### DIFF
--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -475,10 +475,11 @@
                         2500)))))
 
 (defmethod continue :default
-  [_ _ _]
+  [state _ _]
   (.println *err* (with-out-str
                     (print-stack-trace
-                      (Exception. "Continue clicked at the wrong time")
+                      (Exception.
+                        (str "Continue clicked at the wrong time, run phase: " (:phase (:run @state))))
                       2500))))
 
 (defn redirect-run


### PR DESCRIPTION
The majority of errors in the logs look like this:

```
java.lang.Exception: Continue clicked at the wrong time
 at game.core.runs$fn__9682$fn__9683.invoke (runs.clj:480)
    game.core.runs$fn__9682.invokeStatic (runs.clj:479)
    game.core.runs/fn (runs.clj:477)
    clojure.lang.MultiFn.invoke (MultiFn.java:239)
    clojure.lang.Var.invoke (Var.java:393)
    game.core.process_actions$process_action.invokeStatic (process_actions.clj:91)
    game.core.process_actions$process_action.invoke (process_actions.clj:88)
    game.main$handle_action.invokeStatic (main.clj:16)
    game.main$handle_action.invoke (main.clj:13)
    clojure.lang.AFn.applyToHelper (AFn.java:165)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:669)
    clojure.core$apply.invoke (core.clj:662)
    web.game$update_and_send_diffs_BANG_.invokeStatic (game.clj:42)
    web.game$update_and_send_diffs_BANG_.doInvoke (game.clj:36)
    clojure.lang.RestFn.invoke (RestFn.java:490)
    web.game$fn__84495.invokeStatic (game.clj:183)
    web.game/fn (game.clj:169)
    clojure.lang.MultiFn.invoke (MultiFn.java:229)
    web.ws$event_msg_handler.invokeStatic (ws.clj:116)
    web.ws$event_msg_handler.invoke (ws.clj:112)
    taoensso.sente$_start_chsk_router_BANG_$fn__79224$state_machine__70478__auto____79245$fn__79247$inst_79215__79265.invoke (sente.cljc:2092)
    taoensso.sente$_start_chsk_router_BANG_$fn__79142.invoke (sente.cljc:2078)
    taoensso.sente$_start_chsk_router_BANG_$fn__79224$state_machine__70478__auto____79245$fn__79247.invoke (sente.cljc:2080)
    taoensso.sente$_start_chsk_router_BANG_$fn__79224$state_machine__70478__auto____79245.invoke (sente.cljc:2080)
    clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic (ioc_macros.clj:978)
    clojure.core.async.impl.ioc_macros$run_state_machine.invoke (ioc_macros.clj:977)
    clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic (ioc_macros.clj:982)
    clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke (ioc_macros.clj:980)
    clojure.core.async$ioc_alts_BANG_$fn__70707.invoke (async.clj:421)
    clojure.core.async$do_alts$fn__70646$fn__70649.invoke (async.clj:288)
    clojure.core.async.impl.channels.ManyToManyChannel$fn__68771$fn__68772.invoke (channels.clj:99)
    clojure.lang.AFn.run (AFn.java:22)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    clojure.core.async.impl.concurrent$counted_thread_factory$reify__68674$fn__68675.invoke (concurrent.clj:29)
    clojure.lang.AFn.run (AFn.java:22)
    java.lang.Thread.run (Thread.java:829)
```

I'm unable to figure out how to reproduce this issue locally, and the current error doesn't show what path the multimethod tried to go down.