### PR TITLE
dont display empty prompt buttons

### DIFF
--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1652,7 +1652,7 @@
        ;; otherwise choice of all present choices
        :else
        (doall (for [{:keys [idx uuid value]} choices]
-                (when (not= value "Hide")
+                (when (and (seq value) (not= value "Hide"))
                   [:button {:key idx
                             :on-click #(do (send-command "choice" {:choice {:uuid uuid}})
                                            (card-highlight-mouse-out % value button-channel))


### PR DESCRIPTION
This isn't a great fix, because I still have no clue how empty options end up in the prompt state, but at the very least this is a stopgap.

Honestly, if somebody else can spy a reason for there to be some extra entries in the prompt state, they're better at inspecting code than I am :joy: 

It adds a test, but that test was just to determine that the issue was actually on the frontend and not the backend (still, doesn't hurt).

Closes #7424