### PR TITLE
fix: missing translation calls in front-end

### DIFF
--- a/src/cljs/nr/chat.cljs
+++ b/src/cljs/nr/chat.cljs
@@ -34,9 +34,9 @@
 (defmethod ws/event-msg-handler :chat/blocked
   [{{:keys [reason]} :?data}]
   (let [reason-str (case reason
-                     :rate-exceeded "Rate exceeded"
-                     :length-exceeded "Length exceeded")]
-    (non-game-toast (str "Message Blocked" (when reason-str (str ": " reason-str)))
+                     :rate-exceeded (tr [:chat.rate-exceeded "Rate exceeded"])
+                     :length-exceeded (tr [:chat.length-exceeded "Length exceeded"]))]
+    (non-game-toast (tr [:chat.message-blocked] reason-str)
                     "warning" nil)))
 
 (defn current-block-list []

--- a/src/cljs/nr/deckbuilder.cljs
+++ b/src/cljs/nr/deckbuilder.cljs
@@ -278,7 +278,7 @@
     (map add-deck cards)))
 
 (defn new-deck
-  ([s side] (new-deck s side "New Deck" "standard" [] nil))
+  ([s side] (new-deck s side (tr [:deck-builder.new-deck "New Deck"]) "standard" [] nil))
   ([s side name format cards id]
   (let [old-deck (:deck @s)
         identities (->> (side-identities side)

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -84,8 +84,8 @@
 
      [:section
       [:h4 (tr [:ingame-settings.preview-zoom "Card preview zoom"])]
-      (doall (for [option [{:name "Card Image" :ref "image"}
-                           {:name "Card Text" :ref "text"}]]
+      (doall (for [option [{:name (tr [:ingame-settings.card-image "Card Image"]) :ref "image"}
+                          {:name (tr [:ingame-settings.card-text "Card Text"]) :ref "text"}]]
                [:div.radio {:key (:name option)}
                 [:label [:input {:type "radio"
                                  :name "card-zoom"

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -161,11 +161,9 @@
      (str "🟢 " (tr [:lobby.save-replay "Save replay"]))]]
    [:div.infobox.blue-shade
     {:style {:display (if (:save-replay @options) "block" "none")}}
-    [:p "This will save a replay file of this match with open information (e.g. open cards in hand)."
-     " The file is available only after the game is finished."]
-    [:p "Only your latest 15 unshared games will be kept, so make sure to either download or share the match afterwards."]
-    [:p [:b "BETA Functionality:"] " Be aware that we might need to reset the saved replays, so " [:b "make sure to download games you want to keep."]
-     " Also, please keep in mind that we might need to do future changes to the site that might make replays incompatible."]]])
+    [:p (tr [:lobby.save-replay-details "This will save a replay file of this match with open information (e.g. open cards in hand). The file is available only after the game is finished."])]
+    [:p (tr [:lobby.save-replay-unshared "Only your latest 15 unshared games will be kept, so make sure to either download or share the match afterwards."])]
+    [:p (tr [:lobby.save-replay-beta "BETA Functionality: Be aware that we might need to reset the saved replays, so make sure to download games you want to keep. Also, please keep in mind that we might need to do future changes to the site that might make replays incompatible."])]]])
 
 (defn api-access [options user]
   [:<>

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -181,7 +181,7 @@
          (str " " (tr [:lobby.api-requires-key "(Requires an API Key in Settings)"])))]])
    [:div.infobox.blue-shade
     {:style {:display (if (:api-access @options) "block" "none")}}
-    [:p "This allows access to information about your game to 3rd party extensions. Requires an API Key to be created in Settings"]]])
+    [:p (tr [:lobby.api-access-details "This allows access to information about your game to 3rd party extensions. Requires an API Key to be created in Settings"])]]])
 
 (defn options-section [options user]
   [:section

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -88,8 +88,8 @@
    [singleton-only options fmt-state]
    [:div.infobox.blue-shade
     {:style {:display (if (:singleton @options) "block" "none")}}
-    [:p "This will restrict decklists to only those which do not contain any duplicate cards. It is recommended you use the listed singleton-based identities."]
-    [:p "1) Nova Initiumia: Catalyst & Impetus" " 2) Ampere: Cybernetics For Anyone"]]])
+    [:p (tr [:lobby.singleton-details "This will restrict decklists to only those which do not contain any duplicate cards. It is recommended you use the listed singleton-based identities."])]
+    [:p (tr [:lobby.singleton-example "1) Nova Initiumia: Catalyst & Impetus 2) Ampere: Cybernetics For Anyone"])]]])
 
 (defn allow-spectators [options]
   [:p

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -108,9 +108,8 @@
      (tr [:lobby.hidden "Make players' hidden information visible to spectators"])]]
    [:div.infobox.blue-shade
     {:style {:display (if (:spectatorhands @options) "block" "none")}}
-    [:p "This will reveal both players' hidden information to ALL spectators of your game, "
-     "including hand and face-down cards."]
-    [:p "We recommend using a password to prevent strangers from spoiling the game."]]])
+    [:p (tr [:lobby.hidden-details "This will reveal both players' hidden information to ALL spectators of your game, including hand and face-down cards."])]
+    [:p (tr [:lobby.hidden-password "We recommend using a password to prevent strangers from spoiling the game."])]]])
 
 (defn password-input [options]
   [:<>

--- a/src/cljs/nr/new_game.cljs
+++ b/src/cljs/nr/new_game.cljs
@@ -149,7 +149,7 @@
                           :placeholder (tr [:lobby.timer-length "Timer length (minutes)"])}]])
    [:div.infobox.blue-shade
     {:style {:display (if (:timed @options) "block" "none")}}
-    [:p "Timer is only for convenience: the game will not stop when timer runs out."]]])
+    [:p (tr [:lobby.timed-game-details "Timer is only for convenience: the game will not stop when timer runs out."])]]])
 
 (defn save-replay [options]
   [:<>

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -20,7 +20,7 @@
                              :deck-id (:_id deck)}]
                1500
                #(when (sente/cb-error? %)
