### PR TITLE
make unbeatable and beat-trace buttons

### DIFF
--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -200,6 +200,8 @@
    :base
    :bonus
    :strength
+   :unbeatable
+   :beat-trace
    :link
    :corp-credits
    :runner-credits])

--- a/src/clj/game/core/prompts.clj
+++ b/src/clj/game/core/prompts.clj
@@ -75,7 +75,7 @@
   "Specific function for displaying a trace prompt. Works like `show-prompt` with some extensions.
    Always uses `:credit` as the `choices` variable, and passes on some extra properties, such as base and bonus."
   ([state side card message f args] (show-trace-prompt state side (make-eid state) card message f args))
-  ([state side eid card message f {:keys [corp-credits runner-credits player other base bonus strength link targets]}]
+  ([state side eid card message f {:keys [corp-credits runner-credits player other base bonus strength link targets unbeatable beat-trace]}]
    (let [prompt (if (string? message) message (message state side eid card targets))
          corp-credits (corp-credits eid)
          runner-credits (runner-credits eid)
@@ -92,6 +92,8 @@
                   :base base
                   :bonus bonus
                   :strength strength
+                  :unbeatable unbeatable
+                  :beat-trace beat-trace
                   :link link}]
      (add-to-prompt-queue state side newitem))))
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1527,51 +1527,50 @@
 
 (defn trace-div
   [{:keys [base strength player link bonus choices corp-credits runner-credits unbeatable beat-trace] :as prompt-state}]
-  [:div
-   (when base
-     ;; This is the initial trace prompt
-     (if (nil? strength)
-       (if (= "corp" player)
-         ;; This is a trace prompt for the corp, show runner link + credits
-         [:div.info (tr [:side.runner "Runner"]) ": " link [:span {:class "anr-icon link"}]
-          " + " runner-credits [:span {:class "anr-icon credit"}]]
-         ;; Trace in which the runner pays first, showing base trace strength and corp credits
-         [:div.info (tr [:game.trace "Trace"]) ": " (if bonus (+ base bonus) base)
-          " + " corp-credits [:span {:class "anr-icon credit"}]])
-       ;; This is a trace prompt for the responder to the trace, show strength
-       (if (= "corp" player)
-         [:div.info "vs Trace: " strength]
-         [:div.info "vs Runner: " strength [:span {:class "anr-icon link"}]])))
-   [:div.credit-select
-    ;; Inform user of base trace / link and any bonuses
-    (when base
-      (if (nil? strength)
-        (if (= "corp" player)
-          (let [strength (if bonus (+ base bonus) base)]
-            [:span (str strength " + ")])
-          [:span link " " [:span {:class "anr-icon link"}] (str " + " )])
-        (if (= "corp" player)
-          [:span link " " [:span {:class "anr-icon link"}] (str " + " )]
-          (let [strength (if bonus (+ base bonus) base)]
-            [:span (str strength " + ")]))))
-    [:select#credit {:value (or (get-in @app-state [:select :credits]) 0)
-                     :on-change #(swap! app-state assoc-in [:select :credits] (.. % -target -value))
-                     :onKeyUp #(when (= "Enter" (.-key %))
-                                 (-> "#trace-submit" js/$ .click)
-                                 (.stopPropagation %))}
-     (doall (for [i (range (inc choices))]
-              [:option {:value i :key i} i]))] (str " " (tr [:game.credits "credits"]))]
-   (when (or unbeatable beat-trace)
-     (let [beat-str (if unbeatable
-                      (tr [:game.unbeatable "Make Unbeatable"])
-                      (tr [:game.beat-trace "Beat Trace"]))]
-       [:button#trace-unbeatable
-        {:on-click
-         #(swap! app-state assoc-in [:select :credits] (or unbeatable beat-trace))}
-        [:div (str beat-str " (" (or unbeatable beat-trace)) [:span {:class "anr-icon credit"}] ")"]]))
-   [:button#trace-submit {:on-click #(do (send-command "choice" {:choice (-> "#credit" js/$ .val str->int)})
-                                         (swap! app-state assoc-in [:select :credits] 0))}
-    (tr [:game.ok "OK"])]])
+  (r/with-let [!value (r/atom 0)]
+    [:div
+     (when base
+       ;; This is the initial trace prompt
+       (if (nil? strength)
+         (if (= "corp" player)
+           ;; This is a trace prompt for the corp, show runner link + credits
+           [:div.info (tr [:side.runner "Runner"]) ": " link [:span {:class "anr-icon link"}]
+            " + " runner-credits [:span {:class "anr-icon credit"}]]
+           ;; Trace in which the runner pays first, showing base trace strength and corp credits
+           [:div.info (tr [:game.trace "Trace"]) ": " (if bonus (+ base bonus) base)
+            " + " corp-credits [:span {:class "anr-icon credit"}]])
+         ;; This is a trace prompt for the responder to the trace, show strength
+         (if (= "corp" player)
+           [:div.info "vs Trace: " strength]
+           [:div.info "vs Runner: " strength [:span {:class "anr-icon link"}]])))
+     [:div.credit-select
+      ;; Inform user of base trace / link and any bonuses
+      (when base
+        (if (nil? strength)
+          (if (= "corp" player)
+            (let [strength (if bonus (+ base bonus) base)]
+              [:span (str strength " + ")])
+            [:span link " " [:span {:class "anr-icon link"}] (str " + " )])
+          (if (= "corp" player)
+            [:span link " " [:span {:class "anr-icon link"}] (str " + " )]
+            (let [strength (if bonus (+ base bonus) base)]
+              [:span (str strength " + ")]))))
+      [:select#credit {:value @!value
+                       :on-change #(reset! !value (.. % -target -value))
+                       :onKeyUp #(when (= "Enter" (.-key %))
+                                   (-> "#trace-submit" js/$ .click)
+                                   (.stopPropagation %))}
+       (doall (for [i (range (inc choices))]
+                [:option {:value i :key i} i]))] (str " " (tr [:game.credits "credits"]))]
+     (when (or unbeatable beat-trace)
+       (let [beat-str (if unbeatable
+                        (tr [:game.unbeatable "Make Unbeatable"])
+                        (tr [:game.beat-trace "Beat Trace"]))]
+         [:button#trace-unbeatable
+          {:on-click #(reset! !value (or unbeatable beat-trace))}
+          [:div (str beat-str " (" (or unbeatable beat-trace)) [:span {:class "anr-icon credit"}] ")"]]))
+     [:button#trace-submit {:on-click #(send-command "choice" {:choice (-> "#credit" js/$ .val str->int)})}
+      (tr [:game.ok "OK"])]]))
 
 (defn prompt-div
   [me {:keys [card msg prompt-type choices] :as prompt-state}]


### PR DESCRIPTION
Adds these buttons into the trace prompt, where relevant:

![make-unbeatable](https://github.com/user-attachments/assets/3d77123f-32f0-47bf-9c19-40c0eafd3bfc)

![beat-trace](https://github.com/user-attachments/assets/78b6d08b-51b1-4bb2-b724-c0c2f41eac1c)

The buttons only show up if it's possible to guarantee a victory, and have a minimum value of 0 (will show up if zero is a winning bid still).

The button doesn't confirm, it just adjusts the interior selector (I figured this would be less jarring for new players).

I'm not going to lie, it took an embarrassing amount of time to figure out how to hook the select box up to be controllable. I'm not sure I chose the best key (or even atom) to use, so if you suggest something better I'll change it.

Closes #5602