### PR TITLE
RWR bugfixes

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -732,7 +732,7 @@
                                           (corp-installable-type? %))}
                     :msg "install and rez 1 card from HQ, paying 5 [Credits] less"
                     :async true
-                    :effect (req (corp-install state side (make-eid state eid) target nil
+                    :effect (req (corp-install state side eid target nil
                                                {:install-state :rezzed
                                                 :combined-credit-discount 5}))}
         score-abi {:interactive (req true)

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1943,7 +1943,7 @@
                                   (assoc {:msg (msg "make the runner encounter " (card-str state enc-ice) " again")
                                           :async true
                                           :effect (req
-                                                    (force-ice-encounter state side eid enc-ice))}
+                                                    (force-ice-encounter state side eid enc-ice :encounter-ice))}
                                          :cost (if (= target "Pay 1 [Credit]")
                                                  [:credit 1]
                                                  [:trash-from-hand 1]))

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1164,6 +1164,8 @@
             {:event :runner-turn-ends
              :req (req (seq (filter #(= (:zone %) [:servers zone :ices])
                                     (all-active-installed state :corp))))
+             :duration :end-of-turn
+             :unregister-once-resolved true
              :effect (req (let [derez-count
                                 (min 2 (count (filter #(= (:zone %) [:servers zone :ices])
                                                       (all-active-installed state :corp))))]

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -18,7 +18,7 @@
    [game.core.damage :refer [damage damage-bonus]]
    [game.core.def-helpers :refer [corp-recur defcard do-net-damage
                                   offer-jack-out reorder-choice get-x-fn]]
-   [game.core.drawing :refer [draw]]
+   [game.core.drawing :refer [draw draw-up-to]]
    [game.core.effects :refer [register-lingering-effect]]
    [game.core.eid :refer [effect-completed make-eid]]
    [game.core.engine :refer [pay register-events resolve-ability
@@ -1129,10 +1129,11 @@
                       (update-all-agenda-points state)
                       (check-win-by-agenda state side)
                       (effect-completed state side eid))
-         :cancel-effect (effect (system-msg (str "declines to use " (:title card))))}]
+         :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
+                                (effect-completed eid))}]
     {:on-score {:async true
                 :effect (req (wait-for
-                               (draw state side 3)
+                               (draw-up-to state side card 3)
                                (continue-ability state side add-abi card nil)))}}))
 
 (defcard "Labyrinthine Servers"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1165,7 +1165,6 @@
              :req (req (seq (filter #(= (:zone %) [:servers zone :ices])
                                     (all-active-installed state :corp))))
              :duration :end-of-turn
-             :unregister-once-resolved true
              :effect (req (let [derez-count
                                 (min 2 (count (filter #(= (:zone %) [:servers zone :ices])
                                                       (all-active-installed state :corp))))]

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -4140,7 +4140,7 @@
                   (if (seq targets-in-the-grip)
                     {:prompt "Choose 1 program or piece of hardware"
                      :waiting-prompt true
-                     :choices (req targets-in-the-grip)
+                     :choices (req (cancellable targets-in-the-grip))
                      :async true
                      :effect (effect (runner-install (assoc eid :source card :source-type :runner-install) target))
                      :msg (msg "install " (:title target) " from the grip")}

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -180,8 +180,8 @@
 (defcard "Amanuensis"
   {:static-abilities [(mu+ 1)]
    :events [{:event :runner-lose-tag
-             :req (req (= :runner side))
              :optional {:prompt "Remove 1 power counter to draw 2 cards?"
+                        :req (req (= :runner (second targets)))
                         :yes-ability {:cost [:power 1]
                                       :msg "draw 2 cards"
                                       :async true

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1199,18 +1199,18 @@
    :events [{:event :end-of-encounter
              :req (req (and (= :this-turn (:rezzed card))
                             (same-card? (:ice context) card)))
-             :msg "force the Runner to choose a subroutine to resolve"
+             :msg "force the Runner to choose an effect"
              :effect (effect (continue-ability
                                {:prompt "Choose one"
                                 :player :runner
-                                :choices (req [(when (seq (all-installed-runner state)) "Corp trashes 1 Runner card")
+                                :choices (req ["Corp trashes 1 Runner card"
                                                (when-not (forced-to-avoid-tags? state side) "Take 2 tags")
                                                (when (can-pay? state :runner eid card nil :net 3)
                                                  "Suffer 3 net damage")])
                                 :async true
                                 :effect (req
                                           (continue-ability
-                                            state :runner
+                                            state (if (= target "Corp trashes 1 Runner card") :corp :runner)
                                             (cond
                                               (= target "Corp trashes 1 Runner card")
                                               trash-installed-sub

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2005,6 +2005,7 @@
   (let [shuffle-ab
         {:label "Draw 1 card and shuffle 2 agendas in HQ and/or Archives into R&D"
          :msg "draw 1 card"
+         :cost [:credit 1]
          :effect
          (req (wait-for
                 (draw state side 1)

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2005,6 +2005,7 @@
   (let [shuffle-ab
         {:label "Draw 1 card and shuffle 2 agendas in HQ and/or Archives into R&D"
          :msg "draw 1 card"
+         :async true
          :cost [:credit 1]
          :effect
          (req (wait-for

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2746,10 +2746,10 @@
              :effect (effect (add-counter :runner card :virus 2))}]})
 
 (defcard "Pressure Spike"
-  (auto-icebreaker {:implementation "Once per run restriction not enforced"
-                    :abilities [(break-sub 1 1 "Barrier")
-                                (strength-pump 2 3)
-                                (strength-pump 2 9 :end-of-encounter {:req (req (threat-level 4 state))})]}))
+  {:implementation "Once per run restriction not enforced. Auto-breaking disabled for this card."
+   :abilities [(break-sub 1 1 "Barrier")
+               (strength-pump 2 3)
+               (strength-pump 2 9 :end-of-encounter {:req (req (threat-level 4 state))})]}_)
 
 (defcard "Progenitor"
   {:abilities [{:label "Install and host a virus program"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -685,11 +685,11 @@
   (letfn [(was-a-runner-card?
             [target]
             (runner? (:card (first target))))]
-    (auto-icebreaker {:implementation "Effect only applies for printed abilities"
-                      :abilities [(break-sub 1 2 "Sentry" (cond-breaker :runner-trash was-a-runner-card?))
-                                  (break-sub 2 2 "Sentry")
-                                  (strength-pump 2 3 :end-of-encounter (cond-breaker :runner-trash was-a-runner-card?))
-                                  (strength-pump 3 3)]})))
+    {:implementation "Effect only applies for printed abilities"
+     :abilities [(break-sub 1 2 "Sentry" (cond-breaker :runner-trash was-a-runner-card?))
+                 (break-sub 2 2 "Sentry")
+                 (strength-pump 2 3 :end-of-encounter (cond-breaker :runner-trash was-a-runner-card?))
+                 (strength-pump 3 3)]}))
 
 (defcard "Botulus"
   {:implementation "[Erratum] Program: Virus - Trojan"
@@ -2749,7 +2749,7 @@
   {:implementation "Once per run restriction not enforced. Auto-breaking disabled for this card."
    :abilities [(break-sub 1 1 "Barrier")
                (strength-pump 2 3)
-               (strength-pump 2 9 :end-of-encounter {:req (req (threat-level 4 state))})]}_)
+               (strength-pump 2 9 :end-of-encounter {:req (req (threat-level 4 state))})]})
 
 (defcard "Progenitor"
   {:abilities [{:label "Install and host a virus program"

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -29,6 +29,7 @@
    [game.core.flags :refer [can-host? can-trash? card-flag? lock-zone release-zone zone-locked?]]
    [game.core.gaining :refer [gain-clicks gain-credits lose-credits]]
    [game.core.hosting :refer [host]]
+   [game.core.identities :refer [disable-card enable-card]]
    [game.core.ice :refer [all-subs-broken-by-card? all-subs-broken?
                           any-subs-broken-by-card? auto-icebreaker break-sub
                           break-subroutine! break-subroutines-msg breaker-strength-bonus dont-resolve-subroutine!
@@ -1044,12 +1045,13 @@
                                         :sorted))
              :cost [:credit 1]
              :msg (msg "host " (:title target) " on itself")
-             :effect (req (host state side (assoc card :seen true) target)
+             :effect (req (disable-card state side (get-card state target))
+                          (host state side (assoc card :seen true) target)
                           (effect-completed state side eid))}
             {:event :breach-server
              :async true
-             :optional {:req (req (= :hq target)
-                                  (seq (filter corp? (:hosted card))))
+             :optional {:req (req (and (= :hq target)
+                                       (seq (filter corp? (:hosted card)))))
                         :prompt "Trash this program to access 2 additional cards from HQ?"
                         :yes-ability {:async true
                                       :effect (effect (access-bonus :hq 2)
@@ -1062,9 +1064,12 @@
                                    :cost [:credit 1]
                                    :msg (msg "host " (:title target) " on itself")
                                    :async true
-                                   :effect (req (host state side (assoc card :seen true) target)
-                                                (swap! state dissoc :access)
-                                                (effect-completed state side eid))}}})
+                                   :effect (req
+                                             (disable-card state side (get-card state target))
+                                             (host state side (assoc card :seen true)
+                                                   (get-card state target))
+                                             (swap! state dissoc :access)
+                                             (effect-completed state side eid))}}})
 
 (defcard "Curupira"
   (auto-icebreaker {:abilities [(break-sub 1 1 "Barrier")

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -3701,6 +3701,7 @@
                                                                                                 " to " (decapitalize target))))
                                :else (effect-completed state side eid)))}
    :events [{:event :runner-lose-tag
+             :req (req (= :runner (second targets)))
              :player :runner
              :msg "gain 1 [Credits]"
              :async true

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1832,7 +1832,12 @@
   {:data {:counter {:power 4}}
    :events [(trash-on-empty :power)
             {:event :runner-spent-click
+             :once :per-turn
              :req (req (let [all-cards (get-all-cards state)]
+                         ;; TODO - assert this works when (e.g.) using the last click on lib-acc
+                         ;; and having it trashed (all-cards wont find it)
+                         ;; also asset that the first-event? fn actually works right...
+                         ;; -nbk, mar '24
                          (and (resource? (find-cid (first target) all-cards))
                               (first-event? state side :runner-spent-click
                                             #(resource?

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -77,7 +77,8 @@
                                  (conj (server->zone state target) :content))]
                      (unregister-events state side card)
                      (register-default-events state side c)
-                     (continue-ability state side callback c nil)))}}}))
+                     (wait-for (resolve-ability state side callback c nil)
+                               (effect-completed state side eid))))}}}))
 
 ;; Card definitions
 
@@ -897,18 +898,13 @@
                                        (zero? (get-counters % :advancement))
                                        (same-server? card %))
                                  (all-installed-corp state)))
-                 :async true
-                 :effect
-                 (effect
-                   (continue-ability
-                     {:prompt "Choose a piece of ice protecting this server to place 1 advancement counter on"
-                      :waiting-prompt true
-                      :choices {:card #(and (ice? %)
-                                            (zero? (get-counters % :advancement))
-                                            (same-server? % card))}
-                      :msg (msg "place 1 advancement counter on " (card-str state target))
-                      :effect (effect (add-prop target :advance-counter 1 {:placed true}))}
-                     card nil))}]
+                 :prompt "Choose a piece of ice protecting this server to place 1 advancement counter on"
+                 :waiting-prompt true
+                 :choices {:req (req (and (ice? target)
+                                          (zero? (get-counters target :advancement))
+                                          (same-server? target card)))}
+                 :msg (msg "place 1 advancement counter on " (card-str state target))
+                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]
     {:static-abilities [{:type :ice-strength
                          :req (req (and (ice? target)
                                         (= (card->server state card) (card->server state target))))

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -346,27 +346,24 @@
     (encounter-ice state side eid ice)))
 
 (defn force-ice-encounter
-  [state side eid ice]
-  ;; clears the broken subs out of the prompt, otherwise they can get stuck with some cards
-  (reset-all-subs! state (get-card state ice))
-  (show-run-prompts state (str "encountering " (:title ice)) ice)
-  ;; do we need to mess with the run state
-  (let [old-state (get-in @state [:run :phase])
-        new-state (if (= :movement old-state)
-                    :encounter-ice
-                    old-state)]
-    (system-msg state side old-state)
-    (system-msg state side new-state)
-    (set-phase state new-state)
-    (wait-for (encounter-ice state side (make-eid state eid) ice)
-              ;; reset the state if needed
-              (when (= new-state (get-in @state [:run :phase]))
-                (set-phase state old-state))
-              (clear-run-prompts state)
-              (if (and (not (:run @state))
-                       (empty? (:encounters @state)))
-                (forced-encounter-cleanup state :runner eid)
-                (effect-completed state side eid)))))
+  ([state side eid ice] (force-ice-encounter state side eid ice nil))
+  ([state side eid ice new-state]
+   ;; clears the broken subs out of the prompt, otherwise they can get stuck with some cards
+   (reset-all-subs! state (get-card state ice))
+   (show-run-prompts state (str "encountering " (:title ice)) ice)
+   ;; do we need to mess with the run state
+   (let [old-state (get-in @state [:run :phase])]
+     (when new-state
+       (set-phase state new-state))
+     (wait-for (encounter-ice state side (make-eid state eid) ice)
+               ;; reset the state if needed
+               (clear-run-prompts state)
+               (if (and (not (:run @state))
+                        (empty? (:encounters @state)))
+                 (forced-encounter-cleanup state :runner eid)
+                 (do (when (and new-state (= new-state (get-in @state [:run :phase])))
+                       (set-phase state old-state))
+                     (effect-completed state side eid)))))))
 
 (defmethod continue :encounter-ice
   [state side _]

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -2132,11 +2132,25 @@
                    (count (:hand (get-corp))) 1
                    (:agenda-point (get-corp)) 3]
                   (play-and-score state "Kingmaking")
+                  (click-prompt state :corp "3")
                   (click-card state :corp "Project Atlas")
                   (is (not (no-prompt? state :corp)) "Couldn't choose 2-points agenda")
                   (click-card state :corp "House of Knives"))
         "Corp drew 3 cards (2 of which moved to the score area)")
     (is (zero? (get-counters (get-scored state :runner 1) :agenda)) "House of Knives should have 0 agenda counters")))
+
+(deftest kingmaking-draw-n
+  (dotimes [n 4]
+    (do-game
+      (new-game {:corp {:hand ["Kingmaking" "Hedge Fund"]
+                        :deck ["House of Knives" "Project Atlas" "Hedge Fund"]}})
+      (is (changed? [(count (:deck (get-corp))) (- n)
+                     (count (:hand (get-corp))) (- n 1)]
+                    (play-and-score state "Kingmaking")
+                    (click-prompt state :corp (str n))
+                    (click-prompt state :corp "Done"))
+          (str "Corp drew " n " cards")))))
+
 
 (deftest license-acquisition
   ;; License Acquisition

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -2216,7 +2216,10 @@
       (click-card state :corp rime)
       (is (not (rezzed? (refresh archer))))
       (is (not (rezzed? (refresh rime))))
-      (is (rezzed? (refresh bloop))))))
+      (is (rezzed? (refresh bloop)))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (no-prompt? state :corp) "no repeat prompt"))))
 
 (deftest longevity-serum-basic-behavior
     ;; Basic behavior

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -7422,7 +7422,7 @@
       (take-credits state :corp)
       (play-from-hand state :runner "Window of Opportunity")
       (click-prompt state :runner "HQ")
-      (is (= 2 (-> (prompt-map :runner) :choices count)) "Runner has 2 choices")
+      (is (= 3 (-> (prompt-map :runner) :choices count)) "Runner has 3 choices (done is a choice)")
       (is (changed? [(:credit (get-runner)) -1]
                     (click-prompt state :runner "Fermenter"))
           "Runner paid Fermenter install cost")

--- a/test/clj/game/cards/hardware_test.clj
+++ b/test/clj/game/cards/hardware_test.clj
@@ -183,6 +183,20 @@
                   (click-prompt state :runner "Yes"))
         "Spend a power counter when removing a tag to draw 2 cards")))
 
