### PR TITLE
Enforce first-time where possible

### DIFF
--- a/src/clj/game/cards/agendas.clj
+++ b/src/clj/game/cards/agendas.clj
@@ -158,7 +158,6 @@
    [{:event :run
      :req (req (first-event? state side :run))
      :player :corp
-     :once :per-turn
      :async true
      :waiting-prompt true
      :prompt "Choose one"
@@ -619,7 +618,6 @@
                              :effect (effect (purge eid))}}}
    :events [{:event :purge
              :req (req (first-event? state :corp :purge))
-             :once :per-turn
              :msg "gain 4 [Credits]"
              :async true
              :effect (req (gain-credits state :corp eid 4))}]})
@@ -627,8 +625,9 @@
 (defcard "Dedicated Neural Net"
   {:events [{:event :successful-run
              :interactive (req true)
-             :psi {:req (req (= :hq (target-server context)))
-                   :once :per-turn
+             :psi {:req (req (= :hq (target-server context))
+                             (first-event? state side :successful-run
+                                           #(= :hq (target-server (first %)))))
                    :not-equal {:effect (effect (register-lingering-effect
                                                  card
                                                  {:type :corp-choose-hq-access

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1315,7 +1315,6 @@
                  (installed? (:card target))))]
     {:events [{:event :runner-trash
                :async true
-               :once :per-turn
                :once-per-instance false
                :req (req (and (valid-trash target)
                               (first-event? state side :runner-trash #(valid-trash (first %)))))
@@ -1332,8 +1331,8 @@
 
 (defcard "Hyoubu Research Facility"
   {:events [{:event :reveal-spent-credits
-             :req (req (some? (first targets)))
-             :once :per-turn
+             :req (req (and (some? (first targets))
+                            (first-event? state side :reveal-spent-credits)))
              :msg (msg "gain " target " [Credits]")
              :async true
              :effect (effect (gain-credits :corp eid target))}]})

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -710,7 +710,7 @@
      :events [{:event :encounter-ice
                :optional
                {:prompt "Install a program?"
-                :once :per-run
+                :req (req (first-run-event? state side :encounter-ice))
                 :yes-ability
                 {:async true
                  :prompt "Choose where to install the program from"
@@ -2032,7 +2032,6 @@
              :effect (effect (make-run eid target card))}
    :events [{:event :encounter-ice
              :req (req (first-run-event? state side :encounter-ice))
-             :once :per-run
              :msg (msg "bypass " (:title (:ice context)))
              :effect (req (bypass-ice state))}]})
 
@@ -2864,9 +2863,9 @@
 
 (defcard "Power to the People"
   {:events [{:event :access
-             :req (req (agenda? target))
+             :req (req (and (agenda? target)
+                            (first-event? state side :access #(agenda? (first %)))))
              :duration :end-of-turn
-             :once :per-turn
              :unregister-once-resolved true
              :msg "gain 7 [Credits]"
              :async true

--- a/src/clj/game/cards/hardware.clj
+++ b/src/clj/game/cards/hardware.clj
@@ -628,7 +628,6 @@
 (defcard "Daredevil"
   {:static-abilities [(mu+ 2)]
    :events [{:event :run
-             :once :per-turn
              :req (req (and (<= 2 (:position target))
                             (first-event? state side :run #(<= 2 (:position (first %))))))
              :msg "draw 2 cards"
@@ -1487,9 +1486,9 @@
 
 (defcard "Muresh Bodysuit"
   {:events [{:event :pre-damage
-             :once :per-turn
              :once-key :muresh-bodysuit
-             :req (req (= (:type context) :meat))
+             :req (req (and (= (:type context) :meat)
+                            (first-event? state side :pre-damage #(= :meat (:type (first %))))))
              :msg "prevent the first meat damage this turn"
              :effect (effect (damage-prevent :meat 1))}]})
 
@@ -1529,7 +1528,6 @@
   {:static-abilities [(mu+ 1)
                       (runner-hand-size+ (req (count-tags state)))]
    :events [{:event :run-ends
-             :once :per-turn
              :interactive (req true) ;;interact with other run-ends effects which modify the deck (ie boomerang)
              :req (req (and (:successful target)
                             (#{:rd :hq} (target-server target))
@@ -1917,7 +1915,7 @@
         event {:req (req (zero? (count (:hand runner))))
                :async true
                :effect (effect (continue-ability ability card targets))}]
-    {:implementation "Only watches trashes, playing events, and installing"
+    {:implementation "Only watches trashes, playing events, and installing. Doesn't know about your hand size pre-install."
      :on-install {:async true
                   :msg "suffer 1 meat damage"
                   :effect (effect (damage eid :meat 1 {:unboostable true
@@ -2163,7 +2161,6 @@
                             (first-event? state side :runner-trash
                                           (fn [targets]
                                             (some #(corp? (:card %)) targets)))))
-             :once :per-turn
              :msg "place 1 power counter on itself"
              :effect (effect (add-counter :runner card :power 1)
                              (effect-completed eid))}]})

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -20,8 +20,8 @@
    [game.core.effects :refer [register-lingering-effect is-disabled?]]
    [game.core.eid :refer [effect-completed get-ability-targets is-basic-advance-action? make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events register-once resolve-ability trigger-event]]
-   [game.core.events :refer [event-count first-event? first-run-event?
-                             first-successful-run-on-server? no-event? not-last-turn? run-events turn-events]]
+   [game.core.events :refer [event-count first-event?
+                             first-successful-run-on-server? no-event? not-last-turn? run-events run-event-count turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-latest]]
    [game.core.flags :refer [card-flag? clear-persistent-flag!
@@ -450,7 +450,7 @@
              :req (req (and (:card-target card)
                             (first-event? state :runner :play-event)
                             (is-type? (:card context) (:card-target card))))
-
+             :async true
              :effect (effect (gain-credits :corp eid 2))
              :msg (msg "gain 2 [Credits] from " (:card-target card))}]})
 
@@ -1020,7 +1020,7 @@
   {:flags {:forced-to-avoid-tag true}
    :events [{:event :pre-tag
              :async true
-             :req (req (and run (first-run-event? state side :pre-tag)))
+             :req (req (and run (<= (run-event-count state side :pre-tag) 1)))
              :msg "avoid the first tag during this run"
              :effect (effect (tag-prevent :runner eid 1))}]})
 

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -20,7 +20,7 @@
    [game.core.effects :refer [register-lingering-effect is-disabled?]]
    [game.core.eid :refer [effect-completed get-ability-targets is-basic-advance-action? make-eid]]
    [game.core.engine :refer [not-used-once? pay register-events register-once resolve-ability trigger-event]]
-   [game.core.events :refer [event-count first-event?
+   [game.core.events :refer [event-count first-event? first-run-event?
                              first-successful-run-on-server? no-event? not-last-turn? run-events turn-events]]
    [game.core.expose :refer [expose]]
    [game.core.finding :refer [find-latest]]
@@ -445,15 +445,13 @@
                             (not (:facedown context))))
              :async true
              :effect (effect (gain-credits :corp eid 2))
-             :once :per-turn
              :msg (msg "gain 2 [Credits] from " (:card-target card))}
             {:event :play-event
              :req (req (and (:card-target card)
                             (first-event? state :runner :play-event)
                             (is-type? (:card context) (:card-target card))))
-             :async true
+
              :effect (effect (gain-credits :corp eid 2))
-             :once :per-turn
              :msg (msg "gain 2 [Credits] from " (:card-target card))}]})
 
 (defcard "Blue Sun: Powering the Future"
@@ -479,7 +477,6 @@
 
 (defcard "Captain Padma Isbister: Intrepid Explorer"
   {:events [{:event :run
-             :once :per-turn
              :async true
              :req (req (and (= (:server target) [:rd])
                             (first-event? state side :run #(= [:rd] (:server (first %))))))
@@ -848,7 +845,6 @@
                             (not (:facedown context))))
              :interactive (req (some #(card-flag? % :runner-install-draw)
                                      (all-installed state :runner)))
-             :once :per-turn
              :async true
              :waiting-prompt true
              :effect
@@ -923,8 +919,9 @@
 
 (defcard "Hyoubu Institute: Absolute Clarity"
   {:events [{:event :corp-reveal
-             :once :per-turn
-             :req (req (first-event? state side :corp-reveal #(pos? (count %))))
+             :req (req (and
+                         (pos? (count targets))
+                         (first-event? state side :corp-reveal #(pos? (count %)))))
              :msg "gain 1 [Credits]"
              :async true
              :effect (effect (gain-credits eid 1))}]
@@ -1023,8 +1020,7 @@
   {:flags {:forced-to-avoid-tag true}
    :events [{:event :pre-tag
              :async true
-             :once :per-run
-             :req (req (:run @state))
+             :req (req (and run (first-run-event? state side :pre-tag)))
              :msg "avoid the first tag during this run"
              :effect (effect (tag-prevent :runner eid 1))}]})
 
@@ -1243,8 +1239,8 @@
 
 (defcard "Los: Data Hijacker"
   {:events [{:event :rez
-             :once :per-turn
-             :req (req (ice? (:card context)))
+             :req (req (and (ice? (:card context))
+                            (first-event? state side :rez #(ice? (:card (first %))))))
              :msg "gain 2 [Credits]"
              :async true
              :effect (effect (gain-credits :runner eid 2))}]})
@@ -1579,10 +1575,10 @@
                                (trash eid target {:unpreventable true}))}}}]})
 
 (defcard "Nuvem SA: Law of the Land"
-  (let [abi2 {:once :per-turn
-              :event :corp-trash
+  (let [abi2 {:event :corp-trash
               :req (req (and (= :corp (:active-player @state))
-                             (= [:deck] (:zone (:card target)))))
+                             (= [:deck] (:zone (:card target)))
+                             (first-event? state side :corp-trash #(= [:deck] (:zone (:card (first %)))))))
               :msg "gain 2 [Credits]"
               :async true
               :effect (effect (gain-credits :corp eid 2))}
@@ -1812,7 +1808,7 @@
 
 (defcard "Rielle \"Kit\" Peddler: Transhuman"
   {:events [{:event :encounter-ice
-             :once :per-turn
+             :req (req (first-event? state side :encounter-ice))
              :msg (msg "make " (:title (:ice context))
                        " gain Code Gate until the end of the run")
              :effect (effect (register-lingering-effect

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -704,9 +704,9 @@
 
 (defcard "Defective Brainchips"
   {:events [{:event :pre-damage
-             :req (req (= (:type context) :brain))
+             :req (req (and (= (:type context) :brain)
+                            (first-event? state side :pre-damage #(= :brain (:type (first %))))))
              :msg "do 1 additional core damage"
-             :once :per-turn
              :effect (effect (damage-bonus :brain 1))}]})
 
 (defcard "Digital Rights Management"
@@ -2474,7 +2474,7 @@
    :static-abilities [{:type :play-cost
                        :value 1}]
    :events [{:event :play-event
-             :once :per-turn
+             :req (req (first-event? state side :play-event))
              :msg "gain 1 [Credits]"
              :async true
              :effect (effect (gain-credits :corp eid 1))}]})

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -2333,6 +2333,8 @@
 (defcard "Net Shield"
   {:interactions {:prevent [{:type #{:net}
                              :req (req true)}]}
+   ;; TODO - once a proper prevention system is set up, we can actually enforce the conditions
+   ;; on this card. nbkelly, 2024
    :abilities [{:cost [(->c :credit 1)]
                 :once :per-turn
                 :msg "prevent the first net damage this turn"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -1114,8 +1114,8 @@
                                       targets))
                    trash-event (fn [side-trash]
                                  {:event side-trash
-                                  :once :per-turn
                                   :once-per-instance true
+                                  :once :per-turn
                                   :req (req (and (prog-or-hw targets)
                                                  (first-event? state side side-trash prog-or-hw)))
                                   :msg "place 1 power counter on itself"
@@ -1707,15 +1707,15 @@
   {:events [mark-changed-event
             (assoc identify-mark-ability :event :runner-turn-begins)
             {:event :run-ends
-              :async true
-              :interactive (req true)
-              :once :per-turn
-              :req (req (first-event? state side :run-ends #(is-mark? state (target-server (first %)))))
-              :effect
-              (req (if (first-event? state side :end-breach-server #(is-mark? state (:from-server (first %))))
-                     (do (system-msg state :runner (str "uses " (:title card) " to gain 2 [Credits]"))
-                         (gain-credits state :runner eid 2))
-                     (effect-completed state side eid)))}]})
+             :async true
+             :interactive (req true)
+             :once :per-turn
+             :req (req (first-event? state side :run-ends #(is-mark? state (target-server (first %)))))
+             :effect
+             (req (if (first-event? state side :end-breach-server #(is-mark? state (:from-server (first %))))
+                    (do (system-msg state :runner (str "uses " (:title card) " to gain 2 [Credits]"))
+                        (gain-credits state :runner eid 2))
+                    (effect-completed state side eid)))}]})
 
 (defcard "Inside Man"
   {:recurring 2
@@ -2397,7 +2397,6 @@
                                       (remove (fn [[context]]
                                                 (= (:action context) :corp-click-credit)))
                                       count))))
-             :once :per-turn
              :msg "gain 1 [Credits]"
              :async true
              :effect (effect (gain-credits :runner eid 1))}]

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -1327,8 +1327,13 @@
                        :value true}]})
 
 (defcard "NeoTokyo Grid"
-  (let [ng {:req (req (in-same-server? card (:card context)))
-            :once :per-turn
+  (let [only-ev
+        (fn [state side ev no-ev card]
+          (and (first-event? state side ev #(in-same-server? card (:card (first %))))
+               (no-event? state side no-ev #(in-same-server? card (:card (first %))))))
+        ng {:req (req (and (in-same-server? card (:card context))
+                           (or (only-ev state side :advance :advancement-placed card)
+                               (only-ev state side :advancement-placed :advance card))))
             :msg "gain 1 [Credits]"
             :async true
             :effect (effect (gain-credits eid 1))}]

--- a/test/clj/game/cards/agendas_test.clj
+++ b/test/clj/game/cards/agendas_test.clj
@@ -995,6 +995,19 @@
       (click-card state :corp "Ice Wall")
       (click-prompt state :runner "No action")))
 
+(deftest dedicated-neural-net-first-time-each-turn
+  (do-game
+    (new-game {:corp {:score-area ["Dedicated Neural Net"]
+                      :hand ["Hedge Fund" "IPO"]}})
+    (take-credits state :corp)
+    (run-empty-server state :hq)
+    (click-prompt state :corp "0 [Credits]")
+    (click-prompt state :runner "0 [Credits]")
+    (click-prompt state :runner "No action")
+    (run-empty-server state :hq)
+    (click-prompt state :runner "No action")
+    (is (no-prompt? state :runner) "Neural net only works on the first event each turn")))
+
 (deftest degree-mill-basic-behavior
     ;; Basic behavior
     (do-game


### PR DESCRIPTION
I went through all the cards with `first-time` triggers, and in (almost) every case ensured they were actually checking it was the first time.

Ones where the check was correct, I removed irrelevant once keys. Cards like dbs that merge triggers need to keep those keys though.

Closes #4701