### PR TITLE
Ack toasts explicitly and prevent toast cycles

### DIFF
--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -19,7 +19,7 @@
    [game.core.say :refer [indicate-action say system-msg system-say]]
    [game.core.set-up :refer [keep-hand mulligan]]
    [game.core.shuffling :refer [shuffle-deck]]
-   [game.core.toasts :refer [toast]]
+   [game.core.toasts :refer [ack-toast]]
    [game.core.turns :refer [end-phase-12 end-turn start-turn]]
    [game.core.winning :refer [concede]]))
 
@@ -78,7 +78,7 @@
    "start-turn" #'start-turn
    "subroutine" #'play-subroutine
    "system-msg" #(system-msg %1 %2 (:msg %3))
-   "toast" #'toast
+   "toast" #'ack-toast
    "toggle-auto-no-action" #'toggle-auto-no-action
    "trash" #(trash %1 %2 (make-eid %1) (get-card %1 (:card %3)) (dissoc %3 :card))
    "trash-resource" #'trash-resource

--- a/src/clj/game/core/toasts.clj
+++ b/src/clj/game/core/toasts.clj
@@ -1,4 +1,6 @@
-(ns game.core.toasts)
+(ns game.core.toasts
+  (:require
+    [clj-uuid :as uuid]))
 
 (defn toast
   "Adds a message to toast with specified severity (default as a warning) to the toast message list.
@@ -13,11 +15,13 @@
   ([state side message msg-type] (toast state side message msg-type nil))
   ([state side message msg-type options]
    ;; Allows passing just the toast msg-type as the options parameter
-   (if message
+   (when  message
      ;; normal toast - add to list
-     (swap! state update-in [side :toast] #(conj % {:msg message :type msg-type :options options}))
-     ;; no message - remove top toast from list
-     (swap! state update-in [side :toast] rest))))
+     (swap! state update-in [side :toast] #(conj % {:msg message :type msg-type :options options :id (uuid/v4)})))))
+
+(defn ack-toast
+  ([state side {:keys [id]}]
+   (swap! state update-in [side :toast] (fn [toasts] (remove #(= (:id %) (uuid/as-uuid id)) toasts)))))
 
 (defn show-error-toast
   [state side]

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -108,18 +108,19 @@
       (build-report-url error)
       "');\">Report on GitHub</button></div>")))
 
+(defn ack-toast ([id] (send-command "toast" {:id id})))
+
 (defn toast
   "Display a toast warning with the specified message.
   Sends a command to clear any server side toasts."
   [msg toast-type options]
   (set! (.-options js/toastr) (toastr-options options))
   (let [f (aget js/toastr (if (= "exception" toast-type) "error" toast-type))]
-    (f (if (= "exception" toast-type) (build-exception-msg msg (:last-error @game-state)) msg))
-    (when-not (or (= "error" toast-type) (= "exception" toast-type))
-      (send-command "toast"))))
+    (f (if (= "exception" toast-type) (build-exception-msg msg (:last-error @game-state)) msg))))
 
 (defonce side (r/cursor game-state [:side]))
 (defonce me-toasts (ratom/reaction (get-in @game-state [@side :toast])))
-(defn handle-toasts-changed [] (doseq [{:keys [msg type options]} @me-toasts]
-                                 (toast msg type options)))
+(defn handle-toasts-changed [] (doseq [{:keys [id msg type options]} @me-toasts]
+                                 (toast msg type options)
+                                 (ack-toast id)))
 (defonce watch-toasts (r/track! handle-toasts-changed))


### PR DESCRIPTION
There's currently an issue where toasts seem to be able to cause a cycle where the existing toast isn't cleared but updates the client state to think there is a new toast which leads to a new diff which then cycles infinitely popping up a toast over and over.

The current way of dismissing the toasts is currently not consistent as toasts are just dismissed FIFO regardless of what triggered.  This change adds a uuid to each toast to allow them to be explicitly ack'd.

Further I've memoized the ack function on the client side to ensure it only sends a message once to the server for that client's session to prevent an infinite loop if the message fails to ack on the server for whatever reason.