### PR TITLE
Only highlight player name when player name is at start of message

### DIFF
--- a/src/cljs/nr/utils.cljs
+++ b/src/cljs/nr/utils.cljs
@@ -307,11 +307,12 @@
   (render-specials (render-icons (render-cards input))))
 
 (defn- player-highlight-patterns-impl [corp runner]
-  (letfn [(regex-of [player-name] (re-pattern (str "(?i)" (regex-escape player-name))))]
+  (letfn [(regex-of [player-name] (re-pattern (str "^" (regex-escape player-name))))]
     (->> {corp [:span.corp-username corp]
           runner [:span.runner-username runner]}
          (filter (fn [[k _]] (not-empty k)))
-         (map (fn [[k v]] [(regex-of k) v]))
+         (mapcat (fn [[k v]] [[(regex-of k) v]
+                              [(regex-of (str "[!]" k)) [:<> [:div.smallwarning "!"] v]]]))
          (sort-by (comp count str first) >))))
 (def player-highlight-patterns (memoize player-highlight-patterns-impl))
 


### PR DESCRIPTION
This is to handle cases like this:

![image](https://github.com/mtgred/netrunner/assets/5345/02290e07-f623-49e4-adc3-39366ecdd33d)

This change will now only highlight the front:
![image](https://github.com/mtgred/netrunner/assets/5345/72847187-a390-408f-bc0d-817f5de807db)

and ignore matching potentially any card names as well

![image](https://github.com/mtgred/netrunner/assets/5345/5edac645-b673-429f-b627-e2685bd106c0)