+(deftest amanuensis-corp-spend-tag
+  (do-game
+    (new-game {:runner {:hand ["Amanuensis"]
+                        :deck [(qty "Sure Gamble" 2)]}
+               :corp {:hand ["End of the Line"]}})
+    (take-credits state :corp)
+    (gain-tags state :runner 1)
+    (play-from-hand state :runner "Amanuensis")
+    (is (changed? [(get-counters (get-hardware state 0) :power) 1]
+                  (take-credits state :runner))
+        "Amanuensis gains a power counter at end of turn")
+    (play-from-hand state :corp "End of the Line")
+    (is (no-prompt? state :runner) "No runner prompt for amen")))
+
 (deftest aniccam-trash-trash-before-and-after-install-does-not-trigger
   ;; Aniccam
   (doseq [first-side [:corp :runner]

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1577,7 +1577,7 @@
                     (card-subroutine state :corp (refresh ce) 2))
           "Runner suffered 3 net damage")
       (run-continue state :movement)
-      (is (= 1 (count (prompt-buttons :runner))) "Runner doesn't have the option to suffer net damage or trash installed cards")
+      (is (= 2 (count (prompt-buttons :runner))) "Runner doesn't have the option to suffer net damage")
       (is (changed? [(count-tags state) 2]
                     (click-prompt state :runner "Take 2 tags"))
           "Runner got 2 tags")

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2042,6 +2042,21 @@
                     (dotimes [_ 3] (click-prompt state :runner "No action")))
           "Cupellation and its hosted card are trashed"))))
 
