### PR TITLE
Clean up :source messiness

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -76,7 +76,8 @@
                                   [integrant/repl "0.3.2"]
                                   [lambdaisland/kaocha "1.68.1059"]
                                   [thheller/shadow-cljs "2.16.8"]]
-                   :plugins [[lein-eftest "0.6.0"]]
+                   :plugins [[lein-eftest "0.6.0"]
+                             [cider/cider-nrepl "0.47.1"]]
                    :eftest {:report eftest.report.pretty/report
                             :fail-fast? false}
                    :source-paths ["src/clj" "src/cljs" "src/cljc" "src/css"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1944,9 +1944,9 @@
                               (first-event? state side :pass-ice
                                             #(rezzed-gate-or-sentry (first %)))))
                :prompt (msg "Make the runner encounter " (:title (:ice context)) " again?")
-               :choices (req [(when (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil (->c :credit 1))
+               :choices (req [(when (can-pay? state :corp eid card nil (->c :credit 1))
                                 "Pay 1 [Credit]")
-                              (when (can-pay? state :corp (assoc eid :source card :source-type :ability) card nil (->c :trash-from-hand 1))
+                              (when (can-pay? state :corp eid card nil (->c :trash-from-hand 1))
                                 "Trash 1 card from HQ")
                               "Done"])
                :async true

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2665,31 +2665,21 @@
              :effect (req (win state :corp (:title card)))}]})
 
 (defcard "Sundew"
-  ; If this a run event then handle in :begin-run as we do not know the server
-  ; being run on in :runner-spent-click.
   {:events [{:event :runner-spent-click
              :req (req (first-event? state side :runner-spent-click))
-             :msg (req (when-not (= :make-run (:source-type eid))
-                         "gain 2 [Credits]"))
+             :msg "gain 2 [Credits]"
              :async true
-             :effect (req (if (or (= :make-run (:source-type eid))
-                                  (and (:source eid)
-                                       (:makes-run (card-def (:source eid))))
-                                  (and (get-ability-targets eid)
-                                       (:makes-run (card-def (:card (get-ability-targets eid))))))
-                            (effect-completed state side eid)
-                            (gain-credits state :corp eid 2)))}
+             :effect (req (update! state side (assoc-in card [:special :spent-click] true))
+                          (gain-credits state :corp eid 2))}
             {:event :run
-             :once :per-turn
-             :req (req (first-event? state side :runner-spent-click))
-             :msg (req (when (and (= :make-run (:source-type eid))
-                                  (not this-server))
-                         "gain 2 [Credits]"))
+             :req (req (and (first-event? state side :runner-spent-click)
+                            run
+                            this-server
+                            (get-in card [:special :spent-click])))
+             :msg "lose 2 [Credits]"
              :async true
-             :effect (req (if (and (= :make-run (:source-type eid))
-                                   (not this-server))
-                            (gain-credits state :corp eid 2)
-                            (effect-completed state side eid)))}]})
+             :effect (req (update! state side (dissoc-in card [:special :spent-click]))
+                          (lose-credits state :corp eid 2))}]})
 
 (defcard "Svyatogor Excavator"
   (let [ability {:async true

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -615,7 +615,10 @@
      :abilities [ability]}))
 
 (defcard "Cohort Guidance Program"
-  (let [abi {:prompt "Choose one"
+  {:flags {:corp-phase-12 (req true)}
+   :derezzed-events [corp-rez-toast]
+   :events [{:event :corp-turn-begins
+             :prompt "Choose one"
              :interactive (req true)
              :choices (req [(when (seq (:hand corp)) "Trash 1 card from HQ to gain 2 [Credits] and draw 1 card")
                             (when (some #(not (:seen %)) (:discard corp))
@@ -656,10 +659,7 @@
                                                                      :advance-counter 1
                                                                      {:placed true}))}
                                                 card nil))})
-                              card nil)))}]
-    {:flags {:corp-phase-12 (req true)}
-     :derezzed-events [corp-rez-toast]
-     :events [(assoc abi :event :corp-turn-begins)]}))
+                              card nil)))}]})
 
 (defcard "Commercial Bankers Group"
   (let [ability {:req (req unprotected)

--- a/src/clj/game/cards/basic.clj
+++ b/src/clj/game/cards/basic.clj
@@ -59,21 +59,21 @@
                                      (upgrade? target-card))
                                  (if server
                                    (corp-can-pay-and-install?
-                                     state side (assoc eid :source-type :corp-install)
+                                     state side eid
                                      target-card server {:base-cost [(->c :click 1)]
                                                     :action :corp-click-install
                                                     :no-toast true})
                                    (some
                                      (fn [server]
                                        (corp-can-pay-and-install?
-                                         state side (assoc eid :source-type :corp-install)
+                                         state side eid
                                          target-card server {:base-cost [(->c :click 1)]
                                                         :action :corp-click-install
                                                         :no-toast true}))
                                      (installable-servers state target-card))))))
                 :effect (req (let [{target-card :card server :server} context]
                                (corp-install
-                                 state side (assoc eid :source-type :corp-install)
+                                 state side eid
                                  target-card server {:base-cost [(->c :click 1)]
                                                      :action :corp-click-install})))}
                {:action true
@@ -83,9 +83,9 @@
                             (and (not-empty (:hand corp))
                                  (in-hand? target-card)
                                  (operation? target-card)
-                                 (can-play-instant? state :corp (assoc eid :source-type :play)
+                                 (can-play-instant? state :corp eid
                                                     target-card {:base-cost [(->c :click 1)]}))))
