### PR TITLE
marilyn no longer interrupts regenisis working

### DIFF
--- a/src/clj/game/core/events.clj
+++ b/src/clj/game/core/events.clj
@@ -9,6 +9,16 @@
   [state _ ev]
   (mapcat rest (filter #(= ev (first %)) (:turn-events @state))))
 
+(defn truncate-turn-event
+  "Truncates the last occurance of an event, if possible."
+  ([state _ ev] truncate-turn-event state nil ev (constantly true))
+  ([state _ ev pred]
+   (when-let [matching (first (filter pred (turn-events state nil ev)))]
+     (let [converted-ev [ev matching]
+           [pre post] (split-with #(not= converted-ev %) (reverse (:turn-events @state)))
+           updated-turn-events (reverse (concat pre (rest post)))]
+       (swap! state assoc :turn-events updated-turn-events)))))
+
 (defn last-turn?
   [state side event]
   (get-in @state [side :register-last-turn event]))

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -3533,6 +3533,23 @@
     (click-card state :corp "Obokata Protocol")
     (is (= 5 (:agenda-point (get-corp))) "3+1+1 agenda points from obo + regen + regen")))
 
+(deftest regenesis-vs-marilyn-campaign-trash-replacement
+  ;; Regenesis - if no cards have been added to discard, reveal a face-down agenda
+  ;; and add it to score area
+  (do-game
+    (new-game {:corp {:deck ["Regenesis" "Marilyn Campaign"]
+                      :discard ["Obokata Protocol"]}})
+    (play-from-hand state :corp "Marilyn Campaign" "New remote")
+    (rez state :corp (get-content state :remote1 0))
+    (dotimes [_ 4]
+      (take-credits state :corp)
+      (take-credits state :runner))
+    ;; marilyn should pop now
+    (click-prompt state :corp "Yes")
+    (play-and-score state "Regenesis")
+    (click-card state :corp "Obokata Protocol")
+    (is (= 4 (:agenda-point (get-corp))) "3+1 agenda points from obo + regen")))
+
 (deftest regenesis-not-affected-by-subliminal-messaging
   ;; Regenesis - Leaving Subliminal Messaging in Archives doesn't interfere
   (do-game


### PR DESCRIPTION
Added the ability to selectively remove things from turn-events. It sounds cursed, and it is a bit of a hack, but the alternative is completely rewriting how cards are trashed again to insert another hack, and this one at least has the potential to help us fix interactions later.

Really, every solution I can think of for this is cursed.

Closes #6895 
Closes #7614