### PR TITLE
Card disable system experimental overhaul

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -9,7 +9,7 @@
    [game.core.bad-publicity :refer [gain-bad-publicity lose-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed all-installed-corp
                             all-installed-runner-type get-remote-names installable-servers server->zone]]
-   [game.core.card :refer [agenda? asset?
+   [game.core.card :refer [agenda? asset? can-be-advanced?
                            corp-installable-type? corp? facedown? faceup? get-agenda-points
                            get-card get-counters get-title get-zone has-subtype? ice? in-discard? in-hand?
                            in-scored? installed? operation? program? resource? rezzed? runner? upgrade?]]
@@ -25,7 +25,7 @@
                              unregister-events]]
    [game.core.events :refer [first-event? first-run-event? no-event? run-events run-event-count turn-events]]
    [game.core.finding :refer [find-latest]]
-   [game.core.flags :refer [can-really-be-advanced? in-runner-scored? is-scored? register-run-flag!
+   [game.core.flags :refer [in-runner-scored? is-scored? register-run-flag!
                             register-turn-flag! when-scored? zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-clicks
                               lose-credits]]
@@ -263,19 +263,19 @@
    :abilities [{:cost [(->c :agenda 1)]
                 :label "place 1 advancement counter"
                 :msg (msg "place 1 advancement counter on " (card-str state target))
-                :choices {:req (req (can-really-be-advanced? state target))}
+                :choices {:req (req (can-be-advanced? state target))}
                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]})
 
 (defcard "Award Bait"
   {:flags {:rd-reveal (req true)}
    :on-access {:async true
-               :req (req (not-empty (filter #(can-really-be-advanced? state %) (all-installed state :corp))))
+               :req (req (not-empty (filter #(can-be-advanced? state %) (all-installed state :corp))))
                :waiting-prompt true
                :prompt "How many advancement tokens do you want to place?"
                :choices ["0" "1" "2"]
                :effect (effect (continue-ability
                                  (let [c (str->int target)]
-                                   {:choices {:req (req (can-really-be-advanced? state target))}
+                                   {:choices {:req (req (can-be-advanced? state target))}
                                     :msg (msg "place " (quantify c "advancement token")
                                               " on " (card-str state target))
                                     :effect (effect (add-prop :corp target :advance-counter c {:placed true}))})
@@ -824,7 +824,7 @@
    :abilities [{:cost [(->c :agenda 1)]
                 :label "Place 1 advancement counter"
                 :choices {:req (req (and (ice? target)
-                                         (can-really-be-advanced? state target)))}
+                                         (can-be-advanced? state target)))}
                 :req (req (pos? (get-counters card :agenda)))
                 :msg (msg "place 1 advancement counter on " (card-str state target))
                 :once :per-turn
@@ -1002,7 +1002,7 @@
                             (continue-ability
                               state side
                               {:choices {:not-self true
-                                         :req (req (can-really-be-advanced? state target))}
+                                         :req (req (can-be-advanced? state target))}
                                :msg (msg "place " (quantify n "advancement token")
                                          " on " (card-str state target))
                                :effect (effect (add-prop :corp target :advance-counter n {:placed true}))}
@@ -1681,7 +1681,7 @@
              :interactive (req true)
              :waiting-prompt true
              :prompt "Choose a card that can be advanced to place 1 advancement token on"
-             :choices {:req (req (can-really-be-advanced? state card))}
+             :choices {:req (req (can-be-advanced? state card))}
              :msg (msg "place 1 advancement token on " (card-str state target))
              :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}]})
 
@@ -1965,9 +1965,9 @@
                                   card nil))))}]}))
 
 (defcard "Slash and Burn Agriculture"
-  {:expend {:req (req (some #(can-really-be-advanced? state %) (all-installed state :corp)))
+  {:expend {:req (req (some #(can-be-advanced? state %) (all-installed state :corp)))
             :cost [(->c :credit 1)]
-            :choices {:req (req (can-really-be-advanced? state target))}
+            :choices {:req (req (can-be-advanced? state target))}
             :msg (msg "place 2 advancement counters on " (card-str state target))
             :async true
             :effect (req

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -9,7 +9,7 @@
    [game.core.bad-publicity :refer [gain-bad-publicity lose-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed all-installed-corp
                             all-installed-runner-type get-remote-names installable-servers server->zone]]
-   [game.core.card :refer [agenda? asset? can-be-advanced?
+   [game.core.card :refer [agenda? asset?
                            corp-installable-type? corp? facedown? faceup? get-agenda-points
                            get-card get-counters get-title get-zone has-subtype? ice? in-discard? in-hand?
                            in-scored? installed? operation? program? resource? rezzed? runner? upgrade?]]
@@ -25,7 +25,7 @@
                              unregister-events]]
    [game.core.events :refer [first-event? first-run-event? no-event? run-events run-event-count turn-events]]
    [game.core.finding :refer [find-latest]]
-   [game.core.flags :refer [in-runner-scored? is-scored? register-run-flag!
+   [game.core.flags :refer [can-really-be-advanced? in-runner-scored? is-scored? register-run-flag!
                             register-turn-flag! when-scored? zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-clicks
                               lose-credits]]
@@ -263,19 +263,19 @@
    :abilities [{:cost [(->c :agenda 1)]
                 :label "place 1 advancement counter"
                 :msg (msg "place 1 advancement counter on " (card-str state target))
-                :choices {:card can-be-advanced?}
+                :choices {:req (req (can-really-be-advanced? state target))}
                 :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]})
 
 (defcard "Award Bait"
   {:flags {:rd-reveal (req true)}
    :on-access {:async true
-               :req (req (not-empty (filter #(can-be-advanced? %) (all-installed state :corp))))
+               :req (req (not-empty (filter #(can-really-be-advanced? state %) (all-installed state :corp))))
                :waiting-prompt true
                :prompt "How many advancement tokens do you want to place?"
                :choices ["0" "1" "2"]
                :effect (effect (continue-ability
                                  (let [c (str->int target)]
-                                   {:choices {:card can-be-advanced?}
+                                   {:choices {:req (req (can-really-be-advanced? state target))}
                                     :msg (msg "place " (quantify c "advancement token")
                                               " on " (card-str state target))
                                     :effect (effect (add-prop :corp target :advance-counter c {:placed true}))})
@@ -823,8 +823,8 @@
               :effect (effect (add-counter card :agenda 3))}
    :abilities [{:cost [(->c :agenda 1)]
                 :label "Place 1 advancement counter"
-                :choices {:card #(and (ice? %)
-                                      (can-be-advanced? %))}
+                :choices {:req (req (and (ice? target)
+                                         (can-really-be-advanced? state target)))}
                 :req (req (pos? (get-counters card :agenda)))
                 :msg (msg "place 1 advancement counter on " (card-str state target))
                 :once :per-turn
@@ -1002,7 +1002,7 @@
                             (continue-ability
                               state side
                               {:choices {:not-self true
-                                         :card #(can-be-advanced? %)}
+                                         :req (req (can-really-be-advanced? state target))}
                                :msg (msg "place " (quantify n "advancement token")
                                          " on " (card-str state target))
                                :effect (effect (add-prop :corp target :advance-counter n {:placed true}))}
@@ -1681,7 +1681,7 @@
              :interactive (req true)
              :waiting-prompt true
              :prompt "Choose a card that can be advanced to place 1 advancement token on"
-             :choices {:card can-be-advanced?}
+             :choices {:req (req (can-really-be-advanced? state card))}
              :msg (msg "place 1 advancement token on " (card-str state target))
              :effect (effect (add-prop :corp target :advance-counter 1 {:placed true}))}]})
 
@@ -1965,9 +1965,9 @@
                                   card nil))))}]}))
 
 (defcard "Slash and Burn Agriculture"
-  {:expend {:req (req (some #(can-be-advanced? %) (all-installed state :corp)))
+  {:expend {:req (req (some #(can-really-be-advanced? state %) (all-installed state :corp)))
             :cost [(->c :credit 1)]
-            :choices {:card #(can-be-advanced? %)}
+            :choices {:req (req (can-really-be-advanced? state target))}
             :msg (msg "place 2 advancement counters on " (card-str state target))
             :async true
             :effect (req

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -11,7 +11,7 @@
                                     lose-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed all-installed-runner-type get-remotes
                             installable-servers]]
-   [game.core.card :refer [agenda? asset? corp? event? corp-installable-type?
+   [game.core.card :refer [agenda? asset? can-be-advanced? corp? event? corp-installable-type?
                            faceup? fake-identity? get-advancement-requirement
                            get-agenda-points get-card get-counters get-title get-zone hardware? has-subtype? ice?
                            identity? in-deck? in-discard? in-hand? in-server? installed? is-type?
@@ -28,7 +28,7 @@
    [game.core.engine :refer [pay register-events resolve-ability trigger-event]]
    [game.core.events :refer [first-event? no-event? turn-events event-count]]
    [game.core.expose :refer [expose-prevent]]
-   [game.core.flags :refer [can-really-be-advanced? lock-zone prevent-current
+   [game.core.flags :refer [lock-zone prevent-current
                             prevent-draw
                             register-turn-flag! release-zone]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-clicks
@@ -684,7 +684,7 @@
                                    :title)]
                   (as-> (all-installed state :corp) it
                     (filter ice? it)
-                    (filter #(can-really-be-advanced? state %) it)
+                    (filter #(can-be-advanced? state %) it)
                     (remove empty? it)
                     (map :title it)
                     (split-with (partial not= a-token) it)
@@ -702,7 +702,7 @@
                               {:prompt "Choose a piece of ice that can be advanced"
                                :choices {:req (req (and (ice? target)
                                                         (not (same-card? from-ice target))
-                                                        (can-really-be-advanced? state target)))}
+                                                        (can-be-advanced? state target)))}
                                :msg (msg "move an advancement token from "
                                          (card-str state from-ice)
                                          " to "
@@ -920,12 +920,12 @@
 
 (defcard "Early Premiere"
   {:derezzed-events [corp-rez-toast]
-   :flags {:corp-phase-12 (req (some #(and (can-really-be-advanced? state %)
+   :flags {:corp-phase-12 (req (some #(and (can-be-advanced? state %)
                                            (in-server? %))
                                      (all-installed state :corp)))}
    :abilities [{:cost [(->c :credit 1)]
                 :label "Place 1 advancement token on a card that can be advanced in a server"
-                :choices {:req (req (and (can-really-be-advanced? state target)
+                :choices {:req (req (and (can-be-advanced? state target)
                                          (installed? target)
                                          (in-server? target)))} ; should be *in* a server
                 :once :per-turn
@@ -1244,7 +1244,7 @@
 (defcard "Hearts and Minds"
   (let [political {:req (req unprotected)
                    :prompt "Choose a card you can advance to place 1 advancement counter on"
-                   :choices {:req (req (and (can-really-be-advanced? state target)
+                   :choices {:req (req (and (can-be-advanced? state target)
                                             (installed? target)))}
                    :msg (msg "place 1 advancement counter on " (card-str state target))
                    :effect (effect (add-prop target :advance-counter 1 {:placed true}))}
@@ -1261,7 +1261,7 @@
                              (let [from-ice target]
                                {:prompt "Choose an installed card you can advance"
                                 :choices {:req (req (and (installed? target)
-                                                         (can-really-be-advanced? state target)
+                                                         (can-be-advanced? state target)
                                                          (not (same-card? from-ice target))))}
                                 :msg (msg "move 1 hosted advancement counter from "
                                           (card-str state from-ice)
@@ -2333,7 +2333,7 @@
                                  state side
                                  {:async true
                                   :prompt "Choose a card that can be advanced"
-                                  :choices {:req (req (can-really-be-advanced? state target))}
+                                  :choices {:req (req (can-be-advanced? state target))}
                                   :effect (effect (add-counter target :advancement num-counters {:placed true})
                                                   (system-msg (str "uses " (:title card) " to move " (quantify num-counters "hosted advancement token") " to " (card-str state target)))
                                                   (effect-completed eid))}
@@ -2614,7 +2614,7 @@
                 :prompt "Place 1 advancement token on a card that can be advanced?"
                 :yes-ability {:msg (msg "place 1 advancement token on " (card-str state target))
                               :prompt "Choose a card to place an advancement token on"
-                              :choices {:req (req (can-really-be-advanced? state target))}
+                              :choices {:req (req (can-be-advanced? state target))}
                               :effect (effect (add-prop target :advance-counter 1 {:placed true}))}}}})
 
 (defcard "Spin Doctor"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -22,9 +22,9 @@
                                   reorder-choice trash-on-empty get-x-fn]]
    [game.core.drawing :refer [draw first-time-draw-bonus max-draw
                               remaining-draws]]
-   [game.core.effects :refer [register-lingering-effect]]
+   [game.core.effects :refer [is-disabled? register-lingering-effect]]
    [game.core.eid :refer [complete-with-result effect-completed is-basic-advance-action? make-eid]]
-   [game.core.engine :refer [pay register-events resolve-ability]]
+   [game.core.engine :refer [pay register-events resolve-ability trigger-event]]
    [game.core.events :refer [first-event? no-event? turn-events event-count]]
    [game.core.expose :refer [expose-prevent]]
    [game.core.flags :refer [lock-zone prevent-current
@@ -1595,6 +1595,7 @@
 (defcard "Malia Z0L0K4"
   (let [unmark
         (req (when-let [malia-target (:malia-target card)]
+               (update! state side (assoc (get-card state card) :malia-target nil))
                (remove-icon state :runner card (get-card state malia-target)))
              ;; I'm not sure why the side is nil here
              ;; but the old impl had it, so 🤷
@@ -1610,7 +1611,10 @@
      :leave-play unmark
      :move-zone unmark
      :static-abilities [{:type :disable-card
-                         :req (req (same-card? target (get-in card [:malia-target])))
+                         :req (req (and
+                                     (get-card state card)
+                                     (rezzed? (get-card state card))
+                                     (same-card? target (get-in card [:malia-target]))))
                          :value true}]}))
 
 

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1593,16 +1593,25 @@
              :effect (req (gain-tags state :runner eid 1))}]})
 
 (defcard "Malia Z0L0K4"
-  {:on-rez {:msg (msg "blank the text box of " (card-str state target))
-            :choices {:card #(and (runner? %)
-                                  (installed? %)
-                                  (resource? %)
-                                  (not (has-subtype? % "Virtual")))}
-            :effect (effect (add-icon card target "MZ" (faction-label card))
-                            (update! (assoc (get-card state card) :malia-target target)))}
-   :static-abilities [{:type :disable-card
-                       :req (req (same-card? target (get-in card [:malia-target])))
-                       :value true}]})
+  (let [unmark
+        (req (when-let [malia-target (:malia-target card)]
+               (remove-icon state :runner card (get-card state malia-target)))
+             ;; I'm not sure why the side is nil here
+             ;; but the old impl had it, so 🤷
+             ;; --nbk, Apr '24
+             (effect-completed state nil eid))]
+    {:on-rez {:msg (msg "blank the text box of " (card-str state target))
+              :choices {:card #(and (runner? %)
+                                    (installed? %)
+                                    (resource? %)
+                                    (not (has-subtype? % "Virtual")))}
+              :effect (effect (add-icon card target "MZ" (faction-label card))
+                              (update! (assoc (get-card state card) :malia-target target)))}
+     :leave-play unmark
+     :move-zone unmark
+     :static-abilities [{:type :disable-card
+                         :req (req (same-card? target (get-in card [:malia-target])))
+                         :value true}]}))
 
 
 (defcard "Marilyn Campaign"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1591,28 +1591,17 @@
              :effect (req (gain-tags state :runner eid 1))}]})
 
 (defcard "Malia Z0L0K4"
-  (let [re-enable-target
-        (req (if-let [malia-target (:malia-target card)]
-               (if (:disabled (get-card state malia-target))
-                 (do (system-msg state side (str "uses " (:title card) " to unblank "
-                                                 (card-str state malia-target)))
-                     (enable-card state :runner (get-card state malia-target))
-                     (remove-icon state :runner card (get-card state malia-target))
-                     (if-let [reactivate-effect (:reactivate (card-def malia-target))]
-                       (resolve-ability state :runner eid reactivate-effect (get-card state malia-target) nil)
-                       (effect-completed state nil eid)))
-                 (effect-completed state nil eid))
-               (effect-completed state nil eid)))]
-    {:on-rez {:msg (msg "blank the text box of " (card-str state target))
-              :choices {:card #(and (runner? %)
-                                    (installed? %)
-                                    (resource? %)
-                                    (not (has-subtype? % "Virtual")))}
-              :effect (effect (add-icon card target "MZ" (faction-label card))
-                              (update! (assoc (get-card state card) :malia-target target))
-                              (disable-card :runner (get-card state target)))}
-     :leave-play re-enable-target
-     :move-zone re-enable-target}))
+  {:on-rez {:msg (msg "blank the text box of " (card-str state target))
+            :choices {:card #(and (runner? %)
+                                  (installed? %)
+                                  (resource? %)
+                                  (not (has-subtype? % "Virtual")))}
+            :effect (effect (add-icon card target "MZ" (faction-label card))
+                            (update! (assoc (get-card state card) :malia-target target)))}
+   :static-abilities [{:type :disable-card
+                       :req (req (same-card? target (get-in card [:malia-target])))
+                       :value true}]})
+
 
 (defcard "Marilyn Campaign"
   (let [ability {:once :per-turn

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1116,7 +1116,6 @@
                                      (same-card? target (:identity runner))))
 
                        :value true}]
-   :disable-id true
    :on-play {:async true
              :effect (req
                        ;; note - this fake checkpoint forces abilities like RP to be blank
@@ -1291,8 +1290,7 @@
   {:on-play {:msg "disable the Corp's identity"}
    :static-abilities [{:type :disable-card
                        :req (req (same-card? target (:identity corp)))
-                       :value true}]
-   :disable-id true})
+                       :value true}]})
 
 (defcard "En Passant"
   {:on-play
@@ -3329,9 +3327,9 @@
                                  (or (asset? card)
                                      (upgrade? card))
                                  (not (has-subtype? card "Region"))))]
-    {:static-abilities[{:type :disable-card
-                        :req (req (eligible? target))
-                        :value true}]}))
+    {:static-abilities [{:type :disable-card
+                         :req (req (eligible? target))
+                         :value true}]}))
 
 (defcard "Run Amok"
   (letfn [(get-rezzed-cids [ice]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -140,7 +140,8 @@
   ([cost qty] (bioroid-break cost qty nil))
   ([cost qty args]
    (break-sub [(->c :lose-click cost)] qty nil
-              (assoc args :req (req (currently-encountering-card card state))))))
+              (assoc args :req (req (and (not (is-disabled-reg? state card))
+                                         (currently-encountering-card card state)))))))
 
 ;;; General subroutines
 (def end-the-run
@@ -3549,7 +3550,7 @@
                                     (let [choice (:card-target card)
                                           cards async-result
                                           dmg (some #(when (= (:type %) choice) %) cards)]
-                                      (if dmg
+                                      (if (and dmg (not (is-disabled-reg? state card)))
                                         (do (system-msg state :corp (str "uses " (:title card) " to deal 1 additional net damage"))
                                             (damage state side eid :net 1 {:card card}))
                                         (effect-completed state side eid)))))}]

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2158,7 +2158,6 @@
    :subroutines [end-the-run]})
 
 (defcard "Hive"
-  ;; TODO - make this work with hush
   (let [corp-points (fn [corp] (min 5 (max 0 (- 5 (:agenda-point corp 0)))))
         ability {:silent (req true)
                  :effect (effect (reset-printed-subs card (corp-points corp) end-the-run))}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -489,6 +489,7 @@
     {:on-rez {:effect ef}
      :events [(assoc rez-ability :event :rez)
               (assoc rez-ability :event :derez)
+              (assoc trash-ability :event :subroutines-should-update :req nil)
               (assoc trash-ability :event :game-trash)
               (assoc trash-ability :event :corp-trash)
               (assoc trash-ability :event :runner-trash)]}))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -7,7 +7,7 @@
    [game.core.board :refer [all-active-installed all-installed all-installed-runner 
                             all-installed-runner-type card->server
                             get-all-cards get-all-installed server->zone]]
-   [game.core.card :refer [active? agenda? asset? card-index
+   [game.core.card :refer [active? agenda? asset? card-index can-be-advanced?
                            corp? corp-installable-type? faceup?
                            get-card get-counters get-zone
                            hardware? has-subtype? ice? in-discard? in-hand? installed? is-type? operation?
@@ -27,7 +27,7 @@
                              ]]
    [game.core.events :refer [first-event? run-events]]
    [game.core.finding :refer [find-cid]]
-   [game.core.flags :refer [can-really-be-advanced? can-rez? card-flag? prevent-draw prevent-jack-out
+   [game.core.flags :refer [can-rez? card-flag? prevent-draw prevent-jack-out
                             register-run-flag! register-turn-flag! run-flag? zone-locked?]]
    [game.core.gaining :refer [gain-credits lose-clicks lose-credits]]
    [game.core.hand-size :refer [hand-size]]
@@ -1038,7 +1038,7 @@
   (let [sub {:label "Place 1 advancement token on a piece of ice that can be advanced protecting this server"
              :msg (msg "place 1 advancement token on " (card-str state target))
              :choices {:req (req (and (ice? target)
-                                      (can-really-be-advanced? state target)))}
+                                      (can-be-advanced? state target)))}
              :effect (effect (add-prop target :advance-counter 1 {:placed true}))}]
     {:abilities [{:label "Move this ice to the outermost position of any server"
                   :cost [(->c :click 1)]
@@ -2142,7 +2142,7 @@
                                                  state side
                                                  {:msg (msg "pay " c " [Credits] and place " (quantify c "advancement token")
                                                             " on " (card-str state target))
-                                                  :choices {:req (req (can-really-be-advanced? state target))}
+                                                  :choices {:req (req (can-be-advanced? state target))}
                                                   :effect (effect (add-prop target :advance-counter c {:placed true}))}
                                                  card nil)))
                                    (effect-completed state side eid))))}]
@@ -2894,7 +2894,7 @@
 
 (defcard "Matrix Analyzer"
   {:on-encounter {:cost [(->c :credit 1)]
-                  :choices {:req (req (can-really-be-advanced? state target))}
+                  :choices {:req (req (can-be-advanced? state target))}
                   :msg (msg "place 1 advancement token on " (card-str state target))
                   :effect (effect (add-prop target :advance-counter 1 {:placed true}))}
    :subroutines [(tag-trace 2)]})
@@ -4286,10 +4286,10 @@
                :waiting-prompt true
                :req (req (and (can-pay? state side eid card nil [(->c :credit 1)])
                               (some #(or (not (rezzed? %))
-                                         (can-really-be-advanced? state %))
+                                         (can-be-advanced? state %))
                                     (all-installed state :corp))))
                :yes-ability {:cost [(->c :credit 1)]
-                             :choices {:req (req (can-really-be-advanced? state target))}
+                             :choices {:req (req (can-be-advanced? state target))}
                              :prompt "Choose a card that can be advanced"
                              :msg (msg "place 1 advancement counter on " (card-str state target))
                              :effect (effect (add-prop target :advance-counter 1 {:placed true}))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -17,7 +17,7 @@
                              enable-corp-damage-choice]]
    [game.core.def-helpers :refer [corp-recur defcard offer-jack-out]]
    [game.core.drawing :refer [draw]]
-   [game.core.effects :refer [register-lingering-effect]]
+   [game.core.effects :refer [register-lingering-effect is-disabled?]]
    [game.core.eid :refer [effect-completed is-basic-advance-action? make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events register-once resolve-ability trigger-event]]
    [game.core.events :refer [event-count first-event?
@@ -455,6 +455,7 @@
 
 (defcard "Blue Sun: Powering the Future"
   {:flags {:corp-phase-12 (req (and (not (:disabled card))
+                                    (not (is-disabled? state side card))
                                     (some rezzed? (all-installed state :corp))))}
    :abilities [{:choices {:card rezzed?}
                 :label "Add 1 rezzed card to HQ and gain credits equal to its rez cost"
@@ -676,6 +677,7 @@
      :once :per-turn
      :label "Trash card"
      :req (req (and (not (:disabled card))
+                    (not (is-disabled? state side card))
                     (not (agenda? target))
                     (not (in-discard? target))
                     (<= (play-cost state side target)
@@ -707,6 +709,7 @@
             {:event :runner-turn-begins
              :player :corp
              :req (req (and (not (:disabled card))
+                            (not (is-disabled? state side card))
                             (has-most-faction? state :corp "Weyland Consortium")
                             (some ice? (all-installed state side))))
              :prompt "Choose a piece of ice to place 1 advancement token on"
@@ -959,6 +962,7 @@
 
 (defcard "Information Dynamics: All You Need To Know"
   {:events (let [inf {:req (req (and (not (:disabled card))
+                                     (not (is-disabled? state side card))
                                      (has-most-faction? state :corp "NBN")))
                       :msg "give the Runner 1 tag"
                       :async true
@@ -1081,9 +1085,9 @@
 (defcard "Jinteki: Potential Unleashed"
   {:events [{:async true
              :event :pre-resolve-damage
-             :req (req (and (-> @state :corp :disable-id not)
-                            (= target :net)
-                            (pos? (last targets))))
+             :req (req (and ;;(-> @state :corp :disable-id not)
+                         (= target :net)
+                         (pos? (last targets))))
              :effect (req (let [c (first (get-in @state [:runner :deck]))]
                             (system-msg state :corp (str "uses " (:title card) " to trash " (:title c)
                                                          " from the top of the stack"))
@@ -1254,6 +1258,7 @@
                                         (draw state :runner eid 1)))}]
     {:flags {:runner-turn-draw true
              :runner-phase-12 (req (and (not (:disabled card))
+                                        (not (is-disabled? state side card))
                                         (some #(card-flag? % :runner-turn-draw true) (all-active-installed state :runner))))}
      :events [(assoc ability :event :runner-turn-begins)]
      :abilities [ability]}))
@@ -1406,6 +1411,7 @@
                                 (effect-completed state side eid)))}]
     {:flags {:drip-economy true
              :runner-phase-12 (req (and (not (:disabled card))
+                                        (not (is-disabled? state side card))
                                         (some #(card-flag? % :runner-turn-draw true) (all-active-installed state :runner))))}
      :abilities [ability]
      :events [(assoc ability :event :runner-turn-begins)]}))
@@ -2005,6 +2011,7 @@
              :effect draft-points-target}
             {:event :runner-turn-ends
              :req (req (and (not (:disabled card))
+                            (not (is-disabled? state side card))
                             (has-most-faction? state :corp "Haas-Bioroid")
                             (pos? (count (:discard corp)))))
              :prompt "Choose a card in Archives to shuffle into R&D"
@@ -2043,6 +2050,7 @@
   {:events [{:event :pre-start-game
              :effect draft-points-target}]
    :flags {:corp-phase-12 (req (and (not (:disabled (get-card state card)))
+                                    (not (is-disabled? state side card))
                                     (has-most-faction? state :corp "Jinteki")
                                     (<= 2 (count (filter ice? (all-installed state :corp))))))}
    :abilities [{:prompt "Choose 2 installed pieces of ice to swap"
@@ -2078,6 +2086,7 @@
 
 (defcard "Tennin Institute: The Secrets Within"
   {:flags {:corp-phase-12 (req (and (not (:disabled (get-card state card)))
+                                    (not (is-disabled? state side card))
                                     (not-last-turn? state :runner :successful-run)))}
    :abilities [{:msg (msg "place 1 advancement token on " (card-str state target))
                 :label "Place 1 advancement token on a card if the Runner did not make a successful run last turn"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -5,7 +5,7 @@
    [game.core.bad-publicity :refer [gain-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed card->server
                             get-remote-names get-remotes server->zone]]
-   [game.core.card :refer [agenda? asset?
+   [game.core.card :refer [agenda? asset? can-be-advanced?
                            corp-installable-type? corp? faceup? get-advancement-requirement
                            get-agenda-points get-card get-counters get-title get-zone hardware? has-subtype?
                            ice? in-discard? in-hand? in-play-area? installed? is-type? operation? program?
@@ -24,7 +24,7 @@
                              first-successful-run-on-server? no-event? not-last-turn? run-events turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-latest]]
-   [game.core.flags :refer [can-really-be-advanced? card-flag? clear-persistent-flag!
+   [game.core.flags :refer [card-flag? clear-persistent-flag!
                             register-persistent-flag! register-turn-flag! zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-credits]]
    [game.core.hand-size :refer [corp-hand-size+ hand-size+]]
@@ -1060,7 +1060,7 @@
                                      (continue-ability
                                        state side
                                        {:prompt "Choose a card that can be advanced"
-                                        :choices {:req (req (can-really-be-advanced? state target))}
+                                        :choices {:req (req (can-be-advanced? state target))}
                                         :effect (effect (add-prop target :advance-counter 4 {:placed true}))}
                                        card nil))
                                  (toast state :corp (str "Unknown Jinteki Biotech: Life Imagined card: " flip) "error"))))}]})
@@ -1765,7 +1765,7 @@
              :async true
              :waiting-prompt true
              :prompt "Choose a card that can be advanced to place 1 advancement token on"
-             :choices {:req (req (and (installed? target) (can-really-be-advanced? state target)))}
+             :choices {:req (req (and (installed? target) (can-be-advanced? state target)))}
              :msg (msg "place 1 advancement token on " (card-str state target))
              :effect (effect (add-prop :corp eid target :advance-counter 1 {:placed true}))
              :cancel-effect (effect (system-msg (str "declines to use " (:title card)))

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1078,7 +1078,7 @@
 (defcard "Jinteki: Potential Unleashed"
   {:events [{:async true
              :event :pre-resolve-damage
-             :req (req (and ;;(-> @state :corp :disable-id not)
+             :req (req (and
                          (= target :net)
                          (pos? (last targets))))
              :effect (req (let [c (first (get-in @state [:runner :deck]))]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -160,26 +160,23 @@
                                                 card nil)))}
                               card nil)))}]
    ;; This effect will be resolved when the ID is reenabled after Strike / Direct Access
-   :effect (effect
-             (continue-ability
-               {:req (req (< 2 (count (get-remotes state))))
-                :prompt "Choose 2 servers to be saved from the rules apocalypse"
-                :choices (req (get-remote-names state))
-                :async true
-                :effect (req (let [saved target]
-                               (continue-ability
-                                 state side
-                                 {:prompt "Choose another server to save"
-                                  :choices (req (filter #(not= saved %) (get-remote-names state)))
-                                  :async true
-                                  :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target saved] (zone->name (second (get-zone %))))
-                                                                           (all-installed state :corp))]
-                                                 (system-msg state side (str "chooses " target " and " saved " to be saved from the rules apocalypse and trashes "
-                                                                             (quantify (count to-be-trashed) "card")))
-                                                 ;; these cards get trashed by the game and not by players
-                                                 (trash-cards state side eid to-be-trashed {:unpreventable true :game-trash true})))}
-                                 card nil)))}
-               card nil))})
+   :enforce-conditions {:req (req (< 2 (count (get-remotes state))))
+                        :prompt "Choose 2 servers to be saved from the rules apocalypse"
+                        :choices (req (get-remote-names state))
+                        :async true
+                        :effect (req (let [saved target]
+                                       (continue-ability
+                                         state side
+                                         {:prompt "Choose another server to save"
+                                          :choices (req (filter #(not= saved %) (get-remote-names state)))
+                                          :async true
+                                          :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target saved] (zone->name (second (get-zone %))))
+                                                                                   (all-installed state :corp))]
+                                                         (system-msg state side (str "chooses " target " and " saved " to be saved from the rules apocalypse and trashes "
+                                                                                     (quantify (count to-be-trashed) "card")))
+                                                         ;; these cards get trashed by the game and not by players
+                                                         (trash-cards state side eid to-be-trashed {:unpreventable true :game-trash true})))}
+                                         card nil)))}})
 
 (defcard "Acme Consulting: The Truth You Need"
   (letfn [(outermost? [state ice]
@@ -553,21 +550,17 @@
                                           (in-coll? (keys (get-remotes state)) (:server (second targets))))))
                          :value (req [(->c :credit (if (:flipped card) 6 1))])}]
      :async true
-     ; This effect will be resolved when the ID is reenabled after Strike / Direct Access
-     :effect (effect
-               (continue-ability
-                 {:req (req (< 1 (count (get-remotes state))))
-                  :prompt "Choose a server to be saved from the rules apocalypse"
-                  :choices (req (get-remote-names state))
-                  :async true
-                  :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target] (zone->name (second (get-zone %))))
-                                                           (all-installed state :corp))]
-                                 (system-msg state side (str "chooses " target
-                                                             " to be saved from the rules apocalypse and trashes "
-                                                             (quantify (count to-be-trashed) "card")))
-                                 ; these cards get trashed by the game and not by players
-                                 (trash-cards state side eid to-be-trashed {:unpreventable true :game-trash true})))}
-                 card nil))
+     :enforce-conditions {:req (req (< 1 (count (get-remotes state))))
+                          :prompt "Choose a server to be saved from the rules apocalypse"
+                          :choices (req (get-remote-names state))
+                          :async true
+                          :effect (req (let [to-be-trashed (remove #(in-coll? ["Archives" "R&D" "HQ" target] (zone->name (second (get-zone %))))
+                                                                   (all-installed state :corp))]
+                                         (system-msg state side (str "chooses " target
+                                                                     " to be saved from the rules apocalypse and trashes "
+                                                                     (quantify (count to-be-trashed) "card")))
+                                        ; these cards get trashed by the game and not by players
+                                         (trash-cards state side eid to-be-trashed {:unpreventable true :game-trash true})))}
      :abilities [{:label "Flip identity to Earth Station: Ascending to Orbit"
                   :req (req (not (:flipped card)))
                   :cost [(->c :click 1)]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -5,7 +5,7 @@
    [game.core.bad-publicity :refer [gain-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed card->server
                             get-remote-names get-remotes server->zone]]
-   [game.core.card :refer [agenda? asset? can-be-advanced?
+   [game.core.card :refer [agenda? asset?
                            corp-installable-type? corp? faceup? get-advancement-requirement
                            get-agenda-points get-card get-counters get-title get-zone hardware? has-subtype?
                            ice? in-discard? in-hand? in-play-area? installed? is-type? operation? program?
@@ -24,7 +24,7 @@
                              first-successful-run-on-server? no-event? not-last-turn? run-events turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-latest]]
-   [game.core.flags :refer [card-flag? clear-persistent-flag!
+   [game.core.flags :refer [can-really-be-advanced? card-flag? clear-persistent-flag!
                             register-persistent-flag! register-turn-flag! zone-locked?]]
    [game.core.gaining :refer [gain gain-clicks gain-credits lose lose-credits]]
    [game.core.hand-size :refer [corp-hand-size+ hand-size+]]
@@ -1060,7 +1060,7 @@
                                      (continue-ability
                                        state side
                                        {:prompt "Choose a card that can be advanced"
-                                        :choices {:card can-be-advanced?}
+                                        :choices {:req (req (can-really-be-advanced? state target))}
                                         :effect (effect (add-prop target :advance-counter 4 {:placed true}))}
                                        card nil))
                                  (toast state :corp (str "Unknown Jinteki Biotech: Life Imagined card: " flip) "error"))))}]})
@@ -1765,7 +1765,7 @@
              :async true
              :waiting-prompt true
              :prompt "Choose a card that can be advanced to place 1 advancement token on"
-             :choices {:card #(and (installed? %) (can-be-advanced? %))}
+             :choices {:req (req (and (installed? target) (can-really-be-advanced? state target)))}
              :msg (msg "place 1 advancement token on " (card-str state target))
              :effect (effect (add-prop :corp eid target :advance-counter 1 {:placed true}))
              :cancel-effect (effect (system-msg (str "declines to use " (:title card)))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -567,9 +567,11 @@
                                      (damage state side eid :brain 1 {:card card})))}}}})
 
 (defcard "Cerebral Static"
-  {:on-play {:msg "disable the Runner's identity"
-             :effect (effect (disable-identity :runner))}
-   :leave-play (effect (enable-identity :runner))})
+  {:on-play {:msg "disable the Runner's identity"}
+   :static-abilities [{:type :disable-card
+                       :req (req (same-card? target (:identity runner)))
+                       :value true}]
+   :disable-id true})
 
 (defcard "\"Clones are not People\""
   {:events [{:event :agenda-scored

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -7,7 +7,7 @@
    [game.core.board :refer [all-active-installed all-installed
                             get-all-installed get-remote-names get-remotes
                             installable-servers server->zone]]
-   [game.core.card :refer [active? agenda? asset? can-be-advanced? card-index corp? corp-installable-type?
+   [game.core.card :refer [active? agenda? asset? card-index corp? corp-installable-type?
                            event? facedown? faceup? get-advancement-requirement
                            get-card get-counters get-title get-zone hardware? has-subtype? ice? identity?
                            in-discard? in-hand? installed? is-type? operation? program? resource?
@@ -24,7 +24,7 @@
    [game.core.engine :refer [pay register-events resolve-ability should-trigger?]]
    [game.core.events :refer [first-event? last-turn? no-event? not-last-turn?
                              turn-events]]
-   [game.core.flags :refer [can-score? clear-persistent-flag! in-corp-scored?
+   [game.core.flags :refer [can-really-be-advanced? can-score? clear-persistent-flag! in-corp-scored?
                             in-runner-scored? is-scored? prevent-jack-out
                             register-persistent-flag! register-turn-flag! when-scored? zone-locked?]]
    [game.core.gaining :refer [gain-clicks gain-credits lose-clicks
@@ -286,7 +286,7 @@
   (letfn [(audacity [x]
             {:prompt (msg "Choose a card that can be advanced to place advancement counters on (" x " remaining)")
              :async true
-             :choices {:card can-be-advanced?
+             :choices {:req (req (can-really-be-advanced? state target))
                        :all true}
              :msg (msg "place 1 advancement counter on " (card-str state target))
              :effect (req (wait-for (add-prop state side target :advance-counter 1 {:placed true})
@@ -295,7 +295,7 @@
                                       (effect-completed state side eid))))})]
     {:on-play
      {:req (req (and (<= 3 (count (:hand corp)))
-                     (some can-be-advanced? (all-installed state :corp))))
+                     (some #(can-really-be-advanced? state %) (all-installed state :corp))))
       :async true
       :msg "trash all cards in HQ"
       :effect (req (wait-for (trash-cards state side (:hand corp) {:unpreventable true :cause-card card})
@@ -508,9 +508,9 @@
                     :effect (effect (add-counter target :virus (* -1 (get-counters target :virus))))
                     :msg (msg "remove all virus counters from " (card-str state target))}
         kaguya {:choices {:max 2
-                          :card #(and (corp? %)
-                                      (installed? %)
-                                      (can-be-advanced? %))}
+                          :req (req (and (corp? target)
+                                         (installed? target)
+                                         (can-really-be-advanced? state target)))}
                 :msg (msg "place 1 advancement counter on " (quantify (count targets) "card"))
                 :effect (req (doseq [t targets]
                                (add-prop state :corp t :advance-counter 1 {:placed true})))}]
@@ -2099,7 +2099,7 @@
                                  (continue-ability
                                    state side
                                    {:msg (msg "place " (quantify c " advancement token") " on " (card-str state target))
-                                    :choices {:card can-be-advanced?}
+                                    :choices {:req (req (can-really-be-advanced? state target))}
                                     :effect (effect (add-prop target :advance-counter c {:placed true}))}
                                    card nil)))
                      (effect-completed state side eid))))}})
@@ -2269,9 +2269,9 @@
 
 (defcard "Red Planet Couriers"
   {:on-play
-   {:req (req (some #(can-be-advanced? %) (all-installed state :corp)))
+   {:req (req (some #(can-really-be-advanced? state %) (all-installed state :corp)))
     :prompt "Choose an installed card that can be advanced"
-    :choices {:card can-be-advanced?}
+    :choices {:req (req (can-really-be-advanced? state target))}
     :async true
     :effect (req (let [installed (get-all-installed state)
                        total-adv (reduce + (map #(get-counters % :advancement) installed))]
@@ -2584,9 +2584,9 @@
 (defcard "Shipment from Kaguya"
   {:on-play
    {:choices {:max 2
-              :card #(and (corp? %)
-                          (installed? %)
-                          (can-be-advanced? %))}
+              :req (req (and (corp? target)
+                             (installed? target)
+                             (can-really-be-advanced? state target)))}
     :msg (msg "place 1 advancement token on " (quantify (count targets) "card"))
     :effect (req (doseq [t targets]
                    (add-prop state :corp t :advance-counter 1 {:placed true})))}})
@@ -2613,7 +2613,7 @@
     :effect (req (let [c (str->int target)]
                    (continue-ability
                      state side
-                     {:choices {:card can-be-advanced?}
+                     {:choices {:req (req (can-really-be-advanced? state target))}
                       :msg (msg "place " (quantify c "advancement token") " on " (card-str state target))
                       :effect (effect (add-prop :corp target :advance-counter c {:placed true}))}
                      card nil)))}})
@@ -2868,7 +2868,7 @@
               (effect-completed state side eid)))]
     {:on-play
      {:additional-cost [(->c :forfeit)]
-      :choices {:card can-be-advanced?}
+      :choices {:req (req (can-really-be-advanced? state target))}
       :msg (msg "advance " (card-str state target)
              " " (quantify (get-advancement-requirement (cost-target eid :forfeit)) "time"))
       :async true
@@ -3047,12 +3047,12 @@
 (defcard "Trick of Light"
   {:on-play
    {:prompt "Choose an installed card you can advance"
-    :req (req (let [advanceable (some can-be-advanced? (get-all-installed state))
+    :req (req (let [advanceable (some #(can-really-be-advanced? state %) (get-all-installed state))
                     num-installed (count (get-all-installed state))]
                  (and advanceable
                       (> num-installed 1))))
-    :choices {:card #(and (can-be-advanced? %)
-                          (installed? %))}
+    :choices {:req (req (and (can-really-be-advanced? state target)
+                             (installed? target)))}
     :async true
     :effect (effect
               (continue-ability

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -570,8 +570,7 @@
   {:on-play {:msg "disable the Runner's identity"}
    :static-abilities [{:type :disable-card
                        :req (req (same-card? target (:identity runner)))
-                       :value true}]
-   :disable-id true})
+                       :value true}]})
 
 (defcard "\"Clones are not People\""
   {:events [{:event :agenda-scored

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2984,13 +2984,16 @@
                             (can-host? state target)))}
    :events [{:event :rez
              :req (req (same-card? (:card context) (:host card)))
-             ;;(not= (:title (:card context)) "Magnet")))
              :msg "gain 3 [Credits]"
              :async true
              :effect (effect (gain-credits :runner eid 3))}
             {:event :derez
              :req (req (same-card? (:card context) (:host card)))
              ;; special cheat for working with magnet
+             ;;   current guidance from rules is that saci doesn't get
+             ;;   a payout on magnet rez, but does get one when magnet is
+             ;;   derezzed. It is what it is.
+             ;; - Apr 13 '24, nbkelly
              :while-disabled true
              :msg "gain 3 [Credits]"
              :async true

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -33,7 +33,7 @@
                           break-subroutine! break-subroutines-msg breaker-strength-bonus dont-resolve-subroutine!
                           get-strength ice-strength pump pump-ice set-current-ice strength-pump
                           unbroken-subroutines-choice update-all-icebreakers update-breaker-strength]]
-   [game.core.initializing :refer [ability-init card-init]]
+   [game.core.initializing :refer [ability-init card-init subroutines-init]]
    [game.core.installing :refer [install-locked? runner-can-install? runner-can-pay-and-install?
                                  runner-install]]
    [game.core.link :refer [get-link]]
@@ -1774,42 +1774,17 @@
       (strength-pump (->c :credit 2 {:stealth 1}) 4 :end-of-run)]}))
 
 (defcard "Hush"
-  ;; quick laundry list of ice with some variable subs that hush cares about, and other interactions:
-  ;;  ! Afshar (breaking restriction check) (done)
-  ;;  ! Akhet (advancable-while-hushed, +str, breaking restriction check) (done)
-  ;;  ! Anansi (done)
-  ;;  ! attini (the payment thing) (done)
-  ;;  ! blockchain * (done)
-  ;;  ! echo * (done)
-  ;;  ! envelopment * (done)
-  ;;  hive *
-  ;;  hortum
-  ;;  information overload
-  ;;  masvingo *
-  ;;  mausolus
-  ;;  anansi
-  ;;  cloud eater
-  ;;  NEXT Bronze, Gold, Opal, Silver *
-  ;; Orion (nebula, wormhole, asteroid belt)
-  ;;  saisentan
-  ;;  seraph
-  ;;  searchlight
-  ;;  surveyor
-  ;;  swarm *
-  ;;  thoth
-  ;;  tithonium
-  ;;  tour guide *
-  ;;  turing
-  ;;  tyr
-  ;;  tyrant *
-  ;;  wraparound
   (let [reset-card-to-printed-subs
         (fn [state side card]
           (let [card (get-card state card)
-                old-subs (vec (remove #(or (:variable %)
-                                           (not (:printed %)))
-                                      (:subroutines card)))
-                new-card (assoc card :subroutines old-subs)]
+                subs (vec (remove #(or (:variable %)
+                                       (not (:printed %)))
+                                  (:subroutines card)))
+                ;; special case for hive, because it unprints subroutines...
+                subs (if (= "Hive" (:title card))
+                       (subroutines-init card (card-def card))
+                       subs)
+                new-card (assoc card :subroutines subs)]
             (update! state :corp new-card)
             (trigger-event state side :subroutines-changed (get-card state new-card))))
         subroutines-should-update {:silent (req true)

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -703,8 +703,8 @@
 (defcard "Botulus"
   {:implementation "[Erratum] Program: Virus - Trojan"
    :data {:counter {:virus 1}}
-   :hosting {:card #(and (ice? %)
-                         (can-host? %))}
+   :hosting {:req (req (and (ice? target)
+                            (can-host? state target)))}
    :events [{:event :runner-turn-begins
              :effect (effect (add-counter card :virus 1))}]
    :abilities [(break-sub
@@ -821,8 +821,9 @@
 
 (defcard "Chisel"
   {:implementation "[Erratum] Program: Virus - Trojan"
-   :hosting {:card #(and (ice? %)
-                         (can-host? %))}
+   :hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (can-host? state target)))}
    :static-abilities [{:type :ice-strength
                        :req (req (same-card? target (:host card)))
                        :value (req (- (get-virus-counters state card)))}]
@@ -1373,9 +1374,9 @@
 
 (defcard "Egret"
   {:implementation "[Erratum] Program: Trojan"
-   :hosting {:card #(and (ice? %)
-                         (can-host? %)
-                         (rezzed? %))}
+   :hosting {:req (req (and (ice? target)
+                            (can-host? state target)
+                            (rezzed? target)))}
    :on-install {:msg (msg "make " (card-str state (:host card))
                           " gain Barrier, Code Gate and Sentry subtypes")}
    :static-abilities [{:type :gain-subtype
@@ -1547,8 +1548,8 @@
                                 (strength-pump 1 1)]}))
 
 (defcard "Flux Capacitor"
-  {:hosting {:card #(and (ice? %)
-                         (can-host? %))}
+  {:hosting {:req (req (and (ice? target)
+                            (can-host? state target)))}
     :events [{:event :subroutines-broken
               :once :per-encounter
               :async true
@@ -1816,8 +1817,8 @@
                                                   state :corp
                                                   :subroutines-should-update))}]
   {:implementation "Experimentally implemented. If it doesn't work correctly, please file a bug report with the exact case and cards used, and we will investigate."
-   :hosting {:card #(and (ice? %)
-                         (can-host? %))}
+   :hosting {:req (req (and (ice? target)
+                            (can-host? state target)))}
    :static-abilities [{:type :disable-card
                        :req (req (same-card? target (:host card)))
                        :value true}]
@@ -1835,9 +1836,9 @@
    :abilities [{:label "Host on a piece of ice"
                 :prompt "Choose a piece of ice"
                 :cost [(->c :click 1)]
-                :choices {:card #(and (ice? %)
-                                      (installed? %)
-                                      (can-host? %))}
+                :choices {:req (req (and (ice? target)
+                                         (installed? target)
+                                         (can-host? state target)))}
                 :msg (msg "host itself on " (card-str state target))
                 :async true
                 :effect (req (host state side target card)
@@ -1867,9 +1868,9 @@
                     :abilities [{:label "Host on a piece of ice"
                                  :prompt "Choose a piece of ice"
                                  :cost [(->c :credit 2)]
-                                 :choices {:card #(and (ice? %)
-                                                       (installed? %)
-                                                       (can-host? %))}
+                                 :choices {:req (req (and (ice? target)
+                                                          (installed? target)
+                                                          (can-host? state target)))}
                                  :msg (msg "host itself on " (card-str state target))
                                  :effect (effect (host target card))}
                                 (break-sub 1 2 "Sentry")
@@ -1983,18 +1984,18 @@
                                    {:prompt (msg "Choose a piece of ice"
                                                  (when hosted " not before or after the current host ice"))
                                     :cost [(->c :click 1)]
-                                    :choices {:card #(if hosted
-                                                       (and (or (when (= (get-zone %) (get-zone (:host k)))
-                                                                  (not= 1 (abs (- (card-index state %) icepos))))
-                                                                (not= (get-zone %) (get-zone (:host k))))
-                                                            (ice? %)
-                                                            (can-host? %)
-                                                            (installed? %)
-                                                            (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
-                                                       (and (ice? %)
-                                                            (installed? %)
-                                                            (can-host? %)
-                                                            (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
+                                    :choices {:req (req (if hosted
+                                                          (and (or (when (= (get-zone target) (get-zone (:host k)))
+                                                                     (not= 1 (abs (- (card-index state target) icepos))))
+                                                                   (not= (get-zone target) (get-zone (:host k))))
+                                                               (ice? target)
+                                                            (can-host? state target)
+                                                            (installed? target)
+                                                            (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted target)))
+                                                          (and (ice? target)
+                                                            (installed? target)
+                                                            (can-host? state target)
+                                                            (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted target)))))}
                                     :msg (msg "host itself on " (card-str state target))
                                     :effect (effect (host target card))}
                                    card nil)))}
@@ -2002,8 +2003,9 @@
 
 (defcard "Kyuban"
   {:implementation "[Erratum] Program: Trojan"
-   :hosting {:card #(and (ice? %)
-                         (can-host? %))}
+   :hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (can-host? state target)))}
    :events [{:event :pass-ice
              :interactive (req true)
              :req (req (same-card? (:ice context) (:host card)))
@@ -2087,8 +2089,9 @@
   (auto-icebreaker {:on-install {:req (req (threat-level 4 state))
                                  :msg "gain 3 strength for the remainder of the turn"
                                  :effect (effect (pump card 3 :end-of-turn))}
-                    :hosting {:card #(and (ice? %)
-                                          (can-host? %))}
+                    :hosting {:req (req (and (ice? target)
+                                             (installed? target)
+                                             (can-host? state target)))}
                     :abilities [(break-sub 1 1 "Sentry" {:req (req (protecting-same-server? current-ice (:host card)))})
                                 (strength-pump 1 2)]}))
 
@@ -2341,8 +2344,9 @@
                                 (strength-pump 2 2)]}))
 
 (defcard "Monkeywrench"
-  {:hosting {:card #(and (ice? %)
-                         (can-host? %))}
+  {:hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (can-host? state target)))}
    :static-abilities [{:type :ice-strength
                        :req (req (and (ice? target)
                                       (= (get-zone (:host card)) (get-zone target))))
@@ -2615,9 +2619,10 @@
 
 (defcard "Parasite"
   {:implementation "[Erratum] Program: Virus - Trojan"
-   :hosting {:card #(and (ice? %)
-                         (can-host? %)
-                         (rezzed? %))}
+   :hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (rezzed? target)
+                            (can-host? state target)))}
    :on-install
    {:effect (req (when-let [h (:host card)]
                    (update! state side (assoc-in card [:special :installing] true))
@@ -2655,18 +2660,18 @@
    :abilities [{:label "Host on the outermost piece of ice of a central server"
                 :cost [(->c :click 1)]
                 :prompt "Choose the outermost piece of ice of a central server"
-                :choices {:card #(and (ice? %)
-                                      (can-host? %)
-                                      (= (last (get-zone %)) :ices)
-                                      (is-central? (second (get-zone %))))}
+                :choices {:req (req (and (ice? target)
+                                         (can-host? state target)
+                                         (= (last (get-zone target)) :ices)
+                                         (is-central? (second (get-zone target)))))}
                 :msg (msg "host itself on " (card-str state target))
                 :effect (effect (host target card))}
                {:label "Host on the next innermost piece of ice"
                 :prompt "Choose the next innermost piece of ice"
-                :choices {:card #(and (ice? %)
-                                      (can-host? %)
-                                      (= (last (get-zone %)) :ices)
-                                      (is-central? (second (get-zone %))))}
+                :choices {:req (req (and (ice? target)
+                                         (can-host? state target)
+                                         (= (last (get-zone target)) :ices)
+                                         (is-central? (second (get-zone target)))))}
                 :msg (msg "host itself on " (card-str state target))
                 :effect (effect (host target card))}
                {:req (req (not (zone-locked? state :runner :discard)))
@@ -2758,8 +2763,9 @@
                                 :type :recurring}}})
 
 (defcard "Physarum Entangler"
-  {:hosting {:card #(and (ice? %)
-                         (can-host? %))}
+  {:hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (can-host? state target)))}
    :events [{:event :purge
              :async true
              :msg "trash itself"
@@ -2783,8 +2789,9 @@
 (defcard "Pichação"
   ;; TODO - there's not really a way to tell if an event happened during a run?
   ;; this can be cleaned up a little later
-  {:hosting {:card #(and (ice? %)
-                         (can-host? %))}
+  {:hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (can-host? state target)))}
    :events [{:event :pass-ice
              :optional {:interactive (req true)
                         :prompt "Gain [Click]?"
@@ -2977,17 +2984,17 @@
                                             (msg "Choose a piece of ice protecting this server or at position "
                                                  icepos " of a different server")
                                             (msg "Choose a piece of ice protecting any server"))
-                                  :choices {:card #(if hosted?
-                                                     (and (or (= (get-zone %) (get-zone (:host r)))
-                                                              (= (card-index state %) icepos))
-                                                          (= (last (get-zone %)) :ices)
-                                                          (ice? %)
-                                                          (can-host? %)
-                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %)))
-                                                     (and (ice? %)
-                                                          (can-host? %)
-                                                          (= (last (get-zone %)) :ices)
-                                                          (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted %))))}
+                                  :choices {:req (req (if hosted?
+                                                        (and (or (= (get-zone target) (get-zone (:host r)))
+                                                                 (= (card-index state target) icepos))
+                                                             (= (last (get-zone target)) :ices)
+                                                             (ice? target)
+                                                             (can-host? state target)
+                                                             (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted target)))
+                                                        (and (ice? target)
+                                                             (can-host? state target)
+                                                             (= (last (get-zone target)) :ices)
+                                                             (not-any? (fn [c] (has-subtype? c "Caïssa")) (:hosted target)))))}
                                   :msg (msg "host itself on " (card-str state target))
                                   :effect (effect (host target card))}
                                  card nil)))}]
@@ -2997,8 +3004,9 @@
                        :value 2}]})
 
 (defcard "Saci"
-  {:hosting {:card #(and (ice? %)
-                         (can-host? %))}
+  {:hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (can-host? state target)))}
    :events [{:event :rez
              :req (req (same-card? (:card context) (:host card)))
              ;;(not= (:title (:card context)) "Magnet")))
