### PR TITLE
Media blitz just works + scored keys in tests

### DIFF
--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -1638,17 +1638,13 @@
 (defcard "Media Blitz"
   {:on-play
    {:async true
-    :effect
-    (effect
-      (continue-ability
-        {:prompt "Choose an agenda in the runner's score area"
-         :choices {:card #(and (agenda? %)
-                               (is-scored? state :runner %))}
-         :change-in-game-state (req (seq (:scored runner)))
-         :effect (req (update! state side (assoc card :title (:title target) :abilities (ability-init (card-def target))))
-                      (card-init state side (get-card state card) {:resolve-effect false :init-data true})
-                      (update! state side (assoc (get-card state card) :title "Media Blitz")))}
-        card nil))}})
+    :prompt "Choose an agenda in the runner's score area"
+    :choices {:req (req (and (agenda? target)
+                             (is-scored? state :runner target)))}
+    :change-in-game-state (req (seq (:scored runner)))
+    :effect (req (update! state side (assoc card :title (:title target) :abilities (ability-init (card-def target))))
+                 (card-init state side (get-card state card) {:resolve-effect false :init-data true})
+                 (update! state side (assoc (get-card state card) :title "Media Blitz")))}})
 
 (defcard "Medical Research Fundraiser"
   {:on-play

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2711,6 +2711,21 @@
     (click-prompt state :runner "Steal")
     (is (last-log-contains? state "Media Blitz is trashed") "Media Blitz should be trashed")))
 
+(deftest media-blitz-isnt-so-cursed-after-all
+  (do-game
+    (new-game {:corp {:hand ["Media Blitz" "Bladderwort"]}
+               :runner {:scored ["Rebranding Team"]}})
+    (play-from-hand state :corp "Bladderwort" "New remote")
+    (let [bla (get-content state :remote1 0)]
+      (rez state :corp bla)
+      (is (not (has-subtype? (refresh bla) "Advertisement")) "Not an ad")
+      (play-from-hand state :corp "Media Blitz")
+      (click-prompt state :corp "Rebranding Team")
+      (is (has-subtype? (refresh bla) "Advertisement") "Gained advertisement")
+      (core/move state :corp (first (get-in @state [:corp :current])) :discard)
+      (is (not (has-subtype? (refresh bla) "Advertisement")) "Not an ad")
+      (is (= "Media Blitz" (first (:discard (get-corp))))))))
+
 (deftest medical-research-fundraiser
   ;; Medical Research Fundraiser - runner gains 8creds, runner gains 3creds
   (do-game

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -1535,27 +1535,17 @@
 (deftest exchange-of-information
   ;; Exchange of Information
   (do-game
-      (new-game {:corp {:deck ["Exchange of Information"
-                               "Market Research"
-                               "Breaking News"
-                               "Project Beale"
-                               "Explode-a-palooza"]}})
-      (score-agenda state :corp (find-card "Market Research" (:hand (get-corp))))
-      (score-agenda state :corp (find-card "Breaking News" (:hand (get-corp))))
-      (is (= 2 (count-tags state)) "Runner gained 2 tags")
-      (take-credits state :corp)
-      (is (zero? (count-tags state)) "Runner lost 2 tags")
-      (core/steal state :runner (make-eid state) (find-card "Project Beale" (:hand (get-corp))))
-      (core/steal state :runner (make-eid state) (find-card "Explode-a-palooza" (:hand (get-corp))))
-      (take-credits state :runner)
-      (is (= 4 (:agenda-point (get-runner))))
-      (is (= 3 (:agenda-point (get-corp))))
-      (gain-tags state :runner 1)
-      (play-from-hand state :corp "Exchange of Information")
-      (click-card state :corp (find-card "Project Beale" (:scored (get-runner))))
-      (click-card state :corp (find-card "Breaking News" (:scored (get-corp))))
-      (is (= 3 (:agenda-point (get-runner))))
-      (is (= 4 (:agenda-point (get-corp))))))
+    (new-game {:corp {:hand ["Exchange of Information"]
+                      :score-area ["Market Research" "Breaking News"]}
+               :runner {:score-area ["Project Beale" "Explode-a-palooza"]}})
+    (is (= 4 (:agenda-point (get-runner))))
+    (is (= 3 (:agenda-point (get-corp))))
+    (gain-tags state :runner 1)
+    (play-from-hand state :corp "Exchange of Information")
+    (click-card state :corp (find-card "Project Beale" (:scored (get-runner))))
+    (click-card state :corp (find-card "Breaking News" (:scored (get-corp))))
+    (is (= 3 (:agenda-point (get-runner))))
+    (is (= 4 (:agenda-point (get-corp))))))
 
 (deftest exchange-of-information-swapping-a-just-scored-breaking-news-keeps-the-tags
     ;; Swapping a just scored Breaking News keeps the tags
@@ -2717,7 +2707,7 @@
                       :discard ["NGO Front"]
                       :credits 10
                       :id "Spark Agency: Worldswide Reach"}
