### PR TITLE
tatu bola swaps the correct ice after already being swapped

### DIFF
--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -4015,7 +4015,7 @@
                                               :waiting-prompt true
                                               :choices (req (filter ice? (:hand corp)))
                                               :async true
-                                              :effect (req (wait-for (swap-cards-async state side (make-eid state eid) target current-ice)
+                                              :effect (req (wait-for (swap-cards-async state side (make-eid state eid) target (get-card state card))
                                                                      (gain-credits state :corp eid 4)))
                                               :msg (msg "swap " (card-str state card)
                                                         " with a piece of ice from HQ and gain 4 [Credits]")}}}

--- a/test/clj/game/cards/ice_test.clj
+++ b/test/clj/game/cards/ice_test.clj
@@ -7301,6 +7301,30 @@
           (click-prompt state :corp "OK"))
         "Corp gained no credits")))
 
+(deftest tatu-bola-swaps-correct-ice-when-swapped
+  (do-game
+    (new-game {:corp {:hand ["Tatu-Bola" "Vanilla" "Ice Wall"]}
+               :runner {:hand ["Inversificator"]
+                        :credits 10
+                        :id "Rielle \"Kit\" Peddler: Transhuman"}})
+    (play-from-hand state :corp "Tatu-Bola" "HQ")
+    (play-from-hand state :corp "Vanilla" "R&D")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Inversificator")
+    (run-on state :hq)
+    (rez state :corp (get-ice state :hq 0))
+    (run-continue state :encounter-ice)
+    (card-ability state :runner (get-program state 0) 0)
+    (click-prompt state :runner "End the run")
+    (run-continue state :movement)
+    (click-prompt state :runner "Yes")
+    (click-card state :runner "Vanilla")
+    (click-prompt state :corp "Yes")
+    (click-prompt state :corp "Ice Wall")
+    (is (= "Ice Wall" (:title (get-ice state :rd 0))) "Ice wall on R&D")
+    (is (= "Vanilla" (:title (get-ice state :hq 0))) "Vanilla on HQ")
+    (is (= ["Tatu-Bola"] (map :title (:hand (get-corp)))) "Tatu bola in HQ")))
+
 (deftest thimblerig-thimblerig-does-not-open-a-prompt-if-it-s-the-only-piece-of-ice
   ;; Thimblerig does not open a prompt if it's the only piece of ice
   (do-game


### PR DESCRIPTION
Actually chooses tatu bola, rather than selecting the current encounter and trusting that it's tatu bola.

Closes #7284 (again :joy:)

Also closes #7293. That one was failing for the same reason (trying to select the current encounter when `current-encounter` returned nil. The test covers that case.