### PR TITLE
Restructure ganked to encounter ice after the card is done being accessed

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1722,15 +1722,21 @@
              :waiting-prompt true
              :choices (req [(when (can-pay? state :runner eid card nil [(->c :credit 3)])
                               "Pay 3 [Credits]")
-                            (when (or (not (can-pay? state :runner eid card nil [(->c :credit 3)]))
-                                      (can-pay? state :runner eid card nil [(->c :trash-installed 1)]))
-                              "Trash an installed card")])
+                            (when (can-pay? state :runner eid card nil [(->c :trash-installed 1)])
+                              "Trash an installed card")
+                            (when (and (not (can-pay? state :runner eid card nil [(->c :trash-installed 1)]))
+                                       (not (can-pay? state :runner eid card nil [(->c :credit 3)])))
+                              "Done")])
              :async true
-             :effect (req (if (= target "Pay 3 [Credits]")
+             :effect (req (cond
+                            (= target "Pay 3 [Credits]")
                             (wait-for (pay state side (make-eid state eid) card (->c :credit 3))
                                       (system-msg state side (:msg async-result))
                                       (effect-completed state side eid))
-                            (continue-ability state :runner runner-trash-installed-sub card nil)))}]
+                            (= target "Trash an installed card")
+                            (continue-ability state :runner runner-trash-installed-sub card nil)
+                            (= target "Done")
+                            (effect-completed state side eid)))}]
     {:subroutines [sub
                    sub
                    {:label "Do 1 core damage or end the run"
@@ -1741,7 +1747,10 @@
                     :async true
                     :effect (req (if (= target "Do 1 core damage")
                                    (damage state side eid :brain 1 {:card card})
-                                   (end-run state side eid card)))}]
+                                   ;; note - we need to clear the waiting prompt here or else forced
+                                   ;; ice encounters will break -nbkelly, 2024
+                                   (do (clear-wait-prompt state :runner)
+                                       (end-run state :corp eid card))))}]
      :runner-abilities [(bioroid-break 3 3)]}))
 
 (defcard "Fenris"

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1747,10 +1747,7 @@
                     :async true
                     :effect (req (if (= target "Do 1 core damage")
                                    (damage state side eid :brain 1 {:card card})
-                                   ;; note - we need to clear the waiting prompt here or else forced
-                                   ;; ice encounters will break -nbkelly, 2024
-                                   (do (clear-wait-prompt state :runner)
-                                       (end-run state :corp eid card))))}]
+                                   (end-run state :corp eid card)))}]
      :runner-abilities [(bioroid-break 3 3)]}))
 
 (defcard "Fenris"

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -736,8 +736,18 @@
                                (rezzed? target)
                                (protecting-same-server? card target)))}
       :msg (msg "force the Runner to encounter " (card-str state target))
-      :effect (req (wait-for (trash state :corp (assoc card :seen true) {:unpreventable true :cause-card card})
-                             (force-ice-encounter state side eid target)))}
+      :effect (req
+                ;; note - post-access events (like maw, aeneas informant)
+                ;; need to fire before ganked does - same for corp side post-access events
+                (let [target-card target]
+                  (register-events
+                    state side card
+                    [{:event :post-access-card
+                      :duration :end-of-run
+                      :unregister-once-resolved true
+                      :async true
+                      :effect (req (force-ice-encounter state side eid target-card))}]))
+                (trash state side eid (assoc card :seen true) {:unpreventable true :cause-card card}))}
      :no-ability {:effect (effect (system-msg (str "declines to use " (:title card))))}}}})
 
 (defcard "Georgia Emelyov"

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -1663,7 +1663,7 @@
     (run-continue-until state :success)
     (click-prompt state :corp "Yes")
     (click-card state :corp "Ice Wall")
-    (is (= "Hedge fund" (:title (second (:discard (get-corp))))) "Maw fired too")
+    (is (= "Hedge Fund" (:title (second (:discard (get-corp))))) "Maw fired too")
     (click-prompt state :runner "Yes")
     (let [iwall (:ice (core/get-current-encounter state))]
       (is (= "Ice Wall" (:title iwall)))

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -1624,6 +1624,30 @@
      (is (no-prompt? state :corp) "No more prompts")
      (is (no-prompt? state :runner) "No more prompts")))
 
