### PR TITLE
trick shot checks run eid

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -3959,12 +3959,14 @@
    :on-play {:req (req rd-runnable)
              :msg "make a run on R&D"
              :async true
-             :effect (effect (make-run eid :rd card))}
+             :effect (req (update! state side (assoc-in card [:special :run-eid] eid))
+                          (make-run state side eid :rd card))}
    :events [{:event :successful-run
              :unregister-once-resolved true
              :silent (req true)
              :req (req (and (= :rd (target-server context))
-                            this-card-run))
+                            this-card-run
+                            (= (get-in card [:special :run-eid :eid]) (get-in @state [:run :eid :eid]))))
              :msg "place 2 [Credits] on itself and access 1 additional card from R&D"
              :effect (effect
                        (add-counter card :credit 2 {:placed true})


### PR DESCRIPTION
One more safeguard for NSG's least cursed card.

We now check the run eid against the eid that the first run was registered with when assessing the credits/access ability on trick shot.

Closes #7455