### PR TITLE
Revert "fix-black-screen-in-lobby"

### DIFF
--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -21,13 +21,14 @@
 (defn create-new-lobby
   [{uid :uid
     user :user
-    {:keys [gameid allow-spectator api-access format mute-spectators password room save-replay
+    {:keys [gameid now
+            allow-spectator api-access format mute-spectators password room save-replay
             side singleton spectatorhands timer title]
-     :or {gameid (random-uuid)}} :options}]
+     :or {gameid (random-uuid)
+          now (inst/now)}} :options}]
   (let [player {:user user
                 :uid uid
-                :side side}
-        now (inst/now)]
+                :side side}]
     {:gameid gameid
      :date now
      :last-update now


### PR DESCRIPTION
Reverts mtgred/netrunner#7501

As per discussion in slack:
> ok, so this is a little bizzare:
> * PR #7407 causes black screens in the lobby because the types don't match for the time computation (initially I wasn't sure how they got it to work at all)
> * I thought I fixed it with #7501, and it appeared to work on my end
It currently works on playtest (with the game running as a jar, rather than through the repl)
> * we get this issue (https://github.com/mtgred/netrunner/issues/7508) - apparently it doesn't actually fix it
> * Now I can reproduce it locally
> 
> And I did (sort of) track down the cause (and why the original authors were able to get theirs to work before committing, which is the same thing that made it appear my patch fixed the issue), but it's only made me more confused:
> 
> * web/lobby.clj initially spits out the wrong type (the time is in the format of a string)
> * if that class gets reloaded at any point, then it spits out time in the correct format (instant types) for the already existing lobby, and all future lobbies

It honestly is sort of bizzare.  I think it works fine when run as an uberjar as well, and potentially via docker. It's just when run through the repl that it seems to act very strange.