### PR TITLE
swapping installed cards no longer fizzles pending events.

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -2086,6 +2086,7 @@
                :effect (effect (register-events
                                  card
                                  [{:event :pass-ice
+                                   :silent (req true)
                                    :duration :end-of-run
                                    :effect (effect (update! (update-in (get-card state card) [:special :how-deep-are-we] (fnil inc 0))))}])
                                (make-run eid target card))}

--- a/src/clj/game/core/engine.clj
+++ b/src/clj/game/core/engine.clj
@@ -3,12 +3,13 @@
     [clj-uuid :as uuid]
     [clojure.stacktrace :refer [print-stack-trace]]
     [cond-plus.core :refer [cond+]]
-    [game.core.board :refer [clear-empty-remotes get-all-cards all-installed-runner
+    [game.core.board :refer [clear-empty-remotes get-all-cards all-installed all-installed-runner
                              all-installed-runner-type all-active-installed]]
-    [game.core.card :refer [active? facedown? faceup? get-card get-cid get-title in-discard? in-hand? installed? rezzed? program? console? unique?]]
+    [game.core.card :refer [active? facedown? faceup? get-card get-cid get-title ice? in-discard? in-hand? installed? rezzed? program? console? unique?]]
     [game.core.card-defs :refer [card-def]]
     [game.core.effects :refer [get-effect-maps unregister-lingering-effects is-disabled? is-disabled-reg? update-disabled-cards]]
     [game.core.eid :refer [complete-with-result effect-completed make-eid]]
+    [game.core.finding :refer [find-cid]]
     [game.core.payment :refer [build-spend-msg can-pay? handler]]
     [game.core.prompt-state :refer [add-to-prompt-queue]]
     [game.core.prompts :refer [clear-wait-prompt show-prompt show-select show-wait-prompt]]
@@ -605,8 +606,14 @@
 (defn- card-for-ability
   [state {:keys [card duration] :as ability}]
   (if (#{:default-duration :pending} duration)
-    (when-let [card (get-card state card)]
-      (valid-condition? state card ability))
+    (if-let [card (get-card state card)]
+      (valid-condition? state card ability)
+      (when-let [card (and (installed? card) (find-cid (:cid card) (all-installed state (:side card))))]
+        ;; ice that's swapped still triggers events when passed
+        ;; get-card wont find it because the zone is different
+        ;; any other card that gets swapped while pending should also maintain triggers,
+        ;; so long as it remains on the field/doesn't become inactive
+        (valid-condition? state card ability)))
     card))
 
 (defn trigger-suppress

--- a/test/clj/game/cards/events_test.clj
+++ b/test/clj/game/cards/events_test.clj
@@ -3891,6 +3891,27 @@
     (click-prompt state :runner "No action")
     (is (= 4 (get-counters (get-program state 0) :power)) "4 counters on david")))
 
+(deftest into-the-depths-inversificator-still-counts-the-ice
+  (do-game
+    (new-game {:runner {:hand ["Into the Depths" "Inversificator"]
+                        :credits 20}
+               :corp {:hand [(qty "Quandary" 2)]}})
+    (play-from-hand state :corp "Quandary" "HQ")
+    (play-from-hand state :corp "Quandary" "R&D")
+    (take-credits state :corp)
+    (rez state :corp (get-ice state :hq 0))
+    (play-from-hand state :runner "Inversificator")
+    (play-from-hand state :runner "Into the Depths")
+    (click-prompt state :runner "HQ")
+    (run-continue state :encounter-ice)
+    (card-ability state :runner (get-program state 0) 0)
+    (click-prompt state :runner "End the run")
+    (run-continue state :pass-ice)
+    (click-prompt state :runner "Yes")
+    (click-card state :runner (get-ice state :rd 0))
+    (run-continue-until state :success)
+    (click-prompt state :runner "Gain 4 [Credits]")))
+
 (deftest isolation
   ;; Isolation - A resource must be trashed, gain 7c
   (do-game

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -7175,6 +7175,50 @@
       (is (= "Vanilla" (:title (get-ice state :hq 0))) "Vanilla outermost ice on HQ after swap during run")
       (is (= "Thimblerig" (:title (get-ice state :remote1 0))) "Thimblerig ice on remote after swap during run"))))
 
+(deftest thimblerig-swap-doesnt-mash-events
+  ;; Swap ability on runner pass
+  (do-game
+    (new-game {:corp {:deck ["Vanilla" "Thimblerig"]}
+               :runner {:hand ["Sure Gamble" "Inversificator"]}})
+    (play-from-hand state :corp "Thimblerig" "HQ")
+    (play-from-hand state :corp "Vanilla" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Sure Gamble")
+    (play-from-hand state :runner "Inversificator")
+    (let [thimble (get-ice state :hq 0)
+          vanilla (get-ice state :remote1 0)
+          inv (get-program state 0)]
+      (run-on state "HQ")
+      (rez state :corp thimble)
+      (run-continue state)
+      (card-ability state :runner (refresh inv) 0)
+      (click-prompt state :runner "End the run")
+      (run-continue state)
+      (click-prompt state :runner "Yes")
+      (click-card state :runner (get-ice state :remote1 0))
+      (click-prompt state :corp "Yes")
+      (is (= "Thimblerig" (:title (get-ice state :remote1 0))) "Thimblerig outermost ice on HQ")
+      (is (= "Vanilla" (:title (get-ice state :hq 0))) "Vanilla ice on remote")
+      (click-card state :corp (get-ice state :hq 0))
+      (is (= "Vanilla" (:title (get-ice state :remote1 0))) "Vanilla outermost ice on HQ after swap during run")
+      (is (= "Thimblerig" (:title (get-ice state :hq 0))) "Thimblerig ice on remote after swap during run"))))
+
+(deftest thimblerig-swapping-doesnt-lose-prompts
+  ;; Swap ability on runner pass
+  (do-game
+    (new-game {:corp {:deck [(qty "Thimblerig" 2)]}})
+    (play-from-hand state :corp "Thimblerig" "HQ")
+    (play-from-hand state :corp "Thimblerig" "R&D")
+    (take-credits state :corp)
+    (let [thimble1 (get-ice state :hq 0)
+          thimble2 (get-ice state :rd 0)]
+      (rez state :corp thimble1)
+      (rez state :corp thimble2)
+      (take-credits state :runner)
+      (click-prompt state :corp "Yes")
+      (click-card state :corp thimble2)
+      (click-prompt state :corp "Yes"))))
+
 (deftest thimblerig-swapping-issues-related-to-trashing-5197
   ;; Swapping issues related to trashing #5197
   (do-game

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -4454,6 +4454,7 @@
       (click-card state :runner "Drafter")
       (is (= ["Border Control" "Thimblerig"] (map :title (get-ice state :rd))))
       (is (= ["Vanilla" "Drafter"] (map :title (get-ice state :hq))))
+      (click-prompt state :corp "No")
       (is (no-prompt? state :corp) "Corp gets no Thimblerig prompt")
       (is (no-prompt? state :runner) "No more prompts open")))
 


### PR DESCRIPTION
This is our accommodation for the rules reversal NSG did on this/our engine handling of cards being swapped.

I added tests for the outstanding issues I could find.

Closes #7421
Closes #7269
Closes #6915

Also Closes #5591 in a more conclusive way than the interactive tag did.