### PR TITLE
added a system to condense the install messages a bit

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -115,7 +115,9 @@
                                     (trash-cards eid choices {:unpreventable true :cause-card card}))
              :effect (req (wait-for (corp-install state side target nil
                                                   {:ignore-all-cost true
-                                                   :install-state :rezzed-no-cost})
+                                                   :install-state :rezzed-no-cost
+                                                   :msg-keys {:install-source card
+                                                              :display-origin true}})
                                     (let [choices (remove-once #(= target %) choices)]
                                       (cond
                                         ;; Shuffle ends the ability
@@ -206,18 +208,13 @@
                                        :choices (cancellable (filter corp-installable-type?
                                                                      (take 5 (:deck corp))))
                                        :async true
-                                       :effect (req (let [target-position (first (positions #{target} (take 3 (:deck corp))))
-                                                          position (case target-position
-                                                                     0 "first "
-                                                                     1 "second "
-                                                                     2 "third "
-                                                                     3 "fourth "
-                                                                     4 "fifth "
-                                                                     "this-should-not-happen ")]
-                                                      (system-msg state side (str "uses " (:title card) " to install the " position "card from R&D"))
+                                       :effect (req (let [target-position (first (positions #{target} (take 5 (:deck corp))))]
                                                       (corp-install state side
                                                         eid target nil
                                                         {:ignore-all-cost true
+                                                         :msg-keys {:install-source card
+                                                                    :index target-position
+                                                                    :display-origin true}
                                                          :install-state :rezzed-no-cost})))
                                        :cancel-effect
                                        (effect (system-msg
@@ -648,12 +645,10 @@
                                    (not (operation? %))
                                    (or (in-hand? %)
                                        (in-discard? %)))}
-             :msg (msg (corp-install-msg target)
-                       (when (zero? n)
-                         ", creating a new remote server")
-                       ", ignoring all install costs")
              :async true
-             :effect (req (wait-for (corp-install state side target server-name {:ignore-all-cost true})
+             :effect (req (wait-for (corp-install state side target server-name {:ignore-all-cost true
+                                                                                 :msg-keys {:install-source card
+                                                                                            :display-origin true}})
                                     (continue-ability state side
                                                       (when (< n 2)
                                                         (install-ability (last (get-remote-names state)) (inc n)))
@@ -755,6 +750,8 @@
                     :async true
                     :effect (req (corp-install state side eid target nil
                                                {:install-state :rezzed
+                                                :msg-keys {:install-source card
+                                                           :display-origin true}
                                                 :combined-credit-discount 5}))}
         score-abi {:interactive (req true)
                    :optional
@@ -771,14 +768,14 @@
                                                        (sort-by :title)
                                                        (seq))
                                                   ["Done"]))
-                                  :msg (msg (if (= target "Done")
-                                              "shuffle R&D"
-                                              (str "install and rez " (:title target) " from R&D, ignoring all costs")))
                                   :effect (req (shuffle! state side :deck)
                                                (if (= "Done" target)
-                                                 (effect-completed state side eid)
+                                                 (do (system-msg state side (str "uses " (:title card) " to shuffle R&D"))
+                                                     (effect-completed state side eid))
                                                  (corp-install state side eid target nil
                                                                {:install-state :rezzed-no-cost
+                                                                :msg-keys {:install-source card
+                                                                           :display-origin true}
                                                                 :ignore-all-cost true})))}
                                  card nil))}}}]
     {:on-score score-abi
@@ -1045,10 +1042,10 @@
               :choices {:card #(and (corp-installable-type? %)
                                     (in-discard? %)
                                     (not (faceup? %)))}
-              :effect (effect (corp-install eid target nil nil))
+              :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                       :display-origin true}}))
               :cancel-effect (effect (system-msg (str "declines to use " (:title card)))
-                                     (effect-completed eid))
-              :msg (msg (corp-install-msg target))}})
+                                     (effect-completed eid))}})
 
 (defcard "Hyperloop Extension"
   (let [he {:msg "gain 3 [Credits]"
@@ -1179,7 +1176,9 @@
                                     (or (in-hand? %) (in-discard? %)))}
               :msg (msg "install and rez " (:title target) ", ignoring all costs")
               :async true
-              :effect (effect (corp-install eid target nil {:install-state :rezzed-no-cost}))}})
+              :effect (effect (corp-install eid target nil {:install-state :rezzed-no-cost
+                                                            :msg-keys {:install-source card
+                                                                       :display-origin true}}))}})
 
 (defcard "Lightning Laboratory"
   ;; TODO - I feel this card is OVERLY verbose
@@ -1382,8 +1381,9 @@
                             :async true
                             :effect (effect (corp-install
                                               eid target "New remote"
-                                              (when (<= 5 (get-counters (get-card state card) :advancement))
-                                                {:install-state :rezzed-no-cost})))}}}]})
+                                              {:install-state (when (<= 5 (get-counters (get-card state card) :advancement)) :rezzed-no-cost)
+                                               :msg-keys {:install-source card
+                                                          :display-origin true}}))}}}]})
 
 (defcard "NEXT Wave 2"
   {:on-score
@@ -1826,7 +1826,9 @@
                                                      (corp-install-list state chosen-ice))
                                     :effect (effect (shuffle! :deck)
                                                     (corp-install eid chosen-ice target
-                                                                  {:install-state :rezzed-no-rez-cost}))})
+                                                                  {:install-state :rezzed-no-rez-cost
+                                                                   :msg-keys {:install-source card
+                                                                              :display-origin true}}))})
                                  card nil))}
                     {:prompt "You have no ice in R&D"
                      :choices ["Carry on!"]
@@ -2127,7 +2129,9 @@
                                    (not (operation? %))
                                    (in-hand? %))}
              :effect (req (wait-for
-                            (corp-install state side target nil {:ignore-all-cost true})
+                            (corp-install state side target nil {:ignore-all-cost true
+                                                                 :msg-keys {:install-source card
+                                                                            :display-origin true}})
                             (continue-ability state side (when (< n max-ops) (sft (inc n) max-ops)) card nil)))})]
     {:on-score {:async true
                 :msg "install cards from HQ, ignoring all costs"
@@ -2191,8 +2195,8 @@
                 :choices {:card #(and (ice? %)
                                       (or (in-hand? %)
                                           (in-discard? %)))}
-                :msg (msg (corp-install-msg target))
                 :async true
+                :msg "install an ice from HQ or Archives"
                 :effect (effect
                           (continue-ability
                             (let [chosen-ice target]
@@ -2209,7 +2213,9 @@
                                               :async true
                                               :effect (req (let [target (Integer/parseInt target)]
                                                              (corp-install state side eid chosen-ice chosen-server
-                                                                           {:ignore-all-cost true :index target})))})
+                                                                           {:ignore-all-cost true :index target
+                                                                            :msg-keys {:install-source card
+                                                                                       :display-origin true}})))})
                                            card nil))})
                             card nil))}]})
 

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -2732,8 +2732,9 @@
                                    (corp? %)
                                    (or (in-hand? %)
                                        (in-discard? %)))}
