### PR TITLE
use the disabled registry a tiny bit more

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -830,7 +830,7 @@
   (let [sub {:label "Do 1 net damage unless the Runner pays 2 [Credits]"
              :async true
              :effect (req (if (and (threat-level 3 state)
-                                   (not (is-disabled? state side card)))
+                                   (not (is-disabled-reg? state card)))
                             (damage state side eid :net 1 {:card card})
                             (continue-ability
                               state side

--- a/src/clj/game/core/cost_fns.clj
+++ b/src/clj/game/core/cost_fns.clj
@@ -2,7 +2,7 @@
   (:require
     [game.core.card :refer [runner?]]
     [game.core.card-defs :refer [card-def]]
-    [game.core.effects :refer [any-effects get-effects sum-effects get-effect-maps get-effect-value is-disabled? is-disabled-reg?]]
+    [game.core.effects :refer [any-effects get-effects sum-effects get-effect-maps get-effect-value is-disabled-reg?]]
     [game.core.eid :refer [make-eid]]
     [game.core.payment :refer [merge-costs]]))
 
@@ -44,7 +44,7 @@
   ([state side card] (rez-additional-cost-bonus state side card nil))
   ([state side card pred]
    (let [costs (merge-costs
-                 [(when-not (is-disabled? state side card) (:additional-cost (card-def card)))
+                 [(when-not (is-disabled-reg? state card) (:additional-cost (card-def card)))
                   (get-effects state side :rez-additional-cost card)])]
      (filterv (or pred identity) costs))))
 


### PR DESCRIPTION
Just did a double-check to make sure no function that gets called often is checking disabled cards the hard way.

I changed the additional cost check in `cost-fns` to use the reg ~because I feel like that gets called several times each server frame as all costs are recalculated~ nevermind, I was wrong on that (it's just the reqs that do this), but this is still a good change.

All the rest of the direct checks in engine are the ones that only happen during distinct event handlers, so they're fine.