### PR TITLE
Automatically pay trivial costs

### DIFF
--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -23,6 +23,10 @@
    [game.macros :refer [continue-ability req wait-for]]
    [game.utils :refer [enumerate-str quantify same-card?]]))
 
+(defn- auto-confirm-cost?
+  [state side]
+  (get-in @state [side :options :auto-confirm-costs]))
+
 ;; Click
 (defmethod value :click [cost] (:cost/amount cost))
 (defmethod label :click [cost]
@@ -271,7 +275,8 @@
                  :paid/type :forfeit
                  :paid/value (value cost)
                  :paid/targets targets})))]
-    (if (= (value cost) (count (get-in @state [side :scored])))
+    (if (and (auto-confirm-cost? state side)
+             (= (value cost) (count (get-in @state [side :scored]))))
         ;; if we need to forfiet agendas exactly equal to what we have, it can be automated
       (resolve-forfiets state side eid cost (get-in @state [side :scored]))
       (continue-ability

--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -44,9 +44,12 @@
 
 (defn update-player-setting
   [state side {:keys [setting value]}]
-  (swap! state assoc-in [side :options setting] value)
-  (toast state side (str "The " (name setting) " setting has been "
-                         (if value "enabled" "disabled"))))
+  (swap! state assoc-in [side :user :options setting] value)
+  (let [setting-name (case setting
+                       :auto-confirm-costs "automatically paying trivial costs"
+                       "unknown setting")
+        funct (if value "Enabled" "Disabled")]
+    (toast state side (str funct " " setting-name))))
 
 (def commands
   {"ability" #'play-ability

--- a/src/clj/game/core/process_actions.clj
+++ b/src/clj/game/core/process_actions.clj
@@ -19,7 +19,7 @@
    [game.core.say :refer [indicate-action say system-msg system-say]]
    [game.core.set-up :refer [keep-hand mulligan]]
    [game.core.shuffling :refer [shuffle-deck]]
-   [game.core.toasts :refer [ack-toast]]
+   [game.core.toasts :refer [ack-toast toast]]
    [game.core.turns :refer [end-phase-12 end-turn start-turn]]
    [game.core.winning :refer [concede]]))
 
@@ -41,6 +41,12 @@
         (command state side)
         (system-say state side (str "[!]" (:username author) " uses a command: " text)))
       (say state side args))))