@@ -3116,8 +3124,9 @@
   (break-and-enter "Sentry"))
 
 (defcard "Slap Vandal"
-  {:hosting {:card #(and (ice? %)
-                         (can-host? %))}
+  {:hosting {:req (req (and (ice? target)
+                            (installed? target)
+                            (can-host? state target)))}
    :abilities [(break-sub 1 1 "All" {:req (req (same-card? current-ice (:host card)))
                                      :repeatable false})]})
 
@@ -3357,8 +3366,9 @@
                                (<= 3 (get-virus-counters state (get-card state card))))
                       (derez state side (get-card state (:host card)))))]
     {:implementation "[Erratum] Program: Virus - Trojan"
-     :hosting {:card #(and (ice? %)
-                           (can-host? %))}
+     :hosting {:req (req (and (ice? target)
+                              (installed? target)
+                              (can-host? state target)))}
      :on-install {:interactive (req true)
                   :effect action}
      :events [{:event :runner-turn-begins
@@ -3408,8 +3418,9 @@
                                 (trash state :runner eid h {:cause-card card}))
                             (effect-completed state side eid))))]
     {:implementation "[Erratum] Program: Virus - Trojan"
-     :hosting {:card #(and (ice? %)
-                           (can-host? %))}
+     :hosting {:req (req (and (ice? target)
+                              (installed? target)
+                              (can-host? state target)))}
      :on-install {:async true
                   :effect trash-if-5}
      :abilities [(set-autoresolve :auto-place-counter "Trypano placing virus counters on itself")]

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2948,13 +2948,14 @@
   {:hosting {:card #(and (ice? %)
                          (can-host? %))}
    :events [{:event :rez
-             :req (req (and (same-card? (:card context) (:host card))
-                            (not= (:title (:card context)) "Magnet")))
+             :req (req (same-card? (:card context) (:host card)))
+             ;;(not= (:title (:card context)) "Magnet")))
              :msg "gain 3 [Credits]"
              :async true
              :effect (effect (gain-credits :runner eid 3))}
             {:event :derez
              :req (req (same-card? (:card context) (:host card)))
+             :while-disabled true
              :msg "gain 3 [Credits]"
              :async true
              :effect (effect (gain-credits :runner eid 3))}]})

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -110,15 +110,8 @@
 
 (defn- trash-when-tagged-contructor
   "Constructor for a 'trash when tagged' card. Does not overwrite `:effect` key."
-  [card-name definition]
-  (let [trash-effect {:async true
-                      :effect (req (if tagged
-                                     (do (system-msg state :runner (str "trashes " card-name " for being tagged"))
-                                         (trash state :runner eid card {:unpreventable true :cause-card card}))
-                                     (effect-completed state side eid)))}]
-    (-> definition
-        (update :events conj (assoc trash-effect :event :tags-changed))
-        (assoc :reactivate trash-effect))))
+  [definition]
+  (assoc definition :trash-when-tagged true))
 
 (defn companion-builder
   "pay-credits-req says when it can be used. turn-ends-ability defines what happens,
@@ -2658,7 +2651,8 @@
   {:static-abilities [(runner-hand-size+ 2)]})
 
 (defcard "Rachel Beckman"
-  (trash-when-tagged-contructor "Rachel Beckman" {:in-play [:click-per-turn 1]}))
+  {:trash-when-tagged true
+   :in-play [:click-per-turn 1]})
 
 (defcard "Raymond Flint"
   {:events [{:event :corp-gain-bad-publicity
@@ -3794,14 +3788,13 @@
                        :value 1}]})
 
 (defcard "Zona Sul Shipping"
-  (trash-when-tagged-contructor
-    "Zona Sul Shipping"
-    {:events [{:event :runner-turn-begins
-               :effect (effect (add-counter card :credit 1))}]
-     :abilities [{:cost [(->c :click 1)]
-                  :msg (msg "gain " (get-counters card :credit) " [Credits]")
-                  :label "Take all credits"
-                  :async true
-                  :effect (effect (add-counter card :credit
-                                               (- (get-counters card :credit)))
-                                  (gain-credits eid (get-counters card :credit)))}]}))
+  {:events [{:event :runner-turn-begins
+             :effect (effect (add-counter card :credit 1))}]
+   :trash-when-tagged true
+   :abilities [{:cost [(->c :click 1)]
+                :msg (msg "gain " (get-counters card :credit) " [Credits]")
+                :label "Take all credits"
+                :async true
+                :effect (effect (add-counter card :credit
+                                             (- (get-counters card :credit)))
+                                (gain-credits eid (get-counters card :credit)))}]})

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2007,12 +2007,20 @@
                           card nil))}]})
 
 (defcard "Light the Fire!"
-  (let [successful-run-trigger {:event :successful-run
-                                  :duration :end-of-run
-                                  :async true
-                                  :req (req (is-remote? (:server run)))
-                                  :effect (effect (trash-cards eid (:content run-server)))
-                                  :msg "trash all cards in the server for no cost"}]
+  (let [successful-run-event
+        {:event :successful-run
+         :duration :end-of-run
+         :async true
+         :req (req (and run
+                        (is-remote? (:server run))))
+         :effect (effect (trash-cards eid (:content run-server)))
+         :msg "trash all cards in the server for no cost"}
+        disable-card-effect
+        {:type :disable-card
+         :duration :end-of-run
+         :req (req (and run
+                        (some #{:content} (:zone target))
+                        (some #{run-server} (:zone target))))}]
     {:abilities [{:label "Run a remote server"
                   :cost [(->c :click 1) (->c :trash-can) (->c :brain 1)]
                   :prompt "Choose a remote server"
@@ -2021,15 +2029,9 @@
                   :makes-run true
                   :async true
                   :effect (effect
-                            (register-events card [successful-run-trigger])
-                            (make-run eid target card)
-                            (register-lingering-effect
-                              card
-                              {:type :disable-card
-                               :duration :end-of-run
-                               :req (req (and run
-                                              (some #{:content} (:zone target))
-                                              (some #{run-server} (:zone target))))}))}]}))
+                            (register-events card [successful-run-event])
+                            (register-lingering-effect card [disable-card-effect])
+                            (make-run eid target card))}]}))
 
 (defcard "Logic Bomb"
   {:abilities [{:label "Bypass the encountered ice"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -15,6 +15,7 @@
                            installed? is-type? program? resource? rezzed? runner? upgrade? virus-program?]]
    [game.core.card-defs :refer [card-def]]
    [game.core.charge :refer [can-charge charge-ability]]
+   [game.core.checkpoint :refer [fake-checkpoint]]
    [game.core.cost-fns :refer [has-trash-ability? install-cost rez-cost
                                trash-cost]]
    [game.core.costs :refer [total-available-credits]]
@@ -1171,13 +1172,15 @@
                            [{:event :post-runner-turn-ends
                              :unregister-once-resolved true
                              :effect (req (let [disabled-card (get-card state c)]
-                                            (remove-icon state side card (get-card state disabled-card))))}])
+                                            (remove-icon state side card (get-card state disabled-card))
+                                            (fake-checkpoint state)))}])
                          (register-lingering-effect
                            state side card
                            {:type :disable-card
                             :duration :runner-turn-ends
                             :req (req (same-card? c target))
-                            :value (req true)})))}]})
+                            :value (req true)})
+                         (fake-checkpoint state)))}]})
 
                             ;;
                             ;; (disable-card state side (get-card state target))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -109,11 +109,6 @@
                 :msg message
                 :effect (effect (effect-fn eid card targets))}]})
 
