### PR TITLE
Re-organize stat logging and include more server stats

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -183,12 +183,16 @@
            lobby-summaries (summaries-for-lobbies filtered-lobbies)]
        [uid [:lobby/list lobby-summaries]])))
 
+(defn lobby-update-uids
+  []
+  (filter #(app-state/receive-lobby-updates? %) (ws/connected-uids)))
+
 (defn broadcast-lobby-list
   "Sends the lobby list to all users or a given list of users.
   Filters the list per each users block list."
   ([]
    (let [user-cache (:users @app-state/app-state)
-         uids (filter #(app-state/receive-lobby-updates? %) (ws/connected-uids))
+         uids (lobby-update-uids)
          users (map #(get user-cache %) uids)]
      (broadcast-lobby-list users)))
   ([users]

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -29,6 +29,7 @@
    [web.app-state :as app-state]
    [web.game]
    [web.lobby :as lobby]
+   [web.telemetry]
    [web.utils :refer [tick]]
    [web.versions :refer [banned-msg frontend-version]]
    [web.ws :refer [ch-chsk event-msg-handler]]))

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -1,0 +1,39 @@
+(ns web.telemetry
+  (:require
+    [clojure.core.async :refer [<! go timeout]]
+    [web.app-state :refer [app-state]]
+    [web.lobby :refer [lobby-update-uids]]
+    [web.ws :refer [connected-sockets connections_]]
+    [taoensso.encore :as enc]
+    [taoensso.timbre :as timbre]))
+
+(def log-stat-frequency (enc/ms :mins 5))
+
+(defonce log-stats
+  (go (while true
+    (<! (timeout log-stat-frequency))
+    (let [lobbies-count (count (:lobbies @app-state))
+          user-cache-count (count (:users @app-state))
+          lobby-sub-count (count (filter identity (vals (:lobby-updates @app-state))))
+          lobby-update-uids (count (lobby-update-uids))
+          ajax-uid-count (count (:ajax @connected-sockets))
+          ajax-conn-counts (seq (map count (:ajax @connections_)))
+          ajax-conn-total (reduce + ajax-conn-counts)
+          ws-uid-count (count (:ws @connected-sockets))
+          ws-conn-counts (seq (map count (:ws @connections_)))
+          ws-conn-total (reduce + ws-conn-counts)]
+      (timbre/info (str
+                     "stats -"
+                     " lobbies: " lobbies-count
+                     " cached-users: " user-cache-count
+                     " lobby-subs: " lobby-sub-count
+                     " lobby-update-uids: " lobby-update-uids
+                     " | "
+                     "websockets -"
+                     " :ajax { "
+                     " uid: " ajax-uid-count
+                     " conn: " ajax-conn-total
+                     " } :ws { "
+                     " uid: " ws-uid-count
+                     " conn: " ws-conn-total
+                     " }"))))))

--- a/src/clj/web/ws.clj
+++ b/src/clj/web/ws.clj
@@ -3,7 +3,6 @@
    [clojure.core.async :refer [<! >! chan go timeout]]
    [web.app-state :refer [register-user! deregister-user!]]
    [web.user :refer [active-user?]]
-   [taoensso.encore :as enc]
    [taoensso.sente :as sente]
    [taoensso.sente.server-adapters.http-kit :refer [get-sch-adapter]]
    [taoensso.timbre :as timbre]))
@@ -45,29 +44,6 @@
 (def websocket-buffer (chan buffer-size))
 
 (defn connected-uids [] (seq (:any @connected-sockets)))
-
-(defonce log-connected-uid-counts
-  (go (while true
-    (<! (timeout (enc/ms :mins 5)))
-    (let [ajax-uid-count (count (:ajax @connected-sockets))
-          ajax-conn-counts (seq (map count (:ajax @connections_)))
-          ajax-conn-total (reduce + ajax-conn-counts)
-          ajax-conn-max (apply max (conj ajax-conn-counts 0))
-          ws-uid-count (count (:ws @connected-sockets))
-          ws-conn-counts (seq (map count (:ws @connections_)))
-          ws-conn-total (reduce + ws-conn-counts)
-          ws-conn-max (apply max (conj ws-conn-counts 0))
-          ]
-      (timbre/info (str "connected -"
-                        " :ajax { "
-                        " uid: " ajax-uid-count
-                        " conn: " ajax-conn-total
-                        " conn-max: " ajax-conn-max
-                        " } :ws { "
-                        " uid: " ws-uid-count
-                        " conn: " ws-conn-total
-                        " conn-max: " ws-conn-max
-                        " }"))))))
 
 (defonce ratelimiter
   (go (while true


### PR DESCRIPTION
<img width="1132" alt="image" src="https://github.com/mtgred/netrunner/assets/5345/9d91e813-d0a5-4411-9cb4-60efd2ff7fd7">

Moved all the telemetry logging to its own file to make it easier to extend it with non-web socket info.

Removed the max conn per uid stats as they never seemed to change.

Added 3 new stats to log:

- `lobbies` the number of lobbies in app-state
- `cached-users` the number of users stored in app-state
- `lobby-subs` the number of uids we track in `lobby-updates` that are set to true e.g. would get lobby updates if their connection exists
- `lobby-update-uids` the number of uids that will get lobby updates on each broadcast