### PR TITLE
Color-code stats page wins/losses

### DIFF
--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -159,8 +159,12 @@
   [state {:keys [title corp runner turn winner replay-shared has-replay start-date] :as game} log-scroll-top]
   (let [corp-id (get @all-cards (:identity corp))
         runner-id (get @all-cards (:identity runner))
-        turn-count (if turn turn 0)]
-    [:div.gameline {:style {:min-height "auto"}}
+        turn-count (if turn turn 0)
+        user (:user @app-state)
+        shade (if (= (str winner) "corp") 
+                (if (= (:username user) (get-in corp [:player :username])) "#618b61" "#Ea7d7f")
+                (if (= (:username user) (get-in runner [:player :username])) "#618b61" "#Ea7d7f"))]
+    [:div.gameline {:style {:min-height "auto" :background-color shade}}
      [:button.float-right
       {:on-click #(do
                     (fetch-log state game)

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -164,7 +164,7 @@
         shade (if (= (str winner) "corp") 
                 (if (= (:username user) (get-in corp [:player :username])) "#618b61" "#Ea7d7f")
                 (if (= (:username user) (get-in runner [:player :username])) "#618b61" "#Ea7d7f"))]
-    [:div.gameline {:style {:min-height "auto" :background-color shade}}
+    [:div.gameline {:style {:min-height "auto" :border-color shade}}
      [:button.float-right
       {:on-click #(do
                     (fetch-log state game)

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -162,8 +162,8 @@
         turn-count (if turn turn 0)
         user (:user @app-state)
         shade (if (= (str winner) "corp") 
-                (if (= (:username user) (get-in corp [:player :username])) "#618b61" "#Ea7d7f")
-                (if (= (:username user) (get-in runner [:player :username])) "#618b61" "#Ea7d7f"))]
+                (if (= (:username user) (get-in corp [:player :username])) "#6AB56A" "#Ea7d7f")
+                (if (= (:username user) (get-in runner [:player :username])) "#6AB56A" "#Ea7d7f"))]
     [:div.gameline {:style {:min-height "auto" :border-color shade}}
      [:button.float-right
       {:on-click #(do

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -161,10 +161,10 @@
         runner-id (get @all-cards (:identity runner))
         turn-count (if turn turn 0)
         user (:user @app-state)
-        shade (if (= (str winner) "corp") 
+        user-win (if (= (str winner) "corp") 
                 (if (= (:username user) (get-in corp [:player :username])) " (You)" "")
                 (if (= (:username user) (get-in runner [:player :username])) " (You)" ""))]
-    [:div.gameline {:style {:min-height "auto" :border-color (if (= shade " (You)") "#6AB56A" "#Ea7d7f")}}
+    [:div.gameline {:style {:min-height "auto" :border-color (if (= user-win " (You)") "#6AB56A" "#Ea7d7f")}}
      [:button.float-right
       {:on-click #(do
                     (fetch-log state game)
@@ -189,7 +189,7 @@
        (faction-icon-memo (:faction runner-id) (:title runner-id)) " " (:title runner-id)]]
 
      (when winner
-       [:h4 (tr [:stats.winner "Winner"]) ": " (tr-side winner) (str shade)])]))
+       [:h4 (tr [:stats.winner "Winner"]) ": " (tr-side winner) (str user-win)])]))
 
 (defn history [_state list-scroll-top _log-scroll-top]
   (r/create-class

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -164,7 +164,8 @@
         user-win (if (= (str winner) "corp") 
                 (if (= (:username user) (get-in corp [:player :username])) " (You)" "")
                 (if (= (:username user) (get-in runner [:player :username])) " (You)" ""))]
-    [:div.gameline {:style {:min-height "auto" :border-color (if (= user-win " (You)") "#6AB56A" "#Ea7d7f")}}
+    [:div.gameline {:style {:min-height "auto"
+                            :border-color (when winner (if (= user-win " (You)") "#6AB56A" "#Ea7d7f"))}}
      [:button.float-right
       {:on-click #(do
                     (fetch-log state game)

--- a/src/cljs/nr/stats.cljs
+++ b/src/cljs/nr/stats.cljs
@@ -162,9 +162,9 @@
         turn-count (if turn turn 0)
         user (:user @app-state)
         shade (if (= (str winner) "corp") 
-                (if (= (:username user) (get-in corp [:player :username])) "#6AB56A" "#Ea7d7f")
-                (if (= (:username user) (get-in runner [:player :username])) "#6AB56A" "#Ea7d7f"))]
-    [:div.gameline {:style {:min-height "auto" :border-color shade}}
+                (if (= (:username user) (get-in corp [:player :username])) " (You)" "")
+                (if (= (:username user) (get-in runner [:player :username])) " (You)" ""))]
+    [:div.gameline {:style {:min-height "auto" :border-color (if (= shade " (You)") "#6AB56A" "#Ea7d7f")}}
      [:button.float-right
       {:on-click #(do
                     (fetch-log state game)
@@ -189,7 +189,7 @@
        (faction-icon-memo (:faction runner-id) (:title runner-id)) " " (:title runner-id)]]
 
      (when winner
-       [:h4 (tr [:stats.winner "Winner"]) ": " (tr-side winner)])]))
+       [:h4 (tr [:stats.winner "Winner"]) ": " (tr-side winner) (str shade)])]))
 
 (defn history [_state list-scroll-top _log-scroll-top]
   (r/create-class


### PR DESCRIPTION
This pull request addresses the color-coding feature described in issue #5873. 

What the feature entails:
- games that you won are outlined in green
- games that you lost are outlined in pink
- games that resulted in no winner are still outlined in white
- games that you won now have "(You)" beside the winner label. 

Reasoning for the feature:
As described in the issue, it can be difficult to see which games you won and which games you lost. The addition of the "(You)" label also makes it easier to cmd+F to count the number of games won/lost. 

Screenshot:
![color-code-game-stats](https://github.com/mtgred/netrunner/assets/93751272/d0ccdbe0-db8e-4785-9694-65c581b45e98)