-(defn- trash-when-tagged-contructor
-  "Constructor for a 'trash when tagged' card. Does not overwrite `:effect` key."
-  [definition]
-  (assoc definition :trash-when-tagged true))
-
 (defn companion-builder
   "pay-credits-req says when it can be used. turn-ends-ability defines what happens,
   and requires `effect-completed`."
@@ -1161,7 +1156,6 @@
              :prompt "Choose an installed card to make its text box blank for the remainder of the turn"
              :once :per-turn
              :interactive (req true)
-             ;;:async true
              :choices {:card installed?}
              :msg (msg "make the text box of " (:title target) " blank for the remainder of the turn")
              :effect (req
@@ -1181,10 +1175,6 @@
                             :req (req (same-card? c target))
                             :value (req true)})
                          (fake-checkpoint state)))}]})
-
-                            ;;
-                            ;; (disable-card state side (get-card state target))
-                            ;; (effect-completed state side eid)))}]})
 
 (defcard "Dr. Nuka Vrolyck"
   {:data {:counter {:power 2}}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -8,7 +8,7 @@
    [game.core.bad-publicity :refer [lose-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed all-installed-corp card->server
                             get-remotes server->zone server-list]]
-   [game.core.card :refer [agenda? asset?
+   [game.core.card :refer [agenda? asset? can-be-advanced?
                            corp-installable-type? corp? get-card get-counters get-zone
                            has-subtype? ice? in-discard? in-hand? installed? operation? program? resource? rezzed?
                            runner? upgrade?]]
@@ -25,7 +25,7 @@
    [game.core.events :refer [first-event? first-run-event? no-event? turn-events]]
    [game.core.expose :refer [expose-prevent]]
    [game.core.finding :refer [find-cid find-latest]]
-   [game.core.flags :refer [can-really-be-advanced? clear-persistent-flag! is-scored? register-persistent-flag!
+   [game.core.flags :refer [clear-persistent-flag! is-scored? register-persistent-flag!
                             register-run-flag!]]
    [game.core.gaining :refer [gain-credits lose-clicks lose-credits]]
    [game.core.hand-size :refer [corp-hand-size+]]
@@ -1817,7 +1817,7 @@
                 :msg (msg "place 2 advancement counters on " (card-str state target))
                 :choices {:not-self true
                           :req (req (and (installed? target)
-                                         (can-really-be-advanced? state target)
+                                         (can-be-advanced? state target)
                                          (in-same-server? card target)))}
                 :effect (effect (add-prop target :advance-counter 2 {:placed true}))}]})
 

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -8,7 +8,7 @@
    [game.core.bad-publicity :refer [lose-bad-publicity]]
    [game.core.board :refer [all-active-installed all-installed all-installed-corp card->server
                             get-remotes server->zone server-list]]
-   [game.core.card :refer [agenda? asset? can-be-advanced?
+   [game.core.card :refer [agenda? asset?
                            corp-installable-type? corp? get-card get-counters get-zone
                            has-subtype? ice? in-discard? in-hand? installed? operation? program? resource? rezzed?
                            runner? upgrade?]]
@@ -25,7 +25,7 @@
    [game.core.events :refer [first-event? first-run-event? no-event? turn-events]]
    [game.core.expose :refer [expose-prevent]]
    [game.core.finding :refer [find-cid find-latest]]
-   [game.core.flags :refer [clear-persistent-flag! is-scored? register-persistent-flag!
+   [game.core.flags :refer [can-really-be-advanced? clear-persistent-flag! is-scored? register-persistent-flag!
                             register-run-flag!]]
    [game.core.gaining :refer [gain-credits lose-clicks lose-credits]]
    [game.core.hand-size :refer [corp-hand-size+]]
@@ -1817,7 +1817,7 @@
                 :msg (msg "place 2 advancement counters on " (card-str state target))
                 :choices {:not-self true
                           :req (req (and (installed? target)
-                                         (can-be-advanced? target)
+                                         (can-really-be-advanced? state target)
                                          (in-same-server? card target)))}
                 :effect (effect (add-prop target :advance-counter 2 {:placed true}))}]})
 

--- a/src/clj/game/core/checkpoint.clj
+++ b/src/clj/game/core/checkpoint.clj
@@ -32,5 +32,4 @@
                  (< i 10))
         (recur (inc i)))))
   (clear-empty-remotes state)
