### PR TITLE
Highlight active cards in discard

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -422,6 +422,7 @@
 
 (defcard "Breached Dome"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:async true
                :effect (req (let [c (first (get-in @state [:runner :deck]))]
                               (system-msg state :corp (str "uses " (:title card) " to do 1 meat damage"
@@ -1280,6 +1281,7 @@
 
 (defcard "Honeyfarm"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:msg "force the Runner to lose 1 [Credits]"
                :async true
                :effect (effect (lose-credits :runner eid 1))}})
@@ -1927,6 +1929,7 @@
 
 (defcard "News Team"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:async true
                :msg (msg "force the Runner to " (decapitalize target))
                :player :runner
@@ -1976,6 +1979,7 @@
 
 (defcard "Nightmare Archive"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:async true
                :msg (msg (if (= target "Suffer 1 core damage")
                            "do 1 core damage"
@@ -2544,7 +2548,8 @@
                      :effect (effect (trash-cards eid targets {:cause-card card}))}))
 
 (defcard "Shi.Kyū"
-  {:on-access
+  {:poison true
+   :on-access
    {:optional
     {:req (req (not (in-deck? card)))
      :waiting-prompt true
@@ -2574,6 +2579,7 @@
 
 (defcard "Shock!"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:msg "do 1 net damage"
                :async true
                :effect (effect (damage eid :net 1 {:card card}))}})
@@ -2608,6 +2614,7 @@
 
 (defcard "Space Camp"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:optional
                {:waiting-prompt true
                 :prompt "Place 1 advancement token on a card that can be advanced?"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -2845,6 +2845,7 @@
                                        :msg "gain [Click]"
                                        :effect (effect (gain-clicks :corp 1))}
                                       card nil)))}
+   :highlight-in-discard true
    :events [{:event :corp-phase-12
              :location :discard
              :optional

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -101,6 +101,7 @@
   (Conspiracy suite: Black Orchestra, MKUltra, Paperclip)"
   [title ice-type abilities]
   {:abilities abilities
+   :highlight-in-discard true
    :events [{:event :encounter-ice
              :async true
              :location :discard
@@ -1659,12 +1660,6 @@
                    (flip-facedown state side card)))}})
 
 (defcard "Heliamphora"
-  (let [traps-we-care-about #{"Mavirus" "Cyberdeck Virus Suite" "Breached Dome"
-                              "Honeyfarm" "Increased Drop Rates" "News Team"
-                              "Nightmare Archive" "Shi.Kyū" "Shock!"
-                              "Space Camp"}]
-    ;; TODO - we should probably just add a flag to the cdef of all archives activated ambushes
-    ;; instead of manually listing them. It might come in handy later, too -nbkelly
   {:events [{:event :breach-server
              :async true
              :interactive (req true)
@@ -1689,7 +1684,7 @@
                          (in-discard? target)
                          (or (agenda? target)
                              (not (:seen target))
-                             (contains? traps-we-care-about (:title target)))))
+                             (:poison target))))
              :async true
              ;; note that it's possible for cards to get added to archives mid-access (even by this card)
              ;; because of this, we can't just treat this like archives interface
@@ -1698,7 +1693,7 @@
              :effect (req (let [target-card target
                                 is-facedown? (not (:seen target))
                                 is-agenda? (agenda? target)
-                                is-trap? (contains? traps-we-care-about (:title target))]
+                                is-poison? (:poison target)]
                             (continue-ability
                               state side
                               (cond
@@ -1708,7 +1703,7 @@
                                   :yes-ability {:msg "host a facedown card on itself instead of accessing it"
                                                 :effect (effect (update! (assoc-in card [:special :host-available] false))
                                                                 (host card target-card))}}}
-                                (or is-agenda? is-trap?)
+                                (or is-agenda? is-poison?)
                                 {:optional
                                  {:prompt (msg "Host " (:title target-card) " on this program instead of accessing it?")
                                   :yes-ability {:msg (msg "host " (:title target-card) " on itself instead of accessing it")
@@ -1721,7 +1716,7 @@
              :effect (req (wait-for
                             (trash-cards state :corp (make-eid state eid)
                                          (take 2 (shuffle (:hand corp))) {:cause-card card})
-                            (trash state :runner eid card {:cause :purge :cause-card card})))}]}))
+                            (trash state :runner eid card {:cause :purge :cause-card card})))}]})
 
 (defcard "Hemorrhage"
   {:events [{:event :successful-run

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -884,6 +884,7 @@
                                                     (draw state :runner eid 1))
                                           (effect-completed state side eid))))}]
     {:data {:counter {:credit 3}}
+     :highlight-in-discard true
      :flags {:drip-economy true
              :runner-turn-draw (req (= 1 (get-counters (get-card state card) :credit)))
              :runner-phase-12 (req (= 1 (get-counters (get-card state card) :credit)))}

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -502,6 +502,7 @@
 
 (defcard "Cyberdex Virus Suite"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:optional
                {:waiting-prompt true
                 :prompt "Purge virus counters?"
@@ -856,6 +857,7 @@
 
 (defcard "Increased Drop Rates"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:interactive (req true)
                :player :runner
                :async true
@@ -1125,6 +1127,7 @@
 
 (defcard "Mavirus"
   {:flags {:rd-reveal (req true)}
+   :poison true
    :on-access {:optional
                {:waiting-prompt true
                 :prompt "Purge virus counters?"

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -143,6 +143,8 @@
    :strength
    :subroutines
    :subtype-target
+   :poison
+   :highlight-in-discard
    :subtypes
    :title
    :type

--- a/src/clj/game/core/initializing.clj
+++ b/src/clj/game/core/initializing.clj
@@ -193,6 +193,8 @@
                 :enforce-conditions (:enforce-conditions cdef)
                 :trash-when-tagged (:trash-when-tagged cdef)
                 :x-fn (:x-fn cdef)
+                :poison (:poison cdef)
+                :highlight-in-discard (:highlight-in-discard cdef)
                 :printed-title (:title card))
          (dissoc :setname :text :_id :influence :number :influencelimit
                  :image_url :factioncost :format :quantity)

--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -38,6 +38,11 @@
         text-shadow 1px 1px 2px black-solid
         border-radius: 4px
 
+    .graveyard-highlight-bg
+        background: alpha(purple-core, o-60)
+        text-shadow 1px 1px 2px purple-core
+        border-radius: 4px
+
     .server-label
         color: white-solid
         text-align: center
@@ -73,6 +78,18 @@
             box-shadow: 0 0 1px 2px gold-base, 0px 0px 0px 0px lighten(alpha(gold-base, 30%), 80%), 0px 0px 0px 0px lighten(alpha(gold-base, 30%), 80%), 0 0 0px 0px spin(alpha(gold-base, 70%), -15deg)
         }
     }
+
+    @keyframes graveyard-card {
+        0% {
+            box-shadow: 0 0 1px 2px purple-core, 20px 20px 15px 10px lighten(alpha(purple-core, 30%), 80%), -20px -20px 15px 10px lighten(alpha(purple-core, 30%), 80%), 0 0 30px 15px spin(alpha(purple-core, 70%), -15deg)
+        }
+        100% {
+            box-shadow: 0 0 1px 2px purple-core, 0px 0px 0px 0px lighten(alpha(purple-core, 30%), 80%), 0px 0px 0px 0px lighten(alpha(purple-core, 30%), 80%), 0 0 0px 0px spin(alpha(purple-core, 70%), -15deg)
+        }
+    }
+
+    .card.graveyard-highlight
+        animation: graveyard-card 1s cubic-bezier(0.5,1,0.5,1) forwards
 
     .card.new
         animation: new-card 1s cubic-bezier(0.5,1,0.5,1) forwards


### PR DESCRIPTION
This is mainly a usability feature (since we can't physically see the cards on a table, a little bit of hinting is nice).

Highlight active cards (agendas, poison, cards like subliminal/crowdfunding/conspiracy breakers) in discard piles when they are otherwise visible.

The idea is that this should help boardstates be comprehensible to both players. And I've seen one too many games ruined by "I access archives for value *whoops* I forgot it was poisoned"

Additionally, I reworked *Heliamphora* to look for a `:poison` key in a card, rather than working on a list of names. This way, we can maintain the card in the long term without needing to rework it around new cards.

![demo_000](https://github.com/mtgred/netrunner/assets/9095245/3d2595d2-10db-4e9c-9b6e-7560823d108e)
![demo_001](https://github.com/mtgred/netrunner/assets/9095245/d0d7fa96-c75c-4f68-9770-3d61d77239c5)
