### PR TITLE
update take/gain templating on a few cards

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1420,7 +1420,7 @@
                  {:cost [(->c :click 1)]
                   :label "Take all hosted credits and add this asset to HQ. Install 1 card from HQ"
                   :async true
-                  :msg (msg "take " (get-counters (get-card state card) :credit) " [Credits] and add itself to HQ")
+                  :msg (msg "gain " (get-counters (get-card state card) :credit) " [Credits] and add itself to HQ")
                   :effect (req (wait-for (gain-credits state side (make-eid state eid)
                                                        (get-counters (get-card state card) :credit))
                                          (move state :corp card :hand)
@@ -1672,7 +1672,7 @@
                 :effect (effect (gain-credits eid 2))}]})
 
 (defcard "Marked Accounts"
-  (let [ability {:msg "take 1 [Credits]"
+  (let [ability {:msg "gain 1 [Credits]"
                  :label "Take 1 [Credits] (start of turn)"
                  :once :per-turn
                  :req (req (pos? (get-counters card :credit)))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2892,7 +2892,7 @@
                                :label "Take 1 [Credits] (start of turn)"
                                :req (req (and (:runner-phase-12 @state)
                                               (pos? (get-counters card :credit))))
-                               :msg "take 1 [Credits]"
+                               :msg "gain 1 [Credits]"
                                :async true
                                :effect (req (add-counter state side card :credit -1)
                                          (gain-credits state side eid 1))}]


### PR DESCRIPTION
These were the only cards that still said "take credits" on them.

Since we currently use `take` exclusively to refer to illegal game actions (manually fixing the boardstate with cards that host credits), I updated this. They're now consistent with all our other cards.