### PR TITLE
reveals cards if you can't rez them when instructed to do so

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -206,10 +206,19 @@
                                        :choices (cancellable (filter corp-installable-type?
                                                                      (take 5 (:deck corp))))
                                        :async true
-                                       :effect (effect (corp-install
-                                                         eid target nil
-                                                         {:ignore-all-cost true
-                                                          :install-state :rezzed-no-cost}))
+                                       :effect (req (let [target-position (first (positions #{target} (take 3 (:deck corp))))
+                                                          position (case target-position
+                                                                     0 "first "
+                                                                     1 "second "
+                                                                     2 "third "
+                                                                     3 "fourth "
+                                                                     4 "fifth "
+                                                                     "this-should-not-happen ")]
+                                                      (system-msg state side (str "uses " (:title card) " to install the " position "card from R&D"))
+                                                      (corp-install state side
+                                                        eid target nil
+                                                        {:ignore-all-cost true
+                                                         :install-state :rezzed-no-cost})))
                                        :cancel-effect
                                        (effect (system-msg
                                                  (str "declines to use "

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -4324,11 +4324,11 @@
         "Corp gained 4 credits and put 1 advancement counter on a card")
     (play-from-hand state :corp "Restore")
     (click-card state :corp (find-card "Stoke the Embers" (:discard (get-corp))))
-    (click-prompt state :corp "New remote")
     (is (changed? [(:credit (get-corp)) 3
                    (get-counters (refresh (get-content state :remote3 0)) :advancement) 1]
+                  (click-prompt state :corp "New remote")
                   (click-prompt state :corp "Yes")
-                  (is (last-n-log-contains? state 3 "reveal itself from Archives"))
+                  (is (last-n-log-contains? state 3 "reveals Stoke the Embers in Server 3"))
                   (click-card state :corp (get-content state :remote3 0)))
         "Corp gained 2 credits (+1 from Hyobu because the agenda was revealed) and put 1 advancement counter on a card")))
 


### PR DESCRIPTION
As the title says. This is something that should happen with all effects that have the rez instruction on them: if you cannot pay, or decline to pay, any of the costs, the card is not rezzed - but the corp is forced to reveal the card to prove that.
According to the rules team, it's an actual functional reveal for the purposes of card effects too.

I also made ADT say where in R&D you pull the card from.