### PR TITLE
maybe deregister users when they disconnect from the game or close their websocket connections

### DIFF
--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -56,9 +56,7 @@
   "Remove user from app-state. Mutates."
   [uid]
   (let [users (:users @app-state)
-        _ (println "USERS" users)
-        new-users (dissoc users uid)
-        _ (println "NEW USERS" new-users)]
+        new-users (dissoc users uid)]
     (swap! app-state #(assoc %1 :users new-users))))
 
 (defn pause-lobby-updates

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -288,4 +288,5 @@
           main/handle-notification lobby? (str (:username user) " has left the game.")))))
   (lobby/send-lobby-list uid)
   (lobby/broadcast-lobby-list)
+  (app-state/deregister-user! uid)
   (when ?reply-fn (?reply-fn true)))


### PR DESCRIPTION
I'm not sure if this was the source of the lag or not, but I think it's worth a try.

This should stop us having 1600 cached users in the app state I think.