-  ;;(system-msg state nil (str "disabled: " (vec (map :title (:disabled-card-reg @state)))))
   (generate-runnable-zones state nil nil))

--- a/src/clj/game/core/checkpoint.clj
+++ b/src/clj/game/core/checkpoint.clj
@@ -3,11 +3,13 @@
    [game.core.agendas :refer [update-all-advancement-requirements update-all-agenda-points]]
    [game.core.actions :refer [generate-runnable-zones]]
    [game.core.board :refer [get-remotes clear-empty-remotes]]
+   [game.core.effects :refer [update-disabled-cards]]
    [game.core.ice :refer [update-all-ice update-all-icebreakers]]
    [game.core.hand-size :refer [update-hand-size]]
    [game.core.initializing :refer [update-all-card-labels]]
    [game.core.link :refer [update-link]]
    [game.core.memory :refer [update-mu]]
+   [game.core.say :refer [system-msg]]
    [game.core.subtypes :refer [update-all-subtypes]]
    [game.core.tags :refer [update-tag-status]]))
 
@@ -24,9 +26,11 @@
                    (update-hand-size state :corp)
                    (update-hand-size state :runner)
                    (update-all-subtypes state)
-                   (update-tag-status state)]]
+                   (update-tag-status state)
+                   (update-disabled-cards state)]]
       (when (and (some true? changed)
                  (< i 10))
         (recur (inc i)))))
   (clear-empty-remotes state)
+  ;;(system-msg state nil (str "disabled: " (vec (map :title (:disabled-card-reg @state)))))
   (generate-runnable-zones state nil nil))

--- a/src/clj/game/core/checkpoint.clj
+++ b/src/clj/game/core/checkpoint.clj
@@ -9,7 +9,6 @@
    [game.core.initializing :refer [update-all-card-labels]]
    [game.core.link :refer [update-link]]
    [game.core.memory :refer [update-mu]]
-   [game.core.say :refer [system-msg]]
    [game.core.subtypes :refer [update-all-subtypes]]
    [game.core.tags :refer [update-tag-status]]))
 

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as string]
    [game.core.board :refer [all-installed server->zone]]
