### PR TITLE
wrap very long card names behind the card image

### DIFF
--- a/src/css/gameboard.styl
+++ b/src/css/gameboard.styl
@@ -69,6 +69,8 @@
             float: left
             font-size: .625rem
             line-height: .75rem
+            max-width: 60px
+            word-wrap: break-word
 
     @keyframes new-card {
         0% {


### PR DESCRIPTION
Constrains the card-name span to inside the card image, so very long card names no longer overflow past the edge of the card.

Closes #3809

* without the change
![long-name](https://github.com/mtgred/netrunner/assets/9095245/6b6f05fe-c7b3-4a04-895e-8fa608a39e65)
* with the change
![long-name_000](https://github.com/mtgred/netrunner/assets/9095245/b920e4d0-962d-4aef-a0f6-29b0c0bb4b20)