-                  (non-game-toast "Cannot select that deck" "error")))
+                  (non-game-toast (tr [:lobby.select-error "Cannot select that deck"]) "error")))
   (reagent-modals/close-modal!))
 
 (defn select-deck-modal [user current-game]
@@ -82,7 +82,7 @@
 (defn singleton-info-box [current-game]
   (when (:singleton @current-game)
     [:div.infobox.blue-shade
-     [:p "This lobby is running in singleton mode. This means decklists will be restricted to only those which do not contain any duplicate cards."]]))
+     [:p (tr [:lobby.singleton-restriction "This lobby is running in singleton mode. This means decklists will be restricted to only those which do not contain any duplicate cards."])]]))
 
 (defn swap-sides-button [user gameid players]
   (when (first-user? @players @user)

--- a/src/cljs/nr/pending_game.cljs
+++ b/src/cljs/nr/pending_game.cljs
@@ -154,13 +154,9 @@
         [:<>
          [:li (str "🟢 " (tr [:lobby.save-replay "Save replay"]))]
          [:div.infobox.blue-shade {:style {:display (if save-replay "block" "none")}}
-          [:p "This will save a replay file of this match with open information (e.g. open cards in hand)."
-           " The file is available only after the game is finished."]
-          [:p "Only your latest 15 unshared games will be kept, so make sure to either download or share the match afterwards."]
-          [:p [:b "BETA Functionality:"]
-           " Be aware that we might need to reset the saved replays, so "
-           [:b "make sure to download games you want to keep."]
-           " Also, please keep in mind that we might need to do future changes to the site that might make replays incompatible."]]])
+          [:p (tr [:lobby.save-replay-details "This will save a replay file of this match with open information (e.g. open cards in hand). The file is available only after the game is finished."])]
+          [:p (tr [:lobby.save-replay-unshared "Only your latest 15 unshared games will be kept, so make sure to either download or share the match afterwards."])]
+          [:p (tr [:lobby.save-replay-beta "BETA Functionality: Be aware that we might need to reset the saved replays, so make sure to download games you want to keep. Also, please keep in mind that we might need to do future changes to the site that might make replays incompatible."])]]])
       (when api-access
         [:li (tr [:lobby.api-access "Allow API access to game information"])])]]))
 

--- a/src/cljs/nr/status_bar.cljs
+++ b/src/cljs/nr/status_bar.cljs
@@ -57,7 +57,7 @@
     (when (:started game)
       (let [c (count (:spectators game))]
         (when (pos? c)
-          [:div.spectators-count.float-right (str c " Spectator" (when (< 1 c) "s"))
+          [:div.spectators-count.float-right (tr [:game.spec-count] c)
            [:div.blue-shade.spectators
             (for [p (:spectators game)]
               ^{:key (get-in p [:user :_id])}

--- a/src/cljs/nr/translations.cljs
+++ b/src/cljs/nr/translations.cljs
@@ -89,7 +89,8 @@
      :delete "Delete Message"
      :delete-all "Delete All Messages From User"
      :block "Block User"
-     :cancel "Cancel"}
+     :cancel "Cancel"
+     :message-blocked (fn [[reason-str]] (str "Message Blocked" (when reason-str (str ": " reason-str))))}
     :nav
     {:chat "Chat"
      :cards "Cards"


### PR DESCRIPTION
This pull request adds missing translation calls, ensuring consistency with existing naming conventions.

Note that the addition of new translation keys in two files - `new_games.cljs` and `pending_game.cljs` - led to the removal of bold formatting in two statements regarding the replay beta feature. I hope this is not an issue, otherwise I will revert these two commits and work on an alternative solution.