-   [game.core.card :refer [agenda? corp? get-card
+   [game.core.card :refer [agenda? can-be-advanced? corp? get-card
                            has-subtype? ice? in-hand? installed? map->Card rezzed?
                            runner?]]
    [game.core.change-vals :refer [change]]
@@ -11,7 +11,7 @@
    [game.core.drawing :refer [draw]]
    [game.core.eid :refer [effect-completed make-eid]]
    [game.core.engine :refer [resolve-ability trigger-event]]
-   [game.core.flags :refer [can-really-be-advanced? is-scored?]]
+   [game.core.flags :refer [is-scored?]]
    [game.core.hosting :refer [host]]
    [game.core.identities :refer [disable-identity disable-card enable-card]]
    [game.core.initializing :refer [card-init deactivate make-card]]
@@ -84,7 +84,7 @@
      :effect (req (let [existing (:counter target)
                         value (constrain-value (if-let [n (string->num (first args))] n 0) 0 1000)
                         counter-type (cond (= 1 (count existing)) (first (keys existing))
-                                     (can-really-be-advanced? state target) :advance-counter
+                                     (can-be-advanced? state target) :advance-counter
                                      (and (agenda? target) (is-scored? state side target)) :agenda
                                      (and (runner? target) (has-subtype? target "Virus")) :virus)
                         advance (= :advance-counter counter-type)]

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as string]
    [game.core.board :refer [all-installed server->zone]]
-   [game.core.card :refer [agenda? can-be-advanced? corp? get-card
+   [game.core.card :refer [agenda? corp? get-card
                            has-subtype? ice? in-hand? installed? map->Card rezzed?
                            runner?]]
    [game.core.change-vals :refer [change]]
@@ -11,7 +11,7 @@
    [game.core.drawing :refer [draw]]
    [game.core.eid :refer [effect-completed make-eid]]
    [game.core.engine :refer [resolve-ability trigger-event]]
-   [game.core.flags :refer [is-scored?]]
+   [game.core.flags :refer [can-really-be-advanced? is-scored?]]
    [game.core.hosting :refer [host]]
    [game.core.identities :refer [disable-identity disable-card enable-card]]
    [game.core.initializing :refer [card-init deactivate make-card]]
@@ -84,7 +84,7 @@
      :effect (req (let [existing (:counter target)
                         value (constrain-value (if-let [n (string->num (first args))] n 0) 0 1000)
                         counter-type (cond (= 1 (count existing)) (first (keys existing))
-                                     (can-be-advanced? target) :advance-counter
+                                     (can-really-be-advanced? state target) :advance-counter
                                      (and (agenda? target) (is-scored? state side target)) :agenda
                                      (and (runner? target) (has-subtype? target "Virus")) :virus)
                         advance (= :advance-counter counter-type)]

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.card :refer [runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [any-effects get-effects sum-effects get-effect-maps get-effect-value]]
+    [game.core.effects :refer [any-effects get-effects sum-effects get-effect-maps get-effect-value is-disabled?]]
     [game.core.eid :refer [make-eid]]
     [game.core.payment :refer [merge-costs]]))
 
@@ -44,8 +44,13 @@
   ([state side card] (rez-additional-cost-bonus state side card nil))
   ([state side card pred]
    (let [costs (merge-costs
-                 [(:additional-cost card)
-                  (:additional-cost (card-def card))
+                 ;; idk what the difference is between the additional cost for the card,
+                 ;; and the additional cost for the cdef, but we should probably actually
+                 ;; have a note here explaining it (somewhere in this file)
+                 [;(when-not (is-disabled? state side card)
+                    (:additional-cost card)
+                  ;  )
+                  (when-not (is-disabled? state side card) (:additional-cost (card-def card)))
                   (get-effects state side :rez-additional-cost card)])]
      (filterv (or pred identity) costs))))
 

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -23,8 +23,7 @@
 (defn play-additional-cost-bonus
   [state side card]
   (merge-costs
-    (concat (:additional-cost card)
-            (get-in (card-def card) [:on-play :additional-cost])
+    (concat (get-in (card-def card) [:on-play :additional-cost])
             (get-effects state side :play-additional-cost card))))
 
 (defn rez-cost
@@ -45,21 +44,14 @@
   ([state side card] (rez-additional-cost-bonus state side card nil))
   ([state side card pred]
    (let [costs (merge-costs
-                 ;; idk what the difference is between the additional cost for the card,
-                 ;; and the additional cost for the cdef, but we should probably actually
-                 ;; have a note here explaining it (somewhere in this file)
-                 [;(when-not (is-disabled? state side card)
-                  (:additional-cost card)
-                  ;  )
-                  (when-not (is-disabled? state side card) (:additional-cost (card-def card)))
+                 [(when-not (is-disabled? state side card) (:additional-cost (card-def card)))
                   (get-effects state side :rez-additional-cost card)])]
      (filterv (or pred identity) costs))))
 
 (defn score-additional-cost-bonus
   [state side card]
   (merge-costs
-    [(:additional-cost card)
-     (:additional-cost (card-def card))
+    [(:additional-cost (card-def card))
      (get-effects state side :score-additional-cost card)]))
 
 (defn trash-cost
@@ -92,8 +84,7 @@
 (defn install-additional-cost-bonus
   [state side card]
   (merge-costs
-    [(:additional-cost card)
-     (:additional-cost (card-def card))
+    [(:additional-cost (card-def card))
      (get-effects state side :install-additional-cost card)]))
 
 (defn ignore-install-cost?

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -49,7 +49,7 @@
                  ;; and the additional cost for the cdef, but we should probably actually
                  ;; have a note here explaining it (somewhere in this file)
                  [;(when-not (is-disabled? state side card)
-                    (:additional-cost card)
+                  (:additional-cost card)
                   ;  )
                   (when-not (is-disabled? state side card) (:additional-cost (card-def card)))
                   (get-effects state side :rez-additional-cost card)])]

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.card :refer [runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [any-effects get-effects sum-effects get-effect-maps get-effect-value is-disabled?]]
+    [game.core.effects :refer [any-effects get-effects sum-effects get-effect-maps get-effect-value is-disabled? is-disabled-reg?]]
     [game.core.eid :refer [make-eid]]
     [game.core.payment :refer [merge-costs]]))
 
@@ -34,7 +34,8 @@
    (when-not (nil? cost)
      (->> [cost
            (or cost-bonus 0)
-           (when-let [rezfun (:rez-cost-bonus (card-def card))]
+           (when-let [rezfun (and (not (is-disabled-reg? state card))
+                                  (:rez-cost-bonus (card-def card)))]
              (rezfun state side (make-eid state) card nil))
            (sum-effects state side :rez-cost card)]
           (reduce (fnil + 0 0))

--- a/src/clj/game/core/def_helpers.clj
+++ b/src/clj/game/core/def_helpers.clj
@@ -7,6 +7,7 @@
     [game.core.damage :refer [damage]]
     [game.core.eid :refer [effect-completed]]
     [game.core.engine :refer [resolve-ability trigger-event-sync]]
+    [game.core.effects :refer [is-disabled-reg?]]
     [game.core.gaining :refer [gain-credits]]
     [game.core.moving :refer [move trash]]
     [game.core.play-instants :refer [async-rfg]]
@@ -204,7 +205,7 @@
 (defn get-x-fn []
   (fn get-x-fn-inner
     [state side eid card targets]
-    (if-let [x-fn (and (not (:disabled card)) (:x-fn card))]
+    (if-let [x-fn (and (not (is-disabled-reg? state card)) (:x-fn card))]
       (x-fn state side eid card targets)
       0)))
 

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -6,6 +6,7 @@
    [game.core.card :refer :all]
    [game.core.cost-fns :refer [card-ability-cost]]
    [game.core.engine :refer [can-trigger?]]
+   [game.core.effects :refer [is-disabled-reg?]]
    [game.core.installing :refer [corp-can-pay-and-install?
                                  runner-can-pay-and-install?]]
    [game.core.payment :refer [can-pay? ->c]]
@@ -54,6 +55,13 @@
              :source-info {:ability-idx ability-idx}}]
     (if (and (or (active? card)
                  (:autoresolve ability))
+             ;; using the reg instead of any-effect here because this function gets called
+             ;; a LOT, and this is very close to linear time and should (I think)
+             ;; always be correct when this fn is called.
+             ;; If that's ever an issue, we can switch this to:
+             ;; (is-disabled? state side card)
+             ;; --n kelly, apr 2024
+             (not (is-disabled-reg? state card))
              (can-pay? state side eid card nil cost)
              (can-trigger? state side eid ability card nil))
       (assoc ability :playable true)

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -6,6 +6,10 @@
             [game.core.board :refer [get-all-cards]]
             [game.utils :refer [same-card? to-keyword]]))
 
+(defn is-disabled-reg?
+  [state card]
+  (some #(same-card? % card) (:disabled-card-reg @state)))
+
 (defn register-static-abilities
   [state _ card]
   (when (:static-abilities (card-def card))
@@ -58,11 +62,10 @@
 (defn gather-effects
   [state _ effect-type]
   (let [get-side #(-> % :card :side to-keyword)
-        is-active-player #(= (:active-player @state) (get-side %))
-        is-disabled-reg (fn [state c] (some #(same-card? % (:card c)) (:disabled-card-reg @state)))]
+        is-active-player #(= (:active-player @state) (get-side %))]
     (->> (:effects @state)
          (filter #(= effect-type (:type %)))
-         (filter #(not (and (:static %) (is-disabled-reg state %))))
+         (filter #(not (and (:static %) (is-disabled-reg? state (:card %)))))
          (sort-by (complement is-active-player))
          (into []))))
 

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -145,6 +145,7 @@
   (let [all-cards (get-all-cards state)
         disabled-cards (filter #(is-disabled? state nil %) all-cards)]
     (into {} (map (juxt :cid identity)) disabled-cards)))
+
 (defn update-disabled-cards [state]
   (swap! state assoc-in [:disabled-card-reg] (all-disabled-cards state))
   (get-in @state [:disabled-card-reg]))

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -8,7 +8,7 @@
 
 (defn is-disabled-reg?
   [state card]
-  (some #(same-card? % card) (:disabled-card-reg @state)))
+  (get (:disabled-card-reg @state) (:cid card)))
 
 (defn register-static-abilities
   [state _ card]
@@ -144,8 +144,7 @@
   [state]
   (let [all-cards (get-all-cards state)
         disabled-cards (filter #(is-disabled? state nil %) all-cards)]
-    (into [] disabled-cards)))
-
+    (into {} (map (juxt :cid identity)) disabled-cards)))
 (defn update-disabled-cards [state]
   (swap! state assoc-in [:disabled-card-reg] (all-disabled-cards state))
   (get-in @state [:disabled-card-reg]))

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -39,6 +39,7 @@
   (let [ability (assoc
                   (select-keys ability [:type :duration :req :value])
                   :card card
+                  :lingering true
                   :uuid (uuid/v1))]
     (swap! state update :effects conj ability)
     ability))

--- a/src/clj/game/core/effects.clj
+++ b/src/clj/game/core/effects.clj
@@ -12,6 +12,8 @@
           abilities (for [ability static-abilities]
                       (assoc
                         (select-keys ability [:type :req :value])
+                        ;; this is so I can select them later
+                        :static true
                         :duration :while-active
                         :card card
                         :uuid (uuid/v1)))]
@@ -124,3 +126,8 @@
   ([state side effect-type pred target] (any-effects state side effect-type pred target nil))
   ([state side effect-type pred target targets]
    (some pred (get-effects state side effect-type target targets))))
+
+(defn is-disabled?
+  "Check if a card is disabled"
+  ([state side target]
+   (any-effects state side :disable-card true? target)))

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -579,7 +579,7 @@
   (= (:active-player @state) (get-side ability)))
 
 (defn- valid-condition?
-  [state card {:keys [condition location]}]
+  [state card {:keys [condition location] :as ability}]
   (when (case condition
           :accessed (same-card? card (:access @state))
           :active (active? card)
@@ -596,9 +596,14 @@
                            (and (contains? location :hand)
                                 (in-hand? card)))
           :test-condition true)
-    (and
-      (not (is-disabled? state nil card))
-      (not (is-disabled-reg? state card))
+    (when
+        ;; special case for abilities which persist while disabled
+        ;; primarily, this is to cheat abilities based on rulings
+        ;; that aren't properly supported by the current design
+        ;; of our engine (eg Saci) - nbk, Apr 2024
+        (or (:while-disabled ability)
+            (and (not (is-disabled? state nil card))
+                 (not (is-disabled-reg? state card))))
       card)))
 
 (defn- card-for-ability

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -505,6 +505,7 @@
    :unregister-once-resolved (or (:unregister-once-resolved ability) false)
    :once-per-instance (or (:once-per-instance ability) false)
    :ability (dissoc ability :event :duration :condition)
+   :while-disabled (:while-disabled ability)
    :card card
    :uuid (uuid/v1)})
 

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -6,7 +6,7 @@
     [game.core.board :refer [clear-empty-remotes all-installed-runner-type all-active-installed]]
     [game.core.card :refer [active? facedown? faceup? get-card get-cid get-title in-discard? in-hand? installed? rezzed? program? console? unique?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [get-effect-maps unregister-lingering-effects]]
+    [game.core.effects :refer [get-effect-maps unregister-lingering-effects is-disabled?]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.payment :refer [build-spend-msg can-pay? handler]]
     [game.core.prompt-state :refer [add-to-prompt-queue]]
@@ -594,7 +594,9 @@
                            (and (contains? location :hand)
                                 (in-hand? card)))
           :test-condition true)
-    card))
+    (and
+      (not (is-disabled? state nil card))
+      card)))
 
 (defn- card-for-ability
   [state {:keys [card duration] :as ability}]

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -1050,7 +1050,6 @@
                       (filter console?))
         consoles (when (< 1 (count consoles))
                    (butlast consoles))
-
         cards-to-trash (-> (concat corp-uniques runner-uniques consoles)
                            distinct
                            seq)]
@@ -1135,7 +1134,7 @@
   ([state _ eid] (checkpoint state nil eid nil))
   ([state _ eid {:keys [duration durations] :as args}]
    ;; a: Any ability that has met its condition creates the appropriate instances of itself and marks them as pending
-   (let [{:keys [handlers context-maps]} (mark-pending-abilities state eid nil)]
+   (let [{:keys [handlers context-maps]} (mark-pending-abilities state eid args)]
      ;; b: Any ability with a duration that has passed is removed from the game state
      (wait-for
        (unregister-expired-durations state nil (make-eid state eid) (conj durations duration) context-maps)

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -859,7 +859,7 @@
                  (let [card (card-for-ability state handler)
                        ability (:ability handler)]
                    (and (not (apply trigger-suppress state (to-keyword (:side card)) (:event handler) card context))
-                        card
+                        (or card (:while-disabled ability))
                         (can-trigger? state (to-keyword (:side card)) eid ability card context)))))
        (sort-by (complement #(is-active-player state (:handler %))))
        (seq)))
@@ -1063,7 +1063,7 @@
   [state _ eid]
   (let [trash-when-tagged (when (jinteki.utils/is-tagged? state)
                             (filter :trash-when-tagged (all-installed-runner state)))
-        trash-when-tagged (filter #(not (is-disabled? state %)) trash-when-tagged)]
+        trash-when-tagged (filter #(not (is-disabled? state nil %)) trash-when-tagged)]
     (if (seq trash-when-tagged)
       (wait-for (move* state nil (make-eid state eid)
                        :trash-cards trash-when-tagged

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -10,13 +10,6 @@
     [game.core.toasts :refer [toast]]
     [game.utils :refer [enumerate-str same-card? same-side?]]))
 
-(defn can-really-be-advanced?
-  "Like can be advanced, but takes into account that abilities allowing advancability may be disabled"
-  [state card]
-  (and (can-be-advanced? card)
-       (or (agenda? card)
-           (not (is-disabled-reg? state card)))))
-
 (defn card-flag?
   "Checks the card to see if it has a :flags entry of the given flag-key, and with the given value if provided"
   ;; TODO: add a register for mutable state card flags, separate from this
@@ -278,8 +271,6 @@
   "Checks if the corp can advance cards"
   [state side card]
   (and (check-flag-types? state side card :can-advance [:current-turn :persistent])))
-;; this flag should *probably* be there, but it appears to break some of the tests
-;; (can-really-be-advanced? state card))) ;; we can fix this later - nbkelly, apr '24
 
 (defn can-score?
   "Checks if the corp can score a given card"

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -1,14 +1,21 @@
 (ns game.core.flags
   (:require
     [game.core.board :refer [all-active all-installed]]
-    [game.core.card :refer [agenda? get-advancement-requirement get-cid get-counters installed? in-scored? rezzed?]]
+    [game.core.card :refer [agenda? can-be-advanced? get-advancement-requirement get-cid get-counters installed? in-scored? rezzed? ]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [any-effects]]
+    [game.core.effects :refer [any-effects is-disabled-reg?]]
     [game.core.eid :refer [make-eid]]
     [game.core.servers :refer [zone->name]]
     [game.core.to-string :refer [card-str]]
     [game.core.toasts :refer [toast]]
     [game.utils :refer [enumerate-str same-card? same-side?]]))
+
+(defn can-really-be-advanced?
+  "Like can be advanced, but takes into account that abilities allowing advancability may be disabled"
+  [state card]
+  (and (can-be-advanced? card)
+       (or (agenda? card)
+           (not (is-disabled-reg? state card)))))
 
 (defn card-flag?
   "Checks the card to see if it has a :flags entry of the given flag-key, and with the given value if provided"
@@ -270,7 +277,8 @@
 (defn can-advance?
   "Checks if the corp can advance cards"
   [state side card]
-  (check-flag-types? state side card :can-advance [:current-turn :persistent]))
+  (and (check-flag-types? state side card :can-advance [:current-turn :persistent])
+       (can-really-be-advanced? state card)))
 
 (defn can-score?
   "Checks if the corp can score a given card"

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -321,9 +321,10 @@
 
 (defn can-host?
   "Checks if the specified card is able to host other cards"
-  [card]
+  [state card]
   (or (not (rezzed? card))
-      (not (:cannot-host (card-def card)))))
+      (not (:cannot-host (card-def card)))
+      (is-disabled-reg? state card)))
 
 (defn when-scored?
   "Checks if the specified card is able to be used for a when-scored text ability"

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -277,8 +277,9 @@
 (defn can-advance?
   "Checks if the corp can advance cards"
   [state side card]
-  (and (check-flag-types? state side card :can-advance [:current-turn :persistent])
-       (can-really-be-advanced? state card)))
+  (and (check-flag-types? state side card :can-advance [:current-turn :persistent])))
+;; this flag should *probably* be there, but it appears to break some of the tests
+;; (can-really-be-advanced? state card))) ;; we can fix this later - nbkelly, apr '24
 
 (defn can-score?
   "Checks if the corp can score a given card"

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -155,15 +155,15 @@
   "Marks a given subroutine as broken"
   ([ice sub] (break-subroutine ice sub nil))
   ([ice sub breaker]
-   (assoc ice :subroutines (assoc (:subroutines ice) (:index sub) (if breaker
-                                                                    (assoc sub :broken true :breaker (:cid breaker))
-                                                                    (assoc sub :broken true))))))
+   (let [replacement-sub (assoc sub :broken true :breaker (when breaker (:cid breaker)))
+         replacement-subs (assoc (vec (:subroutines ice)) (:index sub) replacement-sub)]
+     (assoc ice :subroutines replacement-subs))))
 
 (defn break-subroutine!
   "Marks a given subroutine as broken, update!s state"
   ([state ice sub] (break-subroutine! state ice sub nil))
   ([state ice sub breaker]
-   (update! state :corp (break-subroutine ice sub breaker))))
+   (update! state :corp (break-subroutine (get-card state ice) sub breaker))))
 
 (defn break-all-subroutines
   ([ice]

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -135,7 +135,9 @@
   ([state side ice sub] (add-extra-sub! state side ice sub (:cid ice) {:back true}))
   ([state side ice sub cid] (add-extra-sub! state side ice sub cid {:back true}))
   ([state side ice sub cid args]
-   (add-sub! state side (assoc-in ice [:special :extra-subs] true) sub cid args)))
+   (add-sub! state side (assoc-in ice [:special :extra-subs] true) sub cid args)
+   (trigger-event state side :subroutines-changed (get-card state ice))
+   ))
 
 (defn remove-extra-subs!
   "Remove runtime subroutines assigned from the given cid from a piece of ice."

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -190,6 +190,8 @@
                 :subroutines (subroutines-init (assoc card :cid cid) cdef)
                 :abilities (ability-init cdef)
                 :expend (:expend cdef)
+                :enforce-conditions (:enforce-conditions cdef)
+                :trash-when-tagged (:trash-when-tagged cdef)
                 :x-fn (:x-fn cdef)
                 :printed-title (:title card))
          (dissoc :setname :text :_id :influence :number :influencelimit

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -8,7 +8,7 @@
     [game.core.cost-fns :refer [ignore-install-cost? install-additional-cost-bonus install-cost]]
     [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
     [game.core.engine :refer [checkpoint register-pending-event pay queue-event register-events trigger-event-simult unregister-events]]
-    [game.core.effects :refer [register-static-abilities unregister-static-abilities]]
+    [game.core.effects :refer [register-static-abilities unregister-static-abilities is-disabled-reg?]]
     [game.core.flags :refer [turn-flag? zone-locked?]]
     [game.core.hosting :refer [host]]
     [game.core.ice :refer [update-breaker-strength]]
@@ -58,12 +58,14 @@
     ;; A Teia cannot have more than two servers
     (and (clojure.string/starts-with? (:title (get-in @state [:corp :identity])) "A Teia")
          (not (:disabled (get-in @state [:corp :identity])))
+         (not (is-disabled-reg? state (get-in @state [:corp :identity])))
          (<= 2 (count (get-remotes state)))
          (not (in-coll? (conj (keys (get-remotes state)) :archives :rd :hq) (second slot))))
     :a-teia
     ;; Earth station cannot have more than one server
     (and (= "Earth Station" (subs (:title (get-in @state [:corp :identity])) 0 (min 13 (count (:title (get-in @state [:corp :identity]))))))
          (not (:disabled (get-in @state [:corp :identity])))
+         (not (is-disabled-reg? state (get-in @state [:corp :identity])))
          (pos? (count (get-remotes state)))
          (not (in-coll? (conj (keys (get-remotes state)) :archives :rd :hq) (second slot))))
     :earth-station

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -3,7 +3,7 @@
     [game.core.card :refer [asset? condition-counter? get-card ice? upgrade?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [rez-additional-cost-bonus rez-cost]]
-    [game.core.effects :refer [unregister-static-abilities is-disabled?]]
+    [game.core.effects :refer [is-disabled? unregister-static-abilities update-disabled-cards]]
     [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
     [game.core.engine :refer [register-pending-event queue-event checkpoint pay register-events resolve-ability trigger-event unregister-events]]
     [game.core.flags :refer [can-host? can-rez?]]
@@ -142,4 +142,5 @@
       (when-let [derezzed-events (:derezzed-events cdef)]
         (register-events state side card (map #(assoc % :condition :derezzed) derezzed-events))))
     (unregister-static-abilities state side card)
+    (update-disabled-cards state)
     (trigger-event state side :derez {:card card :side side})))

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -3,7 +3,7 @@
     [game.core.card :refer [asset? condition-counter? get-card ice? upgrade?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [rez-additional-cost-bonus rez-cost]]
-    [game.core.effects :refer [unregister-static-abilities]]
+    [game.core.effects :refer [unregister-static-abilities is-disabled?]]
     [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
     [game.core.engine :refer [register-pending-event queue-event checkpoint pay register-events resolve-ability trigger-event unregister-events]]
     [game.core.flags :refer [can-host? can-rez?]]
@@ -24,7 +24,7 @@
   (merge-costs
     (cond
       (= :all-costs ignore-cost) [(->c :credit 0)]
-      alternative-cost alternative-cost
+      alternative-cost (when-not (is-disabled? state side card) alternative-cost)
       :else (let [cost (rez-cost state side card {:cost-bonus cost-bonus})
                   additional-costs (rez-additional-cost-bonus state side card (when ignore-cost #(not= :credit (:cost/type %))))]
               (concat

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -36,7 +36,7 @@
 (defn trash-hosted-cards
   [state side eid card]
   (let [hosted-cards (seq (remove condition-counter? (:hosted card)))]
-    (if (can-host? card)
+    (if (can-host? state card)
       (effect-completed state side eid)
       (wait-for (trash-cards state side hosted-cards {:unpreventable true :game-trash true})
                 (when (pos? (count hosted-cards))
@@ -102,6 +102,7 @@
          card (get-card state card)
          alternative-cost (when (and card
                                      (not alternative-cost)
+                                     (not (is-disabled? state side card))
                                      (not declined-alternative-cost))
                             (:alternative-cost (card-def card)))]
      (if (and card

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -1,7 +1,7 @@
 (ns game.core.tags
   (:require
     [game.core.effects :refer [any-effects sum-effects]]
-    [game.core.eid :refer [effect-completed]]
+    [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [trash-on-tag trigger-event trigger-event-simult trigger-event-sync]]
     [game.core.flags :refer [cards-can-prevent? get-prevent-list]]
     [game.core.gaining :refer [deduct gain]]

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -34,7 +34,7 @@
                                                    :old-total old-total
                                                    :is-tagged is-tagged?}))
      (when is-tagged?
-       (trash-on-tag state nil (make-eid state eid)))
+       (trash-on-tag state nil (make-eid state)))
      changed?)))
 
 (defn tag-prevent

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.effects :refer [any-effects sum-effects]]
     [game.core.eid :refer [effect-completed]]
-    [game.core.engine :refer [trigger-event trigger-event-simult trigger-event-sync]]
+    [game.core.engine :refer [trash-on-tag trigger-event trigger-event-simult trigger-event-sync]]
     [game.core.flags :refer [cards-can-prevent? get-prevent-list]]
     [game.core.gaining :refer [deduct gain]]
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-wait-prompt]]
@@ -33,7 +33,11 @@
        (trigger-event state :runner :tags-changed {:new-total new-total
                                                    :old-total old-total
                                                    :is-tagged is-tagged?}))
-     changed?)))
+     (if is-tagged?
+       (wait-for
+         (trash-on-tag state nil)
+         changed?)
+       changed?))))
 
 (defn tag-prevent
   [state side eid n]

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -33,11 +33,9 @@
        (trigger-event state :runner :tags-changed {:new-total new-total
                                                    :old-total old-total
                                                    :is-tagged is-tagged?}))
-     (if is-tagged?
-       (wait-for
-         (trash-on-tag state nil)
-         changed?)
-       changed?))))
+     (when is-tagged?
+       (trash-on-tag state nil (make-eid state eid)))
+     changed?)))
 
 (defn tag-prevent
   [state side eid n]

--- a/src/clj/game/core/threat.clj
+++ b/src/clj/game/core/threat.clj
@@ -14,6 +14,10 @@
   (or (<= threshold (get-in @state [:runner :agenda-point]))
       (<= threshold (get-in @state [:corp :agenda-point]))))
 
+(defn get-threat-level [state]
+  (max (get-in @state [:runner :agenda-point])
+       (get-in @state [:corp :agenda-point])))
+
 (defn threat
   ([threshold accept-ab]
    (threat threshold accept-ab nil))

--- a/src/cljc/game/core/card.cljc
+++ b/src/cljc/game/core/card.cljc
@@ -355,21 +355,31 @@
       (:agendapoints card)
       0))
 
+(defn- is-disabled-reg?
+  [state card]
+  (get (:disabled-card-reg @state) (:cid card)))
+
 (defn can-be-advanced?
   "Returns true if the card can be advanced"
-  [card]
-  (or (card-is? card :advanceable #?(:clj :always
-                                     :cljs "always"))
-      ;; e.g. Tyrant, Woodcutter
-      (and (card-is? card :advanceable #?(:clj :while-rezzed
-                                          :cljs "while-rezzed"))
-           (rezzed? card))
-      ;; e.g. Haas Arcology AI
-      (and (card-is? card :advanceable #?(:clj :while-unrezzed
-                                          :cljs "while-unrezzed"))
-           (not (rezzed? card)))
-      (and (is-type? card "Agenda")
-           (installed? card))))
+  ([card]
+   (or (card-is? card :advanceable #?(:clj :always
+                                      :cljs "always"))
+       ;; e.g. Tyrant, Woodcutter
+       (and (card-is? card :advanceable #?(:clj :while-rezzed
+                                           :cljs "while-rezzed"))
+            (rezzed? card))
+       ;; e.g. Haas Arcology AI
+       (and (card-is? card :advanceable #?(:clj :while-unrezzed
+                                           :cljs "while-unrezzed"))
+            (not (rezzed? card)))
+       (and (is-type? card "Agenda")
+            (installed? card))))
+  ([state card]
+   (and (can-be-advanced? card)
+        ;; note - the text allowing a card to be advanceable is an ability,
+        ;;    except for agendas, where it's implicit to the card type -nbk, apr '24
+        (or (agenda? card)
+            (not (is-disabled-reg? state card))))))
 
 (defn get-counters
   "Get number of counters of specified type."

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -97,6 +97,11 @@
     (if (:host card) (update card :host card-for-click) card)
     click-card-keys))
 
+(defn playable?
+  "Checks whether a card or ability is playable"
+  [action]
+  (:playable action))
+
 (defn handle-abilities
   [side {:keys [abilities corp-abilities runner-abilities subroutines facedown] :as card}]
   (let [actions (action-list card)
@@ -134,14 +139,10 @@
         ;; Trigger first (and only) ability / action
         (and (= c 1)
              (= side card-side))
-        (if (= (count abilities) 1)
+        (if (and (= (count abilities) 1)
+                 (playable? (first abilities)))
           (send-command "ability" {:card (card-for-click card) :ability 0})
           (send-command (first actions) {:card (card-for-click card)}))))))
-
-(defn playable?
-  "Checks whether a card or ability is playable"
-  [action]
-  (:playable action))
 
 (defn handle-card-click [{:keys [type zone] :as card}]
   (let [side (:side @game-state)]

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -2617,6 +2617,27 @@
       (is (= 4 (count (:discard (get-runner))))
           "Discard is 4 cards - 2 from Philotic, 1 EStrike, 1 from PU mill")))
 