-                :effect (req (play-instant state :corp (assoc eid :source-type :play)
+                :effect (req (play-instant state :corp eid
                                            (:card context) {:base-cost [(->c :click 1)]}))}
                {:action true
                 :label "Advance 1 installed card"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1019,18 +1019,17 @@
                           :prompt "How many credits do you want to pay?"
                           :choices {:number (req numtargets)}
                           :effect (req (let [c target]
-                                         (if (can-pay? state side (assoc eid :source card :source-type :ability) card (:title card) (->c :credit c))
-                                           (let [new-eid (make-eid state {:source card :source-type :ability})]
-                                             (wait-for (pay state :corp new-eid card (->c :credit c))
-                                                       (when-let [payment-str (:msg async-result)]
-                                                         (system-msg state :corp payment-str))
-                                                       (continue-ability
-                                                         state :corp
-                                                         {:msg (msg "place " (quantify c " advancement token") " on "
-                                                                    (card-str state target))
-                                                          :choices {:card installed?}
-                                                          :effect (effect (add-prop target :advance-counter c {:placed true}))}
-                                                         card nil)))
+                                         (if (can-pay? state side eid card (:title card) (->c :credit c))
+                                           (wait-for (pay state :corp card (->c :credit c))
+                                                     (when-let [payment-str (:msg async-result)]
+                                                       (system-msg state :corp payment-str))
+                                                     (continue-ability
+                                                       state :corp
+                                                       {:msg (msg "place " (quantify c " advancement token") " on "
+                                                                  (card-str state target))
+                                                        :choices {:card installed?}
+                                                        :effect (effect (add-prop target :advance-counter c {:placed true}))}
+                                                       card nil))
                                            (effect-completed state side eid))))})
                        card nil))))}})
 
