### PR TITLE
Fix differ issues from json->edn conversion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,7 @@
                  [potemkin "0.4.5"]
                  [cond-plus "1.1.1"]
                  [org.clojure/data.csv "1.0.0"]
-                 [medley "1.3.0"]
+                 [dev.weavejester/medley "1.8.0"]
                  [org.slf4j/slf4j-nop "1.7.32"]
                  [integrant "0.8.0"]
                  [cljc.java-time "0.1.18"]

--- a/src/clj/game/core/diffs.clj
+++ b/src/clj/game/core/diffs.clj
@@ -204,13 +204,26 @@
 
 (defn prompt-summary
   [prompt same-side?]
-  (if same-side?
-    (not-empty (select-non-nil-keys prompt prompt-keys))
-    nil))
+  (when same-side?
+    (-> prompt
+        (update :card #(not-empty (select-non-nil-keys % card-keys)))
+        (update :choices (fn [choices]
+                           (if (sequential? choices)
+                             (->> choices
+                                  (mapv
+                                   (fn [choice]
+                                     (if (-> choice :value :cid)
+                                       (update choice :value select-non-nil-keys card-keys)
+                                       choice)))
+                                  (not-empty))
+                             choices)))
+        (select-non-nil-keys prompt-keys)
+        (not-empty))))
 
 (defn toast-summary
   [toast same-side?]
-  (if same-side? toast nil))
+  (when same-side?
+    toast))
 
 (def player-keys
   [:aid

--- a/src/cljs/nr/gameboard/actions.cljs
+++ b/src/cljs/nr/gameboard/actions.cljs
@@ -43,7 +43,7 @@
 
 (defn handle-diff! [{:keys [gameid diff]}]
   (when (= gameid (str (current-gameid app-state)))
-    (swap! game-state #(differ/patch @last-state diff))
+    (reset! game-state (differ/patch @last-state diff))
     (check-lock?)
     (reset! last-state @game-state)))
 

--- a/src/cljs/nr/gameboard/board.cljs
+++ b/src/cljs/nr/gameboard/board.cljs
@@ -1606,16 +1606,16 @@
 
        ;; otherwise choice of all present choices
        :else
-       (doall (for [{:keys [idx uuid value]} choices]
-                (when (not= value "Hide")
-                  [:button {:key idx
-                            :on-click #(do (send-command "choice" {:choice {:uuid uuid}})
-                                           (card-highlight-mouse-out % value button-channel))
-                            :on-mouse-over
-                            #(card-highlight-mouse-over % value button-channel)
-                            :on-mouse-out
-                            #(card-highlight-mouse-out % value button-channel)}
-                   (render-message (or (not-empty (get-title value)) value))]))))]))
+       (doall (for [{:keys [idx uuid value]} choices
+                    :when (not= value "Hide")]
+                [:button {:key idx
+                          :on-click #(do (send-command "choice" {:choice {:uuid uuid}})
+                                         (card-highlight-mouse-out % value button-channel))
+                          :on-mouse-over
+                          #(card-highlight-mouse-over % value button-channel)
+                          :on-mouse-out
+                          #(card-highlight-mouse-out % value button-channel)}
+                 (render-message (or (not-empty (get-title value)) value))])))]))
 
 (defn basic-actions [{:keys [side active-player end-turn runner-phase-12 corp-phase-12 me]}]
   [:div.panel.blue-shade


### PR DESCRIPTION
Closes #7424.

Would be handled by #7564 but that's a mess and would break all game histories, so that's on pause.

Differ handles [sequential types](https://github.com/robinheghan/differ?tab=readme-ov-file#sequential-types) in a special way, with `:+` meaning "insert at the end". Our reliance on json means that it was always being treated as `"+"` and thus differ would ignore it. I believe this has infected every portion of the entire frontend as long as we've used differ, but it's only surfaced here cuz we tend to ignore nils everywhere lol.

The result of this bug would be that the diff from the waiting prompt to the choices prompt would have `:choices ["+" {:value {:title "Overseer Matrix" ...} ...} "+" {:value {:title "Overseer Matrix" ...} ...} "+" {:value {:title "Overseer Matrix" ...} ...} "+" {:value {:title "Yakov Erikovich Avdakov" ...} ...}]`, and thus be rendered incorrectly because you can't destructure a string. With this fix, it'll now just be the correct values merged in to their right place.

Having written all of this out, I have also updated the `prompt-state` differ stuff to be smarter, borrowing code from #7564.