+(deftest ganked-vs-fc3.0-run-actually-ends
+  (do-game
+    (new-game {:corp {:hand ["Fairchild 3.0" "Ganked!"]}
+               :runner {:credits 10}})
+    (play-from-hand state :corp "Fairchild 3.0" "HQ")
+    (take-credits state :corp)
+    (run-on state :hq)
+    (rez state :corp (get-ice state :hq 0))
+    (run-continue-until state :success)
+    (is (last-log-contains? state "Runner accesses Ganked!") "Ganked! message printed to log")
+    (click-prompt state :corp "Yes")
+    (click-card state :corp "Fairchild 3.0")
+    (let [fc3 (:ice (core/get-current-encounter state))]
+      (is (= "Fairchild 3.0" (:title fc3)) "Encountering fc3.0")
+      (fire-subs state fc3))
+    (click-prompt state :runner "Pay 3 [Credits]")
+    (click-prompt state :runner "Pay 3 [Credits]")
+    (click-prompt state :corp "End the run")
+    (is (not (:run @state)) "No more run")
+    (is (not (core/get-current-encounter state)) "No more encounter")
+    (is (no-prompt? state :corp) "No corp prompt")
+    (is (no-prompt? state :runner) "No runner prompt")
+    (take-credits state :runner)))
+    
 (deftest georgia-emelyov
   ;; Georgia Emelyov
   (do-game

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -1647,7 +1647,30 @@
     (is (no-prompt? state :corp) "No corp prompt")
     (is (no-prompt? state :runner) "No runner prompt")
     (take-credits state :runner)))
-    
+
+(deftest ganked-vs-informant-or-maw-timing
+  (do-game
+    (new-game {:corp {:hand ["Ice Wall" "Ganked!" "Hedge Fund"]}
+               :runner {:hand ["Aeneas Informant" "Maw"]
+                        :credits 10}})
+    (play-from-hand state :corp "Ice Wall" "New remote")
+    (play-from-hand state :corp "Ganked!" "Server 1")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Maw")
+    (play-from-hand state :runner "Aeneas Informant")
+    (run-on state :remote1)
+    (rez state :corp (get-ice state :remote1 0))
+    (run-continue-until state :success)
+    (click-prompt state :corp "Yes")
+    (click-card state :corp "Ice Wall")
+    (is (= '("Ganked!" "Hedge fund") (map :title (:discard (get-corp)))) "Maw fired too")
+    (click-prompt state :runner "Yes")
+    (let [iwall (:ice (core/get-current-encounter state))]
+      (is (= "Ice Wall" (:title iwall)))
+      (is (:run @state))
+      (fire-subs state iwall)
+      (is (not (:run @state))))))
+
 (deftest georgia-emelyov
   ;; Georgia Emelyov
   (do-game

--- a/test/clj/game/cards/upgrades_test.clj
+++ b/test/clj/game/cards/upgrades_test.clj
@@ -1663,13 +1663,42 @@
     (run-continue-until state :success)
     (click-prompt state :corp "Yes")
     (click-card state :corp "Ice Wall")
-    (is (= '("Ganked!" "Hedge fund") (map :title (:discard (get-corp)))) "Maw fired too")
+    (is (= "Hedge fund" (:title (second (:discard (get-corp))))) "Maw fired too")
     (click-prompt state :runner "Yes")
     (let [iwall (:ice (core/get-current-encounter state))]
       (is (= "Ice Wall" (:title iwall)))
       (is (:run @state))
       (fire-subs state iwall)
       (is (not (:run @state))))))
+
+(deftest ganked-vs-acme
+  (do-game
+    (new-game {:corp {:hand ["Ganked!" "Hedge Fund" "Ice Wall"]
+                      :score-area ["Dedicated Neural Net"]
+                      :id "Acme Consulting: The Truth You Need"}
+               :runner {:hand ["Jailbreak"]}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Jailbreak")
+    (click-prompt state :runner "HQ")
+    (rez state :corp (get-ice state :hq 0))
+    (is (= 0 (count-tags state)) "Runner not consided tagged")
+    (run-continue state :encounter-ice)
+    (is (= 1 (count-tags state)) "Runner consided during encounter")
+    (run-continue-until state :success)
+    (is (= 0 (count-tags state)) "Runner not consided tagged anymore")
+    (click-prompt state :corp "0 [Credits]")
+    (click-prompt state :runner "1 [Credits]")
+    (click-card state :corp "Ganked!")
+    (click-prompt state :corp "Yes")
+    (click-card state :corp "Ice Wall")
+    (is (= 1 (count-tags state)) "Runner consided during forced encounter")
+    (run-continue state)
+    (is (= 0 (count-tags state)) "Runner not consided tagged anymore after forced encounter")
+    (click-card state :corp "Hedge Fund")
+    (click-prompt state :runner "No action")
+    (is (not (:run @state)) "Run ended")
+    (is (= 0 (count-tags state)) "Runner not consided tagged anymore after run")))
 
 (deftest georgia-emelyov
   ;; Georgia Emelyov


### PR DESCRIPTION
Essentially we're firing the post-access event after the trash and before the encounter, which according to the rules team, is how the card works.

This lets us make maw and aeneas informant correctly with with ganked (Closes #6248).

Additionally, it prevents the waiting prompt on FC3.0 breaking the forced encounter (Closes #6943).

And then I added a test for ganked! vs. acme too (Closes #6155).