@@ -2785,7 +2784,7 @@
                                       (let [is-first-mandate? (first-event? state side :play-operation #(has-subtype? (:card (first %)) "Mandate"))]
                                         (if (= target "Done")
                                           (continue-ability state side (when is-first-mandate? play-instant-second) card nil)
-                                          (wait-for (play-instant state side (assoc (make-eid state eid) :source target :source-type :play) target nil)
+                                          (wait-for (play-instant state side (make-eid state eid) target nil)
                                                     (continue-ability state side (when is-first-mandate? play-instant-second) card nil)))))}]
     {:on-play {:msg "draw 2 cards"
                :async true

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1905,7 +1905,8 @@
                :once-per-instance false
                :req (req (let [cause (:cause context)
                                cause-card (:cause-card context)]
-                           (and (or (corp? (:source eid))
+                           (and (not= :corp-install (:source-type eid))
+                                (or (corp? (:source eid))
                                     (= :ability-cost cause)
                                     (= :subroutine cause)
                                     (and (corp? cause-card)

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -593,7 +593,7 @@
   {:recurring 2
    :interactions {:pay-credits {:req (req (and (= :corp-install (:source-type eid))
                                                (= (second (get-zone card))
-                                                  (unknown->kw (:source eid)))))
+                                                  (unknown->kw (:server (get-ability-targets eid))))))
                                 :type :recurring}}})
 
 (defcard "Defense Construct"
@@ -1598,7 +1598,7 @@
 
 (defcard "Simone Diego"
   {:recurring 2
-   :interactions {:pay-credits {:req (req (let [ab-target (first (get-ability-targets eid))]
+   :interactions {:pay-credits {:req (req (let [ab-target (:card (get-ability-targets eid))]
                                             (and (same-server? card ab-target)
                                                  (or (= :advance (:source-type eid))
                                                      (is-basic-advance-action? eid)))))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -429,7 +429,7 @@
                       :player :runner
                       :waiting-prompt true
                       :prompt "Choose one"
-                      :choices [(when (can-pay? state :runner (assoc eid :source card :source-type :ability) card nil [(->c :credit cost)])
+                      :choices [(when (can-pay? state :runner eid card nil [(->c :credit cost)])
                                   (str "Pay " cost " [Credits]"))
                                 "End the run"]
                       :msg (msg (if (= target "End the run")
@@ -531,11 +531,8 @@
                       card :can-trash
                       (fn [state _ card]
                         (or (not (same-card? target card))
-                            (can-pay?
-                              state :runner
-                              (assoc eid :source card :source-type :ability)
-                              card nil
-                              [(->c :add-random-from-hand-to-bottom-of-deck 2)])))))}
+                            (can-pay? state :runner eid
+                                      card nil [(->c :add-random-from-hand-to-bottom-of-deck 2)])))))}
               steal-cost]
      :on-trash {:async true
                 :interactive (req true)

--- a/src/clj/game/core.clj
+++ b/src/clj/game/core.clj
@@ -334,7 +334,6 @@
   [game.core.eid
    complete-with-result
    effect-completed
-   eid-set-defaults
    get-ability-targets
    is-basic-advance-action?
    make-eid

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -9,7 +9,7 @@
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [break-sub-ability-cost card-ability-cost score-additional-cost-bonus]]
     [game.core.effects :refer [any-effects]]
-    [game.core.eid :refer [effect-completed eid-set-defaults make-eid]]
+    [game.core.eid :refer [effect-completed make-eid]]
     [game.core.engine :refer [ability-as-handler checkpoint register-pending-event pay queue-event resolve-ability trigger-event-simult]]
     [game.core.flags :refer [can-advance? can-score?]]
     [game.core.ice :refer [break-subroutine! get-current-ice get-pump-strength get-strength pump resolve-subroutine! resolve-unbroken-subs!]]
@@ -588,7 +588,7 @@
   ([state side card no-cost] (advance state side (make-eid state) card no-cost))
   ([state side eid card no-cost]
    (let [card (get-card state card)
-         eid (eid-set-defaults eid :source nil :source-type :advance)]
+         eid (assoc eid :source-type :advance)]
      (if (can-advance? state side card)
        (wait-for (pay state side
                       (make-eid state (assoc eid :action :corp-advance))

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -26,7 +26,7 @@
               (some
                 (fn [server]
                   (corp-can-pay-and-install?
-                    state :corp {:source server :source-type :corp-install}
+                    state :corp {:source card :source-type :corp-install}
                     card server {:base-cost [(->c :click 1)]
                                  :action :corp-click-install
                                  :no-toast true}))
@@ -35,13 +35,13 @@
                   (program? card)
                   (resource? card))
               (runner-can-pay-and-install?
-                state :runner {:source :action :source-type :runner-install}
+                state :runner {:source card :source-type :runner-install}
                 card {:base-cost [(->c :click 1)]
                       :no-toast true})]
              [(or (event? card)
                   (operation? card))
               (can-play-instant?
-                state side {:source :action :source-type :play}
+                state side {:source card :source-type :play}
                 card {:base-cost [(->c :click 1)]
                       :silent true})])
            true)

--- a/src/clj/game/core/eid.clj
+++ b/src/clj/game/core/eid.clj
@@ -9,11 +9,6 @@
   ([state existing-eid]
    (assoc existing-eid :eid (:eid (swap! state update :eid inc)))))
 
-(defn eid-set-defaults
-  "Set default values for fields in the `eid` if they are not already set."
-  [eid & {:as args}]
-  (conj args eid))
-
 (defn get-ability-targets
   [eid]
   (get-in eid [:source-info :ability-targets 0]))

--- a/src/clj/game/core/eid.clj
+++ b/src/clj/game/core/eid.clj
@@ -16,7 +16,7 @@
 
 (defn get-ability-targets
   [eid]
-  (get-in eid [:source-info :ability-targets]))
+  (get-in eid [:source-info :ability-targets 0]))
 
 (defn is-basic-advance-action?
   [eid]

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -252,8 +252,8 @@
 
 (defn is-ability?
   "Checks to see if a given map represents a card ability."
-  [{:keys [effect msg]}]
-  (or effect msg (seq (keys @ability-types))))
+  [{:keys [effect msg] :as ability}]
+  (or effect msg (seq (select-keys ability (keys @ability-types)))))
 
 (defn resolve-ability
   ([state side {:keys [eid] :as ability} card targets]

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -269,10 +269,11 @@
     (effect-completed state side eid)
     ;; This was called directly without an eid present
     (and ability (not eid))
-    (resolve-ability-eid state side (assoc ability :eid (make-eid state eid)) card targets)
+    (resolve-ability state side ability card targets)
     ;; Both ability and eid are present, so we're good to go
     (and ability eid)
-    (let [ab (select-ability-kw ability)
+    (let [ability (assoc-in ability [:eid :source] card)
+          ab (select-ability-kw ability)
           ability-fn (get @ability-types ab)]
       (cond
         ab (ability-fn state side ability card targets)

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -542,7 +542,7 @@
                      args)]
      {:async true
       :effect (req (wait-for
-                     (resolve-ability state side (make-eid state eid) (break-subroutines-impl ice (if (zero? n) (count (:subroutines current-ice)) n) '() args) card nil)
+                     (resolve-ability state side (break-subroutines-impl ice (if (zero? n) (count (:subroutines current-ice)) n) '() args) card nil)
                      (let [broken-subs (:broken-subs async-result)
                            early-exit (:early-exit async-result)
                            total-cost (when (seq broken-subs)
@@ -553,10 +553,7 @@
                                                                 card ice))
                            message (when (seq broken-subs)
                                      (break-subroutines-msg ice broken-subs breaker args))]
-                       (wait-for (pay state side (make-eid state {:source card
-                                                                  :source-info {:ability-idx (:ability-idx args)}
-                                                                  :source-type :ability})
-                                      card total-cost)
+                       (wait-for (pay state side card total-cost)
                                  (if-let [payment-str (:msg async-result)]
                                    (do (when (not (string/blank? message))
                                          (system-msg state :runner (str payment-str " to " message)))
@@ -646,16 +643,15 @@
                              (add-stealth-to-label cost))))
         :effect (effect (continue-ability
                           (let [n (if (fn? n)
-                                    (n state side (assoc eid :source-type :ability) card nil)
+                                    (n state side eid card nil)
                                     n)]
-                            (when (can-pay? state side
-                                            (assoc eid :source-type :ability)
+                            (when (can-pay? state side eid
                                             card nil
                                             (break-sub-ability-cost
                                               state side
                                               (assoc args :break-cost cost :broken-subs (take n (:subroutines current-ice)))
                                               card current-ice))
-                              (break-subroutines current-ice card cost n (assoc args :ability-idx (:ability-idx (:source-info eid))))))
+                              (break-subroutines current-ice card cost n args)))
                           card nil))}))))
 
 (defn strength-pump

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -133,7 +133,7 @@
                 (not no-mu))
        (init-mu-cost state c))
      (if (and resolve-effect (is-ability? cdef))
-       (resolve-ability state side eid (dissoc cdef :cost :additional-cost) c nil)
+       (resolve-ability state side (assoc eid :source-type :ability) (dissoc cdef :cost :additional-cost) c nil)
        (effect-completed state side eid))
      (when-let [in-play (:in-play cdef)]
        (apply gain state side in-play))

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -35,48 +35,48 @@
   (let [play-msg (if ignore-cost
                    "play "
                    (build-spend-msg payment-str "play"))]
-    (system-msg state side (str play-msg title (when ignore-cost " at no cost"))))
-  (implementation-msg state card)
-  (play-sfx state side "play-instant")
-  ;; Select the "on the table" version of the card
-  (let [card (current-handler state side card)
-        cdef (-> (:on-play (card-def card))
-                 (dissoc :cost :additional-cost)
-                 (dissoc-req))
-        card (card-init state side
-                        (if (:rfg-instead-of-trashing cdef)
-                          (assoc card :rfg-instead-of-trashing true)
-                          card)
-                        ;; :resolve-effect is true as a temporary solution to allow Direct Access to blank IDs
-                        {:resolve-effect true :init-data true})
-        play-event (if (= side :corp) :play-operation :play-event)
-        resolved-event (if (= side :corp) :play-operation-resolved :play-event-resolved)]
-    (queue-event state play-event {:card card :event play-event})
-    (wait-for (checkpoint state nil (make-eid state eid) {:duration play-event})
-              (wait-for (resolve-ability state side (make-eid state eid) cdef card nil)
-                        (let [c (some #(when (same-card? card %) %) (get-in @state [side :play-area]))
-                              trash-after-resolving (:trash-after-resolving cdef true)
-                              zone (if (:rfg-instead-of-trashing c) :rfg :discard)]
-                          (if (and c trash-after-resolving)
-                            (let [trash-or-move (if (= zone :rfg) async-rfg trash)]
-                              (wait-for (trash-or-move state side c {:unpreventable true})
-                                        (unregister-events state side card)
-                                        (unregister-static-abilities state side card)
-                                        (when (= zone :rfg)
-                                          (system-msg state side
-                                                      (str "removes " (:title c) " from the game instead of trashing it")))
-                                        (when (has-subtype? card "Terminal")
-                                          (lose state side :click (-> @state side :click))
-                                          (swap! state assoc-in [:corp :register :terminal] true))
-                                        ;; this is explicit support for nuvem,
-                                        ;; which wants 'after the op finishes resolving' as an event
-                                        (queue-event state resolved-event {:card card :event resolved-event})
-                                        (checkpoint state nil eid {:duration resolved-event})))
-                            (do (when (has-subtype? card "Terminal")
-                                  (lose state side :click (-> @state side :click))
-                                  (swap! state assoc-in [:corp :register :terminal] true))
-                                (queue-event state resolved-event {:card card :event resolved-event})
-                                (checkpoint state nil eid {:duration resolved-event}))))))))
+    (system-msg state side (str play-msg title (when ignore-cost " at no cost")))
+    (implementation-msg state card)
+    (play-sfx state side "play-instant")
+    ;; Select the "on the table" version of the card
+    (let [card (current-handler state side card)
+          cdef (-> (:on-play (card-def card))
+                   (dissoc :cost :additional-cost)
+                   (dissoc-req))
+          card (card-init state side
+                          (if (:rfg-instead-of-trashing cdef)
+                            (assoc card :rfg-instead-of-trashing true)
+                            card)
+                          ;; :resolve-effect is true as a temporary solution to allow Direct Access to blank IDs
+                          {:resolve-effect true :init-data true})
+          play-event (if (= side :corp) :play-operation :play-event)
+          resolved-event (if (= side :corp) :play-operation-resolved :play-event-resolved)]
+      (queue-event state play-event {:card card :event play-event})
+      (wait-for (checkpoint state nil (make-eid state eid) {:duration play-event})
+                (wait-for (resolve-ability state side (make-eid state eid) cdef card nil)
+                          (let [c (some #(when (same-card? card %) %) (get-in @state [side :play-area]))
+                                trash-after-resolving (:trash-after-resolving cdef true)
+                                zone (if (:rfg-instead-of-trashing c) :rfg :discard)]
+                            (if (and c trash-after-resolving)
+                              (let [trash-or-move (if (= zone :rfg) async-rfg trash)]
+                                (wait-for (trash-or-move state side c {:unpreventable true})
+                                          (unregister-events state side card)
+                                          (unregister-static-abilities state side card)
+                                          (when (= zone :rfg)
+                                            (system-msg state side
+                                                        (str "removes " (:title c) " from the game instead of trashing it")))
+                                          (when (has-subtype? card "Terminal")
+                                            (lose state side :click (-> @state side :click))
+                                            (swap! state assoc-in [:corp :register :terminal] true))
+                                          ;; this is explicit support for nuvem,
+                                          ;; which wants 'after the op finishes resolving' as an event
+                                          (queue-event state resolved-event {:card card :event resolved-event})
+                                          (checkpoint state nil eid {:duration resolved-event})))
+                              (do (when (has-subtype? card "Terminal")
+                                    (lose state side :click (-> @state side :click))
+                                    (swap! state assoc-in [:corp :register :terminal] true))
+                                  (queue-event state resolved-event {:card card :event resolved-event})
+                                  (checkpoint state nil eid {:duration resolved-event})))))))))
 
 (defn play-instant-costs
   [state side card {:keys [ignore-cost base-cost no-additional-cost cached-costs]}]

--- a/src/clj/game/core/play_instants.clj
+++ b/src/clj/game/core/play_instants.clj
@@ -4,7 +4,7 @@
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [play-additional-cost-bonus play-cost]]
     [game.core.effects :refer [unregister-static-abilities]]
-    [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
+    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.engine :refer [checkpoint dissoc-req merge-costs-paid pay queue-event resolve-ability should-trigger? unregister-events]]
     [game.core.flags :refer [can-run? zone-locked?]]
     [game.core.gaining :refer [lose]]
@@ -99,7 +99,7 @@
 (defn can-play-instant?
   ([state side eid card] (can-play-instant? state side eid card nil))
   ([state side eid card {:keys [targets silent] :as args}]
-   (let [eid (eid-set-defaults eid :source card :source-type :play)
+   (let [eid (assoc eid :source card :source-type :play)
          on-play (or (:on-play (card-def card)) {})
          costs (play-instant-costs state side card args)]
      (and ;; req is satisfied
@@ -125,7 +125,7 @@
   "Plays an Event or Operation."
   ([state side eid card] (play-instant state side eid card nil))
   ([state side eid card {:keys [ignore-cost] :as args}]
-   (let [eid (eid-set-defaults eid :source card :source-type :play)
+   (let [eid (assoc eid :source card :source-type :play)
          costs (play-instant-costs state side card (dissoc args :cached-costs))]
      ;; ensure the instant can be played
      (if (can-play-instant? state side eid card (assoc args :cached-costs costs))

--- a/src/clj/game/core/rezzing.clj
+++ b/src/clj/game/core/rezzing.clj
@@ -4,13 +4,13 @@
     [game.core.card-defs :refer [card-def]]
     [game.core.cost-fns :refer [rez-additional-cost-bonus rez-cost]]
     [game.core.effects :refer [is-disabled? unregister-static-abilities update-disabled-cards]]
-    [game.core.eid :refer [complete-with-result effect-completed eid-set-defaults make-eid]]
+    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.engine :refer [register-pending-event queue-event checkpoint pay register-events resolve-ability trigger-event unregister-events]]
     [game.core.flags :refer [can-host? can-rez?]]
     [game.core.ice :refer [update-ice-strength]]
     [game.core.initializing :refer [card-init deactivate]]
     [game.core.moving :refer [trash-cards]]
-    [game.core.payment :refer [build-spend-msg can-pay? merge-costs ->c value]]
+    [game.core.payment :refer [build-spend-msg can-pay? merge-costs ->c]]
     [game.core.runs :refer [continue]]
     [game.core.say :refer [play-sfx system-msg implementation-msg]]
     [game.core.toasts :refer [toast]]
@@ -98,7 +98,7 @@
   ([state side eid card] (rez state side eid card nil))
   ([state side eid card
     {:keys [ignore-cost force declined-alternative-cost alternative-cost] :as args}]
-   (let [eid (eid-set-defaults eid :source nil :source-type :rez)
+   (let [eid (assoc eid :source-type :rez)
          card (get-card state card)
          alternative-cost (when (and card
                                      (not alternative-cost)

--- a/src/clj/game/core/update.clj
+++ b/src/clj/game/core/update.clj
@@ -1,7 +1,7 @@
 (ns game.core.update
-  (:require [game.core.card :refer [get-card ice?]]
+  (:require [game.core.card :refer [get-card]]
             [game.core.finding :refer [get-scoring-owner]]
-            [game.utils :refer [to-keyword same-card?]]))
+            [game.utils :refer [to-keyword]]))
 
 (declare update-hosted!)
 

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -85,6 +85,8 @@
   (let [needed-locals (find-undefined-locals expr)
         nls (emit-only needed-locals)]
     `(fn ~['state 'side 'eid 'card 'targets]
+       (assert (or (nil? (:source ~'eid)) (:cid (:source ~'eid)))
+               (str ":source should be a card, received: " (:source ~'eid)))
        (let [~@nls]
          ~@expr))))
 
@@ -101,7 +103,7 @@
                          (first body)
                          [[{'async-result :result}] (first body)])
         expr (next body)
-        abnormal? (#{'apply 'handler 'payable?} (first action))
+        abnormal? (#{'handler 'payable?} (first action))
         to-take (if abnormal? 4 3)
         fn-name (gensym (name (first action)))
         [_ state _ eid?] (if abnormal? (next action) action)]

--- a/src/clj/game/macros.clj
+++ b/src/clj/game/macros.clj
@@ -96,7 +96,6 @@
 (defmacro msg [& expr]
   `(req (str ~@expr)))
 
-
 (defmacro wait-for
   [& body]
   (let [[binds action] (if (vector? (first body))
@@ -109,7 +108,8 @@
         [_ state _ eid?] (if abnormal? (next action) action)]
     `(let [eid?# ~eid?
            use-eid# (and (map? eid?#) (:eid eid?#))
-           new-eid# (if use-eid# eid?# (game.core.eid/make-eid ~state))]
+           existing-eid# ~(when (contains? &env 'eid) 'eid)
+           new-eid# (if use-eid# eid?# (game.core.eid/make-eid ~state existing-eid#))]
        (game.core.eid/register-effect-completed
          ~state new-eid#
          (fn ~fn-name ~(if (vector? binds) binds [binds])

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1623,13 +1623,17 @@
      (when (and (not (or @runner-phase-12 @corp-phase-12))
                 (zero? (:click @me))
                 (not @end-turn))
-       [:button {:on-click #(send-command "end-turn")} (tr [:game.end-turn "End Turn"])])
+       [:button {:on-click #(send-command "end-turn")}
+        (tr [:game.end-turn "End Turn"])])
      (when @end-turn
-       [:button {:on-click #(send-command "start-turn")} (tr [:game.start-turn "Start Turn"])]))
+       [:button {:on-click #(send-command "start-turn")}
+        (tr [:game.start-turn "Start Turn"])]))
    (when (and (= (keyword @active-player) side)
               (or @runner-phase-12 @corp-phase-12))
      [:button {:on-click #(send-command "end-phase-12")}
-      (if (= side :corp) (tr [:game.mandatory-draw "Mandatory Draw"]) (tr [:game.take-clicks "Take Clicks"]))])
+      (if (= side :corp)
+        (tr [:game.mandatory-draw "Mandatory Draw"])
+        (tr [:game.take-clicks "Take Clicks"]))])
    (when (= side :runner)
      [:div
       [cond-button (tr [:game.remove-tag "Remove Tag"])

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -430,7 +430,7 @@
       (is (= 0 (count (:discard (get-corp)))) "Did not trashed PAD Campaign")
       (is (= 0 (count (:scored (get-corp)))) "Azef Protocol not scored"))))
 
-(deftest ^:kaocha/pending azef-protocol-cant-target-self
+(deftest azef-protocol-cant-target-self
   ;; Azef Protocol can't trash itself to pay its cost
   (do-game
    (new-game {:corp {:hand ["Azef Protocol", "PAD Campaign"]}

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -5240,7 +5240,11 @@
         ;; spend a click running the sundew server
         (run-on state "Server 1")
         (is (= 15 (:credit (get-corp))) "Corp did not gain 2cr from run on Sundew")
-        (is (= 3 (:click (get-runner))) "Runner spent 1 click to start run"))))
+        (is (= 3 (:click (get-runner))) "Runner spent 1 click to start run")
+        (run-jack-out state)
+        (run-on state "Server 1")
+        (is (= 15 (:credit (get-corp))) "Corp did not gain additional credits")
+        (is (= 2 (:click (get-runner)))))))
 
 (deftest sundew-multiple-sundews
     ;; Multiple Sundews
@@ -5301,7 +5305,7 @@
         (click-prompt state :runner "Expose 1 ice and make a run")
         (click-card state :runner (get-ice state :remote1 0))
         (click-prompt state :runner "Server 1")
-        (is (= 6 (:credit (get-corp))) "Corp gained 2cr from Sundew because DW is not a run event"))))
+        (is (= 4 (:credit (get-corp))) "Corp lost 2 because a run began on the server"))))
 
 (deftest sundew-sundew-out-of-the-ashes
     ;; Sundew - Out of the Ashes

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -1032,33 +1032,33 @@
         (is (no-prompt? state :corp)))))
 
 (deftest cohort-guidance-program
-    (do-game
-      (new-game {:corp {:hand ["Cohort Guidance Program" "NGO Front" "PAD Campaign"]
-                        :deck [(qty "Hedge Fund" 5)]}})
-      (play-from-hand state :corp "Cohort Guidance Program" "New remote")
-      (play-from-hand state :corp "NGO Front" "New remote")
-      (let [cgp (get-content state :remote1 0)
-            ngo (get-content state :remote2 0)]
-        (rez state :corp cgp)
-        (take-credits state :corp)
-        (take-credits state :runner)
-        (is (:corp-phase-12 @state) "Corp has opportunity to use Cohort Guidance Program")
-        (end-phase-12 state :corp)
-        (is (changed? [(:credit (get-corp)) 2
-                       (count (:discard (get-corp))) 1
-                       (count (:hand (get-corp))) 1]
-                      (click-prompt state :corp "Trash 1 card from HQ to gain 2 [Credits] and draw 1 card")
-                      (click-card state :corp "PAD Campaign"))
-            "Corp discarded 1 card, gained 2 credits, and drew 1 card")
-        (take-credits state :corp)
-        (take-credits state :runner)
-        (end-phase-12 state :corp)
-        (is (changed? [(get-counters (refresh ngo) :advancement) 1]
-                      (click-prompt state :corp "Turn 1 facedown card in Archives faceup to place 1 advancement counter on an installed card")
-                      (click-card state :corp (find-card "PAD Campaign" (:discard (get-corp))))
-                      (click-card state :corp ngo))
-            "Corp turned 1 facedown card in Archived to advance 1 card")
-        (is (empty? (remove #(:seen %) (:discard (get-corp)))) "PAD Campaign was turned faceup"))))
+  (do-game
+    (new-game {:corp {:hand ["Cohort Guidance Program" "NGO Front" "PAD Campaign"]
+                      :deck [(qty "Hedge Fund" 5)]}})
+    (play-from-hand state :corp "Cohort Guidance Program" "New remote")
+    (play-from-hand state :corp "NGO Front" "New remote")
+    (let [cgp (get-content state :remote1 0)
+          ngo (get-content state :remote2 0)]
+      (rez state :corp cgp)
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (:corp-phase-12 @state) "Corp has opportunity to use Cohort Guidance Program")
+      (end-phase-12 state :corp)
+      (is (changed? [(:credit (get-corp)) 2
+                     (count (:discard (get-corp))) 1
+                     (count (:hand (get-corp))) 1]
+            (click-prompt state :corp "Trash 1 card from HQ to gain 2 [Credits] and draw 1 card")
+            (click-card state :corp "PAD Campaign"))
+          "Corp discarded 1 card, gained 2 credits, and drew 1 card")
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (end-phase-12 state :corp)
+      (is (changed? [(get-counters (refresh ngo) :advancement) 1]
+            (click-prompt state :corp "Turn 1 facedown card in Archives faceup to place 1 advancement counter on an installed card")
+            (click-card state :corp (find-card "PAD Campaign" (:discard (get-corp))))
+            (click-card state :corp ngo))
+          "Corp turned 1 facedown card in Archived to advance 1 card")
+      (is (empty? (remove #(:seen %) (:discard (get-corp)))) "PAD Campaign was turned faceup"))))
 
 (deftest commercial-bankers-group
   ;; Commercial Bankers Group - Gain 3 credits at turn start if unprotected by ice

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -5492,7 +5492,7 @@
      (is (changed? [(:credit (get-corp)) 3]
            (click-card state :corp (refresh pad)))
          "~ sells PAD Campaign before it triggers so only 3 credits gained")
-     (is (= (refresh pad) nil) "PAD Campaign should be in Heap"))))
+     (is (nil? (refresh pad)) "PAD Campaign should be in Heap"))))
 
 (deftest syvatogor-excavator-card-str-6471
   (do-game

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -4686,7 +4686,7 @@
                   (click-prompt state :corp "Hedge Fund"))
         "Hedge Fund was played")))
 
-(deftest ^:kaocha/pending sudden-commandment-threat
+(deftest sudden-commandment-threat
   (do-game
     (new-game {:corp {:hand [(qty "Sudden Commandment" 2) "Bellona"]
                       :deck ["IPO" "Hedge Fund"]

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -1368,7 +1368,7 @@
       (is (no-prompt? state :corp) "Corp should be waiting on Runner")
       (is (no-prompt? state :runner) "Runner should be able to take actions")))
 
-(deftest Djupstad-grid
+(deftest djupstad-grid
   (do-game
     (new-game {:corp {:hand ["Project Atlas" "Djupstad Grid"] :credits 10}
                :runner {:hand [(qty "Sure Gamble" 5)]}})

--- a/test/clj/game/core/optional_test.clj
+++ b/test/clj/game/core/optional_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [game.core :as core]
+   [game.core.initializing :refer [make-card]]
    [game.macros :refer [req]]
    [game.test-framework :refer :all]))
 
@@ -14,5 +15,5 @@
                              {:req (req (swap! spy conj "inner") true)
                               :prompt "Yes or no"
                               :yes-ability {:effect (req true)}}}
-                            {} nil)
+                            (make-card {:title "test"}) nil)
       (is (= ["inner"] @spy) "Only the inner req of optional should be checked"))))

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -4,12 +4,13 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [game.core :as core :refer [map->Card]]
+   [game.core :as core]
    [game.core.board :refer [server-list]]
    [game.core.card :refer [active? get-card get-counters get-title installed?
                            rezzed?]]
    [game.core.eid :as eid]
    [game.core.ice :refer [active-ice?]]
+   [game.core.initializing :refer [make-card]]
    [game.test-framework.asserts]
    [game.utils :as utils]
    [game.utils-test :refer [error-wrapper is']]
@@ -849,7 +850,7 @@
 (defn trace
   [state base]
   (core/init-trace state :corp
-                   (map->Card {:title "/trace command" :side :corp})
+                   (make-card {:title "/trace command" :side "Corp"})
                    {:base base}))
 
 (defn log-str [state]


### PR DESCRIPTION
It's a big pain point that we have to manually set `:source card :source-type :ability` or whatever in every single fuckin call. It drives me nuts, especially as we've gotten more strict about it. So I'm here to solve it. Set `:source card :source-type :ability` in `do-play-ability`, and then set the appropriate `:source-type` in each of the major action functions, and then trim out all of the unnecessary calls.

I have plans/desires to remove a lot of the `can-pay?` calls too, but we'll see.