### PR TITLE
fix-black-screen-in-lobby

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -21,14 +21,13 @@
 (defn create-new-lobby
   [{uid :uid
     user :user
-    {:keys [gameid now
-            allow-spectator api-access format mute-spectators password room save-replay
+    {:keys [gameid allow-spectator api-access format mute-spectators password room save-replay
             side singleton spectatorhands timer title]
-     :or {gameid (random-uuid)
-          now (inst/now)}} :options}]
+     :or {gameid (random-uuid)}} :options}]
   (let [player {:user user
                 :uid uid
-                :side side}]
+                :side side}
+        now (inst/now)]
     {:gameid gameid
      :date now
      :last-update now


### PR DESCRIPTION
@NoahTheDuke I know I said I was done for this release, but this one fixes a site-breaking bug

See: #7407 and my comment there:

> I'm finding this is actually causing me errors (black screen in the lobby whenever there is an active game).
> 
> I can force this to work if I make `create-new-lobby` in `lobby.clj` to create a new `instant` for the date (it's fallback behavior). Otherwise I think this will work for some people (if their browser doesn't support whatever date function we use? I'm not sure what the conditions are to not send a `:date` through ws), and will cause black screens if a `:date` key is passed through the ws connection.
> 
> With a tiny bit of deconstruction, I'm seeing that the `:date` we get from `game` is some sort of native code not compatible with the `instant` type.
> 
> ![check](https://private-user-images.githubusercontent.com/9095245/344591367-4ed0f949-903d-4f89-9790-8dac1fb4f328.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTk4OTQzMzMsIm5iZiI6MTcxOTg5NDAzMywicGF0aCI6Ii85MDk1MjQ1LzM0NDU5MTM2Ny00ZWQwZjk0OS05MDNkLTRmODktOTc5MC04ZGFjMWZiNGYzMjguanBnP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDcwMiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA3MDJUMDQyMDMzWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZjIzNDBkOGY3MzJhMGFkODM5YTc4MTQ4MGM1NWZlZjRjNTFhZTIyY2QzNjkzMWNlZWEyYTVhNzczMjE1MjBhYyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.gWzZepuvpdE6BXA0eFHFMwqq4OPuFS5bzKYapsfWXUk)
> 
> so:
> 
>     * type of `inst/now` as called in the lobby:  correct
> 
>     * date object that my browser is spitting at me (as a string): Mon Jul 01 2024 19:18:02 GMT+1200 (New Zealand Standard Time)
> 
>     * type of that object: `function Date() { [native code] }`

That one causes a black screen in lobbies when an active game is in progress, but I strongly believe it's browser or environment based (so potentially would randomly hit like 30-70% of our users).

This is kind of a dirty fix, but I'm sure it's better to set lobby creation time based on the server time rather than the client time anyway.