-             :msg (msg (corp-install-msg target))
-             :effect (effect (corp-install eid target nil {:ignore-install-cost true}))}]})
+             :effect (effect (corp-install eid target nil {:ignore-install-cost true
+                                                           :msg-keys {:install-source card
+                                                                      :display-origin true}}))}]})
 
 (defcard "Tech Startup"
   {:derezzed-events [corp-rez-toast]

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -133,9 +133,9 @@
                                       (not (agenda? %))
                                       (in-hand? %)
                                       (corp? %))}
-                :msg (msg (corp-install-msg target))
                 :cost [(->c :trash-can)]
-                :effect (effect (corp-install eid target nil nil))}]})
+                :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                         :display-origin true}}))}]})
 
 (defcard "Aggressive Secretary"
   (advance-ambush 2 {:req (req (pos? (get-counters (get-card state card) :advancement)))
@@ -388,8 +388,8 @@
                                       (corp? %))}
                 :cost [(->c :trash-can)]
                 :async true
-                :effect (effect (corp-install eid target nil nil))
-                :msg (msg (corp-install-msg target))}]})
+                :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                         :display-origin true}}))}]})
 
 (defcard "Blacklist"
   {:on-rez {:effect (effect (lock-zone (:cid card) :runner :discard))}
@@ -1430,8 +1430,8 @@
                                             :prompt "Choose 1 card to install"
                                             :choices {:card #(and (corp-installable-type? %)
                                                                   (in-hand? %))}
-                                            :msg (msg (corp-install-msg target))
-                                            :effect (effect (corp-install eid target nil nil))}
+                                            :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                                                     :display-origin true}}))}
                                            card nil)))}]}))
 
 (defcard "Jeeves Model Bioroids"
@@ -1807,7 +1807,9 @@
                                (shuffle! state side :deck)
                                (if (operation? target)
                                  (play-instant state side eid target nil)
-                                 (corp-install state side eid target nil nil))))}]})
+                                 (corp-install state side eid target nil {:msg-keys {:install-source card
+                                                                                     :known true
+                                                                                     :display-origin true}}))))}]})
 
 (defcard "Mumbad Construction Co."
   {:derezzed-events [corp-rez-toast]
@@ -2101,7 +2103,10 @@
                                              (wait-for
                                                (corp-install
                                                  state side agenda nil
-                                                 {:install-state (:install-state (card-def agenda) :unrezzed)})
+                                                 {:install-state (:install-state (card-def agenda) :unrezzed)
+                                                  :msg-keys {:install-source card
+                                                             :known true
+                                                             :display-origin true}})
                                                (remove-from-currently-drawing state side agenda)
                                                (continue-ability state side (pdhelper (next agendas)) card nil))))}
                 :no-ability {:async true
@@ -2750,7 +2755,9 @@
                                (wait-for
                                  (reveal state side target)
                                  (shuffle! state side :deck)
-                                 (corp-install state side eid target nil nil))))}]})
+                                 (corp-install state side eid target nil {:msg-keys {:install-source card
+                                                                                     :known true
+                                                                                     :display-origin true}}))))}]})
 
 (defcard "TechnoCo"
   (letfn [(is-techno-target [card]
@@ -2824,8 +2831,9 @@
              :choices {:card #(and (corp-installable-type? %)
                                    (or (in-hand? %)
                                        (in-discard? %)))}
-             :msg (msg (corp-install-msg target))
-             :effect (effect (corp-install eid target nil {:ignore-install-cost true}))}]})
+             :effect (effect (corp-install eid target nil {:ignore-install-cost true
+                                                           :msg-keys {:install-source card
+                                                                      :display-origin true}}))}]})
 
 (defcard "The Root"
   {:recurring 3
@@ -2933,7 +2941,6 @@
               :choices {:card #(and (corp? %)
                                     (in-hand? %)
                                     (not (operation? %)))}
-              :msg (msg (corp-install-msg target))
               :effect
               (effect
                 (continue-ability
@@ -2942,7 +2949,9 @@
                      :prompt "Choose a server"
                      :choices (req (remove (set (zone->name (get-zone card)))
                                            (installable-servers state card-to-install)))
-                     :effect (effect (corp-install eid card-to-install target {:ignore-all-cost true}))})
+                     :effect (effect (corp-install eid card-to-install target {:ignore-all-cost true
+                                                                               :msg-keys {:install-source card
+                                                                                          :display-origin true}}))})
                   card nil))}
    :abilities [{:label "Install 1 card"
                 :async true
@@ -2952,7 +2961,9 @@
                                       (in-hand? %)
                                       (not (operation? %)))}
                 :msg (msg (corp-install-msg target))
