### PR TITLE
pending test on attini + attini/prana test + RSVP

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -849,8 +849,7 @@
                                            "do 1 net damage"
                                            (str "force the runner to " (decapitalize target))))}
                               card nil)))}]
-    {:implementation "preventing paid abilities with credit costs not implemented (yet)"
-     :events [{:event :pre-resolve-subroutine
+    {:events [{:event :pre-resolve-subroutine
                :req (req (threat-level 3 state))
                :silent (req true)
                :effect (req (register-lingering-effect
@@ -3492,6 +3491,20 @@
 (defcard "Rototurret"
   {:subroutines [trash-program-sub
                  end-the-run]})
+
+(defcard "RSVP"
+  {:subroutines [{:label "Runner cannot spend credits this run"
+                  :msg "prevent the runner from spending credits this run"
+                  :effect (req (when run
+                                 (register-lingering-effect
+                                   state side card
+                                   {:type :cannot-pay-credit
+                                    ;; you're allowed to spend 0 credits, our rules are just cursed
+                                    :req (req (if (:amount context)
+                                                (pos? (:amount context))
+                                                true))
+                                    :value (constantly true)
+                                    :duration :end-of-run})))}]})
 
 (defcard "Sadaka"
   (let [maybe-draw-effect

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -850,6 +850,15 @@
                                            (str "force the runner to " (decapitalize target))))}
                               card nil)))}]
     {:implementation "preventing paid abilities with credit costs not implemented (yet)"
+     :events [{:event :pre-resolve-subroutine
+               :req (req (threat-level 3 state))
+               :silent (req true)
+               :effect (req (register-lingering-effect
+                              state side card
+                              {:type :cannot-pay-credit
+                               :req (req true)
+                               :value (constantly true)
+                               :duration :subroutine-currently-resolving}))}]
      :subroutines [sub
                    sub
                    sub]}))

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -856,7 +856,7 @@
                               state side card
                               {:type :cannot-pay-credit
                                :req (req true)
-                               :value (constantly true)
+                               :value true
                                :duration :subroutine-currently-resolving}))}]
      :subroutines [sub
                    sub
@@ -3500,10 +3500,8 @@
                                    state side card
                                    {:type :cannot-pay-credit
                                     ;; you're allowed to spend 0 credits, our rules are just cursed
-                                    :req (req (if (:amount context)
-                                                (pos? (:amount context))
-                                                true))
-                                    :value (constantly true)
+                                    :req (req (or (nil? (:amount context)) (pos? (:amount context))))
+                                    :value true
                                     :duration :end-of-run})))}]})
 
 (defcard "Sadaka"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1537,11 +1537,11 @@
 
 (defcard "Guru Davinder"
   {:static-abilities [{:type :cannot-pay-net
-                       :value (constantly true)}
+                       :value true}
                       {:type :cannot-pay-meat
-                       :value (constantly true)}
+                       :value true}
                       {:type :cannot-pay-brain
-                       :value (constantly true)}]
+                       :value true}]
    :events [{:event :pre-damage
              :req (req (and (#{:meat :net} (:type context))
                             (pos? (:amount context))))

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1536,7 +1536,12 @@
                             (continue-ability state side ab card targets)))}]})
 
 (defcard "Guru Davinder"
-  {:flags {:cannot-pay-net true}
+  {:static-abilities [{:type :cannot-pay-net
+                       :value (constantly true)}
+                      {:type :cannot-pay-meat
+                       :value (constantly true)}
+                      {:type :cannot-pay-brain
+                       :value (constantly true)}]
    :events [{:event :pre-damage
              :req (req (and (#{:meat :net} (:type context))
                             (pos? (:amount context))))

--- a/src/clj/game/core/ice.clj
+++ b/src/clj/game/core/ice.clj
@@ -275,11 +275,11 @@
                (update-current-encounter state :replace-subroutine nil)
                (update-current-encounter state :prevent-subroutine nil)
                (if prevent
-                 (checkpoint state nil eid)
+                 (checkpoint state nil eid {:duration :subroutine-currently-resolving})
                  ;; see if there are any effects which can prevent this subroutine
                  (wait-for (resolve-ability state side (make-eid state eid) (:sub-effect sub) (get-card state ice) nil)
                            (queue-event state :subroutine-fired {:sub sub :ice ice})
-                           (checkpoint state nil eid)))))))
+                           (checkpoint state nil eid {:duration :subroutine-currently-resolving})))))))
 
 (defn- resolve-next-unbroken-sub
   ([state side ice subroutines]

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -4,7 +4,7 @@
     [game.core.board :refer [all-active-installed]]
     [game.core.card :refer [ice?]]
     [game.core.eid :refer [make-eid]]
-    [game.core.flags :refer [card-flag?]]
+    [game.core.effects :refer [any-effects]]
     [game.core.toasts :refer [toast]]
     [jinteki.utils :refer [capitalize]]))
 
@@ -86,11 +86,11 @@
   (= [(->c :click 4) (->c :credit 2)] (merge-costs [[(->c :click 1)] [(->c :click 3)] [(->c :credit 1)] [(->c :credit 1)]]))
   (= [(->c :click 4) (->c :credit 2)] (merge-costs [[(->c :credit 1)] [(->c :credit 1)] [(->c :click 1)] [(->c :click 3)]])))
 
