### PR TITLE
Show game time in lobby

### DIFF
--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -1,6 +1,9 @@
 (ns nr.game-row
   (:require
    [jinteki.utils :refer [superuser?]]
+   [cljc.java-time.instant :as inst]
+   [cljc.java-time.duration :as duration]
+   [cljc.java-time.temporal.chrono-unit :as chrono]
    [nr.appstate :refer [app-state]]
    [nr.auth :refer [authenticated] :as auth]
    [nr.player-view :refer [player-view]]
@@ -134,6 +137,20 @@
    [:span.format-type (tr-format (slug->format fmt "Unknown"))]
    [:span.format-singleton (str (when singleton? " (singleton)"))]])
 
+(defn- time-since
+  "Helper method for match duration. Computes how much time since game start"
+  [start]
+  (let [now (inst/now)
+        diff (duration/between start now)
+        total-seconds (duration/get diff chrono/seconds)
+        minutes (abs (quot total-seconds 60))
+        seconds (mod (abs total-seconds) 60)]
+    {:minutes minutes :seconds seconds}))
+
+(defn game-time [game]
+  [:span.game-time (str (time-since (:date game)))]
+   )
+
 (defn players-row [{players :players :as game}]
   (into
     [:div]
@@ -153,4 +170,5 @@
      [game-title state user game]
      [mod-menu-popup state user game]
      [game-format game]
+     [game-time game]
      [players-row game]]))

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -138,18 +138,17 @@
    [:span.format-singleton (str (when singleton? " (singleton)"))]])
 
 (defn- time-since
-  "Helper method for match duration. Computes how much time since game start"
+  "Helper method for game-time. Computes how many minutes since game start"
   [start]
   (let [now (inst/now)
         diff (duration/between start now)
         total-seconds (duration/get diff chrono/seconds)
-        minutes (abs (quot total-seconds 60))
-        seconds (mod (abs total-seconds) 60)]
-    {:minutes minutes :seconds seconds}))
+        minutes (abs (quot total-seconds 60))]
+    minutes))
 
 (defn game-time [game]
-  [:span.game-time (str (str (:minutes (time-since (:date game)))) "m")]
-   )
+(when (:started game)
+  [:div.game-time (str (time-since (:date game)) "m")]))
 
 (defn players-row [{players :players :as game}]
   (into

--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -148,7 +148,7 @@
     {:minutes minutes :seconds seconds}))
 
 (defn game-time [game]
-  [:span.game-time (str (time-since (:date game)))]
+  [:span.game-time (str (str (:minutes (time-since (:date game)))) "m")]
    )
 
 (defn players-row [{players :players :as game}]

--- a/src/css/lobby.styl
+++ b/src/css/lobby.styl
@@ -140,6 +140,7 @@
         .game-time
             float: right
             margin-bottom: 10px
+            margin-right: 10px
 
         .player
             &:first-child:after

--- a/src/css/lobby.styl
+++ b/src/css/lobby.styl
@@ -137,6 +137,10 @@
         .format-label
             font-weight: bold
 
+        .game-time
+            float: right
+            margin-bottom: 10px
+
         .player
             &:first-child:after
                 content: "vs"


### PR DESCRIPTION
This PR addresses issue #6994 around showing the game time in lobby. The idea is that it would help users figure out if a game is worth watching or not. 

As shown in the screenshot below, the expected behavior is that it:

-  displays the number of minutes a game has taken in the bottom right corner of the game row
- does not display a number if the game has not started

Screenshot:
<img width="470" alt="image" src="https://github.com/mtgred/netrunner/assets/93751272/fff65739-7a35-4d01-b841-f0d22d70dca8">
