### PR TITLE
fixed card preview when mousing over cards

### DIFF
--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -304,7 +304,8 @@
   (let [title (tr-data :title card)
         icon (faction-icon (:faction card) title)
         uniq (when (:uniqueness card) "◇ ")
-        subtypes (or (when (seq (:subtypes card)) (s/join " - " (:subtypes card))) (:subtype card))]
+        subtypes (or (when (seq (:subtypes card)) (s/join " - " (:subtypes card))) (:subtype card))
+        impl (when (and (:implementation card) (not= (:implementation card) "full")) (:implementation card))]
     [:div
      [:h4 uniq title icon
       (when-let [influence (:factioncost card)]
@@ -330,6 +331,9 @@
        [:div.heading (str (tr [:card-browser.min-deck "Minimum deck size"]) ": " min-deck-size)])
      (when-let [influence-limit (:influencelimit card)]
        [:div.heading (str (tr [:card-browser.inf-limit "Influence limit"]) ": " influence-limit)])
+
+     (when impl
+       [:div.heading (str (tr [:card-browser.implementation-note "Implementation note"]) ": " impl)])
 
      [:div.text.card-body
       [:p [:span.type (tr-type (:type card))]

--- a/src/cljs/nr/cardbrowser.cljs
+++ b/src/cljs/nr/cardbrowser.cljs
@@ -303,7 +303,8 @@
   [card show-extra-info]
   (let [title (tr-data :title card)
         icon (faction-icon (:faction card) title)
-        uniq (when (:uniqueness card) "◇ ")]
+        uniq (when (:uniqueness card) "◇ ")
+        subtypes (or (when (seq (:subtypes card)) (s/join " - " (:subtypes card))) (:subtype card))]
     [:div
      [:h4 uniq title icon
       (when-let [influence (:factioncost card)]
@@ -332,7 +333,7 @@
 
      [:div.text.card-body
       [:p [:span.type (tr-type (:type card))]
-       (if (empty? (:subtype card)) "" (str ": " (:subtype card)))]
+       (if-not subtypes "" (str ": " subtypes))]
       [:pre (render-icons (tr-data :text (get @all-cards (:title card))))]
 
       (when show-extra-info

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -19,7 +19,7 @@
    [nr.gameboard.actions :refer [send-command]]
    [nr.gameboard.card-preview :refer [card-highlight-mouse-out
                                       card-highlight-mouse-over card-preview-mouse-out
-                                      card-preview-mouse-over zoom-channel]]
+                                      card-preview-mouse-over put-game-card-in-channel zoom-channel]]
    [nr.gameboard.player-stats :refer [stat-controls stats-view]]
    [nr.gameboard.replay :refer [replay-panel]]
    [nr.gameboard.right-pane :refer [content-pane]]
@@ -316,7 +316,7 @@
   [{:keys [code] :as card}]
   (when code
     [:div.card-frame
-     [:div.blue-shade.card {:on-mouse-enter #(put! zoom-channel card)
+     [:div.blue-shade.card {:on-mouse-enter #(put-game-card-in-channel card zoom-channel)
                             :on-mouse-leave #(put! zoom-channel false)}
       (when-let [url (image-url card)]
         [:div
@@ -670,7 +670,7 @@
                             :on-mouse-enter #(when (or (not (or (not code) flipped facedown))
                                                        (spectator-view-hidden?)
                                                        (= (:side @game-state) (keyword (lower-case side))))
-                                               (put! zoom-channel card))
+                                               (put-game-card-in-channel card zoom-channel))
                             :on-mouse-leave #(put! zoom-channel false)
                             :on-click #(when (not disable-click)
                                          (handle-card-click card))
@@ -1309,7 +1309,7 @@
                                [:img.start-card {:src (str "/img/" card-back "-" (lower-case (:side @my-ident)) ".png")}]]
                               [:div.card-front
                                (when-let [url (image-url card)]
-                                 [:div {:on-mouse-enter #(put! zoom-channel card)
+                                 [:div {:on-mouse-enter #(put-game-card-in-channel card zoom-channel)
                                         :on-mouse-leave #(put! zoom-channel false)}
                                   [:img.start-card {:src url :alt title :onError #(-> % .-target js/$ .hide)}]])]]
                              (when-let [elem (.querySelector js/document (str "#startcard" i))]

--- a/src/cljs/nr/gameboard/card_preview.cljs
+++ b/src/cljs/nr/gameboard/card_preview.cljs
@@ -9,6 +9,13 @@
         title (.getAttribute target "data-card-title")]
     (not-empty title)))
 
+(defn put-game-card-in-channel
+  [card channel]
+  (if-let [server-card (get-in @app-state [:all-cards-and-flips (:title card)])]
+    (put! channel (merge server-card card))
+    (put! channel card))
+  nil)
+
 (defn card-preview-mouse-over
   [e channel]
   (.preventDefault e)


### PR DESCRIPTION
Ok the clue here was that it worked for the text cards (in the chat log) and not the card cards (on the gameboard). Turns out we were just jamming the wrong data in.

I added the `merge (server-card) card` part so game-state changes to cards (like subtype gain, etc) can be expressed on the mouseover.

![text-view-works-now](https://github.com/user-attachments/assets/4371c408-9137-40c6-a1c6-698aef7fbb86)

Closes #7515
Closes #6932
Closes #6383

While I'm at it, I made it so the implementation notes for the card show up in the text preview as well.

Closes #3785 - it only took six years for us to discover how :joy: 