### PR TITLE
Move disable-checking into more responsible locations

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -23,7 +23,7 @@
                                   reorder-choice trash-on-empty get-x-fn]]
    [game.core.drawing :refer [draw first-time-draw-bonus max-draw
                               remaining-draws]]
-   [game.core.effects :refer [register-lingering-effect]]
+   [game.core.effects :refer [register-lingering-effect update-disabled-cards]]
    [game.core.eid :refer [complete-with-result effect-completed is-basic-advance-action? make-eid get-ability-targets]]
    [game.core.engine :refer [pay register-events resolve-ability]]
    [game.core.events :refer [first-event? no-event? turn-events event-count]]
@@ -1608,7 +1608,7 @@
                                     (not (has-subtype? % "Virtual")))}
               :effect (req (add-icon state side card target "MZ" (faction-label card))
                            (update! state side (assoc-in (get-card state card) [:special :malia-target] target))
-                           (fake-checkpoint state))}
+                           (update-disabled-cards state))}
      :leave-play unmark
      :move-zone unmark
      :static-abilities [{:type :disable-card

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -23,7 +23,7 @@
    [game.core.def-helpers :refer [breach-access-bonus defcard offer-jack-out
                                   reorder-choice trash-on-empty do-net-damage]]
    [game.core.drawing :refer [draw click-draw-bonus]]
-   [game.core.effects :refer [register-lingering-effect]]
+   [game.core.effects :refer [register-lingering-effect update-disabled-cards]]
    [game.core.eid :refer [complete-with-result effect-completed make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events
                              register-once register-suppress resolve-ability
@@ -1175,7 +1175,7 @@
                             :duration :end-of-turn
                             :req (req (same-card? c target))
                             :value (req true)})
-                         (fake-checkpoint state)))}]})
+                         (update-disabled-cards state)))}]})
 
 (defcard "Dr. Nuka Vrolyck"
   {:data {:counter {:power 2}}

--- a/src/clj/game/core/checkpoint.clj
+++ b/src/clj/game/core/checkpoint.clj
@@ -25,8 +25,7 @@
                    (update-hand-size state :corp)
                    (update-hand-size state :runner)
                    (update-all-subtypes state)
-                   (update-tag-status state)
-                   (update-disabled-cards state)]]
+                   (update-tag-status state)]]
       (when (and (some true? changed)
                  (< i 10))
         (recur (inc i)))))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -8,7 +8,7 @@
     [game.core.cost-fns :refer [ignore-install-cost? install-additional-cost-bonus install-cost]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
     [game.core.engine :refer [checkpoint register-pending-event pay queue-event register-events trigger-event-simult unregister-events]]
-    [game.core.effects :refer [register-static-abilities unregister-static-abilities is-disabled-reg?]]
+    [game.core.effects :refer [is-disabled-reg? register-static-abilities unregister-static-abilities update-disabled-cards]]
     [game.core.flags :refer [turn-flag? zone-locked?]]
     [game.core.hosting :refer [host]]
     [game.core.ice :refer [update-breaker-strength]]
@@ -167,6 +167,7 @@
                 (let [eid (assoc eid :source moved-card)]
                   (queue-event state :corp-install {:card (get-card state moved-card)
                                                     :install-state install-state})
+                  (update-disabled-cards state)
                   (case install-state
                     ;; Ignore all costs
                     :rezzed-no-cost
@@ -378,6 +379,7 @@
     (when-not facedown
       (implementation-msg state card))
     (play-sfx state side "install-runner")
+    (update-disabled-cards state)
     (when (and (not facedown)
                (resource? card))
       (swap! state assoc-in [:runner :register :installed-resource] true))


### PR DESCRIPTION
maybe checking during every fake checkpoint is too much (since those pop off constantly).
Now we update the register whenever:
1) a card is installed (before it becomes active)
2) an effect is registered or deregistered