+(deftest employee-strike-vs-pe-philotic
+  ;; vs PU/Philotic
+  (do-game
+    (new-game {:corp {:id "Jinteki: Personal Evolution"
+                      :deck ["Sting!" (qty "Braintrust" 2)]}
+               :runner {:hand [(qty "Employee Strike" 5)]}})
+    (play-from-hand state :corp "Braintrust" "New remote")
+    (play-from-hand state :corp "Braintrust" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Employee Strike")
+    (run-empty-server state "Server 1")
+    (click-prompt state :runner "Steal")
+    (run-empty-server state "Server 2")
+    (click-prompt state :runner "Steal")
+    (take-credits state :runner)
+    (play-and-score state "Sting!")
+    (is (no-prompt? state :corp) "No prompt to interact because PE is dead")
+    (is (= 2 (count (:discard (get-runner))))
+        "Discard is 2 cards - 1 from String1, 1 EStrike")))
+
+
 (deftest en-passant
   ;; En Passant
   (do-game

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -6266,17 +6266,18 @@
       (click-prompt state :runner "0")
       (is (= 1 (count-tags state)) "Trace succeeds with 1 advancement"))))
 
-(deftest ^:kaocha/pending searchlight-x-fn
+(deftest searchlight-x-fn
   (do-game
-    (new-game {:corp {:deck ["Searchlight"]}})
+    (new-game {:corp {:deck ["Searchlight"]}
+               :runner {:hand ["Hush"]}})
     (core/gain state :corp :credit 10)
     (play-from-hand state :corp "Searchlight" "HQ")
     (let [searchlight (get-ice state :hq 0)]
       (rez state :corp searchlight)
       (advance state (refresh searchlight) 1)
       (take-credits state :corp)
-      (core/disable-card state :corp (refresh searchlight))
-      (core/fake-checkpoint state)
+      (play-from-hand state :runner "Hush")
+      (click-card state :runner "Searchlight")
       (run-on state "HQ")
       (run-continue state)
       (card-subroutine state :corp (refresh searchlight) 0)
@@ -6285,8 +6286,7 @@
       (click-prompt state :corp "0")
       (click-prompt state :runner "0")
       (is (zero? (count-tags state)) "Trace failed with 0 advancements")
-      (core/enable-card state :corp (refresh searchlight))
-      (core/fake-checkpoint state)
+      (trash state :runner (first (:hosted (get-ice state :hq 0))))
       (card-subroutine state :corp (refresh searchlight) 0)
       (is (= :trace (prompt-type :corp)) "Trace is initiated")
       (is (= 1 (:base (prompt-map :corp))) "Trace is now base 1")

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -6266,7 +6266,7 @@
       (click-prompt state :runner "0")
       (is (= 1 (count-tags state)) "Trace succeeds with 1 advancement"))))
 
-(deftest searchlight-x-fn
+(deftest ^:kaocha/pending searchlight-x-fn
   (do-game
     (new-game {:corp {:deck ["Searchlight"]}})
     (core/gain state :corp :credit 10)

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3771,17 +3771,12 @@
 
     ;; hush vs. hive
     (do-game
-      (install-hush-and-run "Hive" {:rig ["Simulchip"]
-                                    :scored ["City Works Project"]
-                                    :players {:runner {:discard ["Fermenter"]}}
+      (install-hush-and-run "Hive" {:scored ["City Works Project"]
                                     :hushed true})
-      (let [ice (get-ice state :hq 0)
-            sim (get-hardware state 0)]
+      (let [ice (get-ice state :hq 0)]
         (is (= 5 (count (:subroutines ice))) "full subs on hive because hush")
-        (card-ability state :runner sim 0)
-        (click-card state :runner "Hush")
-        (click-card state :runner "Fermenter")
-        (is (= 2 (count (:subroutines ice))) "5-3 subs on hive now")))
+        (trash state :runner (first (:hosted (refresh ice))))
+        (is (= 2 (count (:subroutines (refresh ice)))) "5-3 subs on hive now")))
 
     ;; hush vs. hortum
     (advancable-while-hushed-test? "Hortum" true)

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3804,6 +3804,8 @@
         (is (= 6 (count (:subroutines (refresh ice)))) "5+1 on masvingo subs now")))
 
     ;;  mausolus
+    (advancable-while-hushed-test? "Mausolus" true)
+
     ;;  cloud eater
     (do-game
       (install-hush-and-run "Cloud Eater" {:hushed true})
@@ -3811,7 +3813,51 @@
       (run-continue state)
       (is (no-prompt? state :runner) "No Cloud Eater prompt because of hush"))
 
-    ;;  NEXT Bronze, Gold, Opal, Silver *
+    ;; NEXT Bronze
+    (do-game
+      (install-hush-and-run "NEXT Bronze" {:hushed true})
+      (let [ice (get-ice state :hq 0)]
+        (is (= 0 (get-strength ice)) "NEXt Bronze: X is 0 while hushed")
+        (trash state :runner (first (:hosted (refresh ice))))
+        (is (= 1 (get-strength (refresh ice))) "NEXt Bronze: X is 1 post-hush")))
+
+    ;; NEXT Gold
+    (do-game
+      (install-hush-and-run "NEXT Gold" {:hushed true :runner {:hand 2}})
+      (let [ice (get-ice state :hq 0)]
+        (run-continue-until state :encounter-ice)
+        (fire-subs state ice)
+        (is (zero? (count (:discard (get-runner)))) "X is 0, so gold does 0 net")
+        (is (no-prompt? state :corp) "X is 0, so gold trashes 0 programs")))
+
+    ;; NEXT Silver
+    (do-game
+      (install-hush-and-run "NEXT Silver" {:hushed true})
+      (let [ice (get-ice state :hq 0)]
+        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+        (trash state :runner (first (:hosted (refresh ice))))
+        (is (= 1 (count (:subroutines (refresh ice)))) "1 on NEXT Silver subs now")))
+
+    ;; NEXT Opal
+    (do-game
+      (install-hush-and-run "NEXT Opal" {:hushed true})
+      (let [ice (get-ice state :hq 0)]
+        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+        (trash state :runner (first (:hosted (refresh ice))))
+        (is (= 1 (count (:subroutines (refresh ice)))) "1 on NEXT Opal subs now")))
+
+    ;; Orion, Nebula, Wormhole, Asteroid Belt
+    (doseq [const ["Orion" "Wormhole" "Nebula" "Asteroid Belt"]]
+      (advancable-while-hushed-test? const true)
+      (do-game
+        (install-hush-and-run const {:hushed true
+                                     :unrezzed true
+                                     :counters {:advancement 5}})
+        (let [ice (get-ice state :hq 0)
+              creds (:credit (get-corp))]
+          (rez state :corp ice)
+          (is (not= creds (:credit (get-corp))) (str "Paid full price for " const " (hushed)")))))
+
     ;; Orion (nebula, wormhole, asteroid belt)
     ;;  saisentan
     ;;  salbage
@@ -3857,6 +3903,11 @@
       (is (no-prompt? state :corp) "No Thoth prompt because of hush"))
 
     ;;  tithonium
+    (do-game
+      (install-hush-and-run "Tithonium" {:hushed true :unrezzed true :scored ["City Works Project"]})
+      (rez state :corp (get-ice state :hq 0))
+      (is (no-prompt? state :corp) "No alternate cost prompt")
+      (is (zero? (count (:discard (get-runner)))) "Hush not trashed"))
     ;;  tollbooth
     (do-game
       (install-hush-and-run "Tollbooth" {:hushed true})

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -4094,9 +4094,8 @@
           (rez state :corp magnet)
           (click-card state :corp ika)
           (is (zero?(count (:hosted (refresh enigma)))) "Ika was removed from Enigma")
-          ;; note that when cards are disabled now, the abilities still exist
-          ;; we just don't allow them to be used
-          ;; since card-ability bypasses :playable, that wont work in the test
+          (is (not (:playable (first (:abilities (refresh ika))))) "Ika abilities are not playable")
+          (is (not (:playable (second (:abilities (refresh ika))))) "Ika abilities are not playable")
           (is (= 1 (count (:hosted (refresh magnet)))) "Ika was hosted onto Magnet")))))
 
 (deftest imp-full-test

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [game.core.flags :refer [can-really-be-advanced?]]
    [game.core :as core]
    [game.core.card :refer :all]
    [game.core.cost-fns :refer [card-ability-cost]]
@@ -11,6 +10,126 @@
    [game.core.threat :refer [threat-level get-threat-level]]
    [game.test-framework :refer :all]
    [game.utils :as utils]))
