### PR TITLE
prana once per damage instance!

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2130,8 +2130,11 @@
    :abilities [{:label "Prevent 1 net damage to place power counter on Prāna Condenser"
                 :msg "prevent 1 net damage, place 1 power counter, and gain 3 [Credits]"
                 :async true
-                :req (req true)
+                :req (req (and (= (get-in @state [:prevent :current :type]) :net)
+                               (not= (get-in card [:special :last-prevented-eid])
+                                     (get-in @state [:prevent :current :eid :eid]))))
                 :effect (req (add-counter state side card :power 1)
+                             (update! state side (assoc-in (get-card state card) [:special :last-prevented-eid] (get-in @state [:prevent :current :eid :eid])))
                              (gain-credits state :corp eid 3)
                              (damage-prevent state :corp :net 1))}
                {:msg (msg "deal " (get-counters card :power) " net damage")

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1072,10 +1072,9 @@
   (let [ability {:async true
                  :req (req (not (:winner @state)))
                  :msg "do 1 net damage"
+                 :interactive (req true)
                  :effect (effect (damage eid :net 1 {:card card}))}]
-    {:events [(assoc ability
-                     :event :agenda-scored
-                     :interactive (req true))
+    {:events [(assoc ability :event :agenda-scored)
               (assoc ability :event :agenda-stolen)]}))
 
 (defcard "Jinteki: Potential Unleashed"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -2225,7 +2225,7 @@
                                             run
                                             (= :corp (:active-player @state))
                                             (#{:psi :trace} (:source-type eid))
-                                            (#{:net :meat :brain :tag} (get-in @state [:prevent :current]))))
+                                            (#{:net :meat :brain :tag} (get-in @state [:prevent :current :type]))))
                                 :type :credit}}})
 
 (defcard "Network Exchange"
@@ -2299,7 +2299,7 @@
                                :req (req (first-chance? state side))}]}
      :abilities [{:msg "force the Corp to trace"
                   :async true
-                  :effect (req (let [prevent-type (get-in @state [:prevent :current])]
+                  :effect (req (let [prevent-type (get-in @state [:prevent :current :type])]
                                  (wait-for (trash state side card {:unpreventable true :cause-card card})
                                            (continue-ability state side (start-trace prevent-type)
                                                              card nil))))}]}))

--- a/src/clj/game/core/bad_publicity.clj
+++ b/src/clj/game/core/bad_publicity.clj
@@ -45,7 +45,7 @@
                         (cards-can-prevent? state :corp prevent :bad-publicity))
                  (do (system-msg state :corp "has the option to avoid bad publicity")
                      (show-wait-prompt state :runner "Corp to prevent bad publicity")
-                     (swap! state assoc-in [:prevent :current] :bad-publicity)
+                     (swap! state assoc-in [:prevent :current] {:type :bad-publicity :eid eid})
                      (show-prompt
                        state :corp nil
                        (str "Avoid " (when (< 1 n) "any of the ") n " bad publicity?") ["Done"]

--- a/src/clj/game/core/damage.clj
+++ b/src/clj/game/core/damage.clj
@@ -161,7 +161,7 @@
        ;; player can prevent damage
        (do (system-msg state player "has the option to prevent damage")
            (show-wait-prompt state other-player (str (side-str player) " to prevent damage"))
-           (swap! state assoc-in [:prevent :current] type)
+           (swap! state assoc-in [:prevent :current] {:type type :eid eid})
            (show-prompt
              state player nil
              (str "Prevent " (when (< 1 (- n already-prevented)) "any of the ") (- n already-prevented) " " (damage-name type) " damage?")

--- a/src/clj/game/core/tags.clj
+++ b/src/clj/game/core/tags.clj
@@ -74,7 +74,7 @@
                         (cards-can-prevent? state :runner prevent :tag))
                  (do (system-msg state :runner "has the option to avoid tags")
                      (show-wait-prompt state :corp "Runner to prevent tags")
-                     (swap! state assoc-in [:prevent :current] :tag)
+                     (swap! state assoc-in [:prevent :current] {:type :tag :eid eid})
                      (show-prompt
                        state :runner nil
                        (str "Avoid " (when (< 1 n) "any of the ") (quantify n "tag") "?") ["Done"]

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -4153,6 +4153,30 @@
         (card-ability state :corp  pc 1)
         (is (= 3 (count (:hand (get-runner)))) "2 damage dealt"))))
 
+(deftest prana-condenser-once-per-instance
+  (do-game
+    (new-game {:corp {:hand ["Prāna Condenser" "Fujii Asset Retrieval"]
+                      :id "Jinteki: Personal Evolution"}
+               :runner {:hand [(qty "Sure Gamble" 5)]}})
+    (play-from-hand state :corp "Prāna Condenser" "New remote")
+    (take-credits state :corp)
+    (let [pran (get-content state :remote1 0)]
+      (rez state :corp pran)
+      (run-empty-server state :hq)
+      (click-prompt state :runner "Steal")
+      (click-prompt state :corp "Fujii Asset Retrieval")
+      (is (changed? [(:credit (get-corp)) 3]
+                    (card-ability state :corp (refresh pran) 0))
+          "Prevented one damage")
+      (is (changed? [(:credit (get-corp)) 0]
+                    (card-ability state :corp (refresh pran) 0))
+          "Couldn't prevent the other!")
+      (click-prompt state :corp "Done")
+      (is (= 1 (count (:discard (get-runner)))) "Took 1 net")
+      (is (changed? [(:credit (get-corp)) 3]
+                    (card-ability state :corp (refresh pran) 0))
+          "Prevented one damage (PE)"))))
+
 (deftest prana-condenser-refuse-to-prevent-damage
     ;; Refuse to prevent damage
     (do-game


### PR DESCRIPTION
Instead of just swapping the type of damage into the state damage prevent thing, we swap in a map with `{:type type :eid eid}`.

I updated all *checks notes* one other things that used this area of the engine to match (we really should enforce this a little more :joy:)

Closes #5765

Also made both halves of PE interactive, instead of just the on-score

Closes #5861 (the player wanted pe and sting to interact on steal)