+
+(defn update-player-setting
+  [state side {:keys [setting value]}]
+  (swap! state assoc-in [side :options setting] value)
+  (toast state side (str "The " (name setting) " setting has been "
+                         (if value "enabled" "disabled"))))
 
 (def commands
   {"ability" #'play-ability
@@ -83,6 +89,7 @@
    "trash" #(trash %1 %2 (make-eid %1) (get-card %1 (:card %3)) (dissoc %3 :card))
    "trash-resource" #'trash-resource
    "unbroken-subroutines" #'play-unbroken-subroutines
+   "update-player-setting" #'update-player-setting
    "view-deck" #'view-deck})
 
 (defn process-action

--- a/src/clj/web/auth.clj
+++ b/src/clj/web/auth.clj
@@ -162,8 +162,8 @@
 (defn profile-keys []
   [:background :pronouns :language :default-format :show-alt-art :blocked-users
    :alt-arts :card-resolution :deckstats :gamestats :card-zoom :pin-zoom
-   :card-back :stacked-cards :ghost-trojans :sides-overlap :archives-sorted :heap-sorted
-   :labeled-cards :labeled-unrezzed-cards])
+   :card-back  :stacked-cards :ghost-trojans :sides-overlap :archives-sorted :heap-sorted
+   :labeled-cards :labeled-unrezzed-cards :auto-confirm-costs])
 
 (defn update-profile-handler
   [{db :system/db

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -67,7 +67,7 @@
   (.setItem js/localStorage "log-player-highlight" (:log-player-highlight @s))
   (.setItem js/localStorage "player-stats-icons" (:player-stats-icons @s))
   (.setItem js/localStorage "stacked-cards" (:stacked-cards @s))
-  (.setItem js/localStore "auto-confirm-costs" (:auto-confirm-costs @s))
+  (.setItem js/localStorage "auto-confirm-costs" (:auto-confirm-costs @s))
   (.setItem js/localStorage "ghost-trojans" (:ghost-trojans @s))
   (.setItem js/localStorage "sides-overlap" (:sides-overlap @s))
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -340,7 +340,7 @@
            [:h3 (tr [:settings.gameplay-options "Gameplay options"])]
            [:div
             [:label [:input {:type "checkbox"
-                             :value true
+                             :value false
                              :checked (:auto-confirm-costs @s)
                              :on-change #(swap! s assoc-in [:auto-confirm-costs] (.. % -target -checked))}]
              (tr [:settings.auto-confirm-costs "Automatically confirm trivial costs (costs where there is only one valid selection)"])]]

--- a/src/cljs/nr/account.cljs
+++ b/src/cljs/nr/account.cljs
@@ -46,6 +46,7 @@
   (swap! app-state assoc-in [:options :card-resolution] (:card-resolution @s))
   (swap! app-state assoc-in [:options :player-stats-icons] (:player-stats-icons @s))
   (swap! app-state assoc-in [:options :stacked-cards] (:stacked-cards @s))
+  (swap! app-state assoc-in [:options :auto-confirm-costs] (:auto-confirm-costs @s))
   (swap! app-state assoc-in [:options :ghost-trojans] (:ghost-trojans @s))
   (swap! app-state assoc-in [:options :sides-overlap] (:sides-overlap @s))
   (swap! app-state assoc-in [:options :runner-board-order] (:runner-board-order @s))
@@ -66,6 +67,7 @@
   (.setItem js/localStorage "log-player-highlight" (:log-player-highlight @s))
   (.setItem js/localStorage "player-stats-icons" (:player-stats-icons @s))
   (.setItem js/localStorage "stacked-cards" (:stacked-cards @s))
+  (.setItem js/localStore "auto-confirm-costs" (:auto-confirm-costs @s))
   (.setItem js/localStorage "ghost-trojans" (:ghost-trojans @s))
   (.setItem js/localStorage "sides-overlap" (:sides-overlap @s))
   (.setItem js/localStorage "runner-board-order" (:runner-board-order @s))
@@ -335,6 +337,13 @@
              [:option {:value k} (tr-format v)]))]]
 
           [:section
+           [:h3 (tr [:settings.gameplay-options "Gameplay options"])]
+           [:div
+            [:label [:input {:type "checkbox"
+                             :value true
+                             :checked (:auto-confirm-costs @s)
+                             :on-change #(swap! s assoc-in [:auto-confirm-costs] (.. % -target -checked))}]
+             (tr [:settings.auto-confirm-costs "Automatically confirm trivial costs (costs where there is only one valid selection)"])]]
            [:h3 (tr [:settings.layout-options "Layout options"])]
            [:div
             [:label [:input {:type "checkbox"
@@ -579,6 +588,7 @@
                        :alt-arts (get-in @app-state [:options :alt-arts])
                        :all-art-select "wc2015"
                        :card-resolution (get-in @app-state [:options :card-resolution])
+                       :auto-confirm-costs (get-in @app-state [:options :auto-confirm-costs])
                        :stacked-cards (get-in @app-state [:options :stacked-cards])
                        :ghost-trojans (get-in @app-state [:options :ghost-trojans])
                        :sides-overlap (get-in @app-state [:options :sides-overlap])

--- a/src/cljs/nr/appstate.cljs
+++ b/src/cljs/nr/appstate.cljs
@@ -39,6 +39,7 @@
                             :card-resolution "default"
                             :player-stats-icons (= (get-local-value "player-stats-icons" "true") "true")
                             :stacked-servers (= (get-local-value "stacked-servers" "true") "true")
+                            :auto-confirm-costs (= (get-local-value "auto-confirm-costs" "true") "true")
                             :sides-overlap (= (get-local-value "sides-overlap" "true") "true")
                             :runner-board-order (let [value (get-local-value "runner-board-order" "irl")]
                                                   (case value

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -87,6 +87,13 @@
 (defn stack-cards []
   (swap! app-state update-in [:options :stacked-cards] not))
 
+(defn automatically-confirm-trivial-costs []
+  (when (not (:replay @game-state))
+    (let [value (get-in @app-state [:options :auto-confirm-costs])]
+      (send-command "update-player-setting" {:setting :auto-confirm-costs
+                                             :value value}))))
+
+
 ; (defn flip-runner-board []
 ;   (let [layout (if (= "irl" (get-in @app-state [:options :runner-board-order])) "jnet" "irl")]
 ;     (swap! app-state assoc-in [:options :runner-board-order] layout)))

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -42,7 +42,7 @@
         [:h4 (tr [:ingame-settings.gameplay-settings "Gameplay settings"])]
         [:div
          [:label [:input {:type "checkbox"
-                          :value true
+                          :value false
                           :checked (get-in @app-state [:options :auto-confirm-costs])
                           :on-change #(do (swap! app-state assoc-in [:options :auto-confirm-costs] (.. % -target -checked))
                                           (automatically-confirm-trivial-costs))}]

--- a/src/cljs/nr/gameboard/settings.cljs
+++ b/src/cljs/nr/gameboard/settings.cljs
@@ -2,7 +2,9 @@
   (:require
    [nr.account :refer [post-options]]
    [nr.appstate :refer [app-state]]
-   [nr.translations :refer [tr]]))
+   [nr.translations :refer [tr]]
+   [nr.gameboard.actions :refer [automatically-confirm-trivial-costs]]
+   [nr.gameboard.state :refer [not-spectator?]]))
 
 (defn settings-pane []
   (fn []
@@ -33,6 +35,18 @@
                         :checked (get-in @app-state [:options :ghost-trojans])
                         :on-change #(swap! app-state assoc-in [:options :ghost-trojans] (.. % -target -checked))}]
         (tr [:ingame-settings.ghost-trojans "Display hosted trojans in rig"])]]]
+
+     ;; todo - make this visible only for active players in a game!
+     (when (not-spectator?)
+       [:section
+        [:h4 (tr [:ingame-settings.gameplay-settings "Gameplay settings"])]
+        [:div
+         [:label [:input {:type "checkbox"
+                          :value true
+                          :checked (get-in @app-state [:options :auto-confirm-costs])
+                          :on-change #(do (swap! app-state assoc-in [:options :auto-confirm-costs] (.. % -target -checked))
+                                          (automatically-confirm-trivial-costs))}]
+          (tr [:ingame-settings.auto-confirm-costs "Automatically confirm trivial costs"])]]])
 
      [:section
       [:h4 (tr [:ingame-settings.card-sorting "Sorting"])]


### PR DESCRIPTION
This is a little usability/convenience feature I'm working on.

If there's only one possible set of targets for an action (in this case, paying costs), it should be possible to automate it. I've made it optional so that you're not forced into the feature (people who play physical as well can get their mechanical practice in)

Additionally, this adds functionality to update *in-game* settings, which will be important later when I add explicit reveals into the game, or options for the runner to pre-trash programs regardless of MU, or the corp to pre-trash ice.

Closes #7505

* If you need to forfeit exactly as many agendas as there are in your score area, this can be done automatically

* If you need to rfg exactly as many programs as you have installed programs, this can be done automatically (applies to Rosetta 2.0 and nothing else)

* If you need to trash exactly as many cards as you have installed (or exactly as many "other" cards), this can be done automatically

[auto-trash-installed.webm](https://github.com/mtgred/netrunner/assets/9095245/78403603-c571-490c-a40d-2600417da2b1)

* If you need to trash exactly as much hardware/programs/resources/connections as you have installed

* If you need to derez exactly as many harmonics as you have installed (bloop enjoyers will appreciate this)
* If you need to trash exactly as many cards in hand as you have in hand (ie playing moshing at 4 cards in hand)