### PR TITLE
remove users from the lobby update list when they time out

### DIFF
--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -59,9 +59,7 @@
 
 (defn pause-lobby-updates
   [uid]
-  (let [lobby-update (:lobby-updates @app-state)
-        new-lobby-updates (dissoc lobby-update uid)]
-    (swap! app-state #(assoc %1 :lobby-updates new-lobby-updates))))
+  (swap! app-state dissoc-in [:lobby-updates uid]))
 
 (defn continue-lobby-updates
   [uid]

--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -2,7 +2,7 @@
   (:require
    [cljc.java-time.temporal.chrono-unit :as chrono]
    [cljc.java-time.instant :as inst]
-   [medley.core :refer [find-first]]))
+   [medley.core :refer [dissoc-in find-first]]))
 
 (defonce app-state
   (atom {:lobbies {}

--- a/src/clj/web/app_state.clj
+++ b/src/clj/web/app_state.clj
@@ -77,7 +77,5 @@
 (defn deregister-user!
   "Remove user from app-state. Mutates."
   [uid]
-  (let [users (:users @app-state)
-        new-users (dissoc users uid)]
-    (pause-lobby-updates uid)
-    (swap! app-state #(assoc %1 :users new-users))))
+  (pause-lobby-updates uid)
+  (swap! app-state dissoc-in [:users uid]))

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -16,7 +16,7 @@
   "average time | oldest"
   [subs]
   (let [now (inst/now)
-        age #(duration/get (duration/between % now) chrono/minutes)
+        age #(quot (duration/get (duration/between % now) chrono/seconds) 60)
         subs-by-minute (sort (map age subs))
         oldest (or (last subs-by-minute) 0)
         average (quot (reduce + 0 subs-by-minute) (max 1 (count subs)))]

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -10,7 +10,7 @@
    [taoensso.encore :as enc]
    [taoensso.timbre :as timbre]))
 
-(def log-stat-frequency (enc/ms :mins 1))
+(def log-stat-frequency (enc/ms :mins 5))
 
 (defn subscriber-time-metrics
   "average time | oldest"

--- a/src/clj/web/telemetry.clj
+++ b/src/clj/web/telemetry.clj
@@ -1,13 +1,26 @@
 (ns web.telemetry
   (:require
-    [clojure.core.async :refer [<! go timeout]]
-    [web.app-state :refer [app-state]]
-    [web.lobby :refer [lobby-update-uids]]
-    [web.ws :refer [connected-sockets connections_]]
-    [taoensso.encore :as enc]
-    [taoensso.timbre :as timbre]))
+   [clojure.core.async :refer [<! go timeout]]
+   [cljc.java-time.temporal.chrono-unit :as chrono]
+   [cljc.java-time.duration :as duration]
+   [cljc.java-time.instant :as inst]
+   [web.app-state :refer [app-state]]
+   [web.lobby :refer [lobby-update-uids]]
+   [web.ws :refer [connected-sockets connections_]]
+   [taoensso.encore :as enc]
+   [taoensso.timbre :as timbre]))
 
-(def log-stat-frequency (enc/ms :mins 5))
+(def log-stat-frequency (enc/ms :mins 1))
+
+(defn subscriber-time-metrics
+  "average time | oldest"
+  [subs]
+  (let [now (inst/now)
+        age #(duration/get (duration/between % now) chrono/minutes)
+        subs-by-minute (sort (map age subs))
+        oldest (or (last subs-by-minute) 0)
+        average (quot (reduce + 0 subs-by-minute) (max 1 (count subs)))]
+    [average oldest]))
 
 (defonce log-stats
   (go (while true
@@ -16,6 +29,7 @@
           user-cache-count (count (:users @app-state))
           lobby-sub-count (count (filter identity (vals (:lobby-updates @app-state))))
           lobby-update-uids (count (lobby-update-uids))
+          [average-sub-time oldest-sub-time] (subscriber-time-metrics (filter identity (vals (:lobby-updates @app-state))))
           ajax-uid-count (count (:ajax @connected-sockets))
           ajax-conn-counts (seq (map count (:ajax @connections_)))
           ajax-conn-total (reduce + ajax-conn-counts)
@@ -28,6 +42,8 @@
                      " cached-users: " user-cache-count
                      " lobby-subs: " lobby-sub-count
                      " lobby-update-uids: " lobby-update-uids
+                     " average-lobby-subs-lifetime: " average-sub-time "m"
+                     " oldest-lobby-sub: " oldest-sub-time "m"
                      " | "
                      "websockets -"
                      " :ajax { "


### PR DESCRIPTION
Our server looks like this right now:
`2024-07-23T07:58:10.906Z ns521372 INFO [web.telemetry:25] - stats - lobbies: 3 cached-users: 403 lobby-subs: 64 lobby-update-uids: 18 | websockets - :ajax {  uid: 0 conn: 0 } :ws {  uid: 54 conn: 108 }`

We're caching a silly amount of users (I think I fixed that early), and we're sending updates to a bunch of people that probably don't even exist. This is maybe one of the reasons for lag? idk

In any case, here's an attempt.

Instead of just true/false, we're putting  a timestamp in lobby-subscriptions. We only send out updates to people who are active within the last two hours.

That timeframe is actually super generous, any time you click out and into the page, tab in, enter or exit a game, or change to the play tab, that gets reset. Realistically, it could be 15 minutes and it would be fine. But right now this is going to be no worse than what we have, and probably somewhat better.

I also updated the telemetry to show us the average subscription lifetime, and the oldest subscription.

These little bits will be inserted into the telemetry:
`lobby-update-uids: 1 average-lobby-subs-lifetime: 4m oldest-lobby-sub: 4m`

Thanks to @butzopower for the leads to follow on this one.