### PR TITLE
nanuq behaves correctly when moving out of play now

### DIFF
--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1963,7 +1963,7 @@
                :max (req (get-counters (get-card state card) :advancement))}
      :msg (msg "shuffle " (enumerate-str (map :title targets)) " into the stack")
      :effect (req (doseq [c targets]
-                    (move state :runner c :deck))
+                    (move state :runner c :deck {:shuffled true}))
                   (shuffle! state :runner :deck)
                   (effect-completed state side eid))}))
 

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -887,7 +887,7 @@
                :all true
                :card (every-pred installed? (if (= :corp side) corp? runner?))}
      :async true
-     :effect (req (let [cards (keep #(move state side % :deck) targets)]
+     :effect (req (let [cards (keep #(move state side % :deck {:shuffled true}) targets)]
                     (shuffle! state side :deck)
                     (complete-with-result
                       state side eid

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -200,7 +200,7 @@
                                                                                           :target-zone dest
                                                                                           :shuffled shuffled}]))
                dest (or dest-replacement dest)
-               moved-card (get-moved-card state side card to)]
+               moved-card (get-moved-card state side card (or (last dest-replacement) to))]
            (update-effects state card moved-card)
            (remove-old-card state side card)
            (let [pos-to-move-to (cond index index

--- a/src/clj/game/core/moving.clj
+++ b/src/clj/game/core/moving.clj
@@ -224,7 +224,7 @@
              (trigger-event state side :card-moved {:card card
                                                     :moved-card (get-card state moved-card)}))
            ;; move-zone-fn and the event can both modify the card, so re-bind here
-           (when [moved-card (get-card state moved-card)]
+           (let [moved-card (get-card state moved-card)]
              ; This is for removing `:location :X` events that are non-default locations,
              ; such as Subliminal Messaging only registering in :discard. We first unregister
              ; any non-default events from the previous zone and the register the non-default

--- a/test/clj/game/cards/programs_test.clj
+++ b/test/clj/game/cards/programs_test.clj
@@ -5872,6 +5872,36 @@
       (click-card state :runner (get-program state 0))
       (is (= 3 (count (:rfg (get-runner)))) "Nanuq removed from the game when uninstalled")))
 
+(deftest nanuq-vs-keegan-lane
+  (do-game
+    (new-game {:corp {:hand ["Keegan Lane"]}
+               :runner {:hand ["Nanuq"]}})
+    (play-from-hand state :corp "Keegan Lane" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Nanuq")
+    (run-on state :hq)
+    (gain-tags state :runner 1)
+    (rez state :corp (get-content state :hq 0))
+    (card-ability state :corp (get-content state :hq 0) 0)
+    (click-card state :corp "Nanuq")
+    (is (= 1 (count (:rfg (get-runner)))) "Nanuq in rfg")
+    (is (= 0 (count (:discard (get-runner)))) "Nanuq not in discard")))
+
+(deftest nanuq-vs-degree-mill
+  ;; note - if they're shuffled in, they don't get rfg'd...
+  (do-game
+    (new-game {:corp {:hand ["Degree Mill"]}
+               :runner {:deck ["PAD Tap" "Nanuq"]}})
+    (take-credits state :corp)
+    (play-from-hand state :runner "Nanuq")
+    (play-from-hand state :runner "PAD Tap")
+    (run-empty-server state :hq)
+    (click-prompt state :runner "Pay to steal")
+    (click-card state :runner "Nanuq")
+    (click-card state :runner "PAD Tap")
+    (is (= 2 (count (:deck (get-runner)))) "Both cards in deck")
+    (is (= 0 (count (:rfg (get-runner)))) "Nanuq not rfg'd")))
+
 (deftest nfr
   ;; Nfr
   (do-game


### PR DESCRIPTION
Nanuq now substitutes it's destination zone to `:rfg` where appropriated. It cant do this if it's meant to be shuffled in, though (exactly degree mill and that one jinteki asset I can't remember of the name of do that), so we check for that.

Closes #6924