### PR TITLE
Fix :tag-or-bad-pub cost always resolving to remove tag when tag available

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -328,7 +328,7 @@
        :choices [(str "Remove " (quantify (value cost) "tag"))
                  (str "Gain " (value cost) " bad publicity")]
        :async true
-       :effect (req (if (= target (str "Gain " (value cost) "bad publicity"))
+       :effect (req (if (= target (str "Gain " (value cost) " bad publicity"))
                       (wait-for (gain-bad-publicity state side (make-eid state eid) (value cost) nil)
                                 (complete-with-result state side eid {:msg (str "gains " (value cost) " bad publicity")
                                                                       :type :tag-or-bad-pub

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -7447,6 +7447,17 @@
           (rez state :corp (get-ice state :rd 0)))
         "Corp got 1 bad publicity even if runner is considered tagged")))
 
+(deftest valentao-choosing-bad-pub-with-tags
+  (do-game
+    (new-game {:corp {:hand ["Valentão"]}})
+    (play-from-hand state :corp "Valentão" "HQ")
+    (gain-tags state :runner 1)
+    (is (changed? [(count-bad-pub state) 1
+                   (count-tags state) 0]
+          (rez state :corp (get-ice state :hq 0) {:expect-rez false})
+          (click-prompt state :corp "Gain 1 bad publicity"))
+        "Corp gained 1 bad publicity")))
+
 (deftest valentao-subs
   (do-game
     (new-game {:corp {:hand ["Valentão"]


### PR DESCRIPTION
We forgot a space when checking if prompt was bad pub choice

Fixes #7283