-                :effect (effect (corp-install eid target nil {:ignore-all-cost true}))}]})
+                :effect (effect (corp-install eid target nil {:ignore-all-cost true
+                                                              :msg-keys {:install-source card
+                                                                         :display-origin true}}))}]})
 
 (defcard "Vera Ivanovna Shuyskaya"
   (let [select-and-trash {:async true
@@ -3075,9 +3086,9 @@
                  :async true
                  :choices {:card #(and (corp-installable-type? %)
                                        (in-hand? %))}
-                 :msg (msg (corp-install-msg target))
                  :effect
-                 (req (wait-for (corp-install state side (make-eid state eid) target nil nil)
+                 (req (wait-for (corp-install state side (make-eid state eid) target nil {:msg-keys {:install-source card
+                                                                                                     :display-origin true}})
                                 (let [installed-card async-result]
                                   (register-turn-flag!
                                     state side

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -387,9 +387,9 @@
     :choices {:card #(and (corp-installable-type? %)
                           (or (in-hand? %)
                               (in-discard? %)))}
-    :msg (msg (corp-install-msg target))
     :async true
-    :effect (effect (corp-install eid target nil args))}))
+    :effect (effect (corp-install eid target nil (assoc args :msg-keys {:install-source card
+                                                                        :display-origin true})))}))
 
 (def cannot-steal-or-trash-sub
   {:label "The Runner cannot steal or trash Corp cards for the remainder of this run"
@@ -628,8 +628,8 @@
                                               :waiting-prompt true
                                               :choices (req (remove #(= this %) (corp-install-list state nice)))
                                               :async true
-                                              :msg (msg (corp-install-msg nice))
-                                              :effect (effect (corp-install eid nice target nil))}
+                                              :effect (effect (corp-install eid nice target {:msg-keys {:install-source card
+                                                                                                        :display-origin true}}))}
                                              card nil)))}})
 
 (defcard "Anemone"
@@ -802,7 +802,10 @@
                             {:prompt "Choose a card to install"
                              :choices (cancellable (filter corp-installable-type? (take 5 (:deck corp))))
                              :async true
-                             :effect (effect (corp-install eid target nil {:ignore-all-cost true}))
+                             :effect (effect (corp-install eid target nil {:ignore-all-cost true
+                                                                           :msg-keys {:install-source card
+                                                                                      :index (first (positions #{target} (take 5 (:deck corp))))
+                                                                                      :display-origin true}}))
                              :cancel-effect (effect (system-msg "does not install any of the top 5 cards")
                                                     (effect-completed eid))}
                             card nil))}
@@ -983,7 +986,9 @@
                                       {:prompt (str "Choose a location to install " (:title target))
                                        :choices (req (remove #(= this %) (corp-install-list state nice)))
                                        :async true
-                                       :effect (effect (corp-install eid nice target {:ignore-all-cost true}))}
+                                       :effect (effect (corp-install eid nice target {:ignore-all-cost true
+                                                                                      :msg-keys {:install-source card
+                                                                                                 :display-origin true}}))}
                                       card nil)))}
     {:label "Install a piece of ice from HQ in the next innermost position, protecting this server, ignoring all costs"
      :prompt "Choose a piece of ice to install from HQ in this server"
@@ -993,6 +998,8 @@
      :effect (req (corp-install state side eid
                                 target (zone->name (target-server run))
                                 {:ignore-all-cost true
+                                 :msg-keys {:install-source card
+                                            :display-origin true}
                                  :index (max (dec run-position) 0)}))}]})
 
 (defcard "Bloop"
@@ -1057,10 +1064,11 @@
                   :choices {:card #(and (ice? %)
                                         (or (in-hand? %)
                                             (in-discard? %)))}
-                  :msg (msg (corp-install-msg target))
                   :effect (req (wait-for (corp-install state :corp target
                                                        (zone->name (second (get-zone card)))
                                                        {:ignore-install-cost true
+                                                        :msg-keys {:install-source card
+                                                                   :display-origin true}
                                                         :index (:index card)})
                                          (effect-completed state side eid)))
                   :cancel-effect (effect (system-msg :corp (str "declines to use " (:title card) " to install a card"))
@@ -1319,8 +1327,8 @@
                   :async true
                   :choices {:card #(and (corp-installable-type? %)
                                         (in-discard? %))}
-                  :msg (msg (corp-install-msg target))
-                  :effect (effect (corp-install eid target nil nil))}]
+                  :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                           :display-origin true}}))}]
    :static-abilities [(ice-strength-bonus (req (protecting-archives? card)) 3)]})
 
 (defcard "Curtain Wall"
@@ -2254,6 +2262,8 @@
      :effect (req (wait-for (corp-install state side (make-eid state eid)
                                           target (zone->name (target-server run))
                                           {:ignore-all-cost true
+                                           :msg-keys {:install-source card
+                                                      :display-origin true}
                                            :index (card-index state card)})
                             (let [new-ice async-result]
                               (register-events
@@ -3036,12 +3046,13 @@
                                                      (effect-completed state side eid)))))})]})
 
 (defcard "Minelayer"
-  {:subroutines [{:msg "install a piece of ice from HQ"
-                  :async true
+  {:subroutines [{:async true
                   :choices {:card #(and (ice? %)
                                         (in-hand? %))}
                   :prompt "Choose a piece of ice to install from HQ"
-                  :effect (effect (corp-install eid target (zone->name (target-server run)) {:ignore-all-cost true}))}]})
+                  :effect (effect (corp-install eid target (zone->name (target-server run)) {:ignore-all-cost true
+                                                                                             :msg-keys {:install-source card
+                                                                                                        :display-origin true}}))}]})
 
 (defcard "Mirāju"
   {:events [{:event :end-of-encounter
@@ -3219,8 +3230,8 @@
              :choices {:card #(and (corp-installable-type? %)
                                    (in-hand? %))}
              :async true
-             :effect (effect (corp-install eid target nil nil))
-             :msg (msg (corp-install-msg target))}]
+             :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                      :display-origin true}}))}]
     (next-ice-variable-subs sub)))
 
 (defcard "NEXT Sapphire"
@@ -4150,7 +4161,9 @@
                                                                      {:prompt (str "Choose a location to install " (:title target))
                                                                       :choices (req (remove #(= this %) (corp-install-list state nice)))
                                                                       :async true
-                                                                      :effect (effect (corp-install eid nice target {:ignore-install-cost true}))}
+                                                                      :effect (effect (corp-install eid nice target {:ignore-install-cost true
+                                                                                                                     :msg-keys {:install-source card
+                                                                                                                                :display-origin true}}))}
                                                                      card nil)))}
                                    card nil)))}
                  {:label "Give +2 strength to each piece of ice for the remainder of the run"

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1838,7 +1838,7 @@
                                   ((constantly false)
                                    (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
                                   true))))
