### PR TITLE
use pronouns in the game where appropriate

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1132,7 +1132,7 @@
                                (in-hand? %)
                                (>= 1 (:agendapoints %)))}
          :waiting-prompt true
-         :msg (msg "add " (:title target) " from HQ to " (pronoun state side) " score area")
+         :msg (msg "add " (:title target) " from HQ to [their] score area")
          :effect (req
                    (let [c (move state :corp target :scored)]
                         (card-init state :corp c {:resolve-effect false
@@ -1324,7 +1324,7 @@
 
 (defcard "Midnight-3 Arcology"
   {:on-score {:async true
-              :msg (msg "draw 3 cards and skip " (pronoun state side) " discard step this turn")
+              :msg (msg "draw 3 cards and skip [their] discard step this turn")
               :effect (effect
                         (register-lingering-effect
                           card
@@ -1694,7 +1694,7 @@
                :interactive (req true)
                :prompt "Quantum Predictive Model will be added to the Corp's score area"
                :choices ["OK"]
-               :msg (msg "add itself to " (pronoun state side) " score area and gain 1 agenda point")
+               :msg (msg "add itself to [their] score area and gain 1 agenda point")
                :effect (effect (move :corp card :scored {:force true})
                                (update-all-agenda-points)
                                (check-win-by-agenda))}})
@@ -1715,7 +1715,7 @@
              :msg (req (let [n (count chosen)]
                          (str "add " (quantify n "card") " from HQ to the bottom of R&D and draw " (quantify n "card")
                               ". The Runner randomly adds " (quantify (min n (count (:hand runner))) "card")
-                              " from " (pronoun state :runner) " Grip to the bottom of the Stack")))
+                              " from [runner-pronoun] Grip to the bottom of the Stack")))
              :effect (req (let [n (count chosen)]
                             (if (= target "Done")
                               (do (doseq [c (reverse chosen)] (move state :corp c :deck))
@@ -1760,7 +1760,7 @@
                                     (not (faceup? %)))}
               :show-discard true
               :async true
-              :msg (msg "reveal " (:title (first targets)) " and add it to " (pronoun state side) " score area")
+              :msg (msg "reveal " (:title (first targets)) " and add it to [their] score area")
               :effect (req (wait-for (reveal state side target)
                                      (let [c (move state :corp target :scored)]
                                        (card-init state :corp c {:resolve-effect false
@@ -1787,7 +1787,7 @@
 (defcard "Remote Data Farm"
   {:move-zone (req (when (and (in-scored? card)
                               (= :corp (:scored-side card)))
-                     (system-msg state side (str "uses " (:title card) " to increase " (pronoun state side) " maximum hand size by 2"))))
+                     (system-msg state side (str "uses " (:title card) " to increase [their] maximum hand size by 2"))))
    :static-abilities [(corp-hand-size+ 2)]})
 
 (defcard "Remote Enforcement"

--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -1132,7 +1132,7 @@
                                (in-hand? %)
                                (>= 1 (:agendapoints %)))}
          :waiting-prompt true
-         :msg (msg "add " (:title target) " from HQ to their score area")
+         :msg (msg "add " (:title target) " from HQ to " (pronoun state side) " score area")
          :effect (req
                    (let [c (move state :corp target :scored)]
                         (card-init state :corp c {:resolve-effect false
@@ -1324,7 +1324,7 @@
 
 (defcard "Midnight-3 Arcology"
   {:on-score {:async true
-              :msg "draw 3 cards and skip their discard step this turn"
+              :msg (msg "draw 3 cards and skip " (pronoun state side) " discard step this turn")
               :effect (effect
                         (register-lingering-effect
                           card
@@ -1694,7 +1694,7 @@
                :interactive (req true)
                :prompt "Quantum Predictive Model will be added to the Corp's score area"
                :choices ["OK"]
-               :msg "add itself to their score area and gain 1 agenda point"
+               :msg (msg "add itself to " (pronoun state side) " score area and gain 1 agenda point")
                :effect (effect (move :corp card :scored {:force true})
                                (update-all-agenda-points)
                                (check-win-by-agenda))}})
@@ -1715,7 +1715,7 @@
              :msg (req (let [n (count chosen)]
                          (str "add " (quantify n "card") " from HQ to the bottom of R&D and draw " (quantify n "card")
                               ". The Runner randomly adds " (quantify (min n (count (:hand runner))) "card")
-                              " from their Grip to the bottom of the Stack")))
+                              " from " (pronoun state :runner) " Grip to the bottom of the Stack")))
              :effect (req (let [n (count chosen)]
                             (if (= target "Done")
                               (do (doseq [c (reverse chosen)] (move state :corp c :deck))
@@ -1760,7 +1760,7 @@
                                     (not (faceup? %)))}
               :show-discard true
               :async true
-              :msg (msg "reveal " (:title (first targets)) " and add it to their score area")
+              :msg (msg "reveal " (:title (first targets)) " and add it to " (pronoun state side) " score area")
               :effect (req (wait-for (reveal state side target)
                                      (let [c (move state :corp target :scored)]
                                        (card-init state :corp c {:resolve-effect false
@@ -1787,7 +1787,7 @@
 (defcard "Remote Data Farm"
   {:move-zone (req (when (and (in-scored? card)
                               (= :corp (:scored-side card)))
-                     (system-msg state side (str "uses " (:title card) " to increase their maximum hand size by 2"))))
+                     (system-msg state side (str "uses " (:title card) " to increase " (pronoun state side) " maximum hand size by 2"))))
    :static-abilities [(corp-hand-size+ 2)]})
 
 (defcard "Remote Enforcement"

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -934,7 +934,7 @@
 (defcard "Echo Chamber"
   {:abilities [{:label "Add this asset to your score area as an agenda worth 1 agenda point"
                 :cost [(->c :click 3)]
-                :msg "add itself to their score area as an agenda worth 1 agenda point"
+                :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
                 :effect (req (as-agenda state :corp card 1))}]})
 
 (defcard "Edge of World"
@@ -1065,7 +1065,7 @@
                  :effect (effect (gain-tags :corp eid (tag-count (get-card state card))))}
      :abilities [{:cost [(->c :click 1) (->c :advancement 7)]
                   :label "Add this asset to your score area as an agenda worth 3 agenda points"
-                  :msg "add itself to their score area as an agenda worth 3 agenda points"
+                  :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 3 agenda points")
                   :effect (req (as-agenda state :corp card 3))}]}))
 
 (defcard "Federal Fundraising"
@@ -1111,7 +1111,7 @@
 (defcard "Franchise City"
   {:events [{:event :access
              :req (req (agenda? target))
-             :msg "add itself to their score area as an agenda worth 1 agenda point"
+             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
              :effect (req (as-agenda state :corp card 1))}]})
 
 (defcard "Front Company"
@@ -1205,11 +1205,11 @@
                                        {:card card}))}
    :abilities [{:cost [(->c :click 1) (->c :advancement 3)]
                 :label "Add this asset to your score area as an agenda worth 1 agenda point"
-                :msg "add itself to their score area as an agenda worth 1 agenda point"
+                :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
                 :effect (req (as-agenda state :corp card 1))}]})
 
 (defcard "Genetics Pavilion"
-  {:on-rez {:msg "prevent the Runner from drawing more than 2 cards during their turn"
+  {:on-rez {:msg (msg "prevent the Runner from drawing more than 2 cards during " (pronoun state :runner) " turn")
             :effect (req (max-draw state :runner 2)
                          (when (zero? (remaining-draws state :runner))
                            (prevent-draw state :runner)))}
@@ -2195,7 +2195,7 @@
             {:event :counter-added
              :req (req (same-card? card target)
                        (not (pos? (get-counters card :power))))
-             :msg "add itself to their score area as an agenda worth 1 agenda point"
+             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
              :effect (effect (as-agenda card 1))}]})
 
 (defcard "Quarantine System"
@@ -2564,7 +2564,7 @@
                      :async true
                      :effect (req (if (str/starts-with? target "Add")
                                     (do (system-msg state :runner (str "adds " (:title card)
-                                                                       " to their score area as an agenda worth "
+                                                                       " to " (pronoun state side) " score area as an agenda worth "
                                                                        (quantify -1 "agenda point")))
                                         (as-agenda state :runner card -1)
                                         (effect-completed state side eid))

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -934,7 +934,7 @@
 (defcard "Echo Chamber"
   {:abilities [{:label "Add this asset to your score area as an agenda worth 1 agenda point"
                 :cost [(->c :click 3)]
-                :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+                :msg (msg "add itself to [their] score area as an agenda worth 1 agenda point")
                 :effect (req (as-agenda state :corp card 1))}]})
 
 (defcard "Edge of World"
@@ -1065,7 +1065,7 @@
                  :effect (effect (gain-tags :corp eid (tag-count (get-card state card))))}
      :abilities [{:cost [(->c :click 1) (->c :advancement 7)]
                   :label "Add this asset to your score area as an agenda worth 3 agenda points"
-                  :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 3 agenda points")
+                  :msg (msg "add itself to [their] score area as an agenda worth 3 agenda points")
                   :effect (req (as-agenda state :corp card 3))}]}))
 
 (defcard "Federal Fundraising"
@@ -1111,7 +1111,7 @@
 (defcard "Franchise City"
   {:events [{:event :access
              :req (req (agenda? target))
-             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+             :msg "add itself to [their] score area as an agenda worth 1 agenda point"
              :effect (req (as-agenda state :corp card 1))}]})
 
 (defcard "Front Company"
@@ -1205,11 +1205,11 @@
                                        {:card card}))}
    :abilities [{:cost [(->c :click 1) (->c :advancement 3)]
                 :label "Add this asset to your score area as an agenda worth 1 agenda point"
-                :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+                :msg "add itself to [their] score area as an agenda worth 1 agenda point"
                 :effect (req (as-agenda state :corp card 1))}]})
 
 (defcard "Genetics Pavilion"
-  {:on-rez {:msg (msg "prevent the Runner from drawing more than 2 cards during " (pronoun state :runner) " turn")
+  {:on-rez {:msg (msg "prevent the Runner from drawing more than 2 cards during [runner-pronoun] turn")
             :effect (req (max-draw state :runner 2)
                          (when (zero? (remaining-draws state :runner))
                            (prevent-draw state :runner)))}
@@ -2195,7 +2195,7 @@
             {:event :counter-added
              :req (req (same-card? card target)
                        (not (pos? (get-counters card :power))))
-             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+             :msg "add itself to [their] score area as an agenda worth 1 agenda point"
              :effect (effect (as-agenda card 1))}]})
 
 (defcard "Quarantine System"
@@ -2564,7 +2564,7 @@
                      :async true
                      :effect (req (if (str/starts-with? target "Add")
                                     (do (system-msg state :runner (str "adds " (:title card)
-                                                                       " to " (pronoun state side) " score area as an agenda worth "
+                                                                       " to [their] score area as an agenda worth "
                                                                        (quantify -1 "agenda point")))
                                         (as-agenda state :runner card -1)
                                         (effect-completed state side eid))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -713,7 +713,7 @@
                 {:async true
                  :prompt "Choose where to install the program from"
                  :choices (req (if (not (zone-locked? state :runner :discard)) ["Stack" "Heap"] ["Stack"]))
-                 :msg (msg "install a program from " (pronoun state side) " " target)
+                 :msg (msg "install a program from [their] " target)
                  :effect (effect (continue-ability
                                    (compile-fn (if (= "Stack" target) :deck :discard))
                                    card nil))}}}
@@ -1003,13 +1003,13 @@
    {:req (req (not (zone-locked? state :runner :discard)))
     :prompt "Choose a card to add to Grip"
     :choices (req (cancellable (:discard runner) :sorted))
-    :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
+    :msg (msg "add " (:title target) " to [their] Grip")
     :async true
     :effect (effect (move target :hand)
                     (continue-ability
                       (when (has-subtype? target "Virus")
                         {:prompt "Choose a virus to add to Grip"
-                         :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
+                         :msg (msg "add " (:title target) " to [their] Grip")
                          :choices (req (cancellable (filter #(has-subtype? % "Virus") (:discard runner)) :sorted))
                          :effect (effect (move target :hand))})
                       card nil))}})
@@ -1635,7 +1635,7 @@
 
 (defcard "\"Freedom Through Equality\""
   {:events [{:event :agenda-stolen
-             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+             :msg (msg "add itself to [their] score area as an agenda worth 1 agenda point")
              :effect (req (as-agenda state :runner card 1))}]})
 
 (defcard "Freelance Coding Contract"
@@ -2374,7 +2374,7 @@
              :req (req this-card-run)
              :effect (req (if (:did-steal target)
                             (do (system-msg state :runner
-                                            (str "adds Mad Dash to " (pronoun state side) " score area as an agenda worth 1 agenda point"))
+                                            (str "adds Mad Dash to [their] score area as an agenda worth 1 agenda point"))
                                 (as-agenda state :runner (get-card state card) 1)
                                 (effect-completed state side eid))
                             (do (system-msg state :runner
@@ -2425,7 +2425,7 @@
                             :value [blocked-server]
                             :duration :end-of-turn}))
                        (when (:successful target)
-                         (system-msg state :runner (str "gains [Click] and adds Marathon to " (pronoun state side) " grip"))
+                         (system-msg state :runner (str "gains [Click] and adds Marathon to [their] grip"))
                          (gain-clicks state :runner 1)
                          (move state :runner card :hand)
                          (unregister-events state side card)))}]})
@@ -2616,7 +2616,7 @@
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
                    (some #{:rd} (:successful-run runner-reg))
                    (some #{:archives} (:successful-run runner-reg))))
-    :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+    :msg (msg "add itself to [their] score area as an agenda worth 1 agenda point")
     :effect (req (as-agenda state :runner card 1))}})
 
 (defcard "Office Supplies"
@@ -2803,7 +2803,7 @@
 
 (defcard "Populist Rally"
   {:on-play {:req (req (seq (filter #(has-subtype? % "Seedy") (all-active-installed state :runner))))
-             :msg (msg "give the Corp 1 fewer [Click] to spend on " (pronoun state :corp) " next turn")
+             :msg (msg "give the Corp 1 fewer [Click] to spend on [corp-pronoun] next turn")
              :effect (effect (lose :corp :click-per-turn 1))}
    :events [{:event :corp-turn-ends
              :duration :until-corp-turn-ends
@@ -3825,7 +3825,7 @@
                               {:async true
                                :prompt "Choose a server"
                                :choices (req runnable-servers)
-                               :msg (msg "trash " (pronoun state side) " grip and make a run on " target
+                               :msg (msg "trash [their] grip and make a run on " target
                                          ", preventing all damage")
                                :effect (effect (make-run eid target card))}
                               card nil)))}
@@ -3867,7 +3867,7 @@
 (defcard "The Price of Freedom"
   {:on-play {:additional-cost [(->c :connection 1)]
              :rfg-instead-of-trashing true
-             :msg (msg "prevent the Corp from advancing cards during " (pronoun state :corp) " next turn")}
+             :msg (msg "prevent the Corp from advancing cards during [their] next turn")}
    :events [{:event :corp-turn-begins
              :duration :until-runner-turn-begins
              :effect (effect (register-turn-flag!
@@ -3992,7 +3992,7 @@
                           (not (facedown? %))
                           (or (hardware? %)
                               (program? %)))}
-    :msg (msg "move " (:title target) " to " (pronoun state side) " Grip")
+    :msg (msg "move " (:title target) " to [their] Grip")
     :effect (effect (move target :hand))}})
 
 (defcard "Unscheduled Maintenance"

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -713,7 +713,7 @@
                 {:async true
                  :prompt "Choose where to install the program from"
                  :choices (req (if (not (zone-locked? state :runner :discard)) ["Stack" "Heap"] ["Stack"]))
-                 :msg (msg "install a program from their " target)
+                 :msg (msg "install a program from " (pronoun state side) " " target)
                  :effect (effect (continue-ability
                                    (compile-fn (if (= "Stack" target) :deck :discard))
                                    card nil))}}}
@@ -1003,13 +1003,13 @@
    {:req (req (not (zone-locked? state :runner :discard)))
     :prompt "Choose a card to add to Grip"
     :choices (req (cancellable (:discard runner) :sorted))
-    :msg (msg "add " (:title target) " to their Grip")
+    :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
     :async true
     :effect (effect (move target :hand)
                     (continue-ability
                       (when (has-subtype? target "Virus")
                         {:prompt "Choose a virus to add to Grip"
-                         :msg (msg "add " (:title target) " to their Grip")
+                         :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
                          :choices (req (cancellable (filter #(has-subtype? % "Virus") (:discard runner)) :sorted))
                          :effect (effect (move target :hand))})
                       card nil))}})
@@ -1635,7 +1635,7 @@
 
 (defcard "\"Freedom Through Equality\""
   {:events [{:event :agenda-stolen
-             :msg "add itself to their score area as an agenda worth 1 agenda point"
+             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
              :effect (req (as-agenda state :runner card 1))}]})
 
 (defcard "Freelance Coding Contract"
@@ -2374,7 +2374,7 @@
              :req (req this-card-run)
              :effect (req (if (:did-steal target)
                             (do (system-msg state :runner
-                                            (str "adds Mad Dash to their score area as an agenda worth 1 agenda point"))
+                                            (str "adds Mad Dash to " (pronoun state side) " score area as an agenda worth 1 agenda point"))
                                 (as-agenda state :runner (get-card state card) 1)
                                 (effect-completed state side eid))
                             (do (system-msg state :runner
@@ -2425,7 +2425,7 @@
                             :value [blocked-server]
                             :duration :end-of-turn}))
                        (when (:successful target)
-                         (system-msg state :runner "gains [Click] and adds Marathon to their grip")
+                         (system-msg state :runner (str "gains [Click] and adds Marathon to " (pronoun state side) " grip"))
                          (gain-clicks state :runner 1)
                          (move state :runner card :hand)
                          (unregister-events state side card)))}]})
@@ -2616,7 +2616,7 @@
    {:req (req (and (some #{:hq} (:successful-run runner-reg))
                    (some #{:rd} (:successful-run runner-reg))
                    (some #{:archives} (:successful-run runner-reg))))
-    :msg "add itself to their score area as an agenda worth 1 agenda point"
+    :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
     :effect (req (as-agenda state :runner card 1))}})
 
 (defcard "Office Supplies"
@@ -2803,7 +2803,7 @@
 
 (defcard "Populist Rally"
   {:on-play {:req (req (seq (filter #(has-subtype? % "Seedy") (all-active-installed state :runner))))
-             :msg "give the Corp 1 fewer [Click] to spend on their next turn"
+             :msg (msg "give the Corp 1 fewer [Click] to spend on " (pronoun state :corp) " next turn")
              :effect (effect (lose :corp :click-per-turn 1))}
    :events [{:event :corp-turn-ends
              :duration :until-corp-turn-ends
@@ -3825,7 +3825,7 @@
                               {:async true
                                :prompt "Choose a server"
                                :choices (req runnable-servers)
-                               :msg (msg "trash their grip and make a run on " target
+                               :msg (msg "trash " (pronoun state side) " grip and make a run on " target
                                          ", preventing all damage")
                                :effect (effect (make-run eid target card))}
                               card nil)))}
@@ -3867,7 +3867,7 @@
 (defcard "The Price of Freedom"
   {:on-play {:additional-cost [(->c :connection 1)]
              :rfg-instead-of-trashing true
-             :msg "prevent the Corp from advancing cards during their next turn"}
+             :msg (msg "prevent the Corp from advancing cards during " (pronoun state :corp) " next turn")}
    :events [{:event :corp-turn-begins
              :duration :until-runner-turn-begins
              :effect (effect (register-turn-flag!
@@ -3992,7 +3992,7 @@
                           (not (facedown? %))
                           (or (hardware? %)
                               (program? %)))}
-    :msg (msg "move " (:title target) " to their Grip")
+    :msg (msg "move " (:title target) " to " (pronoun state side) " Grip")
     :effect (effect (move target :hand))}})
 
 (defcard "Unscheduled Maintenance"

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1868,7 +1868,7 @@
                 :once :per-turn
                 :req (req (:runner-phase-12 @state))
                 :effect (effect (update! (assoc card :qianju-active true)))
-                :msg (msg "lose [Click] and avoid the first tag received until " (pronoun state side) " next turn")}]
+                :msg (msg "lose [Click] and avoid the first tag received until [their] next turn")}]
    :events [{:event :corp-turn-ends
              :effect (effect (update! (dissoc card :qianju-active)))}
             {:event :runner-turn-begins
@@ -2136,7 +2136,7 @@
                {:prompt "Lower your maximum hand size by 1 to reduce the strength of encountered ice to 0?"
                 :once :per-turn
                 :yes-ability
-                {:msg (msg "lower " (pronoun state side) " maximum hand size by 1 and reduce the strength of " (:title current-ice) " to 0")
+                {:msg (msg "lower [their] maximum hand size by 1 and reduce the strength of " (:title current-ice) " to 0")
                  :effect (effect
                            (register-lingering-effect
                              card

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -1868,7 +1868,7 @@
                 :once :per-turn
                 :req (req (:runner-phase-12 @state))
                 :effect (effect (update! (assoc card :qianju-active true)))
-                :msg "lose [Click] and avoid the first tag received until their next turn"}]
+                :msg (msg "lose [Click] and avoid the first tag received until " (pronoun state side) " next turn")}]
    :events [{:event :corp-turn-ends
              :effect (effect (update! (dissoc card :qianju-active)))}
             {:event :runner-turn-begins
@@ -2136,7 +2136,7 @@
                {:prompt "Lower your maximum hand size by 1 to reduce the strength of encountered ice to 0?"
                 :once :per-turn
                 :yes-ability
-                {:msg (msg "lower their maximum hand size by 1 and reduce the strength of " (:title current-ice) " to 0")
+                {:msg (msg "lower " (pronoun state side) " maximum hand size by 1 and reduce the strength of " (:title current-ice) " to 0")
                  :effect (effect
                            (register-lingering-effect
                              card

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2092,7 +2092,7 @@
 
 (defcard "Harvester"
   (let [sub {:label "Runner draws 3 cards and discards down to maximum hand size"
-             :msg (msg "make the Runner draw 3 cards and discard down to " (pronoun state :runner) " maximum hand size")
+             :msg "make the Runner draw 3 cards and discard down to [runner-pronoun] maximum hand size"
              :async true
              :effect (req (wait-for (draw state :runner 3)
                                     (continue-ability
@@ -3266,8 +3266,8 @@
 (defcard "Nightdancer"
   (let [sub {:label (str "The Runner loses [Click], if able. "
                          "You have an additional [Click] to spend during your next turn")
-             :msg (msg "force the runner to lose a [Click], if able. "
-                       "Corp gains an additional [Click] to spend during " (pronoun state side) " next turn")
+             :msg (str "force the runner to lose a [Click], if able. "
+                       "Corp gains an additional [Click] to spend during [their] next turn")
              :effect (req (lose-clicks state :runner 1)
                           (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}]
     {:subroutines [sub

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -2092,7 +2092,7 @@
 
 (defcard "Harvester"
   (let [sub {:label "Runner draws 3 cards and discards down to maximum hand size"
-             :msg "make the Runner draw 3 cards and discard down to their maximum hand size"
+             :msg (msg "make the Runner draw 3 cards and discard down to " (pronoun state :runner) " maximum hand size")
              :async true
              :effect (req (wait-for (draw state :runner 3)
                                     (continue-ability
@@ -3266,8 +3266,8 @@
 (defcard "Nightdancer"
   (let [sub {:label (str "The Runner loses [Click], if able. "
                          "You have an additional [Click] to spend during your next turn")
-             :msg (str "force the runner to lose a [Click], if able. "
-                       "Corp gains an additional [Click] to spend during their next turn")
+             :msg (msg "force the runner to lose a [Click], if able. "
+                       "Corp gains an additional [Click] to spend during " (pronoun state side) " next turn")
              :effect (req (lose-clicks state :runner 1)
                           (swap! state update-in [:corp :extra-click-temp] (fnil inc 0)))}]
     {:subroutines [sub

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -526,7 +526,7 @@
 
 (defcard "Earth Station: SEA Headquarters"
   (let [flip-effect (effect (update! (if (:flipped card)
-                                       (do (system-msg state :corp (str "flipped " (pronoun state :corp) " identity to Earth Station: SEA Headquarters"))
+                                       (do (system-msg state :corp "flipped [pronoun] identity to Earth Station: SEA Headquarters")
                                            (assoc card
                                                   :flipped false
                                                   :face :front
@@ -564,7 +564,7 @@
      :abilities [{:label "Flip identity to Earth Station: Ascending to Orbit"
                   :req (req (not (:flipped card)))
                   :cost [(->c :click 1)]
-                  :msg (msg "flip " (pronoun state side) " identity to Earth Station: Ascending to Orbit")
+                  :msg "flip [their] identity to Earth Station: Ascending to Orbit"
                   :effect flip-effect}
                  {:label "Manually flip identity to Earth Station: SEA Headquarters"
                   :req (req (:flipped card))
@@ -816,14 +816,14 @@
               {:event :tags-changed
                :effect (req (if (is-tagged? state)
                               (when-not (get-in @state [:runner :openhand])
-                                (system-msg state :corp (str "uses " (get-title card) " make the Runner play with " (pronoun state :runner) " grip revealed"))
+                                (system-msg state :corp (str "uses " (get-title card) " make the Runner play with [runner-pronoun] grip revealed"))
                                 (system-msg state :corp (str "uses " (get-title card) " to see that the Runner currently has "
-                                                             (format-grip runner) " in " (pronoun state :runner) " grip"))
+                                                             (format-grip runner) " in [runner-pronoun] grip"))
                               (reveal-hand state :runner))
                             (when (get-in @state [:runner :openhand])
-                              (system-msg state :corp (str "uses " (get-title card) " stop making the Runner play with " (pronoun state :runner) " grip revealed"))
-                              (system-msg state :corp (str "uses " (get-title card) " to see that the Runner had "
-                                                           (format-grip runner) " in " (pronoun state :runner) " grip before it was concealed"))
+                              (system-msg state :corp (str "uses " (get-title card) " stop making the Runner play with [runner-pronoun] grip revealed"))
+                              (system-msg state :corp (str "uses " (get-title card) " to note that the Runner had "
+                                                           (format-grip runner) " in [runner-pronoun] grip before it was concealed"))
                               (conceal-hand state :runner))))}]
    :effect (req (when (is-tagged? state)
                   (reveal-hand state :runner)))
@@ -893,13 +893,13 @@
                :effect (req (cond
                               (and (:flipped card)
                                    (not (:accessed-cards runner-reg)))
-                              (do (system-msg state :runner (str "flips " (pronoun state :runner) " identity to Hoshiko Shiro: Untold Protagonist"))
+                              (do (system-msg state :runner "flips [their] identity to Hoshiko Shiro: Untold Protagonist")
                                   (continue-ability state :runner {:effect flip-effect} card nil))
 
                               (and (not (:flipped card))
                                    (:accessed-cards runner-reg))
                               (wait-for (gain-credits state :runner 2)
-                                        (system-msg state :runner (str "gains 2 [Credits] and flips " (pronoun state side) " identity to Hoshiko Shiro: Mahou Shoujo"))
+                                        (system-msg state :runner "gains 2 [Credits] and flips [their] identity to Hoshiko Shiro: Mahou Shoujo")
                                         (continue-ability state :runner {:effect flip-effect} card nil))
 
                               :else
@@ -912,7 +912,7 @@
                                                 (system-msg state :runner (str "uses " (:title card) " to draw 1 card and lose 1 [Credits]"))
                                                 (effect-completed state side eid))))}]
      :abilities [{:label "flip identity"
-                  :msg (msg "flip " (pronoun state side) " identity manually")
+                  :msg "flip [their] identity manually"
                   :effect flip-effect}]}))
 
 (defcard "Hyoubu Institute: Absolute Clarity"
@@ -2037,7 +2037,7 @@
                                (update! state side (-> card (assoc :sync-flipped false :face :front :code "09001")))
                                (update! state side (-> card (assoc :sync-flipped true :face :back :code "sync")))))
                 :label "Flip this identity"
-                :msg (msg "flip " (pronoun state side) " identity")}]})
+                :msg (msg "flip [their] identity")}]})
 
 (defcard "Synthetic Systems: The World Re-imagined"
   {:events [{:event :pre-start-game

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -526,7 +526,7 @@
 
 (defcard "Earth Station: SEA Headquarters"
   (let [flip-effect (effect (update! (if (:flipped card)
-                                       (do (system-msg state :corp "flipped their identity to Earth Station: SEA Headquarters")
+                                       (do (system-msg state :corp (str "flipped " (pronoun state :corp) " identity to Earth Station: SEA Headquarters"))
                                            (assoc card
                                                   :flipped false
                                                   :face :front
@@ -564,7 +564,7 @@
      :abilities [{:label "Flip identity to Earth Station: Ascending to Orbit"
                   :req (req (not (:flipped card)))
                   :cost [(->c :click 1)]
-                  :msg "flip their identity to Earth Station: Ascending to Orbit"
+                  :msg (msg "flip " (pronoun state side) " identity to Earth Station: Ascending to Orbit")
                   :effect flip-effect}
                  {:label "Manually flip identity to Earth Station: SEA Headquarters"
                   :req (req (:flipped card))
@@ -816,14 +816,14 @@
               {:event :tags-changed
                :effect (req (if (is-tagged? state)
                               (when-not (get-in @state [:runner :openhand])
-                                (system-msg state :corp (str "uses " (get-title card) " make the Runner play with their grip revealed"))
+                                (system-msg state :corp (str "uses " (get-title card) " make the Runner play with " (pronoun state :runner) " grip revealed"))
                                 (system-msg state :corp (str "uses " (get-title card) " to see that the Runner currently has "
-                                                             (format-grip runner) " in their grip"))
+                                                             (format-grip runner) " in " (pronoun state :runner) " grip"))
                               (reveal-hand state :runner))
                             (when (get-in @state [:runner :openhand])
-                              (system-msg state :corp (str "uses " (get-title card) " stop making the Runner play with their grip revealed"))
+                              (system-msg state :corp (str "uses " (get-title card) " stop making the Runner play with " (pronoun state :runner) " grip revealed"))
                               (system-msg state :corp (str "uses " (get-title card) " to see that the Runner had "
-                                                           (format-grip runner) " in their grip before it was concealed"))
+                                                           (format-grip runner) " in " (pronoun state :runner) " grip before it was concealed"))
                               (conceal-hand state :runner))))}]
    :effect (req (when (is-tagged? state)
                   (reveal-hand state :runner)))
@@ -893,13 +893,13 @@
                :effect (req (cond
                               (and (:flipped card)
                                    (not (:accessed-cards runner-reg)))
-                              (do (system-msg state :runner "flips their identity to Hoshiko Shiro: Untold Protagonist")
+                              (do (system-msg state :runner (str "flips " (pronoun state :runner) " identity to Hoshiko Shiro: Untold Protagonist"))
                                   (continue-ability state :runner {:effect flip-effect} card nil))
 
                               (and (not (:flipped card))
                                    (:accessed-cards runner-reg))
                               (wait-for (gain-credits state :runner 2)
-                                        (system-msg state :runner "gains 2 [Credits] and flips their identity to Hoshiko Shiro: Mahou Shoujo")
+                                        (system-msg state :runner (str "gains 2 [Credits] and flips " (pronoun state side) " identity to Hoshiko Shiro: Mahou Shoujo"))
                                         (continue-ability state :runner {:effect flip-effect} card nil))
 
                               :else
@@ -912,7 +912,7 @@
                                                 (system-msg state :runner (str "uses " (:title card) " to draw 1 card and lose 1 [Credits]"))
                                                 (effect-completed state side eid))))}]
      :abilities [{:label "flip identity"
-                  :msg "flip their identity manually"
+                  :msg (msg "flip " (pronoun state side) " identity manually")
                   :effect flip-effect}]}))
 
 (defcard "Hyoubu Institute: Absolute Clarity"
@@ -2037,7 +2037,7 @@
                                (update! state side (-> card (assoc :sync-flipped false :face :front :code "09001")))
                                (update! state side (-> card (assoc :sync-flipped true :face :back :code "sync")))))
                 :label "Flip this identity"
-                :msg "flip their identity"}]})
+                :msg (msg "flip " (pronoun state side) " identity")}]})
 
 (defcard "Synthetic Systems: The World Re-imagined"
   {:events [{:event :pre-start-game

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -116,17 +116,17 @@
 
 (defcard "Active Policing"
   (let [lose-click-abi
-        {:msg (msg "give the Runner -1 allotted [Click] for " (pronoun state :runner) " next turn")
+        {:msg "give the Runner -1 allotted [Click] for [runner-pronoun] next turn"
          :async true
          :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil dec 0))
                       (continue-ability
                         state side
                         (when (threat-level 3 state)
                           {:optional
-                           {:prompt (msg "Pay 2 [credits] to give the Runner -1 allotted [Click] for " (pronoun state side) " next turn?")
+                           {:prompt "Pay 2 [credits] to give the Runner -1 allotted [Click] for [runner-pronoun] next turn?"
                             :yes-ability
                             {:cost [(->c :credit 2)]
-                             :msg (msg "give the Runner -1 allotted [Click] for " (pronoun state :runner) " next turn")
+                             :msg "give the Runner -1 allotted [Click] for [runner-pronoun] next turn"
                              :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil dec 0)))}}})
                         card nil))}]
   {:on-play {:req (req (or (last-turn? state :runner :trashed-card)
@@ -189,7 +189,7 @@
                                 :effect (effect (clear-wait-prompt :corp)
                                                 (make-run eid serv card)
                                                 (prevent-jack-out))}
-                  :no-ability {:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+                  :no-ability {:msg "add itself to [their] score area as an agenda worth 1 agenda point"
                                :effect (effect (clear-wait-prompt :corp)
                                                (as-agenda :corp card 1))}}})
               card nil))}})
@@ -628,7 +628,7 @@
     :msg (msg "search R&D for " (:title target) " and play it")
     :async true
     :effect (effect (shuffle! :deck)
-                    (system-msg (str "shuffles " (pronoun state side) " deck"))
+                    (system-msg "shuffles [their] deck")
                     (play-instant eid target nil))}})
 
 (defcard "Corporate Hospitality"
@@ -1390,7 +1390,7 @@
 
 (defcard "Hypoxia"
   {:on-play {:req (req tagged)
-             :msg (msg "do 1 core damage and give the Runner -1 allotted [Click] for " (pronoun state :runner) " next turn")
+             :msg "do 1 core damage and give the Runner -1 allotted [Click] for [runner-pronoun] next turn"
              :rfg-instead-of-trashing true
              :async true
              :effect (req (wait-for (damage state :runner :brain 1 {:card card})
@@ -1538,7 +1538,7 @@
                            (gain-credits state side eid (* (count targets) 3))))}})
 
 (defcard "Load Testing"
-  {:on-play {:msg (msg "make the Runner lose [Click] when " (pronoun state :runner) " next turn begins")}
+  {:on-play {:msg (msg "make the Runner lose [Click] when [runner-pronoun] next turn begins")}
    :events [{:event :runner-turn-begins
              :duration :until-runner-turn-begins
              :msg "make the Runner lose [Click]"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -60,7 +60,6 @@
    [game.utils :refer :all]
    [jinteki.utils :refer :all]))
 
-
 (defn- lockdown
   ;; Helper function for lockdowns. Enforces the "cannot play if there's another active lockdown"
   ;; restriction, and handles the card staying in the play area/trashing at the start of the corp
@@ -117,17 +116,17 @@
 
 (defcard "Active Policing"
   (let [lose-click-abi
-        {:msg "give the Runner -1 allotted [Click] for their next turn"
+        {:msg (msg "give the Runner -1 allotted [Click] for " (pronoun state :runner) " next turn")
          :async true
          :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil dec 0))
                       (continue-ability
                         state side
                         (when (threat-level 3 state)
                           {:optional
-                           {:prompt "Pay 2 [credits] to give the Runner -1 allotted [Click] for their next turn?"
+                           {:prompt (msg "Pay 2 [credits] to give the Runner -1 allotted [Click] for " (pronoun state side) " next turn?")
                             :yes-ability
                             {:cost [(->c :credit 2)]
-                             :msg "give the Runner -1 allotted [Click] for their next turn"
+                             :msg (msg "give the Runner -1 allotted [Click] for " (pronoun state :runner) " next turn")
                              :effect (req (swap! state update-in [:runner :extra-click-temp] (fnil dec 0)))}}})
                         card nil))}]
   {:on-play {:req (req (or (last-turn? state :runner :trashed-card)
@@ -190,7 +189,7 @@
                                 :effect (effect (clear-wait-prompt :corp)
                                                 (make-run eid serv card)
                                                 (prevent-jack-out))}
-                  :no-ability {:msg "add itself to their score area as an agenda worth 1 agenda point"
+                  :no-ability {:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
                                :effect (effect (clear-wait-prompt :corp)
                                                (as-agenda :corp card 1))}}})
               card nil))}})
@@ -629,7 +628,7 @@
     :msg (msg "search R&D for " (:title target) " and play it")
     :async true
     :effect (effect (shuffle! :deck)
-                    (system-msg "shuffles their deck")
+                    (system-msg (str "shuffles " (pronoun state side) " deck"))
                     (play-instant eid target nil))}})
 
 (defcard "Corporate Hospitality"
@@ -1391,7 +1390,7 @@
 
 (defcard "Hypoxia"
   {:on-play {:req (req tagged)
-             :msg "do 1 core damage and give the Runner -1 allotted [Click] for their next turn"
+             :msg (msg "do 1 core damage and give the Runner -1 allotted [Click] for " (pronoun state :runner) " next turn")
              :rfg-instead-of-trashing true
              :async true
              :effect (req (wait-for (damage state :runner :brain 1 {:card card})
@@ -1539,7 +1538,7 @@
                            (gain-credits state side eid (* (count targets) 3))))}})
 
 (defcard "Load Testing"
-  {:on-play {:msg "make the Runner lose [Click] when their next turn begins"}
+  {:on-play {:msg (msg "make the Runner lose [Click] when " (pronoun state :runner) " next turn begins")}
    :events [{:event :runner-turn-begins
              :duration :until-runner-turn-begins
              :msg "make the Runner lose [Click]"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1028,7 +1028,7 @@
 (defcard "Dean Lister"
   {:abilities [{:req (req run)
                 :label "pump icebreaker"
-                :msg (msg "give +1 strength for each card in their Grip to " (:title target) " until the end of the run")
+                :msg (msg "give +1 strength for each card in " (pronoun state side) " Grip to " (:title target) " until the end of the run")
                 :choices {:card #(and (installed? %)
                                       (has-subtype? % "Icebreaker"))}
                 :cost [(->c :trash-can)]
@@ -1347,7 +1347,7 @@
 
 (defcard "Fan Site"
   {:events [{:event :agenda-scored
-             :msg "add itself to their score area as an agenda worth 0 agenda points"
+             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 0 agenda points")
              :req (req (installed? card))
              :effect (req (as-agenda state :runner card 0))}]})
 
@@ -1403,7 +1403,7 @@
                   :req (req (get-agenda card))
                   :async true
                   :msg (msg (let [c (get-agenda card)]
-                              (str "add " (:title c) " to their score area and gain "
+                              (str "add " (:title c) " to " (pronoun state side) " score area and gain "
                                    (quantify (get-agenda-points c) "agenda point"))))
                   :effect (req (let [c (move state :runner (get-agenda card) :scored)]
                                  (when (card-flag? c :has-events-when-stolen true)
@@ -1722,7 +1722,7 @@
                 :effect (effect (gain-bad-publicity :corp 1))}]})
 
 (defcard "Investigator Inez Delgado"
-  {:abilities [{:msg "add itself to their score area as an agenda worth 0 agenda points"
+  {:abilities [{:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 0 agenda points")
                 :label "Add to score area and reveal cards in server"
                 :async true
                 :prompt "Choose a server"
@@ -1864,7 +1864,7 @@
               :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}}}
             {:event :counter-added
              :req (req (<= 4 (get-counters (get-card state card) :power)))
-             :msg "add itself to their score area as an agenda worth 1 agenda point"
+             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
              :effect (req (as-agenda state :runner card 1))}]
    :abilities [(set-autoresolve :auto-place-counter "Kasi String placing power counters on itself")]})
 
@@ -1972,7 +1972,8 @@
 
 (defcard "Liberated Chela"
   {:abilities [{:cost [(->c :click 5) (->c :forfeit)]
-                :msg "add itself to their score area"
+                :msg (msg "add itself to " (pronoun state side) " score area")
+                :label "Add liberated Chela to your score area"
                 :async true
                 :effect
                 (effect (continue-ability
@@ -1991,9 +1992,9 @@
                                                       (move state :runner card :rfg)
                                                       (effect-completed state side eid)))}
                               :no-ability
-                              {:msg "add itself to their score area as an agenda worth 2 points"
+                              {:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 2 points")
                                :effect (effect (as-agenda :runner card 2))}}}
-                            {:msg "add itself to their score area as an agenda worth 2 points"
+                            {:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 2 points")
                              :effect (effect (as-agenda :runner card 2))})
                           card nil))}]})
 
@@ -2052,7 +2053,7 @@
                 :cost [(->c :click 1)]
                 :keep-menu-open :while-clicks-left
                 :choices {:req (req (same-card? card (:host target)))}
-                :msg (msg "add " (:title target) " to their Grip")
+                :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
                 :effect (effect (move target :hand))}]
    :events [{:event :runner-turn-ends
              :interactive (req true)
@@ -3596,7 +3597,7 @@
 
 (defcard "Tyson Observatory"
   {:abilities [{:prompt "Choose a piece of Hardware"
-                :msg (msg "add " (:title target) " to their Grip")
+                :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
                 :label "Search stack for a piece of hardware"
                 :choices (req (cancellable (filter hardware? (:deck runner)) :sorted))
                 :cost [(->c :click 2)]

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1028,7 +1028,7 @@
 (defcard "Dean Lister"
   {:abilities [{:req (req run)
                 :label "pump icebreaker"
-                :msg (msg "give +1 strength for each card in " (pronoun state side) " Grip to " (:title target) " until the end of the run")
+                :msg (msg "give +1 strength for each card in [their] Grip to " (:title target) " until the end of the run")
                 :choices {:card #(and (installed? %)
                                       (has-subtype? % "Icebreaker"))}
                 :cost [(->c :trash-can)]
@@ -1347,7 +1347,7 @@
 
 (defcard "Fan Site"
   {:events [{:event :agenda-scored
-             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 0 agenda points")
+             :msg (msg "add itself to [their] score area as an agenda worth 0 agenda points")
              :req (req (installed? card))
              :effect (req (as-agenda state :runner card 0))}]})
 
@@ -1403,7 +1403,7 @@
                   :req (req (get-agenda card))
                   :async true
                   :msg (msg (let [c (get-agenda card)]
-                              (str "add " (:title c) " to " (pronoun state side) " score area and gain "
+                              (str "add " (:title c) " to [their] score area and gain "
                                    (quantify (get-agenda-points c) "agenda point"))))
                   :effect (req (let [c (move state :runner (get-agenda card) :scored)]
                                  (when (card-flag? c :has-events-when-stolen true)
@@ -1722,7 +1722,7 @@
                 :effect (effect (gain-bad-publicity :corp 1))}]})
 
 (defcard "Investigator Inez Delgado"
-  {:abilities [{:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 0 agenda points")
+  {:abilities [{:msg (msg "add itself to [their] score area as an agenda worth 0 agenda points")
                 :label "Add to score area and reveal cards in server"
                 :async true
                 :prompt "Choose a server"
@@ -1864,7 +1864,7 @@
               :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}}}
             {:event :counter-added
              :req (req (<= 4 (get-counters (get-card state card) :power)))
-             :msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 1 agenda point")
+             :msg "add itself to [their] score area as an agenda worth 1 agenda point"
              :effect (req (as-agenda state :runner card 1))}]
    :abilities [(set-autoresolve :auto-place-counter "Kasi String placing power counters on itself")]})
 
@@ -1972,7 +1972,7 @@
 
 (defcard "Liberated Chela"
   {:abilities [{:cost [(->c :click 5) (->c :forfeit)]
-                :msg (msg "add itself to " (pronoun state side) " score area")
+                :msg "add itself to [their] score area"
                 :label "Add liberated Chela to your score area"
                 :async true
                 :effect
@@ -1992,9 +1992,9 @@
                                                       (move state :runner card :rfg)
                                                       (effect-completed state side eid)))}
                               :no-ability
-                              {:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 2 points")
+                              {:msg "add itself to [their] score area as an agenda worth 2 points"
                                :effect (effect (as-agenda :runner card 2))}}}
-                            {:msg (msg "add itself to " (pronoun state side) " score area as an agenda worth 2 points")
+                            {:msg "add itself to [their] score area as an agenda worth 2 points"
                              :effect (effect (as-agenda :runner card 2))})
                           card nil))}]})
 
@@ -2053,7 +2053,7 @@
                 :cost [(->c :click 1)]
                 :keep-menu-open :while-clicks-left
                 :choices {:req (req (same-card? card (:host target)))}
-                :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
+                :msg (msg "add " (:title target) " to [their] Grip")
                 :effect (effect (move target :hand))}]
    :events [{:event :runner-turn-ends
              :interactive (req true)
@@ -3597,7 +3597,7 @@
 
 (defcard "Tyson Observatory"
   {:abilities [{:prompt "Choose a piece of Hardware"
-                :msg (msg "add " (:title target) " to " (pronoun state side) " Grip")
+                :msg (msg "add " (:title target) " to [their] Grip")
                 :label "Search stack for a piece of hardware"
                 :choices (req (cancellable (filter hardware? (:deck runner)) :sorted))
                 :cost [(->c :click 2)]

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -27,7 +27,8 @@
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
-    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards]]))
+    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards]]
+    [jinteki.utils :refer [pronoun]]))
 
 (defn- update-click-state
   "Update :click-states to hold latest 4 moments before performing actions."
@@ -559,13 +560,13 @@
 (defn view-deck
   "Allows the player to view their deck by making the cards in the deck public."
   [state side _]
-  (system-msg state side "looks at their deck")
+  (system-msg state side "looks at " (pronoun state side) " deck")
   (swap! state assoc-in [side :view-deck] true))
 
 (defn close-deck
   "Closes the deck view and makes cards in deck private again."
   [state side _]
-  (system-msg state side "stops looking at their deck")
+  (system-msg state side "stops looking at " (pronoun state side) " deck")
   (swap! state update-in [side] dissoc :view-deck))
 
 (defn generate-install-list

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -27,8 +27,7 @@
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
-    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards]]
-    [jinteki.utils :refer [pronoun]]))
+    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards]]))
 
 (defn- update-click-state
   "Update :click-states to hold latest 4 moments before performing actions."
@@ -560,13 +559,13 @@
 (defn view-deck
   "Allows the player to view their deck by making the cards in the deck public."
   [state side _]
-  (system-msg state side "looks at " (pronoun state side) " deck")
+  (system-msg state side "looks at [their] deck")
   (swap! state assoc-in [side :view-deck] true))
 
 (defn close-deck
   "Closes the deck view and makes cards in deck private again."
   [state side _]
-  (system-msg state side "stops looking at " (pronoun state side) " deck")
+  (system-msg state side "stops looking at [their] deck")
   (swap! state update-in [side] dissoc :view-deck))
 
 (defn generate-install-list

--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -9,7 +9,8 @@
     [game.core.memory :refer [available-mu update-mu]]
     [game.core.say :refer [system-msg]]
     [game.core.tags :refer [update-tag-status]]
-    [game.macros :refer [req]]))
+    [game.macros :refer [req]]
+    [jinteki.utils :refer [pronoun]]))
 
 (defn- change-msg
   "Send a system message indicating the property change"
@@ -69,7 +70,7 @@
        :value delta}))
   (update-all-agenda-points state side)
   (system-msg state side
-              (str "sets their agenda points to " (get-in @state [side :agenda-point])
+              (str "sets " (pronoun state side) " agenda points to " (get-in @state [side :agenda-point])
                    " (" (if (pos? delta) (str "+" delta) delta) ")")))
 
 (defn- change-link
@@ -81,7 +82,7 @@
      :value delta})
   (update-link state)
   (system-msg state side
-              (str "sets their [link] to " (get-link state)
+              (str "sets " (pronoun state side) " [link] to " (get-link state)
                    " (" (if (pos? delta) (str "+" delta) delta) ")")))
 
 (defn- change-hand-size
@@ -95,7 +96,7 @@
        :value delta}))
   (update-hand-size state side)
   (system-msg state side
-              (str "sets their hand size to " (hand-size state side)
+              (str "sets " (pronoun state side) " hand size to " (hand-size state side)
                    " (" (if (pos? delta) (str "+" delta) delta) ")")))
 
 (defn- change-generic

--- a/src/clj/game/core/change_vals.clj
+++ b/src/clj/game/core/change_vals.clj
@@ -9,8 +9,7 @@
     [game.core.memory :refer [available-mu update-mu]]
     [game.core.say :refer [system-msg]]
     [game.core.tags :refer [update-tag-status]]
-    [game.macros :refer [req]]
-    [jinteki.utils :refer [pronoun]]))
+    [game.macros :refer [req]]))
 
 (defn- change-msg
   "Send a system message indicating the property change"
@@ -70,7 +69,7 @@
        :value delta}))
   (update-all-agenda-points state side)
   (system-msg state side
-              (str "sets " (pronoun state side) " agenda points to " (get-in @state [side :agenda-point])
+              (str "sets [their] agenda points to " (get-in @state [side :agenda-point])
                    " (" (if (pos? delta) (str "+" delta) delta) ")")))
 
 (defn- change-link
@@ -82,7 +81,7 @@
      :value delta})
   (update-link state)
   (system-msg state side
-              (str "sets " (pronoun state side) " [link] to " (get-link state)
+              (str "sets [their] [link] to " (get-link state)
                    " (" (if (pos? delta) (str "+" delta) delta) ")")))
 
 (defn- change-hand-size
@@ -96,7 +95,7 @@
        :value delta}))
   (update-hand-size state side)
   (system-msg state side
-              (str "sets " (pronoun state side) " hand size to " (hand-size state side)
+              (str "sets [their] hand size to " (hand-size state side)
                    " (" (if (pos? delta) (str "+" delta) delta) ")")))
 
 (defn- change-generic

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -21,7 +21,8 @@
    [game.core.update :refer [update!]]
    [game.core.virus :refer [number-of-virus-counters]]
    [game.macros :refer [continue-ability req wait-for]]
-   [game.utils :refer [enumerate-str quantify same-card?]]))
+   [game.utils :refer [enumerate-str quantify same-card?]]
+   [jinteki.utils :refer [pronoun]]))
 
 ;; Click
 (defmethod value :click [cost] (:cost/amount cost))
@@ -365,7 +366,7 @@
   (complete-with-result
     state side eid
     {:paid/msg (str "returns " (:title card)
-                   " to " (if (= :corp side) "HQ" "their grip"))
+                   " to " (if (= :corp side) "HQ" (str (pronoun state side) " grip")))
      :paid/type :return-to-hand
      :paid/value 1
      :paid/targets [card]}))
@@ -730,7 +731,7 @@
               (complete-with-result
                 state side eid
                 {:paid/msg (str "trashes all (" (count async-result) ") cards in "
-                               (if (= :runner side) "their grip" "HQ")
+                               (if (= :runner side) (str (pronoun state side) " grip") "HQ")
                                (when (and (= :runner side)
                                           (pos? (count async-result)))
                                  (str " (" (enumerate-str (map :title async-result)) ")")))
@@ -760,7 +761,7 @@
                               {:paid/msg (str "trashes " (quantify (count async-result) "piece")
                                              " of hardware"
                                              " (" (enumerate-str (map :title targets)) ")"
-                                             " from their grip")
+                                             " from " (pronoun state side) " grip")
                                :paid/type :trash-hardware-from-hand
                                :paid/value (count async-result)
                                :paid/targets async-result})))}

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -21,8 +21,7 @@
    [game.core.update :refer [update!]]
    [game.core.virus :refer [number-of-virus-counters]]
    [game.macros :refer [continue-ability req wait-for]]
-   [game.utils :refer [enumerate-str quantify same-card?]]
-   [jinteki.utils :refer [pronoun]]))
+   [game.utils :refer [enumerate-str quantify same-card?]]))
 
 ;; Click
 (defmethod value :click [cost] (:cost/amount cost))
@@ -366,7 +365,7 @@
   (complete-with-result
     state side eid
     {:paid/msg (str "returns " (:title card)
-                   " to " (if (= :corp side) "HQ" (str (pronoun state side) " grip")))
+                   " to " (if (= :corp side) "HQ" "[their] grip"))
      :paid/type :return-to-hand
      :paid/value 1
      :paid/targets [card]}))
