### PR TITLE
enforced players playing their own abilities (in the backend)

### DIFF
--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -27,7 +27,7 @@
     [game.core.toasts :refer [toast]]
     [game.core.update :refer [update!]]
     [game.macros :refer [continue-ability req wait-for]]
-    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards]]))
+    [game.utils :refer [dissoc-in quantify remove-once same-card? same-side? server-cards to-keyword]]))
 
 (defn- update-click-state
   "Update :click-states to hold latest 4 moments before performing actions."
@@ -61,6 +61,7 @@
          args (assoc args :card card)
          ability (nth (:abilities card) ability-idx)
          cannot-play (or (:disabled card)
+                         (not= side (to-keyword (:side card)))
                          (any-effects state side :prevent-paid-ability true? card [ability ability-idx]))]
      (when-not cannot-play
        (do-play-ability state side eid (assoc args :ability-idx ability-idx :ability ability))))))

--- a/test/clj/game/cards/assets_test.clj
+++ b/test/clj/game/cards/assets_test.clj
@@ -6331,8 +6331,8 @@
     (play-from-hand state :corp "15 Minutes" "New remote")
     (rez state :corp (get-content state :remote1 0))
     ;; Toggle autoresolve
-    (card-ability state :runner (get-content state :remote1 0) 0)
-    (click-prompt state :runner "Always")
+    (card-ability state :corp (get-content state :remote1 0) 0)
+    (click-prompt state :corp "Always")
     (play-and-score state "15 Minutes")
     (is (last-log-contains? state "Sure Gamble, Hippo, and Endurance") "Revealed Runner grip")
     (is (changed? [(count (:hand (get-runner))) -1]

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -2786,6 +2786,28 @@
       (is (= 4 (core/available-mu state)) "0 MU used")
       (is (= 6 (get-strength adpt)) "Adept at 6 strength hosted"))))
 
+(deftest dhegdheer-corp-cant-use-the-card
+  (do-game
+    (new-game {:runner {:hand ["Dhegdheer" (qty "Fermenter" 2)]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Dhegdheer")
+    (play-from-hand state :runner "Fermenter")
+    (click-prompt state :runner "Dhegdheer")
+    (play-from-hand state :runner "Fermenter")
+    (click-prompt state :runner "The Rig")
+    (take-credits state :runner)
+    (is (changed? [(:credit (get-corp)) 0 (:credit (get-runner)) 0]
+                  (card-ability state :corp (get-program state 1) 0))
+        "Fermenter on the table cannot be used by the corp")
+    (is (changed?
+          [(:credit (get-corp)) 0 (:credit (get-runner)) 0]
+          (let [ferm (first (:hosted (get-program state 0)))]
+            (is (empty? (:corp-abilities ferm)) "No corp abilities")
+            (is (empty? (filter :corp (map :side (:abilities ferm)))) "No corp side abilities")
+            (card-ability state :corp ferm 0)
+            (is (= ferm (first (:hosted (get-program state 0)))) "Fermenter went nowhere")))
+        "Fermenter hosted on dhegdheer cannot be used by the corp")))
+
 (deftest disrupter
   ;; Disrupter
   (do-game


### PR DESCRIPTION
So at some point (I don't know when), we changed the front end to not send through commands of you clicking on your opponents cards.

Turns out, after writing a unit test, that we never actually fixed it on the backend though :joy:.

There was even an invalid test (vera) where the runner set the corp's own autoresolve on their card.

Closes #3820