-                          (corp-install state side eid chosen target {:counters {:advancement 1}
+                          (corp-install state side eid chosen target {:counters {:advance-counter 1}
                                                                       :msg-keys {:install-source card
                                                                                  :display-origin true}}))})]
     {:abilities [{:async true

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -1838,10 +1838,9 @@
                                   ((constantly false)
                                    (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
                                   true))))
-                          (wait-for (corp-install state side chosen target {:msg-keys {:install-source card
-                                                                                       :display-origin true}})
-                                    (add-prop state :corp (find-latest state chosen) :advance-counter 1 {:placed true})
-                                    (effect-completed state side eid)))})]
+                          (corp-install state side eid chosen target {:counters {:advancement 1}
+                                                                      :msg-keys {:install-source card
+                                                                                 :display-origin true}}))})]
     {:abilities [{:async true
                   :label "Install a card from HQ"
                   :cost [(->c :click 1) (->c :credit 1)]

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -152,11 +152,12 @@
                                                 state side
                                                 {:prompt "Choose a remote server"
                                                  :waiting-prompt true
-                                                 :msg "install a card from HQ ignoring all costs"
                                                  :choices (req (conj (vec (filter #(not= original-server %)
                                                                                   (get-remote-names state))) "New remote"))
                                                  :async true
-                                                 :effect (effect (corp-install eid chosen-card target {:ignore-install-cost true}))}
+                                                 :effect (effect (corp-install eid chosen-card target {:ignore-install-cost true
+                                                                                                       :msg-keys {:install-source card
+                                                                                                                  :display-origin true}}))}
                                                 card nil)))}
                               card nil)))}]
    ;; This effect will be resolved when the ID is reenabled after Strike / Direct Access
@@ -377,7 +378,8 @@
                                                      (or (is-remote? z) (not (asset? %)))
                                                      (not (agenda? %)))}
                                :async true
-                               :effect (effect (corp-install eid target (zone->name z) nil))}
+                               :effect (effect (corp-install eid target (zone->name z) {:msg-keys {:install-source card
+                                                                                                   :display-origin true}}))}
                               card nil)))}]})
 
 (defcard "Ayla \"Bios\" Rahim: Simulant Specialist"
@@ -623,11 +625,9 @@
                                             :cancel-effect
                                             (effect (system-msg (str "declines to use " (get-title card) " to install a card from the top of R&D"))
                                                     (effect-completed eid))
-                                            :msg (msg "install the "
-                                                      (pprint/cl-format nil "~:R"
-                                                        (inc (first (keep-indexed #(when (same-card? target %2) %1) top))))
-                                                      " card from the top of R&D")
-                                            :effect (effect (corp-install eid target nil))}
+                                            :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                                                     :index (first (keep-indexed #(when (same-card? target %2) %1) top))
+                                                                                                     :display-origin true}}))}
                                            card nil))))}]}))
 
 (defcard "Esâ Afontov: Eco-Insurrectionist"
@@ -1356,7 +1356,7 @@
                                 :choices {:card #(and (ice? %)
                                                       (in-hand? %))}
                                 :async true
-                                :msg "install a piece of ice at the innermost position of this server. Runner is now approaching that piece of ice"
+                                :msg "install a piece of ice from HQ at the innermost position of this server. Runner is now approaching that piece of ice"
                                 :effect (req (wait-for (corp-install state side target (zone->name (target-server run))
                                                                      {:ignore-all-cost true
                                                                       :front true})
@@ -1514,7 +1514,8 @@
                              :choices {:card #(and (corp? %)
                                                    (ice? %)
                                                    (in-hand? %))}
-                             :effect (req (wait-for (corp-install state side target nil nil)
+                             :effect (req (wait-for (corp-install state side target nil {:msg-keys {:install-source card
+                                                                                                    :display-origin true}})
                                                     (continue-ability state side (when (< n 3) (nd (inc n))) card nil)))})]
     {:events [{:event :pre-first-turn
                :req (req (= side :corp))
@@ -1837,7 +1838,8 @@
                                   ((constantly false)
                                    (toast state :corp "Cannot score due to Saraswati Mnemonics: Endless Exploration." "warning"))
                                   true))))
