### PR TITLE
[wip] prevent players playing cards outside of expected times

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2630,7 +2630,6 @@
             :effect (effect (draw eid 2))}
    :abilities [{:label "Shuffle up to 2 cards from Archives into R&D"
                 :cost [(->c :remove-from-game)]
-                :waiting-prompt true
                 :async true
                 :effect (effect (shuffle-into-rd-effect eid card 2))}]})
 

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2630,6 +2630,7 @@
             :effect (effect (draw eid 2))}
    :abilities [{:label "Shuffle up to 2 cards from Archives into R&D"
                 :cost [(->c :remove-from-game)]
+                :waiting-prompt true
                 :async true
                 :effect (effect (shuffle-into-rd-effect eid card 2))}]})
 

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -18,6 +18,7 @@
 (defn playable? [card state side]
   (if (and ((if (= :corp side) corp? runner?) card)
            (in-hand? card)
+           (not= (get-in @state [side :prompt-state :promp-type]) :waiting)
            (cond+
              [(or (agenda? card)
                   (asset? card)

--- a/src/clj/game/core/shuffling.clj
+++ b/src/clj/game/core/shuffling.clj
@@ -2,6 +2,7 @@
   (:require
     [game.core.card :refer [corp? in-discard?]]
     [game.core.engine :refer [trigger-event]]
+    [game.core.eid :refer [effect-completed]]
     [game.core.moving :refer [move move-zone]]
     [game.core.say :refer [system-msg]]
     [game.macros :refer [continue-ability msg req]]
@@ -36,6 +37,7 @@
                 :card #(and (corp? %)
                             (in-discard? %))
                 :all all?}
+      :waiting-prompt true
       :msg (msg "shuffle "
                 (let [seen (filter :seen targets)
                       m (count (filter #(not (:seen %)) targets))]
@@ -44,12 +46,15 @@
                          (str (when-not (empty? seen) " and ")
                               (quantify m "unseen card")))))
                 " into R&D")
+      :async true
       :effect (req (doseq [c targets]
                      (move state side c :deck))
-                   (shuffle! state side :deck))
+                   (shuffle! state side :deck)
+                   (effect-completed state side eid))
       :cancel-effect (req 
                       (system-msg state side (str " uses " (:title card) " to shuffle their deck")) 
-                      (shuffle! state side :deck))}
+                      (shuffle! state side :deck)
+                      (effect-completed state side eid))}
      card nil)))
 
 (defn shuffle-deck

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -110,7 +110,6 @@
     (swap! card-menu dissoc :keep-menu-open)
     (when-not (and (= card-side :runner) facedown)
       (cond
-
         ;; Toggle abilities panel
         (or (< 1 c)
             (pos? (+ (count corp-abilities)
@@ -640,6 +639,11 @@
                     (faceup? card)
                     (= (:side host) "Runner"))))))
 
+(defn- should-highlight-playable
+  [side card zone]
+  (let [side (if-not (keyword? side) (keyword (lower-case side)) side)]
+    (and (playable? card) (nil? (get-in @game-state [side :prompt-state :prompt-type])))))
+
 (defn card-view
   [{:keys [zone code type abilities counter
            subtypes strength current-strength selected hosted
@@ -651,7 +655,7 @@
      [:div.blue-shade.card {:class (str (cond selected "selected"
                                               (same-card? card (:button @app-state)) "hovered"
                                               (same-card? card (-> @game-state :encounters :ice)) "encountered"
-                                              (playable? card) "playable"
+                                              (should-highlight-playable side card zone) "playable"
                                               (graveyard-highlight-card? card) "graveyard-highlight"
                                               new "new"))
                             :tab-index (when (and (not disable-click)

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -169,6 +169,7 @@
         (and (= side :runner)
              (= "Runner" (:side card))
              (= "hand" (first zone))
+             (nil? (get-in @game-state [side :prompt-state]))
              (playable? card))
         (send-command "play" {:card (card-for-click card)})
 
@@ -176,6 +177,7 @@
         (and (= side :corp)
              (= "Corp" (:side card))
              (= "hand" (first zone))
+             (nil? (get-in @game-state [side :prompt-state]))
              (playable? card))
         (if (= "Operation" type)
           (send-command "play" {:card (card-for-click card)})


### PR DESCRIPTION
As per the title, I essentially want to do the foolproofing our engine has needed for quite a while.

This one is going to take a while to finish/figure out completely/test, so I'll chip away at it over the next week or so.

Here's the basic checklist of things that need to happen:
- [x] (front-end only) Disable interacting with cards in hand except when there are no prompts open, or there is a selection prompt open. This is enough to make it so you can't accidentally play programs during runs, or install while your mandatory draw is pending, etc  - but doesn't protect against both players quickly doing stuff at the same time (network race conditions)
- [x] (backend) check if there are any open prompts when receiving the `play` fn, and short-circuit it if there are - this will protect against network race conditions

This will actually tackle a few issues. I'll need to dig deeper to find out exactly which ones, but for a start, it will hit these: 
Closes #7170
Closes #7150
Closes #5870
Closes #5009 (in combination with the install commands)

- [x] Make cards and abilities unplayable (in-engine) when there is an active `:waiting` type prompt
- [x] Make cards and abilities unplayable (frontend) when there is an active `:waiting` type prompt
- [ ] Also gray out the buttons on the front-end when this is the case

Means we can also clear the following, by disallowing scenarios where they can happen:
Closes #6708
Closes #6718

- [ ] Make abilities on cards unplayable if there is any prompt open other a `run` type prompt, unless there's an active prevention window going on

Closes #6944 (by preventing the scenario where it happens)
Closes #6930 (by preventing the scenario where it happens)

- [x] Add a /install command. This will help fix gamestates, and will charge full cost. Can target cards in hand or discard.
- [x] Add a /install-free command. This will help fix gamestates, and will install for free. Can target cards in hand or discard.
- [x] Prevent cards in hand being highlighted while a prompt is open/they're not actually playable.

Additionally, if we do the following:
- [x] Prevent players from using basic actions while there is a prompt open (this already happens by the prompt overlapping the button, but it can't hurt )
- [x] Add a waiting prompt to Spin Doctor

Then this also closes #5776 and closes  #7198 (cancel, or shuffle 0, on spin doc left an open eid)

Then if we also do:
- [ ] Add `(req (not (:run @state)))` to all of the cards in the game with a `:click` cost

we can prevent runners bricking a turn by clicking one of these mid-run