@@ -731,7 +730,7 @@
               (complete-with-result
                 state side eid
                 {:paid/msg (str "trashes all (" (count async-result) ") cards in "
-                               (if (= :runner side) (str (pronoun state side) " grip") "HQ")
+                               (if (= :runner side) "[their] grip" "HQ")
                                (when (and (= :runner side)
                                           (pos? (count async-result)))
                                  (str " (" (enumerate-str (map :title async-result)) ")")))
@@ -761,7 +760,7 @@
                               {:paid/msg (str "trashes " (quantify (count async-result) "piece")
                                              " of hardware"
                                              " (" (enumerate-str (map :title targets)) ")"
-                                             " from " (pronoun state side) " grip")
+                                             " from [their] grip")
                                :paid/type :trash-hardware-from-hand
                                :paid/value (count async-result)
                                :paid/targets async-result})))}

--- a/src/clj/game/core/mark.clj
+++ b/src/clj/game/core/mark.clj
@@ -4,7 +4,8 @@
    [game.core.say :refer [system-msg]]
    [game.core.servers :refer [central->name]]
    [game.core.update :refer [update!]]
-   [game.macros :refer [req]]))
+   [game.macros :refer [req]]
+   [jinteki.utils :refer [pronoun]]))
 
 (defn set-mark
   [state new-mark]
@@ -19,7 +20,7 @@
   [state]
   (let [new-mark (rand-nth [:hq :rd :archives])]
     (set-mark state new-mark)
-    (system-msg state :runner (str "identifies their mark to be " (central->name new-mark)))))
+    (system-msg state :runner (str "identifies " (pronoun state :runner) " mark to be " (central->name new-mark)))))
 
 (def identify-mark-ability
   {:effect (req (when (nil? (:mark @state)) (identify-mark state)))})

