### PR TITLE
Check types match at runtime for time comparison

### DIFF
--- a/src/cljs/nr/game_row.cljs
+++ b/src/cljs/nr/game_row.cljs
@@ -147,8 +147,13 @@
     minutes))
 
 (defn game-time [game]
-(when (:started game)
-  [:div.game-time (str (time-since (:date game)) "m")]))
+  ;; NOTE: while running locally (repl), the :date field ends up being
+  ;; native code, rather than Instant type. I don't understand this,
+  ;; but when running via uberjar (or after reloading web/lobby.clj)
+  ;; it is of the correct type. IDK how to fix the problem, but this
+  ;; is a workable temporary fix - NBKelly, Jul 2024
+  (when (and (:started game) (= (type (:date game)) (type (inst/now))))
+    [:div.game-time (str (time-since (:date game)) "m")]))
 
 (defn players-row [{players :players :as game}]
   (into


### PR DESCRIPTION
Again, I think this issue is really bizarre.

From what I can tell now, it only occurs when running locally via REPL, and will disappear when web/lobby.clj is reloaded. I can only guess that it's either some sort of weird dependency order issue in our project, or it's a genuine repl bug of some sort. I genuinely got gaslit by the issue the first time around.

Also funny enough, we can't run instance? .. time because the native code that the time sometimes is isn't interoperable, so we're stuck with the `type` comparison, which looks uglier :joy: 

We should still merge #7509 because that fix ended up being invalid.

Closes #7508