### PR TITLE
first five mode

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -22,7 +22,7 @@
   [{uid :uid
     user :user
     {:keys [gameid now
-            allow-spectator api-access format mute-spectators password room save-replay
+            allow-spectator api-access first-five format mute-spectators password room save-replay
             side singleton spectatorhands timer title]
      :or {gameid (random-uuid)
           now (inst/now)}} :options}]
@@ -38,6 +38,7 @@
      ;; options
      :allow-spectator allow-spectator
      :api-access api-access
+     :first-five first-five
      :format format
      :mute-spectators mute-spectators
      :password (when (not-empty password) (bcrypt/encrypt password))
@@ -109,6 +110,7 @@
   [:allow-spectator
    :api-access
    :date
+   :first-five
    :format
    :gameid
    :messages

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -128,11 +128,12 @@
         (let [c (count (:spectators game))]
           (when (pos? c) (str " (" (tr [:lobby.spectator-count] c) ")"))))])
 
-(defn game-format [{fmt :format singleton? :singleton}]
+(defn game-format [{fmt :format singleton? :singleton first-five? :first-five}]
   [:div {:class "game-format"}
    [:span.format-label (tr [:lobby.format "Format"]) ":  "]
    [:span.format-type (tr-format (slug->format fmt "Unknown"))]
-   [:span.format-singleton (str (when singleton? " (singleton)"))]])
+   [:span.format-singleton (str (when singleton? " (singleton)"))]
+   [:span.format-first-five (str (when first-five? " (first-five mode)"))]])
 
 (defn players-row [{players :players :as game}]
   (into

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -11,6 +11,7 @@
 (def new-game-keys
   [:allow-spectator
    :api-access
+   :first-five
    :format
    :password
    :room
@@ -69,11 +70,17 @@
                   :checked (= @side-state option)}]
          (tr-side option)]]))])
 
-(defn singleton-only [options fmt-state]
+(defn singleton-only [options]
   [:label
    [:input {:type "checkbox" :checked (:singleton @options)
             :on-change #(swap! options assoc :singleton (.. % -target -checked))}]
    (tr [:lobby.singleton "Singleton"])])
+
+(defn first-five-mode [options]
+  [:label
+   [:input {:type "checkbox" :checked (:first-five @options)
+            :on-change #(swap! options assoc :first-five (.. % -target -checked))}]
+   (tr [:lobby.first-five "First Five Mode"])])
 
 (defn format-section [fmt-state options]
   [:section
@@ -85,7 +92,7 @@
       (for [[k v] slug->format]
         ^{:key k}
         [:option {:value k} (tr-format v)]))]
-   [singleton-only options fmt-state]
+   [singleton-only options]
    [:div.infobox.blue-shade
     {:style {:display (if (:singleton @options) "block" "none")}}
     [:p "This will restrict decklists to only those which do not contain any duplicate cards. It is recommended you use the listed singleton-based identities."]
@@ -187,6 +194,10 @@
 (defn options-section [options user]
   [:section
    [:h3 (tr [:lobby.options "Options"])]
+   [first-five-mode options]
+   [:div.infobox.blue-shade
+    {:style {:display (if (:first-five @options) "block" "none")}}
+    [:p "This will allow each player to choose their starting hand, instead of the regular draw/mulligan system."]]
    [allow-spectators options]
    [toggle-hidden-info options]
    [password-input options]
@@ -202,6 +213,7 @@
                               :title (str (:username @user) "'s game")})
                options (r/atom {:allow-spectator true
                                 :api-access false
+                                :first-five false
                                 :password ""
                                 :protected false
                                 :save-replay (not= "casual" (:room @lobby-state))

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -84,6 +84,11 @@
     [:div.infobox.blue-shade
      [:p "This lobby is running in singleton mode. This means decklists will be restricted to only those which do not contain any duplicate cards."]]))
 
+(defn first-five-info-box [current-game]
+  (when (:first-five @current-game)
+    [:div.infobox.blue-shade
+     [:p "This lobby is running in first-five mode. This means that instead of draws and mulligans, players will decide their opening hands."]]))
+
 (defn swap-sides-button [user gameid players]
   (when (first-user? @players @user)
     (if (< 1 (count @players))
@@ -191,6 +196,7 @@
      [:div.content
       [:h2 (:title @current-game)]
       [singleton-info-box current-game]
+      [first-five-info-box current-game]
       (when-not (every? :deck @players)
         [:div.flash-message
          (tr [:lobby.waiting "Waiting players deck selection"])])

--- a/src/css/lobby.styl
+++ b/src/css/lobby.styl
@@ -134,6 +134,12 @@
             color: #ff571a;
             font-style: bold;
 
+        .format-first-five
+            background-image: linear-gradient(to left, green, yellow, orange, red);
+            -webkit-background-clip: text;
+            font-style: bold;
+            color: transparent;
+
         .format-label
             font-weight: bold
 


### PR DESCRIPTION
A mode allowing for starting hands to be pulled from the deck (non-dupliates only).

Intended for april fools, but I believe it's a keepable feature.

Why yes, every single corp list does include one copy of Crisium Grid, how could you tell?