--- a/src/clj/game/core/mark.clj
+++ b/src/clj/game/core/mark.clj
@@ -4,8 +4,7 @@
    [game.core.say :refer [system-msg]]
    [game.core.servers :refer [central->name]]
    [game.core.update :refer [update!]]
-   [game.macros :refer [req]]
-   [jinteki.utils :refer [pronoun]]))
+   [game.macros :refer [req]]))
 
 (defn set-mark
   [state new-mark]
@@ -20,7 +19,7 @@
   [state]
   (let [new-mark (rand-nth [:hq :rd :archives])]
     (set-mark state new-mark)
-    (system-msg state :runner (str "identifies " (pronoun state :runner) " mark to be " (central->name new-mark)))))
+    (system-msg state :runner (str "identifies [their] mark to be " (central->name new-mark)))))
 
 (def identify-mark-ability
   {:effect (req (when (nil? (:mark @state)) (identify-mark state)))})

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -8,8 +8,7 @@
     [game.core.props :refer [add-counter]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
-    [game.utils :refer [enumerate-str in-coll? quantify same-card?]]
-    [jinteki.utils :refer [pronoun]]))
+    [game.utils :refer [enumerate-str in-coll? quantify same-card?]]))
 
 (defn- pick-counter-triggers
   [state side eid current-cards selected-cards counter-count message]
@@ -109,7 +108,7 @@
                                              " and ")
                                            remainder-str
                                            (when (and card-strs remainder-str)
-                                             " from " (pronoun state side) " credit pool"))]
+                                             " from [their] credit pool"))]
                           (lose state side :credit remainder)
                           (let [cards (->> (vals selected-cards)
                                           (map :card)

--- a/src/clj/game/core/pick_counters.clj
+++ b/src/clj/game/core/pick_counters.clj
@@ -8,7 +8,8 @@
     [game.core.props :refer [add-counter]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
-    [game.utils :refer [enumerate-str in-coll? quantify same-card?]]))
+    [game.utils :refer [enumerate-str in-coll? quantify same-card?]]
+    [jinteki.utils :refer [pronoun]]))
 
 (defn- pick-counter-triggers
   [state side eid current-cards selected-cards counter-count message]
@@ -108,7 +109,7 @@
                                              " and ")
                                            remainder-str
                                            (when (and card-strs remainder-str)
-                                             " from their credit pool"))]
+                                             " from " (pronoun state side) " credit pool"))]
                           (lose state side :credit remainder)
                           (let [cards (->> (vals selected-cards)
                                           (map :card)

--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -16,8 +16,7 @@
    [game.core.state :refer [new-state]]
    [game.macros :refer [wait-for]]
    [game.quotes :as quotes]
-   [game.utils :refer [server-card]]
-   [jinteki.utils :refer [pronoun]]))
+   [game.utils :refer [server-card]]))
 
 (defn build-card
   [card]
@@ -54,7 +53,7 @@
   "Choose not to mulligan."
   [state side _]
   (swap! state assoc-in [side :keep] :keep)
-  (system-msg state side (str "keeps " (pronoun state side) " hand"))
+  (system-msg state side "keeps [their] hand")
   (trigger-event state side :pre-first-turn)
   (when (and (= side :corp) (-> @state :runner :identity :title))
     (clear-wait-prompt state :runner)

--- a/src/clj/game/core/set_up.clj
+++ b/src/clj/game/core/set_up.clj
@@ -16,7 +16,8 @@
    [game.core.state :refer [new-state]]
    [game.macros :refer [wait-for]]
    [game.quotes :as quotes]
-   [game.utils :refer [server-card]]))
+   [game.utils :refer [server-card]]
+   [jinteki.utils :refer [pronoun]]))
 
 (defn build-card
   [card]
@@ -53,7 +54,7 @@
   "Choose not to mulligan."
   [state side _]
   (swap! state assoc-in [side :keep] :keep)
-  (system-msg state side "keeps their hand")
+  (system-msg state side (str "keeps " (pronoun state side) " hand"))
   (trigger-event state side :pre-first-turn)
   (when (and (= side :corp) (-> @state :runner :identity :title))
     (clear-wait-prompt state :runner)

--- a/src/clj/game/core/shuffling.clj
+++ b/src/clj/game/core/shuffling.clj
@@ -5,7 +5,8 @@
     [game.core.moving :refer [move move-zone]]
     [game.core.say :refer [system-msg]]
     [game.macros :refer [continue-ability msg req]]
-    [game.utils :refer [enumerate-str quantify]]))
+    [game.utils :refer [enumerate-str quantify]]
+    [jinteki.utils :refer [pronoun]]))
 
 (defn shuffle!
   "Shuffles the vector in @state [side kw]."
@@ -46,8 +47,8 @@
       :effect (req (doseq [c targets]
                      (move state side c :deck))
                    (shuffle! state side :deck))
-      :cancel-effect (req 
-                      (system-msg state side (str " uses " (:title card) " to shuffle their deck")) 
+      :cancel-effect (req
+                      (system-msg state side (str " uses " (:title card) " to shuffle " (pronoun state side) " deck"))
                       (shuffle! state side :deck))}
      card nil)))
 
