### PR TITLE
Trash for mu on install is a runner source

### DIFF
--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -1120,7 +1120,8 @@
                      :card #(and (installed? %)
                                  (program? %))}
            :async true
-           :effect (req (wait-for (move* state side (make-eid state eid) :trash-cards targets {:unpreventable true})
+           :effect (req (wait-for (move* state side (make-eid state eid) :trash-cards targets {:game-trash true
+                                                                                               :unpreventable true})
                                   (update-mu state)
                                   (effect-completed state side eid)))})
         nil nil)

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -1120,7 +1120,7 @@
                      :card #(and (installed? %)
                                  (program? %))}
            :async true
-           :effect (req (wait-for (move* state side (make-eid state eid) :trash-cards targets {:game-trash true})
+           :effect (req (wait-for (move* state side (make-eid state eid) :trash-cards targets {:unpreventable true})
                                   (update-mu state)
                                   (effect-completed state side eid)))})
         nil nil)

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -434,7 +434,7 @@
                      :card #(and (installed? %)
                                  (program? %))}
            :async true
-           :effect (req (wait-for (trash-cards state side (make-eid state eid) targets {:game-trash true})
+           :effect (req (wait-for (trash-cards state side (make-eid state eid) targets {:unpreventable true})
                                   (update-mu state)
                                   (runner-install-pay state side eid card args)))
            :cancel-effect (effect (effect-completed eid))}


### PR DESCRIPTION
As it says in the description. The runner is the source for this action, so it should interact with "runner trashes" facets like Reaver.

This is different than the checkpoint one we apply, which is for if the game-state becomes illegal.