-                          (wait-for (corp-install state side chosen target nil)
+                          (wait-for (corp-install state side chosen target {:msg-keys {:install-source card
+                                                                                       :display-origin true}})
                                     (add-prop state :corp (find-latest state chosen) :advance-counter 1 {:placed true})
                                     (effect-completed state side eid)))})]
     {:abilities [{:async true

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1494,7 +1494,7 @@
                                                (upgrade? %))
                                            (in-discard? %))}
                      :effect (req (corp-install state side (assoc eid :source card :source-type :corp-install)
-                                                target nil {:counters {:advancement 2}
+                                                target nil {:counters {:advance-counter 2}
                                                             :msg-keys {:install-source card
                                                                        :display-origin true}}))}]
     {:on-play
@@ -1707,7 +1707,7 @@
 
 (defcard "Mitosis"
   (letfn [(mitosis-ability [state side card eid target-cards]
-            (wait-for (corp-install state side (first target-cards) "New remote" {:counters {:advancement 2}
+            (wait-for (corp-install state side (first target-cards) "New remote" {:counters {:advance-counter 2}
                                                                                   :msg-keys {:install-source card
                                                                                              :display-origin true}})
                       (let [installed-card async-result]
@@ -1746,7 +1746,7 @@
                           (corp? %)
                           (in-hand? %))}
     :async true
-    :effect (req (wait-for (corp-install state side target "New remote" {:counters {:advancement 3}
+    :effect (req (wait-for (corp-install state side target "New remote" {:counters {:advance-counter 3}
                                                                          :msg-keys {:install-source card
                                                                                     :display-origin true}})
                            (let [installed-card async-result]

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -136,10 +136,10 @@
              :choices {:card #(and (corp-installable-type? %)
                                    (in-hand? %))}
              :async true
-             :msg (msg (corp-install-msg target))
              :cancel-effect (effect (system-msg (str "declines to use " (:title card) " to install a card from HQ"))
                                     (continue-ability lose-click-abi card nil))
-             :effect (req (wait-for (corp-install state side target nil nil)
+             :effect (req (wait-for (corp-install state side target nil {:msg-keys {:install-source card
+                                                                                    :display-origin true}})
                                     (continue-ability state side lose-click-abi card nil)))}}))
 
 (defcard "Ad Blitz"
@@ -152,7 +152,9 @@
                                      (has-subtype? % "Advertisement")
                                      (or (in-hand? %)
                                          (in-discard? %)))}
-               :effect (req (wait-for (corp-install state side target nil {:install-state :rezzed})
+               :effect (req (wait-for (corp-install state side target nil {:install-state :rezzed
+                                                                           :msg-keys {:install-source card
+                                                                                      :display-origin true}})
                                       (continue-ability state side (ab (inc n) total) card nil)))}))]
     {:on-play
      {:prompt "How many Advertisements do you want to install and rez?"
@@ -503,6 +505,8 @@
     :effect (req (wait-for
                    (reveal state side target)
                    (corp-install state side eid target nil {:ignore-all-cost true
+                                                            :msg-keys {:install-source card
+                                                                       :display-origin true}
                                                             :install-state :rezzed-no-cost})))}})
 
 (defcard "Business As Usual"
@@ -538,7 +542,9 @@
              :change-in-game-state (req (seq (:hand corp)))
              :async true
              :effect (req (wait-for
-                            (corp-install state side target nil {:install-state :face-up})
+                            (corp-install state side target nil {:install-state :face-up
+                                                                 :msg-keys {:install-source card
+                                                                            :display-origin true}})
                             (let [agenda async-result]
                               (system-msg state side (str "hosts " (:title card) " on " (:title agenda)))
                               (install-as-condition-counter state side eid card agenda))))}
@@ -755,7 +761,8 @@
                                                    {:prompt "Choose a server"
                                                     :choices (remove #{"HQ" "R&D" "Archives"} (corp-install-list state card-to-install))
                                                     :async true
-                                                    :effect (effect (corp-install eid card-to-install target nil))})
+                                                    :effect (effect (corp-install eid card-to-install target {:msg-keys {:install-source card
+                                                                                                                         :display-origin true}}))})
                                                  target nil)
                                                (end-effect state side eid card targets)))
                         :cancel-effect (effect (system-msg (str "declines to use " (:title card) " to install a card"))
@@ -963,7 +970,8 @@
                                                         (in-hand? %)
                                                         (seq (filter (fn [c] (= server c)) (corp-install-list state %))))}
                                   :effect (req (wait-for
-                                                 (corp-install state side target server nil)
+                                                 (corp-install state side target server {:msg-keys {:install-source card
+                                                                                                    :display-origin true}})
                                                  (let [server (remote->name (second (:zone async-result)))]
                                                    (if (< n ((get-x-fn) state side eid card targets))
                                                      (continue-ability state side (install-cards server (inc n)) card nil)
@@ -1081,12 +1089,11 @@
                                                    (not (operation? %))
                                                    (in-discard? %))}
                              :effect (req (wait-for
-                                            (corp-install state side target nil nil)
-                                            (do (system-msg state side (str "uses " (:title card) " to "
-                                                                            (corp-install-msg target)))
-                                                (if (< n 2)
-                                                  (continue-ability state side (fhp (inc n)) card nil)
-                                                  (effect-completed state side eid)))))})]
+                                            (corp-install state side target nil {:msg-keys {:install-source card
+                                                                                            :display-origin true}})
+                                            (if (< n 2)
+                                              (continue-ability state side (fhp (inc n)) card nil)
+                                              (effect-completed state side eid))))})]
     {:on-play
      {:async true
       :change-in-game-state (req (seq (:discard corp)))
@@ -1198,10 +1205,10 @@
                                                     (corp-installable-type? %)
                                                     (in-hand? %))}
                               :async true
-                              :msg (msg (corp-install-msg target))
                               :cancel-effect (effect (system-msg (str "declines to use " (:title card) " to install a card from HQ"))
                                                      (effect-completed eid))
-                              :effect (req (wait-for (corp-install state :corp (make-eid state eid) target nil nil)
+                              :effect (req (wait-for (corp-install state :corp (make-eid state eid) target nil {:msg-keys {:install-source card
+                                                                                                                           :display-origin true}})
                                                      (let [installed-card async-result]
                                                        (if (not (zero? (count-tags state)))
                                                          (continue-ability
@@ -1430,9 +1437,10 @@
                           (corp? %)
                           (or (in-hand? %)
                               (in-discard? %)))}
-    :msg (msg (corp-install-msg target))
     :async true
-    :effect (effect (corp-install eid target nil {:ignore-install-cost true}))}})
+    :effect (effect (corp-install eid target nil {:ignore-install-cost true
+                                                  :msg-keys {:install-source card
+                                                             :display-origin true}}))}})
 
 (defcard "Invasion of Privacy"
   (letfn [(iop [x]
@@ -1486,7 +1494,8 @@
                                                (upgrade? %))
                                            (in-discard? %))}
                      :effect (req (wait-for (corp-install state side (make-eid state {:source card :source-type :corp-install})
-                                                          target nil nil)
+                                                          target nil {:msg-keys {:install-source card
+                                                                                 :display-origin true}})
                                             (system-msg state side (str "uses " (:title card) " to place 2 advancements counters on the installed card"))
                                             (add-prop state side eid async-result :advance-counter 2 {:placed true})))}]
     {:on-play
@@ -1540,10 +1549,10 @@
                                                     (corp-installable-type? %)
                                                     (in-hand? %))}
                               :async true
-                              :msg (msg (corp-install-msg target))
                               :cancel-effect (effect (system-msg (str "declines to use " (:title card) " to install a card"))
                                                      (effect-completed eid))