@@ -58,5 +59,5 @@
   (if close
     (do
       (swap! state update-in [side] dissoc :view-deck)
-      (system-msg state side "stops looking at their deck and shuffles it"))
-    (system-msg state side "shuffles their deck")))
+      (system-msg state side "stops looking at " (pronoun state side) " deck and shuffles it"))
+    (system-msg state side "shuffles " (pronoun state side) " deck")))

--- a/src/clj/game/core/shuffling.clj
+++ b/src/clj/game/core/shuffling.clj
@@ -5,8 +5,7 @@
     [game.core.moving :refer [move move-zone]]
     [game.core.say :refer [system-msg]]
     [game.macros :refer [continue-ability msg req]]
-    [game.utils :refer [enumerate-str quantify]]
-    [jinteki.utils :refer [pronoun]]))
+    [game.utils :refer [enumerate-str quantify]]))
 
 (defn shuffle!
   "Shuffles the vector in @state [side kw]."
@@ -48,7 +47,7 @@
                      (move state side c :deck))
                    (shuffle! state side :deck))
       :cancel-effect (req
-                      (system-msg state side (str " uses " (:title card) " to shuffle " (pronoun state side) " deck"))
+                      (system-msg state side (str " uses " (:title card) " to shuffle R&D"))
                       (shuffle! state side :deck))}
      card nil)))
 