-(defn- flag-stops-pay?
-  "Checks installed cards to see if payment type is prevented by a flag"
+(defn- any-effect-stops-pay?
+  "Checks installed cards to see if payment type is being prevented by an active card"
   [state side cost]
-  (let [flag (keyword (str "cannot-pay-" (name (:cost/type cost))))]
-    (some #(card-flag? % flag true) (all-active-installed state side))))
+  (let [kw-cost (keyword (str "cannot-pay-" (name (:cost/type cost))))]
+    (any-effects state side kw-cost)))
 
 (defn can-pay?
   "Returns nil if the player cannot pay the cost args, or a truthy map otherwise.
@@ -101,7 +101,7 @@
    (let [remove-zero-credit-cost (and (= (:source-type eid) :corp-install)
                                       (not (ice? card)))
          costs (merge-costs (filter some? args) remove-zero-credit-cost)]
-     (if (every? #(and (not (flag-stops-pay? state side %))
+     (if (every? #(and (not (any-effect-stops-pay? state side %))
                        (payable? % state side eid card))
                  costs)
        costs

--- a/src/clj/game/core/payment.clj
+++ b/src/clj/game/core/payment.clj
@@ -90,7 +90,7 @@
   "Checks installed cards to see if payment type is being prevented by an active card"
   [state side cost]
   (let [kw-cost (keyword (str "cannot-pay-" (name (:cost/type cost))))]
-    (any-effects state side kw-cost)))
+    (any-effects state side kw-cost true? {:amount (:cost/amount cost)})))
 
 (defn can-pay?
   "Returns nil if the player cannot pay the cost args, or a truthy map otherwise.

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -6026,6 +6026,24 @@
       (is (= 1 (core/get-strength (refresh iw1))) "Rime no longer gives bonus strength to ice on previous server")
       (is (= 2 (core/get-strength (refresh iw2))) "Rime only gives ice on current server bonus strength"))))
 
+(deftest rsvp-full-test
+  (do-game
+    (new-game {:corp {:hand ["RSVP" "Forced Connection"]}
+               :runner {:credits 50}})
+    (play-from-hand state :corp "RSVP" "HQ")
+    (take-credits state :corp)
+    (let [rsvp (get-ice state :hq 0)]
+      (run-on state :hq)
+      (rez state :corp rsvp)
+      (run-continue state :encounter-ice)
+      (card-subroutine state :corp (refresh rsvp) 0)
+      (run-continue-until state :success)
+      ;; we're still allowed to pay 0 credits for traces and trashes
+      (click-prompt state :corp "0")
+      (is (= 0 (:choices (prompt-map :runner))))
+      (click-prompt state :runner "0")
+      (click-prompt state :runner "Pay 0 [Credits] to trash")))) ; trash
+
 (deftest sadaka-sub-1-look-at-the-top-3-cards-of-r-d-arrange-those-or-shuffle-r-d-you-may-draw-1-card
   ;; Sub 1 - Look at the top 3 cards of R&D, arrange those or shuffle R&D. You may draw 1 card
   (do-game

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -725,7 +725,27 @@
             (fire-subs state att))
           "Runner took 3 damage and couldn't choose to spend credits"))))
 
-(deftest ^:kaocha/pending attini-threat-ability-cannot-spend-credits
+(deftest attini-threat-vs-prana-condenser
+  (do-game
+    (new-game {:corp {:hand ["Attini" "Prāna Condenser" "Obokata Protocol"]
+                      :credits 10}})
+    (play-from-hand state :corp "Prāna Condenser" "New remote")
+    (play-from-hand state :corp "Attini" "HQ")
+    (play-and-score state "Obokata Protocol")
+    (let [att (get-ice state :hq 0)
+          pc (get-content state :remote1 0)]
+      (rez state :corp pc)
+      (take-credits state :corp)
+      (run-on state :hq)
+      (rez state :corp att)
+      (run-continue state :encounter-ice)
+      (fire-subs state (refresh att))
+      (dotimes [_ 3]
+        (is (changed? [(:credit (get-corp)) 3]
+                      (card-ability state :corp (get-content state :remote1 0) 0))
+            "prevented 1 net with prana")))))
+
+(deftest attini-threat-ability-cannot-spend-credits
   (do-game
     (new-game {:corp {:hand ["Attini" "Obokata Protocol"]
                       :credits 10}
@@ -736,10 +756,17 @@
     (let [att (get-ice state :hq 0)]
       (play-from-hand state :runner "Caldera")
       (run-on state "HQ")
-      (rez state :corp (refresh att))
+      (rez state :corp att)
       (run-continue state)
-      (is (changed? [(count (:hand (get-runner))) -3]
-            (fire-subs state att))
+      (is (changed?
+            [(count (:hand (get-runner))) -3]
+            (fire-subs state (refresh att))
+            (dotimes [_ 3]
+              (is (changed?
+                    [(:credit (get-runner)) 0]
+                    (card-ability state :runner (get-resource state 0) 0)
+                    (click-prompt state :runner "Done"))
+                  "couldn't spend on caldera")))
           "Runner took 3 damage and couldn't prevent any of them by spending credits"))))
 
 (deftest authenticator-encounter-decline-to-take-tag


### PR DESCRIPTION
Attini now actually has a cut-in which makes the runner unable to pay for credits during subroutine resolution. The pending test we had in that regard does just work now.

This means one less use of the flags system as well, so we're slowly getting there with that - and I updated guru davinder to match (and also take into account core/meat damage).

I also added in a test for prana threat + corp prevent with prana condenser - Closes #7277

And just to follow this system to it's logical conclusion, I implemented RSVP as well and added a unit test for that, which I guess would close  #1074, but it's already closed!