### PR TITLE
Add system messages for Bacterial Programming and Spin Doctor

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -296,14 +296,15 @@
                             (wait-for (trash-cards state :corp to-trash {:unpreventable true :cause-card card})
                                       (doseq [h to-hq]
                                         (move state :corp h :hand))
-                                      (if (seq remaining)
-                                        (continue-ability state :corp (reorder-choice :corp (vec remaining)) card nil)
-                                        (do (system-msg state :corp
-                                                        (str "uses " (:title card)
-                                                             " to add " (quantify (count to-hq) "card")
-                                                             " to HQ, discard " (count to-trash)
-                                                             ", and arrange the top cards of R&D"))
-                                            (effect-completed state :corp eid))))
+                                      (do
+                                        (system-msg state :corp
+                                                    (str "uses " (:title card)
+                                                         " to trash " (quantify (count to-trash) "card")
+                                                         ", add " (quantify (count to-hq) "card")
+                                                         " to HQ, and arrange the top " (quantify (- 7 (count to-trash) (count to-hq)) "card") " of R&D"))
+                                        (if (seq remaining)
+                                          (continue-ability state :corp (reorder-choice :corp (vec remaining)) card nil)
+                                          (effect-completed state :corp eid))))
                             (continue-ability state :corp (hq-step
                                                             (set/difference (set remaining) (set [target]))
                                                             to-trash

--- a/src/clj/game/core/shuffling.clj
+++ b/src/clj/game/core/shuffling.clj
@@ -46,7 +46,9 @@
       :effect (req (doseq [c targets]
                      (move state side c :deck))
                    (shuffle! state side :deck))
-      :cancel-effect (req (shuffle! state side :deck))}
+      :cancel-effect (req 
+                      (system-msg state side (str " uses " (:title card) " to shuffle their deck")) 
+                      (shuffle! state side :deck))}
      card nil)))
 
 (defn shuffle-deck


### PR DESCRIPTION
Bacterial Programming only spits out a message if you dont reorder RnD, I fixed that. It prints the message after the corp trashes and adds to HQ, that's when we know the final numbers for everything. I wanted to print the message when the corp was done reordering but that ended up being more difficult than I expected so I settled for this.

I saw from a stream that people didnt know that although Spin Doctor doesnt print anything when you shuffle 0 cards in, but still shuffles the deck. I put a system message in the shuffle-rnd `cancel` effect because its not really a cancel as it still does a shuffle.