@@ -59,5 +58,5 @@
   (if close
     (do
       (swap! state update-in [side] dissoc :view-deck)
-      (system-msg state side "stops looking at " (pronoun state side) " deck and shuffles it"))
-    (system-msg state side "shuffles " (pronoun state side) " deck")))
+      (system-msg state side "stops looking at [pronoun] deck and shuffles it"))
+    (system-msg state side "shuffles [pronoun] deck")))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -18,16 +18,17 @@
     [game.core.winning :refer [flatline]]
     [game.macros :refer [continue-ability req wait-for]]
     [game.utils :refer [dissoc-in enumerate-str quantify]]
+    [jinteki.utils :refer [pronoun]]
     [clojure.string :as string]))
 
 (defn- turn-message
   "Prints a message for the start or end of a turn, summarizing credits and cards in hand."
   [state side start-of-turn]
   (let [pre (if start-of-turn "started" "is ending")
-        hand (if (= side :runner) "their Grip" "HQ")
+        hand (if (= side :runner) (str (pronoun state side) " Grip") "HQ")
         cards (count (get-in @state [side :hand]))
         credits (get-in @state [side :credit])
-        text (str pre " their turn " (:turn @state) " with " credits " [Credit] and " (quantify cards "card") " in " hand)]
+        text (str pre " " (pronoun state side) " turn " (:turn @state) " with " credits " [Credit] and " (quantify cards "card") " in " hand)]
     (system-msg state side text {:hr (not start-of-turn)})))
 
 (defn end-phase-12
@@ -101,7 +102,7 @@
               (effect-completed state side eid))
           (any-effects state side :skip-discard)
           (do
-            (system-msg state side "skips their discard step this turn")
+            (system-msg state side (str "skips " (pronoun state side) " discard step this turn"))
             (effect-completed state side eid))
           (> cur-hand-size max-hand-size)
           (continue-ability
@@ -115,7 +116,7 @@
                                            (if (= :runner side)
                                              (enumerate-str (map :title targets))
                                              (quantify (count targets) "card"))
-                                           " from " (if (= :runner side) "their Grip" "HQ")
+                                           " from " (if (= :runner side) (str (pronoun state side) " Grip") "HQ")
                                            " at end of turn"))
                           (doseq [t targets]
                             (move state side t :discard))