-                              :effect (effect (corp-install eid target nil nil))}
+                              :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                                       :display-origin true}}))}
                              card nil)))}})
 
 (defcard "Liquidation"
@@ -1699,7 +1708,8 @@
 
 (defcard "Mitosis"
   (letfn [(mitosis-ability [state side card eid target-cards]
-            (wait-for (corp-install state side (first target-cards) "New remote" nil)
+            (wait-for (corp-install state side (first target-cards) "New remote" {:msg-keys {:install-source card
+                                                                                             :display-origin true}})
                       (let [installed-card async-result]
                         (add-prop state side installed-card :advance-counter 2 {:placed true})
                         (register-turn-flag!
@@ -1740,7 +1750,8 @@
                           (corp? %)
                           (in-hand? %))}
     :async true
-    :effect (req (wait-for (corp-install state side target "New remote" nil)
+    :effect (req (wait-for (corp-install state side target "New remote" {:msg-keys {:install-source card
+                                                                                    :display-origin true}})
                            (let [installed-card async-result]
                              (add-prop state side installed-card :advance-counter 3 {:placed true})
                              (register-persistent-flag!
@@ -1994,9 +2005,9 @@
                                                             card nil)
                                                           (continue-ability
                                                             state side
-                                                            {:msg (msg (corp-install-msg target-card))
-                                                             :async true
-                                                             :effect (effect (corp-install eid target-card nil nil))}
+                                                            {:async true
+                                                             :effect (effect (corp-install eid target-card nil {:msg-keys {:install-source card
+                                                                                                                           :display-origin true}}))}
                                                             card nil))))}
                                         card nil)
                                       (effect-completed state side eid))))}})
@@ -2090,7 +2101,9 @@
             {:prompt "Choose a remote server"
              :choices (req (conj (vec (get-remote-names state)) "New remote"))
              :async true
-             :effect (effect (corp-install eid (assoc chosen :advance-counter 3) target {:ignore-all-cost true}))})]
+             :effect (effect (corp-install eid (assoc chosen :advance-counter 3) target {:ignore-all-cost true
+                                                                                         :msg-keys {:install-source card
+                                                                                                    :display-origin true}}))})]
     {:on-play
      {:prompt "Choose a piece of ice in HQ to install"
       :change-in-game-state (req (seq (:hand corp)))
@@ -2143,7 +2156,9 @@
              :waiting-prompt true
              :choices (req (conj (vec (get-remote-names state)) "New remote"))
              :async true
-             :effect (effect (corp-install eid chosen target nil))})]
+             :effect (effect (corp-install eid chosen target {:msg-keys {:install-source card
+                                                                         :index (first (positions #{chosen} (take 5 (:deck corp))))
+                                                                         :display-origin true}}))})]
     {:on-play
      {:async true
       :change-in-game-state (req (seq (:deck corp)))
@@ -2166,7 +2181,6 @@
                   (cancellable (filter #(and (corp-installable-type? %)
                                              (some #{"New remote"} (installable-servers state %)))
                                        top-five))
-                  :msg "install a card from the top of the R&D in a remote server"
                   :effect (effect (continue-ability (install-card target) card nil))
                   :cancel-effect (effect (system-msg (str "declines to use " (get-title card) " to install a card from the top of R&D"))
                                          (effect-completed eid))}
@@ -2275,7 +2289,8 @@
                                     (corp-installable-type? %)
                                     (in-hand? %))}
               :async true
-              :effect (effect (corp-install eid target nil nil))}]
+              :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                       :display-origin true}}))}]
         can-install? (fn [hand]
                        (seq (remove #(or (agenda? %)
                                          (operation? %))
@@ -2324,7 +2339,9 @@
              :choices {:card #(and (corp? %)
                                    (not (operation? %))
                                    (in-hand? %))}
-             :effect (req (wait-for (corp-install state side target nil {:ignore-all-cost true})
+             :effect (req (wait-for (corp-install state side target nil {:ignore-all-cost true
+                                                                         :msg-keys {:install-source card
+                                                                                    :display-origin true}})
                                     (if (< n 2)
                                       (continue-ability state side (replant (inc n)) card nil)
                                       (effect-completed state side eid))))})]
@@ -2347,16 +2364,15 @@
                           (in-discard? %))}
     :async true
     :effect (req (wait-for
-                   (corp-install state side target nil {:install-state :rezzed})
-                   (let [seen (assoc target :seen true)]
-                     (system-msg state side (str "uses " (:title card) " to "
-                                                 (corp-install-msg seen)))
-                     (let [leftover (filter #(= (:title target) (:title %)) (-> @state :corp :discard))]
-                       (when (seq leftover)
-                         (doseq [c leftover]
-                           (move state side c :rfg))
-                         (system-msg state side (str "removes " (count leftover) " copies of " (:title target) " from the game"))))
-                     (effect-completed state side eid))))}})
+                   (corp-install state side target nil {:install-state :rezzed
+                                                        :msg-keys {:install-source card
+                                                                   :display-origin true}})
+                   (let [leftover (filter #(= (:title target) (:title %)) (-> @state :corp :discard))]
+                     (when (seq leftover)
+                       (doseq [c leftover]
+                         (move state side c :rfg))
+                       (system-msg state side (str "removes " (count leftover) " copies of " (:title target) " from the game"))))
+                   (effect-completed state side eid)))}})
 
 (defcard "Restoring Face"
   {:on-play
@@ -2591,7 +2607,9 @@
                              :effect (req (wait-for
                                             (reveal state side chosen-ice)
                                             (shuffle! state side :deck)
-                                            (corp-install state side eid chosen-ice target {:cost-bonus -3})))})
+                                            (corp-install state side eid chosen-ice target {:cost-bonus -3
+                                                                                            :msg-keys {:install-source card
+                                                                                                       :display-origin true}})))})
                           card nil))}
                      card nil)
                    (do (shuffle! state side :deck)
@@ -2634,7 +2652,8 @@
                :choices {:card #(and (corp? %)
                                      (not (operation? %))
                                      (in-hand? %))}