+
+;; helper functions for writing tests
+
+(defn- install-hush-and-run
+  [card {:keys [hushed counters server tags threat players rig unrezzed scored assets] :as args}]
+  (let [;; remap things like ':hand x' to ':hand [(qty 'ipo' x)] (and deck too, for both sides)
+        players (if (int? (get-in players [:corp :hand]))
+                  (assoc-in players [:corp :hand] (qty "IPO" (get-in players [:corp :hand])))
+                  players)
+        players (if (int? (get-in players [:corp :deck]))
+                  (assoc-in players [:corp :deck] (qty "IPO" (get-in players [:corp :deck])))
+                  players)
+        players (if (int? (get-in players [:runner :hand]))
+                         (assoc-in players [:runner :hand]
+                                   (qty "Inti" (get-in players [:runner :hand])))
+                         players)
+        players (if (int? (get-in players [:runner :deck]))
+                  (assoc-in players [:runner :deck]
+                            (qty "Inti" (get-in players [:runner :deck])))
+                  players)
+        ;; add the target ice to the corp hand
+        players (assoc-in players [:corp :hand]
+                          (cons card (get-in players [:corp :hand])))
+        ;; add agendas to score to the corp hand
+        players (assoc-in players [:corp :hand]
+                          (concat scored (get-in players [:corp :hand])))
+        ;; add assets to the corp hand
+        players (assoc-in players [:corp :hand]
+                          (concat assets (get-in players [:corp :hand])))
+        ;; add the rig to the runner hand
+        players (assoc-in players [:runner :hand]
+                          (concat rig (get-in players [:runner :hand])))
+        ;; add hush to the runner hand
+        players (if hushed
+                  (assoc-in players [:runner :hand]
+                            (concat ["Hush"] (get-in players [:runner :hand])))
+                  players)
+        state (new-game players)
+        server (or server "HQ")
+        server-key (cond
+                     (= server "New remote") :remote1
+                     (= server "HQ") :hq
+                     (= server "R&D") :rd
+                     (= server "Archives") :archives)]
+    ;; adjust the threat level for threat: ... subs
+    (when threat
+      (do (game.core.change-vals/change
+            ;; theoretically, either side is fine!
+            state (first (shuffle [:corp :runner])) {:key :agenda-point :delta threat})
+          (is (threat-level threat state) "Threat set")
+          (is (not (threat-level (inc threat) state)) "Threat is accurate")))
+    (play-from-hand state :corp card server)
+    (let [ice (get-ice state server-key 0)]
+      ;; gain credits to rez the ice
+      (core/gain state :corp :credit (:cost ice))
+      ;; score agendas when needed
+      (doseq [s scored]
+        (play-and-score state s))
+      (doseq [a assets]
+        (let [target-card (first (filter #(= (:title %) a) (:hand (:corp @state))))
+              cost (:cost target-card)]
+          (core/gain state :corp :credit cost)
+          (core/gain state :corp :click 1)
+          (play-from-hand state :corp a "New remote")
+          (rez state :corp
+               (get-content state (keyword (str "remote" (dec (:rid @state)))) 0))))
+      ;;adjust counters when needed
+      (when counters
+        ;; counters of the form :counter {:power x :credit x}
+        (doseq [[c-type c-count] counters]
+          (core/add-counter state :corp (get-ice state server-key 0) c-type c-count)))
+      (when-not unrezzed
+        (rez state :corp (get-ice state server-key 0)))
+      ;; gain tags when required
+      (when tags
+        (gain-tags state :runner tags)
+        (is (= tags (count-tags state)) (str "Have " tags " tags")))
+      ;; ensure we start with the specified credit count (default 5)
+      ;; by not actually clicking for creds
+      (core/lose state :corp :click 2)
+      (take-credits state :corp)
+      ;; install any cards from the runner rig (cheat click/cred costs)
+      (doseq [r rig]
+        (let [target-card (first (filter #(= (:title %) r) (:hand (:runner @state))))
+              cost (:cost target-card)]
+          (core/gain state :runner :credit cost)
+          (core/gain state :runner :click 1)
+          (play-from-hand state :runner r)))
+      ;; install hush if desired
+      (when hushed
+        (do (core/gain state :runner :credit 1)
+            (core/gain state :runner :click 1)
+            (play-from-hand state :runner "Hush")
+            (click-card state :runner card)))
+      (run-on state server-key))
+    state))
+
+(defn- advancable-while-hushed-test?
+  "Tests that a card is not advanceable while hushed, and also checks the rez requirement too"
+  [card rez-req]
+  (do-game
+    (new-game {:corp {:hand [card] :credits 15}
+               :runner {:hand ["Hush"]}})
+    (play-from-hand state :corp card "HQ")
+    (let [ice (get-ice state :hq 0)]
+      (when rez-req
+        (is (can-be-advanced? state (refresh ice)) (str card " is advancable while unrezzed")))
+      (rez state :corp ice)
+      (is (can-be-advanced? state (refresh ice)) (str card " is advancable while rezzed"))
+      (take-credits state :corp)
+      (play-from-hand state :runner "Hush")
+      (click-card state :runner card)
+      (is (not (can-be-advanced? state (refresh ice)))
+          (str card " is no longer advancable due to hush (rezzed)"))
+      (when rez-req
+        (derez state :corp (refresh ice))
+        (is (not (can-be-advanced? state (refresh ice)))
+            (str card " is no longer advancable due to hush (derezzed)"))))))
+
+;; rest of tests
 
 (deftest abaasy
   ;; Abaasy
@@ -3544,477 +3663,392 @@
       (is (= 3 (get-counters (refresh sg) :power)) "Has 3 power counters")
       (is (= 3 (get-strength (refresh sg))) "3 strength"))))
 
-(deftest hush-has-caused-me-to-suffer
-  (letfn
-      [(install-hush-and-run
-         [card {:keys [hushed counters server tags threat
-                       players rig unrezzed scored assets] :as args}]
-         (let [
-               ;; just incase I only care about the card counts
-               players (if (int? (get-in players [:corp :hand]))
-                         (assoc-in players [:corp :hand] (qty "IPO" (get-in players [:corp :hand])))
-                         players)
-               players (if (int? (get-in players [:corp :deck]))
-                         (assoc-in players [:corp :deck] (qty "IPO" (get-in players [:corp :deck])))
-                         players)
-               players (if (int? (get-in players [:runner :hand]))
-                         (assoc-in players [:runner :hand]
-                                   (qty "Inti" (get-in players [:runner :hand])))
-                         players)
-               players (if (int? (get-in players [:runner :deck]))
-                         (assoc-in players [:runner :deck]
-                                   (qty "Inti" (get-in players [:runner :deck])))
-                         players)
-               ;; add the ice to the corp hand
-               players (assoc-in players [:corp :hand]
-                                 (cons card (get-in players [:corp :hand])))
+(deftest hush-vs-afshar
+  ;; Hush vs. Afshar
+  (do-game
+    (install-hush-and-run "Afshar" {:hushed true :rig ["Buzzsaw"]})
+    (let [buzz (get-program state 0)]
+      (run-continue-until state :encounter-ice)
+      (card-ability state :runner (refresh buzz) 0)
+      (click-prompt state :runner "Make the Runner lose 2 [Credits]")
+      (click-prompt state :runner "End the run")
+      (is (no-prompt? state :runner) "No break prompt as Afshar has no unbroken subroutines"))))
 
-               ;; add agendas to score to the corp hand
-               players (assoc-in players [:corp :hand]
-                                 (concat scored (get-in players [:corp :hand])))
+(deftest hush-vs-akhet
+  ;; Hush vs. Akhet
+  (advancable-while-hushed-test? "Akhet" true)
+  (do-game
+    (install-hush-and-run "Akhet" {:hushed true :rig ["Cleaver"] :counters {:advancement 3}})
+    (let [akhet (get-ice state :hq 0)
+          cleaver (get-program state 0)]
+      (is (= 2 (get-strength (refresh akhet))) "No str gain while hushed")
+      (run-continue-until state :encounter-ice)
+      (card-ability state :runner cleaver 0)
+      (click-prompt state :runner "Gain 1 [Credit]. Place 1 advancement token")
+      (click-prompt state :runner "End the run"))))
 
-               ;; add assets to the corp hand
-               players (assoc-in players [:corp :hand]
-                                 (concat assets (get-in players [:corp :hand])))
+(deftest hush-vs-anansi
+  ;;Hush vs. Anansi
+  (do-game
+    (new-game {:corp {:hand ["Anansi"] :credits 15}
+               :runner {:hand ["Hush" (qty "Sure Gamble" 5)]}})
+    (play-from-hand state :corp "Anansi" "HQ")
+    (rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Hush")
+    (click-card state :runner "Anansi")
+    (run-on state :hq)
+    (run-continue-until state :encounter-ice)
+    (run-continue state :pass-ice)
+    (is (not (seq (:discard (get-runner)))) "No anansi damage")))
 
-               ;; add the rig to the runner hand
-               players (assoc-in players [:runner :hand]
-                                 (concat rig (get-in players [:runner :hand])))
-               ;; add hush to the runner hand
-               players (if hushed
-                         (assoc-in players [:runner :hand]
-                                   (concat ["Hush"] (get-in players [:runner :hand])))
-                         players)
-               state (new-game players)
-               server (or server "HQ")
-               server-key (cond
-                            (= server "New remote") :remote1
-                            (= server "HQ") :hq
-                            (= server "R&D") :rd
-                            (= server "Archives") :archives)]
-           ;; adjust the threat level for threat: ... subs
-           (when threat
-             (do (game.core.change-vals/change
-                   ;; theoretically, either side is fine!
-                   state (first (shuffle [:corp :runner])) {:key :agenda-point :delta threat})
-                 (is (threat-level threat state) "Threat set")
-                 (is (not (threat-level (inc threat) state)) "Threat is accurate")))
-           (play-from-hand state :corp card server)
-           (let [ice (get-ice state server-key 0)]
-             ;; gain credits to rez the ice
-             (core/gain state :corp :credit (:cost ice))
-             ;; score agendas when needed
-             (doseq [s scored]
-               (play-and-score state s))
-             (doseq [a assets]
-               (let [target-card (first (filter #(= (:title %) a) (:hand (:corp @state))))
-                     cost (:cost target-card)]
-                 (core/gain state :corp :credit cost)
-                 (core/gain state :corp :click 1)
-                 (play-from-hand state :corp a "New remote")
-                 (rez state :corp
-                      (get-content state (keyword (str "remote" (dec (:rid @state)))) 0))))
-             ;;adjust counters when needed
-             (when counters
-               ;; counters of the form :counter {:power x :credit x}
-               (doseq [[c-type c-count] counters]
-                 (core/add-counter state :corp (get-ice state server-key 0) c-type c-count)))
-             (when-not unrezzed
-               (rez state :corp (get-ice state server-key 0)))
-             ;; gain tags when required
-             (when tags
-               (gain-tags state :runner tags)
-               (is (= tags (count-tags state)) (str "Have " tags " tags")))
-             ;; ensure we start with the specified credit count (default 5)
-             ;; by not actually clicking for creds
-             (core/lose state :corp :click 2)
-             (take-credits state :corp)
-             ;; install any cards from the runner rig (cheat click/cred costs)
-             (doseq [r rig]
-               (let [target-card (first (filter #(= (:title %) r) (:hand (:runner @state))))
-                     cost (:cost target-card)]
-                 (core/gain state :runner :credit cost)
-                 (core/gain state :runner :click 1)
-                 (play-from-hand state :runner r)))
-             ;; install hush if desired
-             (when hushed
-               (do (core/gain state :runner :credit 1)
-                   (core/gain state :runner :click 1)
-                   (play-from-hand state :runner "Hush")
-                   (click-card state :runner card)))
-             (run-on state server-key))
-           state))
-       (advancable-while-hushed-test?
-         [card rez-req]
-         (do-game
-           (new-game {:corp {:hand [card] :credits 15}
-                      :runner {:hand ["Hush"]}})
-           (play-from-hand state :corp card "HQ")
-           (let [ice (get-ice state :hq 0)]
-             (when rez-req
-               (is (can-really-be-advanced? state (refresh ice)) (str card " is advancable while unrezzed")))
-             (rez state :corp ice)
-             (is (can-really-be-advanced? state (refresh ice)) (str card " is advancable while rezzed"))
-             (take-credits state :corp)
-             (play-from-hand state :runner "Hush")
-             (click-card state :runner card)
-             (is (not (can-really-be-advanced? state (refresh ice)))
-                 (str card " is no longer advancable due to hush (rezzed)"))
-             (when rez-req
-               (derez state :corp (refresh ice))
-               (is (not (can-really-be-advanced? state (refresh ice)))
-                   (str card " is no longer advancable due to hush (derezzed)"))))))]
+(deftest hush-vs-attini
+  ;;hush interacts with attini
+  (do-game
+    (new-game {:corp {:hand ["Attini" "City Works Project"]
+                      :credits 50}
+               :runner {:hand ["Hush"]}})
+    (play-and-score state "City Works Project")
+    (play-from-hand state :corp "Attini" "HQ")
+    (rez state :corp (get-ice state :hq 0))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Hush")
+    (click-card state :runner "Attini")
+    (run-on state :hq)
+    (run-continue-until state :encounter-ice)
+    (card-subroutine state :corp (get-ice state :hq 0) 0)
+    (is (not (no-prompt? state :runner)) "(hush)Can pay for attini despite threat")
+    (click-prompt state :runner "Pay 2 [Credits]")))
 
-    ;; Hush vs. Afshar
-    (do-game
-      (install-hush-and-run "Afshar" {:hushed true :rig ["Buzzsaw"]})
-      (let [buzz (get-program state 0)]
-        (run-continue-until state :encounter-ice)
-        (card-ability state :runner (refresh buzz) 0)
-        (click-prompt state :runner "Make the Runner lose 2 [Credits]")
-        (click-prompt state :runner "End the run")
-        (is (no-prompt? state :runner) "No break prompt as Afshar has no unbroken subroutines")))
-
-    ;; Hush vs. Akhet
-    (advancable-while-hushed-test? "Akhet" true)
-    (do-game
-      (install-hush-and-run "Akhet" {:hushed true :rig ["Cleaver"] :counters {:advancement 3}})
-      (let [akhet (get-ice state :hq 0)
-            cleaver (get-program state 0)]
-        (is (= 2 (get-strength (refresh akhet))) "No str gain while hushed")
-        (run-continue-until state :encounter-ice)
-        (card-ability state :runner cleaver 0)
-        (click-prompt state :runner "Gain 1 [Credit]. Place 1 advancement token")
-        (click-prompt state :runner "End the run")))
-
-    ;;Hush vs. Anansi
-    (do-game
-      (new-game {:corp {:hand ["Anansi"] :credits 15}
-                 :runner {:hand ["Hush" (qty "Sure Gamble" 5)]}})
-      (play-from-hand state :corp "Anansi" "HQ")
-      (rez state :corp (get-ice state :hq 0))
+(deftest hush-vs-blockchain
+  ;;hush interacts with blockchain
+  (do-game
+    (new-game {:corp {:hand ["Blockchain" (qty "Hedge Fund" 2)]}
+               :runner {:hand ["Hush" "Spec Work"]}})
+    (play-from-hand state :corp "Hedge Fund")
+    (play-from-hand state :corp "Hedge Fund")
+    (play-from-hand state :corp "Blockchain" "HQ")
+    (let [block (get-ice state :hq 0)]
+      (rez state :corp block)
+      (is (= 3 (count (:subroutines (refresh block)))) "3 subs to start")
       (take-credits state :corp)
       (play-from-hand state :runner "Hush")
-      (click-card state :runner "Anansi")
-      (run-on state :hq)
+      (click-card state :runner "Blockchain")
+      (is (= 2 (count (:subroutines (refresh block)))) "blockchain lost a sub to hush")
+      (play-from-hand state :runner "Spec Work")
+      (click-card state :runner "Hush")
+      (is (= 3 (count (:subroutines (refresh block)))) "blockchain is back to 3 subs"))))
+
+(deftest hush-vs-echo
+  ;;  hush vs. echo
+  (do-game
+    (install-hush-and-run "Echo" {:rig ["Simulchip"]
+                                  :players {:runner {:discard ["Fermenter"]}}
+                                  :counters {:power 5}
+                                  :hushed true})
+    (let [echo (get-ice state :hq 0)
+          sim (get-hardware state 0)]
+      (is (= 0 (count (:subroutines echo))) "No subroutines because we're hushed")
+      (card-ability state :runner sim 0)
+      (click-card state :runner "Hush")
+      (click-card state :runner "Fermenter")
+      (is (= 6 (count (:subroutines (refresh echo)))) "5+1 subs now"))))
+
+(deftest hush-vs-envelopment
+  ;; hush vs envelopment
+  (do-game
+    (install-hush-and-run "Envelopment" {:rig ["Simulchip"]
+                                         :players {:runner {:discard ["Fermenter"]}}
+                                         :hushed true})
+    (let [env (get-ice state :hq 0)
+          sim (get-hardware state 0)]
+      (is (= 1 (count (:subroutines env))) "1 subroutine because we're hushed")
+      (card-ability state :runner sim 0)
+      (click-card state :runner "Hush")
+      (click-card state :runner "Fermenter")
+      (is (= 5 (count (:subroutines (refresh env)))) "4+1 subs now"))))
+
+(deftest hush-vs-funhouse
+  ;; hush vs. funhouse
+  (do-game
+    (install-hush-and-run "Funhouse" {:hushed true})
+    (run-continue-until state :encounter-ice)
+    (is (no-prompt? state :runner) "No funhouse prompt because of hush")))
+
+(deftest hush-vs-hive
+  ;; hush vs. hive
+  (do-game
+    (install-hush-and-run "Hive" {:scored ["City Works Project"]
+                                  :hushed true})
+    (let [ice (get-ice state :hq 0)]
+      (is (= 5 (count (:subroutines ice))) "full subs on hive because hush")
+      (trash state :runner (first (:hosted (refresh ice))))
+      (is (= 2 (count (:subroutines (refresh ice)))) "5-3 subs on hive now"))))
+
+(deftest hush-vs-hortum
+  ;; hush vs. hortum
+  (advancable-while-hushed-test? "Hortum" true)
+  (do-game
+    (install-hush-and-run "Hortum" {:rig ["Alpha"] :counters {:advancement 3} :hushed true})
+    (run-continue-until state :encounter-ice)
+    (let [prog (get-program state 0)]
+      (card-ability state :runner prog 1)
+      (card-ability state :runner prog 1)
+      (card-ability state :runner prog 1)
+      (card-ability state :runner prog 0)
+      (click-prompt state :runner "Gain 1 [Credits] (Gain 4 [Credits])")
+      (click-prompt state :runner "End the run (Search R&D for up to 2 cards and add them to HQ, shuffle R&D, end the run)"))))
+
+(deftest hush-vs-information-overload
+  ;; hush vs. information overload
+  (do-game
+    (install-hush-and-run "Information Overload" {:hushed true :tags 5})
+    (run-continue-until state :encounter-ice)
+    (is (no-prompt? state :runner) "No Info Overload prompt because of hush")
+    (let [ice (get-ice state :hq 0)]
+      (is (= 0 (count (:subroutines (refresh ice)))) "No subs due to hush")
+      (trash state :runner (first (:hosted (refresh ice))))
+      (is (= 5 (count (:subroutines (refresh ice)))) "5 subs now"))))
+
+(deftest hush-vs-masvingo
+  ;;  masvingo *
+  (advancable-while-hushed-test? "Masvingo" true)
+  (do-game
+    (install-hush-and-run "Masvingo" {:counters {:advancement 5}
+                                      :hushed true})
+    (let [ice (get-ice state :hq 0)]
+      (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+      (trash state :runner (first (:hosted (refresh ice))))
+      (is (= 6 (count (:subroutines (refresh ice)))) "5+1 on masvingo subs now"))))
+
+(deftest hush-vs-mausolus
+  ;;  mausolus
+  (advancable-while-hushed-test? "Mausolus" true))
+
+(deftest hush-vs-cloud-eater
+  ;;  cloud eater
+  (do-game
+    (install-hush-and-run "Cloud Eater" {:hushed true})
+    (run-continue-until state :encounter-ice)
+    (run-continue state)
+    (is (no-prompt? state :runner) "No Cloud Eater prompt because of hush")))
+
+(deftest hush-vs-next-bronze
+  ;; NEXT Bronze
+  (do-game
+    (install-hush-and-run "NEXT Bronze" {:hushed true})
+    (let [ice (get-ice state :hq 0)]
+      (is (= 0 (get-strength ice)) "NEXt Bronze: X is 0 while hushed")
+      (trash state :runner (first (:hosted (refresh ice))))
+      (is (= 1 (get-strength (refresh ice))) "NEXt Bronze: X is 1 post-hush"))))
+
+(deftest hush-vs-next-gold
+  ;; NEXT Gold
+  (do-game
+    (install-hush-and-run "NEXT Gold" {:hushed true :runner {:hand 2}})
+    (let [ice (get-ice state :hq 0)]
       (run-continue-until state :encounter-ice)
-      (run-continue state :pass-ice)
-      (is (not (seq (:discard (get-runner)))) "No anansi damage"))
+      (fire-subs state ice)
+      (is (zero? (count (:discard (get-runner)))) "X is 0, so gold does 0 net")
+      (is (no-prompt? state :corp) "X is 0, so gold trashes 0 programs"))))
 
-    ;;hush interacts with attini
+(deftest hush-vs-next-silver
+  ;; NEXT Silver
+  (do-game
+    (install-hush-and-run "NEXT Silver" {:hushed true})
+    (let [ice (get-ice state :hq 0)]
+      (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+      (trash state :runner (first (:hosted (refresh ice))))
+      (is (= 1 (count (:subroutines (refresh ice)))) "1 on NEXT Silver subs now"))))
+
+(deftest hush-vs-next-opal
+  ;; NEXT Opal
+  (do-game
+    (install-hush-and-run "NEXT Opal" {:hushed true})
+    (let [ice (get-ice state :hq 0)]
+      (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+      (trash state :runner (first (:hosted (refresh ice))))
+      (is (= 1 (count (:subroutines (refresh ice)))) "1 on NEXT Opal subs now"))))
+
+(deftest hush-vs-space-ice
+  ;; Orion, Nebula, Wormhole, Asteroid Belt
+  (doseq [space ["Orion" "Wormhole" "Nebula" "Asteroid Belt"]]
+    (advancable-while-hushed-test? space true)
     (do-game
-      (new-game {:corp {:hand ["Attini" "City Works Project"]
-                        :credits 50}
-                 :runner {:hand ["Hush"]}})
-      (play-and-score state "City Works Project")
-      (play-from-hand state :corp "Attini" "HQ")
-      (rez state :corp (get-ice state :hq 0))
-      (take-credits state :corp)
-      (play-from-hand state :runner "Hush")
-      (click-card state :runner "Attini")
-      (run-on state :hq)
-      (run-continue-until state :encounter-ice)
-      (card-subroutine state :corp (get-ice state :hq 0) 0)
-      (is (not (no-prompt? state :runner)) "(hush)Can pay for attini despite threat")
-      (click-prompt state :runner "Pay 2 [Credits]"))
-
-    ;;hush interacts with blockchain
-    (do-game
-      (new-game {:corp {:hand ["Blockchain" (qty "Hedge Fund" 2)]}
-                 :runner {:hand ["Hush" "Spec Work"]}})
-      (play-from-hand state :corp "Hedge Fund")
-      (play-from-hand state :corp "Hedge Fund")
-      (play-from-hand state :corp "Blockchain" "HQ")
-      (let [block (get-ice state :hq 0)]
-        (rez state :corp block)
-        (is (= 3 (count (:subroutines (refresh block)))) "3 subs to start")
-        (take-credits state :corp)
-        (play-from-hand state :runner "Hush")
-        (click-card state :runner "Blockchain")
-        (is (= 2 (count (:subroutines (refresh block)))) "blockchain lost a sub to hush")
-        (play-from-hand state :runner "Spec Work")
-        (click-card state :runner "Hush")
-        (is (= 3 (count (:subroutines (refresh block)))) "blockchain is back to 3 subs")))
-
-    ;;  hush vs. echo
-    (do-game
-      (install-hush-and-run "Echo" {:rig ["Simulchip"]
-                                    :players {:runner {:discard ["Fermenter"]}}
-                                    :counters {:power 5}
-                                    :hushed true})
-      (let [echo (get-ice state :hq 0)
-            sim (get-hardware state 0)]
-        (is (= 0 (count (:subroutines echo))) "No subroutines because we're hushed")
-        (card-ability state :runner sim 0)
-        (click-card state :runner "Hush")
-        (click-card state :runner "Fermenter")
-        (is (= 6 (count (:subroutines (refresh echo)))) "5+1 subs now")))
-
-    ;; hush vs envelopment
-    (do-game
-      (install-hush-and-run "Envelopment" {:rig ["Simulchip"]
-                                           :players {:runner {:discard ["Fermenter"]}}
-                                           :hushed true})
-      (let [env (get-ice state :hq 0)
-            sim (get-hardware state 0)]
-        (is (= 1 (count (:subroutines env))) "1 subroutine because we're hushed")
-        (card-ability state :runner sim 0)
-        (click-card state :runner "Hush")
-        (click-card state :runner "Fermenter")
-        (is (= 5 (count (:subroutines (refresh env)))) "4+1 subs now")))
-
-    ;; hush vs. funhouse
-    (do-game
-      (install-hush-and-run "Funhouse" {:hushed true})
-      (run-continue-until state :encounter-ice)
-      (is (no-prompt? state :runner) "No funhouse prompt because of hush"))
-
-    ;; hush vs. hive
-    (do-game
-      (install-hush-and-run "Hive" {:scored ["City Works Project"]
-                                    :hushed true})
-      (let [ice (get-ice state :hq 0)]
-        (is (= 5 (count (:subroutines ice))) "full subs on hive because hush")
-        (trash state :runner (first (:hosted (refresh ice))))
-        (is (= 2 (count (:subroutines (refresh ice)))) "5-3 subs on hive now")))
-
-    ;; hush vs. hortum
-    (advancable-while-hushed-test? "Hortum" true)
-    (do-game
-      (install-hush-and-run "Hortum" {:rig ["Alpha"] :counters {:advancement 3} :hushed true})
-      (run-continue-until state :encounter-ice)
-      (let [prog (get-program state 0)]
-        (card-ability state :runner prog 1)
-        (card-ability state :runner prog 1)
-        (card-ability state :runner prog 1)
-        (card-ability state :runner prog 0)
-        (click-prompt state :runner "Gain 1 [Credits] (Gain 4 [Credits])")
-        (click-prompt state :runner "End the run (Search R&D for up to 2 cards and add them to HQ, shuffle R&D, end the run)")))
-
-    ;; hush vs. information overload
-    (do-game
-      (install-hush-and-run "Information Overload" {:hushed true :tags 5})
-      (run-continue-until state :encounter-ice)
-      (is (no-prompt? state :runner) "No Info Overload prompt because of hush")
-      (let [ice (get-ice state :hq 0)]
-        (is (= 0 (count (:subroutines (refresh ice)))) "No subs due to hush")
-        (trash state :runner (first (:hosted (refresh ice))))
-        (is (= 5 (count (:subroutines (refresh ice)))) "5 subs now")))
-
-    ;;  masvingo *
-    (advancable-while-hushed-test? "Masvingo" true)
-    (do-game
-      (install-hush-and-run "Masvingo" {:counters {:advancement 5}
-                                        :hushed true})
-      (let [ice (get-ice state :hq 0)]
-        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
-        (trash state :runner (first (:hosted (refresh ice))))
-        (is (= 6 (count (:subroutines (refresh ice)))) "5+1 on masvingo subs now")))
-
-    ;;  mausolus
-    (advancable-while-hushed-test? "Mausolus" true)
-
-    ;;  cloud eater
-    (do-game
-      (install-hush-and-run "Cloud Eater" {:hushed true})
-      (run-continue-until state :encounter-ice)
-      (run-continue state)
-      (is (no-prompt? state :runner) "No Cloud Eater prompt because of hush"))
-
-    ;; NEXT Bronze
-    (do-game
-      (install-hush-and-run "NEXT Bronze" {:hushed true})
-      (let [ice (get-ice state :hq 0)]
-        (is (= 0 (get-strength ice)) "NEXt Bronze: X is 0 while hushed")
-        (trash state :runner (first (:hosted (refresh ice))))
-        (is (= 1 (get-strength (refresh ice))) "NEXt Bronze: X is 1 post-hush")))
-
-    ;; NEXT Gold
-    (do-game
-      (install-hush-and-run "NEXT Gold" {:hushed true :runner {:hand 2}})
-      (let [ice (get-ice state :hq 0)]
-        (run-continue-until state :encounter-ice)
-        (fire-subs state ice)
-        (is (zero? (count (:discard (get-runner)))) "X is 0, so gold does 0 net")
-        (is (no-prompt? state :corp) "X is 0, so gold trashes 0 programs")))
-
-    ;; NEXT Silver
-    (do-game
-      (install-hush-and-run "NEXT Silver" {:hushed true})
-      (let [ice (get-ice state :hq 0)]
-        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
-        (trash state :runner (first (:hosted (refresh ice))))
-        (is (= 1 (count (:subroutines (refresh ice)))) "1 on NEXT Silver subs now")))
-
-    ;; NEXT Opal
-    (do-game
-      (install-hush-and-run "NEXT Opal" {:hushed true})
-      (let [ice (get-ice state :hq 0)]
-        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
-        (trash state :runner (first (:hosted (refresh ice))))
-        (is (= 1 (count (:subroutines (refresh ice)))) "1 on NEXT Opal subs now")))
-
-    ;; Orion, Nebula, Wormhole, Asteroid Belt
-    (doseq [space ["Orion" "Wormhole" "Nebula" "Asteroid Belt"]]
-      (advancable-while-hushed-test? space true)
-      (do-game
-        (install-hush-and-run space {:hushed true
-                                     :unrezzed true
-                                     :counters {:advancement 5}})
-        (let [ice (get-ice state :hq 0)
-              creds (:credit (get-corp))]
-          (rez state :corp ice)
-          (is (not= creds (:credit (get-corp))) (str "Paid full price for " space " (hushed)")))))
-
-    ;;  saisentan
-    (do-game
-      (install-hush-and-run "Saisentan" {:hushed true})
-      (run-continue-until state :encounter-ice)
-      (is (no-prompt? state :corp) "No Saisentan prompt because of hush"))
-
-    ;;  salbage
-    (advancable-while-hushed-test? "Salvage" false)
-    (do-game
-      (install-hush-and-run "Salvage" {:rig ["Simulchip"]
-                                       :counters {:advancement 5}
-                                       :players {:runner {:discard ["Fermenter"]}}
-                                       :hushed true})
+      (install-hush-and-run space {:hushed true
+                                   :unrezzed true
+                                   :counters {:advancement 5}})
       (let [ice (get-ice state :hq 0)
-            sim (get-hardware state 0)]
-        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
-        (card-ability state :runner sim 0)
-        (click-card state :runner "Hush")
-        (click-card state :runner "Fermenter")
-        (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on salvage now")))
-    ;;  seraph
-    (do-game
-      (install-hush-and-run "Seraph" {:hushed true})
-      (run-continue-until state :encounter-ice)
-      (is (no-prompt? state :runner) "No Seraph prompt because of hush"))
+            creds (:credit (get-corp))]
+        (rez state :corp ice)
+        (is (not= creds (:credit (get-corp))) (str "Paid full price for " space " (hushed)"))))))
 
-    ;;  searchlight
-    (advancable-while-hushed-test? "Searchlight" true)
+(deftest hush-vs-saisentan
+  ;;  saisentan
+  (do-game
+    (install-hush-and-run "Saisentan" {:hushed true})
+    (run-continue-until state :encounter-ice)
+    (is (no-prompt? state :corp) "No Saisentan prompt because of hush")))
 
-    ;; Stavka
-    (do-game
-      (install-hush-and-run "Stavka" {:hushed true :unrezzed true :assets ["PAD Campaign"]})
-      (rez state :corp (get-ice state :hq 0))
-      (is (no-prompt? state :corp) "No stavka prompt due to hush"))
-
-    ;;  surveyor
-    (do-game
-      (install-hush-and-run "Surveyor" {:hushed true})
-      (run-continue-until state :encounter-ice)
-      (fire-subs state (get-ice state :hq 0))
-      (click-prompt state :corp "0")
-      (click-prompt state :runner "0")
-      (click-prompt state :corp "0")
-      (click-prompt state :runner "0")
-      (is (zero? (count-tags state)) "No tags from surveyor")
-      (is (:run @state) "run didn't end (X = 0, surveyor)"))
-    
-    ;;  swarm
-    (advancable-while-hushed-test? "Swarm" true)
-    (do-game
-      (install-hush-and-run "Swarm" {:rig ["Simulchip"]
+(deftest hush-vs-salvage
+  ;;  salbage
+  (advancable-while-hushed-test? "Salvage" false)
+  (do-game
+    (install-hush-and-run "Salvage" {:rig ["Simulchip"]
                                      :counters {:advancement 5}
                                      :players {:runner {:discard ["Fermenter"]}}
                                      :hushed true})
-      (let [ice (get-ice state :hq 0)
-            sim (get-hardware state 0)]
-        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
-        (card-ability state :runner sim 0)
-        (click-card state :runner "Hush")
-        (click-card state :runner "Fermenter")
-        (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on swarm now")))
+    (let [ice (get-ice state :hq 0)
+          sim (get-hardware state 0)]
+      (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+      (card-ability state :runner sim 0)
+      (click-card state :runner "Hush")
+      (click-card state :runner "Fermenter")
+      (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on salvage now"))))
 
-    ;;  thoth
-    (do-game
-      (install-hush-and-run "Thoth" {:hushed true})
-      (run-continue-until state :encounter-ice)
-      (is (no-prompt? state :corp) "No Thoth prompt because of hush"))
+(deftest hush-vs-seraph
+  ;;  seraph
+  (do-game
+    (install-hush-and-run "Seraph" {:hushed true})
+    (run-continue-until state :encounter-ice)
+    (is (no-prompt? state :runner) "No Seraph prompt because of hush")))
 
-    ;;  tithonium
-    (do-game
-      (install-hush-and-run "Tithonium" {:hushed true :unrezzed true :scored ["City Works Project"]})
-      (rez state :corp (get-ice state :hq 0))
-      (is (no-prompt? state :corp) "No alternate cost prompt")
-      (is (zero? (count (:discard (get-runner)))) "Hush not trashed"))
+(deftest hush-vs-searchlight
+  ;;  searchlight
+  (advancable-while-hushed-test? "Searchlight" true))
 
-    ;;  tollbooth
-    (do-game
-      (install-hush-and-run "Tollbooth" {:hushed true})
-      (is (= 5 (:credit (get-runner))))
-      (run-continue-until state :encounter-ice)
-      (is (= 5 (:credit (get-runner))) "No payment to tollbooth")
-      (is (no-prompt? state :runner) "No tollbooth prompt because of hush"))
+(deftest hush-vs-stavka
+  ;; Stavka
+  (do-game
+    (install-hush-and-run "Stavka" {:hushed true :unrezzed true :assets ["PAD Campaign"]})
+    (rez state :corp (get-ice state :hq 0))
+    (is (no-prompt? state :corp) "No stavka prompt due to hush")))
 
-    ;;  tour guide *
-    (do-game
-      (install-hush-and-run "Tour Guide" {:hushed true
-                                          :assets ["PAD Campaign" "NGO Front"]})
-      (run-continue-until state :encounter-ice)
-      (let [ice (get-ice state :hq 0)]
-        (is (= 0 (count (:subroutines (refresh ice)))) "No subs on tour guide due to hush")
-        (trash state :runner (first (:hosted (refresh ice))))
-        (is (= 2 (count (:subroutines (refresh ice)))) "2 subs on tour guide now")))
+(deftest hush-vs-surveyor
+  ;;  surveyor
+  (do-game
+    (install-hush-and-run "Surveyor" {:hushed true})
+    (run-continue-until state :encounter-ice)
+    (fire-subs state (get-ice state :hq 0))
+    (click-prompt state :corp "0")
+    (click-prompt state :runner "0")
+    (click-prompt state :corp "0")
+    (click-prompt state :runner "0")
+    (is (zero? (count-tags state)) "No tags from surveyor")
+    (is (:run @state) "run didn't end (X = 0, surveyor)")))
 
-    ;;  turing
-    (do-game
-      (install-hush-and-run "Turing" {:hushed true
-                                      :rig ["Alpha"]
-                                      :server "New remote"})
-      (run-continue-until state :encounter-ice)
-      (let [prog (get-program state 0)
-            tur (get-ice state :remote1 0)]
-        (is (= 2 (get-strength tur)) "Turing is 2 strength due to hush")
-        (card-ability state :runner prog 1)
-        (is (= 2 (get-strength (refresh prog))) "Alpha is 2 strength")
-        (card-ability state :runner prog 0)
-        (click-prompt state :runner "End the run unless the Runner pays [Click][Click][Click]")))
+(deftest hush-vs-swarm
+  ;;  swarm
+  (advancable-while-hushed-test? "Swarm" true)
+  (do-game
+    (install-hush-and-run "Swarm" {:rig ["Simulchip"]
+                                   :counters {:advancement 5}
+                                   :players {:runner {:discard ["Fermenter"]}}
+                                   :hushed true})
+    (let [ice (get-ice state :hq 0)
+          sim (get-hardware state 0)]
+      (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+      (card-ability state :runner sim 0)
+      (click-card state :runner "Hush")
+      (click-card state :runner "Fermenter")
+      (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on swarm now"))))
 
-    ;;  tyr
-    (do-game
-      (install-hush-and-run "Týr" {:hushed true})
-      (run-continue state :encounter-ice)
-      (card-side-ability state :runner (get-ice state :hq 0) 0)
-      ;; NOTE - this isn't possible in game, but it is in the test....
-      (is (no-prompt? state :runner) "No prompt to break, the ability is not active"))
+(deftest hush-vs-thoth
+  ;;  thoth
+  (do-game
+    (install-hush-and-run "Thoth" {:hushed true})
+    (run-continue-until state :encounter-ice)
+    (is (no-prompt? state :corp) "No Thoth prompt because of hush")))
 
-    ;;  tyrant *
-    (advancable-while-hushed-test? "Tyrant" false)
-    (do-game
-      (install-hush-and-run "Tyrant" {:rig ["Simulchip"]
-                                      :counters {:advancement 5}
-                                      :players {:runner {:discard ["Fermenter"]}}
-                                      :hushed true})
-      (let [ice (get-ice state :hq 0)
-            sim (get-hardware state 0)]
-        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
-        (card-ability state :runner sim 0)
-        (click-card state :runner "Hush")
-        (click-card state :runner "Fermenter")
-        (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on tyrant now")))
+(deftest hush-vs-tithonium
+  ;;  tithonium
+  (do-game
+    (install-hush-and-run "Tithonium" {:hushed true :unrezzed true :scored ["City Works Project"]})
+    (rez state :corp (get-ice state :hq 0))
+    (is (no-prompt? state :corp) "No alternate cost prompt")
+    (is (zero? (count (:discard (get-runner)))) "Hush not trashed")))
 
-    ;; woodcutter
-    (advancable-while-hushed-test? "Woodcutter" false)
-    (do-game
-      (install-hush-and-run "Woodcutter" {:rig ["Simulchip"]
-                                          :counters {:advancement 5}
-                                          :players {:runner {:discard ["Fermenter"]}}
-                                          :hushed true})
-      (let [ice (get-ice state :hq 0)
-            sim (get-hardware state 0)]
-        (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
-        (card-ability state :runner sim 0)
-        (click-card state :runner "Hush")
-        (click-card state :runner "Fermenter")
-        (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on woodcutter now")))
+(deftest hush-vs-tollbooth
+  ;;  tollbooth
+  (do-game
+    (install-hush-and-run "Tollbooth" {:hushed true})
+    (is (= 5 (:credit (get-runner))))
+    (run-continue-until state :encounter-ice)
+    (is (= 5 (:credit (get-runner))) "No payment to tollbooth")
+    (is (no-prompt? state :runner) "No tollbooth prompt because of hush")))
 
-    ;;  wraparound
-    (do-game
-      (install-hush-and-run "Wraparound" {:hushed true})
-      (is (= 0 (get-strength (get-ice state :hq 0))) "Hushed wrap is 0 str"))))
+(deftest hush-vs-tour-guide
+  ;;  tour guide *
+  (do-game
+    (install-hush-and-run "Tour Guide" {:hushed true
+                                        :assets ["PAD Campaign" "NGO Front"]})
+    (run-continue-until state :encounter-ice)
+    (let [ice (get-ice state :hq 0)]
+      (is (= 0 (count (:subroutines (refresh ice)))) "No subs on tour guide due to hush")
+      (trash state :runner (first (:hosted (refresh ice))))
+      (is (= 2 (count (:subroutines (refresh ice)))) "2 subs on tour guide now"))))
+
+(deftest hush-vs-turing
+  ;;  turing
+  (do-game
+    (install-hush-and-run "Turing" {:hushed true
+                                    :rig ["Alpha"]
+                                    :server "New remote"})
+    (run-continue-until state :encounter-ice)
+    (let [prog (get-program state 0)
+          tur (get-ice state :remote1 0)]
+      (is (= 2 (get-strength tur)) "Turing is 2 strength due to hush")
+      (card-ability state :runner prog 1)
+      (is (= 2 (get-strength (refresh prog))) "Alpha is 2 strength")
+      (card-ability state :runner prog 0)
+      (click-prompt state :runner "End the run unless the Runner pays [Click][Click][Click]"))))
+
+(deftest hush-vs-tyr
+  ;;  tyr
+  (do-game
+    (install-hush-and-run "Týr" {:hushed true})
+    (run-continue state :encounter-ice)
+    (card-side-ability state :runner (get-ice state :hq 0) 0)
+    ;; NOTE - this isn't possible in game, but it is in the test....
+    (is (no-prompt? state :runner) "No prompt to break, the ability is not active")))
+
+(deftest hush-vs-tyrant
+  ;;  tyrant *
+  (advancable-while-hushed-test? "Tyrant" false)
+  (do-game
+    (install-hush-and-run "Tyrant" {:rig ["Simulchip"]
+                                    :counters {:advancement 5}
+                                    :players {:runner {:discard ["Fermenter"]}}
+                                    :hushed true})
+    (let [ice (get-ice state :hq 0)
+          sim (get-hardware state 0)]
+      (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+      (card-ability state :runner sim 0)
+      (click-card state :runner "Hush")
+      (click-card state :runner "Fermenter")
+      (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on tyrant now"))))
+
+(deftest hush-vs-woodcutter
+  ;; woodcutter
+  (advancable-while-hushed-test? "Woodcutter" false)
+  (do-game
+    (install-hush-and-run "Woodcutter" {:rig ["Simulchip"]
+                                        :counters {:advancement 5}
+                                        :players {:runner {:discard ["Fermenter"]}}
+                                        :hushed true})
+    (let [ice (get-ice state :hq 0)
+          sim (get-hardware state 0)]
+      (is (= 0 (count (:subroutines ice))) "0 subroutine because we're hushed")
+      (card-ability state :runner sim 0)
+      (click-card state :runner "Hush")
+      (click-card state :runner "Fermenter")
+      (is (= 5 (count (:subroutines (refresh ice)))) "5 subs on woodcutter now"))))
+
+(deftest hush-vs-wraparound
+  ;;  wraparound
+  (do-game
+    (install-hush-and-run "Wraparound" {:hushed true})
+    (is (= 0 (get-strength (get-ice state :hq 0))) "Hushed wrap is 0 str")))
 
 
 (deftest hyperdriver

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -3618,9 +3618,10 @@
           (rez state :corp magnet)
           (click-card state :corp ika)
           (is (zero?(count (:hosted (refresh enigma)))) "Ika was removed from Enigma")
-          (is (= 1 (count (:hosted (refresh magnet)))) "Ika was hosted onto Magnet")
-          (let [ika (first (:hosted (refresh magnet)))]
-            (is (zero?(count (:abilities ika))) "Ika was blanked"))))))
+          ;; note that when cards are disabled now, the abilities still exist
+          ;; we just don't allow them to be used
+          ;; since card-ability bypasses :playable, that wont work in the test
+          (is (= 1 (count (:hosted (refresh magnet)))) "Ika was hosted onto Magnet")))))
 
 (deftest imp-full-test
     ;; Full test

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -7453,7 +7453,7 @@
 (deftest zona-sul-shipping
   ;; Zona Sul Shipping - Gain 1c per turn, click to take all credits. Trash when tagged
   (do-game
-    (new-game {:runner {:deck ["Zona Sul Shipping"]}})
+    (new-game {:runner {:deck ["Zona Sul Shipping" "Rogue Trading"]}})
     (take-credits state :corp)
     (play-from-hand state :runner "Zona Sul Shipping")
     (let [zss (get-resource state 0)]
@@ -7466,5 +7466,7 @@
       (card-ability state :runner zss 0)
       (is (= 12 (:credit (get-runner))) "Took 2c off Zona Sul")
       (is (= 3 (:click (get-runner))) "Spent 1 click")
-      (gain-tags state :runner 1)
+      (play-from-hand state :runner "Rogue Trading")
+      (card-ability state :runner (get-resource state 1) 0)
+      ;;(gain-tags state :runner 1)
       (is (= 1 (count (:discard (get-runner)))) "Zona Sul trashed when tag taken"))))

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -1880,8 +1880,6 @@
               hosted-ct #(first (:hosted (refresh dj-fenris)))]
           (rez state :corp malia)
           (click-card state :corp dj-fenris)
-          (is (:disabled (refresh dj-fenris)) "DJ Fenris is disabled")
-          (is (:disabled (hosted-ct)) "CT is disabled")
           (is (= 4 (core/available-mu state)) "Disabling DJ Fenris also disabled CT, reducing MU back to 4")
           ;; Trash Malia to stop disable
           (trash state :corp (refresh malia))
@@ -3741,7 +3739,7 @@
    (take-credits state :corp)
    (click-prompt state :runner "Dr. Lovegood")
    (click-card state :runner "Lewi Guilherme")
-   (is (= 5 (hand-size :corp)) "-1 hand size from lewi")
+   (is (= 5 (hand-size :corp)) "regular hand size from lewi")
    (is (no-prompt? state :runner) "No more prompt to activate")))
 
 (deftest liberated-account

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -7443,6 +7443,15 @@
       (rez state :corp lc)
       (is (= 2 (:credit (get-corp))) "Paid 1 to rez Launch Campaign; no effect on non-ice"))))
 
+(deftest zona-sul-shipping-trash-on-install
+  ;; Zona Sul Shipping - Gain 1c per turn, click to take all credits. Trash when tagged
+  (do-game
+    (new-game {:runner {:deck ["Zona Sul Shipping"]}})
+    (take-credits state :corp)
+    (gain-tags state :runner 1)
+    (play-from-hand state :runner "Zona Sul Shipping")
+    (is (= 1 (count (:discard (get-runner)))) "Zona Sul trashed when tag taken")))
+
 (deftest zona-sul-shipping
   ;; Zona Sul Shipping - Gain 1c per turn, click to take all credits. Trash when tagged
   (do-game

--- a/test/clj/game/cards/resources_test.clj
+++ b/test/clj/game/cards/resources_test.clj
@@ -7453,7 +7453,7 @@
 (deftest zona-sul-shipping
   ;; Zona Sul Shipping - Gain 1c per turn, click to take all credits. Trash when tagged
   (do-game
-    (new-game {:runner {:deck ["Zona Sul Shipping" "Rogue Trading"]}})
+    (new-game {:runner {:deck ["Zona Sul Shipping"]}})
     (take-credits state :corp)
     (play-from-hand state :runner "Zona Sul Shipping")
     (let [zss (get-resource state 0)]
@@ -7466,7 +7466,5 @@
       (card-ability state :runner zss 0)
       (is (= 12 (:credit (get-runner))) "Took 2c off Zona Sul")
       (is (= 3 (:click (get-runner))) "Spent 1 click")
-      (play-from-hand state :runner "Rogue Trading")
-      (card-ability state :runner (get-resource state 1) 0)
-      ;;(gain-tags state :runner 1)
+      (gain-tags state :runner 1)
       (is (= 1 (count (:discard (get-runner)))) "Zona Sul trashed when tag taken"))))

--- a/test/clj/game/core/rezzing_test.clj
+++ b/test/clj/game/core/rezzing_test.clj
@@ -20,10 +20,6 @@
       (is (= () (rezzing/get-rez-cost state nil card {:ignore-cost true})))))
   (before-each [state (new-game)
                 card {:title "No match" :cost 5 :additional-cost [(->c :trash-can)]}]
-    (testing "ignoring cost with additional costs"
-      (is (= [(->c :trash-can 1)] (rezzing/get-rez-cost state nil card {:ignore-cost true}))))
-    (testing "with additional costs"
-      (is (= [(->c :credit 5) (->c :trash-can 1)] (rezzing/get-rez-cost state nil card nil))))
     (testing "with additional costs and card disabled"
       (let [card (assoc card :disabled true)]
         (is (= [(->c :credit 5)] (rezzing/get-rez-cost state nil card nil)))))))


### PR DESCRIPTION
Basically an overhaul of how we enable/disable cards. I've applied it in most cases.
It still doesn't correctly axe static-abilities of cards. 
I'm currently trying to think of a way to correctly apply this without having `any-effects?` recursively call itself with every call. 
I believe it may require updating checkpoint to cache a list of disabled cards in state, and the effect's functions to check
1) if a an effect belongs to a static ability
2) if the owner of that effect is in the disabled cards list
and then you see if the list of disabled cards has changed, and if you do, you resolve another checkpoint (yuck, I know, but that resolves chains with malia/light the fire)

A consequence of this should be that when the above is resolved, **hush** should be *at least* 99% correct.

Closes #6872
Closes #7301 ~~(I'll write a test for this case)~~
Closes #6916 ~~(I'll write a test for this case)~~
Closes #6909 ~~(I'll write a test for this case)~~

I'm going to tackle this too:
Closes #7247 (I'll be writing tests for this)

Some older issues this will close:
Closes #6627
Closes #6728

Ice that I'm adding tests for right now. This seems like a large list, but I added a few helpers to make it not as horrible to do:
- [x] Afshar
- [x] Akhet
- [x] Anansi
- [x] Attini
- [x] Blockchain
- [x] Echo
- [x] Envelopment
- [x] Funhouse
- [x] Hive
- [x] Hortum
- [x] Information Overload
- [x] Masvingo
- [x] Mausolus
- [x] Cloud Eater
- [x] NEXT Bronze
- [x] NEXT Gold
- [x] NEXT Sapphire
- [x] NEXT Silver
- [x] Nebula
- [x] Orion
- [x] Wormhole
- [x] Asteroid Belt
- [x] Saisentan
- [x] Salvage
- [x] Seraph
- [x] Searchlight
- [x] Stavka
- [x] Surveyor
- [x] Swarm
- [x] Thoth
- [x] Tithonium
- [x] Tollbooth
- [x] Tour Guide
- [x] Turing
- [x] Tyr
- [x] Tyrant
- [x] Woodcutter
- [x] Wraparound