--- a/src/clj/game/core/turns.clj
+++ b/src/clj/game/core/turns.clj
@@ -18,17 +18,16 @@
     [game.core.winning :refer [flatline]]
     [game.macros :refer [continue-ability req wait-for]]
     [game.utils :refer [dissoc-in enumerate-str quantify]]
-    [jinteki.utils :refer [pronoun]]
     [clojure.string :as string]))
 
 (defn- turn-message
   "Prints a message for the start or end of a turn, summarizing credits and cards in hand."
   [state side start-of-turn]
   (let [pre (if start-of-turn "started" "is ending")
-        hand (if (= side :runner) (str (pronoun state side) " Grip") "HQ")
+        hand (if (= side :runner) "[their] Grip" "HQ")
         cards (count (get-in @state [side :hand]))
         credits (get-in @state [side :credit])
-        text (str pre " " (pronoun state side) " turn " (:turn @state) " with " credits " [Credit] and " (quantify cards "card") " in " hand)]
+        text (str pre " [their] turn " (:turn @state) " with " credits " [Credit] and " (quantify cards "card") " in " hand)]
     (system-msg state side text {:hr (not start-of-turn)})))
 
 (defn end-phase-12
@@ -42,7 +41,7 @@
              (unregister-lingering-effects state side (if (= side :corp) :until-corp-turn-begins :until-runner-turn-begins))
              (unregister-floating-events state side (if (= side :corp) :until-corp-turn-begins :until-runner-turn-begins))
              (if (= side :corp)
-               (do (system-msg state side "makes mandatory start of turn draw")
+               (do (system-msg state side "makes [their] mandatory start of turn draw")
                    (wait-for (draw state side 1 nil)
                              (trigger-event-simult state side eid :corp-mandatory-draw nil nil)))
                (effect-completed state nil eid))
@@ -102,7 +101,7 @@
               (effect-completed state side eid))
           (any-effects state side :skip-discard)
           (do
-            (system-msg state side (str "skips " (pronoun state side) " discard step this turn"))
+            (system-msg state side (str "skips [their] discard step this turn"))
             (effect-completed state side eid))
           (> cur-hand-size max-hand-size)
           (continue-ability
@@ -116,7 +115,7 @@
                                            (if (= :runner side)
                                              (enumerate-str (map :title targets))
                                              (quantify (count targets) "card"))
-                                           " from " (if (= :runner side) (str (pronoun state side) " Grip") "HQ")
+                                           " from " (if (= :runner side) "[their] Grip" "HQ")
                                            " at end of turn"))
                           (doseq [t targets]
                             (move state side t :discard))

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -65,6 +65,17 @@
        (filter seq $)
        (str/join sep $)))))
 