+(deftest cupellation-disables-cards
+  (do-game
+    (new-game {:runner {:hand ["Cupellation"]}
+               :corp {:hand ["Marilyn Campaign"]}})
+    (play-from-hand state :corp "Marilyn Campaign" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Cupellation")
+    (is (= 8 (get-counters (get-content state :remote1 0) :credit)) "Marilyn Campaign should start with 8 credits")
+    (run-on state "Server 1")
+    (run-continue state)
+    (click-prompt state :runner "[Cupellation] 1 [Credits]: Host a card")
+    (take-credits state :runner)
+    (is (= 8 (get-counters (first (:hosted (get-program state 0))) :credit)))))
+
 (deftest curupira
   (do-game
     (new-game {:runner {:hand ["Curupira"]

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -891,7 +891,7 @@
       (run-continue state)
       (is (no-prompt? state :runner) "Black Orchestra prompt did not come up")))
 
-(deftest boi-tata
+(deftest ^:kaocha/pending boi-tata
   (do-game
     (new-game {:corp {:credits 6 :deck ["Ansel 1.0"] }
                :runner {:credits 15

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -7118,6 +7118,18 @@
                   (click-prompt state :runner "Gain 2 [Credits]"))
         "Threat 3: Runner can gain 2 credits when installing Valentina")))
 
+(deftest valentina-ferreira-carvalho-op-tag
+  (do-game
+    (new-game {:runner {:hand ["Valentina Ferreira Carvalho"]}
+               :corp {:hand ["End of the Line"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Valentina Ferreira Carvalho")
+    (gain-tags state :runner 1)
+    (take-credits state :runner)
+    (is (changed? [(:credit (get-runner)) 0]
+                  (play-from-hand state :corp "End of the Line"))
+        "Runner does NOT gain a credit from EOTL")))
+
 (deftest verbal-plasticity
   ;; Verbal Plasticity
   (do-game

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -1914,7 +1914,8 @@
       (is (changed? [(get-strength (refresh tithe)) 2
                      (get-counters (refresh tithe) :advancement) 1]
                     (click-card state :corp tithe))
-          "Tithe got +2 strength and 1 advancement counter"))))
+          "Tithe got +2 strength and 1 advancement counter")
+      (is (no-prompt? state :runner) "No lingering prompt"))))
 
 (deftest jinja-city-grid-single-draws
     ;; Single draws


### PR DESCRIPTION
descent charges a credit when expended (closes #7312) - not testing
Juli moreira once per turn (closes #7310)
valentina only when runner removes tags (closes #7309) - unit tests
amaneunsis only works when runner removes tags (closes #7313) - unit tests
cloud eater trash program ability (closes #7321)
lightning lab demanding use every turn (closes #7324) - unit tests
kingmaking draw-up-to (and async on decline) (closes #7316, closes #7325) - unit tests
cupellation disables cards when hosting them (closes #7326) - unit tests
fixed async issues on descent and eminent domain (closes #7327 ) - no tests
fixed isaac lingering prompt (closes #7319) - unit tests
fixed Window of Op optional (closes #7315) - no tests
removed auto-break from pressure spike and boi-tata until we figure those out (closes #7322, closes #7320)
Updated force-ice-encounter to not offer jack-out when used during a run (but before access) (Closes #7308)

===============

Praccess actually works they way it's meant to now. The changes are mostly sane, needing to store an ephemeral state while resolving each install is so that Jarogniew Mercs taking a tag doesn't load a second copy of the same event (which is now resolving in a different window), which would then resolve first (before allowing you to resolve, say, your trigger from seb), before returning you to the first window with an empty button to press (because it's already resolved).
Reading that paragraph may induce a schizm. It is what it is. I'm not probably not writing a unit test for this case, because it's cumbersome to actually reproduce the bad behaviour.
If we get more complaints later then I'll work that out.
Closes #7317 and also Closes #7311 (I'm getting all three installs, before if you ordered wrong you missed one)