-               :effect (req (wait-for (corp-install state side target nil nil)
+               :effect (req (wait-for (corp-install state side target nil {:msg-keys {:install-source card
+                                                                                      :display-origin true}})
                                       (continue-ability state side (shelper (inc n)) card nil)))}))]
     {:on-play
      {:async true
@@ -3148,6 +3167,8 @@
                  :cancel-effect (effect (system-msg (str "declines to use " (:title card) " to install a card"))
                                         (effect-completed eid))
                  :effect (effect (corp-install eid target nil {:ignore-all-cost true
+                                                               :msg-keys {:install-source card
+                                                                          :display-origin true}
                                                                :install-state :rezzed-no-cost}))}]
     {:on-play {:req (req tagged)
                :msg (msg "trash " (:title target))
@@ -3176,11 +3197,11 @@
                         :choices {:card #(and (in-hand? %)
                                               (corp? %)
                                               (not (operation? %)))}
-                        :msg (msg (corp-install-msg target))
                         :cancel-effect (effect (system-msg (str "declines to use " (:title card) " to install a card"))
                                                (effect-completed eid))
                         :async true
-                        :effect (effect (corp-install eid target nil nil))}
+                        :effect (effect (corp-install eid target nil {:msg-keys {:install-source card
+                                                                                 :display-origin true}}))}
                        card nil))))}})
 
 (defcard "Under the Bus"

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1493,11 +1493,10 @@
                                                (asset? %)
                                                (upgrade? %))
                                            (in-discard? %))}