-               :runner {:scored ["Rebranding Team"]}})
+               :runner {:score-area ["Rebranding Team"]}})
     (play-from-hand state :corp "Bladderwort" "New remote")
     (let [bla (get-content state :remote1 0)]
       (rez state :corp bla)

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2723,17 +2723,19 @@
       (rez state :corp bla)
       (is (not (has-subtype? (refresh bla) "Advertisement")) "Not an ad")
       (play-from-hand state :corp "Media Blitz")
-      (click-prompt state :corp "Rebranding Team")
+      (click-card state :corp "Rebranding Team")
       (is (has-subtype? (refresh bla) "Advertisement") "Gained advertisement")
       (core/gain state :corp :click 10)
       (play-from-hand state :corp "Ad Blitz")
-      (is (changed? [(:credit get-runner) -1]
-                    (click-prompt state :corp "NGO Front")
+      (is (changed? [(:credit (get-runner)) -1]
+                    (click-prompt state :corp "1")
+                    (click-card state :corp "NGO Front")
                     (click-prompt state :corp "New remote"))
           "Runner lost 1 from first advertisement rez!")
       (core/move state :corp (first (get-in @state [:corp :current])) :discard)
+      (core/fake-checkpoint state)
       (is (not (has-subtype? (refresh bla) "Advertisement")) "Not an ad")
-      (is (= "Media Blitz" (first (:discard (get-corp))))))))
+      (is (= "Media Blitz" (second (:discard (get-corp))))))))
 
 (deftest medical-research-fundraiser
   ;; Medical Research Fundraiser - runner gains 8creds, runner gains 3creds

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2735,7 +2735,7 @@
       (core/move state :corp (first (get-in @state [:corp :current])) :discard)
       (core/fake-checkpoint state)
       (is (not (has-subtype? (refresh bla) "Advertisement")) "Not an ad")
-      (is (= "Media Blitz" (second (:discard (get-corp))))))))
+      (is (= "Media Blitz" (:title (second (:discard (get-corp)))))))))
 
 (deftest medical-research-fundraiser
   ;; Medical Research Fundraiser - runner gains 8creds, runner gains 3creds

--- a/test/clj/game/cards/operations_test.clj
+++ b/test/clj/game/cards/operations_test.clj
@@ -2713,7 +2713,10 @@
 
 (deftest media-blitz-isnt-so-cursed-after-all
   (do-game
-    (new-game {:corp {:hand ["Media Blitz" "Bladderwort"]}
+    (new-game {:corp {:hand ["Ad Blitz" "Media Blitz" "Bladderwort"]
+                      :discard ["NGO Front"]
+                      :credits 10
+                      :id "Spark Agency: Worldswide Reach"}
                :runner {:scored ["Rebranding Team"]}})
     (play-from-hand state :corp "Bladderwort" "New remote")
     (let [bla (get-content state :remote1 0)]
@@ -2722,6 +2725,12 @@
       (play-from-hand state :corp "Media Blitz")
       (click-prompt state :corp "Rebranding Team")
       (is (has-subtype? (refresh bla) "Advertisement") "Gained advertisement")
+      (core/gain state :corp :click 10)
+      (play-from-hand state :corp "Ad Blitz")
+      (is (changed? [(:credit get-runner) -1]
+                    (click-prompt state :corp "NGO Front")
+                    (click-prompt state :corp "New remote"))
+          "Runner lost 1 from first advertisement rez!")
       (core/move state :corp (first (get-in @state [:corp :current])) :discard)
       (is (not (has-subtype? (refresh bla) "Advertisement")) "Not an ad")
       (is (= "Media Blitz" (first (:discard (get-corp))))))))

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -182,7 +182,8 @@
           (core/card-init state :corp c {:resolve-effect false :init-data true})))
       (doseq [ctitle score-area-runner]
         (core/move state :runner (find-card ctitle (get-in @state [:corp :deck])) :scored {:force true}))
-      (core/move state :corp  (take hand-size (get-in @state [:corp :deck])) :hand))))
+      (doseq [c (take hand-size (get-in @state [:corp :deck]))]
+        (core/move state :corp c :hand)))))
 
 (defn ensure-no-prompts [state]
   (is' (no-prompt? state :corp) "Corp has prompts open")

--- a/test/clj/game/test_framework.clj
+++ b/test/clj/game/test_framework.clj
@@ -170,6 +170,20 @@
   (doseq [ctitle cards]
     (core/move state side (find-card ctitle (get-in @state [side :deck])) :hand)))
 
+(defn starting-scored
+  "Moves all cards that should be in the scored zones into their respective score areas"
+  [state scored-corp scored-runner]
+  (when (or (seq scored-corp) (seq scored-runner))
+    (let [hand-size (count (get-in @state [:corp :hand]))]
+      (doseq [c (get-in @state [:corp :hand])]
+        (core/move state :corp c :deck))
+      (doseq [ctitle scored-corp]
+        (core/move state :corp (find-card ctitle (get-in @state [:corp :deck])) :scored))
+      (doseq [ctitle scored-runner]
+        (core/move state :runner (find-card ctitle (get-in @state [:corp :deck])) :scored {:force true}))
+      ;;(dotimes [_ hand-size]
+        (core/move state :corp  (take hand-size (get-in @state [:corp :deck])) :hand))))
+
 (defn ensure-no-prompts [state]
   (is' (no-prompt? state :corp) "Corp has prompts open")
   (is' (no-prompt? state :runner) "Runner has prompts open"))
@@ -222,10 +236,14 @@
   [{:keys [corp runner options]}]
   {:corp {:deck (or (transform "Corp" (conj (:deck corp)
                                             (:hand corp)
+                                            (:scored runner)
+                                            (:scored corp)
                                             (:discard corp)))
                     (transform "Corp" (qty "Hedge Fund" 3)))
           :hand (when-let [hand (:hand corp)]
                   (flatten hand))
+          :scored (when-let [scored (:scored corp)]
+                    (flatten scored))
           :discard (when-let [discard (:discard corp)]
                      (flatten discard))
           :identity (when-let [id (or (:id corp) (:identity corp))]
@@ -238,6 +256,8 @@
                       (transform "Runner" (qty "Sure Gamble" 3)))
             :hand (when-let [hand (:hand runner)]
                     (flatten hand))
+            :scored (when-let [scored (:scored runner)]
+                    (flatten scored))
             :discard (when-let [discard (:discard runner)]
                        (flatten discard))
             :identity (when-let [id (or (:id runner) (:identity runner))]
@@ -275,6 +295,7 @@
          (click-prompt state :runner "Keep"))
        (when-not dont-start-turn (core/start-turn state :corp nil)))
      ;; Gotta move cards where they need to go
+     (starting-scored state (:scored corp) (:scored runner))
      (doseq [side [:corp :runner]]
        (let [side-map (if (= :corp side) corp runner)]
          (when-let [hand (:hand side-map)]


### PR DESCRIPTION
Media blitz was fixed in 98e5f3a, but I added a few new unit tests to close some old issues.

Closes #4933
Closes #5028

I also added a feature that I wanted ages ago and forgot about, which is setting `:scored` keys for the runner and corp in the test framework. I just think it makes a whole lot of tests easier and cleaner to implement.