+(defn pronoun
+  "Selects an appropriate plurular pronoun
+  'their' is neuter, so it's appropriate to everyone as a fallback"
+  [state side]
+  (let [key (get-in @state [side :user :options :pronouns])]
+    (case key
+      "she" "her"
+      "he" "his"
+      "it" "its"
+      "their")))
+
 (defn superuser?
   [user]
   (or (:isadmin user)

--- a/src/cljc/jinteki/utils.cljc
+++ b/src/cljc/jinteki/utils.cljc
@@ -65,17 +65,6 @@
        (filter seq $)
        (str/join sep $)))))
 
-(defn pronoun
-  "Selects an appropriate plurular pronoun
-  'their' is neuter, so it's appropriate to everyone as a fallback"
-  [state side]
-  (let [key (get-in @state [side :user :options :pronouns])]
-    (case key
-      "she" "her"
-      "he" "his"
-      "it" "its"
-      "their")))
-
 (defn superuser?
   [user]
   (or (:isadmin user)


### PR DESCRIPTION
Added a `pronoun` fn in jinteki.utils which checks the users options and selects the correct pronoun if possible, or falls back to `their` otherwise. 

And then I replaced (almost) every occurance of `their` in code with the pronoun function, targeting the correct side when necessary.

I only put mappings in the following, because I don't know what's correct for everything else:
* he/him -> his
* she/her -> her
* it/its -> its

Closes #5280

![pronouns](https://github.com/mtgred/netrunner/assets/9095245/3922abc9-11f4-467e-b397-95792a2dc3ee)
![pronouns_000](https://github.com/mtgred/netrunner/assets/9095245/181982ec-182d-44cc-828f-f061e348a2d0)
![pronouns_001](https://github.com/mtgred/netrunner/assets/9095245/33787d15-b83f-47b5-b11f-bc7d22908622)
![pronouns_002](https://github.com/mtgred/netrunner/assets/9095245/a2ef3475-2c01-43a7-9d80-5cefeb884a17)