-                     :effect (req (wait-for (corp-install state side (make-eid state {:source card :source-type :corp-install})
-                                                          target nil {:msg-keys {:install-source card
-                                                                                 :display-origin true}})
-                                            (system-msg state side (str "uses " (:title card) " to place 2 advancements counters on the installed card"))
-                                            (add-prop state side eid async-result :advance-counter 2 {:placed true})))}]
+                     :effect (req (corp-install state side (assoc eid :source card :source-type :corp-install)
+                                                target nil {:counters {:advancement 2}
+                                                            :msg-keys {:install-source card
+                                                                       :display-origin true}}))}]
     {:on-play
      {:prompt "Choose any number of cards in HQ to trash"
       :rfg-instead-of-trashing true
@@ -1708,10 +1707,10 @@
 
 (defcard "Mitosis"
   (letfn [(mitosis-ability [state side card eid target-cards]
-            (wait-for (corp-install state side (first target-cards) "New remote" {:msg-keys {:install-source card
+            (wait-for (corp-install state side (first target-cards) "New remote" {:counters {:advancement 2}
+                                                                                  :msg-keys {:install-source card
                                                                                              :display-origin true}})
                       (let [installed-card async-result]
-                        (add-prop state side installed-card :advance-counter 2 {:placed true})
                         (register-turn-flag!
                           state side
                           card :can-rez
@@ -1736,9 +1735,6 @@
                             (corp? %)
                             (in-hand? %))
                 :max 2}
-      :msg (msg (if (= 2 (count targets))
-                  "install 2 cards from HQ in new remote servers, and place two advancements on each of them"
-                  "install a card from HQ in a new remote server, and place two advancements on it"))
       :async true
       :effect (req (mitosis-ability state side card eid targets))}}))
 
@@ -1750,10 +1746,10 @@
                           (corp? %)
                           (in-hand? %))}
     :async true
-    :effect (req (wait-for (corp-install state side target "New remote" {:msg-keys {:install-source card
+    :effect (req (wait-for (corp-install state side target "New remote" {:counters {:advancement 3}
+                                                                         :msg-keys {:install-source card
                                                                                     :display-origin true}})
                            (let [installed-card async-result]
-                             (add-prop state side installed-card :advance-counter 3 {:placed true})
                              (register-persistent-flag!
                                state side
                                installed-card :can-rez

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -171,7 +171,7 @@
          :async true
          :cancel-effect (req (effect-completed state side eid))
          :effect (req (corp-install state :corp eid target nil {:ignore-all-cost true
-                                                                :counters {:advancement 1}
+                                                                :counters {:advance-counter 1}
                                                                 :msg-keys {:install-source card
                                                                            :display-origin true}}))}]
     {:events [{:event :agenda-scored

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -170,13 +170,10 @@
                                (corp? %))}
          :async true
          :cancel-effect (req (effect-completed state side eid))
-         :effect (req (wait-for (corp-install state :corp target nil {:ignore-all-cost true :display-message false})
-                                (let [inst-target (find-latest state target)]
-                                  (add-prop state :corp inst-target :advance-counter 1 {:placed true})
-                                  (system-msg state :corp
-                                              (str "uses " (:title card) " to install and place a counter on "
-                                                   (card-str state inst-target) ", ignoring all costs"))
-                                  (effect-completed state side eid))))}]
+         :effect (req (corp-install state :corp eid target nil {:ignore-all-cost true
+                                                                :counters {:advancement 1}
+                                                                :msg-keys {:install-source card
+                                                                           :display-origin true}}))}]
     {:events [{:event :agenda-scored
                :req (req (= (:previous-zone (:card context)) (get-zone card)))
                :interactive (req (some corp-installable-type? (:hand corp)))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -206,7 +206,9 @@
                                       (in-hand? %))}
                 :msg "host a piece of Bioroid ice"
                 :async true
-                :effect (req (corp-install state side eid target card {:ignore-all-cost true}))}]
+                :effect (req (corp-install state side eid target card {:ignore-all-cost true
+                                                                       :msg-keys {:install-source card
+                                                                                  :display-origin true}}))}]
    :events [{:event :pass-all-ice
              :optional
              {:req (req (and this-server
@@ -919,7 +921,10 @@
                               (wait-for
                                 (reveal state side ice)
                                 (system-msg state side (str "reveals that they drew " (:title ice)))
-                                (wait-for (corp-install state side ice server {:cost-bonus -4})
+                                (wait-for (corp-install state side ice server {:cost-bonus -4
+                                                                               :msg-keys {:install-source card
+                                                                                          :known true
+                                                                                          :display-origin true}})
                                           (remove-from-currently-drawing state side ice)
                                           (continue-ability
                                             state side
@@ -1763,7 +1768,9 @@
                  :interactive (req true)
                  :choices (req (cancellable (filter ice? (:deck corp)) true))
                  :msg (msg "install and rez " (card-str state target) ", paying a total of 3 [Credits] less")
-                 :effect (req (wait-for (corp-install state side (make-eid state eid) target nil {:install-state :rezzed :combined-credit-discount 3})
+                 :effect (req (wait-for (corp-install state side (make-eid state eid) target nil {:install-state :rezzed :combined-credit-discount 3
+                                                                                                  :msg-keys {:install-source card
+                                                                                                             :display-origin true}})
                                         (shuffle! state :corp :deck)
                                         (system-msg state side (str "shuffles R&D"))
                                         (effect-completed state side eid)))

--- a/src/clj/game/core/installing.clj
+++ b/src/clj/game/core/installing.clj
@@ -109,9 +109,9 @@
   "Places counters on a card via installation"
   [state side eid target-card {:keys [counters] :as args}]
   ;; for now, only advancement counters are checked
-  (if-not (:advancement counters)
+  (if-not (:advance-counter counters)
     (effect-completed state side eid)
-    (add-prop state side eid target-card :advance-counter (:advancement counters) {:placed true})))
+    (add-prop state side eid target-card :advance-counter (:advance-counter counters) {:placed true})))
 
 (defn- corp-install-asset-agenda
   "Forces the corp to trash an existing asset or agenda if a second was just installed."
@@ -133,10 +133,10 @@
       :else (effect-completed state side eid))))
 
 (defn- format-counters-msg
-  [{:keys [advancement] :as counters}]
+  [{:keys [advance-counter] :as counters}]
   ;; TODO - rewrite this if/when we support more counter types through installs
-  (if advancement
-    (str ", and place " (quantify advancement "Advancement counter") " on it")
+  (if advance-counter
+    (str ", and place " (quantify advance-counter "Advancement counter") " on it")
     ""))
 
 (defn- corp-install-message

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -1250,21 +1250,21 @@
     (take-credits state :corp)
     (run-on state :hq)
     (let [bran (get-ice state :hq 0)
-          unrezzed-msg "Corp uses Brân 1.0 to install an unseen card from Archives."
-          rezzed-msg "Corp uses Brân 1.0 to install Ice Wall from Archives."
+          unrezzed-msg "pays 0 [Credits] to use Brân 1.0 to install ice from Archives protecting HQ"
+          rezzed-msg "pays 0 [Credits] to use Brân 1.0 to install Ice Wall from Archives protecting HQ"
           declined-msg "Corp declines to use Brân 1.0 to install a card."]
       (rez state :corp bran)
       (run-continue state)
       (card-subroutine state :corp bran 0)
       (click-card state :corp "Mausolus")
-      (is (second-last-log-contains? state unrezzed-msg) "Mausolus is face down and should not be revealed in the log")
+      (is (last-log-contains? state unrezzed-msg) "Mausolus is face down and should not be revealed in the log")
       (card-subroutine state :corp bran 1)
       (run-empty-server state :archives)
       (run-on state :hq)
       (run-continue state)
       (card-subroutine state :corp bran 0)
       (click-card state :corp "Ice Wall")
-      (is (second-last-log-contains? state rezzed-msg) "Ice Wall is face up and should be revealed in the log")
+      (is (last-log-contains? state rezzed-msg) "Ice Wall is face up and should be revealed in the log")
       (card-subroutine state :corp bran 1)
       (run-on state :hq)
       (run-continue state)

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -3627,7 +3627,7 @@
       (click-card state :corp (find-card "Project Vitruvius" (:discard (get-corp))))
       (click-prompt state :corp "New remote")
       (is (not(:seen (get-content state :remote1 0))) "Agenda is facedown")
-      (is (last-log-contains? state "Corp uses Restore to install Project Vitruvius from Archives.") "Should write correct log")))
+      (is (last-n-log-contains? state 1 "uses Restore to install Project ") "Should write correct log")))
 
 (deftest restore-show-removed-count-in-log-when-installed
     ;; Show removed count in log when installed


### PR DESCRIPTION
Teamspo is the test case here.

I'm going to run through all the corp installs in the game and clarify this wherever it seems appropriate.

We can do the following:
* Say the source of the card (archives, hq, etc)
* Say the source of the install ("uses team sponsorship to ...")
* Where relevant (ie Architect deployment test), say the index the card came from
* When the card is known, say the name of the card (ie when the corp is instructed to rez the card, or it's a faceup card in archives, or we pass a key in because the card has already been revealed)

Previous case would be:
`nealpro uses Team Sponsorship to install an unseen card from Archives.`
`nealpro installs a card in Server 3 (new remote).`
Closes #3542

A few example cases:
  * Mumbad City Hall ![mch](https://github.com/user-attachments/assets/5df7b45a-f45f-4758-b67a-1906ec250509)
  * Team Sponsorship ![teamspo-cleanup](https://github.com/user-attachments/assets/c30f74f4-3f26-4b88-9630-041a5f67d549)
  * Epiphany Analytica ![epiphany_000](https://github.com/user-attachments/assets/00b1d97f-b076-44c2-9854-a36dbef98b8c)
  * ADT ![adt](https://github.com/user-attachments/assets/239e1b95-63c3-43bf-a919-9dd7ffb81a35)
  * Psychokinesis ![psycho](https://github.com/user-attachments/assets/a5e42b55-2e1b-45ce-9aa3-5d6631f18fbc)

While I was at it, I also made it so we could condense abilities which install a card and place an advancement counter on it - so these now are easier to program, and also have messages which are actually useful.

A few example cases:

![mushin](https://github.com/user-attachments/assets/582bfafb-c9ee-4100-8e25-5f62ed129db6)
![mitosis](https://github.com/user-attachments/assets/7b97d9a9-3f30-4efb-9ab5-4f822591d426)
![kakurenbo](https://github.com/user-attachments/assets/7df42282-0294-4d51-a536-4791c6967426)

Closes #7545

Closes #7549