### PR TITLE
Limit undo click stack to 4 clicks max

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -36,7 +36,8 @@
   [cost state side eid card actions]
   (let [a (keep :action actions)]
     (when (not (some #{:steal-cost} a))
-      (swap! state update :click-states conj (dissoc @state :log :history)))
+      (swap! state update :click-states (fn [click-states]
+                                          (vec (take-last 4 (conj click-states (dissoc @state :log :history)))))))
     (swap! state update-in [:stats side :lose :click] (fnil + 0) (value cost))
     (deduct state side [:click (value cost)])
     (wait-for (trigger-event-sync state side (make-eid state eid)


### PR DESCRIPTION
People like to make stuff like infinite click tricks and "win before runner gets a turn" stuff - in those cases there might be enough undo clicks to start to cause memory issues.