### PR TITLE
saisentant and bankhar play nice

### DIFF
--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -3560,8 +3560,11 @@
                             (trigger-event-sync state side eid :spent-credits-from-card card)))}))
 
 (defcard "Tsakhia \"Bankhar\" Gantulga"
-  (let [subroutine {:variable true
-                    :sub-effect (do-net-damage 1)}
+  (let [sub {:variable true
+             :sub-effect {:effect (req (damage state :corp eid :net 1 {:card card :cause :subroutine}))
+                          :label "Do 1 net damage"
+                          :async true
+                          :msg "do 1 net damage"}}
         matches-server (fn [target card state side]
                          (= (:card-target card)
                             (zone->name (second (get-zone target)))))
@@ -3587,7 +3590,7 @@
                              :duration :end-of-encounter
                              :async true
                              :msg "force the Corp to resolve \"[Subroutine] Do 1 net damage\""
-                             :effect (req (update-current-encounter state :replace-subroutine subroutine)
+                             :effect (req (update-current-encounter state :replace-subroutine sub)
                                           (effect-completed state side eid))}]))}
               {:event :runner-turn-ends
                :silent (req true)

--- a/src/clj/game/core/damage.clj
+++ b/src/clj/game/core/damage.clj
@@ -103,7 +103,7 @@
 (defn- resolve-damage
   "Resolves the attempt to do n damage, now that both sides have acted to boost or
   prevent damage."
-  [state side eid dmg-type n {:keys [card]}]
+  [state side eid dmg-type n {:keys [card cause]}]
   (swap! state update-in [:damage :defer-damage] dissoc dmg-type)
   (swap! state dissoc-in [:damage :chosen-damage])
   (damage-choice-priority state)
@@ -134,6 +134,7 @@
                               (queue-event state :damage {:amount n
                                                           :card card
                                                           :damage-type dmg-type
+                                                          :cause cause
                                                           :cards-trashed cards-trashed})
                               (let [trash-event (get-trash-event side false)
                                     args {:durations [:damage trash-event]}]

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -6050,6 +6050,26 @@
       (card-subroutine state :corp sai 0)
       (is (= 2 (-> (get-runner) :discard count)) "Two cards should be trashed due to correctly guessing"))))
 
+(deftest saisentan-bankhar-interaction
+  ;; Corp chooses correctly
+  (do-game
+    (new-game {:corp {:hand ["Saisentan"]}
+               :runner {:hand ["Tsakhia \"Bankhar\" Gantulga" (qty "Sure Gamble" 4)]}})
+    (play-from-hand state :corp "Saisentan" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Tsakhia \"Bankhar\" Gantulga")
+    (take-credits state :runner)
+    (take-credits state :corp)
+    (click-prompt state :runner "HQ")
+    (run-on state "HQ")
+    (let [sai (get-ice state :hq 0)]
+      (rez state :corp sai)
+      (run-continue state)
+      (click-prompt state :corp "Event")
+      (is (zero? (-> (get-runner) :discard count)) "Heap should be empty")
+      (card-subroutine state :corp sai 0)
+      (is (= 2 (-> (get-runner) :discard count)) "Two cards should be trashed due to correctly guessing"))))
+
 (deftest saisentan-corp-chooses-incorrectly
   ;; Corp chooses incorrectly
   (do-game


### PR DESCRIPTION
I reworked saisentan to be an event that triggers on damage, and specifies that:
* The damage comes from a subroutine
* Is net damage
* Comes from saisentan
Ontop of the card being the right type.

This also theoretically works if effects are later introduces which boost net damage or something. I left a comment to that effect.

I modified the damage event to add a `:cause` key to it's context, which can be passed in the args when calling `(damage`. It's only really touched by saisentan (and set by saisentan and bankhar), but it's there if we ever need it for stuff in the future too.

Closes #6875
Closes #7466

Because this divorces the event from the subroutine, this also Closes #6013 (but I'm not writing a test for this, since it's an illegal game state anyway)