### PR TITLE
install and install-free commands

### DIFF
--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -209,6 +209,28 @@
     (swap! state dissoc-in [side :selected])
     (effect-completed state side (:eid prompt))))
 
+(defn command-install
+  ([state side] (command-install state side nil))
+  ([state side {:keys [ignore-all-cost] :as args}]
+   (resolve-ability
+     state side
+     (if (= side :corp)
+       {:prompt (str "Choose a card to install" (when ignore-all-cost " (ignoring all costs)"))
+        :choices {:card #(and (corp? %)
+                              (not (installed? %)))}
+        :async true
+        :effect (req (corp-install state side eid target nil {:ignore-all-cost ignore-all-cost}))}
+       {:prompt (str "Choose a card to install" (when ignore-all-cost " (ignoring all costs)"))
+        :choices {:card #(and (runner? %)
+                              (not (installed? %)))}
+        :async true
+        :effect (req (runner-install state side eid target {:ignore-all-cost ignore-all-cost}))})
+     nil nil)))
+
+(defn command-install-free
+  [state side]
+  (command-install state side {:ignore-all-cost true}))
+
 (defn command-install-ice
   [state side]
   (when (= side :corp)
@@ -395,7 +417,9 @@
                                       :delta (- (constrain-value value -1000 1000)
                                                 (get-in @%1 [%2 :hand-size :total]))})
         "/host"       command-host
+        "/install" command-install
         "/install-ice" command-install-ice
+        "/install-free" command-install-free
         "/jack-out"   (fn [state side]
                         (when (and (= side :runner)
                                    (or (:run @state)

--- a/src/clj/game/core/commands.clj
+++ b/src/clj/game/core/commands.clj
@@ -225,7 +225,7 @@
                               (not (installed? %)))}
         :async true
         :effect (req (runner-install state side eid target {:ignore-all-cost ignore-all-cost}))})
-     nil nil)))
+     (make-card {:title (str "/install" (when ignore-all-cost "-free") " command")}) nil)))
 
 (defn command-install-free
   [state side]


### PR DESCRIPTION
If we're going to disallow installing from hand while prompts are up, we should allow a way to fix gamestates if they're broke - so these commands will do.

Closes #5009, in concert with #7498